### PR TITLE
Don't allow adding official teams to team battles

### DIFF
--- a/modules/tournament/src/main/TournamentApi.scala
+++ b/modules/tournament/src/main/TournamentApi.scala
@@ -119,7 +119,7 @@ final class TournamentApi(
       data: TeamBattle.DataForm.Setup,
       filterExistingTeamIds: Set[TeamID] => Fu[Set[TeamID]]
   ): Funit =
-    filterExistingTeamIds(data.potentialTeamIds) flatMap { teamIds =>
+    filterExistingTeamIds(data.potentialTeamIds.filter(!_.contains("lichess")) flatMap { teamIds =>
       tournamentRepo.setTeamBattle(tour.id, TeamBattle(teamIds, data.nbLeaders)) >>-
         cached.tourCache.clear(tour.id)
     }

--- a/modules/tournament/src/main/TournamentApi.scala
+++ b/modules/tournament/src/main/TournamentApi.scala
@@ -119,7 +119,7 @@ final class TournamentApi(
       data: TeamBattle.DataForm.Setup,
       filterExistingTeamIds: Set[TeamID] => Fu[Set[TeamID]]
   ): Funit =
-    filterExistingTeamIds(data.potentialTeamIds.filter(!_.contains("lichess")) flatMap { teamIds =>
+    filterExistingTeamIds(data.potentialTeamIds.filter(!_.contains("lichess"))) flatMap { teamIds =>
       tournamentRepo.setTeamBattle(tour.id, TeamBattle(teamIds, data.nbLeaders)) >>-
         cached.tourCache.clear(tour.id)
     }

--- a/ui/site/src/teamBattleForm.ts
+++ b/ui/site/src/teamBattleForm.ts
@@ -30,7 +30,7 @@ lichess.load.then(() => {
                 .split('\n')
                 .map(t => t.split(' ')[0])
                 .slice(0, -1);
-              callback(res.filter(t => !current.includes(t.id)));
+              callback(res.filter(t => !current.includes(t.id) && !t.id.includes("lichess")));
             },
             _ => callback([])
           );

--- a/ui/site/src/teamBattleForm.ts
+++ b/ui/site/src/teamBattleForm.ts
@@ -30,7 +30,7 @@ lichess.load.then(() => {
                 .split('\n')
                 .map(t => t.split(' ')[0])
                 .slice(0, -1);
-              callback(res.filter(t => !current.includes(t.id) && !t.id.includes("lichess")));
+              callback(res.filter(t => !current.includes(t.id) && !t.id.includes('lichess')));
             },
             _ => callback([])
           );


### PR DESCRIPTION
This isn't really something that makes much sense and it allows making random tournaments (with potentially not really Lichess-aligned messages) seem official.