### PR TITLE
fix double like (or unlike)

### DIFF
--- a/modules/study/src/main/StudyRepo.scala
+++ b/modules/study/src/main/StudyRepo.scala
@@ -201,21 +201,21 @@ final class StudyRepo(private[study] val coll: AsyncColl)(implicit
     coll(_.exists($id(studyId) ++ (s"members.$userId" $exists true)))
 
   def like(studyId: Study.Id, userId: User.ID, v: Boolean): Fu[Study.Likes] =
-    countLikes(studyId).flatMap {
-      case None => fuccess(Study.Likes(0))
-      case Some((prevLikes, createdAt)) =>
-        val likes = Study.Likes(prevLikes.value + (if (v) 1 else -1))
-        coll {
-          _.update.one(
-            $id(studyId),
-            $set(
-              F.likes -> likes,
-              F.rank  -> Study.Rank.compute(likes, createdAt)
-            ) ++ {
-              if (v) $addToSet(F.likers -> userId) else $pull(F.likers -> userId)
-            }
-          ) inject likes
+    coll { c =>
+      c.update.one($id(studyId), if (v) $addToSet(F.likers -> userId) else $pull(F.likers -> userId)) >> {
+        countLikes(studyId).flatMap {
+          case None                     => fuccess(Study.Likes(0))
+          case Some((likes, createdAt)) =>
+            // Multiple updates may race to set denormalized likes and rank,
+            // but values should be approximately correct, match a real like
+            // count (though perhaps not the latest one), and any uncontended
+            // query will set the precisely correct value.
+            c.update.one(
+              $id(studyId),
+              $set(F.likes -> likes, F.rank -> Study.Rank.compute(likes, createdAt))
+            ) inject likes
         }
+      }
     }
 
   def liked(study: Study, user: User): Fu[Boolean] =
@@ -259,7 +259,7 @@ final class StudyRepo(private[study] val coll: AsyncColl)(implicit
           Project(
             $doc(
               "_id"       -> false,
-              F.likes     -> $doc("$size" -> s"$$${F.likers}"),
+              F.likes     -> $doc("$size" -> s"$$${F.likers}"), // do not use denormalized field
               F.createdAt -> true
             )
           )


### PR DESCRIPTION
Fixes https://hackerone.com/reports/1500457 and
https://hackerone.com/reports/1500956.

Users could increase or decrease the denormalized like counter arbitrarily.
Split the query to ensure the like count and rank matches a value that
has really been achieved.

There is a race condition with very limited impact that I consider to be
acceptable. It was also present before this patch.

---

Queries on master:

1. Count likers
2. Write denormalized count of likers and rank after unchecked +/-1

With patch:

1. Update set of likers
2. Count likers
3. Write denormalized count of likers and rank