### PR TITLE
fix inbox bouncing when "<user> is typing..." is shown

### DIFF
--- a/ui/msg/css/_convoMsgs.scss
+++ b/ui/msg/css/_convoMsgs.scss
@@ -18,6 +18,9 @@
 
   &__typing {
     color: $c-font-dim;
+    line-height: 0.9em;
+    min-height: 0.9em;
+    font-size: 0.9em;
   }
 
   &__content {

--- a/ui/msg/src/view/msgs.ts
+++ b/ui/msg/src/view/msgs.ts
@@ -35,7 +35,7 @@ export default function renderMsgs(ctrl: MsgCtrl, convo: Convo): VNode {
             )
           : null,
         ...contentMsgs(ctrl, convo.msgs),
-        ctrl.typing ? h('div.msg-app__convo__msgs__typing', `${convo.user.name} is typing...`) : null,
+        h('div.msg-app__convo__msgs__typing', ctrl.typing ? `${convo.user.name} is typing...` : null),
       ]),
     ]
   );


### PR DESCRIPTION
reserve space for text even when it's not there.