### PR TITLE
Hook like rating range fix

### DIFF
--- a/app/controllers/Setup.scala
+++ b/app/controllers/Setup.scala
@@ -10,6 +10,7 @@ import lila.api.{ BodyContext, Context }
 import lila.app._
 import lila.common.{ HTTPRequest, IpAddress }
 import lila.game.{ AnonCookie, Pov }
+import lila.rating.Glicko
 import lila.setup.Processor.HookResult
 import lila.setup.ValidFen
 import lila.socket.Socket.Sri
@@ -176,7 +177,7 @@ final class Setup(
                   hookConfig = lila.setup.HookConfig.default(ctx.isAuth)
                   hookConfigWithRating = get("rr").fold(
                     hookConfig.withRatingRange(
-                      ctx.me.fold(0.some)(_.perfs.ratingOf(game.perfKey)),
+                      ctx.me.fold(Glicko.default.rating.toInt.some)(_.perfs.ratingOf(game.perfKey)),
                       get("deltaMin"),
                       get("deltaMax")
                     )

--- a/modules/rating/src/main/RatingRange.scala
+++ b/modules/rating/src/main/RatingRange.scala
@@ -37,8 +37,20 @@ object RatingRange {
       if min < max
     } yield RatingRange(min, max)
 
-  def orDefault(from: String)         = apply(from) | default
-  def orDefault(from: Option[String]) = from.flatMap(apply) | default
+  def apply(rating: Int, deltaMin: Option[String], deltaMax: Option[String]): Option[RatingRange] =
+    for {
+      dmin <- deltaMin.flatMap(_.toIntOption)
+      min = rating + dmin
+      if acceptable(min)
+      dmax <- deltaMax.flatMap(_.toIntOption)
+      max = rating + dmax
+      if acceptable(max)
+      if min < max
+    } yield RatingRange(min, max)
+
+  def orDefault(from: String) = apply(from) | default
+  def orDefault(rating: Option[Int], deltaMin: Option[String], deltaMax: Option[String]) =
+    rating.flatMap(r => apply(r, deltaMin, deltaMax)) | default
 
   def noneIfDefault(from: String) =
     if (from == default.toString) none

--- a/modules/setup/src/main/HookConfig.scala
+++ b/modules/setup/src/main/HookConfig.scala
@@ -103,7 +103,9 @@ case class HookConfig(
       mode = game.mode
     )
 
-  def withRatingRange(str: Option[String]) = copy(ratingRange = RatingRange orDefault str)
+  def withRatingRange(ratingRange: String) = copy(ratingRange = RatingRange orDefault ratingRange)
+  def withRatingRange(rating: Option[Int], deltaMin: Option[String], deltaMax: Option[String]) =
+    copy(ratingRange = RatingRange orDefault (rating, deltaMin, deltaMax))
 }
 
 object HookConfig extends BaseHumanConfig {

--- a/ui/lobby/src/boot.ts
+++ b/ui/lobby/src/boot.ts
@@ -61,8 +61,10 @@ export default function LichessLobby(opts: LobbyOpts) {
   lichess.StrongSocket.firstConnect.then(() => {
     const gameId = getParameterByName('hook_like');
     if (!gameId) return;
-    const ratingRange = lobby.setupCtrl.hookRatingRange();
-    xhr.text(`/setup/hook/${lichess.sri}/like/${gameId}?rr=${ratingRange || ''}`, { method: 'post' });
+    const { ratingMin, ratingMax } = lobby.setupCtrl.makeSetupStore('hook')();
+    xhr.text(xhr.url(`/setup/hook/${lichess.sri}/like/${gameId}`, { deltaMin: ratingMin, deltaMax: ratingMax }), {
+      method: 'post',
+    });
     lobby.setTab('real_time');
     history.replaceState(null, '', '/');
   });

--- a/ui/lobby/src/setupCtrl.ts
+++ b/ui/lobby/src/setupCtrl.ts
@@ -84,7 +84,7 @@ export default class SetupController {
   // Namespace the store by username for user specific modal settings
   private storeKey = (gameType: GameType) => `lobby.setup.${this.root.me?.username || 'anon'}.${gameType}`;
 
-  private makeSetupStore = (gameType: GameType) =>
+  makeSetupStore = (gameType: GameType) =>
     storedJsonProp<SetupStore>(this.storeKey(gameType), () => ({
       variant: 'standard',
       fen: '',
@@ -197,15 +197,6 @@ export default class SetupController {
     if (!this.root.data.ratingMap) return '';
     const rating = this.root.data.ratingMap[this.selectedPerf()];
     return `${rating + this.ratingMin()}-${rating + this.ratingMax()}`;
-  };
-
-  // This function is a special version of the above function that does not require the modal to
-  // be opened. Used in boot.ts for hook-like games ("New opponent" button).
-  hookRatingRange = (): string => {
-    if (!this.root.data.ratingMap) return '';
-    const { variant, timeMode, time, increment, ratingMin, ratingMax } = this.makeSetupStore('hook')();
-    const rating = this.root.data.ratingMap[getPerf(variant, timeMode, time, increment)];
-    return `${rating + ratingMin}-${rating + ratingMax}`;
   };
 
   hookToPoolMember = (color: Color | 'random'): PoolMember | null => {


### PR DESCRIPTION
I realized with the last refactor that we are using a somewhat arbitrary rating range when creating hook like games ("new opponent" button for non-pool games). Currently, we compute a rating range based on the perf of what was last selected in the modal. This change makes it such that we only grab the deltas (min and max) from the modal, and give those to the backend. Then we apply those deltas to the appropriate rating.

My scala has a long way to go... I'm sure some refactoring is in order :D