### PR TITLE
setup: Disallow empty rating range

### DIFF
--- a/ui/lobby/src/setupCtrl.ts
+++ b/ui/lobby/src/setupCtrl.ts
@@ -128,6 +128,10 @@ export default class SetupController {
     if (this.gameMode() === 'rated' && this.ratedModeDisabled()) {
       this.gameMode = this.propWithApply('casual');
     }
+
+    if (this.ratingMin() === 0 && this.ratingMax() === 0) {
+      this.ratingMax = this.propWithApply(50);
+    }
   };
 
   private savePropsToStore = () =>

--- a/ui/lobby/src/view/setup/components/ratingDifferenceSliders.ts
+++ b/ui/lobby/src/view/setup/components/ratingDifferenceSliders.ts
@@ -19,7 +19,11 @@ export const ratingDifferenceSliders = (ctrl: LobbyController) => {
             value: setupCtrl.ratingMin(),
           },
           on: {
-            input: (e: Event) => setupCtrl.ratingMin(parseInt((e.target as HTMLInputElement).value)),
+            input: (e: Event) => {
+              const newVal = parseInt((e.target as HTMLInputElement).value);
+              if (newVal === 0 && setupCtrl.ratingMax() === 0) setupCtrl.ratingMax(50);
+              setupCtrl.ratingMin(newVal);
+            },
           },
         }),
         h('span.rating-min', '-' + Math.abs(setupCtrl.ratingMin())),
@@ -34,7 +38,11 @@ export const ratingDifferenceSliders = (ctrl: LobbyController) => {
             value: setupCtrl.ratingMax(),
           },
           on: {
-            input: (e: Event) => setupCtrl.ratingMax(parseInt((e.target as HTMLInputElement).value)),
+            input: (e: Event) => {
+              const newVal = parseInt((e.target as HTMLInputElement).value);
+              if (newVal === 0 && setupCtrl.ratingMin() === 0) setupCtrl.ratingMin(-50);
+              setupCtrl.ratingMax(newVal);
+            },
           },
         }),
       ]),


### PR DESCRIPTION
Don't love the implementation but this seems like the most user-friendly way to handle this.

Alternative might be to silently (or maybe even explicitly) increase 0-0 to -25 - 25 or something like that?