### PR TITLE
fix rating in meta description on profile page

### DIFF
--- a/app/templating/UserHelper.scala
+++ b/app/templating/UserHelper.scala
@@ -269,7 +269,7 @@ trait UserHelper { self: I18nHelper with StringHelper =>
     val nbGames = user.count.game
     val createdAt = org.joda.time.format.DateTimeFormat forStyle "M-" print user.createdAt
     val currentRating = user.perfs.bestPerf ?? {
-      case (pt, perf) => s" Current ${pt.name} rating: $perf."
+      case (pt, perf) => s" Current ${pt.name} rating: ${perf.intRating}."
     }
     s"$name played $nbGames games since $createdAt.$currentRating"
   }


### PR DESCRIPTION
currently printing object inspection

`<meta content="flugsio played 135 games since Dec 8, 2013. Current Chess960 rating: Perf(1467 79,27,List(1467, 1489, 1474, 1457, 1458, 1438, 1461, 1438, 1412, 1435, 1404, 1398),Some(2014-12-09T00:11:46.501+01:00))." name="description">`
