### PR TITLE
Show rating distribution for particular player

### DIFF
--- a/app/controllers/User.scala
+++ b/app/controllers/User.scala
@@ -627,9 +627,6 @@ final class User(
       }
     }
 
-  def ratingDistributionCompare(perfKey: lila.rating.Perf.Key, username: String) =
-    ratingDistribution(perfKey, Some(username))
-
   def myself =
     Auth { _ => me =>
       fuccess(Redirect(routes.User.show(me.username)))

--- a/app/controllers/User.scala
+++ b/app/controllers/User.scala
@@ -610,16 +610,25 @@ final class User(
       }
     }
 
-  def ratingDistribution(perfKey: lila.rating.Perf.Key) =
+  def ratingDistribution(perfKey: lila.rating.Perf.Key, username: Option[String] = None) =
     Open { implicit ctx =>
       lila.rating.PerfType(perfKey).filter(lila.rating.PerfType.leaderboardable.has) match {
         case Some(perfType) =>
-          env.user.rankingApi.weeklyRatingDistribution(perfType) dmap { data =>
-            Ok(html.stat.ratingDistribution(perfType, data))
+          env.user.rankingApi.weeklyRatingDistribution(perfType) flatMap { data =>
+            username match {
+              case Some(name) =>
+                EnabledUser(name) { u =>
+                  fuccess(html.stat.ratingDistribution(perfType, data, Some(u)))
+                }
+              case _ => fuccess(html.stat.ratingDistribution(perfType, data, None))
+            }
           }
         case _ => notFound
       }
     }
+
+  def ratingDistributionCompare(perfKey: lila.rating.Perf.Key, username: String) =
+    ratingDistribution(perfKey, Some(username))
 
   def myself =
     Auth { _ => me =>

--- a/app/views/stat/ratingDistribution.scala
+++ b/app/views/stat/ratingDistribution.scala
@@ -8,13 +8,13 @@ import lila.app.templating.Environment._
 import lila.app.ui.ScalatagsTemplate._
 import lila.common.String.html.safeJsonValue
 import lila.rating.PerfType
-import lila.user.{ User => UserModel }
+import lila.user.User
 
 import controllers.routes
 
 object ratingDistribution {
 
-  def apply(perfType: PerfType, data: List[Int], otherUser: Option[UserModel])(implicit ctx: Context) =
+  def apply(perfType: PerfType, data: List[Int], otherUser: Option[User])(implicit ctx: Context) =
     views.html.base.layout(
       title = trans.weeklyPerfTypeRatingDistribution.txt(perfType.trans),
       moreCss = cssTag("user.rating.stats"),
@@ -25,7 +25,7 @@ object ratingDistribution {
             Json.obj(
               "freq"        -> data,
               "myRating"    -> ctx.me.ifTrue(ctx.pref.showRatings).map(_.perfs(perfType).intRating),
-              "otherRating" -> otherUser.filter(_ => ctx.pref.showRatings).map(_.perfs(perfType).intRating),
+              "otherRating" -> otherUser.ifTrue(ctx.pref.showRatings).map(_.perfs(perfType).intRating),
               "otherPlayer" -> otherUser.map(_.username),
               "i18n"        -> i18nJsObject(i18nKeys)
             )

--- a/app/views/stat/ratingDistribution.scala
+++ b/app/views/stat/ratingDistribution.scala
@@ -44,10 +44,7 @@ object ratingDistribution {
                   a(
                     dataIcon := pt.iconChar,
                     cls      := (perfType == pt).option("current"),
-                    href := (otherUser match {
-                      case Some(u) => routes.User.ratingDistributionCompare(pt.key, u.username)
-                      case _       => routes.User.ratingDistribution(pt.key)
-                    })
+                    href     := routes.User.ratingDistribution(pt.key, otherUser.map(_.username))
                   )(pt.trans)
                 }
               )

--- a/app/views/user/perfStat.scala
+++ b/app/views/user/perfStat.scala
@@ -102,7 +102,9 @@ object perfStat {
             } else {
               trans.userIsBetterThanPercentOfPerfTypePlayers(
                 a(href := routes.User.show(u.username))(u.username),
-                a(href := routes.User.ratingDistribution(perfType.key))(strong(percentile, "%")),
+                a(href := routes.User.ratingDistributionCompare(perfType.key, u.username))(
+                  strong(percentile, "%")
+                ),
                 a(href := routes.User.topNb(200, perfType.key))(perfType.trans)
               )
             }

--- a/app/views/user/perfStat.scala
+++ b/app/views/user/perfStat.scala
@@ -102,7 +102,7 @@ object perfStat {
             } else {
               trans.userIsBetterThanPercentOfPerfTypePlayers(
                 a(href := routes.User.show(u.username))(u.username),
-                a(href := routes.User.ratingDistributionCompare(perfType.key, u.username))(
+                a(href := routes.User.ratingDistribution(perfType.key, u.username.some))(
                   strong(percentile, "%")
                 ),
                 a(href := routes.User.topNb(200, perfType.key))(perfType.trans)

--- a/conf/routes
+++ b/conf/routes
@@ -647,7 +647,8 @@ POST  /appeal/:username/snooze/:dur    controllers.Appeal.snooze(username: Strin
 POST  /appeal/:username/send-to-zulip  controllers.Appeal.sendToZulip(username: String)
 
 # Stats
-GET    /stat/rating/distribution/:perf controllers.User.ratingDistribution(perf: String)
+GET    /stat/rating/distribution/:perf           controllers.User.ratingDistribution(perf: String)
+GET    /stat/rating/distribution/:perf/:username controllers.User.ratingDistributionCompare(perf: String, username: String)
 
 # API
 GET   /api                             controllers.Api.index

--- a/conf/routes
+++ b/conf/routes
@@ -647,8 +647,7 @@ POST  /appeal/:username/snooze/:dur    controllers.Appeal.snooze(username: Strin
 POST  /appeal/:username/send-to-zulip  controllers.Appeal.sendToZulip(username: String)
 
 # Stats
-GET    /stat/rating/distribution/:perf           controllers.User.ratingDistribution(perf: String)
-GET    /stat/rating/distribution/:perf/:username controllers.User.ratingDistributionCompare(perf: String, username: String)
+GET    /stat/rating/distribution/:perf controllers.User.ratingDistribution(perf: String, username: Option[String] ?= None)
 
 # API
 GET   /api                             controllers.Api.index

--- a/ui/chart/src/ratingDistribution.ts
+++ b/ui/chart/src/ratingDistribution.ts
@@ -11,6 +11,30 @@ export default async function (data: any) {
     const arraySum = (arr: number[]) => arr.reduce((a, b) => a + b, 0);
     const sum = arraySum(data.freq);
     const cumul = [];
+    const buildRatingLine = (v: number, color: string, yCoord: number, label: string) => {
+      const right = v > 1800;
+      return v
+        ? [
+            {
+              label: {
+                text: label,
+                verticalAlign: 'top',
+                align: right ? 'right' : 'left',
+                y: yCoord,
+                x: right ? -5 : 5,
+                style: {
+                  color: color,
+                },
+                rotation: -0,
+              },
+              dashStyle: 'dash',
+              color: color,
+              width: 3,
+              value: v,
+            },
+          ]
+        : [];
+    };
     for (let i = 0; i < data.freq.length; i++) cumul.push(Math.round((arraySum(data.freq.slice(0, i)) / sum) * 100));
     Highcharts.chart(this, {
       credits: disabled,
@@ -74,30 +98,9 @@ export default async function (data: any) {
         gridLineWidth: 1,
         gridZIndex: -1,
         tickInterval: 100,
-        plotLines: (v => {
-          const right = v > 1800;
-          return v
-            ? [
-                {
-                  label: {
-                    text: trans.noarg('yourRating'),
-                    verticalAlign: 'top',
-                    align: right ? 'right' : 'left',
-                    y: 13,
-                    x: right ? -5 : 5,
-                    style: {
-                      color: colors[2],
-                    },
-                    rotation: -0,
-                  },
-                  dashStyle: 'dash',
-                  color: colors[2],
-                  width: 3,
-                  value: v,
-                },
-              ]
-            : [];
-        })(data.myRating),
+        plotLines: buildRatingLine(data.myRating, colors[2], 13, trans.noarg('yourRating')).concat(
+          buildRatingLine(data.otherRating, colors[6], 50, data.otherPlayer)
+        ),
       },
       yAxis: [
         {


### PR DESCRIPTION
Implements https://github.com/lichess-org/lila/issues/3980

**Summary of changes**
- Add a new `ratingDistributionCompare` endpoint and controller method 
- Modify the rating distribution link on a user's perf stats page to go to the new endpoint
- Show a vertical bar on the rating distribution page indicating the rating of the target user, in addition to the logged-in user

**Screenshot**
<img width="1440" alt="Screen Shot 2022-04-29 at 9 25 35 PM" src="https://user-images.githubusercontent.com/16654911/166086039-49072fff-f559-493f-a981-4ac05d18f004.png">