### PR TITLE
Adds assetlinks.json; android applink verification

### DIFF
--- a/public/.well-known/assetlinks.json
+++ b/public/.well-known/assetlinks.json
@@ -1,0 +1,9 @@
+[{
+  "relation": ["delegate_permission/common.handle_all_urls"],
+  "target": {
+    "namespace": "android_app",
+    "package_name": "org.lichess.mobileapp",
+    "sha256_cert_fingerprints":
+    ["F3:7D:99:F0:1B:15:9F:55:05:F8:1A:93:E5:6E:72:5D:46:08:50:A7:ED:09:A8:D2:63:3C:98:01:FA:BD:0E:B9"]
+  }
+}]

--- a/public/.well-known/assetlinks.json
+++ b/public/.well-known/assetlinks.json
@@ -1,9 +1,12 @@
-[{
-  "relation": ["delegate_permission/common.handle_all_urls"],
-  "target": {
-    "namespace": "android_app",
-    "package_name": "org.lichess.mobileapp",
-    "sha256_cert_fingerprints":
-    ["F3:7D:99:F0:1B:15:9F:55:05:F8:1A:93:E5:6E:72:5D:46:08:50:A7:ED:09:A8:D2:63:3C:98:01:FA:BD:0E:B9"]
-  }
-}]
+[
+  {
+    relation: ["delegate_permission/common.handle_all_urls"],
+    target: {
+      namespace: "android_app",
+      package_name: "org.lichess.mobileapp",
+      sha256_cert_fingerprints: [
+        "F3:7D:99:F0:1B:15:9F:55:05:F8:1A:93:E5:6E:72:5D:46:08:50:A7:ED:09:A8:D2:63:3C:98:01:FA:BD:0E:B9",
+      ],
+    },
+  },
+]


### PR DESCRIPTION
The Android app for lichess is built to open urls starting in http://lichess.org, and is meant to direct those urls to the appropriate
section of the app.

As of Android 12, http/https links require domain verification for apps to actually be allowed to open them. If this verification is not
present, the system will only offer web browser(s) to open the URL. This verification is run at the time the android app is installed on the device, so it may need to be reinstalled after this fix is deployed in order for it to work. Not sure about this part though, we'll have to find out. :)

More information about this process can be found here: [Verify Android App Links](https://developer.android.com/training/app-links/verify-site-associations), and more specifically, the [Declare Website associations](https://developer.android.com/training/app-links/verify-site-associations#web-assoc) section.

The described procedure for obtaining the key fingerprint does not apply for me, considering I have no access to the signing keys (thankfully!). However,I retrieved the key fingerprint from the APK by saving the APK offered through google play to my computer, and running `apksigner verify --print-certs <apk file>`

I verified this method of retrieving the signature works, by running it on a Google Play APK from an app I worked on and have access to the signing key for.

Anyway, once the `/.well-known/assetlinks.json` file is served at lichess.org, http/https lichess links should open in the app again on
devices running android 12 and up.

I initially discussed this over on the [lichobile issue #1457](https://github.com/lichess-org/lichobile/issues/1457).