### PR TITLE
Add keybind to read current eval in analysis nvui

### DIFF
--- a/ui/analyse/src/plugins/nvui.ts
+++ b/ui/analyse/src/plugins/nvui.ts
@@ -63,6 +63,8 @@ export default function (ctrl: AnalyseController) {
     if (data.analysis && !data.analysis.partial) notify.set('Server-side analysis complete');
   });
 
+  window.Mousetrap.bind('c', () => notify.set(renderEvalAndDepth(ctrl)));
+
   return {
     render(): VNode {
       const d = ctrl.data,
@@ -225,6 +227,8 @@ export default function (ctrl: AnalyseController) {
             'z: toggle all computer analysis',
             h('br'),
             'space: play best computer move',
+            h('br'),
+            'c: announce computer evaluation',
             h('br'),
             'x: show threat',
             h('br'),


### PR DESCRIPTION
> Thanks very much for your help, if I might ask one more question, would it be possible to have the "e" key read out loud the current evaluation when going through moves?
As it is, I have to jump into browse mode, go back to the command input, type in eval, then go back out of browse mode and repeat the next time I want to see how the evaluation changed.

Closes #11253