### PR TITLE
Bugfix in continueOrStart

### DIFF
--- a/modules/perfStat/src/main/PerfStat.scala
+++ b/modules/perfStat/src/main/PerfStat.scala
@@ -107,12 +107,14 @@ case class Streak(v: Int, from: Option[GameAt], to: Option[GameAt]) {
   def continueOrStart(cont: Boolean, pov: Pov)(v: Int) =
     if (cont) inc(pov, v)
     else {
-      val at = GameAt(pov.game.createdAt, pov.gameId).some
-      Streak(v, at, at)
+      val at  = GameAt(pov.game.createdAt, pov.gameId).some
+      val end = GameAt(pov.game.movedAt, pov.gameId).some
+      Streak(v, at, end)
     }
   private def inc(pov: Pov, by: Int) = {
-    val at = GameAt(pov.game.createdAt, pov.gameId).some
-    Streak(v + by, from orElse at, at)
+    val at  = GameAt(pov.game.createdAt, pov.gameId).some
+    val end = GameAt(pov.game.movedAt, pov.gameId).some
+    Streak(v + by, from orElse at, end)
   }
   def period = new Period(v * 1000L)
 }


### PR DESCRIPTION
After https://github.com/ornicar/lila/commit/607e47252d162fc9ddd134d9958c333ca9ba5cfe streaks end at the beginning of the last game.

e.g. if current streak is composed by a sole game that lasted 30 minutes
the output will be something like:
`Current streak: 30 minutes from 7 oct 2021, 3:00 PM to 7 oct 2021,`**3:00** `PM`
instead of:
`Current streak: 30 minutes from 7 oct 2021, 3:00 PM to 7 oct 2021,`**3:30** `PM`

This commit restores the `movedAt` dependence.