### PR TITLE
Fix bug in link's preview

### DIFF
--- a/app/templating/GameHelper.scala
+++ b/app/templating/GameHelper.scala
@@ -66,7 +66,7 @@ trait GameHelper { self: I18nHelper with UserHelper with AiHelper with StringHel
         }
       case _ => "Game is still being played"
     }
-    val moves = s"${game.chess.fullMoveNumber} moves"
+    val moves = s"${(1 + game.chess.turns) / 2} moves"
     s"$p1 plays $p2 in a $mode $speedAndClock game of $variant. $result after $moves. Click to replay, analyse, and discuss the game!"
   }
 


### PR DESCRIPTION
When the game ended after black's move the preview said that the game
lasted one move more than those effectively played.

Now the number of moves is computed using (1+ply)/2.