### PR TITLE
time should always be displayed Left to Right

### DIFF
--- a/ui/round/css/_clock.scss
+++ b/ui/round/css/_clock.scss
@@ -85,6 +85,7 @@
     will-change: transform;
     z-index: -1;
     display: flex;
+    direction: ltr;
 
     &.hour {
       font-size: 2.3em;


### PR DESCRIPTION
Fixes issue #11114 

Issue was actually visible on any game using clock