### PR TITLE
study: Don't remove evals on clearAnnotations

### DIFF
--- a/modules/study/src/main/Node.scala
+++ b/modules/study/src/main/Node.scala
@@ -81,8 +81,7 @@ case class Node(
     copy(
       comments = Comments(Nil),
       shapes = Shapes(Nil),
-      glyphs = Glyphs.empty,
-      score = none
+      glyphs = Glyphs.empty
     )
 
   def clearVariations: Node =


### PR DESCRIPTION
See #10608

Arguably, evals are also annotations but it's not great if it leaves a half-broken eval graph. I guess an alternative would be to remove the eval graph/server eval completely? Or maybe add another button for that?