### PR TITLE
use config's net.rateLimit setting in forum actions

### DIFF
--- a/app/controllers/ForumPost.scala
+++ b/app/controllers/ForumPost.scala
@@ -10,7 +10,12 @@ import lila.msg.MsgPreset
 final class ForumPost(env: Env) extends LilaController(env) with ForumController {
 
   private val CreateRateLimit =
-    new lila.memo.RateLimit[IpAddress](4, 5.minutes, key = "forum.post")
+    new lila.memo.RateLimit[IpAddress](
+      credits = 4,
+      duration = 5.minutes,
+      key = "forum.post",
+      enforce = env.net.rateLimit.value
+    )
 
   def search(text: String, page: Int) =
     OpenBody { implicit ctx =>

--- a/app/controllers/ForumTopic.scala
+++ b/app/controllers/ForumTopic.scala
@@ -16,7 +16,7 @@ final class ForumTopic(env: Env) extends LilaController(env) with ForumControlle
       credits = 2,
       duration = 5.minutes,
       key = "forum.topic",
-      enforce = env.dev.rateLimit.value
+      enforce = env.net.rateLimit.value
     )
 
   def form(categSlug: String) =

--- a/app/controllers/ForumTopic.scala
+++ b/app/controllers/ForumTopic.scala
@@ -12,7 +12,12 @@ import lila.user.Holder
 final class ForumTopic(env: Env) extends LilaController(env) with ForumController {
 
   private val CreateRateLimit =
-    new lila.memo.RateLimit[IpAddress](2, 5.minutes, key = "forum.topic")
+    new lila.memo.RateLimit[IpAddress](
+      credits = 2,
+      duration = 5.minutes,
+      key = "forum.topic",
+      enforce = env.dev.rateLimit.value
+    )
 
   def form(categSlug: String) =
     Auth { implicit ctx => me =>


### PR DESCRIPTION
This PR applies the net.rateLimit setting in config to rateLimiters in app/controllers/ForumTopic.scala and app/controllers/ForumPost.scala, in case one wants to create a bunch of stuff quickly in the UI rather than interacting with the db directly.