### PR TITLE
Fix blind mode PGN copy functionality

### DIFF
--- a/app/views/analyse/replay.scala
+++ b/app/views/analyse/replay.scala
@@ -180,7 +180,7 @@ object replay {
           div(cls := "blind-content none")(
             h2("PGN downloads"),
             pgnLinks,
-            input(tpe := "hidden", value := pgn, cls := "game-pgn"),
+            textarea(tpe := "hidden", cls := "game-pgn")(pgn),
             button(cls := "copy-pgn", dataRel := "game-pgn")(
               "Copy PGN to clipboard"
             )


### PR DESCRIPTION
Fixes #10416.

Since we were using a single line `<input>`, we weren't preserving new line characters. Switch to `<textarea>` to preserve those characters.