### PR TITLE
Fix study embed regression

### DIFF
--- a/ui/analyse/rollup.config.mjs
+++ b/ui/analyse/rollup.config.mjs
@@ -7,7 +7,7 @@ export default rollupProject({
     output: 'analysisBoard', // can't call it analyse.js, triggers adblockers :facepalm:
   },
   study: {
-    name: 'LichessAnalyseStudy',
+    name: 'LichessAnalyse',
     input: 'src/plugins/studyMain.ts',
     output: 'analysisBoard.study',
   },


### PR DESCRIPTION
#11202 broke study embeds because analyseEmbed.ts relies on the ui/analyse entry point being called "LichessAnalyse"