### PR TITLE
Force ltr on blog content

### DIFF
--- a/app/templating/DateHelper.scala
+++ b/app/templating/DateHelper.scala
@@ -44,7 +44,8 @@ trait DateHelper { self: I18nHelper with StringHelper =>
     showDateTimeZone(date, DateTimeZone.UTC)
 
   def showDate(date: DateTime)(implicit lang: Lang): String =
-    dateFormatter print date
+    if (lang.language == "ar") dateFormatter print date replaceAll ("\u200f", "")
+    else dateFormatter print date 
 
   def showEnglishDate(date: DateTime): String =
     englishDateFormatter print date

--- a/app/templating/DateHelper.scala
+++ b/app/templating/DateHelper.scala
@@ -45,7 +45,7 @@ trait DateHelper { self: I18nHelper with StringHelper =>
 
   def showDate(date: DateTime)(implicit lang: Lang): String =
     if (lang.language == "ar") dateFormatter print date replaceAll ("\u200f", "")
-    else dateFormatter print date 
+    else dateFormatter print date
 
   def showEnglishDate(date: DateTime): String =
     englishDateFormatter print date

--- a/app/views/appeal/tree.scala
+++ b/app/views/appeal/tree.scala
@@ -14,12 +14,12 @@ object tree {
   import trans.contact.doNotMessageModerators
   import views.html.base.navTree._
 
-  val cleanAllGood = "Your account is not marked or restricted. You're all good!";
-  val engineMarked = "Your account is marked for illegal assistance in games.";
-  val boosterMarked = "Your account is marked for rating manipulation.";
-  val accountMuted = "Your account is muted.";
+  val cleanAllGood             = "Your account is not marked or restricted. You're all good!";
+  val engineMarked             = "Your account is marked for illegal assistance in games.";
+  val boosterMarked            = "Your account is marked for rating manipulation.";
+  val accountMuted             = "Your account is muted.";
   val excludedFromLeaderboards = "Your account has been excluded from leaderboards.";
-  val closedByModerators = "Your account was closed by moderators.";
+  val closedByModerators       = "Your account was closed by moderators.";
 
   private def cleanMenu(implicit ctx: Context): Branch =
     Branch(

--- a/app/views/blog/index.scala
+++ b/app/views/blog/index.scala
@@ -24,7 +24,7 @@ object index {
     )(
       main(cls := "page-menu")(
         bits.menu(none, "lichess".some),
-        div(cls := "blog index page-menu__content page-small box")(
+        div(cls := "blog index page-menu__content page-small box force-ltr")(
           div(cls := "box__top")(
             h1("Lichess Official Blog"),
             a(cls := "atom", st.title := "Atom RSS feed", href := routes.Blog.atom, dataIcon := "")
@@ -54,7 +54,7 @@ object index {
     )(
       main(cls := "page-menu")(
         bits.menu(year.some, none),
-        div(cls := "page-menu__content box")(
+        div(cls := "page-menu__content box force-ltr")(
           div(cls := "box__top")(h1(s"Lichess blog posts from $year")),
           st.section(
             div(cls := "blog-cards")(posts map { bits.postCard(_) })

--- a/app/views/blog/show.scala
+++ b/app/views/blog/show.scala
@@ -26,7 +26,7 @@ object show {
     )(
       main(cls := "page-menu page-small")(
         bits.menu(none, "lichess".some),
-        div(cls := s"blog page-menu__content box post ${~doc.getText("blog.cssClasses")}")(
+        div(cls := s"blog page-menu__content box post force-ltr ${~doc.getText("blog.cssClasses")}")(
           h1(doc.getText("blog.title")),
           bits.metas(doc),
           doc.getImage("blog.image", "main").map { img =>

--- a/app/views/tutor/compare.scala
+++ b/app/views/tutor/compare.scala
@@ -9,7 +9,7 @@ import lila.app.ui.ScalatagsTemplate._
 import lila.common.LilaOpeningFamily
 import lila.insight.{ InsightDimension, Phase }
 import lila.rating.PerfType
-import lila.tutor.{ TutorCompare, TutorMetric, Grade }
+import lila.tutor.{ Grade, TutorCompare, TutorMetric }
 
 private object compare {
 

--- a/ui/site/css/_blog.scss
+++ b/ui/site/css/_blog.scss
@@ -244,7 +244,7 @@
     time {
       position: absolute;
       top: 0;
-      #{$start-direction}: 0;
+      left: 0;
       padding: 0.2em 0.5em;
       background: #111;
       color: #ddd;


### PR DESCRIPTION
Lichess blog is written in English so it is safe to assume it should be left aligned even in ltr languages

There is an issue I'm trying to solve that may not be specific to blog content ...

![semantic date](https://user-images.githubusercontent.com/12477220/179355433-06185494-9163-4ec9-bfe1-4bd2b636ba19.PNG)

Notice that the date is displayed in a strange format

I'm not sure if this is in  the dateFormatter of templating.DateHelper or if this has to do with css ...

