### PR TITLE
Add tab and tablist roles

### DIFF
--- a/app/views/analyse/replay.scala
+++ b/app/views/analyse/replay.scala
@@ -161,17 +161,16 @@ object replay {
                   )
                 }
               ),
-              div(cls := "analyse__underboard__menu")(
+              div(role := "tablist", cls := "analyse__underboard__menu")(
                 game.analysable option
-                  span(
-                    cls := "computer-analysis",
-                    dataPanel := "computer-analysis"
-                  )(trans.computerAnalysis()),
+                  span(role := "tab", cls := "computer-analysis", dataPanel := "computer-analysis")(
+                    trans.computerAnalysis()
+                  ),
                 !game.isPgnImport option frag(
-                  game.turns > 1 option span(dataPanel := "move-times")(trans.moveTimes()),
-                  cross.isDefined option span(dataPanel := "ctable")(trans.crosstable())
+                  game.turns > 1 option span(role := "tab", dataPanel := "move-times")(trans.moveTimes()),
+                  cross.isDefined option span(role := "tab", dataPanel := "ctable")(trans.crosstable())
                 ),
-                span(dataPanel := "fen-pgn")(raw("FEN &amp; PGN"))
+                span(role := "tab", dataPanel := "fen-pgn")(raw("FEN &amp; PGN"))
               )
             )
           )

--- a/ui/analyse/src/study/chapterNewForm.ts
+++ b/ui/analyse/src/study/chapterNewForm.ts
@@ -125,7 +125,7 @@ export function view(ctrl: StudyChapterNewFormCtrl): VNode {
       'span.' + key,
       {
         class: { active: activeTab === key },
-        attrs: { title },
+        attrs: { role: 'tab', title },
         hook: bind('click', () => ctrl.vm.tab(key), ctrl.root.redraw),
       },
       name
@@ -201,7 +201,7 @@ export function view(ctrl: StudyChapterNewFormCtrl): VNode {
               }),
             }),
           ]),
-          h('div.tabs-horiz', [
+          h('div.tabs-horiz', { attrs: { role: 'tablist' } }, [
             makeTab('init', noarg('empty'), noarg('startFromInitialPosition')),
             makeTab('edit', noarg('editor'), noarg('startFromCustomPosition')),
             makeTab('game', 'URL', noarg('loadAGameByUrl')),

--- a/ui/analyse/src/study/studyView.ts
+++ b/ui/analyse/src/study/studyView.ts
@@ -35,7 +35,7 @@ function toolButton(opts: ToolButtonOpts): VNode {
   return h(
     'span.' + opts.tab,
     {
-      attrs: { title: opts.hint },
+      attrs: { role: 'tab', title: opts.hint },
       class: { active: opts.tab === opts.ctrl.vm.toolTab() },
       hook: bind(
         'mousedown',
@@ -56,7 +56,7 @@ function buttons(root: AnalyseCtrl): VNode {
     showSticky = ctrl.data.features.sticky && (canContribute || (ctrl.vm.behind && ctrl.isUpdatedRecently())),
     noarg = root.trans.noarg;
   return h('div.study__buttons', [
-    h('div.left-buttons.tabs-horiz', [
+    h('div.left-buttons.tabs-horiz', { attrs: { role: 'tablist' } }, [
       // distinct classes (sync, write) allow snabbdom to differentiate buttons
       showSticky
         ? h(
@@ -172,6 +172,7 @@ export function side(ctrl: StudyCtrl): VNode {
       'span.' + key,
       {
         class: { active: !tourShow?.active && activeTab === key },
+        attrs: { role: 'tab' },
         hook: bind(
           'mousedown',
           () => {
@@ -199,6 +200,7 @@ export function side(ctrl: StudyCtrl): VNode {
         ),
         attrs: {
           'data-icon': '',
+          role: 'tab',
         },
       },
       'Broadcast'
@@ -209,7 +211,7 @@ export function side(ctrl: StudyCtrl): VNode {
       ? null
       : makeTab('chapters', ctrl.trans.plural(ctrl.relay ? 'nbGames' : 'nbChapters', ctrl.chapters.size()));
 
-  const tabs = h('div.tabs-horiz', [
+  const tabs = h('div.tabs-horiz', { attrs: { role: 'tablist' } }, [
     tourTab,
     chaptersTab,
     !tourTab || ctrl.members.canContribute() || ctrl.data.admin
@@ -219,6 +221,7 @@ export function side(ctrl: StudyCtrl): VNode {
       ? h(
           'span.more',
           {
+            attrs: { role: 'tab' },
             hook: bind('click', () => ctrl.form.open(!ctrl.form.open()), ctrl.redraw),
           },
           [iconTag('')]

--- a/ui/chat/src/view.ts
+++ b/ui/chat/src/view.ts
@@ -55,7 +55,7 @@ function renderPalantir(ctrl: Ctrl) {
 function normalView(ctrl: Ctrl) {
   const active = ctrl.vm.tab;
   return [
-    h('div.mchat__tabs.nb_' + ctrl.allTabs.length, [
+    h('div.mchat__tabs.nb_' + ctrl.allTabs.length, { attrs: { role: 'tablist' } }, [
       ...ctrl.allTabs.map(t => renderTab(ctrl, t, active)),
       renderPalantir(ctrl),
     ]),
@@ -74,6 +74,7 @@ function renderTab(ctrl: Ctrl, tab: Tab, active: Tab) {
   return h(
     'div.mchat__tab.' + tab,
     {
+      attrs: { role: 'tab' },
       class: { 'mchat__tab-active': tab === active },
       hook: bind('click', () => ctrl.setTab(tab)),
     },

--- a/ui/lobby/src/view/main.ts
+++ b/ui/lobby/src/view/main.ts
@@ -28,7 +28,7 @@ export default function (ctrl: LobbyController) {
         break;
     }
   return h('div.lobby__app.lobby__app-' + ctrl.tab, [
-    h('div.tabs-horiz', renderTabs(ctrl)),
+    h('div.tabs-horiz', { attrs: { role: 'tablist' } }, renderTabs(ctrl)),
     h('div.lobby__app__content.l' + (ctrl.redirecting ? 'redir' : ctrl.tab), data, body),
   ]);
 }

--- a/ui/lobby/src/view/tabs.ts
+++ b/ui/lobby/src/view/tabs.ts
@@ -7,6 +7,7 @@ function tab(ctrl: LobbyController, key: Tab, active: Tab, content: MaybeVNodes)
   return h(
     'span',
     {
+      attrs: { role: 'tab' },
       class: {
         active: key === active,
         glowing: key !== active && key === 'pools' && !!ctrl.poolMember,


### PR DESCRIPTION
A very modest accessibility improvement to add the `tab`/`tablist` roles [where appropriate](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/tab_role). I noticed this because I use vimium, which wasn't recognizing our tabs as clickable elements.