### PR TITLE
Actually only query the YouTube API every 15 mins

### DIFF
--- a/modules/streamer/src/main/Streaming.scala
+++ b/modules/streamer/src/main/Streaming.scala
@@ -100,9 +100,7 @@ final private class Streaming(
     (youtubeStreamers.nonEmpty && googleApiKey.value.nonEmpty) ?? {
       val now = DateTime.now
       val res =
-        if (prevYouTubeStreams.list.isEmpty && prevYouTubeStreams.at.isAfter(now minusMinutes 15))
-          fuccess(prevYouTubeStreams)
-        else if (prevYouTubeStreams.at.isAfter(now minusMinutes 1))
+        if (prevYouTubeStreams.at.isAfter(now minusMinutes 15))
           fuccess(prevYouTubeStreams)
         else {
           ws.url("https://www.googleapis.com/youtube/v3/search")


### PR DESCRIPTION
I think the first condition was supposed to be a longer delay in case the previous call failed? Which probably shouldn't be needed now? Unless we want to set it to something even longer? But given that the API quota only seems to reset once a day and for actual errors 15 mins seems like a fine delay, I'm not sure there's much of a point to that.

From the monitoring, I think what currently happens is that the API quota resets once a day, then we immediately use it up with the once-a-minute calls, and then it starts failing and switches to 15 mins waits (but ofc never succeeds until the next day).

So I think this should fix #10921