### PR TITLE
oauth/css: Simplify footer layout

### DIFF
--- a/ui/site/css/_oauth.scss
+++ b/ui/site/css/_oauth.scss
@@ -58,17 +58,12 @@
   }
 
   &__footer {
-    @extend %flex-between-nowrap;
     color: $c-font-dim;
     font-size: 0.9em;
+    text-align: center;
+
     strong {
       @extend %break-word;
     }
-  }
-
-  &__redirect {
-    flex: 0 0 60%;
-    margin-left: 1em;
-    text-align: right;
   }
 }


### PR DESCRIPTION
|Before|After|
|:--:|:--:|
|![Screenshot 2021-08-26 090646](https://user-images.githubusercontent.com/19309705/130917306-247ce1c4-40cc-4a36-a263-d36bd5df1d45.png)|![Screenshot 2021-08-26 090424](https://user-images.githubusercontent.com/19309705/130917321-24c85b04-da04-4250-ab2b-e0ff49703305.png)|

The current layout is a bit confusing and also doesn't handle long redirect URLs well.