### PR TITLE
Move "hide ratings" pref to "display" (renamed from "game display") and rename "site settings" back to "privacy"

### DIFF
--- a/app/controllers/Pref.scala
+++ b/app/controllers/Pref.scala
@@ -23,16 +23,23 @@ final class Pref(env: Env) extends LilaController(env) {
       }
     }
 
+  private val redirects = Map(
+    "game-display" -> "display",
+    "site"         -> "privacy"
+  )
+
   def form(categSlug: String) =
-    if (categSlug == "game-display") Action.async(Redirect(routes.Pref.form("display")).fuccess)
-    else
-      Auth { implicit ctx => me =>
-        lila.pref.PrefCateg(categSlug) match {
-          case None => notFound
-          case Some(categ) =>
-            Ok(html.account.pref(me, forms prefOf ctx.pref, categ)).fuccess
+    redirects get categSlug match {
+      case Some(redir) => Action.async(Redirect(routes.Pref.form(redir)).fuccess)
+      case None =>
+        Auth { implicit ctx => me =>
+          lila.pref.PrefCateg(categSlug) match {
+            case None => notFound
+            case Some(categ) =>
+              Ok(html.account.pref(me, forms prefOf ctx.pref, categ)).fuccess
+          }
         }
-      }
+    }
 
   def formApply =
     AuthBody { implicit ctx => _ =>

--- a/app/controllers/Pref.scala
+++ b/app/controllers/Pref.scala
@@ -24,13 +24,15 @@ final class Pref(env: Env) extends LilaController(env) {
     }
 
   def form(categSlug: String) =
-    Auth { implicit ctx => me =>
-      lila.pref.PrefCateg(categSlug) match {
-        case None => notFound
-        case Some(categ) =>
-          Ok(html.account.pref(me, forms prefOf ctx.pref, categ)).fuccess
+    if (categSlug == "game-display") Action.async(Redirect(routes.Pref.form("display")).fuccess)
+    else
+      Auth { implicit ctx => me =>
+        lila.pref.PrefCateg(categSlug) match {
+          case None => notFound
+          case Some(categ) =>
+            Ok(html.account.pref(me, forms prefOf ctx.pref, categ)).fuccess
+        }
       }
-    }
 
   def formApply =
     AuthBody { implicit ctx => _ =>

--- a/app/controllers/Pref.scala
+++ b/app/controllers/Pref.scala
@@ -30,7 +30,7 @@ final class Pref(env: Env) extends LilaController(env) {
 
   def form(categSlug: String) =
     redirects get categSlug match {
-      case Some(redir) => Action.async(Redirect(routes.Pref.form(redir)).fuccess)
+      case Some(redir) => Action(Redirect(routes.Pref.form(redir)))
       case None =>
         Auth { implicit ctx => me =>
           lila.pref.PrefCateg(categSlug) match {

--- a/app/views/account/bits.scala
+++ b/app/views/account/bits.scala
@@ -25,9 +25,9 @@ object bits {
 
   def categName(categ: lila.pref.PrefCateg)(implicit ctx: Context): String =
     categ match {
-      case PrefCateg.GameDisplay  => trans.preferences.gameDisplay.txt()
+      case PrefCateg.Display      => trans.preferences.display.txt()
       case PrefCateg.ChessClock   => trans.preferences.chessClock.txt()
       case PrefCateg.GameBehavior => trans.preferences.gameBehavior.txt()
-      case PrefCateg.Site         => "Site settings"
+      case PrefCateg.Privacy      => trans.preferences.privacy.txt()
     }
 }

--- a/app/views/account/pref.scala
+++ b/app/views/account/pref.scala
@@ -46,7 +46,7 @@ object pref {
       div(cls := "account box box-pad")(
         h1(bits.categName(categ)),
         postForm(cls := "autosubmit", action := routes.Pref.formApply)(
-          categFieldset(PrefCateg.GameDisplay, categ)(
+          categFieldset(PrefCateg.Display, categ)(
             setting(
               pieceAnimation(),
               radios(form("display.animation"), translatedAnimationChoices)
@@ -86,6 +86,15 @@ object pref {
             setting(
               blindfoldChess(),
               radios(form("display.blindfold"), translatedBlindfoldChoices)
+            ),
+            setting(
+              showPlayerRatings(),
+              frag(
+                radios(form("ratings"), booleanChoices),
+                div(cls := "help text shy", dataIcon := "")(
+                  explainShowPlayerRatings()
+                )
+              )
             )
           ),
           categFieldset(PrefCateg.ChessClock, categ)(
@@ -167,7 +176,7 @@ object pref {
               radios(form("behavior.scrollMoves"), booleanChoices)
             )
           ),
-          categFieldset(PrefCateg.Site, categ)(
+          categFieldset(PrefCateg.Privacy, categ)(
             setting(
               trans.letOtherPlayersFollowYou(),
               radios(form("follow"), booleanChoices)
@@ -191,15 +200,6 @@ object pref {
             setting(
               trans.shareYourInsightsData(),
               radios(form("insightShare"), translatedInsightShareChoices)
-            ),
-            setting(
-              showPlayerRatings(),
-              frag(
-                radios(form("ratings"), booleanChoices),
-                div(cls := "help text shy", dataIcon := "")(
-                  explainShowPlayerRatings()
-                )
-              )
             )
           ),
           p(cls := "saved text none", dataIcon := "")(yourPreferencesHaveBeenSaved())

--- a/modules/i18n/src/main/I18nKeys.scala
+++ b/modules/i18n/src/main/I18nKeys.scala
@@ -1608,7 +1608,8 @@ val `thisAccountIsClosed` = new I18nKey("settings:thisAccountIsClosed")
 
 object preferences {
 val `preferences` = new I18nKey("preferences:preferences")
-val `gameDisplay` = new I18nKey("preferences:gameDisplay")
+val `display` = new I18nKey("preferences:display")
+val `privacy` = new I18nKey("preferences:privacy")
 val `pieceAnimation` = new I18nKey("preferences:pieceAnimation")
 val `materialDifference` = new I18nKey("preferences:materialDifference")
 val `boardHighlights` = new I18nKey("preferences:boardHighlights")

--- a/modules/pref/src/main/PrefCateg.scala
+++ b/modules/pref/src/main/PrefCateg.scala
@@ -4,12 +4,12 @@ sealed abstract class PrefCateg(val slug: String)
 
 object PrefCateg {
 
-  case object GameDisplay  extends PrefCateg("game-display")
+  case object Display      extends PrefCateg("display")
   case object ChessClock   extends PrefCateg("chess-clock")
   case object GameBehavior extends PrefCateg("game-behavior")
-  case object Site         extends PrefCateg("site")
+  case object Privacy      extends PrefCateg("privacy")
 
-  val all: List[PrefCateg] = List(GameDisplay, ChessClock, GameBehavior, Site)
+  val all: List[PrefCateg] = List(Display, ChessClock, GameBehavior, Privacy)
 
   def apply(slug: String) = all.find(_.slug == slug)
 }

--- a/translation/source/preferences.xml
+++ b/translation/source/preferences.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
   <string name="preferences">Preferences</string>
-  <string name="gameDisplay">Game display</string>
+  <string name="display">Display</string>
+  <string name="privacy">Privacy</string>
   <string name="pieceAnimation">Piece animation</string>
   <string name="materialDifference">Material difference</string>
   <string name="boardHighlights">Board highlights (last move and check)</string>

--- a/ui/dasher/src/links.ts
+++ b/ui/dasher/src/links.ts
@@ -23,7 +23,7 @@ export default function (ctrl: DasherCtrl): VNode {
           h(
             'a.text',
             linkCfg(
-              '/account/preferences/game-display',
+              '/account/preferences/display',
               '',
               ctrl.opts.playing ? { target: '_blank', rel: 'noopener' } : undefined
             ),

--- a/ui/dasher/src/view.ts
+++ b/ui/dasher/src/view.ts
@@ -10,9 +10,7 @@ import { view as boardView } from './board';
 import { view as themeView } from './theme';
 import { view as pieceView } from './piece';
 
-export function loading(): VNode {
-  return h('div#dasher_app.dropdown', h('div.initiating', spinner()));
-}
+export const loading = () => h('div#dasher_app.dropdown', h('div.initiating', spinner()));
 
 export function loaded(ctrl: DasherCtrl): VNode {
   let content: VNode | undefined;


### PR DESCRIPTION
Reviving #10052

Time to finally translate that settings category.

After thinking about it a bit more, I think it makes the most sense to rename "game display" to "display" and move "hide ratings" there. The privacy settings are all very clearly related and I think it's good to have an explicit "privacy" category to find that stuff.

Though "game display" also already has a fair amount of settings. If you think it's best not to add more to that, I guess the alternatives are a new category or just sticking with the "site settings" category and possibly finding a slightly better name for that (maybe "general settings" or "other settings"?).

imo, keeping it out of what is essentially just "privacy" is still better. Possibly, we could move it together with the courtesy setting (which really doesn't have much to do with game behavior) in a new "general" category?