### PR TITLE
Fix link to preferences on insights page

### DIFF
--- a/ui/insight/src/info.ts
+++ b/ui/insight/src/info.ts
@@ -17,7 +17,7 @@ export default function (ctrl: Ctrl) {
               'a',
               {
                 attrs: {
-                  href: '/account/preferences/privacy',
+                  href: '/account/preferences/site',
                   target: '_blank',
                   rel: 'noopener',
                 },


### PR DESCRIPTION
`/account/preferences/privacy` was moved to `/account/preferences/site` in 4fa4daf4831c4daec545c1b9650154ddbd9cc5db