### PR TITLE
road to offline support

### DIFF
--- a/app/controllers/Main.scala
+++ b/app/controllers/Main.scala
@@ -145,6 +145,10 @@ Disallow: /games/export
     Ok(html.site.faq()).fuccess
   }
 
+  def offline = Open { implicit ctx =>
+    Ok(html.site.offline()).fuccess
+  }
+
   def movedPermanently(to: String) = Action {
     MovedPermanently(to)
   }

--- a/app/views/site/offline.scala
+++ b/app/views/site/offline.scala
@@ -1,0 +1,26 @@
+package views.html.site
+
+import lila.api.Context
+import lila.app.templating.Environment._
+import lila.app.ui.ScalatagsTemplate._
+
+import controllers.routes
+
+object offline {
+
+  def apply()(implicit ctx: Context) = views.html.base.layout(
+    title = "Offline",
+    moreJs = embedJsUnsafe("""$('#try-again').click(() => window.location.reload());""")
+  ) {
+      main(cls := "page-small box box-pad")(
+        h1("You are offline"),
+        p(
+          a(id := "try-again")("Try again!")
+        ),
+        p(
+          "You can still use the ",
+          a(href := routes.Editor.index)("editor"), "."
+        )
+      )
+    }
+}

--- a/conf/routes
+++ b/conf/routes
@@ -586,6 +586,7 @@ GET   /qa                              controllers.Main.movedPermanently(to: Str
 GET   /help                            controllers.Main.movedPermanently(to: String = "/contact")
 GET   /qa/:id/:slug                    controllers.Main.legacyQaQuestion(id: Int, slug: String)
 GET   /how-to-cheat                    controllers.Page.howToCheat
+GET   /444                             controllers.Main.offline
 
 # Variants
 GET   /variant                         controllers.Page.variantHome

--- a/ui/serviceWorker/package.json
+++ b/ui/serviceWorker/package.json
@@ -8,5 +8,9 @@
   "devDependencies": {
     "@build/tsProject": "2.0.0",
     "types-serviceworker": "^0.0.1"
+  },
+  "dependencies": {
+    "@types/parse5-parser-stream": "^5.0.1",
+    "parse5-parser-stream": "^5.1.1"
   }
 }

--- a/ui/serviceWorker/src/main.ts
+++ b/ui/serviceWorker/src/main.ts
@@ -89,9 +89,12 @@ async function handleActivate() {
 
 self.addEventListener('activate', e => e.waitUntil(handleActivate()));
 
+async function handleResponse(_response: Response) {
+  //console.log(response.url, response.body);
+}
+
 async function handleFetch(event: FetchEvent) {
   const url = new URL(event.request.url, self.location.href);
-  console.log(url.pathname);
   if (url.pathname == '/dasher') {
     const offlineDasher = await caches.match('/dasher', {ignoreSearch: true, ignoreVary: true});
     console.log('offline dasher', offlineDasher);
@@ -106,7 +109,10 @@ async function handleFetch(event: FetchEvent) {
   }
 
   try {
-    return await fetch(event.request);
+    const response = await fetch(event.request);
+    console.log(event.request, response);
+    event.waitUntil(handleResponse(response.clone()));
+    return response;
   } catch(err) {
     if (event.request.mode == 'navigate') {
       const offlinePage = await caches.match('/444');

--- a/ui/serviceWorker/src/main.ts
+++ b/ui/serviceWorker/src/main.ts
@@ -39,7 +39,7 @@ async function handleInstall() {
     '/favicon.ico',
     '/manifest.json',
     ...[
-      // TODO: 'trans/refs.json',
+      'trans/refs.json',
       ...themedStylesheets('site'),
       ...themedStylesheets('editor'),
       ...themedStylesheets('challenge'),
@@ -66,12 +66,13 @@ async function handleInstall() {
       'images/board/svg/brown.svg',
     ].map(versionedAssetUrl),
     ...[
-      'images/logo.256.png',
-      'images/favicon-32-white.png',
-      'favicon.64.png',
-      'favicon.128.png',
-      'favicon.192.png',
-      'favicon.256.png',
+      'logo/lichess-favicon-32.png',
+      'logo/lichess-favicon-32-invert.png',
+      'logo/lichess-favicon-64.png',
+      'logo/lichess-favicon-128.png',
+      'logo/lichess-favicon-256.png',
+      'logo/lichess-favicon-192.png',
+      'logo/lichess-favicon-512.png',
     ].map(assetUrl),
   ]));
 }

--- a/ui/serviceWorker/src/main.ts
+++ b/ui/serviceWorker/src/main.ts
@@ -67,6 +67,16 @@ async function handleInstall() {
 
 self.addEventListener('install', e => e.waitUntil(handleInstall()));
 
+async function handleActivate() {
+  const cacheNames = await caches.keys();
+  await Promise.all(
+    cacheNames
+      .filter(cacheName => !cacheName.endsWith(assetVersion))
+      .map(cacheName => caches.delete(cacheName)));
+}
+
+self.addEventListener('activate', e => e.waitUntil(handleActivate()));
+
 async function handleFetch(event: FetchEvent) {
   const url = new URL(event.request.url, self.location.href);
   if (url.pathname == '/editor' || url.pathname.startsWith('/editor/')) {

--- a/ui/serviceWorker/src/main.ts
+++ b/ui/serviceWorker/src/main.ts
@@ -1,15 +1,26 @@
-const searchParams = new URL(self.location.href).searchParams;
-const assetBase = new URL(searchParams.get('asset-url')!, self.location.href).href;
+const assetBase = new URL(new URL(self.location.href).searchParams.get('asset-url')!, self.location.href).href;
+const assetVersion = self.location.pathname.split('/')[2];
 
 function assetUrl(path: string): string {
-  return `${assetBase}assets/${path}`;
+  const r = `${assetBase}assets/${assetVersion}/${path}`;
+  console.log(r);
+  return r;
 }
+
+self.addEventListener('install', event => {
+  event.waitUntil(caches.open(assetVersion).then(cache => cache.addAll([
+    'css/site.light.dev.css', // TODO: prod
+    'css/site.dark.dev.css', // TODO: prod
+    'font/lichess.woff2',
+    'font/lichess.chess.woff2',
+  ].map(assetUrl))));
+});
 
 self.addEventListener('push', event => {
   const data = event.data!.json();
   return self.registration.showNotification(data.title, {
-    badge: assetUrl('logo/lichess-favicon-256.png'),
-    icon: assetUrl('logo/lichess-favicon-256.png'),
+    badge: assetUrl('images/logo.256.png'),
+    icon: assetUrl('images/logo.256.png'),
     body: data.body,
     tag: data.tag,
     data: data.payload,

--- a/yarn.lock
+++ b/yarn.lock
@@ -50,6 +50,24 @@
   dependencies:
     "@types/jquery" "*"
 
+"@types/node@*":
+  version "12.12.14"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.14.tgz#1c1d6e3c75dba466e0326948d56e8bd72a1903d2"
+  integrity sha512-u/SJDyXwuihpwjXy7hOOghagLEV1KdAST6syfnOk6QZAMzZuWZqXy5aYYZbh8Jdpd4escVFP0MvftHNDb9pruA==
+
+"@types/parse5-parser-stream@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@types/parse5-parser-stream/-/parse5-parser-stream-5.0.1.tgz#37041579a0424ef36827d0513f3a9ab1fd2b7f48"
+  integrity sha512-8JOeaYbHA8/AreMooZkIH1Xl3VNHXgzTWuQJpY/l9Wz74OQD824DbrR+qqhcFwSFdWkteMfypQDzNEmrttLhwg==
+  dependencies:
+    "@types/node" "*"
+    "@types/parse5" "*"
+
+"@types/parse5@*":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@types/parse5/-/parse5-5.0.2.tgz#a877a4658f8238c8266faef300ae41c84d72ec8a"
+  integrity sha512-BOl+6KDs4ItndUWUFchy3aEqGdHhw0BC4Uu+qoDonN/f0rbUnJbm71Ulj8Tt9jLFRaAxPLKvdS1bBLfx1qXR9g==
+
 "@types/sizzle@*":
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/@types/sizzle/-/sizzle-2.3.2.tgz#a811b8c18e2babab7d542b3365887ae2e4d9de47"
@@ -3666,6 +3684,18 @@ parse-passwd@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/parse-passwd/-/parse-passwd-1.0.0.tgz#6d5b934a456993b23d37f40a382d6f1666a8e5c6"
   integrity sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=
+
+parse5-parser-stream@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/parse5-parser-stream/-/parse5-parser-stream-5.1.1.tgz#ac92702f184f63f9fa3b73ccda300edf87d20f59"
+  integrity sha512-kdDykuHv4ZfntWoAmRmfMbeYOPTFImlRABlvxPzHCe9oq53wddVOJEY8aVoUAkb5gjEqhV91L+/f6J6xkjqjQw==
+  dependencies:
+    parse5 "^5.1.1"
+
+parse5@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-5.1.1.tgz#f68e4e5ba1852ac2cadc00f4555fff6c2abb6178"
+  integrity sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==
 
 pascalcase@^0.1.1:
   version "0.1.1"


### PR DESCRIPTION
for #5492 

first milestone: serve a mostly static page like the board editor in offline mode

useful article: https://web.dev/google-search-sw/ (describes how google uses service workers in search with minimal overhead)

* [x] how to get opening name when dests are computed locally?
* [ ] cache essential assets
  * [ ] font
    * [x] ~is woff2 sufficient?~ (not for Safari on El Capitan)
  * [x] css
  * [x] scripts
  * [ ] sounds
* [ ] cache board and pieces
  * [x] cache cburnett and brown svg board
  * [ ] fallback
* [x] delete old caches when asset version changes
* [ ] adjust editor
* [ ] offline first
  * [ ] do not break dasher
  * [x] do not break friends list
  * [ ] do not break challenges
  * [ ] do not break notifications
  * [ ] navigation preload
* [ ] offline page
  * [x] basic functionality
  * [ ] design
* [ ] opportunistic asset caching
* [ ] remember username and important settings
* [ ] backoff for websocket?
* [ ] ensure cache control is not too long
* [ ] beta