### PR TITLE
remove users that quit team from team tourneys

### DIFF
--- a/app/views/tutor/compare.scala
+++ b/app/views/tutor/compare.scala
@@ -9,7 +9,7 @@ import lila.app.ui.ScalatagsTemplate._
 import lila.common.LilaOpeningFamily
 import lila.insight.{ InsightDimension, Phase }
 import lila.rating.PerfType
-import lila.tutor.{ TutorCompare, TutorMetric, Grade }
+import lila.tutor.{ Grade, TutorCompare, TutorMetric }
 
 private object compare {
 

--- a/modules/hub/src/main/actorApi.scala
+++ b/modules/hub/src/main/actorApi.scala
@@ -223,7 +223,7 @@ package team {
   case class JoinTeam(id: String, userId: String)
   case class IsLeader(id: String, userId: String, promise: Promise[Boolean])
   case class IsLeaderOf(leaderId: String, memberId: String, promise: Promise[Boolean])
-  case class KickFromTeam(teamId: String, userId: String)
+  case class QuitTeam(teamId: String, userId: String)
   case class TeamIdsJoinedBy(userId: String, promise: Promise[List[LightTeam.TeamID]])
 }
 

--- a/modules/swiss/src/main/Env.scala
+++ b/modules/swiss/src/main/Env.scala
@@ -83,12 +83,12 @@ final class Env(
     "finishGame",
     "adjustCheater",
     "adjustBooster",
-    "teamKick"
+    "teamQuit"
   ) {
-    case lila.game.actorApi.FinishGame(game, _, _)           => api.finishGame(game).unit
-    case lila.hub.actorApi.team.KickFromTeam(teamId, userId) => api.kickFromTeam(teamId, userId).unit
-    case lila.hub.actorApi.mod.MarkCheater(userId, true)     => api.kickLame(userId).unit
-    case lila.hub.actorApi.mod.MarkBooster(userId)           => api.kickLame(userId).unit
+    case lila.game.actorApi.FinishGame(game, _, _)       => api.finishGame(game).unit
+    case lila.hub.actorApi.team.QuitTeam(teamId, userId) => api.quitTeamTournaments(teamId, userId).unit
+    case lila.hub.actorApi.mod.MarkCheater(userId, true) => api.kickLame(userId).unit
+    case lila.hub.actorApi.mod.MarkBooster(userId)       => api.kickLame(userId).unit
   }
 
   LilaScheduler(_.Every(1 seconds), _.AtMost(20 seconds), _.Delay(20 seconds))(api.startPendingRounds)

--- a/modules/swiss/src/main/SwissApi.scala
+++ b/modules/swiss/src/main/SwissApi.scala
@@ -327,7 +327,7 @@ final class SwissApi(
       }
     }
 
-  private[swiss] def kickFromTeam(teamId: TeamID, userId: User.ID) =
+  private[swiss] def quitTeamTournaments(teamId: TeamID, userId: User.ID) =
     colls.swiss.secondaryPreferred
       .primitive[Swiss.Id]($doc("teamId" -> teamId, "featurable" -> true), "_id")
       .flatMap { swissIds =>

--- a/modules/tournament/src/main/TournamentApi.scala
+++ b/modules/tournament/src/main/TournamentApi.scala
@@ -475,10 +475,10 @@ final class TournamentApi(
       }.sequenceFu.void
     }
 
-  private[tournament] def kickFromTeam(teamId: TeamID, userId: User.ID): Funit =
-    tournamentRepo.withdrawableIds(userId, teamId = teamId.some, reason = "kickFromTeam") flatMap {
+  private[tournament] def quitTeamTournaments(teamId: TeamID, userId: User.ID): Funit =
+    tournamentRepo.withdrawableIds(userId, teamId = teamId.some, reason = "quitTeam") flatMap {
       _.map { tourId =>
-        Parallel(tourId, "kickFromTeam")(tournamentRepo.byId) { tour =>
+        Parallel(tourId, "quitTeamTournaments")(tournamentRepo.byId) { tour =>
           val fu =
             if (tour.isCreated) playerRepo.remove(tour.id, userId)
             else playerRepo.withdraw(tour.id, userId)

--- a/modules/tournament/src/main/TournamentBusHandler.scala
+++ b/modules/tournament/src/main/TournamentBusHandler.scala
@@ -20,7 +20,7 @@ final private class TournamentBusHandler(
     "adjustCheater",
     "adjustBooster",
     "playban",
-    "teamKick",
+    "teamQuit",
     "berserk"
   ) {
 
@@ -47,7 +47,7 @@ final private class TournamentBusHandler(
 
     case lila.hub.actorApi.playban.Playban(userId, _, true) => api.pausePlaybanned(userId).unit
 
-    case lila.hub.actorApi.team.KickFromTeam(teamId, userId) => api.kickFromTeam(teamId, userId).unit
+    case lila.hub.actorApi.team.QuitTeam(teamId, userId) => api.quitTeamTournaments(teamId, userId).unit
   }
 
   private def ejectFromEnterable(userId: User.ID) =


### PR DESCRIPTION
fixes #6620 

Most of this is just name changes to reflect the more general "no longer in team" event circumstance - being kicked can be a special case of quitting but the opposite is less true.  Tried LeaveTeam with a kicked Boolean member in the case class, but kicked ended up unused.  (thought maybe it could inform something like in-progress game forfeit/abort behavior, but a wise man recommended just let the games play out and that's fine by me).  So no distinction between quit and kicked.

Also satisfy scalafmt's need for alphabetical order in all things.