### PR TITLE
Fix the blind mode PGN copy feature

### DIFF
--- a/app/views/analyse/replay.scala
+++ b/app/views/analyse/replay.scala
@@ -180,7 +180,7 @@ object replay {
           div(cls := "blind-content none")(
             h2("PGN downloads"),
             pgnLinks,
-            textarea(style := "display: none", cls := "game-pgn")(pgn),
+            textarea(style := "opacity: 0.01; height: 0", tabindex := -1, cls := "game-pgn")(pgn),
             button(cls := "copy-pgn", dataRel := "game-pgn")(
               "Copy PGN to clipboard"
             )


### PR DESCRIPTION
This is a fix for #10497. Apparently, `display: none` disallows `<textarea>`s from being selected, which we need to do in order to copy the text inside of it. Simply styling it as invisible seems to be the recommended strategy per [Stack Overflow](https://stackoverflow.com/questions/51681669/how-can-i-copy-text-from-hidden-textarea-to-clipboard). I followed that recommendation even though this is a blind mode feature. I also included `tabindex = -1` so that screen readers might skip over it.