### PR TITLE
Show current line instead of mainline in analysis nvui

### DIFF
--- a/ui/analyse/src/plugins/nvui.ts
+++ b/ui/analyse/src/plugins/nvui.ts
@@ -36,6 +36,7 @@ import { bind, MaybeVNodes } from 'common/snabbdom';
 import throttle from 'common/throttle';
 import { Role } from 'chessground/types';
 import explorerView from '../explorer/explorerView';
+import { ops } from 'tree';
 
 const throttled = (sound: string) => throttle(100, () => lichess.sound.play(sound));
 const selectSound = throttled('select');
@@ -84,7 +85,7 @@ export default function (redraw: Redraw) {
                 'aria-live': 'off',
               },
             },
-            renderMainline(ctrl.mainline, ctrl.path, style)
+            renderCurrentLine(ctrl, style)
           ),
           ...(!ctrl.studyPractice
             ? [
@@ -245,6 +246,17 @@ export default function (redraw: Redraw) {
       ]);
     },
   };
+}
+
+function renderCurrentLine(ctrl: AnalyseController, style: Style): (string | VNode)[] {
+  if (ctrl.path.length === 0) {
+    return renderMainline(ctrl.mainline, ctrl.path, style);
+  } else {
+    const currentLine = ctrl.tree.getNodeList(ctrl.path),
+      currentNode = currentLine[currentLine.length - 1],
+      futureNodes = currentNode.children.length > 0 ? ops.mainlineNodeList(currentNode.children[0]) : [];
+    return renderMainline(currentLine.concat(futureNodes), ctrl.path, style);
+  }
 }
 
 function onSubmit(ctrl: AnalyseController, notify: (txt: string) => void, style: () => Style, $input: Cash) {


### PR DESCRIPTION
Addresses https://github.com/lichess-org/lila/issues/11089#issuecomment-1171994503

If you return to an earlier move, the future moves of the current line will still be shown. This is consistent with the existing behavior.