### PR TITLE
Fix puzzle dashboard API firstWins data

### DIFF
--- a/modules/puzzle/src/main/JsonView.scala
+++ b/modules/puzzle/src/main/JsonView.scala
@@ -107,7 +107,7 @@ final class JsonView(
 
   private def dashboardResults(res: PuzzleDashboard.Results) = Json.obj(
     "nb"              -> res.nb,
-    "firstWins"       -> res.wins,
+    "firstWins"       -> res.firstWins,
     "replayWins"      -> res.fixed,
     "puzzleRatingAvg" -> res.puzzleRatingAvg,
     "performance"     -> res.performance


### PR DESCRIPTION
I'm also open to changing the key to `wins`. Either way, one of `firstWins` and `wins` is computable from the other also given `nb` and `replayWins`.