### PR TITLE
close game setup modal on challenge denied

### DIFF
--- a/app/controllers/Setup.scala
+++ b/app/controllers/Setup.scala
@@ -87,8 +87,8 @@ final class Setup(
                   case Some(denied) =>
                     val message = lila.challenge.ChallengeDenied.translated(denied)
                     negotiate(
-                      html = NotAcceptable(jsonError(message)).fuccess,
-                      // 406 tells setupCtrl.ts to close modal
+                      html = Forbidden(jsonError(message)).fuccess,
+                      // 403 tells setupCtrl.ts to close the setup modal
                       api = _ => BadRequest(jsonError(message)).fuccess
                     )
                   case None =>

--- a/app/controllers/Setup.scala
+++ b/app/controllers/Setup.scala
@@ -87,7 +87,8 @@ final class Setup(
                   case Some(denied) =>
                     val message = lila.challenge.ChallengeDenied.translated(denied)
                     negotiate(
-                      html = BadRequest(jsonError(message)).fuccess,
+                      html = NotAcceptable(jsonError(message)).fuccess,
+                      // 406 tells setupCtrl.ts to close modal
                       api = _ => BadRequest(jsonError(message)).fuccess
                     )
                   case None =>

--- a/ui/lobby/src/setupCtrl.ts
+++ b/ui/lobby/src/setupCtrl.ts
@@ -277,6 +277,7 @@ export default class SetupController {
     }
 
     const { ok, redirected, url } = response;
+
     if (!ok) {
       const errs: { [key: string]: string } = await response.json();
       alert(
@@ -286,6 +287,11 @@ export default class SetupController {
               .join('\n')
           : 'Invalid setup'
       );
+      if (response.status == 406) {
+        // 406 NOT_ACCEPTABLE restricts close modal behavior to user id challenges
+        // which will not be accepted.  see friend() in controllers/Setup.scala
+        this.closeModal();
+      }
     } else if (redirected) {
       location.href = url;
     } else {

--- a/ui/lobby/src/setupCtrl.ts
+++ b/ui/lobby/src/setupCtrl.ts
@@ -287,9 +287,9 @@ export default class SetupController {
               .join('\n')
           : 'Invalid setup'
       );
-      if (response.status == 406) {
-        // 406 NOT_ACCEPTABLE restricts close modal behavior to user id challenges
-        // which will not be accepted.  see friend() in controllers/Setup.scala
+      if (response.status == 403) {
+        // 403 FORBIDDEN closes this modal because challenges to the recipient
+        // will not be accepted.  see friend() in controllers/Setup.scala
         this.closeModal();
       }
     } else if (redirected) {


### PR DESCRIPTION
closes #11118

Alternatively, fiddling with the json can provide the hint without abandoning BadRequest.  I do feel somewhat dirty using HTTP status codes for their intended purpose.  Lemme know if json is preferred.