### PR TITLE
Propagate `Low` tiered ublog likes in timeline.

### DIFF
--- a/modules/ublog/src/main/UblogRank.scala
+++ b/modules/ublog/src/main/UblogRank.scala
@@ -71,7 +71,7 @@ final class UblogRank(
                 if (v) $addToSet("likers" -> user.id) else $pull("likers" -> user.id)
               }
             ) >>- {
-              if (v && tier >= UblogBlog.Tier.NORMAL)
+              if (v && tier >= UblogBlog.Tier.LOW)
                 timeline ! (Propagate(UblogPostLike(user.id, id.value, title)) toFollowersOf user.id)
             } inject likes
         }


### PR DESCRIPTION
With `Low` being the default tier for most users, it seems too harsh not to propagate like for them, and problematic ones are quickly downgraded by mods.