### PR TITLE
Select starting move when export broadcast game

### DIFF
--- a/ui/analyse/src/study/studyShare.ts
+++ b/ui/analyse/src/study/studyShare.ts
@@ -148,10 +148,10 @@ export function view(ctrl: StudyShareCtrl): VNode {
         ? [
             ['broadcastUrl', ctrl.relay.tourPath()],
             ['currentRoundUrl', ctrl.relay.roundPath()],
-            ['currentGameUrl', `${ctrl.relay.roundPath()}/${chapter.id}`],
+            ['currentGameUrl', addPly(`${ctrl.relay.roundPath()}/${chapter.id}`), true],
           ]
         : [
-            ['studyUrl', addPly(`/study/${studyId}`), true],
+            ['studyUrl', `/study/${studyId}`],
             ['currentChapterUrl', addPly(`/study/${studyId}/${chapter.id}`), true],
           ]
       ).map(([i18n, path, pastable]: [string, string, boolean]) =>


### PR DESCRIPTION
Show the "Start at <move>" box after "current game url" in broadcasts.

In studies there is the box also after "study url", but it redirect to
the selected move in the first game, so I have removed it.