### PR TITLE
robust markdown links and image whitelist

### DIFF
--- a/modules/team/src/main/TeamForm.scala
+++ b/modules/team/src/main/TeamForm.scala
@@ -4,7 +4,7 @@ import play.api.data._
 import play.api.data.Forms._
 import scala.concurrent.duration._
 
-import lila.common.Form.{ cleanNonEmptyText, cleanText, markdownImage, mustNotContainLichess, numberIn }
+import lila.common.Form.{ cleanNonEmptyText, cleanText, mustNotContainLichess, numberIn }
 import lila.db.dsl._
 
 final private[team] class TeamForm(
@@ -15,7 +15,7 @@ final private[team] class TeamForm(
     extends lila.hub.CaptchedForm {
 
   private object Fields {
-    val name     = "name"     -> cleanText(minLength = 3, maxLength = 60).verifying(mustNotContainLichess(false))
+    val name = "name" -> cleanText(minLength = 3, maxLength = 60).verifying(mustNotContainLichess(false))
     val password = "password" -> optional(cleanText(maxLength = 60))
     def passwordCheck(team: Team) = "password" -> optional(text).verifying(
       "team:incorrectEntryCode",
@@ -25,9 +25,9 @@ final private[team] class TeamForm(
       "message" -> optional(cleanText(minLength = 30, maxLength = 2000))
         .verifying("Request message required", msg => msg.isDefined || team.open)
     val description =
-      "description" -> cleanText(minLength = 30, maxLength = 4000).verifying(markdownImage.constraint)
+      "description" -> cleanText(minLength = 30, maxLength = 4000)
     val descPrivate =
-      "descPrivate" -> optional(cleanNonEmptyText(maxLength = 4000).verifying(markdownImage.constraint))
+      "descPrivate" -> optional(cleanNonEmptyText(maxLength = 4000))
     val request     = "request"     -> boolean
     val gameId      = "gameId"      -> text
     val move        = "move"        -> text

--- a/modules/ublog/src/main/UblogForm.scala
+++ b/modules/ublog/src/main/UblogForm.scala
@@ -4,7 +4,7 @@ import org.joda.time.DateTime
 import play.api.data._
 import play.api.data.Forms._
 
-import lila.common.Form.{ cleanNonEmptyText, cleanText, markdownImage, stringIn }
+import lila.common.Form.{ cleanNonEmptyText, cleanText, stringIn }
 import lila.i18n.{ defaultLang, LangList }
 import lila.user.User
 import play.api.i18n.Lang
@@ -19,7 +19,7 @@ final class UblogForm(markup: UblogMarkup, val captcher: lila.hub.actors.Captche
     mapping(
       "title"       -> cleanNonEmptyText(minLength = 3, maxLength = 80),
       "intro"       -> cleanNonEmptyText(minLength = 0, maxLength = 1_000),
-      "markdown"    -> cleanNonEmptyText(minLength = 0, maxLength = 100_000).verifying(markdownImage.constraint),
+      "markdown"    -> cleanNonEmptyText(minLength = 0, maxLength = 100_000),
       "imageAlt"    -> optional(cleanNonEmptyText(minLength = 3, maxLength = 200)),
       "imageCredit" -> optional(cleanNonEmptyText(minLength = 3, maxLength = 200)),
       "language"    -> optional(stringIn(LangList.popularNoRegion.map(_.code).toSet)),


### PR DESCRIPTION
Goals:
* No postprocessing on raw HTML. If the markdown parser is safe, then the whole pipeline is safe.
* Parse, don't validate: Use the actual markdown parser and a real URL parser for image whitelisting. Fixes https://hackerone.com/reports/1482486.