### PR TITLE
Fix join team view not using markdown to render description

### DIFF
--- a/app/views/team/bits.scala
+++ b/app/views/team/bits.scala
@@ -42,14 +42,14 @@ object bits {
     }
 
   object markdown {
-      import scala.concurrent.duration._
-      private val renderer = new lila.common.Markdown(header = true, list = true, table = true)
-      private val cache = lila.memo.CacheApi.scaffeineNoScheduler
-        .expireAfterAccess(10 minutes)
-        .maximumSize(1024)
-        .build[String, String]()
-      def apply(team: lila.team.Team, text: String): Frag = raw(cache.get(text, renderer(s"team:${team.id}")))
-    }
+    import scala.concurrent.duration._
+    private val renderer = new lila.common.Markdown(header = true, list = true, table = true)
+    private val cache = lila.memo.CacheApi.scaffeineNoScheduler
+      .expireAfterAccess(10 minutes)
+      .maximumSize(1024)
+      .build[String, String]()
+    def apply(team: lila.team.Team, text: String): Frag = raw(cache.get(text, renderer(s"team:${team.id}")))
+  }
 
   private[team] def teamTr(t: lila.team.Team)(implicit ctx: Context) = {
     val isMine = isMyTeamSync(t.id)

--- a/app/views/team/bits.scala
+++ b/app/views/team/bits.scala
@@ -41,7 +41,7 @@ object bits {
       )
     }
 
-  object markdown {
+  private[team] object markdown {
     import scala.concurrent.duration._
     private val renderer = new lila.common.Markdown(header = true, list = true, table = true)
     private val cache = lila.memo.CacheApi.scaffeineNoScheduler

--- a/app/views/team/bits.scala
+++ b/app/views/team/bits.scala
@@ -1,11 +1,9 @@
 package views.html.team
 
 import scala.util.chaining._
-
 import lila.api.Context
 import lila.app.templating.Environment._
 import lila.app.ui.ScalatagsTemplate._
-
 import controllers.routes
 
 object bits {
@@ -41,6 +39,16 @@ object bits {
             newTeam()
           )
       )
+    }
+
+  object markdown {
+      import scala.concurrent.duration._
+      private val renderer = new lila.common.Markdown(header = true, list = true, table = true)
+      private val cache = lila.memo.CacheApi.scaffeineNoScheduler
+        .expireAfterAccess(10 minutes)
+        .maximumSize(1024)
+        .build[String, String]()
+      def apply(team: lila.team.Team, text: String): Frag = raw(cache.get(text, renderer(s"team:${team.id}")))
     }
 
   private[team] def teamTr(t: lila.team.Team)(implicit ctx: Context) = {

--- a/app/views/team/request.scala
+++ b/app/views/team/request.scala
@@ -2,7 +2,6 @@ package views.html.team
 
 import controllers.routes
 import play.api.data.Form
-
 import lila.api.Context
 import lila.app.templating.Environment._
 import lila.app.ui.ScalatagsTemplate._
@@ -22,9 +21,9 @@ object request {
     ) {
       main(cls := "page-menu page-small")(
         bits.menu("requests".some),
-        div(cls := "page-menu__content box box-pad")(
+        div(cls := "page-menu__content box box-pad team-show__desc")(
           h1(title),
-          p(style := "margin:2em 0")(richText(t.description)),
+          p()(bits.markdown(t, t.description)),
           postForm(cls := "form3", action := routes.Team.requestCreate(t.id))(
             !t.open ?? frag(
               form3.group(form("message"), trans.message())(form3.textarea(_)()),

--- a/app/views/team/show.scala
+++ b/app/views/team/show.scala
@@ -192,7 +192,7 @@ object show {
             standardFlash(),
             log.nonEmpty option renderLog(log),
             st.section(cls := "team-show__desc")(
-              markdown(t, t.descPrivate.ifTrue(info.mine) | t.description)
+              bits.markdown(t, t.descPrivate.ifTrue(info.mine) | t.description)
             ),
             t.enabled && info.hasRequests option div(cls := "team-show__requests")(
               h2(xJoinRequests.pluralSame(info.requests.size)),
@@ -239,16 +239,6 @@ object show {
         )
       )
     }
-
-  private object markdown {
-    import scala.concurrent.duration._
-    private val renderer = new lila.common.Markdown(header = true, list = true, table = true)
-    private val cache = lila.memo.CacheApi.scaffeineNoScheduler
-      .expireAfterAccess(10 minutes)
-      .maximumSize(1024)
-      .build[String, String]()
-    def apply(team: Team, text: String): Frag = raw(cache.get(text, renderer(s"team:${team.id}")))
-  }
 
   // handle special teams here
   private def joinButton(t: Team)(implicit ctx: Context) =


### PR DESCRIPTION
fix for #10875

Testing this reveals a related issue, markdown description displayed raw in team lists.  This isn't a huge problem and there's probably overhead/other implications of applying markdown there as well, but it's something to keep in mind - I haven't thought about it any.