### PR TITLE
remove api user from online set before hearing back from lila-ws

### DIFF
--- a/modules/socket/src/main/RemoteSocket.scala
+++ b/modules/socket/src/main/RemoteSocket.scala
@@ -115,6 +115,7 @@ final class RemoteSocket(
     case ApiUserIsOnline(userId, value) =>
       send(Out.apiUserOnline(userId, value))
       if (value) onlineUserIds.getAndUpdate(_ + userId).unit
+      else onlineUserIds.getAndUpdate(_ - userId).unit
     case Follow(u1, u2)   => send(Out.follow(u1, u2))
     case UnFollow(u1, u2) => send(Out.unfollow(u1, u2))
   }


### PR DESCRIPTION
#11155

I don't think this will fix anything, but I can't see how it hurts - and it restores the cosmic if/else balance (which has karmic value).  For whatever reason, the DisconnectUsers message from lila-ws at prod is either not arriving, arriving an hour late or a few seconds before some ninja ConnectUser message, or really any of 100 other unforeseen happenings I'm not equipped to deal with.

Maybe someone who knows prod deployment can take a look and fix this in 30 seconds, I've put a few hours into it and am moving on for now.