### PR TITLE
Update study URL with chapter id

### DIFF
--- a/ui/analyse/src/study/studyCtrl.ts
+++ b/ui/analyse/src/study/studyCtrl.ts
@@ -289,6 +289,7 @@ export default function (
     // path could be gone (because of subtree deletion), go as far as possible
     ctrl.userJump(ctrl.tree.longestValidPath(nextPath));
 
+    history.replaceState(null, '', `/study/${data.id}/${data.chapter.id}`);
     vm.justSetChapterId = undefined;
 
     configurePractice();


### PR DESCRIPTION
Resolves https://github.com/lichess-org/lila/issues/10798.

This change basically always includes the study's chapter id in the URL. I'm not sure of this has any unintended consequences perhaps related to sharing links by copying/pasting the URL from the address bar. On the other hand, it will solve the linked issue.