### PR TITLE
Implement premoves in nvui

### DIFF
--- a/ui/round/src/ctrl.ts
+++ b/ui/round/src/ctrl.ts
@@ -486,7 +486,8 @@ export default class RoundController {
       // https://github.com/lichess-org/lila/issues/343
       const premoveDelay = d.game.variant.key === 'atomic' ? 100 : 1;
       setTimeout(() => {
-        if (!this.chessground.playPremove() && !this.playPredrop()) {
+        if (this.nvui) this.nvui.playPremove(this);
+        else if (!this.chessground.playPremove() && !this.playPredrop()) {
           this.promotion.cancel();
           this.showYourMoveNotification();
         }

--- a/ui/round/src/interfaces.ts
+++ b/ui/round/src/interfaces.ts
@@ -16,6 +16,9 @@ export interface Untyped {
 }
 
 export interface NvuiPlugin {
+  submitMove?: (submitStoredPremove?: boolean) => void;
+  playPremove: (ctrl: RoundController) => void;
+  premoveInput: string;
   render(ctrl: RoundController): VNode;
 }
 

--- a/ui/round/src/plugins/nvui.ts
+++ b/ui/round/src/plugins/nvui.ts
@@ -303,10 +303,9 @@ export default function (redraw: Redraw): NvuiPlugin {
 function createSubmitHandler(ctrl: RoundController, notify: (txt: string) => void, style: () => Style, $input: Cash) {
   return (submitStoredPremove = false) => {
     const nvui = ctrl.nvui!;
-    if (submitStoredPremove && nvui.premoveInput === '') return false;
 
-    let input = submitStoredPremove ? nvui.premoveInput : castlingFlavours(($input.val() as string).trim());
-    if (!submitStoredPremove && input === '') {
+    if (submitStoredPremove && nvui.premoveInput === '') return false;
+    if (!submitStoredPremove && $input.val() === '') {
       if (nvui.premoveInput !== '') {
         // if this is not a premove submission, the input is empty, and we have a stored premove, clear it
         nvui.premoveInput = '';
@@ -314,6 +313,8 @@ function createSubmitHandler(ctrl: RoundController, notify: (txt: string) => voi
       } else notify('Invalid move');
       return false;
     }
+
+    let input = submitStoredPremove ? nvui.premoveInput : castlingFlavours(($input.val() as string).trim());
 
     // commands may be submitted with or without a leading /
     if (isShortCommand(input)) input = '/' + input;


### PR DESCRIPTION
Resolves #10849. Normally, inputting premoves happens via the chessground ui, but we have to do so differently in nvui.  The nvui plug in now holds a bit of state (the premove input) as well as more functions to achieve premove functionality.