### PR TITLE
Local analysis for analysis board & studies

### DIFF
--- a/ui/@types/lichess/index.d.ts
+++ b/ui/@types/lichess/index.d.ts
@@ -255,8 +255,10 @@ interface Window {
   readonly LichessCli: any;
   readonly LichessRound: any;
   readonly LichessRoundNvui?: Nvui;
-  readonly LichessAnalyseNvui?: Nvui;
   readonly LichessPuzzleNvui?: Nvui;
+  readonly LichessAnalyseNvui?: (ctrl: any) => {
+    render(): any;
+  };
   readonly LichessChartGame: {
     acpl: {
       (data: any, mainline: any[], trans: Trans, el: HTMLElement): Promise<void>;

--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -125,7 +125,10 @@ export default class AnalyseCtrl {
     if (this.data.forecast) this.forecast = makeForecast(this.data.forecast, this.data, redraw);
     if (this.opts.wiki) this.wiki = wikiTheory();
 
-    if (window.LichessAnalyseNvui) this.nvui = window.LichessAnalyseNvui(redraw) as NvuiPlugin;
+    if (window.LichessAnalyseNvui) {
+      this.nvui = window.LichessAnalyseNvui(redraw) as NvuiPlugin;
+      this.nvui.bindKeys(this);
+    }
 
     this.instanciateEvalCache();
 

--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -125,10 +125,7 @@ export default class AnalyseCtrl {
     if (this.data.forecast) this.forecast = makeForecast(this.data.forecast, this.data, redraw);
     if (this.opts.wiki) this.wiki = wikiTheory();
 
-    if (window.LichessAnalyseNvui) {
-      this.nvui = window.LichessAnalyseNvui(redraw) as NvuiPlugin;
-      this.nvui.bindKeys(this);
-    }
+    if (window.LichessAnalyseNvui) this.nvui = window.LichessAnalyseNvui(this) as NvuiPlugin;
 
     this.instanciateEvalCache();
 

--- a/ui/analyse/src/interfaces.ts
+++ b/ui/analyse/src/interfaces.ts
@@ -16,6 +16,7 @@ export { Key, Piece } from 'chessground/types';
 
 export interface NvuiPlugin {
   render(ctrl: AnalyseController): VNode;
+  bindKeys(ctrl: AnalyseController): void;
 }
 
 export interface AnalyseApi {

--- a/ui/analyse/src/interfaces.ts
+++ b/ui/analyse/src/interfaces.ts
@@ -4,7 +4,6 @@ import * as cg from 'chessground/types';
 import { ForecastData } from './forecast/interfaces';
 import { StudyPracticeData, Goal as PracticeGoal } from './study/practice/interfaces';
 import { RelayData } from './study/relay/interfaces';
-import AnalyseController from './ctrl';
 import { ChatCtrl } from 'chat';
 import { ExplorerOpts } from './explorer/interfaces';
 import { StudyData } from './study/interfaces';
@@ -15,8 +14,7 @@ export type Seconds = number;
 export { Key, Piece } from 'chessground/types';
 
 export interface NvuiPlugin {
-  render(ctrl: AnalyseController): VNode;
-  bindKeys(ctrl: AnalyseController): void;
+  render(): VNode;
 }
 
 export interface AnalyseApi {

--- a/ui/analyse/src/plugins/nvui.ts
+++ b/ui/analyse/src/plugins/nvui.ts
@@ -205,7 +205,7 @@ export default function (redraw: Redraw) {
           }),
           h('h2', 'Settings'),
           h('label', ['Move notation', renderSetting(moveStyle, ctrl.redraw)]),
-          h('h3', 'Board Settings'),
+          h('h3', 'Board settings'),
           h('label', ['Piece style', renderSetting(pieceStyle, ctrl.redraw)]),
           h('label', ['Piece prefix style', renderSetting(prefixStyle, ctrl.redraw)]),
           h('label', ['Show position', renderSetting(positionStyle, ctrl.redraw)]),
@@ -225,7 +225,7 @@ export default function (redraw: Redraw) {
             'x: show threat',
             h('br'),
           ]),
-          h('h2', 'Board Mode commands'),
+          h('h2', 'Board mode commands'),
           h('p', [
             'Use these commands when focused on the board itself.',
             h('br'),

--- a/ui/analyse/src/plugins/nvui.ts
+++ b/ui/analyse/src/plugins/nvui.ts
@@ -262,7 +262,6 @@ export default function (redraw: Redraw) {
     },
     bindKeys(ctrl: AnalyseController) {
       window.Mousetrap.bind('c', () => {
-        console.log(ctrl.node.ceval?.pvs);
         if (ctrl.threatMode()) {
           notify.set(`${evalInfo(ctrl.node.threat)} ${depthInfo(ctrl, ctrl.node.threat, false)}`);
         } else {

--- a/ui/analyse/src/plugins/nvui.ts
+++ b/ui/analyse/src/plugins/nvui.ts
@@ -319,7 +319,7 @@ function onSubmit(ctrl: AnalyseController, notify: (txt: string) => void, style:
   };
 }
 
-const shortCommands = ['p', 'scan'];
+const shortCommands = ['p', 's'];
 
 function isShortCommand(input: string): boolean {
   return shortCommands.includes(input.split(' ')[0]);

--- a/ui/analyse/src/view.ts
+++ b/ui/analyse/src/view.ts
@@ -368,7 +368,7 @@ function renderPlayerStrips(ctrl: AnalyseCtrl): [VNode, VNode] | undefined {
 }
 
 export default function (ctrl: AnalyseCtrl): VNode {
-  if (ctrl.nvui) return ctrl.nvui.render(ctrl);
+  if (ctrl.nvui) return ctrl.nvui.render();
   const concealOf = makeConcealOf(ctrl),
     study = ctrl.study,
     showCevalPvs = !(ctrl.retro && ctrl.retro.isSolving()) && !ctrl.practice,

--- a/ui/nvui/src/chess.ts
+++ b/ui/nvui/src/chess.ts
@@ -427,7 +427,7 @@ export function pieceJumpingHandler(wrapSound: () => void, errorSound: () => voi
       const $promotionPiece = ev.key.toLowerCase();
       const $form = $moveBox.parent().parent();
       if (!$promotionPiece.match(/^[qnrb]$/)) {
-        $boardLive.text('Invalid promotion piece. q for queen, n for knight, r for rook, b for bisho');
+        $boardLive.text('Invalid promotion piece. q for queen, n for knight, r for rook, b for bishop');
         return false;
       }
       $moveBox.val($moveBox.val() + $promotionPiece);

--- a/ui/puzzle/src/plugins/nvui.ts
+++ b/ui/puzzle/src/plugins/nvui.ts
@@ -179,7 +179,7 @@ export default function (redraw: Redraw) {
           ),
           h('h2', 'Settings'),
           h('label', ['Move notation', renderSetting(moveStyle, ctrl.redraw)]),
-          h('h3', 'Board Settings'),
+          h('h3', 'Board settings'),
           h('label', ['Piece style', renderSetting(pieceStyle, ctrl.redraw)]),
           h('label', ['Piece prefix style', renderSetting(prefixStyle, ctrl.redraw)]),
           h('label', ['Show position', renderSetting(positionStyle, ctrl.redraw)]),
@@ -204,7 +204,7 @@ export default function (redraw: Redraw) {
             commands.scan.help,
             h('br'),
           ]),
-          h('h2', 'Board Mode commands'),
+          h('h2', 'Board mode commands'),
           h('p', [
             'Use these commands when focused on the board itself.',
             h('br'),

--- a/ui/round/src/plugins/nvui.ts
+++ b/ui/round/src/plugins/nvui.ts
@@ -234,7 +234,7 @@ export default function (redraw: Redraw): NvuiPlugin {
           // h('p', takes(ctrl.data.steps.map(data => data.fen))),
           h('h2', 'Settings'),
           h('label', ['Move notation', renderSetting(moveStyle, ctrl.redraw)]),
-          h('h3', 'Board Settings'),
+          h('h3', 'Board settings'),
           h('label', ['Piece style', renderSetting(pieceStyle, ctrl.redraw)]),
           h('label', ['Piece prefix style', renderSetting(prefixStyle, ctrl.redraw)]),
           h('label', ['Show position', renderSetting(positionStyle, ctrl.redraw)]),
@@ -262,7 +262,7 @@ export default function (redraw: Redraw): NvuiPlugin {
             'takeback: Offer or accept take back.',
             h('br'),
           ]),
-          h('h2', 'Board Mode commands'),
+          h('h2', 'Board mode commands'),
           h('p', [
             'Use these commands when focused on the board itself.',
             h('br'),


### PR DESCRIPTION
Minimal initial implementation.

- One new shortcut (c for computer) that announces eval + depth. Works in nvui only. I want to keep the number of shortcuts down since there are so many already.
- Document the shortcuts.
- Reuse existing elements for analysis toggle and pvs.

Covers part of #11089