### PR TITLE
Fix CSS selector when speaking opponent name

### DIFF
--- a/ui/keyboardMove/src/plugins/keyboardMove.ts
+++ b/ui/keyboardMove/src/plugins/keyboardMove.ts
@@ -201,8 +201,8 @@ function readClocks(clockCtrl: any | undefined) {
 }
 
 function readOpponentName(): void {
-  const opponentName = document.querySelector('.ruser-top name') as HTMLInputElement;
-  lichess.sound.say(opponentName.innerText);
+  const opponentName = document.querySelector('.ruser-top') as HTMLInputElement;
+  lichess.sound.say(opponentName.innerText.split('\n')[0]);
 }
 
 function simplePlural(nb: number, word: string) {


### PR DESCRIPTION
Fixes bug from my commit in #11215 which is giving `Uncaught TypeError: Cannot read properties of null (reading 'innerText')` when you run the "who" command in a game right now.

This fixes games against regular opponents and still works for games against Stockfish.