### PR TITLE
Add tournament conditions to API

### DIFF
--- a/modules/tournament/src/main/ApiJsonView.scala
+++ b/modules/tournament/src/main/ApiJsonView.scala
@@ -60,6 +60,9 @@ final class ApiJsonView(lightUserApi: LightUserApi)(implicit ec: scala.concurren
       .add("hasMaxRating", tour.conditions.maxRating.isDefined) // BC
       .add[Condition.RatingCondition]("maxRating", tour.conditions.maxRating)
       .add[Condition.RatingCondition]("minRating", tour.conditions.minRating)
+      .add("minRatedGames", tour.conditions.nbRatedGame)
+      .add("onlyTitled", tour.conditions.titled.isDefined)
+      .add("teamMember", tour.conditions.teamMember.map(_.teamId))
       .add("private", tour.isPrivate)
       .add("position", tour.position.map(positionJson))
       .add("schedule", tour.schedule map scheduleJson)

--- a/modules/tournament/src/main/Condition.scala
+++ b/modules/tournament/src/main/Condition.scala
@@ -239,6 +239,13 @@ object Condition {
           "rating" -> r.rating
         )
       }
+
+    implicit val nbRatedGameConditionWrites: OWrites[Condition.NbRatedGame] =
+      OWrites[Condition.NbRatedGame] { r =>
+        Json
+          .obj("nb" -> r.nb)
+          .add("perf" -> r.perf.map(_.key))
+      }
   }
 
   object DataForm {

--- a/modules/tournament/src/main/JsonView.scala
+++ b/modules/tournament/src/main/JsonView.scala
@@ -131,14 +131,12 @@ final class JsonView(
           })
           .add("description" -> tour.description)
           .add("myUsername" -> me.map(_.username))
-      } ++
-      tour.conditions.relevant ?? Json
-        .obj()
-        .add[Condition.RatingCondition]("minRating", tour.conditions.minRating)
-        .add[Condition.RatingCondition]("maxRating", tour.conditions.maxRating)
-        .add("nbRatedGame", tour.conditions.nbRatedGame)
-        .add("titled", tour.conditions.titled.isDefined)
-        .add("teamMember", tour.conditions.teamMember.map(_.teamId))
+          .add[Condition.RatingCondition]("minRating", tour.conditions.minRating)
+          .add[Condition.RatingCondition]("maxRating", tour.conditions.maxRating)
+          .add("minRatedGames", tour.conditions.nbRatedGame)
+          .add("onlyTitled", tour.conditions.titled.isDefined)
+          .add("teamMember", tour.conditions.teamMember.map(_.teamId))
+      }
 
   def addReloadEndpoint(js: JsObject, tour: Tournament, useLilaHttp: Tournament => Boolean) =
     js + ("reloadEndpoint" -> JsString({

--- a/modules/tournament/src/main/JsonView.scala
+++ b/modules/tournament/src/main/JsonView.scala
@@ -37,6 +37,7 @@ final class JsonView(
 )(implicit ec: ExecutionContext) {
 
   import JsonView._
+  import Condition.JSONHandlers._
 
   def apply(
       tour: Tournament,
@@ -121,14 +122,21 @@ final class JsonView(
           .add("teamBattle" -> tour.teamBattle.map { battle =>
             Json
               .obj(
-                "teams" -> JsObject(battle.sortedTeamIds.map { id =>
-                  id -> JsString(getTeamName(id).getOrElse(id))
-                })
+                "teams" -> JsObject(
+                  battle.sortedTeamIds.map { id =>
+                    id -> JsString(getTeamName(id).getOrElse(id))
+                  },
+                  "nbLeaders" -> battle.nbLeaders
+                )
               )
               .add("joinWith" -> me.isDefined.option(teamsToJoinWith.sorted))
           })
           .add("description" -> tour.description)
           .add("myUsername" -> me.map(_.username))
+          .add[Condition.RatingCondition]("maxRating", tour.conditions.maxRating)
+          .add[Condition.RatingCondition]("minRating", tour.conditions.minRating)
+          .add("minRatedGames", tour.conditions.nbRatedGames)
+          .add("onlyTitled", tour.conditions.titled.isDefined)
       }
 
   def addReloadEndpoint(js: JsObject, tour: Tournament, useLilaHttp: Tournament => Boolean) =

--- a/modules/tournament/src/main/JsonView.scala
+++ b/modules/tournament/src/main/JsonView.scala
@@ -131,11 +131,14 @@ final class JsonView(
           })
           .add("description" -> tour.description)
           .add("myUsername" -> me.map(_.username))
-          .add[Condition.RatingCondition]("maxRating", tour.conditions.maxRating)
-          .add[Condition.RatingCondition]("minRating", tour.conditions.minRating)
-          .add("minRatedGames", tour.conditions.nbRatedGames)
-          .add("onlyTitled", tour.conditions.titled.isDefined)
-      }
+      } ++
+      tour.conditions.relevant ?? Json
+        .obj()
+        .add[Condition.RatingCondition]("minRating", tour.conditions.minRating)
+        .add[Condition.RatingCondition]("maxRating", tour.conditions.maxRating)
+        .add("nbRatedGame", tour.conditions.nbRatedGame)
+        .add("titled", tour.conditions.titled.isDefined)
+        .add("teamMember", tour.conditions.teamMember.map(_.teamId))
 
   def addReloadEndpoint(js: JsObject, tour: Tournament, useLilaHttp: Tournament => Boolean) =
     js + ("reloadEndpoint" -> JsString({

--- a/modules/tournament/src/main/JsonView.scala
+++ b/modules/tournament/src/main/JsonView.scala
@@ -122,12 +122,10 @@ final class JsonView(
           .add("teamBattle" -> tour.teamBattle.map { battle =>
             Json
               .obj(
-                "teams" -> JsObject(
-                  battle.sortedTeamIds.map { id =>
-                    id -> JsString(getTeamName(id).getOrElse(id))
-                  },
-                  "nbLeaders" -> battle.nbLeaders
-                )
+                "teams" -> JsObject(battle.sortedTeamIds.map { id =>
+                  id -> JsString(getTeamName(id).getOrElse(id))
+                }),
+                "nbLeaders" -> battle.nbLeaders
               )
               .add("joinWith" -> me.isDefined.option(teamsToJoinWith.sorted))
           })


### PR DESCRIPTION
Since you can't update the tournament without knowing these (bc they will be reset if you don't specify them again).

Not sure about adding the team member condition, it might be useful to know but at least isn't necessary for updating them and probably isn't useful to know in most cases?

Also, I noticed that you can also specify the perf type for all the conditions but it's not explained in the docs or shown in the UI. Are they intentionally hidden or should they be added? ig if they shouldn't be used, probably would make sense to block them instead?