### PR TITLE
Allow bundling ui/analyse without study code

### DIFF
--- a/app/templating/AssetHelper.scala
+++ b/app/templating/AssetHelper.scala
@@ -53,6 +53,7 @@ trait AssetHelper { self: I18nHelper with SecurityHelper =>
   def roundNvuiTag(implicit ctx: Context) = ctx.blind option jsModule("round.nvui")
 
   def analyseTag                            = jsModule("analysisBoard")
+  def analyseStudyTag                       = jsModule("analysisBoard.study")
   def analyseNvuiTag(implicit ctx: Context) = ctx.blind option jsModule("analysisBoard.nvui")
 
   def puzzleTag                            = jsModule("puzzle")

--- a/app/views/practice/show.scala
+++ b/app/views/practice/show.scala
@@ -18,7 +18,7 @@ object show {
       title = us.practiceStudy.name,
       moreCss = cssTag("analyse.practice"),
       moreJs = frag(
-        analyseTag,
+        analyseStudyTag,
         analyseNvuiTag,
         embedJsUnsafe(s"""lichess.practice=${safeJsonValue(
             Json.obj(

--- a/app/views/relay/show.scala
+++ b/app/views/relay/show.scala
@@ -23,7 +23,7 @@ object show {
       title = rt.fullName,
       moreCss = cssTag("analyse.relay"),
       moreJs = frag(
-        analyseTag,
+        analyseStudyTag,
         analyseNvuiTag,
         embedJsUnsafe(s"""lichess.relay=${safeJsonValue(
             Json.obj(

--- a/app/views/study/embed.scala
+++ b/app/views/study/embed.scala
@@ -50,7 +50,7 @@ object embed {
       views.html.base.layout.inlineJs(config.nonce)(config.lang),
       depsTag,
       jsModule("analysisBoard.embed"),
-      analyseTag,
+      analyseStudyTag,
       embedJsUnsafeLoadThen(
         s"""analyseEmbed(${safeJsonValue(
             Json.obj(

--- a/app/views/study/show.scala
+++ b/app/views/study/show.scala
@@ -22,7 +22,7 @@ object show {
       title = s.name.value,
       moreCss = cssTag("analyse.study"),
       moreJs = frag(
-        analyseTag,
+        analyseStudyTag,
         analyseNvuiTag,
         embedJsUnsafe(s"""lichess.study=${safeJsonValue(
             Json.obj(

--- a/ui/analyse/rollup.config.mjs
+++ b/ui/analyse/rollup.config.mjs
@@ -6,6 +6,11 @@ export default rollupProject({
     input: 'src/main.ts',
     output: 'analysisBoard', // can't call it analyse.js, triggers adblockers :facepalm:
   },
+  study: {
+    name: 'LichessAnalyseStudy',
+    input: 'src/plugins/studyMain.ts',
+    output: 'analysisBoard.study',
+  },
   nvui: {
     name: 'LichessAnalyseNvui',
     input: 'src/plugins/nvui.ts',

--- a/ui/analyse/src/boot.ts
+++ b/ui/analyse/src/boot.ts
@@ -1,36 +1,37 @@
-import { AnalyseOpts } from './interfaces';
-import { start } from './main';
+import { AnalyseApi, AnalyseOpts } from './interfaces';
 
-export default function (cfg: AnalyseOpts) {
-  lichess.socket = new lichess.StrongSocket(cfg.data.url.socket, cfg.data.player.version, {
-    params: {
-      userTv: cfg.data.userTv && cfg.data.userTv.id,
-    },
-    receive(t: string, d: any) {
-      analyse.socketReceive(t, d);
-    },
+export default function (start: (opts: AnalyseOpts) => AnalyseApi) {
+  function startUserAnalysis(cfg: any) {
+    cfg.$side = $('.analyse__side').clone();
+    startAnalyse(cfg);
+  }
+
+  function startAnalyse(cfg: any) {
+    lichess.socket = new lichess.StrongSocket(cfg.socketUrl || '/analysis/socket/v5', cfg.socketVersion, {
+      receive: (t: string, d: any) => analyse.socketReceive(t, d),
+    });
+    cfg.socketSend = lichess.socket.send;
+    const analyse = start(cfg);
+  }
+
+  lichess.load.then(() => {
+    const li: any = lichess;
+    if (li.userAnalysis) startUserAnalysis(li.userAnalysis);
+    else if (li.study || li.practice || li.relay) startAnalyse(li.study || li.practice || li.relay);
   });
-  cfg.$side = $('.analyse__side').clone();
-  cfg.$underboard = $('.analyse__underboard').clone();
-  cfg.socketSend = lichess.socket.send;
-  const analyse = start(cfg);
-}
 
-function startUserAnalysis(cfg: any) {
-  cfg.$side = $('.analyse__side').clone();
-  startAnalyse(cfg);
+  return function (cfg: AnalyseOpts) {
+    lichess.socket = new lichess.StrongSocket(cfg.data.url.socket, cfg.data.player.version, {
+      params: {
+        userTv: cfg.data.userTv && cfg.data.userTv.id,
+      },
+      receive(t: string, d: any) {
+        analyse.socketReceive(t, d);
+      },
+    });
+    cfg.$side = $('.analyse__side').clone();
+    cfg.$underboard = $('.analyse__underboard').clone();
+    cfg.socketSend = lichess.socket.send;
+    const analyse = start(cfg);
+  };
 }
-
-function startAnalyse(cfg: any) {
-  lichess.socket = new lichess.StrongSocket(cfg.socketUrl || '/analysis/socket/v5', cfg.socketVersion, {
-    receive: (t: string, d: any) => analyse.socketReceive(t, d),
-  });
-  cfg.socketSend = lichess.socket.send;
-  const analyse = start(cfg);
-}
-
-lichess.load.then(() => {
-  const li: any = lichess;
-  if (li.userAnalysis) startUserAnalysis(li.userAnalysis);
-  else if (li.study || li.practice || li.relay) startAnalyse(li.study || li.practice || li.relay);
-});

--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -7,7 +7,7 @@ import * as util from './util';
 import * as xhr from 'common/xhr';
 import debounce from 'common/debounce';
 import GamebookPlayCtrl from './study/gamebook/gamebookPlayCtrl';
-import makeStudy from './study/studyCtrl';
+import type makeStudyCtrl from './study/studyCtrl';
 import throttle from 'common/throttle';
 import { AnalyseOpts, AnalyseData, ServerEvalData, Key, JustCaptured, NvuiPlugin, Redraw } from './interfaces';
 import { Api as ChessgroundApi } from 'chessground/api';
@@ -115,7 +115,7 @@ export default class AnalyseCtrl {
   nvui?: NvuiPlugin;
   pvUciQueue: Uci[] = [];
 
-  constructor(readonly opts: AnalyseOpts, readonly redraw: Redraw) {
+  constructor(readonly opts: AnalyseOpts, readonly redraw: Redraw, makeStudy?: typeof makeStudyCtrl) {
     this.data = opts.data;
     this.element = opts.element;
     this.embed = opts.embed;
@@ -154,7 +154,7 @@ export default class AnalyseCtrl {
     this.startCeval();
     this.explorer.setNode();
     this.study = opts.study
-      ? makeStudy(opts.study, this, (opts.tagTypes || '').split(','), opts.practice, opts.relay)
+      ? makeStudy?.(opts.study, this, (opts.tagTypes || '').split(','), opts.practice, opts.relay)
       : undefined;
     this.studyPractice = this.study ? this.study.practice : undefined;
 

--- a/ui/analyse/src/patch.ts
+++ b/ui/analyse/src/patch.ts
@@ -1,0 +1,3 @@
+import { attributesModule, classModule, init } from 'snabbdom';
+
+export default init([classModule, attributesModule]);

--- a/ui/analyse/src/plugins/studyMain.ts
+++ b/ui/analyse/src/plugins/studyMain.ts
@@ -1,12 +1,13 @@
-import patch from './patch';
-import makeBoot from './boot';
-import makeStart from './start';
+import patch from '../patch';
+import makeBoot from '../boot';
+import makeStart from '../start';
 import LichessChat from 'chat';
 import { Chessground } from 'chessground';
+import * as studyDeps from '../study/studyDeps';
 
 export { patch };
 
-export const start = makeStart(patch);
+export const start = makeStart(patch, studyDeps);
 
 export const boot = makeBoot(start);
 

--- a/ui/analyse/src/start.ts
+++ b/ui/analyse/src/start.ts
@@ -1,0 +1,37 @@
+import makeCtrl from './ctrl';
+import menuHover from 'common/menuHover';
+import makeView from './view';
+import { AnalyseApi, AnalyseOpts } from './interfaces';
+import { VNode } from 'snabbdom';
+import type * as studyDeps from './study/studyDeps';
+
+export default function (
+  patch: (oldVnode: VNode | Element | DocumentFragment, vnode: VNode) => VNode,
+  deps?: typeof studyDeps
+) {
+  return function (opts: AnalyseOpts): AnalyseApi {
+    opts.element = document.querySelector('main.analyse') as HTMLElement;
+    opts.trans = lichess.trans(opts.i18n);
+
+    const ctrl = (lichess.analysis = new makeCtrl(opts, redraw, deps?.makeStudy));
+    const view = makeView(deps);
+
+    const blueprint = view(ctrl);
+    opts.element.innerHTML = '';
+    let vnode = patch(opts.element, blueprint);
+
+    function redraw() {
+      vnode = patch(vnode, view(ctrl));
+    }
+
+    menuHover();
+
+    return {
+      socketReceive: ctrl.socket.receive,
+      path: () => ctrl.path,
+      setChapter(id: string) {
+        if (ctrl.study) ctrl.study.setChapter(id);
+      },
+    };
+  };
+}

--- a/ui/analyse/src/study/studyDeps.ts
+++ b/ui/analyse/src/study/studyDeps.ts
@@ -1,0 +1,13 @@
+import relayManager from './relay/relayManagerView';
+import relayTour from './relay/relayTourView';
+import renderPlayerBars from './playerBars';
+import practiceView from '../practice/practiceView';
+import makeStudy from './studyCtrl';
+
+export { relayManager, relayTour, renderPlayerBars, practiceView, makeStudy };
+
+export * as gbEdit from './gamebook/gamebookEdit';
+export * as gbPlay from './gamebook/gamebookPlayView';
+export * as studyPracticeView from './practice/studyPracticeView';
+export { findTag } from './studyChapters';
+export * as studyView from './studyView';

--- a/ui/analyse/src/treeView/contextMenu.ts
+++ b/ui/analyse/src/treeView/contextMenu.ts
@@ -1,7 +1,7 @@
 import { bind, onInsert } from 'common/snabbdom';
 import { h, VNode } from 'snabbdom';
 import AnalyseCtrl from '../ctrl';
-import { patch } from '../main';
+import patch from '../patch';
 import * as studyView from '../study/studyView';
 import { nodeFullName } from '../util';
 

--- a/ui/analyse/src/view.ts
+++ b/ui/analyse/src/view.ts
@@ -31,50 +31,13 @@ import * as chessground from './ground';
 import { ConcealOf } from './interfaces';
 import { view as keyboardView } from './keyboard';
 import * as pgnExport from './pgnExport';
-import practiceView from './practice/practiceView';
 import retroView from './retrospect/retroView';
 import serverSideUnderboard from './serverSideUnderboard';
-import * as gbEdit from './study/gamebook/gamebookEdit';
-import * as gbPlay from './study/gamebook/gamebookPlayView';
 import { StudyCtrl } from './study/interfaces';
-import renderPlayerBars from './study/playerBars';
-import * as studyPracticeView from './study/practice/studyPracticeView';
-import relayManager from './study/relay/relayManagerView';
-import relayTour from './study/relay/relayTourView';
-import { findTag } from './study/studyChapters';
-import * as studyView from './study/studyView';
 import { render as renderTreeView } from './treeView/treeView';
 import { spinnerVdom as spinner } from 'common/spinner';
 import stepwiseScroll from 'common/wheel';
-
-function renderResult(ctrl: AnalyseCtrl): VNode[] {
-  const render = (result: string, status: MaybeVNodes) => [h('div.result', result), h('div.status', status)];
-  if (ctrl.data.game.status.id >= 30) {
-    let result;
-    switch (ctrl.data.game.winner) {
-      case 'white':
-        result = '1-0';
-        break;
-      case 'black':
-        result = '0-1';
-        break;
-      default:
-        result = '½-½';
-    }
-    const winner = getPlayer(ctrl.data, ctrl.data.game.winner!);
-    return render(result, [
-      statusView(ctrl),
-      winner ? ' • ' + ctrl.trans(winner.color == 'white' ? 'whiteIsVictorious' : 'blackIsVictorious') : null,
-    ]);
-  } else if (ctrl.study) {
-    const result = findTag(ctrl.study.data.chapter.tags, 'result');
-    if (!result || result === '*') return [];
-    if (result === '1-0') return render(result, [ctrl.trans.noarg('whiteIsVictorious')]);
-    if (result === '0-1') return render(result, [ctrl.trans.noarg('blackIsVictorious')]);
-    return render('½-½', [ctrl.trans.noarg('draw')]);
-  }
-  return [];
-}
+import type * as studyDeps from './study/studyDeps';
 
 function makeConcealOf(ctrl: AnalyseCtrl): ConcealOf | undefined {
   const conceal =
@@ -111,15 +74,30 @@ export const renderNextChapter = (ctrl: AnalyseCtrl) =>
       )
     : null;
 
-const renderAnalyse = (ctrl: AnalyseCtrl, concealOf?: ConcealOf) =>
-  h('div.analyse__moves.areplay', [
-    h('div', [
-      ctrl.embed && ctrl.study ? h('div.chapter-name', ctrl.study.currentChapter().name) : null,
-      renderTreeView(ctrl, concealOf),
-      ...renderResult(ctrl),
-    ]),
-    !ctrl.practice && !gbEdit.running(ctrl) ? renderNextChapter(ctrl) : null,
-  ]);
+const jumpButton = (icon: string, effect: string, enabled: boolean): VNode =>
+  h('button.fbt', {
+    class: { disabled: !enabled },
+    attrs: { 'data-act': effect, 'data-icon': icon },
+  });
+
+const dataAct = (e: Event): string | null => {
+  const target = e.target as HTMLElement;
+  return target.getAttribute('data-act') || (target.parentNode as HTMLElement).getAttribute('data-act');
+};
+
+function repeater(ctrl: AnalyseCtrl, action: 'prev' | 'next', e: Event) {
+  const repeat = () => {
+    control[action](ctrl);
+    ctrl.redraw();
+    delay = Math.max(100, delay - delay / 15);
+    timeout = setTimeout(repeat, delay);
+  };
+  let delay = 350;
+  let timeout = setTimeout(repeat, 500);
+  control[action](ctrl);
+  const eventName = e.type == 'touchstart' ? 'touchend' : 'mouseup';
+  document.addEventListener(eventName, () => clearTimeout(timeout), { once: true });
+}
 
 function inputs(ctrl: AnalyseCtrl): VNode | undefined {
   if (ctrl.ongoing || !ctrl.data.userAnalysis) return;
@@ -188,31 +166,6 @@ function inputs(ctrl: AnalyseCtrl): VNode | undefined {
       ]),
     ]),
   ]);
-}
-
-const jumpButton = (icon: string, effect: string, enabled: boolean): VNode =>
-  h('button.fbt', {
-    class: { disabled: !enabled },
-    attrs: { 'data-act': effect, 'data-icon': icon },
-  });
-
-const dataAct = (e: Event): string | null => {
-  const target = e.target as HTMLElement;
-  return target.getAttribute('data-act') || (target.parentNode as HTMLElement).getAttribute('data-act');
-};
-
-function repeater(ctrl: AnalyseCtrl, action: 'prev' | 'next', e: Event) {
-  const repeat = () => {
-    control[action](ctrl);
-    ctrl.redraw();
-    delay = Math.max(100, delay - delay / 15);
-    timeout = setTimeout(repeat, delay);
-  };
-  let delay = 350;
-  let timeout = setTimeout(repeat, 500);
-  control[action](ctrl);
-  const eventName = e.type == 'touchstart' ? 'touchend' : 'mouseup';
-  document.addEventListener(eventName, () => clearTimeout(timeout), { once: true });
 }
 
 function controls(ctrl: AnalyseCtrl) {
@@ -337,6 +290,9 @@ const analysisDisabled = (ctrl: AnalyseCtrl): MaybeVNode =>
       ])
     : undefined;
 
+const renderPlayerStrip = (cls: string, materialDiff: VNode, clock?: VNode): VNode =>
+  h('div.analyse__player_strip.' + cls, [materialDiff, clock]);
+
 export function renderMaterialDiffs(ctrl: AnalyseCtrl): [VNode, VNode] {
   const cgState = ctrl.chessground?.state,
     pieces = cgState ? cgState.pieces : readFen(ctrl.node.fen);
@@ -351,9 +307,6 @@ export function renderMaterialDiffs(ctrl: AnalyseCtrl): [VNode, VNode] {
   );
 }
 
-const renderPlayerStrip = (cls: string, materialDiff: VNode, clock?: VNode): VNode =>
-  h('div.analyse__player_strip.' + cls, [materialDiff, clock]);
-
 function renderPlayerStrips(ctrl: AnalyseCtrl): [VNode, VNode] | undefined {
   if (ctrl.embed) return;
 
@@ -367,165 +320,206 @@ function renderPlayerStrips(ctrl: AnalyseCtrl): [VNode, VNode] | undefined {
   ];
 }
 
-export default function (ctrl: AnalyseCtrl): VNode {
-  if (ctrl.nvui) return ctrl.nvui.render();
-  const concealOf = makeConcealOf(ctrl),
-    study = ctrl.study,
-    showCevalPvs = !(ctrl.retro && ctrl.retro.isSolving()) && !ctrl.practice,
-    menuIsOpen = ctrl.actionMenu.open,
-    gamebookPlay = ctrl.gamebookPlay(),
-    gamebookPlayView = gamebookPlay && gbPlay.render(gamebookPlay),
-    gamebookEditView = gbEdit.running(ctrl) ? gbEdit.render(ctrl) : undefined,
-    playerBars = renderPlayerBars(ctrl),
-    playerStrips = !playerBars && renderPlayerStrips(ctrl),
-    gaugeOn = ctrl.showEvalGauge(),
-    needsInnerCoords = !!gaugeOn || !!playerBars,
-    tour = relayTour(ctrl);
+export default function (deps?: typeof studyDeps) {
+  function renderResult(ctrl: AnalyseCtrl): VNode[] {
+    const render = (result: string, status: MaybeVNodes) => [h('div.result', result), h('div.status', status)];
+    if (ctrl.data.game.status.id >= 30) {
+      let result;
+      switch (ctrl.data.game.winner) {
+        case 'white':
+          result = '1-0';
+          break;
+        case 'black':
+          result = '0-1';
+          break;
+        default:
+          result = '½-½';
+      }
+      const winner = getPlayer(ctrl.data, ctrl.data.game.winner!);
+      return render(result, [
+        statusView(ctrl),
+        winner ? ' • ' + ctrl.trans(winner.color == 'white' ? 'whiteIsVictorious' : 'blackIsVictorious') : null,
+      ]);
+    } else if (ctrl.study) {
+      const result = deps?.findTag(ctrl.study.data.chapter.tags, 'result');
+      if (!result || result === '*') return [];
+      if (result === '1-0') return render(result, [ctrl.trans.noarg('whiteIsVictorious')]);
+      if (result === '0-1') return render(result, [ctrl.trans.noarg('blackIsVictorious')]);
+      return render('½-½', [ctrl.trans.noarg('draw')]);
+    }
+    return [];
+  }
 
-  return h(
-    'main.analyse.variant-' + ctrl.data.game.variant.key,
-    {
-      hook: {
-        insert: vn => {
-          const elm = vn.elm as HTMLElement;
-          forceInnerCoords(ctrl, needsInnerCoords);
-          if (!!playerBars != $('body').hasClass('header-margin')) {
-            requestAnimationFrame(() => {
-              $('body').toggleClass('header-margin', !!playerBars);
-              ctrl.redraw();
-            });
-          }
-          if (ctrl.opts.chat) {
-            const chatEl = document.createElement('section');
-            chatEl.classList.add('mchat');
-            elm.appendChild(chatEl);
-            const chatOpts = ctrl.opts.chat;
-            chatOpts.instance?.then(c => c.destroy());
-            chatOpts.parseMoves = true;
-            chatOpts.instance = lichess.makeChat(chatOpts);
-          }
-          gridHacks.start(elm);
-        },
-        update(_, _2) {
-          forceInnerCoords(ctrl, needsInnerCoords);
-        },
-        postpatch(old, vnode) {
-          if (old.data!.gaugeOn !== gaugeOn) document.body.dispatchEvent(new Event('chessground.resize'));
-          vnode.data!.gaugeOn = gaugeOn;
-        },
-      },
-      class: {
-        'comp-off': !ctrl.showComputer(),
-        'gauge-on': gaugeOn,
-        'has-players': !!playerBars,
-        'gamebook-play': !!gamebookPlayView,
-        'has-relay-tour': !!tour,
-        'analyse-hunter': ctrl.opts.hunter,
-        'analyse--wiki': !!ctrl.wiki && !ctrl.study,
-      },
-    },
-    [
-      ctrl.keyboardHelp ? keyboardView(ctrl) : null,
-      study ? studyView.overboard(study) : null,
-      tour ||
-        h(
-          addChapterId(study, 'div.analyse__board.main-board'),
-          {
-            hook:
-              'ontouchstart' in window || lichess.storage.get('scrollMoves') == '0'
-                ? undefined
-                : bindNonPassive(
-                    'wheel',
-                    stepwiseScroll((e: WheelEvent, scroll: boolean) => {
-                      if (ctrl.gamebookPlay()) return;
-                      const target = e.target as HTMLElement;
-                      if (target.tagName !== 'PIECE' && target.tagName !== 'SQUARE' && target.tagName !== 'CG-BOARD')
-                        return;
-                      e.preventDefault();
-                      if (e.deltaY > 0 && scroll) control.next(ctrl);
-                      else if (e.deltaY < 0 && scroll) control.prev(ctrl);
-                      ctrl.redraw();
-                    })
-                  ),
+  const renderAnalyse = (ctrl: AnalyseCtrl, concealOf?: ConcealOf) =>
+    h('div.analyse__moves.areplay', [
+      h('div', [
+        ctrl.embed && ctrl.study ? h('div.chapter-name', ctrl.study.currentChapter().name) : null,
+        renderTreeView(ctrl, concealOf),
+        ...renderResult(ctrl),
+      ]),
+      !ctrl.practice && !deps?.gbEdit.running(ctrl) ? renderNextChapter(ctrl) : null,
+    ]);
+
+  return function (ctrl: AnalyseCtrl): VNode {
+    if (ctrl.nvui) return ctrl.nvui.render();
+    const concealOf = makeConcealOf(ctrl),
+      study = ctrl.study,
+      showCevalPvs = !(ctrl.retro && ctrl.retro.isSolving()) && !ctrl.practice,
+      menuIsOpen = ctrl.actionMenu.open,
+      gamebookPlay = ctrl.gamebookPlay(),
+      gamebookPlayView = gamebookPlay && deps?.gbPlay.render(gamebookPlay),
+      gamebookEditView = deps?.gbEdit.running(ctrl) ? deps?.gbEdit.render(ctrl) : undefined,
+      playerBars = deps?.renderPlayerBars(ctrl),
+      playerStrips = !playerBars && renderPlayerStrips(ctrl),
+      gaugeOn = ctrl.showEvalGauge(),
+      needsInnerCoords = !!gaugeOn || !!playerBars,
+      tour = deps?.relayTour(ctrl);
+
+    return h(
+      'main.analyse.variant-' + ctrl.data.game.variant.key,
+      {
+        hook: {
+          insert: vn => {
+            const elm = vn.elm as HTMLElement;
+            forceInnerCoords(ctrl, needsInnerCoords);
+            if (!!playerBars != $('body').hasClass('header-margin')) {
+              requestAnimationFrame(() => {
+                $('body').toggleClass('header-margin', !!playerBars);
+                ctrl.redraw();
+              });
+            }
+            if (ctrl.opts.chat) {
+              const chatEl = document.createElement('section');
+              chatEl.classList.add('mchat');
+              elm.appendChild(chatEl);
+              const chatOpts = ctrl.opts.chat;
+              chatOpts.instance?.then(c => c.destroy());
+              chatOpts.parseMoves = true;
+              chatOpts.instance = lichess.makeChat(chatOpts);
+            }
+            gridHacks.start(elm);
           },
-          [
-            ...(playerStrips || []),
-            playerBars ? playerBars[ctrl.bottomIsWhite() ? 1 : 0] : null,
-            chessground.render(ctrl),
-            playerBars ? playerBars[ctrl.bottomIsWhite() ? 0 : 1] : null,
-            ctrl.promotion.view(ctrl.data.game.variant.key === 'antichess'),
-          ]
-        ),
-      gaugeOn && !tour ? cevalView.renderGauge(ctrl) : null,
-      menuIsOpen || tour ? null : crazyView(ctrl, ctrl.topColor(), 'top'),
-      gamebookPlayView ||
-        (tour
-          ? null
-          : h(addChapterId(study, 'div.analyse__tools'), [
-              ...(menuIsOpen
-                ? [actionMenu(ctrl)]
-                : [
-                    ctrl.showComputer() ? cevalView.renderCeval(ctrl) : analysisDisabled(ctrl),
-                    showCevalPvs ? cevalView.renderPvs(ctrl) : null,
-                    renderAnalyse(ctrl, concealOf),
-                    gamebookEditView || forkView(ctrl, concealOf),
-                    retroView(ctrl) || practiceView(ctrl) || explorerView(ctrl),
-                  ]),
-            ])),
-      menuIsOpen || tour ? null : crazyView(ctrl, ctrl.bottomColor(), 'bottom'),
-      gamebookPlayView || tour ? null : controls(ctrl),
-      ctrl.embed || tour
-        ? null
-        : h(
-            'div.analyse__underboard',
+          update(_, _2) {
+            forceInnerCoords(ctrl, needsInnerCoords);
+          },
+          postpatch(old, vnode) {
+            if (old.data!.gaugeOn !== gaugeOn) document.body.dispatchEvent(new Event('chessground.resize'));
+            vnode.data!.gaugeOn = gaugeOn;
+          },
+        },
+        class: {
+          'comp-off': !ctrl.showComputer(),
+          'gauge-on': gaugeOn,
+          'has-players': !!playerBars,
+          'gamebook-play': !!gamebookPlayView,
+          'has-relay-tour': !!tour,
+          'analyse-hunter': ctrl.opts.hunter,
+          'analyse--wiki': !!ctrl.wiki && !ctrl.study,
+        },
+      },
+      [
+        ctrl.keyboardHelp ? keyboardView(ctrl) : null,
+        study ? deps?.studyView.overboard(study) : null,
+        tour ||
+          h(
+            addChapterId(study, 'div.analyse__board.main-board'),
             {
               hook:
-                ctrl.synthetic || playable(ctrl.data) ? undefined : onInsert(elm => serverSideUnderboard(elm, ctrl)),
+                'ontouchstart' in window || lichess.storage.get('scrollMoves') == '0'
+                  ? undefined
+                  : bindNonPassive(
+                      'wheel',
+                      stepwiseScroll((e: WheelEvent, scroll: boolean) => {
+                        if (ctrl.gamebookPlay()) return;
+                        const target = e.target as HTMLElement;
+                        if (target.tagName !== 'PIECE' && target.tagName !== 'SQUARE' && target.tagName !== 'CG-BOARD')
+                          return;
+                        e.preventDefault();
+                        if (e.deltaY > 0 && scroll) control.next(ctrl);
+                        else if (e.deltaY < 0 && scroll) control.prev(ctrl);
+                        ctrl.redraw();
+                      })
+                    ),
             },
-            study ? studyView.underboard(ctrl) : [inputs(ctrl)]
+            [
+              ...(playerStrips || []),
+              playerBars ? playerBars[ctrl.bottomIsWhite() ? 1 : 0] : null,
+              chessground.render(ctrl),
+              playerBars ? playerBars[ctrl.bottomIsWhite() ? 0 : 1] : null,
+              ctrl.promotion.view(ctrl.data.game.variant.key === 'antichess'),
+            ]
           ),
-      tour ? null : trainingView(ctrl),
-      ctrl.embed
-        ? null
-        : ctrl.studyPractice
-        ? studyPracticeView.side(study!)
-        : h(
-            'aside.analyse__side',
-            {
-              hook: onInsert(elm => {
-                ctrl.opts.$side && ctrl.opts.$side.length && $(elm).replaceWith(ctrl.opts.$side);
-                $(elm).append($('.context-streamers').clone().removeClass('none'));
-              }),
-            },
-            ctrl.studyPractice
-              ? [studyPracticeView.side(study!)]
-              : study
-              ? [studyView.side(study)]
-              : [
-                  ctrl.forecast ? forecastView(ctrl, ctrl.forecast) : null,
-                  !ctrl.synthetic && playable(ctrl.data)
-                    ? h(
-                        'div.back-to-game',
-                        h(
-                          'a.button.button-empty.text',
-                          {
-                            attrs: {
-                              href: router.game(ctrl.data, ctrl.data.player.color),
-                              'data-icon': '',
+        gaugeOn && !tour ? cevalView.renderGauge(ctrl) : null,
+        menuIsOpen || tour ? null : crazyView(ctrl, ctrl.topColor(), 'top'),
+        gamebookPlayView ||
+          (tour
+            ? null
+            : h(addChapterId(study, 'div.analyse__tools'), [
+                ...(menuIsOpen
+                  ? [actionMenu(ctrl)]
+                  : [
+                      ctrl.showComputer() ? cevalView.renderCeval(ctrl) : analysisDisabled(ctrl),
+                      showCevalPvs ? cevalView.renderPvs(ctrl) : null,
+                      renderAnalyse(ctrl, concealOf),
+                      gamebookEditView || forkView(ctrl, concealOf),
+                      retroView(ctrl) || deps?.practiceView(ctrl) || explorerView(ctrl),
+                    ]),
+              ])),
+        menuIsOpen || tour ? null : crazyView(ctrl, ctrl.bottomColor(), 'bottom'),
+        gamebookPlayView || tour ? null : controls(ctrl),
+        ctrl.embed || tour
+          ? null
+          : h(
+              'div.analyse__underboard',
+              {
+                hook:
+                  ctrl.synthetic || playable(ctrl.data) ? undefined : onInsert(elm => serverSideUnderboard(elm, ctrl)),
+              },
+              study ? deps?.studyView.underboard(ctrl) : [inputs(ctrl)]
+            ),
+        tour ? null : trainingView(ctrl),
+        ctrl.embed
+          ? null
+          : ctrl.studyPractice
+          ? deps?.studyPracticeView.side(study!)
+          : h(
+              'aside.analyse__side',
+              {
+                hook: onInsert(elm => {
+                  ctrl.opts.$side && ctrl.opts.$side.length && $(elm).replaceWith(ctrl.opts.$side);
+                  $(elm).append($('.context-streamers').clone().removeClass('none'));
+                }),
+              },
+              ctrl.studyPractice
+                ? [deps?.studyPracticeView.side(study!)]
+                : study
+                ? [deps?.studyView.side(study)]
+                : [
+                    ctrl.forecast ? forecastView(ctrl, ctrl.forecast) : null,
+                    !ctrl.synthetic && playable(ctrl.data)
+                      ? h(
+                          'div.back-to-game',
+                          h(
+                            'a.button.button-empty.text',
+                            {
+                              attrs: {
+                                href: router.game(ctrl.data, ctrl.data.player.color),
+                                'data-icon': '',
+                              },
                             },
-                          },
-                          ctrl.trans.noarg('backToGame')
+                            ctrl.trans.noarg('backToGame')
+                          )
                         )
-                      )
-                    : null,
-                ]
-          ),
-      study && study.relay && relayManager(study.relay),
-      ctrl.embed
-        ? null
-        : h('div.chat__members.none', {
-            hook: onInsert(lichess.watchers),
-          }),
-    ]
-  );
+                      : null,
+                  ]
+            ),
+        study && study.relay && deps?.relayManager(study.relay),
+        ctrl.embed
+          ? null
+          : h('div.chat__members.none', {
+              hook: onInsert(lichess.watchers),
+            }),
+      ]
+    );
+  };
 }

--- a/ui/build
+++ b/ui/build
@@ -19,7 +19,7 @@ apps2="chess palantir"
 apps3="ceval game tree chat nvui puz keyboardMove"
 apps4="site swiss msg tutor replay opening cli challenge notify learn insight editor puzzle round analyse lobby tournament tournamentSchedule tournamentCalendar simul dasher serviceWorker dgt storm racer coordinateTrainer"
 site_plugins="tvEmbed puzzleEmbed analyseEmbed user clas captcha expandText team forum account coachShow coachForm challengePage checkout plan login passwordComplexity tourForm teamBattleForm gameSearch userComplete infiniteScroll flatpickr appeal publicChats contact userGamesDownload tvGames ublog ublogForm speech"
-other_plugins="round:nvui analyse:nvui analyse:studyTopicForm puzzle:nvui puzzle:dashboard puzzle:opening chart:ratingDistribution chart:ratingHistory chart:game mod:user mod:inquiry mod:search mod:games mod:activity mod:teamAdmin "
+other_plugins="round:nvui analyse:nvui analyse:study analyse:studyTopicForm puzzle:nvui puzzle:dashboard puzzle:opening chart:ratingDistribution chart:ratingHistory chart:game mod:user mod:inquiry mod:search mod:games mod:activity mod:teamAdmin "
 
 if [ $mode == "upgrade" ]; then
   yarn upgrade --non-interactive


### PR DESCRIPTION
Closes #5862.

The wanted label got removed, so I'm not sure what the status of the issue is, but here's an implementation.

Makes a new entry point into ui/analyse and passes study-related code using dependency injection so that rollup knows to tree-shake it.

Study js stripped in:

- game embeds
- game replay analysis
- user analysis

Study js kept in:

- practice
- relay
- studies
- study embeds

Sizes before compression:

| file | size (bytes) | delta |
| --- | ---: | ---: |
| old analysisBoard.min.js | 285953 | +0 |
| new analysisBoard.study.min.js | 287302 | +1349 (+0.5%) |
| new analysisBoard.min.js | 219816 | -66137 (-23.1%) |

I left crazyhouse code in the small bundle because /analysis allows switching variants on the fly. We could make more bundles to cover variant and forecast presence if desired.