### PR TITLE
fix CORS for flutter web

### DIFF
--- a/modules/common/src/main/HTTPRequest.scala
+++ b/modules/common/src/main/HTTPRequest.scala
@@ -24,14 +24,18 @@ object HTTPRequest {
       .get(HeaderNames.ACCEPT)
       .exists(_ startsWith "application/vnd.lichess.v")
 
-  private val appOrigins = Set(
+  private val appOrigins = List(
     "capacitor://localhost", // ios
     "ionic://localhost",     // ios
     "http://localhost"       // android/dev/flutter
   )
 
   def appOrigin(req: RequestHeader): Option[String] =
-    origin(req) filter { o => appOrigins exists o.startsWith }
+    origin(req) filter { reqOrigin =>
+      appOrigins exists { appOrigin =>
+        reqOrigin == appOrigin || reqOrigin.startsWith(s"$appOrigin:")
+      }
+    }
 
   def isApi(req: RequestHeader)      = req.path startsWith "/api/"
   def isApiOrApp(req: RequestHeader) = isApi(req) || appOrigin(req).isDefined

--- a/modules/common/src/main/HTTPRequest.scala
+++ b/modules/common/src/main/HTTPRequest.scala
@@ -31,7 +31,7 @@ object HTTPRequest {
   )
 
   def appOrigin(req: RequestHeader): Option[String] =
-    origin(req) map { case o if appOrigins exists o.startsWith => o }
+    origin(req) filter { o => appOrigins exists o.startsWith }
 
   def isApi(req: RequestHeader)      = req.path startsWith "/api/"
   def isApiOrApp(req: RequestHeader) = isApi(req) || appOrigin(req).isDefined

--- a/modules/common/src/main/HTTPRequest.scala
+++ b/modules/common/src/main/HTTPRequest.scala
@@ -27,11 +27,11 @@ object HTTPRequest {
   private val appOrigins = Set(
     "capacitor://localhost", // ios
     "ionic://localhost",     // ios
-    "http://localhost",      // android
-    "http://localhost:8080"  // local dev
+    "http://localhost"       // android/dev/flutter
   )
 
-  def appOrigin(req: RequestHeader) = origin(req) filter appOrigins
+  def appOrigin(req: RequestHeader): Option[String] =
+    origin(req) map { case o if appOrigins exists o.startsWith => o }
 
   def isApi(req: RequestHeader)      = req.path startsWith "/api/"
   def isApiOrApp(req: RequestHeader) = isApi(req) || appOrigin(req).isDefined


### PR DESCRIPTION
With this change HTTPRequest.appOrigin doesn't do an exact match, instead it returns the client's origin header if it starts with any of those allowed - a source port in the url string no longer prevents matching. 

The Origin header cannot be set in a chrome-js XmlHttpRequest.  It always sends "http://localhost:<port>" and the source port varies.  Other flutter targets (everything but web) can set Origin header directly.  Flutter web probably is not even useful for any lichess development, but who knows.