### PR TITLE
Tiny tweak to checkbox cursor CSS

### DIFF
--- a/ui/analyse/css/study/panel/_share.scss
+++ b/ui/analyse/css/study/panel/_share.scss
@@ -22,6 +22,7 @@
     input {
       margin-right: 0.3em;
       vertical-align: middle;
+      cursor: pointer;
     }
   }
 


### PR DESCRIPTION
The checkbox inputs to share a study have `cursor: default` over the input itself but `cursor: pointer` on the text. This is because the `cursor: pointer` that should be inherited is getting overridden. It should be consistent with the other checkbox inputs on the site

Currently looks like:
![image](https://user-images.githubusercontent.com/30640147/176061992-6b0ff943-5095-4085-af86-a037328f457b.png)

![image](https://user-images.githubusercontent.com/30640147/176062050-2ca5a139-20cf-4b02-82a1-d3882e44ab48.png)

With these changes:
![image](https://user-images.githubusercontent.com/30640147/176062022-4fbe558c-4e61-4a4a-80b4-37a914b881cf.png)

