### PR TITLE
Make it easier to link to a chapter in a study

### DIFF
--- a/ui/analyse/src/study/studyCtrl.ts
+++ b/ui/analyse/src/study/studyCtrl.ts
@@ -285,7 +285,7 @@ export default function (
 
     if (vm.mode.sticky) {
       vm.chapterId = data.position.chapterId;
-      updateUrl(vm.chapterId)
+      updateUrl(vm.chapterId);
       nextPath = (vm.justSetChapterId === vm.chapterId && chapters.localPaths[vm.chapterId]) || data.position.path;
     } else {
       nextPath = sameChapter
@@ -398,7 +398,7 @@ export default function (
     vm.loading = true;
     vm.nextChapterId = id;
     vm.justSetChapterId = id;
-    updateUrl(id)
+    updateUrl(id);
     redraw();
   }
 

--- a/ui/analyse/src/study/studyCtrl.ts
+++ b/ui/analyse/src/study/studyCtrl.ts
@@ -244,6 +244,12 @@ export default function (
     if (practice) practice.onLoad();
   }
 
+  function updateUrl(chapterId: string) {
+    if (!practice) {
+      window.history.replaceState(null, '', `/study/${data.id}/${chapterId}`);
+    }
+  }
+
   function onReload(d: ReloadData) {
     const s = d.study!;
     const prevPath = ctrl.path;
@@ -279,6 +285,7 @@ export default function (
 
     if (vm.mode.sticky) {
       vm.chapterId = data.position.chapterId;
+      updateUrl(vm.chapterId)
       nextPath = (vm.justSetChapterId === vm.chapterId && chapters.localPaths[vm.chapterId]) || data.position.path;
     } else {
       nextPath = sameChapter
@@ -391,6 +398,7 @@ export default function (
     vm.loading = true;
     vm.nextChapterId = id;
     vm.justSetChapterId = id;
+    updateUrl(id)
     redraw();
   }
 


### PR DESCRIPTION
Feel free to close if not wanted. 

This change updates the current url as chapters are changed in a study. This makes it much easier to get the link to a specific chapter (the alternative is to navigate to the somewhat obscure `Share` tab) as the user can just copy the url from their browser.