### PR TITLE
fix text overflow when puzzle upvote count > 999

### DIFF
--- a/public/stylesheets/puzzle.css
+++ b/public/stylesheets/puzzle.css
@@ -140,7 +140,6 @@
   display: block;
   font-size: 24px;
   text-decoration: none;
-  width: 40px;
 }
 #puzzle div.upvote.enabled a:hover,
 #puzzle div.upvote a.active {
@@ -149,7 +148,6 @@
 #puzzle div.upvote span.count {
   display: block;
   font-size: 24px;
-  width: 40px;
   line-height: 1;
 }
 #puzzle #disqus_thread {


### PR DESCRIPTION
http://i.imgur.com/0b19PgY.png

display: block autosizes nicely
