### PR TITLE
i18n: Translate new preferences

### DIFF
--- a/app/views/account/bits.scala
+++ b/app/views/account/bits.scala
@@ -28,6 +28,6 @@ object bits {
       case PrefCateg.GameDisplay  => trans.preferences.gameDisplay.txt()
       case PrefCateg.ChessClock   => trans.preferences.chessClock.txt()
       case PrefCateg.GameBehavior => trans.preferences.gameBehavior.txt()
-      case PrefCateg.Site         => "Site settings"
+      case PrefCateg.Site         => trans.preferences.siteSettings.txt()
     }
 }

--- a/app/views/account/pref.scala
+++ b/app/views/account/pref.scala
@@ -123,9 +123,7 @@ object pref {
               promoteToQueenAutomatically(),
               frag(
                 radios(form("behavior.autoQueen"), translatedAutoQueenChoices),
-                div(cls := "help text shy", dataIcon := "")(
-                  "Hold the <ctrl> key while promoting to temporarily disable auto-promotion"
-                )
+                div(cls := "help text shy", dataIcon := "")(autoQueenHint)
               )
             ),
             setting(
@@ -190,9 +188,7 @@ object pref {
               showPlayerRatings(),
               frag(
                 radios(form("ratings"), booleanChoices),
-                div(cls := "help text shy", dataIcon := "")(
-                  "This allows hiding all ratings from the website, to help focus on the chess. Games can still be rated, this is only about what you get to see."
-                )
+                div(cls := "help text shy", dataIcon := "")(showPlayerRatingsHint)
               )
             )
           ),

--- a/modules/i18n/src/main/I18nKeys.scala
+++ b/modules/i18n/src/main/I18nKeys.scala
@@ -1593,6 +1593,7 @@ val `premovesPlayingDuringOpponentTurn` = new I18nKey("preferences:premovesPlayi
 val `takebacksWithOpponentApproval` = new I18nKey("preferences:takebacksWithOpponentApproval")
 val `inCasualGamesOnly` = new I18nKey("preferences:inCasualGamesOnly")
 val `promoteToQueenAutomatically` = new I18nKey("preferences:promoteToQueenAutomatically")
+val `autoQueenHint` = new I18nKey("preferences:autoQueenHint")
 val `whenPremoving` = new I18nKey("preferences:whenPremoving")
 val `claimDrawOnThreefoldRepetitionAutomatically` = new I18nKey("preferences:claimDrawOnThreefoldRepetitionAutomatically")
 val `whenTimeRemainingLessThanThirtySeconds` = new I18nKey("preferences:whenTimeRemainingLessThanThirtySeconds")
@@ -1608,6 +1609,8 @@ val `snapArrowsToValidMoves` = new I18nKey("preferences:snapArrowsToValidMoves")
 val `sayGgWpAfterLosingOrDrawing` = new I18nKey("preferences:sayGgWpAfterLosingOrDrawing")
 val `yourPreferencesHaveBeenSaved` = new I18nKey("preferences:yourPreferencesHaveBeenSaved")
 val `scrollOnTheBoardToReplayMoves` = new I18nKey("preferences:scrollOnTheBoardToReplayMoves")
+val `siteSettings` = new I18nKey("preferences:siteSettings")
+val `showPlayerRatingsHint` = new I18nKey("preferences:showPlayerRatingsHint")
 
 }
 

--- a/translation/source/preferences.xml
+++ b/translation/source/preferences.xml
@@ -31,6 +31,7 @@
   <string name="takebacksWithOpponentApproval">Takebacks (with opponent approval)</string>
   <string name="inCasualGamesOnly">In casual games only</string>
   <string name="promoteToQueenAutomatically">Promote to Queen automatically</string>
+  <string name="autoQueenHint">Hold the &lt;ctrl&gt; key while promoting to temporarily disable auto-promotion</string>
   <string name="whenPremoving">When premoving</string>
   <string name="claimDrawOnThreefoldRepetitionAutomatically">Claim draw on threefold repetition automatically</string>
   <string name="whenTimeRemainingLessThanThirtySeconds">When time remaining &lt; 30 seconds</string>
@@ -46,4 +47,6 @@
   <string name="sayGgWpAfterLosingOrDrawing" comment="sayGgWpAfterLosingOrDrawing&#10;&#10;When enabled, this setting will automatically send 'Good game, well played' to your opponent if you are lose or draw the game. It's meant as a courtesy message.&#10;&#10;The message will be sent in ENGLISH.&#10;&#10;It is up to you how to deal with this. For example, you may want to put '(message will be sent in English)' in your translated text as one example. Or you can leave the actual English text and put a brief translation in your own language.">Say "Good game, well played" upon defeat or draw</string>
   <string name="yourPreferencesHaveBeenSaved">Your preferences have been saved.</string>
   <string name="scrollOnTheBoardToReplayMoves">Scroll on the board to replay moves</string>
+  <string name="siteSettings">Site settings</string>
+  <string name="showPlayerRatingsHint">This allows hiding all ratings from the website, to help focus on the chess. Games can still be rated, this is only about what you get to see.</string>
 </resources>


### PR DESCRIPTION
Although tbh that new category is kinda weird and not sure how well "site settings" translates? At least in German it seems a little bit awkward.

Maybe it would make more sense to just move the new setting to "Game display" where zen mode is? It's not 100% perfect there but might still be less confusing.