### PR TITLE
Only share mainline study positions 

### DIFF
--- a/ui/analyse/src/study/studyCtrl.ts
+++ b/ui/analyse/src/study/studyCtrl.ts
@@ -316,8 +316,9 @@ export default function (
   if (members.canContribute()) form.openIfNew();
 
   const currentNode = () => ctrl.node;
+  const onMainline = () => ctrl.tree.pathIsMainline(ctrl.path);
 
-  const share = shareCtrl(data, currentChapter, currentNode, relay, redraw, ctrl.trans);
+  const share = shareCtrl(data, currentChapter, currentNode, onMainline, relay, redraw, ctrl.trans);
 
   const practice: StudyPracticeCtrl | undefined = practiceData && practiceCtrl(ctrl, data, practiceData);
 

--- a/ui/analyse/src/study/studyShare.ts
+++ b/ui/analyse/src/study/studyShare.ts
@@ -11,6 +11,7 @@ export interface StudyShareCtrl {
   chapter: () => StudyChapterMeta;
   isPrivate(): boolean;
   currentNode: () => Tree.Node;
+  onMainline: () => boolean;
   withPly: Prop<boolean>;
   relay: RelayCtrl | undefined;
   cloneable: boolean;
@@ -28,21 +29,23 @@ function fromPly(ctrl: StudyShareCtrl): VNode {
   );
   return h(
     'div.ply-wrap',
-    h('label.ply', [
-      h('input', {
-        attrs: { type: 'checkbox' },
-        hook: bind(
-          'change',
-          e => {
-            ctrl.withPly((e.target as HTMLInputElement).checked);
-          },
-          ctrl.redraw
-        ),
-      }),
-      ...(renderedMove
-        ? ctrl.trans.vdom('startAtX', h('strong', renderedMove))
-        : [ctrl.trans.noarg('startAtInitialPosition')]),
-    ])
+    ctrl.onMainline()
+      ? h('label.ply', [
+          h('input', {
+            attrs: { type: 'checkbox', checked: ctrl.withPly() },
+            hook: bind(
+              'change',
+              e => {
+                ctrl.withPly((e.target as HTMLInputElement).checked);
+              },
+              ctrl.redraw
+            ),
+          }),
+          ...(renderedMove
+            ? ctrl.trans.vdom('startAtX', h('strong', renderedMove))
+            : [ctrl.trans.noarg('startAtInitialPosition')]),
+        ])
+      : null
   );
 }
 
@@ -50,6 +53,7 @@ export function ctrl(
   data: StudyData,
   currentChapter: () => StudyChapterMeta,
   currentNode: () => Tree.Node,
+  onMainline: () => boolean,
   relay: RelayCtrl | undefined,
   redraw: () => void,
   trans: Trans
@@ -62,6 +66,7 @@ export function ctrl(
       return data.visibility === 'private';
     },
     currentNode,
+    onMainline,
     withPly,
     relay,
     cloneable: data.features.cloneable,

--- a/ui/analyse/src/study/studyShare.ts
+++ b/ui/analyse/src/study/studyShare.ts
@@ -79,7 +79,8 @@ export function view(ctrl: StudyShareCtrl): VNode {
   const studyId = ctrl.studyId,
     chapter = ctrl.chapter();
   const isPrivate = ctrl.isPrivate();
-  const addPly = (path: string) => (ctrl.withPly() ? `${path}#${ctrl.currentNode().ply}` : path);
+  const addPly = (path: string) =>
+    ctrl.onMainline() ? (ctrl.withPly() ? `${path}#${ctrl.currentNode().ply}` : path) : `${path}#last`;
   const youCanPasteThis = () =>
     h('p.form-help.text', { attrs: { 'data-icon': '' } }, ctrl.trans.noarg('youCanPasteThisInTheForumToEmbed'));
   return h('div.study__share', [


### PR DESCRIPTION
Fixes #10457.

~This change makes it possible to share a position that is on a sideline. Prior, sharing a position was done by ply number, so the linked position would always be on the mainline. Now, we share by tree path.~

~Since we won't be generating sharing URLs with ply number anymore, we eventually want to remove the code that loads a position via ply number. We aren't doing it immediately with this code change so as not to disrupt users who have just generated URLs with ply numbers.~

See below discussion.