### PR TITLE
Hide ratings if selected for studies imported from game

### DIFF
--- a/app/controllers/RelayRound.scala
+++ b/app/controllers/RelayRound.scala
@@ -46,7 +46,7 @@ final class RelayRound(
                       ctx.req,
                       Redirect(routes.RelayTour.redirectOrApiTour(tour.slug, tour.id.value))
                     ) {
-                      env.relay.api.create(setup, me, tour) map { round =>
+                      env.relay.api.create(setup, me, tour, ctx.pref.showRatings) map { round =>
                         Redirect(routes.RelayRound.show(tour.slug, round.slug, round.id.value))
                       }
                     }
@@ -67,7 +67,7 @@ final class RelayRound(
                       setup =>
                         rateLimitCreation(me, req, rateLimited) {
                           JsonOk {
-                            env.relay.api.create(setup, me, tour) map { round =>
+                            env.relay.api.create(setup, me, tour, withRatings = true) map { round =>
                               env.relay.jsonView.withUrl(round withTour tour)
                             }
                           }

--- a/app/controllers/Study.scala
+++ b/app/controllers/Study.scala
@@ -291,7 +291,7 @@ final class Study(
   private def createStudy(data: lila.study.StudyForm.importGame.Data, me: lila.user.User)(implicit
       ctx: Context
   ) =
-    env.study.api.importGame(lila.study.StudyMaker.ImportGame(data), me) flatMap {
+    env.study.api.importGame(lila.study.StudyMaker.ImportGame(data), me, ctx.pref.showRatings) flatMap {
       _.fold(notFound) { sc =>
         Redirect(routes.Study.chapter(sc.study.id.value, sc.chapter.id.value)).fuccess
       }

--- a/modules/relay/src/main/RelayApi.scala
+++ b/modules/relay/src/main/RelayApi.scala
@@ -151,7 +151,7 @@ final class RelayApi(
   def tourUpdate(tour: RelayTour, data: RelayTourForm.Data, user: User): Funit =
     tourRepo.coll.update.one($id(tour.id), data.update(tour, user)).void
 
-  def create(data: RelayRoundForm.Data, user: User, tour: RelayTour): Fu[RelayRound] =
+  def create(data: RelayRoundForm.Data, user: User, tour: RelayTour, withRatings: Boolean): Fu[RelayRound] =
     roundRepo.lastByTour(tour) flatMap {
       _ ?? { last => studyRepo.byId(last.studyId) }
     } flatMap { lastStudy =>
@@ -174,6 +174,7 @@ final class RelayApi(
             from = Study.From.Relay(none).some
           ),
           user,
+          withRatings,
           _.copy(members =
             lastStudy.fold(StudyMembers.empty)(_.members) + StudyMember(
               id = user.id,

--- a/modules/study/src/main/StudyMaker.scala
+++ b/modules/study/src/main/StudyMaker.scala
@@ -11,10 +11,11 @@ final private class StudyMaker(
     pgnDump: lila.game.PgnDump
 )(implicit ec: scala.concurrent.ExecutionContext) {
 
-  def apply(data: StudyMaker.ImportGame, user: User): Fu[Study.WithChapter] =
+  def apply(data: StudyMaker.ImportGame, user: User, withRatings: Boolean): Fu[Study.WithChapter] =
     (data.form.gameId ?? gameRepo.gameWithInitialFen).flatMap {
-      case Some((game, initialFen)) => createFromPov(data, Pov(game, data.form.orientation), initialFen, user)
-      case None                     => createFromScratch(data, user)
+      case Some((game, initialFen)) =>
+        createFromPov(data, Pov(game, data.form.orientation), initialFen, user, withRatings)
+      case None => createFromScratch(data, user)
     } map { sc =>
       // apply specified From if any
       sc.copy(study = sc.study.copy(from = data.from | sc.study.from))
@@ -45,12 +46,13 @@ final private class StudyMaker(
       data: StudyMaker.ImportGame,
       pov: Pov,
       initialFen: Option[FEN],
-      user: User
+      user: User,
+      withRatings: Boolean
   ): Fu[Study.WithChapter] = {
     for {
       root <- chapterMaker.game2root(pov.game, initialFen)
-      tags <- pgnDump.tags(pov.game, initialFen, none, withOpening = true, withRating = true)
-      name <- Namer.gameVsText(pov.game, withRatings = false)(lightUserApi.async) dmap Chapter.Name.apply
+      tags <- pgnDump.tags(pov.game, initialFen, none, withOpening = true, withRatings)
+      name <- Namer.gameVsText(pov.game, withRatings)(lightUserApi.async) dmap Chapter.Name.apply
       study = Study.make(user, Study.From.Game(pov.gameId), data.id, Study.Name("Game study").some)
       chapter = Chapter.make(
         studyId = study.id,


### PR DESCRIPTION
Fixes #10018

This is what it looks like now when importing a game to a study:
![image](https://user-images.githubusercontent.com/15059336/138633107-5272beab-ecfd-45c1-aec2-e54562e91887.png)

I'm not sure what a relay is so didn't test those changes, but would appreciate feedback on that or anything else. 