### PR TITLE
Adding icons to Claim Victory and Claim Draw buttons

### DIFF
--- a/ui/round/src/view/button.ts
+++ b/ui/round/src/view/button.ts
@@ -120,6 +120,7 @@ export function opponentGone(ctrl: RoundController) {
         h(
           'button.button',
           {
+            attrs: { 'data-icon': '' },
             hook: util.bind('click', () => ctrl.socket.sendLoading('resign-force')),
           },
           ctrl.noarg('forceResignation')
@@ -127,6 +128,7 @@ export function opponentGone(ctrl: RoundController) {
         h(
           'button.button',
           {
+            attrs: { 'data-icon': '½' },
             hook: util.bind('click', () => ctrl.socket.sendLoading('draw-force')),
           },
           ctrl.noarg('forceDraw')


### PR DESCRIPTION
Whenever an opponent abandons a match a dialog shows up after a certain amount of timing prompting the user to either claim a victory or claim a draw.  Both buttons are blue and I thought it'd be nice to add a little trophy+1/2 icon to each to better differentiate the two.

Example from my local dev:
![Screen Shot 2021-10-25 at 1 36 09 PM](https://user-images.githubusercontent.com/431342/138743685-abeb2b69-694c-4625-a61e-d9420b4ae9c4.png)

Let me know what you think!
