### PR TITLE
Chat Spam Filter Update

### DIFF
--- a/ui/chat/src/spam.ts
+++ b/ui/chat/src/spam.ts
@@ -1,12 +1,13 @@
 import * as xhr from 'common/xhr';
 
-export const skip = (txt: string) => (suspLink(txt) || followMe(txt)) && !isKnownSpammer();
+export const skip = (txt: string) => (suspLink(txt) || suspWords(txt) || followMe(txt)) && !isKnownSpammer();
 
 export const selfReport = (txt: string) => {
   if (isKnownSpammer()) return;
   const hasSuspLink = suspLink(txt);
-  if (hasSuspLink) xhr.text(`/jslog/${window.location.href.substr(-12)}?n=spam`, { method: 'post' });
-  if (hasSuspLink || followMe(txt)) lichess.storage.set('chat-spam', '1');
+  const hasSusWords = suspWords(txt);
+  if (hasSuspLink || hasSusWords) xhr.text(`/jslog/${window.location.href.substr(-12)}?n=spam`, { method: 'post' });
+  if (hasSuspLink || followMe(txt) || hasSusWords) lichess.storage.set('chat-spam', '1');
 };
 
 const isKnownSpammer = () => lichess.storage.get('chat-spam') == '1';
@@ -44,7 +45,15 @@ const spamRegex = new RegExp(
     .join('|')
 );
 
+const susWordsRegex = new RegExp(
+  [
+    'penis',
+    'fuck you',
+  ]);
+
 const suspLink = (txt: string) => !!txt.match(spamRegex);
+
+const suspWords = (txt: string) => !!txt.match(susWordsRegex);
 
 const followMeRegex = /follow me|join my team/i;
 const followMe = (txt: string) => !!txt.match(followMeRegex);

--- a/ui/chat/src/spam.ts
+++ b/ui/chat/src/spam.ts
@@ -1,57 +1,56 @@
-import * as xhr from 'common/xhr';
+import * as xhr from "common/xhr";
 
-export const skip = (txt: string) => (suspLink(txt) || suspWords(txt) || followMe(txt)) && !isKnownSpammer();
+export const skip = (txt: string) =>
+  (suspLink(txt) || suspWords(txt) || followMe(txt)) && !isKnownSpammer();
 
 export const selfReport = (txt: string) => {
   if (isKnownSpammer()) return;
   const hasSuspLink = suspLink(txt);
   const hasSusWords = suspWords(txt);
-  if (hasSuspLink || hasSusWords) xhr.text(`/jslog/${window.location.href.substr(-12)}?n=spam`, { method: 'post' });
-  if (hasSuspLink || followMe(txt) || hasSusWords) lichess.storage.set('chat-spam', '1');
+  if (hasSuspLink || hasSusWords)
+    xhr.text(`/jslog/${window.location.href.substr(-12)}?n=spam`, {
+      method: "post",
+    });
+  if (hasSuspLink || followMe(txt) || hasSusWords)
+    lichess.storage.set("chat-spam", "1");
 };
 
-const isKnownSpammer = () => lichess.storage.get('chat-spam') == '1';
+const isKnownSpammer = () => lichess.storage.get("chat-spam") == "1";
 
 const spamRegex = new RegExp(
   [
-    'xcamweb.com',
-    '(^|[^i])chess-bot',
-    'chess-cheat',
-    'coolteenbitch',
-    'letcafa.webcam',
-    'tinyurl.com/',
-    'wooga.info/',
-    'bit.ly/',
-    'wbt.link/',
-    'eb.by/',
-    '001.rs/',
-    'shr.name/',
-    'u.to/',
-    '.3-a.net',
-    '.ssl443.org',
-    '.ns02.us',
-    '.myftp.info',
-    '.flinkup.com',
-    '.serveusers.com',
-    'badoogirls.com',
-    'hide.su',
-    'wyon.de',
-    'sexdatingcz.club',
-    'qps.ru',
-    'tiny.cc/',
-    'trasderk.blogspot.com',
+    "xcamweb.com",
+    "(^|[^i])chess-bot",
+    "chess-cheat",
+    "coolteenbitch",
+    "letcafa.webcam",
+    "tinyurl.com/",
+    "wooga.info/",
+    "bit.ly/",
+    "wbt.link/",
+    "eb.by/",
+    "001.rs/",
+    "shr.name/",
+    "u.to/",
+    ".3-a.net",
+    ".ssl443.org",
+    ".ns02.us",
+    ".myftp.info",
+    ".flinkup.com",
+    ".serveusers.com",
+    "badoogirls.com",
+    "hide.su",
+    "wyon.de",
+    "sexdatingcz.club",
+    "qps.ru",
+    "tiny.cc/",
+    "trasderk.blogspot.com",
   ]
-    .map(url => url.replace(/\./g, '\\.').replace(/\//g, '\\/'))
-    .join('|')
+    .map((url) => url.replace(/\./g, "\\.").replace(/\//g, "\\/"))
+    .join("|")
 );
 
-const susWordsRegex = new RegExp(
-  [
-    'penis',
-    'fuck you',
-  ]
-  .join('|')
-  );
+const susWordsRegex = new RegExp(["penis", "fuck you"].join("|"));
 
 const suspLink = (txt: string) => !!txt.match(spamRegex);
 

--- a/ui/chat/src/spam.ts
+++ b/ui/chat/src/spam.ts
@@ -49,7 +49,9 @@ const susWordsRegex = new RegExp(
   [
     'penis',
     'fuck you',
-  ]);
+  ]
+  .join('|')
+  );
 
 const suspLink = (txt: string) => !!txt.match(spamRegex);
 


### PR DESCRIPTION
I added a regex targeting insults and offensive words. I did a second one, because the other one does url operations on the given links.
When implementing the second regex, I followed the scheme of the first regex, please look at it, but it didn't detect any errors on my laptop.
The list must be extended to address a broad variety of messages.