### PR TITLE
don't autoscroll when clicking in analysis move list

### DIFF
--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -353,7 +353,7 @@ export default class AnalyseCtrl {
 
   playedLastMoveMyself = () => !!this.justPlayed && !!this.node.uci && this.node.uci.startsWith(this.justPlayed);
 
-  jump(path: Tree.Path, autoscroll: boolean = true): void {
+  jump(path: Tree.Path, autoscroll = true): void {
     const pathChanged = path !== this.path,
       isForwardStep = pathChanged && path.length == this.path.length + 2;
     this.setPath(path);
@@ -388,7 +388,7 @@ export default class AnalyseCtrl {
     this.showGround();
   }
 
-  userJump = (path: Tree.Path, autoscroll: boolean = true): void => {
+  userJump = (path: Tree.Path, autoscroll = true): void => {
     this.autoplay.stop();
     if (!this.gamebookPlay()) this.withCg(cg => cg.selectSquare(null));
     if (this.practice) {

--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -353,7 +353,7 @@ export default class AnalyseCtrl {
 
   playedLastMoveMyself = () => !!this.justPlayed && !!this.node.uci && this.node.uci.startsWith(this.justPlayed);
 
-  jump(path: Tree.Path): void {
+  jump(path: Tree.Path, autoscroll: boolean = true): void {
     const pathChanged = path !== this.path,
       isForwardStep = pathChanged && path.length == this.path.length + 2;
     this.setPath(path);
@@ -376,7 +376,7 @@ export default class AnalyseCtrl {
     this.justPlayed = this.justDropped = this.justCaptured = undefined;
     this.explorer.setNode();
     this.updateHref();
-    this.autoScroll();
+    if (autoscroll) this.autoScroll();
     this.promotion.cancel();
     if (pathChanged) {
       if (this.retro) this.retro.onJump();
@@ -388,15 +388,15 @@ export default class AnalyseCtrl {
     this.showGround();
   }
 
-  userJump = (path: Tree.Path): void => {
+  userJump = (path: Tree.Path, autoscroll: boolean = true): void => {
     this.autoplay.stop();
     if (!this.gamebookPlay()) this.withCg(cg => cg.selectSquare(null));
     if (this.practice) {
       const prev = this.path;
       this.practice.preUserJump(prev, path);
-      this.jump(path);
+      this.jump(path, autoscroll);
       this.practice.postUserJump(prev, this.path);
-    } else this.jump(path);
+    } else this.jump(path, autoscroll);
   };
 
   canJumpTo = (path: Tree.Path): boolean => !this.study || this.study.canJumpTo(path);

--- a/ui/analyse/src/treeView/treeView.ts
+++ b/ui/analyse/src/treeView/treeView.ts
@@ -138,7 +138,7 @@ export function mainHook(ctrl: AnalyseCtrl): Hooks {
       el.addEventListener('mousedown', (e: MouseEvent) => {
         if (defined(e.button) && e.button !== 0) return; // only touch or left click
         const path = eventPath(e);
-        if (path) ctrl.userJump(path);
+        if (path) ctrl.userJump(path, false);
         ctrl.redraw();
       });
     },


### PR DESCRIPTION
#10864

keyboard nav and playback still trigger autoscroll, just clicks have been changed.

Was thinking about a toggle option but that hamburger menu has too many pieces of meat in it already.  Submitting this PR on the off chance that the behavior was not intentional.  It is pretty bizarre.  Maybe it's just a side effect of the useful and sensible autoscroll for keyboard/scripted events.