### PR TITLE
Add back team setting so that team forum can be seen by everyone again

### DIFF
--- a/app/controllers/Team.scala
+++ b/app/controllers/Team.scala
@@ -87,6 +87,7 @@ final class Team(
       ctx: Context
   ): Boolean =
     team.enabled && !team.isForumFor(_.NONE) && ctx.noKid && {
+      team.isForumFor(_.EVERYONE) ||
       (team.isForumFor(_.LEADERS) && ctx.userId.exists(team.leaders)) ||
       (team.isForumFor(_.MEMBERS) && isMember) ||
       (isGranted(_.ModerateForum) && requestModView)

--- a/app/views/team/form.scala
+++ b/app/views/team/form.scala
@@ -137,9 +137,10 @@ object form {
           form3.select(
             f,
             Seq(
-              Team.Access.NONE    -> "Hide the forum",
-              Team.Access.LEADERS -> "Show to team leaders",
-              Team.Access.MEMBERS -> "Show to members"
+              Team.Access.EVERYONE -> "Show to everyone",
+              Team.Access.MEMBERS  -> "Show to members",
+              Team.Access.LEADERS  -> "Show to team leaders",
+              Team.Access.NONE     -> "Hide the forum"
             )
           )
         }

--- a/app/views/team/form.scala
+++ b/app/views/team/form.scala
@@ -129,8 +129,6 @@ object form {
           help = frag(
             "Who can see the team forum on the team page?",
             br,
-            "Note that the forum remains accessible through direct URL access or forum search.",
-            br,
             "Only team members can post in the team forum."
           ).some
         ) { f =>

--- a/modules/api/src/main/ForumAccess.scala
+++ b/modules/api/src/main/ForumAccess.scala
@@ -9,20 +9,35 @@ final class ForumAccess(teamApi: lila.team.TeamApi, teamCached: lila.team.Cached
     ec: scala.concurrent.ExecutionContext
 ) {
 
-  def isGrantedRead(categSlug: String)(implicit ctx: UserContext): Fu[Boolean] =
+  sealed trait Operation
+  case object Read  extends Operation
+  case object Write extends Operation
+
+  def isGranted(categSlug: String, op: Operation)(implicit ctx: UserContext): Fu[Boolean] =
     Categ.slugToTeamId(categSlug).fold(fuTrue) { teamId =>
       ctx.me ?? { me =>
-        fuccess(Granter(Permission.ModerateForum)(me)) >>| (teamApi
-          .belongsTo(teamId, me.id) >>& teamCached.forumAccess.get(teamId).flatMap {
-          case Team.Access.NONE    => fuFalse
-          case Team.Access.MEMBERS => fuTrue
+        fuccess(Granter(Permission.ModerateForum)(me)) >>| teamCached.forumAccess.get(teamId).flatMap {
+          case Team.Access.NONE => fuFalse
+          case Team.Access.EVERYONE =>
+            op match {
+              case Read => fuTrue
+              case Write =>
+                teamApi.belongsTo(
+                  teamId,
+                  me.id
+                ) // when the team forum is open to everyone, you still need to belong to the team in order to post
+            }
+          case Team.Access.MEMBERS => teamApi.belongsTo(teamId, me.id)
           case Team.Access.LEADERS => teamApi.leads(teamId, me.id)
-        })
+        }
       }
     }
 
+  def isGrantedRead(categSlug: String)(implicit ctx: UserContext): Fu[Boolean] =
+    isGranted(categSlug, Read)
+
   def isGrantedWrite(categSlug: String)(implicit ctx: UserContext): Fu[Boolean] =
-    ctx.me.exists(canWriteInAnyForum) ?? isGrantedRead(categSlug)
+    ctx.me.exists(canWriteInAnyForum) ?? isGranted(categSlug, Write)
 
   private def canWriteInAnyForum(u: User) =
     !u.isBot && {

--- a/modules/team/src/main/Team.scala
+++ b/modules/team/src/main/Team.scala
@@ -65,10 +65,12 @@ object Team {
 
   type Access = Int
   object Access {
-    val NONE    = 0
-    val LEADERS = 10
-    val MEMBERS = 20
-    val all     = List(NONE, LEADERS, MEMBERS)
+    val NONE      = 0
+    val LEADERS   = 10
+    val MEMBERS   = 20
+    val EVERYONE  = 30
+    val allInTeam = List(NONE, LEADERS, MEMBERS)
+    val all       = EVERYONE :: allInTeam
   }
 
   case class IdsStr(value: String) extends AnyVal {

--- a/modules/team/src/main/TeamForm.scala
+++ b/modules/team/src/main/TeamForm.scala
@@ -31,7 +31,7 @@ final private[team] class TeamForm(
     val request     = "request"     -> boolean
     val gameId      = "gameId"      -> text
     val move        = "move"        -> text
-    val chat        = "chat"        -> numberIn(Team.Access.all)
+    val chat        = "chat"        -> numberIn(Team.Access.allInTeam)
     val forum       = "forum"       -> numberIn(Team.Access.all)
     val hideMembers = "hideMembers" -> boolean
   }


### PR DESCRIPTION
tested:
- Outsiders can see but not write in forums
- Member can post when the forum is open to all and members, but not leaders
- Leaders can post in the afored mentioned situation + Leader
- Only mods can post when forum setting set to `NONE`

close https://github.com/lichess-org/lila/issues/10719

Only question pending is if the default setting when creating a team should be switched back to allow forum view for everyone. 