### PR TITLE
color error categories in acpl summary, and taking crayons to tree view

### DIFF
--- a/ui/analyse/css/_acpl.scss
+++ b/ui/analyse/css/_acpl.scss
@@ -15,8 +15,23 @@
     }
     &.symbol {
       cursor: pointer;
+    }
+    &.inaccuracy {
+      color: $c-inaccuracy;
       &:hover {
-        color: $c-link;
+        color: c-clearer(saturate($c-inaccuracy, 100%), 40%);
+      }
+    }
+    &.mistake {
+      color: $c-mistake;
+      &:hover {
+        color: c-clearer($c-mistake, 40%);
+      }
+    }
+    &.blunder {
+      color: $c-blunder;
+      &:hover {
+        color: c-clearer(saturate($c-blunder, 100%), 40%);
       }
     }
   }

--- a/ui/analyse/src/acpl.ts
+++ b/ui/analyse/src/acpl.ts
@@ -49,17 +49,14 @@ function playerTable(ctrl: AnalyseCtrl, color: Color): VNode {
     h('div.advice-summary__player', [h(`i.is.color-icon.${color}`), renderPlayer(ctrl, color)]),
     ...advices.map(a => {
       const nb: number = d.analysis![color][a.kind];
+      const style = nb ? `.symbol.${a.kind}` : '';
       const attrs: VNodeData = nb
         ? {
             'data-color': color,
             'data-symbol': a.symbol,
           }
         : {};
-      return h(
-        `div.advice-summary__mistake${nb ? '.symbol' : ''}`,
-        { attrs },
-        ctrl.trans.vdomPlural(a.i18n, nb, h('strong', nb))
-      );
+      return h(`div.advice-summary__error${style}`, { attrs }, ctrl.trans.vdomPlural(a.i18n, nb, h('strong', nb)));
     }),
     h('div.advice-summary__acpl', [
       h('strong', '' + (defined(acpl) ? acpl : '?')),

--- a/ui/common/css/theme/_dark.scss
+++ b/ui/common/css/theme/_dark.scss
@@ -59,6 +59,11 @@ $c-warn-over: $c-brag-over;
 $c-bad: $c-error;
 $c-bad-over: $c-error-over;
 
+/* move error highlights */
+$c-inaccuracy: hsl(202, 78%, 62%);
+$c-mistake: hsl(41, 100%, 45%);
+$c-blunder: hsl(0, 69%, 60%);
+
 $c-link: $c-primary;
 $c-link-dim: $c-primary-dim;
 $c-link-clear: $c-primary-clear;

--- a/ui/common/css/theme/_default.scss
+++ b/ui/common/css/theme/_default.scss
@@ -89,6 +89,11 @@ $c-heart-over: $c-error-over;
 $c-fancy: hsl(294, 61%, 62%);
 $c-fancy-over: white;
 
+/* move error highlights */
+$c-inaccuracy: hsl(202, 78%, 40%);
+$c-mistake: hsl(41, 100%, 35%);
+$c-blunder: hsl(0, 68%, 50%);
+
 /* text over brag background */
 
 $c-link: $c-primary;

--- a/ui/tree/css/_tree.scss
+++ b/ui/tree/css/_tree.scss
@@ -1,8 +1,8 @@
 @import 'extend';
 
-$c-inaccuracy: #56b4e9;
-$c-mistake: #e69f00;
-$c-blunder: #df5353;
+$c-bg-inaccuracy-hover: c-dimmer($c-inaccuracy, 70%);
+$c-bg-mistake-hover: c-dimmer($c-mistake, 70%);
+$c-bg-blunder-hover: c-dimmer($c-blunder, 70%);
 
 .tview2 {
   white-space: normal;
@@ -24,12 +24,21 @@ $c-blunder: #df5353;
 
     &.inaccuracy {
       color: $c-inaccuracy;
+      &:hover {
+        background: $c-bg-inaccuracy-hover;
+      }
     }
     &.mistake {
       color: $c-mistake;
+      &:hover {
+        background: $c-bg-mistake-hover;
+      }
     }
     &.blunder {
       color: $c-blunder;
+      &:hover {
+        background: $c-bg-blunder-hover;
+      }
     }
   }
 
@@ -74,7 +83,7 @@ $c-blunder: #df5353;
     font-style: italic;
   }
 
-  move:not(.empty):hover {
+  move:not(.empty):not(.blunder):not(.mistake):not(.inaccuracy):hover {
     &,
     index,
     eval {
@@ -196,6 +205,15 @@ $c-blunder: #df5353;
 
     display: block;
     padding: 3px 5px;
+    &.inaccuracy {
+      color: $c-inaccuracy;
+    }
+    &.mistake {
+      color: $c-mistake;
+    }
+    &.blunder {
+      color: $c-blunder;
+    }
   }
 
   &-inline comment {


### PR DESCRIPTION
closes #11051 (if you happen to see this thanks 1vader for that github tip)

I tried for dav1312's "side idea" stretch goal in the video, but honestly the different hover backgrounds in tree view are a bit schizophrentic.  Maybe don't merge changes to _tree.scss except lines 208-216, or even skip those.