### PR TITLE
Allow Shushers to see team mod view again

### DIFF
--- a/app/controllers/Team.scala
+++ b/app/controllers/Team.scala
@@ -44,7 +44,7 @@ final class Team(
   def show(id: String, page: Int, mod: Boolean) =
     Open { implicit ctx =>
       Reasonable(page) {
-        OptionFuOk(api team id) { renderTeam(_, page, mod && isGranted(_.ManageTeam)) }
+        OptionFuOk(api team id) { renderTeam(_, page, mod) }
       }
     }
 
@@ -63,7 +63,7 @@ final class Team(
     for {
       info    <- env.teamInfo(team, ctx.me, withForum = canHaveForum(team, requestModView))
       members <- paginator.teamMembers(team, page)
-      log     <- requestModView.??(env.mod.logApi.teamLog(team.id))
+      log     <- (requestModView && isGranted(_.ManageTeam)).??(env.mod.logApi.teamLog(team.id))
       hasChat = canHaveChat(team, info, requestModView)
       chat <-
         hasChat ?? env.chat.api.userChat.cached


### PR DESCRIPTION
After https://github.com/lichess-org/lila/commit/e6657dac818ce57a2032931a9f5004fe7b4e033d

Everywhere else it already checked for the relevant perms (shusher to see chat, forum mod to see the forum, other stuff only for ManageTeam).

Shushers sometimes need to see this for comms reports.