### PR TITLE
Combine buttons for claiming threefolds and offering draws

### DIFF
--- a/ui/round/css/_control.scss
+++ b/ui/round/css/_control.scss
@@ -51,6 +51,11 @@
     }
   }
 
+  .draw-yes.button {
+    font-size: 1.4em;
+    padding: 0.1em 1em;
+  }
+
   @keyframes flash-once {
     from {
       background: $c-accent;

--- a/ui/round/src/view/button.ts
+++ b/ui/round/src/view/button.ts
@@ -165,7 +165,16 @@ export const drawConfirm = (ctrl: RoundController): VNode =>
     fbtCancel(ctrl, ctrl.offerDraw),
   ]);
 
-export function threefoldClaimDraw(ctrl: RoundController) {
+export const claimThreefold = (ctrl: RoundController): VNode =>
+  h(
+    'button.button.draw-yes',
+    {
+      hook: util.bind('click', () => ctrl.socket.sendLoading('draw-claim')),
+    },
+    h('span', '½')
+  );
+
+export function threefoldSuggestion(ctrl: RoundController) {
   return ctrl.data.game.threefold
     ? h('div.suggestion', [
         h(
@@ -174,13 +183,6 @@ export function threefoldClaimDraw(ctrl: RoundController) {
             hook: onSuggestionHook,
           },
           ctrl.noarg('threefoldRepetition')
-        ),
-        h(
-          'button.button',
-          {
-            hook: util.bind('click', () => ctrl.socket.sendLoading('draw-claim')),
-          },
-          ctrl.noarg('claimADraw')
         ),
       ])
     : null;

--- a/ui/round/src/view/button.ts
+++ b/ui/round/src/view/button.ts
@@ -170,6 +170,7 @@ export const claimThreefold = (ctrl: RoundController): VNode =>
     'button.button.draw-yes',
     {
       hook: util.bind('click', () => ctrl.socket.sendLoading('draw-claim')),
+      attrs: { title: ctrl.noarg('claimADraw') },
     },
     h('span', '½')
   );

--- a/ui/round/src/view/table.ts
+++ b/ui/round/src/view/table.ts
@@ -51,6 +51,8 @@ export const renderTablePlay = (ctrl: RoundController) => {
               : button.standard(ctrl, game.takebackable, '', 'proposeATakeback', 'takeback-yes', ctrl.takebackYes),
             ctrl.drawConfirm
               ? button.drawConfirm(ctrl)
+              : ctrl.data.game.threefold
+              ? button.claimThreefold(ctrl)
               : button.standard(ctrl, ctrl.canOfferDraw, '2', 'offerDraw', 'draw-yes', () => ctrl.offerDraw(true)),
             ctrl.resignConfirm
               ? button.resignConfirm(ctrl)
@@ -63,7 +65,7 @@ export const renderTablePlay = (ctrl: RoundController) => {
       ? [submit]
       : [
           button.opponentGone(ctrl),
-          button.threefoldClaimDraw(ctrl),
+          button.threefoldSuggestion(ctrl),
           button.cancelDrawOffer(ctrl),
           button.answerOpponentDrawOffer(ctrl),
           button.cancelTakebackProposition(ctrl),


### PR DESCRIPTION
Fix #6757

![threefold-button](https://user-images.githubusercontent.com/54592274/152657833-5f90e33b-f522-4532-8ed6-b73bb5a4b777.png)

The threefold button is a bit narrower and higher than the normal button.  
Apart from that, this change appears to work well.

I haven't changed `nvui.ts`, but the issue doesn't appear in accessibility mode anyway, as far as I can tell.