### PR TITLE
Replace deprecated execCommand with clipboard api

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Feel free to use the [Lichess API](https://lichess.org/api) in your applications
 | Name              | Version | Notes                                             |
 | ----------------- | ------- | ------------------------------------------------- |
 | Chromium / Chrome | last 10 | Full support                                      |
-| Firefox           | 61+     | Full support (fastest local analysis since FF 79) |
+| Firefox           | 63+     | Full support (fastest local analysis since FF 79) |
 | Edge              | 91+     | Full support (reasonable support for 17+)         |
 | Opera             | 55+     | Reasonable support                                |
 | Safari            | 11.1+   | Reasonable support                                |

--- a/app/views/analyse/replay.scala
+++ b/app/views/analyse/replay.scala
@@ -218,8 +218,7 @@ object replay {
           div(cls := "blind-content none")(
             h2("PGN downloads"),
             pgnLinks,
-            textarea(style := "opacity: 0.01; height: 0", tabindex := -1, cls := "game-pgn")(pgn),
-            button(cls := "copy-pgn", dataRel := "game-pgn")(
+            button(cls := "copy-pgn", attr("data-pgn") := pgn)(
               "Copy PGN to clipboard"
             )
           )

--- a/ui/analyse/src/plugins/nvui.ts
+++ b/ui/analyse/src/plugins/nvui.ts
@@ -192,11 +192,10 @@ export default function (redraw: Redraw) {
               insert: vnode => {
                 const root = $(vnode.elm as HTMLElement);
                 root.append($('.blind-content').removeClass('none'));
-                root.find('.copy-pgn').on('click', () => {
-                  (root.find('.game-pgn').attr('type', 'text')[0] as HTMLInputElement).select();
-                  document.execCommand('copy');
-                  root.find('.game-pgn').attr('type', 'hidden');
-                  notify.set('PGN copied into clipboard.');
+                root.find('.copy-pgn').on('click', function (this: HTMLElement) {
+                  navigator.clipboard.writeText($(this).data('pgn')).then(() => {
+                    notify.set('PGN copied into clipboard.');
+                  });
                 });
               },
             },

--- a/ui/site/src/site.ts
+++ b/ui/site/src/site.ts
@@ -46,11 +46,10 @@ lichess.load.then(() => {
         this.select();
       })
       .on('click', 'button.copy', function (this: HTMLElement) {
+        const showCheckmark = () => $(this).attr('data-icon', '');
         $('#' + $(this).data('rel')).each(function (this: HTMLInputElement) {
-          this.select();
+          navigator.clipboard.writeText(this.value).then(showCheckmark);
         });
-        document.execCommand('copy');
-        $(this).attr('data-icon', '');
       });
 
     $('body').on('click', 'a.relation-button', function (this: HTMLAnchorElement) {


### PR DESCRIPTION
[`document.execCommand('copy')` is deprecated](https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand) and can be replaced with the clipboard api.

The clipboard api doesn't need to select text to copy it, so I removed the text selection. 

Downside: we would need to bump the minimum Firefox version from 61 (June 2018) to 63 (October 2018). Our other supported browsers already support what we need. [Caniuse](https://caniuse.com/mdn-api_clipboard_writetext).