### PR TITLE
Highlight chat messages when you are mentioned

### DIFF
--- a/ui/chat/css/_discussion.scss
+++ b/ui/chat/css/_discussion.scss
@@ -29,6 +29,10 @@
       &.host {
         background-color: rgba($c-secondary-dim, 0.4);
       }
+
+      &.mentioned {
+        background-color: rgba($c-secondary-dimmer, 0.4);
+      }
     }
 
     .deleted {

--- a/ui/chat/src/discussion.ts
+++ b/ui/chat/src/discussion.ts
@@ -213,7 +213,8 @@ function renderLine(ctrl: Ctrl, line: Line): VNode {
 
   const myUserId = ctrl.data.userId;
   const mentioned =
-    !!myUserId && !!line.t.match(enhance.userPattern)?.find(mention => mention.toLowerCase() == `@${ctrl.data.userId}`);
+    !!myUserId &&
+    !!line.t.match(enhance.userPattern)?.find(mention => mention.trim().toLowerCase() == `@${ctrl.data.userId}`);
 
   return h(
     'li',

--- a/ui/chat/src/discussion.ts
+++ b/ui/chat/src/discussion.ts
@@ -211,7 +211,7 @@ function renderLine(ctrl: Ctrl, line: Line): VNode {
   const userNode = thunk('a', line.u, userLink, [line.u, line.title, line.p]);
   const userId = line.u?.toLowerCase();
 
-  const mentionedUsers = line.t.match(enhance.userPattern);
+  const mentionedUsers = line.t.match(enhance.userPattern)?.map(user => user.trim().toLowerCase());
 
   return h(
     'li',
@@ -219,7 +219,7 @@ function renderLine(ctrl: Ctrl, line: Line): VNode {
       class: {
         me: userId === ctrl.data.userId,
         host: userId === ctrl.data.hostId,
-        mentioned: mentionedUsers !== null && mentionedUsers.includes('@' + ctrl.data.userId),
+        mentioned: mentionedUsers != null && mentionedUsers.includes('@' + ctrl.data.userId),
       },
     },
     ctrl.moderation()

--- a/ui/chat/src/discussion.ts
+++ b/ui/chat/src/discussion.ts
@@ -211,7 +211,9 @@ function renderLine(ctrl: Ctrl, line: Line): VNode {
   const userNode = thunk('a', line.u, userLink, [line.u, line.title, line.p]);
   const userId = line.u?.toLowerCase();
 
-  const mentionedUsers = line.t.match(enhance.userPattern)?.map(user => user.toLowerCase());
+  const mentioned = !!line.t
+    .match(enhance.userPattern)
+    ?.find(mention => mention.toLowerCase() == `@${ctrl.data.userId}`);
 
   return h(
     'li',
@@ -219,7 +221,7 @@ function renderLine(ctrl: Ctrl, line: Line): VNode {
       class: {
         me: userId === ctrl.data.userId,
         host: userId === ctrl.data.hostId,
-        mentioned: mentionedUsers != null && mentionedUsers.includes('@' + ctrl.data.userId),
+        mentioned,
       },
     },
     ctrl.moderation()

--- a/ui/chat/src/discussion.ts
+++ b/ui/chat/src/discussion.ts
@@ -211,15 +211,15 @@ function renderLine(ctrl: Ctrl, line: Line): VNode {
   const userNode = thunk('a', line.u, userLink, [line.u, line.title, line.p]);
   const userId = line.u?.toLowerCase();
 
-  const mentioned = !!line.t
-    .match(enhance.userPattern)
-    ?.find(mention => mention.toLowerCase() == `@${ctrl.data.userId}`);
+  const myUserId = ctrl.data.userId;
+  const mentioned =
+    !!myUserId && !!line.t.match(enhance.userPattern)?.find(mention => mention.toLowerCase() == `@${ctrl.data.userId}`);
 
   return h(
     'li',
     {
       class: {
-        me: userId === ctrl.data.userId,
+        me: userId === myUserId,
         host: userId === ctrl.data.hostId,
         mentioned,
       },
@@ -227,7 +227,7 @@ function renderLine(ctrl: Ctrl, line: Line): VNode {
     ctrl.moderation()
       ? [line.u ? modLineAction() : null, userNode, ' ', textNode]
       : [
-          ctrl.data.userId && line.u && ctrl.data.userId != line.u
+          myUserId && line.u && myUserId != line.u
             ? h('i.flag', {
                 attrs: {
                   'data-icon': '',

--- a/ui/chat/src/discussion.ts
+++ b/ui/chat/src/discussion.ts
@@ -211,12 +211,15 @@ function renderLine(ctrl: Ctrl, line: Line): VNode {
   const userNode = thunk('a', line.u, userLink, [line.u, line.title, line.p]);
   const userId = line.u?.toLowerCase();
 
+  const mentionedUsers = line.t.match(enhance.userPattern);
+
   return h(
     'li',
     {
       class: {
         me: userId === ctrl.data.userId,
         host: userId === ctrl.data.hostId,
+        mentioned: mentionedUsers !== null && mentionedUsers.includes('@' + ctrl.data.userId),
       },
     },
     ctrl.moderation()

--- a/ui/chat/src/discussion.ts
+++ b/ui/chat/src/discussion.ts
@@ -211,7 +211,7 @@ function renderLine(ctrl: Ctrl, line: Line): VNode {
   const userNode = thunk('a', line.u, userLink, [line.u, line.title, line.p]);
   const userId = line.u?.toLowerCase();
 
-  const mentionedUsers = line.t.match(enhance.userPattern)?.map(user => user.trim().toLowerCase());
+  const mentionedUsers = line.t.match(enhance.userPattern)?.map(user => user.toLowerCase());
 
   return h(
     'li',


### PR DESCRIPTION
Implementing the suggestion from #11042. Chat messages that mention you are highlighted green.

Tested in dev:
![Screenshot from 2022-06-22 19-43-37](https://user-images.githubusercontent.com/30640147/175179047-4cb224ca-5a3f-4340-8473-06ffe20097c6.png)

Tested in a simul (where hosts' messages are also highlighted):
![Screenshot from 2022-06-22 19-47-58](https://user-images.githubusercontent.com/30640147/175179122-3e8b15cd-6a72-4f41-9cd7-b2ee1d1e82b2.png)

Let me know any thoughts on the approach/colors used.