### PR TITLE
Use actual forum access policy when displaying post searchs

### DIFF
--- a/app/controllers/ForumPost.scala
+++ b/app/controllers/ForumPost.scala
@@ -23,9 +23,13 @@ final class ForumPost(env: Env) extends LilaController(env) with ForumController
         if (text.trim.isEmpty) Redirect(routes.ForumCateg.index).fuccess
         else
           for {
-            teamIds <- ctx.userId ?? env.team.cached.teamIdsSet
-            posts   <- env.forumSearch(text, page, ctx.troll)
-          } yield html.forum.search(text, posts, teamIds)
+            paginator <- env.forumSearch(text, page, ctx.troll)
+            posts <- paginator.mapFutureResults(post =>
+              access.isGrantedRead(post.categ.id) map { canRead =>
+                lila.forum.PostView.WithReadPerm(post, canRead)
+              }
+            )
+          } yield html.forum.search(text, posts)
       }
     }
 

--- a/app/views/forum/search.scala
+++ b/app/views/forum/search.scala
@@ -10,7 +10,7 @@ import lila.team.Team
 
 object search {
 
-  def apply(text: String, pager: Paginator[lila.forum.PostView], myTeamIds: Set[Team.ID])(implicit
+  def apply(text: String, pager: Paginator[lila.forum.PostView.WithReadPerm])(implicit
       ctx: Context
   ) = {
     val title = s"""${trans.search.search.txt()} "${text.trim}""""
@@ -31,7 +31,8 @@ object search {
         table(cls := "slist slist-pad search__results")(
           if (pager.nbResults > 0)
             tbody(cls := "infinite-scroll")(
-              pager.currentPageResults.map { view =>
+              pager.currentPageResults.map { viewWithRead =>
+                val view = viewWithRead.view
                 val info =
                   td(cls := "info")(
                     momentFromNow(view.post.createdAt),
@@ -39,7 +40,7 @@ object search {
                     bits.authorLink(view.post)
                   )
                 tr(cls := "paginated")(
-                  if (view.categ.team.forall(myTeamIds.contains))
+                  if (viewWithRead.canRead)
                     frag(
                       td(
                         a(cls := "post", href := routes.ForumPost.redirect(view.post.id))(

--- a/modules/forum/src/main/model.scala
+++ b/modules/forum/src/main/model.scala
@@ -49,6 +49,10 @@ case class PostView(
   def show = post.showUserIdOrAuthor + " @ " + topic.name + " - " + post.text.take(80)
 }
 
+object PostView {
+  case class WithReadPerm(view: PostView, canRead: Boolean)
+}
+
 case class PostLiteView(post: Post, topic: Topic)
 
 case class MiniForumPost(


### PR DESCRIPTION
Instead of just checking if the user belongs to the team.

Could not be tested locally due to lack of elasticSearch