### PR TITLE
Allow navigating move list from keyboard move input on puzzle page

### DIFF
--- a/ui/keyboardMove/src/main.ts
+++ b/ui/keyboardMove/src/main.ts
@@ -59,7 +59,7 @@ export interface RootController {
   sendMove: (orig: cg.Key, dest: cg.Key, prom: cg.Role | undefined, meta?: cg.MoveMetadata) => void;
   sendNewPiece?: (role: cg.Role, key: cg.Key, isPredrop: boolean) => void;
   submitMove?: (v: boolean) => void;
-  userJumpPlyCount?: (plyCount: Ply) => void;
+  userJumpPlyDelta?: (plyDelta: Ply) => void;
   redraw: Redraw;
 }
 interface Step {
@@ -126,8 +126,8 @@ export function ctrl(root: RootController, step: Step): KeyboardMove {
     hasSelected: () => cgState.selected,
     confirmMove: () => (root.submitMove ? root.submitMove(true) : null),
     usedSan,
-    jump(plyCount: number) {
-      root.userJumpPlyCount && root.userJumpPlyCount(plyCount);
+    jump(plyDelta: number) {
+      root.userJumpPlyDelta && root.userJumpPlyDelta(plyDelta);
       root.redraw();
     },
     justSelected: () => performance.now() - lastSelect < 500,

--- a/ui/puzzle/src/ctrl.ts
+++ b/ui/puzzle/src/ctrl.ts
@@ -23,6 +23,8 @@ import { pgnToTree, mergeSolution } from './moveTree';
 import { Redraw, Vm, Controller, PuzzleOpts, PuzzleData, MoveTest, ThemeKey, NvuiPlugin } from './interfaces';
 import { Role, Move, Outcome } from 'chessops/types';
 import { storedProp } from 'common/storage';
+import { fromNodeList } from 'tree/dist/path';
+import { last } from 'tree/dist/ops';
 
 export default function (opts: PuzzleOpts, redraw: Redraw): Controller {
   const vm: Vm = {
@@ -85,6 +87,7 @@ export default function (opts: PuzzleOpts, redraw: Redraw): Controller {
           chessground: cg,
           sendMove: playUserMove,
           redraw: this.redraw,
+          userJumpPlyDelta,
         },
         { fen: this.vm.node.fen }
       );
@@ -443,6 +446,14 @@ export default function (opts: PuzzleOpts, redraw: Redraw): Controller {
     withGround(g => g.selectSquare(null));
     jump(path);
     speech.node(vm.node, true);
+  }
+
+  function userJumpPlyDelta(plyDelta: Ply) {
+    // ensure we are jumping to a valid ply
+    let maxValidPly = vm.mainline.length - 1;
+    if (last(vm.mainline)?.puzzle == 'fail' && vm.mode != 'view') maxValidPly -= 1;
+    const newPly = Math.min(Math.max(vm.node.ply + plyDelta, 0), maxValidPly);
+    userJump(fromNodeList(vm.mainline.slice(0, newPly + 1)));
   }
 
   function viewSolution(): void {

--- a/ui/round/src/ctrl.ts
+++ b/ui/round/src/ctrl.ts
@@ -255,7 +255,7 @@ export default class RoundController {
     else this.redraw();
   };
 
-  userJumpPlyCount = (plyCount: Ply) => this.userJump(this.ply + plyCount);
+  userJumpPlyDelta = (plyDelta: Ply) => this.userJump(this.ply + plyDelta);
 
   isPlaying = () => game.isPlayerPlaying(this.data);
 


### PR DESCRIPTION
Similar to what is already possible on the round page when the keyboard input is focused.