### PR TITLE
Fix bug where the last puzzle in racer isn't added to racer history 

### DIFF
--- a/ui/racer/src/ctrl.ts
+++ b/ui/racer/src/ctrl.ts
@@ -135,7 +135,11 @@ export default class RacerCtrl {
   end = (): void => {
     if (this.run.history.length != 0) {
       const index = this.run.current.index;
-      this.run.history.push({ puzzle: this.data.puzzles[index], win:false , millis: getNow() - this.run.current.startAt });
+      this.run.history.push({
+        puzzle: this.data.puzzles[index],
+        win: false,
+        millis: getNow() - this.run.current.startAt,
+      });
     }
     this.setGround();
     this.redraw();


### PR DESCRIPTION
Quick fix.
Has issues that show up as a result of working with a limited puzzle db (from lila-db-seed).

If all puzzles are exhausted, racestatus is not updated from 'racing' to 'post' and the race still continues until clock.flag() is reached.
end() doesn't really end the race until racestatus is updated. end() is called again once clock flags.
As a result, this quickfix causes the last puzzle to appear up-to 3 times if all puzzles are exhausted.
This quickfix should work fine on the actual, larger db. Not sure if it's worth fixing the other issues as they will only arise when working with lila-db-seed.