### PR TITLE
Keyboard draw

### DIFF
--- a/ui/round/src/ctrl.ts
+++ b/ui/round/src/ctrl.ts
@@ -713,14 +713,14 @@ export default class RoundController {
 
   canOfferDraw = (): boolean => game.drawable(this.data) && (this.lastDrawOfferAtPly || -99) < this.ply - 20;
 
-  offerDraw = (v: boolean): void => {
+  offerDraw = (v: boolean, immediately?: boolean): void => {
     if (this.canOfferDraw()) {
       if (this.drawConfirm) {
         if (v) this.doOfferDraw();
         clearTimeout(this.drawConfirm);
         this.drawConfirm = undefined;
       } else if (v) {
-        if (this.data.pref.confirmResign)
+        if (this.data.pref.confirmResign && !immediately)
           this.drawConfirm = setTimeout(() => {
             this.offerDraw(false);
           }, 3000);

--- a/ui/round/src/keyboardMove.ts
+++ b/ui/round/src/keyboardMove.ts
@@ -24,6 +24,7 @@ export interface KeyboardMove {
   jump(delta: number): void;
   justSelected(): boolean;
   clock(): ClockController | undefined;
+  draw(): void;
   resign(v: boolean, immediately?: boolean): void;
 }
 
@@ -106,6 +107,7 @@ export function ctrl(root: RoundController, step: Step, redraw: Redraw): Keyboar
       return performance.now() - lastSelect < 500;
     },
     clock: () => root.clock,
+    draw: () => root.offerDraw(true, true),
     resign: root.resign,
   };
 }

--- a/ui/round/src/plugins/keyboardMove.test.ts
+++ b/ui/round/src/plugins/keyboardMove.test.ts
@@ -19,6 +19,7 @@ const unexpectedErrorThrower = (name: string) => () => {
 const defaultCtrl = {
   clock: unexpectedErrorThrower('clock'),
   confirmMove: () => null,
+  draw: unexpectedErrorThrower('draw'),
   drop: unexpectedErrorThrower('drop'),
   hasFocus: () => true,
   hasSelected: () => undefined,
@@ -57,6 +58,23 @@ describe('keyboardMove', () => {
     keyboardMovePlugin(startingFen, toMap({}), true);
 
     expect(mockResign.mock.calls.length).toBe(1);
+    expect(input.value).toBe('');
+  });
+
+  test('draws game', () => {
+    input.value = 'draw';
+    const mockDraw = jest.fn();
+    const keyboardMovePlugin = keyboardMove({
+      input,
+      ctrl: {
+        ...defaultCtrl,
+        draw: mockDraw,
+      },
+    }) as any;
+
+    keyboardMovePlugin(startingFen, toMap({}), true);
+
+    expect(mockDraw.mock.calls.length).toBe(1);
     expect(input.value).toBe('');
   });
 

--- a/ui/round/src/plugins/keyboardMove.ts
+++ b/ui/round/src/plugins/keyboardMove.ts
@@ -80,6 +80,11 @@ export const keyboardMove = (opts: Opts) => {
         readClocks(opts.ctrl.clock());
         clear();
       }
+    } else if (v.length > 0 && 'draw'.startsWith(v.toLowerCase())) {
+      if ('draw' === v.toLowerCase()) {
+        opts.ctrl.draw();
+        clear();
+      }
     } else if (submitOpts.yourMove && v.length > 0 && legalSans && !sanCandidates(v, legalSans).length) {
       // submitOpts.yourMove is true only when it is newly the player's turn, not on subsequent
       // updates when it is still the player's turn


### PR DESCRIPTION
Fixes #10534.

Adds the ability to offer or accept a draw with the keyboard input. It operates similarly to the resign command in the sense that it will not ask you to confirm; it will immediately offer or except the draw.