### PR TITLE
remove PostView.topicLastPage in model.scala

### DIFF
--- a/modules/forum/src/main/PostApi.scala
+++ b/modules/forum/src/main/PostApi.scala
@@ -147,7 +147,7 @@ final class PostApi(
       for {
         topic <- topics find (_.id == post.topicId)
         categ <- categs find (_.slug == topic.categId)
-      } yield PostView(post, topic, categ, topic lastPage config.postMaxPerPage)
+      } yield PostView(post, topic, categ)
     }
 
   def viewsFromIds(postIds: Seq[Post.ID]): Fu[List[PostView]] =

--- a/modules/forum/src/main/model.scala
+++ b/modules/forum/src/main/model.scala
@@ -43,8 +43,7 @@ case class TopicView(
 case class PostView(
     post: Post,
     topic: Topic,
-    categ: Categ,
-    topicLastPage: Int
+    categ: Categ
 ) {
 
   def show = post.showUserIdOrAuthor + " @ " + topic.name + " - " + post.text.take(80)


### PR DESCRIPTION
This field is unused and unnecessarily complicates the view functions in PostApi in a related branch.  If the need for it arises somewhere, maybe it can be calculated there.  This change was originally made in a feature branch, but was broken out into a separate PR where it is more likely to be accepted.