### PR TITLE
Lighten even rows

### DIFF
--- a/public/stylesheets/common.css
+++ b/public/stylesheets/common.css
@@ -1750,7 +1750,7 @@ div.undertable tr:first-child td {
   border-top: none;
 }
 div.undertable tr:nth-child(even) td {
-  background: #f0f0f0;
+  background: #f8f8f8;
 }
 div.undertable.half {
   width: 250px;


### PR DESCRIPTION
So they stand out less with the rest of the page. #f0f0f0 was quite dark compared with the rest of the page's and tone. #f8f8f8 matches with the items in the games list.
