### PR TITLE
Don't consider hidden practice chapters when calculating completion

### DIFF
--- a/modules/practice/src/main/PracticeStructure.scala
+++ b/modules/practice/src/main/PracticeStructure.scala
@@ -26,7 +26,7 @@ case class PracticeStructure(
 
   lazy val chapterIds: List[Chapter.Id] = sections.flatMap(_.studies).flatMap(_.chapterIds)
 
-  lazy val nbChapters = chapterIds.size
+  lazy val nbUnhiddenChapters = sections.filter(!_.hide).map(s => s.studies.count(!_.hide)).fold(0)(_ + _)
 
   def findSection(id: Study.Id): Option[PracticeSection] = sectionsByStudyIds get id
 

--- a/modules/practice/src/main/UserPractice.scala
+++ b/modules/practice/src/main/UserPractice.scala
@@ -17,7 +17,7 @@ case class UserPractice(
 
   lazy val nbDoneChapters = structure.chapterIds count progress.chapters.contains
 
-  lazy val progressPercent = nbDoneChapters * 100 / structure.nbChapters.atLeast(1)
+  lazy val progressPercent = nbDoneChapters * 100 / structure.nbUnhiddenChapters.atLeast(1)
 }
 
 case class UserStudy(


### PR DESCRIPTION
Will give >100% for ppl with PracticeConfig perms but it's only used in the UI and the percentage bar overflow is hidden anyway so it doesn't even mess anything up for them.