### PR TITLE
Update the proxy `Game` when bookmarking

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -391,7 +391,7 @@ lazy val clas = module("clas",
 )
 
 lazy val bookmark = module("bookmark",
-  Seq(common, memo, db, hub, user, game),
+  Seq(common, memo, db, hub, user, game, round),
   reactivemongo.bundle
 )
 

--- a/modules/bookmark/src/main/Env.scala
+++ b/modules/bookmark/src/main/Env.scala
@@ -18,7 +18,8 @@ final private class BookmarkConfig(
 final class Env(
     appConfig: Configuration,
     db: lila.db.Db,
-    gameRepo: lila.game.GameRepo
+    gameRepo: lila.game.GameRepo,
+    gameProxyRepo: lila.round.GameProxyRepo
 )(implicit
     ec: scala.concurrent.ExecutionContext,
     system: ActorSystem

--- a/modules/game/src/main/Game.scala
+++ b/modules/game/src/main/Game.scala
@@ -560,6 +560,8 @@ case class Game(
 
   def showBookmarks = hasBookmarks ?? bookmarks.toString
 
+  def incBookmarks(value: Int) = copy(bookmarks = bookmarks + value)
+
   def userIds = playerMaps(_.userId)
 
   def twoUserIds: Option[(User.ID, User.ID)] =


### PR DESCRIPTION
Another solution would have been to simply remove this trick which avoids a db call for most games
```scala
  def exists(game: Game, user: User): Fu[Boolean] =
    if (game.bookmarks > 0) exists(game.id, user.id)
    else fuFalse
```