### PR TITLE
specify application/x-ndjson in response header for keep alive api challenge creates

### DIFF
--- a/app/controllers/Challenge.scala
+++ b/app/controllers/Challenge.scala
@@ -337,7 +337,7 @@ final class Challenge(
                       case _ =>
                         destUser ?? { env.challenge.granter.isDenied(me.some, _, config.perfType) } flatMap {
                           case Some(denied) =>
-                            BadRequest(jsonError(lila.challenge.ChallengeDenied.translated(denied))).fuccess
+                            JsonBadRequest(jsonError(lila.challenge.ChallengeDenied.translated(denied))).fuccess
                           case _ =>
                             env.challenge.api create challenge map {
                               case true =>
@@ -349,9 +349,9 @@ final class Challenge(
                                   )
                                 else JsonOk(json)
                               case false =>
-                                BadRequest(jsonError("Challenge not created"))
+                                JsonBadRequest(jsonError("Challenge not created"))
                             }
-                        } map (_ as JSON)
+                        }
                     }
                   }(rateLimitedFu)
                 }(rateLimitedFu)

--- a/app/controllers/LilaController.scala
+++ b/app/controllers/LilaController.scala
@@ -372,6 +372,7 @@ abstract private[controllers] class LilaController(val env: Env)
   protected def JsonOk(body: JsValue): Result             = Ok(body) as JSON
   protected def JsonOk[A: Writes](body: A): Result        = Ok(Json toJson body) as JSON
   protected def JsonOk[A: Writes](fua: Fu[A]): Fu[Result] = fua dmap { JsonOk(_) }
+  protected def JsonBadRequest(body: JsValue): Result     = BadRequest(body) as JSON
 
   protected val jsonOkBody   = Json.obj("ok" -> true)
   protected val jsonOkResult = JsonOk(jsonOkBody)


### PR DESCRIPTION
This may be causing streams to break after 1 minute, but it should be fixed regardless.  The `map (_ as JSON)` call on line 354 of Challenge.scala was blowing away the correct nginx hint and entity type on keep alive requests.

https://discord.com/channels/280713822073913354/436555632964010005/991459275283124365

All props to Torom for isolating this.  I also noticed that the api allows challenges to nonexistent user ids.  The destUser resolves to None which is propagated all throughout the code without triggering any errors.  Is there a reason bad request isn't returned?
