### PR TITLE
Fix cross table not updating at game end

### DIFF
--- a/ui/round/src/boot.ts
+++ b/ui/round/src/boot.ts
@@ -21,7 +21,7 @@ export default function (opts: RoundOpts): void {
             o.player ? [o.player.title, o.player.name, o.player.rating].filter(x => x).join('&nbsp') : 'Anonymous'
           );
       },
-      end() {
+      endData() {
         xhr.text(`${data.tv ? '/tv' : ''}/${data.game.id}/${data.player.color}/sides`).then(html => {
           const $html = $(html),
             $meta = $html.find('.game__meta');


### PR DESCRIPTION
https://lichess.org/forum/lichess-feedback/winslosses-not-scoring-currently

Since we no longer send the "end" event (d8fa8be3d699c739808f1db0c61372650035a290), boot.ts needs to listen to "endData" events instead to update the cross table.