### PR TITLE
[Bugfix] Remove duplicate error messages on email validation

### DIFF
--- a/app/templating/FormHelper.scala
+++ b/app/templating/FormHelper.scala
@@ -44,7 +44,7 @@ trait FormHelper { self: I18nHelper =>
     private def groupLabel(field: Field) = label(cls := "form-label", `for` := id(field))
     private val helper                   = small(cls := "form-help")
 
-    private def errors(errs: Seq[FormError])(implicit ctx: Context): Frag = errs map error
+    private def errors(errs: Seq[FormError])(implicit ctx: Context): Frag = errs.distinct map error
     private def errors(field: Field)(implicit ctx: Context): Frag         = errors(field.errors)
     private def error(err: FormError)(implicit ctx: Context): Frag =
       p(cls := "error")(transKey(err.message, err.args))


### PR DESCRIPTION
Just gonna describe the bug here for simplicity

**Issue Description**
Happens on all OSes and browsers.

1. Go to signup page
2. Put in a random username and password
3. Put `1@gamil.com` as the email (or any clearly illegal email with a domain from [here](https://github.com/lichess-org/lila/blob/c48da4e2cd22837a9f6e8b7eb4a59924967aec3f/modules/security/src/main/DisposableEmailDomain.scala#L49))
4. Click Register
5. Account creation fails with the error message repeated:
![image](https://user-images.githubusercontent.com/30640147/172762349-10daaf30-b01a-48fb-8e38-d1380f88d9c9.png)

This should happen on all instances of `form3` with email validation.

**Issue cause**
An email like `1@gamil.com` triggers multiple instances of `ValidationError("error.email_acceptable")` which are mapped to the same error string. The form displays an error string per instance of this error. Using [distinct](https://www.scala-lang.org/api/current/scala/collection/Seq.html#distinct:C) prevents these duplicate errors.

Not sure if other forms on the site have similar issues but this is the one I found.

**Tested**
Dev lichess without the change:
![Screenshot from 2022-06-09 00-04-30](https://user-images.githubusercontent.com/30640147/172762759-daf06da2-8119-49d9-aeee-65a5f9a5ba6f.png)

Dev with the change:
![Screenshot from 2022-06-09 00-01-28](https://user-images.githubusercontent.com/30640147/172762774-34b25565-4823-4719-a91b-19653d53510f.png)
