### PR TITLE
Fix inaccurate text in newly created team forum

### DIFF
--- a/modules/forum/src/main/CategApi.scala
+++ b/modules/forum/src/main/CategApi.scala
@@ -42,7 +42,7 @@ final class CategApi(
       author = none,
       userId = User.lichessId.some,
       text =
-        "Welcome to the %s forum!\nOnly members of the team can post here, but everybody can read." format name,
+        "Welcome to the %s forum!" format name,
       number = 1,
       troll = false,
       hidden = topic.hidden,


### PR DESCRIPTION
#10806

Changed:

> Welcome to the <team> forum!
> Only members of the team can post here, but everybody can read.

To:

> Welcome to the <team> forum!
