### PR TITLE
Add kolabnow domain to the email whitelist

### DIFF
--- a/modules/security/src/main/DisposableEmailDomain.scala
+++ b/modules/security/src/main/DisposableEmailDomain.scala
@@ -98,6 +98,7 @@ private object DisposableEmailDomain {
     "fastmail.com",
     "fastmail.fm",
     "yandex.com",
+    "mykolab.com",
     /* United States ISP domains */
     "bellsouth.net",
     "charter.net",


### PR DESCRIPTION
Kolabnow domains (https://kolabnow.com/) are currently rejected in lichess. This is not the only available domain for the provider but I didn't found a proper list so I'm adding only the one I personally use, I can send another once they send me the complete list.

Please let me know if I need to provide any extra information in order to whitelist the domain. Thanks!