### PR TITLE
Add option to quickly select game participants in explorer

### DIFF
--- a/ui/analyse/src/explorer/explorerConfig.ts
+++ b/ui/analyse/src/explorer/explorerConfig.ts
@@ -51,7 +51,9 @@ export class ExplorerConfigCtrl {
 
   constructor(readonly root: AnalyseCtrl, readonly variant: VariantKey, readonly onClose: () => void) {
     this.myName = document.body.dataset['user'];
-    this.participants = [root.data.player.user?.id, root.data.opponent.user?.id].filter(name => name && name != this.myName);
+    this.participants = [root.data.player.user?.id, root.data.opponent.user?.id].filter(
+      name => name && name != this.myName
+    );
     if (variant === 'standard') this.allDbs.unshift('masters');
     const byDbData = {} as ByDbSettings;
     for (const db of this.allDbs) {

--- a/ui/analyse/src/explorer/explorerConfig.ts
+++ b/ui/analyse/src/explorer/explorerConfig.ts
@@ -47,9 +47,11 @@ export class ExplorerConfigCtrl {
   data: ExplorerConfigData;
   allDbs: ExplorerDb[] = ['lichess', 'player'];
   myName?: string;
+  participants: (string | undefined)[];
 
   constructor(readonly root: AnalyseCtrl, readonly variant: VariantKey, readonly onClose: () => void) {
     this.myName = document.body.dataset['user'];
+    this.participants = [root.data.player.user?.id, root.data.opponent.user?.id].filter(name => name && name != this.myName);
     if (variant === 'standard') this.allDbs.unshift('masters');
     const byDbData = {} as ByDbSettings;
     for (const db of this.allDbs) {
@@ -80,7 +82,7 @@ export class ExplorerConfigCtrl {
   selectPlayer = (name?: string) => {
     name = name == 'me' ? this.myName : name;
     if (!name) return;
-    if (name != this.myName) {
+    if (name != this.myName && !this.participants.includes(name)) {
       const previous = this.data.playerName.previous().filter(n => n !== name);
       previous.unshift(name);
       this.data.playerName.previous(previous.slice(0, 20));
@@ -289,7 +291,7 @@ const monthSection = (ctrl: ExplorerConfigCtrl) =>
   ]);
 
 const playerModal = (ctrl: ExplorerConfigCtrl) => {
-  const onSelect = (name: string) => {
+  const onSelect = (name: string | undefined) => {
     ctrl.selectPlayer(name);
     ctrl.root.redraw();
   };
@@ -318,7 +320,7 @@ const playerModal = (ctrl: ExplorerConfigCtrl) => {
       ]),
       h(
         'div.previous',
-        [...(ctrl.myName ? [ctrl.myName] : []), ...ctrl.data.playerName.previous()].map(name =>
+        [...(ctrl.myName ? [ctrl.myName] : []), ...ctrl.participants, ...ctrl.data.playerName.previous()].map(name =>
           h(
             `button.button${name == ctrl.myName ? '.button-green' : ''}`,
             {


### PR DESCRIPTION
Closes #10064.
I'm adding the game participants as an option inside `playerModal`. Right now, in my code if you do select a participant, it doesn't get added to the stored prop. I figured I'd do it this way to keep things simple.

Let me know what you think.
![playerModal](https://user-images.githubusercontent.com/16229739/155245055-d95e2508-60d3-49fd-8ef0-a774af42aa7e.png)

