### PR TITLE
Don't show spotlight tournaments without "homepageHours" to unauthenticated users

### DIFF
--- a/modules/tournament/src/main/Spotlight.scala
+++ b/modules/tournament/src/main/Spotlight.scala
@@ -18,7 +18,10 @@ object Spotlight {
   implicit private val importanceOrdering = Ordering.by[Tournament, Int](_.schedule.??(_.freq.importance))
 
   def select(tours: List[Tournament], user: Option[User], max: Int): List[Tournament] =
-    user.fold(tours topN max) { select(tours, _, max) }
+    user.fold(select(tours, max)) { select(tours, _, max) }
+
+  def select(tours: List[Tournament], max: Int): List[Tournament] = 
+    tours filter { tour => tour.spotlight.fold(true) { manually(tour, _) } } topN max
 
   def select(tours: List[Tournament], user: User, max: Int): List[Tournament] =
     tours.filter { select(_, user) } topN max


### PR DESCRIPTION
Like it's already done for authenticated users.

To avoid double BBBs like right now:

![Screenshot 2022-02-12 131436](https://user-images.githubusercontent.com/19309705/153711323-df7e2536-9fbe-4088-a244-ca4755950b83.png)