### PR TITLE
Corrects insight preset variables

### DIFF
--- a/modules/insight/src/main/Preset.scala
+++ b/modules/insight/src/main/Preset.scala
@@ -79,7 +79,7 @@ object Preset {
     Preset(
       "Do I gain rating when I don't castle kingside?",
       Question(
-        D.Perf,
+        D.MyCastling,
         M.RatingDiff,
         List(
           Filter(D.MyCastling, List(Castling.Queenside, Castling.None))
@@ -89,7 +89,7 @@ object Preset {
     Preset(
       "When I trade queens, how do games end?",
       Question(
-        D.Perf,
+        D.QueenTrade,
         M.Result,
         List(
           Filter(D.QueenTrade, List(QueenTrade.Yes))

--- a/modules/team/src/main/TeamForm.scala
+++ b/modules/team/src/main/TeamForm.scala
@@ -15,7 +15,7 @@ final private[team] class TeamForm(
     extends lila.hub.CaptchedForm {
 
   private object Fields {
-    val name = "name" -> cleanText(minLength = 3, maxLength = 60).verifying(mustNotContainLichess(false))
+    val name     = "name"     -> cleanText(minLength = 3, maxLength = 60).verifying(mustNotContainLichess(false))
     val password = "password" -> optional(cleanText(maxLength = 60))
     def passwordCheck(team: Team) = "password" -> optional(text).verifying(
       "team:incorrectEntryCode",


### PR DESCRIPTION
Fixes #10577 

Corrects the dimension variable for two presets:

1. "When I trade queens, how do games end?"
2.  "Do I gain rating when I don't castle kingside?"

Previously, both would appear with "Variant" selected as the dimension.

Now, 
1. "Queen trade"
2. "My castling side"