### PR TITLE
username in window title as dev config option

### DIFF
--- a/app/views/base/layout.scala
+++ b/app/views/base/layout.scala
@@ -240,6 +240,7 @@ object layout {
           st.headTitle {
             if (ctx.blind) "lichess"
             else if (netConfig.isProd) fullTitle | s"$title • lichess.org"
+            else if (env.user.config.showInWindowTitle) ctx.me ?? {_.username}
             else s"[dev] ${fullTitle | s"$title • lichess.dev"}"
           },
           cssTag("site"),

--- a/conf/application.conf.default
+++ b/conf/application.conf.default
@@ -4,4 +4,8 @@ include "version"
 # change for additional encryption of password hashes
 user.password.bpass.secret = "9qEYN0ThHer1KWLNekA76Q=="
 
+# set to true to display the logged in username as the tab title
+# (useful for ff containerized logins)
+user.show_in_window_title = false
+
 # override values from base.conf here

--- a/conf/base.conf
+++ b/conf/base.conf
@@ -397,6 +397,7 @@ evalCache {
   collection.evalCache = eval_cache
 }
 user {
+  show_in_window_title = false
   online.ttl = 7 seconds
   collection {
     user = user4

--- a/modules/user/src/main/Env.scala
+++ b/modules/user/src/main/Env.scala
@@ -12,7 +12,8 @@ import lila.common.config._
 import lila.common.LightUser
 import lila.db.dsl.Coll
 
-private class UserConfig(
+class UserConfig(
+    @ConfigName( "show_in_window_title") val showInWindowTitle: Boolean,
     @ConfigName("online.ttl") val onlineTtl: FiniteDuration,
     @ConfigName("collection.user") val collectionUser: CollName,
     @ConfigName("collection.note") val collectionNote: CollName,
@@ -37,7 +38,7 @@ final class Env(
     ws: StandaloneWSClient
 ) {
 
-  private val config = appConfig.get[UserConfig]("user")(AutoConfig.loader)
+  val config = appConfig.get[UserConfig]("user")(AutoConfig.loader)
 
   val repo = new UserRepo(db(config.collectionUser))
 


### PR DESCRIPTION
This is used for testing multi-user features (basically everything in Lila) with containerized tabs.  If you don't want to make UserConfig public, that's fine can put the option wherever.  or just make it default - seems more useful than [dev] localhost to me.