### PR TITLE
Add color to editor url box

### DIFF
--- a/ui/editor/src/view.ts
+++ b/ui/editor/src/view.ts
@@ -340,7 +340,7 @@ function inputs(ctrl: EditorCtrl, fen: string): VNode | undefined {
         attrs: {
           readonly: true,
           spellcheck: false,
-          value: ctrl.makeEditorUrl(fen),
+          value: ctrl.makeEditorUrl(fen, ctrl.bottomColor()),
         },
       }),
     ]),


### PR DESCRIPTION
1. Go to board editor
2. Make a move
3. Flip the board
4. URL in the box below still has `color=white`

This happens bc `makeEditorUrl` wasn't supplying a value for color so it defaults to White