### PR TITLE
corrected name of swiss german language

### DIFF
--- a/modules/i18n/src/main/LangList.scala
+++ b/modules/i18n/src/main/LangList.scala
@@ -21,7 +21,7 @@ object LangList {
     Lang("cv", "CU")  -> "чӑваш чӗлхи",
     Lang("cy", "GB")  -> "Cymraeg",
     Lang("da", "DK")  -> "Dansk",
-    Lang("de", "CH")  -> "Schwiizerdüütsch",
+    Lang("de", "CH")  -> "Schwizerdütsch", 
     Lang("de", "DE")  -> "Deutsch",
     Lang("el", "GR")  -> "Ελληνικά",
     Lang("en", "US")  -> "English (US)",


### PR DESCRIPTION
(Source: https://de.wikipedia.org/wiki/Schweizerdeutsch / me ><)