### PR TITLE
Add API for timeouts

### DIFF
--- a/app/controllers/LilaController.scala
+++ b/app/controllers/LilaController.scala
@@ -267,23 +267,32 @@ abstract private[controllers] class LilaController(val env: Env)
       scoped: RequestHeader => Holder => Fu[Result]
   ): Action[Unit] =
     Action.async(parse.empty) { req =>
-      if (HTTPRequest isOAuth req) securedScopedAction(perm, req)(scoped)
+      if (HTTPRequest isOAuth req) SecuredScoped(perm)(scoped)(req)
       else Secure(parse.empty)(perm(Permission))(secure)(req)
     }
+
   protected def SecureOrScopedBody(perm: Permission.Selector)(
       secure: BodyContext[_] => Holder => Fu[Result],
-      scoped: RequestHeader => Holder => Fu[Result]
+      scoped: Request[_] => Holder => Fu[Result]
   ): Action[AnyContent] =
     Action.async(parse.anyContent) { req =>
-      if (HTTPRequest isOAuth req) securedScopedAction(perm, req.map(_ => ()))(scoped)
+      if (HTTPRequest isOAuth req) SecuredScopedBody(perm)(scoped)(req)
       else SecureBody(parse.anyContent)(perm(Permission))(secure)(req)
     }
-  private def securedScopedAction(perm: Permission.Selector, req: Request[Unit])(
+
+  protected def SecuredScoped(perm: Permission.Selector)(
       f: RequestHeader => Holder => Fu[Result]
   ) =
     Scoped() { req => me =>
       IfGranted(perm, req, me)(f(req)(Holder(me)))
-    }(req)
+    }
+
+  protected def SecuredScopedBody(perm: Permission.Selector)(
+      f: Request[_] => Holder => Fu[Result]
+  ) =
+    ScopedBody() { req => me =>
+      IfGranted(perm, req, me)(f(req)(Holder(me)))
+    }
 
   def IfGranted(perm: Permission.Selector)(f: => Fu[Result])(implicit ctx: Context): Fu[Result] =
     if (isGranted(perm)) f else authorizationFailed

--- a/app/controllers/Mod.scala
+++ b/app/controllers/Mod.scala
@@ -65,12 +65,16 @@ final class Mod(
       }
     }
 
-  def publicChatTimeout =
-    SecureBody(_.ChatTimeout) { implicit ctx => me =>
+  def publicChatTimeout = {
+    def doTimeout(implicit req: Request[_], me: Holder) =
       FormResult(lila.chat.ChatTimeout.form) { data =>
         env.chat.api.userChat.publicTimeout(data, me)
-      }(ctx.body)
-    }
+      }
+    SecureOrScopedBody(_.ChatTimeout)(
+      secure = ctx => me => doTimeout(ctx.body, me),
+      scoped = req => me => doTimeout(req, me)
+    )
+  }
 
   def booster(username: String, v: Boolean) =
     OAuthModBody(_.MarkBooster) { me =>


### PR DESCRIPTION
Closes #10217

Not sure if I'm missing something here but it seemed quite weird to me that `SecureOrScopedBody` wasn't actually passing the body in the scoped case and changing that was by far the easiest way to implement this.