### PR TITLE
Fix variant PGN imports

### DIFF
--- a/modules/importer/src/main/Importer.scala
+++ b/modules/importer/src/main/Importer.scala
@@ -32,7 +32,7 @@ final class Importer(gameRepo: GameRepo)(implicit ec: scala.concurrent.Execution
 
   def inMemory(data: ImportData): Validated[String, (Game, Option[FEN])] =
     data.preprocess(user = none).flatMap { case Preprocessed(game, _, fen, _) =>
-      if (Encoder.encode(game.sloppy.pgnMoves.toArray) == null)
+      if (game.variant.standard && Encoder.encode(game.sloppy.pgnMoves.toArray) == null)
         Validated.invalid("The PGN contains illegal and/or ambiguous moves.")
       else
         Validated.valid((game withId "synthetic", fen))


### PR DESCRIPTION
The validation from #10887 doesn't work for variant PGNs since the move compression only handles standard games so everything else is invalid by default. This causes all imports of variant PGNs (e.g. on /analysis) including FromPosition setups with at least one move to fail.

Probably would make sense to validate them some other way but for now, reverting the validation on variant games at least makes imports work again.