### PR TITLE
Add follow:read scope

### DIFF
--- a/app/controllers/Relation.scala
+++ b/app/controllers/Relation.scala
@@ -151,7 +151,7 @@ final class Relation(
       )
     }
 
-  def apiFollowing = Scoped() { implicit req => me =>
+  def apiFollowing = Scoped(_.Follow.Read) { implicit req => me =>
     apiC.jsonStream {
       env.relation.stream
         .follow(me, Direction.Following, MaxPerSecond(30))

--- a/modules/oauth/src/main/OAuthScope.scala
+++ b/modules/oauth/src/main/OAuthScope.scala
@@ -44,6 +44,7 @@ object OAuthScope {
   }
 
   object Follow {
+    case object Read  extends OAuthScope("follow:read", "Read followed players")
     case object Write extends OAuthScope("follow:write", "Follow and unfollow other players")
   }
 
@@ -84,6 +85,7 @@ object OAuthScope {
     Puzzle.Read,
     Team.Read,
     Team.Write,
+    Follow.Read,
     Follow.Write,
     Msg.Write,
     Board.Play,


### PR DESCRIPTION
Change the /api/rel/following endpoint from requiring empty scoped token,
to requiring the new follow:read scope.

Resolves: #11250