### PR TITLE
Close study tour when "Add member" dialog is opened

### DIFF
--- a/ui/analyse/src/study/inviteForm.ts
+++ b/ui/analyse/src/study/inviteForm.ts
@@ -30,6 +30,9 @@ export function makeCtrl(
     members,
     spectators,
     toggle() {
+      if (!open()) {
+        lichess.pubsub.emit('tour.stop');
+      }
       open(!open());
     },
     invite(titleName: string) {


### PR DESCRIPTION
Basically the same as #11081 

The study tour should close when the `Add member` dialog is opened otherwise you get stuff like this:

![image](https://user-images.githubusercontent.com/30640147/178111373-7ea3ac4d-2db2-4d02-acfd-6f3b528d639c.png)

The `Add member` dialog should take priority since it was the most recent action by the user