### PR TITLE
suggest additional languages by country

### DIFF
--- a/modules/i18n/src/main/I18nLangPicker.scala
+++ b/modules/i18n/src/main/I18nLangPicker.scala
@@ -20,7 +20,8 @@ object I18nLangPicker {
     }
 
   def allFromRequestHeaders(req: RequestHeader): List[Lang] =
-    req.acceptLanguages.flatMap(findCloser).distinct.toList
+    (req.acceptLanguages.flatMap(findCloser) ++
+      req.acceptLanguages.flatMap(lang => ~byCountry.get(lang.country))).distinct.toList
 
   def byStr(str: String): Option[Lang] =
     Lang get str flatMap findCloser
@@ -37,6 +38,9 @@ object I18nLangPicker {
     LangList.all.keys.foldLeft(Map.empty[String, Lang]) { case (acc, lang) =>
       acc + (lang.language -> lang)
     } ++ LangList.defaultRegions
+
+  private val byCountry: Map[String, List[Lang]] =
+    LangList.all.keys.toList.groupBy(_.country)
 
   def findCloser(to: Lang): Option[Lang] =
     if (LangList.all.keySet contains to) Some(to)

--- a/modules/i18n/src/main/LangList.scala
+++ b/modules/i18n/src/main/LangList.scala
@@ -38,7 +38,7 @@ object LangList {
     Lang("ga", "IE")  -> "Gaeilge",
     Lang("gd", "GB")  -> "Gàidhlig",
     Lang("gl", "ES")  -> "Galego",
-    Lang("gsw", "CH")  -> "Schwizerdütsch",
+    Lang("gsw", "CH") -> "Schwizerdütsch",
     Lang("gu", "IN")  -> "ગુજરાતી",
     Lang("he", "IL")  -> "עִבְרִית",
     Lang("hi", "IN")  -> "हिन्दी, हिंदी",


### PR DESCRIPTION
https://hq.lichess.ovh/#narrow/stream/16-dev-translation/topic/using.20country.20in.20language.20selector

country codes that have multiple languages (which users may not even look for in the full list):

```
{'en-GB', 'gd-GB', 'cy-GB'}
{'af-ZA', 'zu-ZA'}
{'es-ES', 'gl-ES', 'ca-ES', 'eu-ES', 'an-ES'}
{'gu-IN', 'hi-IN', 'ta-IN', 'kn-IN', 'pi-IN', 'mr-IN', 'ml-IN', 'as-IN', 'sa-IN'}
{'co-FR', 'fr-FR', 'br-FR'}
{'it-IT', 'frp-IT'}
{'fy-NL', 'nl-NL'}
{'id-ID', 'jv-ID'}
{'io-EN', 'jbo-EN'}
{'kmr-TR', 'tr-TR'}
{'nb-NO', 'nn-NO'}
```