### PR TITLE
Fix typo in URL in FAQ

### DIFF
--- a/app/views/site/faq.scala
+++ b/app/views/site/faq.scala
@@ -74,7 +74,7 @@ object faq {
             li(a(href := "https://blitztactics.com/about")("Blitz Tactics")),
             li(a(href := "https://tailuge.github.io/chess-o-tron/html/blunder-bomb.html")("Blunder Bomb")),
             li(a(href := "https://lidraughts.org")("lidraughts.org")),
-            li(a(href := "https://https://playstrategy.org")("playstrategy.org")),
+            li(a(href := "https://playstrategy.org")("playstrategy.org")),
             li(a(href := "https://lishogi.org")("lishogi.org"))
           )
         ),


### PR DESCRIPTION
`https://https://playstrategy.org` -> `https://playstrategy.org`