### PR TITLE
fix move list indices when playing from fen with fullmove specified

### DIFF
--- a/ui/round/src/view/replay.ts
+++ b/ui/round/src/view/replay.ts
@@ -117,7 +117,7 @@ function renderMoves(ctrl: RoundController): MaybeVNodes {
   const els: MaybeVNodes = [],
     curPly = ctrl.ply;
   for (let i = 0; i < pairs.length; i++) {
-    els.push(h(indexTag, firstPly + indexOffset + ''));
+    els.push(h(indexTag, i + indexOffset + ''));
     els.push(renderMove(pairs[i][0], curPly, true, drawPlies));
     els.push(renderMove(pairs[i][1], curPly, false, drawPlies));
   }

--- a/ui/round/src/view/replay.ts
+++ b/ui/round/src/view/replay.ts
@@ -101,7 +101,9 @@ function renderMoves(ctrl: RoundController): MaybeVNodes {
   const steps = ctrl.data.steps,
     firstPly = round.firstPly(ctrl.data),
     lastPly = round.lastPly(ctrl.data),
+    indexOffset = Math.trunc(firstPly / 2) + 1,
     drawPlies = new Set(ctrl.data.game.drawOffers || []);
+
   if (typeof lastPly === 'undefined') return [];
 
   const pairs: Array<Array<any>> = [];
@@ -115,7 +117,7 @@ function renderMoves(ctrl: RoundController): MaybeVNodes {
   const els: MaybeVNodes = [],
     curPly = ctrl.ply;
   for (let i = 0; i < pairs.length; i++) {
-    els.push(h(indexTag, i + 1 + ''));
+    els.push(h(indexTag, firstPly + indexOffset + ''));
     els.push(renderMove(pairs[i][0], curPly, true, drawPlies));
     els.push(renderMove(pairs[i][1], curPly, false, drawPlies));
   }


### PR DESCRIPTION
#10989 - the bug where play from fen (copied from game in progress) resulted in move list being unclickable.  With this change, the game will use the FEN's fullmove value as the starting move index (if present) rather than 1 and the user will see this in the index column ("why is 22 the first move?").  However, this is how it works in analysis, so I figured that's better than other solutions such as truncating fullmove from FEN in Lila when creating from position.