### PR TITLE
add alias for /games/export/_ids under /api (fixes #10587)

### DIFF
--- a/conf/routes
+++ b/conf/routes
@@ -17,6 +17,7 @@ GET   /games/search                    controllers.Search.index(page: Int ?= 1)
 
 # Game export
 POST  /games/export/_ids               controllers.Game.exportByIds
+POST  /api/games/export/_ids           controllers.Game.exportByIds
 GET   /games/export/:username          controllers.Game.exportByUser(username: String)
 
 # Bookmark


### PR DESCRIPTION
Moving to `/api` gives us support for CORS preflighting (#10587).

Could also pick a different path for consistency. The only releated one I see is:

```
GET   /api/game/:id                    controllers.Api.game(id: String)
````