### PR TITLE
Make `rankban` permission admin only

### DIFF
--- a/modules/security/src/main/Permission.scala
+++ b/modules/security/src/main/Permission.scala
@@ -101,7 +101,6 @@ object Permission {
           GamifyView,
           SeeReport,
           ModLog,
-          RemoveRanking,
           ModMessage,
           ModNote,
           ViewPrintNoIP,
@@ -159,6 +158,7 @@ object Permission {
       extends Permission(
         "ADMIN",
         List(
+          RemoveRanking,
           BoostHunter,
           CheatHunter,
           Shusher,


### PR DESCRIPTION
As discussed on zulip: https://hq.lichess.ovh/#narrow/stream/24-mod-hunter-boost/topic/rankban.20permission