### PR TITLE
Mobile: Puzzle v2 api

### DIFF
--- a/app/controllers/Puzzle.scala
+++ b/app/controllers/Puzzle.scala
@@ -370,6 +370,22 @@ final class Puzzle(
       }
     }
 
+  def mobileHistory(page: Int) =
+    Auth { implicit ctx => me =>
+      negotiate(
+        html = notFound,
+        _ => {
+          import lila.puzzle.JsonView._
+          Reasonable(page) {
+            env.puzzle.history(me, page) map { historyPaginator =>
+              Ok(lila.common.paginator.PaginatorJson(historyPaginator))
+            }
+          }
+        }
+      )
+
+    }
+
   def history(page: Int) =
     Auth { implicit ctx => me =>
       get("u")

--- a/app/controllers/Puzzle.scala
+++ b/app/controllers/Puzzle.scala
@@ -331,12 +331,23 @@ final class Puzzle(
         .fuccess
     }
 
+  def mobileDashboard(days: Int) =
+    Auth { implicit ctx => me =>
+      negotiate(
+        html = notFound,
+        _ => renderMobileAndApiJson(days, me)
+      )
+    }
+
   def apiDashboard(days: Int) =
     Scoped(_.Puzzle.Read) { implicit req => me =>
       implicit val lang = reqLang
-      JsonOptionOk {
-        env.puzzle.dashboard(me, days) map2 { env.puzzle.jsonView.dashboardJson(_, days) }
-      }
+      renderMobileAndApiJson(days, me)
+    }
+
+  private def renderMobileAndApiJson(days: Int, me: lila.user.User)(implicit lang: play.api.i18n.Lang) =
+    JsonOptionOk {
+      env.puzzle.dashboard(me, days) map2 { env.puzzle.jsonView.dashboardJson(_, days) }
     }
 
   def dashboard(days: Int, path: String = "home") =

--- a/conf/routes
+++ b/conf/routes
@@ -125,6 +125,7 @@ GET   /training/dashboard/$days<\d+>   controllers.Puzzle.dashboard(days: Int, p
 GET   /training/dashboard/$days<\d+>/:path  controllers.Puzzle.dashboard(days: Int, path: String)
 GET   /training/replay/$days<\d+>/:theme controllers.Puzzle.replay(days: Int, theme: String)
 GET   /training/history                controllers.Puzzle.history(page: Int ?= 1)
+GET   /training/mobile/history                controllers.Puzzle.mobileHistory(page: Int ?= 1)
 GET   /training/batch                  controllers.Puzzle.mobileBcBatchSelect
 POST  /training/batch                  controllers.Puzzle.mobileBcBatchSolve
 GET   /training/new                    controllers.Puzzle.mobileBcNew

--- a/conf/routes
+++ b/conf/routes
@@ -121,7 +121,6 @@ GET   /training/frame                  controllers.Puzzle.frame
 GET   /training/export/gif/thumbnail/:id.gif controllers.Export.puzzleThumbnail(id: String)
 GET   /training/themes                 controllers.Puzzle.themes
 GET   /training/of-player              controllers.Puzzle.ofPlayer(name: Option[String] ?= None, page: Int ?= 1)
-GET   /training/mobile/dashboard/$days<\d+>   controllers.Puzzle.mobileDashboard(days: Int)
 GET   /training/dashboard/$days<\d+>   controllers.Puzzle.dashboard(days: Int, path: String = "home")
 GET   /training/dashboard/$days<\d+>/:path  controllers.Puzzle.dashboard(days: Int, path: String)
 GET   /training/replay/$days<\d+>/:theme controllers.Puzzle.replay(days: Int, theme: String)
@@ -644,7 +643,7 @@ POST  /api/users                       controllers.Api.usersByIds
 GET   /api/user/puzzle-activity        controllers.Puzzle.activity
 GET   /api/puzzle/daily                controllers.Puzzle.apiDaily
 GET   /api/puzzle/activity             controllers.Puzzle.activity
-GET   /api/puzzle/dashboard/:days      controllers.Puzzle.apiDashboard(days: Int)
+GET   /api/puzzle/dashboard/$days<\d+> controllers.Puzzle.apiDashboard(days: Int)
 GET   /api/user/:name/tournament/created controllers.Api.tournamentsByOwner(name: String, status: List[Int])
 GET   /api/user/:name                  controllers.Api.user(name: String)
 GET   /api/user/:name/activity         controllers.Api.activity(name: String)

--- a/conf/routes
+++ b/conf/routes
@@ -121,6 +121,7 @@ GET   /training/frame                  controllers.Puzzle.frame
 GET   /training/export/gif/thumbnail/:id.gif controllers.Export.puzzleThumbnail(id: String)
 GET   /training/themes                 controllers.Puzzle.themes
 GET   /training/of-player              controllers.Puzzle.ofPlayer(name: Option[String] ?= None, page: Int ?= 1)
+GET   /training/mobile/dashboard/$days<\d+>   controllers.Puzzle.mobileDashboard(days: Int)
 GET   /training/dashboard/$days<\d+>   controllers.Puzzle.dashboard(days: Int, path: String = "home")
 GET   /training/dashboard/$days<\d+>/:path  controllers.Puzzle.dashboard(days: Int, path: String)
 GET   /training/replay/$days<\d+>/:theme controllers.Puzzle.replay(days: Int, theme: String)


### PR DESCRIPTION
WIP for https://github.com/ornicar/lila/issues/10019

For now only two endpoints added (path names are a bit funky, if you have better ones).

`GET /training/batchV2?nb=X&theme=Y` to fetch puzzles. Sample response:
```json
[
  {
    "game": {
      "id": "5yZe0I6r",
      "perf": {
        "icon": "",
        "name": "Rapid"
      },
      "rated": true,
      "players": [
        {
          "userId": "reda",
          "name": "reda (1984)",
          "color": "white"
        },
        {
          "userId": "cted",
          "name": "cted (1968)",
          "color": "black"
        }
      ],
      "pgn": "e4 c5 Nf3 d6 d4 cxd4 Nxd4 Nf6 Nc3 a6 f3 b5 Be3 e6 Qd2 Nbd7 Nc6 Qc7 Nb4 Bb7 O-O-O Qa5 a3 d5 exd5 Bxb4 dxe6 Ne5 axb4 Qa1+ Nb1 Bd5 exf7+ Kxf7 Qc3 Ba2 Kd2 Rhd8+ Bd3 Nc4+ Ke2 Nxe3 Kxe3",
      "clock": "10+0"
    },
    "puzzle": {
      "id": "9h38Q",
      "rating": 1562,
      "plays": 1859,
      "initialPly": 42,
      "solution": [
        "f6d5",
        "e3f2",
        "d5c3",
        "b1c3",
        "a1b2"
      ],
      "themes": [
        "middlegame",
        "crushing",
        "fork",
        "long",
        "capturingDefender"
      ]
    }
  },
  {
    "game": {
      "id": "6rQZGfsc",
      "perf": {
        "icon": "",
        "name": "Rapid"
      },
      "rated": true,
      "players": [
        {
          "userId": "reda",
          "name": "reda (2411)",
          "color": "white"
        },
        {
          "userId": "cted",
          "name": "cted (2200)",
          "color": "black"
        }
      ],
      "pgn": "c4 c5 Nc3 Nc6 Nf3 Nf6 e3 e6 d4 cxd4 exd4 d5 cxd5 exd5 Bd3 Be7 O-O O-O Be3 Bg4 h3 Bh5 Re1 Rc8 Bf5 Ra8 Qe2 Re8 a3 Bd6 Qd1 a6 b4 Bc7 Rc1 Qd6 g3 Nxd4 Bxd4 Rxe1+ Qxe1 Bxf3 Qe3 Bh5 Qd3 Bg6 Bxf6 Qxf6",
      "clock": "10+0"
    },
    "puzzle": {
      "id": "3Vygw",
      "rating": 2185,
      "plays": 438,
      "initialPly": 47,
      "solution": [
        "c3d5",
        "f6g5",
        "c1c7",
        "g6f5",
        "d3f5",
        "g5f5",
        "d5e7",
        "g8f8",
        "e7f5"
      ],
      "themes": [
        "veryLong",
        "middlegame",
        "crushing",
        "attraction",
        "fork",
        "sacrifice",
        "discoveredAttack"
      ]
    }
  }
]
```

And `GET   /training/mobile/dashboard/<DAYS>`
Sample response:
```json
{
  "days": 6,
  "global": {
    "nb": 12,
    "firstWins": 9,
    "replayWins": 2,
    "puzzleRatingAvg": 1292,
    "performance": 1375
  },
  "themes": {
    "xRayAttack": {
      "theme": "X-Ray attack",
      "results": {
        "nb": 6,
        "firstWins": 5,
        "replayWins": 2,
        "puzzleRatingAvg": 1239,
        "performance": 1239
      }
    },
    "mix": {
      "theme": "Healthy mix",
      "results": {
        "nb": 5,
        "firstWins": 3,
        "replayWins": 0,
        "puzzleRatingAvg": 1495,
        "performance": 1595
      }
    },
    "middlegame": {
      "theme": "Middlegame",
      "results": {
        "nb": 4,
        "firstWins": 4,
        "replayWins": 1,
        "puzzleRatingAvg": 1197,
        "performance": 1447
      }
    }
  ...
}
```
It's only one endpoint, that return the perfs for all themes so the app can build itself strength/weakness. Is that a good design or do you want them to be sorted by Lila?

I've not added yet endpoints for puzzle history and to send back batch of puzzles, because I'm not sure what the apps needs.
* For the batch puzzles, do you want to support vote, rated/unrated mode,  theme vote?
* For the puzzle history, what information would be needed? For now this is how it is handled by Lila: https://github.com/ornicar/lila/blob/master/modules/puzzle/src/main/PuzzleHistory.scala#L18. I was thinking the [`PuzzleRound`](https://github.com/ornicar/lila/blob/10bb53971706fe1620c6336a4aa1ac81287edca2/modules/puzzle/src/main/PuzzleRound.scala#L7) info would be enough.

cc @jas14 @veloce :)