### PR TITLE
Fix bug where study tour breaks if action menu is open

### DIFF
--- a/public/javascripts/study/tour.js
+++ b/public/javascripts/study/tour.js
@@ -18,6 +18,15 @@ lichess.studyTour = function (study) {
         },
       };
     };
+
+    var closeActionMenu = function () {
+      return {
+        'before-show': function () {
+          study.closeActionMenu();
+        },
+      };
+    };
+
     var tour = new Shepherd.Tour({
       defaults: {
         classes: theme,
@@ -40,6 +49,7 @@ lichess.studyTour = function (study) {
         title: 'Shared and saved',
         text: 'Other members can see your moves in real time!<br>' + 'Plus, everything is saved forever.',
         attachTo: 'main.analyse .areplay left',
+        when: closeActionMenu(),
       },
       {
         title: 'Study members',

--- a/ui/@types/lichess/index.d.ts
+++ b/ui/@types/lichess/index.d.ts
@@ -288,6 +288,7 @@ interface Study {
   userId?: string | null;
   isContrib?: boolean;
   isOwner?: boolean;
+  closeActionMenu?(): void;
   setTab(tab: string): void;
 }
 

--- a/ui/analyse/src/study/studyTour.ts
+++ b/ui/analyse/src/study/studyTour.ts
@@ -12,6 +12,10 @@ export function study(ctrl: AnalyseCtrl) {
           ctrl.study!.vm.tab(tab);
           ctrl.redraw();
         },
+        closeActionMenu: () => {
+          ctrl.actionMenu.open = false;
+          ctrl.redraw();
+        },
       });
     });
 }


### PR DESCRIPTION
**Steps to Repro**:
1. Go to any study (eg. https://lichess.org/study/KCtNgx2P)
2. Open the action menu on the left:
![image](https://user-images.githubusercontent.com/30640147/176119920-c71b15d6-b0b4-405e-a76f-ee09d0f4e45b.png)
3. Start the tour and click past the first step. The second step appears in the bottom corner and the tour is entirely broken.
![image](https://user-images.githubusercontent.com/30640147/176120086-c95cfb81-47ab-4f81-be6a-a579c16e645c.png)


**Cause**:
Issue is that the second step tries to attach to [an element on the left](https://github.com/lichess-org/lila/blob/master/public/javascripts/study/tour.js#L42) which doesn't exist when the action menu is open.

**Fix**:
Other tour steps that attach to possibly-nonexistent elements programmatically go to the right screen before the step. I used that pattern to make sure the action menu was closed before this step. Can't really show how this works via screenshot but you can test by trying the repro steps above.

Example of this pattern:
- [`onTab` used in the `before-show` step in the same tour](https://github.com/lichess-org/lila/blob/master/public/javascripts/study/tour.js#L14)
