### PR TITLE
Prevent non-mod posts from mods in team forums without being a member

### DIFF
--- a/app/controllers/ForumController.scala
+++ b/app/controllers/ForumController.scala
@@ -16,9 +16,10 @@ private[controllers] trait ForumController { self: LilaController =>
   protected def teamCache = env.team.cached
 
   protected def CategGrantWrite[A <: Result](
-      categSlug: String
+      categSlug: String,
+      tryingToPostAsMod: Boolean = false
   )(a: => Fu[A])(implicit ctx: Context): Fu[Result] =
-    access.isGrantedWrite(categSlug) flatMap { granted =>
+    access.isGrantedWrite(categSlug, tryingToPostAsMod) flatMap { granted =>
       if (granted) a
       else fuccess(Forbidden("You cannot post to this category"))
     }

--- a/app/controllers/ForumTopic.scala
+++ b/app/controllers/ForumTopic.scala
@@ -62,7 +62,7 @@ final class ForumTopic(env: Env) extends LilaController(env) with ForumControlle
           for {
             unsub       <- ctx.userId ?? env.timeline.status(s"forum:${topic.id}")
             canRead     <- access.isGrantedRead(categ.slug)
-            canWrite    <- access.isGrantedWrite(categ.slug)
+            canWrite    <- access.isGrantedWrite(categ.slug, tryingToPostAsMod = true)
             canModCateg <- access.isGrantedMod(categ.slug)
             inOwnTeam <- ~(categ.team, ctx.me).mapN { case (teamId, me) =>
               env.team.cached.isLeader(teamId, me.id)

--- a/modules/api/src/main/ForumAccess.scala
+++ b/modules/api/src/main/ForumAccess.scala
@@ -34,13 +34,13 @@ final class ForumAccess(teamApi: lila.team.TeamApi, teamCached: lila.team.Cached
     }
 
   def isGrantedRead(categSlug: String)(implicit ctx: UserContext): Fu[Boolean] =
-    if (ctx.me ?? Granter(Permission.ModerateForum)) fuTrue
+    if (ctx.me ?? Granter(Permission.Shusher)) fuTrue
     else isGranted(categSlug, Read)
 
   def isGrantedWrite(categSlug: String, tryingToPostAsMod: Boolean = false)(implicit
       ctx: UserContext
   ): Fu[Boolean] =
-    if (tryingToPostAsMod && ctx.me ?? Granter(Permission.ModerateForum)) fuTrue
+    if (tryingToPostAsMod && ctx.me ?? Granter(Permission.Shusher)) fuTrue
     else ctx.me.exists(canWriteInAnyForum) ?? isGranted(categSlug, Write)
 
   private def canWriteInAnyForum(u: User) =


### PR DESCRIPTION
To avoid accidentally posting in a team they aren't a member of.

And also require Shusher perms.