### PR TITLE
Fix issue where tile colours of past puzzle activity don't match rating changes

### DIFF
--- a/ui/puzzle/src/view/main.ts
+++ b/ui/puzzle/src/view/main.ts
@@ -152,7 +152,7 @@ function session(ctrl: Controller) {
             : round.ratingDiff
           : null;
       return h(
-        `a.result-${round.result}${rd ? '' : '.result-empty'}`,
+        `a.result-${round.ratingDiff == null ? round.result : round.ratingDiff > 0}${rd ? '' : '.result-empty'}`,
         {
           key: round.id,
           class: {


### PR DESCRIPTION
The cause of #10990 is that the tile is created using `round.result` which changes based on the most recent attempt on the puzzle by the user within the session.

This change makes it so:
 - If `ratingDiff` is defined (using `== null` to check for both `null` and `undefined) then we use its value to determine the tile colour.
 - If `ratingDiff` is not defined, which happens when you do puzzles while not logged in, then we default back to the old logic of using the most recent result.

I tested these changes on puzzles while logged in and not logged in. Dev site showing correct tile colours:
![Screenshot from 2022-06-08 00-49-56](https://user-images.githubusercontent.com/30640147/172543763-64460806-6831-4d55-b0ae-4e4c3c806e34.png)

Let me know what you think :)