### PR TITLE
Unselect square when new puzzle is shown

### DIFF
--- a/ui/puzzle/src/ctrl.ts
+++ b/ui/puzzle/src/ctrl.ts
@@ -134,6 +134,7 @@ export default function (opts: PuzzleOpts, redraw: Redraw): Controller {
     }, 4000);
 
     withGround(g => {
+      g.selectSquare(null);
       g.setAutoShapes([]);
       g.setShapes([]);
       showGround(g);


### PR DESCRIPTION
Fixes a common-but-not-always issue where a selected square remains selected when the next puzzle is shown. It doesn't happen everytime and I can't seem to figure out what's actually causing it, some sort of race condition I imagine. In any case clearing the selected square when drawn shapes are being cleared does the job .

Attached is a recording of the bug:
[recording.webm](https://user-images.githubusercontent.com/30640147/179779734-8765435d-e4dd-44d4-a9b8-f0569b3d12fd.webm)

