### PR TITLE
Fixed top menus for small screens / devices

### DIFF
--- a/public/stylesheets/common.css
+++ b/public/stylesheets/common.css
@@ -65,8 +65,7 @@ body.tight div.content {
   border-bottom: 1px solid #c4c4c4;
 }
 body.tight #top {
-  min-width: 780px;
-  overflow: hidden;
+  min-width: 860px;
 }
 #site_description {
   position: absolute;


### PR DESCRIPTION
Removed overflow:hidden so that the menus are visible on smaller screens / touch devices.

Changed the min-width to 860px beacuse toggle background and color selector are hidden when user is logged in. (this also depends on the username, so a more complicated fix might be needed)
