### PR TITLE
Give aniversary arena 24h of homepage hours

### DIFF
--- a/modules/tournament/src/main/TournamentScheduler.scala
+++ b/modules/tournament/src/main/TournamentScheduler.scala
@@ -108,7 +108,7 @@ final private class TournamentScheduler(
 We've had $yo great chess years together!
 
 Thank you all, you rock!""",
-                homepageHours = 24
+                homepageHours = 24.some
               ).some
             )
           }

--- a/modules/tournament/src/main/TournamentScheduler.scala
+++ b/modules/tournament/src/main/TournamentScheduler.scala
@@ -107,7 +107,8 @@ final private class TournamentScheduler(
                 description = s"""
 We've had $yo great chess years together!
 
-Thank you all, you rock!"""
+Thank you all, you rock!""",
+                homepageHours = 24
               ).some
             )
           }


### PR DESCRIPTION
Probably would also make sense to give it a nicer image/icon? ig the event trophy image or the lichess logo?