### PR TITLE
Create analysis with right color

### DIFF
--- a/ui/editor/src/ctrl.ts
+++ b/ui/editor/src/ctrl.ts
@@ -121,9 +121,9 @@ export default class EditorCtrl {
     };
   }
 
-  makeAnalysisUrl(legalFen: string): string {
+  makeAnalysisUrl(legalFen: string, orientation: Color = 'white'): string {
     const variant = this.rules === 'chess' ? '' : lichessVariant(this.rules) + '/';
-    return `/analysis/${variant}${urlFen(legalFen)}`;
+    return `/analysis/${variant}${urlFen(legalFen)}?color=${orientation}`;
   }
 
   makeEditorUrl(fen: string): string {

--- a/ui/editor/src/view.ts
+++ b/ui/editor/src/view.ts
@@ -245,7 +245,7 @@ function controls(ctrl: EditorCtrl, state: EditorState): VNode {
                 attrs: {
                   'data-icon': '',
                   rel: 'nofollow',
-                  ...(state.legalFen ? { href: ctrl.makeAnalysisUrl(state.legalFen) } : {}),
+                  ...(state.legalFen ? { href: ctrl.makeAnalysisUrl(state.legalFen, ctrl.bottomColor()) } : {}),
                 },
                 class: {
                   button: true,


### PR DESCRIPTION
Fixes #11188 by passing in the current orientation as a query param already being handled [here](https://github.com/lichess-org/lila/blob/3a64ba8690ca54bb9064d1b8dcc5328af40a9f0b/app/controllers/UserAnalysis.scala#L46)