### PR TITLE
Only render watchers when necessary

### DIFF
--- a/ui/site/src/component/watchers.ts
+++ b/ui/site/src/component/watchers.ts
@@ -34,13 +34,14 @@ export default function watchers(element: HTMLElement) {
     $numberEl.text('' + data.nb);
 
     if (data.users) {
-      const key = data.users.map(u => (u ? name(u) : '')).join(';');
-      if ($listEl.data('users-key') === key) return;
-      $listEl.data('users-key', key);
-      const tags = data.users.map(u => (u ? `<a class="user-link ulpt" href="/@/${name(u)}">${u}</a>` : 'Anonymous'));
-      if (data.anons === 1) tags.push('Anonymous');
-      else if (data.anons) tags.push(`Anonymous (${data.anons})`);
-      $listEl.html(tags.join(', '));
+      const prevUsers = data.users.map(u => u || '').join(';');
+      if ($listEl.data('prevUsers') !== prevUsers) {
+        $listEl.data('prevUsers', prevUsers);
+        const tags = data.users.map(u => (u ? `<a class="user-link ulpt" href="/@/${name(u)}">${u}</a>` : 'Anonymous'));
+        if (data.anons === 1) tags.push('Anonymous');
+        else if (data.anons) tags.push(`Anonymous (${data.anons})`);
+        $listEl.html(tags.join(', '));
+      }
     } else $listEl.html('');
 
     $element.removeClass('none');

--- a/ui/site/src/component/watchers.ts
+++ b/ui/site/src/component/watchers.ts
@@ -7,6 +7,8 @@ interface Data {
 
 let watchersData: Data | undefined;
 
+const name = (u: string) => (u.includes(' ') ? u.split(' ')[1] : u);
+
 export default function watchers(element: HTMLElement) {
   const $element = $(element);
 
@@ -32,9 +34,10 @@ export default function watchers(element: HTMLElement) {
     $numberEl.text('' + data.nb);
 
     if (data.users) {
-      const tags = data.users.map(u =>
-        u ? `<a class="user-link ulpt" href="/@/${u.includes(' ') ? u.split(' ')[1] : u}">${u}</a>` : 'Anonymous'
-      );
+      const key = data.users.map(u => (u ? name(u) : '')).join(';');
+      if ($listEl.data('users-key') === key) return;
+      $listEl.data('users-key', key);
+      const tags = data.users.map(u => (u ? `<a class="user-link ulpt" href="/@/${name(u)}">${u}</a>` : 'Anonymous'));
       if (data.anons === 1) tags.push('Anonymous');
       else if (data.anons) tags.push(`Anonymous (${data.anons})`);
       $listEl.html(tags.join(', '));


### PR DESCRIPTION
While watching the candidates broadcast, I noticed that the usernames below the chat aren't hover-friendly: the card that appears on hover flickers twice a second or so. This is happening because the username link is being destroyed and recreated on every `socket.in.crowd` message, even when the usernames haven't changed.

With this PR, the username links won't render unless they are different from the previously-rendered usernames.