### PR TITLE
Fix new PayPal button styling

### DIFF
--- a/ui/site/css/_plan.scss
+++ b/ui/site/css/_plan.scss
@@ -177,8 +177,12 @@
           height: 55px;
         }
 
-        #paypal-button-container {
-          height: 55px;
+        .paypal {
+          display: flex;
+
+          iframe {
+            color-scheme: normal;
+          }
         }
       }
 


### PR DESCRIPTION
`#paypal-button-container` doesn't actually get used. And the `color-scheme` is to revert the `color-scheme: dark` on the top-level `html` which for some reason causes white iframe backgrounds.

|Before|![before](https://user-images.githubusercontent.com/19309705/161229743-1f85c2e6-1ea5-4b05-840d-7be41a58cec3.png)|
|--|--|
|After|![after](https://user-images.githubusercontent.com/19309705/161229751-074bd177-3ce7-444a-83a0-5b9aeca7f9fe.png)|