### PR TITLE
Don't show variant team notice on un-official tournaments

### DIFF
--- a/app/views/tournament/side.scala
+++ b/app/views/tournament/side.scala
@@ -58,7 +58,9 @@ object side {
             }
           )
         },
-        variantTeamLinks.get(tour.variant) map { case (team, link) =>
+        variantTeamLinks.get(tour.variant) filter { case (team, _) =>
+          tour.createdBy == lila.user.User.lichessId || tour.conditions.teamMember.exists(_.teamId == team.id)
+        } map { case (team, link) =>
           st.section(
             if (isMyTeamSync(team.id)) frag(trans.team.team(), " ", link)
             else trans.team.joinLichessVariantTeam(link)


### PR DESCRIPTION
Slightly weird going via the condition but I don't think there's a better way to figure out which team a tournament belongs to