### PR TITLE
Fix board jump on mobile

### DIFF
--- a/ui/round/css/_moves-col1.scss
+++ b/ui/round/css/_moves-col1.scss
@@ -5,11 +5,11 @@
   .col1-moves {
     flex: 0 0 $col1-moves-height;
     display: flex;
+    justify-content: space-between;
 
     .fbt {
       flex: 0 0 auto;
       padding: 0 1.3em;
-      opacity: 0.7;
     }
 
     body.playing.zen & {

--- a/ui/round/src/view/replay.ts
+++ b/ui/round/src/view/replay.ts
@@ -213,20 +213,18 @@ function initMessage(ctrl: RoundController) {
 }
 
 function col1Button(ctrl: RoundController, dir: number, icon: string, disabled: boolean) {
-  return disabled
-    ? null
-    : h('button.fbt', {
-        attrs: {
-          disabled: disabled,
-          'data-icon': icon,
-          'data-ply': ctrl.ply + dir,
-        },
-        hook: util.bind('mousedown', e => {
-          e.preventDefault();
-          ctrl.userJump(ctrl.ply + dir);
-          ctrl.redraw();
-        }),
-      });
+  return h('button.fbt', {
+    attrs: {
+      disabled: disabled,
+      'data-icon': icon,
+      'data-ply': ctrl.ply + dir,
+    },
+    hook: util.bind('mousedown', e => {
+      e.preventDefault();
+      ctrl.userJump(ctrl.ply + dir);
+      ctrl.redraw();
+    }),
+  });
 }
 
 export function render(ctrl: RoundController): VNode | undefined {
@@ -256,19 +254,18 @@ export function render(ctrl: RoundController): VNode | undefined {
         },
         renderMoves(ctrl)
       );
+  const renderMovesOrResult = moves ? moves : renderResult(ctrl);
   return ctrl.nvui
     ? undefined
     : h(rmovesTag, [
         renderButtons(ctrl),
         initMessage(ctrl) ||
-          (moves
-            ? isCol1()
-              ? h('div.col1-moves', [
-                  col1Button(ctrl, -1, '', ctrl.ply == round.firstPly(d)),
-                  moves,
-                  col1Button(ctrl, 1, '', ctrl.ply == round.lastPly(d)),
-                ])
-              : moves
-            : renderResult(ctrl)),
+          (isCol1()
+            ? h('div.col1-moves', [
+                col1Button(ctrl, -1, '', ctrl.ply == round.firstPly(d)),
+                renderMovesOrResult,
+                col1Button(ctrl, 1, '', ctrl.ply == round.lastPly(d)),
+              ])
+            : renderMovesOrResult),
       ]);
 }


### PR DESCRIPTION
Closes #9967.

![duringGame](https://user-images.githubusercontent.com/16229739/137603793-647c19bd-75c0-41e4-9ca9-5291caa32858.png)
![after](https://user-images.githubusercontent.com/16229739/137603797-4cc6382d-0c6c-4306-b3d9-7f9e88199fd1.png)

The move navigation buttons were missing if the move list pref was kept to 'never'. I've added the buttons back so the board no longer jumps at the end of a game.
