### PR TITLE
Handle 0 properly in regula falsi

### DIFF
--- a/modules/rating/src/main/java/glicko2/RatingCalculator.java
+++ b/modules/rating/src/main/java/glicko2/RatingCalculator.java
@@ -172,7 +172,7 @@ public class RatingCalculator {
       double C = A + (( (A-B)*fA ) / (fB - fA));
       double fC = f(C , delta, phi, v, a, tau);
 
-      if ( fC * fB < 0 ) {
+      if ( fC * fB <= 0 ) {
         A = B;
         fA = fB;
       } else {


### PR DESCRIPTION
When fC == 0, regula falsi (https://en.wikipedia.org/wiki/Regula_falsi) has found an actual zero C of the function f and should return it. The previous implementation would instead enter an infinite loop, doing fA = fA / 2.0 endlessly. The change from this PR causes this case to be handled correctly, returning after one additional iteration. The paper this code is based on (http://www.glicko.net/glicko/glicko2.pdf) was updated by Mark Glickman today with this change; see step 5.4b.