### PR TITLE
From position fen bug fix

### DIFF
--- a/ui/lobby/css/_setup.scss
+++ b/ui/lobby/css/_setup.scss
@@ -8,6 +8,7 @@ $c-slider: $c-setup;
 
   > div {
     padding: 0;
+    height: 96vh;
   }
 
   h2 {

--- a/ui/lobby/css/_setup.scss
+++ b/ui/lobby/css/_setup.scss
@@ -8,7 +8,7 @@ $c-slider: $c-setup;
 
   > div {
     padding: 0;
-    height: 96vh;
+    max-height: 96vh;
   }
 
   h2 {

--- a/ui/lobby/src/setupCtrl.ts
+++ b/ui/lobby/src/setupCtrl.ts
@@ -120,9 +120,13 @@ export default class SetupController {
   };
 
   private enforcePropRules = () => {
+    // reassign with this.propWithApply in this function to avoid calling this.onPropChange
+
+    // replace underscores with spaces in FEN
+    if (this.variant() === 'fromPosition') this.fen = this.propWithApply(this.fen().replace(/_/g, ' '));
+
     if (this.gameMode() === 'rated' && this.ratedModeDisabled()) {
-      // reassign with propWithEffect here to avoid calling this.onPropChange
-      this.gameMode = propWithEffect('casual', this.onPropChange);
+      this.gameMode = this.propWithApply('casual');
     }
   };
 


### PR DESCRIPTION
Fixes #10858. Chessground was breaking when it encountered underscores in FEN.

Also fixes #10860 with a quick CSS change to make the modal scrollable.