### PR TITLE
Add orientation to editor url

### DIFF
--- a/ui/analyse/src/actionMenu.ts
+++ b/ui/analyse/src/actionMenu.ts
@@ -192,7 +192,7 @@ export function view(ctrl: AnalyseCtrl): VNode {
             {
               attrs: {
                 href: d.userAnalysis
-                  ? '/editor?' + new URLSearchParams({ fen: ctrl.node.fen, variant: d.game.variant.key })
+                  ? '/editor?' + new URLSearchParams({ fen: ctrl.node.fen, variant: d.game.variant.key, color: ctrl.chessground.state.orientation})
                   : `/${d.game.id}/edit?fen=${ctrl.node.fen}`,
                 'data-icon': '',
                 ...(ctrl.embed

--- a/ui/analyse/src/actionMenu.ts
+++ b/ui/analyse/src/actionMenu.ts
@@ -192,7 +192,12 @@ export function view(ctrl: AnalyseCtrl): VNode {
             {
               attrs: {
                 href: d.userAnalysis
-                  ? '/editor?' + new URLSearchParams({ fen: ctrl.node.fen, variant: d.game.variant.key, color: ctrl.chessground.state.orientation})
+                  ? '/editor?' +
+                    new URLSearchParams({
+                      fen: ctrl.node.fen,
+                      variant: d.game.variant.key,
+                      color: ctrl.chessground.state.orientation,
+                    })
                   : `/${d.game.id}/edit?fen=${ctrl.node.fen}`,
                 'data-icon': '',
                 ...(ctrl.embed

--- a/ui/editor/src/ctrl.ts
+++ b/ui/editor/src/ctrl.ts
@@ -47,7 +47,7 @@ export default class EditorCtrl {
 
     window.Mousetrap.bind('f', () => {
       if (this.chessground) this.chessground.toggleOrientation();
-      this.onChange()
+      this.onChange();
     });
 
     this.castlingToggles = { K: false, Q: false, k: false, q: false };
@@ -57,7 +57,7 @@ export default class EditorCtrl {
 
     this.redraw = () => {};
     if (!this.cfg.embed) {
-      this.options.orientation = (params.get('color') === 'black') ? 'black' : 'white'
+      this.options.orientation = params.get('color') === 'black' ? 'black' : 'white';
     }
     this.setFen(this.initialFen);
     this.redraw = redraw;
@@ -132,7 +132,7 @@ export default class EditorCtrl {
   makeEditorUrl(fen: string, orientation: Color = 'white'): string {
     if (fen === INITIAL_FEN && this.rules === 'chess' && orientation === 'white') return this.cfg.baseUrl;
     const variant = this.rules === 'chess' ? '' : '?variant=' + lichessVariant(this.rules);
-    const orientationParam = variant ? `&color=${orientation}` : `?color=${orientation}`
+    const orientationParam = variant ? `&color=${orientation}` : `?color=${orientation}`;
     return `${this.cfg.baseUrl}/${urlFen(fen)}${variant}${orientationParam}`;
   }
 

--- a/ui/editor/src/ctrl.ts
+++ b/ui/editor/src/ctrl.ts
@@ -47,7 +47,7 @@ export default class EditorCtrl {
 
     window.Mousetrap.bind('f', () => {
       if (this.chessground) this.chessground.toggleOrientation();
-      redraw();
+      this.onChange()
     });
 
     this.castlingToggles = { K: false, Q: false, k: false, q: false };
@@ -56,6 +56,9 @@ export default class EditorCtrl {
     this.initialFen = (cfg.fen || params.get('fen') || INITIAL_FEN).replace(/_/g, ' ');
 
     this.redraw = () => {};
+    if (!this.cfg.embed) {
+      this.options.orientation = (params.get('color') === 'black') ? 'black' : 'white'
+    }
     this.setFen(this.initialFen);
     this.redraw = redraw;
   }
@@ -63,7 +66,7 @@ export default class EditorCtrl {
   onChange(): void {
     const fen = this.getFen();
     if (!this.cfg.embed) {
-      window.history.replaceState(null, '', this.makeEditorUrl(fen));
+      window.history.replaceState(null, '', this.makeEditorUrl(fen, this.bottomColor()));
     }
     this.options.onChange?.(fen);
     this.redraw();
@@ -126,10 +129,11 @@ export default class EditorCtrl {
     return `/analysis/${variant}${urlFen(legalFen)}?color=${orientation}`;
   }
 
-  makeEditorUrl(fen: string): string {
-    if (fen === INITIAL_FEN && this.rules === 'chess') return this.cfg.baseUrl;
+  makeEditorUrl(fen: string, orientation: Color = 'white'): string {
+    if (fen === INITIAL_FEN && this.rules === 'chess' && orientation === 'white') return this.cfg.baseUrl;
     const variant = this.rules === 'chess' ? '' : '?variant=' + lichessVariant(this.rules);
-    return `${this.cfg.baseUrl}/${urlFen(fen)}${variant}`;
+    const orientationParam = variant ? `&color=${orientation}` : `?color=${orientation}`
+    return `${this.cfg.baseUrl}/${urlFen(fen)}${variant}${orientationParam}`;
   }
 
   bottomColor(): Color {

--- a/ui/editor/src/view.ts
+++ b/ui/editor/src/view.ts
@@ -233,7 +233,7 @@ function controls(ctrl: EditorCtrl, state: EditorState): VNode {
                 on: {
                   click() {
                     ctrl.chessground!.toggleOrientation();
-                    ctrl.redraw();
+                    ctrl.onChange();
                   },
                 },
               },


### PR DESCRIPTION
Adds orientation to as a query param to board editor. This fixes up two small issues:

**1. Analysis -> board editor orientation not persisted**
i. Go to analysis board
ii. In the action menu, flip the board to be from Black's pov and then go to board editor
iii. Board editor will be from White pov

**2. Board editor orientation change not persisted on refresh**
Unlike FEN changes, orientation of the board editor is not stored anywhere.
i. Go to board editor
ii. Make some moves then flip the board
iii. Refresh the page
iv. Changes made to the board stay but the orientation is flipped back