### PR TITLE
[Bugfix] Fix initial clock values when only White berserks

### DIFF
--- a/modules/round/src/main/TreeBuilder.scala
+++ b/modules/round/src/main/TreeBuilder.scala
@@ -45,9 +45,9 @@ object TreeBuilder {
           fen = fen,
           check = init.situation.check,
           opening = openingOf(fen),
-          clock = withFlags.clocks ?? (game.clock ?? { c =>
-            Centis.ofSeconds(c.limitSeconds).some
-          }),
+          clock = withFlags.clocks ?? game.clock.map { c =>
+            Centis.ofSeconds(c.limitSeconds)
+          },
           crazyData = init.situation.board.crazyData,
           eval = infos lift 0 map makeEval
         )

--- a/modules/round/src/main/TreeBuilder.scala
+++ b/modules/round/src/main/TreeBuilder.scala
@@ -45,7 +45,9 @@ object TreeBuilder {
           fen = fen,
           check = init.situation.check,
           opening = openingOf(fen),
-          clock = withClocks.flatMap(_.headOption),
+          clock = withFlags.clocks ?? (game.clock ?? { c =>
+              Centis.ofSeconds(c.limitSeconds).some
+          }),
           crazyData = init.situation.board.crazyData,
           eval = infos lift 0 map makeEval
         )

--- a/modules/round/src/main/TreeBuilder.scala
+++ b/modules/round/src/main/TreeBuilder.scala
@@ -46,7 +46,7 @@ object TreeBuilder {
           check = init.situation.check,
           opening = openingOf(fen),
           clock = withFlags.clocks ?? (game.clock ?? { c =>
-              Centis.ofSeconds(c.limitSeconds).some
+            Centis.ofSeconds(c.limitSeconds).some
           }),
           crazyData = init.situation.board.crazyData,
           eval = infos lift 0 map makeEval


### PR DESCRIPTION
Addresses #10878 

**Issue Description**
Happens whenever White berserks but Black does not. The clocks in post-game analysis show both players starting with the berserked amount of time. Clocks are correct after the first move.

![Screenshot from 2022-06-15 16-42-57](https://user-images.githubusercontent.com/30640147/173923421-2929a7fd-f25b-44c7-a140-e2771c93c7e2.png)

You can see an example in the listed issue or at this URL: https://lichess.org/TKVJqdRx/white

**Issue Cause**
When the game tree is built in [`TreeBuilder.scala`](https://github.com/lichess-org/lila/blob/c48da4e2cd22837a9f6e8b7eb4a59924967aec3f/modules/round/src/main/TreeBuilder.scala#L48), the root node uses the clock value from the first move. This value is then used to initialise both clocks on the frontend. If White has berserked, both clocks end up initialised to White's berserked time.

**Fix Details**
I'm initialising the clock on the root node to be the starting time both players get. The resulting behaviour is that both clocks start at the full time and are updated to the berserked time by the first move.

This is cleaner than making a bunch of changes to get the UI to check for berserks and initialise clocks differently. It also makes more sense than the current behaviour.

**Tests**
Checked this on the dev env. Note the clocks:

Berserking in rapid:
![Screenshot from 2022-06-15 16-41-32](https://user-images.githubusercontent.com/30640147/173923180-cbd107b1-fb66-4249-9caa-ffdf333de1a6.png)

![Screenshot from 2022-06-15 16-39-44](https://user-images.githubusercontent.com/30640147/173922995-a643b97c-ec3a-40ed-8d78-58a66ff5cfd1.png)

Same as in bullet:
![Screenshot from 2022-06-15 14-49-03](https://user-images.githubusercontent.com/30640147/173923041-40f64151-c918-4c43-a9b4-34bf37184c65.png)
