### PR TITLE
Fix textarea height

### DIFF
--- a/public/stylesheets/analyse.css
+++ b/public/stylesheets/analyse.css
@@ -88,7 +88,7 @@ div.fen_pgn .fen {
 div.fen_pgn textarea {
   display: block;
   width: 100%;
-  height: 200px;
+  height: 150px;
   font-family: monospace;
   line-height: normal;
   margin: 0;


### PR DESCRIPTION
200px for the textarea made the containing div scrollable, thereby making is a scrollable textarea inside a scrollable div - fiddley to use. 150px height for the text area makes it more usable.
