### PR TITLE
Don't clear the keyboard input for valid premoves

### DIFF
--- a/ui/round/src/plugins/keyboardMove.ts
+++ b/ui/round/src/plugins/keyboardMove.ts
@@ -67,7 +67,9 @@ lichess.keyboardMove = function (opts: Opts) {
         readClocks(opts.ctrl.clock());
         clear();
       }
-    } else if (submitOpts.yourMove && v.length > 1) {
+    } else if (submitOpts.yourMove && v.length > 0 && legalSans && !sanCandidates(v, legalSans).length) {
+      // submitOpts.yourMove is true only when it is newly the player's turn, not on subsequent
+      // updates when it is still the player's turn
       setTimeout(() => lichess.sound.play('error'), 500);
       opts.input.value = '';
     } else {


### PR DESCRIPTION
Fixes #5046. See that issue for a detailed explanation of the bug.

With this change, we will no longer erase invalid keyboard moves that are being entered while the opponent makes their move.