### PR TITLE
Throttle async calls safely with throttlePromiseDelay

### DIFF
--- a/ui/analyse/src/study/studyCtrl.ts
+++ b/ui/analyse/src/study/studyCtrl.ts
@@ -1,7 +1,7 @@
 import { Config as CgConfig } from 'chessground/config';
 import { DrawShape } from 'chessground/draw';
 import { prop } from 'common';
-import throttle from 'common/throttle';
+import throttle, { throttlePromiseDelay } from 'common/throttle';
 import debounce from 'common/debounce';
 import AnalyseCtrl from '../ctrl';
 import { ctrl as memberCtrl } from './studyMembers';
@@ -301,12 +301,15 @@ export default function (
     ctrl.startCeval();
   }
 
-  const xhrReload = throttle(700, () => {
-    vm.loading = true;
-    return xhr
-      .reload(practice ? 'practice/load' : 'study', data.id, vm.mode.sticky ? undefined : vm.chapterId)
-      .then(onReload, lichess.reload);
-  });
+  const xhrReload = throttlePromiseDelay(
+    () => 700,
+    () => {
+      vm.loading = true;
+      return xhr
+        .reload(practice ? 'practice/load' : 'study', data.id, vm.mode.sticky ? undefined : vm.chapterId)
+        .then(onReload, lichess.reload);
+    }
+  );
 
   const onSetPath = throttle(300, (path: Tree.Path) => {
     if (vm.mode.sticky && path !== data.position.path)

--- a/ui/common/src/throttle.ts
+++ b/ui/common/src/throttle.ts
@@ -3,7 +3,7 @@
  * flight. Any extra calls are dropped, except the last one, which waits for
  * the previous call to complete.
  */
-export function throttlePromise<T extends (...args: any) => Promise<void>>(
+export function throttlePromise<T extends (...args: any) => Promise<any>>(
   wrapped: T
 ): (...args: Parameters<T>) => void {
   let current: Promise<void> | undefined;
@@ -30,7 +30,7 @@ export function throttlePromise<T extends (...args: any) => Promise<void>>(
  * after completion plus a delay (regardless if the wrapped function resolves
  * or rejects).
  */
-export function finallyDelay<T extends (...args: any) => Promise<void>>(
+export function finallyDelay<T extends (...args: any) => Promise<any>>(
   delay: (...args: Parameters<T>) => number,
   wrapped: T
 ): (...args: Parameters<T>) => Promise<void> {

--- a/ui/common/src/throttle.ts
+++ b/ui/common/src/throttle.ts
@@ -43,6 +43,17 @@ export function finallyDelay<T extends (...args: any) => Promise<void>>(
 }
 
 /**
+ * Wraps an asynchronous function to ensure only one call at a time is in flight. Any extra calls
+ * are dropped, except the last one, which waits for the previous call to complete plus a delay.
+ */
+export function throttlePromiseDelay<T extends (...args: any) => Promise<any>>(
+  delay: (...args: Parameters<T>) => number,
+  wrapped: T
+): (...args: Parameters<T>) => void {
+  return throttlePromise(finallyDelay(delay, wrapped));
+}
+
+/**
  * Ensures calls to the wrapped function are spaced by the given delay.
  * Any extra calls are dropped, except the last one, which waits for the delay.
  */

--- a/ui/coordinateTrainer/src/ctrl.ts
+++ b/ui/coordinateTrainer/src/ctrl.ts
@@ -1,6 +1,6 @@
 import { sparkline } from '@fnando/sparkline';
 import * as xhr from 'common/xhr';
-import throttle from 'common/throttle';
+import { throttlePromiseDelay } from 'common/throttle';
 import { withEffect } from 'common';
 import { storedBooleanProp, storedProp } from 'common/storage';
 import { Api as CgApi } from 'chessground/api';
@@ -43,11 +43,13 @@ export default class CoordinateTrainerCtrl {
   zen: boolean;
 
   constructor(readonly config: CoordinateTrainerConfig, readonly redraw: Redraw) {
-    const setZen = throttle(1000, zen =>
-      xhr.text('/pref/zen', {
-        method: 'post',
-        body: xhr.form({ zen: zen ? 1 : 0 }),
-      })
+    const setZen = throttlePromiseDelay(
+      () => 1000,
+      zen =>
+        xhr.text('/pref/zen', {
+          method: 'post',
+          body: xhr.form({ zen: zen ? 1 : 0 }),
+        })
     );
 
     lichess.pubsub.on('zen', () => {

--- a/ui/insight/src/ctrl.ts
+++ b/ui/insight/src/ctrl.ts
@@ -1,4 +1,4 @@
-import throttle from 'common/throttle';
+import { throttlePromiseDelay } from 'common/throttle';
 import * as xhr from 'common/xhr';
 import { Chart, Dimension, Env, Metric, Question, UI, EnvUser, Vm, Filters } from './interfaces';
 
@@ -58,37 +58,45 @@ export default class {
     this.vm.filters = {};
   }
 
-  askQuestion = throttle(1000, () => {
-    if (!this.validCombinationCurrent()) this.reset();
-    this.pushState();
-    this.vm.loading = true;
-    this.vm.broken = false;
-    this.redraw();
-    setTimeout(() => {
-      xhr
-        .json(this.env.postUrl, {
-          method: 'post',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            metric: this.vm.metric.key,
-            dimension: this.vm.dimension.key,
-            filters: this.vm.filters,
-          }),
-        })
-        .then(
-          (answer: Chart) => {
-            this.vm.answer = answer;
-            this.vm.loading = false;
-            this.redraw();
-          },
-          () => {
-            this.vm.loading = false;
-            this.vm.broken = true;
-            this.redraw();
-          }
+  askQuestion = throttlePromiseDelay(
+    () => 1000,
+    () => {
+      if (!this.validCombinationCurrent()) this.reset();
+      this.pushState();
+      this.vm.loading = true;
+      this.vm.broken = false;
+      this.redraw();
+      return new Promise<void>(resolve => {
+        setTimeout(
+          () =>
+            xhr
+              .json(this.env.postUrl, {
+                method: 'post',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                  metric: this.vm.metric.key,
+                  dimension: this.vm.dimension.key,
+                  filters: this.vm.filters,
+                }),
+              })
+              .then(
+                (answer: Chart) => {
+                  this.vm.answer = answer;
+                  this.vm.loading = false;
+                  this.redraw();
+                },
+                () => {
+                  this.vm.loading = false;
+                  this.vm.broken = true;
+                  this.redraw();
+                }
+              )
+              .finally(resolve),
+          1
         );
-    }, 1);
-  });
+      });
+    }
+  );
 
   makeUrl(dKey: string, mKey: string, filters: Filters) {
     const url = [this.env.pageUrl, mKey, dKey].join('/');

--- a/ui/puzzle/src/xhr.ts
+++ b/ui/puzzle/src/xhr.ts
@@ -1,6 +1,6 @@
 import * as xhr from 'common/xhr';
 import PuzzleStreak from './streak';
-import throttle from 'common/throttle';
+import { throttlePromiseDelay } from 'common/throttle';
 import { defined } from 'common';
 import { PuzzleReplay, PuzzleResult, ThemeKey } from './interfaces';
 import { StoredProp } from 'common/storage';
@@ -37,9 +37,11 @@ export const voteTheme = (puzzleId: string, theme: ThemeKey, vote: boolean | und
     body: defined(vote) ? xhr.form({ vote }) : undefined,
   });
 
-export const setZen = throttle(1000, zen =>
-  xhr.text('/pref/zen', {
-    method: 'post',
-    body: xhr.form({ zen: zen ? 1 : 0 }),
-  })
+export const setZen = throttlePromiseDelay(
+  () => 1000,
+  zen =>
+    xhr.text('/pref/zen', {
+      method: 'post',
+      body: xhr.form({ zen: zen ? 1 : 0 }),
+    })
 );

--- a/ui/racer/src/ctrl.ts
+++ b/ui/racer/src/ctrl.ts
@@ -1,6 +1,6 @@
 import config from './config';
 import CurrentPuzzle from 'puz/current';
-import throttle from 'common/throttle';
+import throttle, { throttlePromiseDelay } from 'common/throttle';
 import * as xhr from 'common/xhr';
 import { Api as CgApi } from 'chessground/api';
 import { Boost } from './boost';
@@ -258,11 +258,13 @@ export default class RacerCtrl {
 
   private socketSend = (tpe: string, data?: any) => lichess.socket.send(tpe, data, { sign: this.sign });
 
-  private setZen = throttle(1000, zen =>
-    xhr.text('/pref/zen', {
-      method: 'post',
-      body: xhr.form({ zen: zen ? 1 : 0 }),
-    })
+  private setZen = throttlePromiseDelay(
+    () => 1000,
+    zen =>
+      xhr.text('/pref/zen', {
+        method: 'post',
+        body: xhr.form({ zen: zen ? 1 : 0 }),
+      })
   );
 
   private toggleZen = () => lichess.pubsub.emit('zen');

--- a/ui/round/src/xhr.ts
+++ b/ui/round/src/xhr.ts
@@ -1,5 +1,5 @@
 import RoundController from './ctrl';
-import throttle from 'common/throttle';
+import { throttlePromiseDelay } from 'common/throttle';
 import * as xhr from 'common/xhr';
 import { RoundData } from './interfaces';
 
@@ -13,9 +13,11 @@ export const challengeRematch = (gameId: string): Promise<unknown> =>
     method: 'post',
   });
 
-export const setZen = throttle(1000, zen =>
-  xhr.text('/pref/zen', {
-    method: 'post',
-    body: xhr.form({ zen: zen ? 1 : 0 }),
-  })
+export const setZen = throttlePromiseDelay(
+  () => 1000,
+  zen =>
+    xhr.text('/pref/zen', {
+      method: 'post',
+      body: xhr.form({ zen: zen ? 1 : 0 }),
+    })
 );

--- a/ui/simul/src/xhr.ts
+++ b/ui/simul/src/xhr.ts
@@ -1,4 +1,4 @@
-import throttle from 'common/throttle';
+import { throttlePromiseDelay } from 'common/throttle';
 import { json } from 'common/xhr';
 
 // when the simul no longer exists
@@ -10,7 +10,10 @@ export default {
   ping: post('host-ping'),
   start: post('start'),
   abort: post('abort'),
-  join: throttle(4000, (id: string, variant: VariantKey) => post(`join/${variant}`)(id)),
+  join: throttlePromiseDelay(
+    () => 4000,
+    (id: string, variant: VariantKey) => post(`join/${variant}`)(id)
+  ),
   withdraw: post('withdraw'),
   accept: (user: string) => post(`accept/${user}`),
   reject: (user: string) => post(`reject/${user}`),

--- a/ui/site/src/ublog.ts
+++ b/ui/site/src/ublog.ts
@@ -1,38 +1,44 @@
 import * as xhr from 'common/xhr';
-import throttle from 'common/throttle';
+import { throttlePromiseDelay } from 'common/throttle';
 
 lichess.load.then(() => {
   $('.flash').addClass('fade');
   $('.ublog-post__like').on(
     'click',
-    throttle(1000, function (this: HTMLButtonElement) {
-      const button = $(this),
-        likeClass = 'ublog-post__like--liked',
-        liked = !button.hasClass(likeClass);
-      xhr
-        .text(`/ublog/${button.data('rel')}/like?v=${liked}`, {
-          method: 'post',
-        })
-        .then(likes => {
-          const label = $('.ublog-post__like .button-label');
-          const newText = label.data(`i18n-${liked ? 'unlike' : 'like'}`);
-          label.text(newText);
-          $('.ublog-post__like').toggleClass(likeClass, liked).attr('title', newText);
-          $('.ublog-post__like__nb').text(likes);
-        });
-    })
+    throttlePromiseDelay(
+      () => 1000,
+      function (this: HTMLButtonElement) {
+        const button = $(this),
+          likeClass = 'ublog-post__like--liked',
+          liked = !button.hasClass(likeClass);
+        return xhr
+          .text(`/ublog/${button.data('rel')}/like?v=${liked}`, {
+            method: 'post',
+          })
+          .then(likes => {
+            const label = $('.ublog-post__like .button-label');
+            const newText = label.data(`i18n-${liked ? 'unlike' : 'like'}`);
+            label.text(newText);
+            $('.ublog-post__like').toggleClass(likeClass, liked).attr('title', newText);
+            $('.ublog-post__like__nb').text(likes);
+          });
+      }
+    )
   );
   $('.ublog-post__follow button').on(
     'click',
-    throttle(1000, function (this: HTMLButtonElement) {
-      const button = $(this),
-        followClass = 'followed';
-      xhr
-        .text(button.data('rel'), {
-          method: 'post',
-        })
-        .then(() => button.parent().toggleClass(followClass));
-    })
+    throttlePromiseDelay(
+      () => 1000,
+      function (this: HTMLButtonElement) {
+        const button = $(this),
+          followClass = 'followed';
+        return xhr
+          .text(button.data('rel'), {
+            method: 'post',
+          })
+          .then(() => button.parent().toggleClass(followClass));
+      }
+    )
   );
   $('#form3-tier').on('change', function (this: HTMLSelectElement) {
     (this.parentNode as HTMLFormElement).submit();

--- a/ui/storm/src/xhr.ts
+++ b/ui/storm/src/xhr.ts
@@ -1,5 +1,5 @@
 import * as xhr from 'common/xhr';
-import throttle from 'common/throttle';
+import { throttlePromiseDelay } from 'common/throttle';
 import { RunResponse, StormRecap } from './interfaces';
 
 export function record(run: StormRecap, notAnExploit: string): Promise<RunResponse> {
@@ -13,9 +13,11 @@ export function record(run: StormRecap, notAnExploit: string): Promise<RunRespon
   });
 }
 
-export const setZen = throttle(1000, zen =>
-  xhr.text('/pref/zen', {
-    method: 'post',
-    body: xhr.form({ zen: zen ? 1 : 0 }),
-  })
+export const setZen = throttlePromiseDelay(
+  () => 1000,
+  zen =>
+    xhr.text('/pref/zen', {
+      method: 'post',
+      body: xhr.form({ zen: zen ? 1 : 0 }),
+    })
 );

--- a/ui/swiss/src/ctrl.ts
+++ b/ui/swiss/src/ctrl.ts
@@ -1,6 +1,6 @@
 import { makeSocket, SwissSocket } from './socket';
 import xhr from './xhr';
-import throttle from 'common/throttle';
+import { throttlePromiseDelay } from 'common/throttle';
 import { maxPerPage, myPage, players } from './pagination';
 import { SwissData, SwissOpts, Pages, Standing, Player } from './interfaces';
 
@@ -143,8 +143,9 @@ export default class SwissCtrl {
 
   private reloadSoon = () => {
     if (!this.reloadSoonThrottle)
-      this.reloadSoonThrottle = throttle(Math.max(2000, Math.min(5000, this.data.nbPlayers * 20)), () =>
-        xhr.reloadNow(this)
+      this.reloadSoonThrottle = throttlePromiseDelay(
+        () => Math.max(2000, Math.min(5000, this.data.nbPlayers * 20)),
+        () => xhr.reloadNow(this)
       );
     this.reloadSoonThrottle();
   };

--- a/ui/swiss/src/xhr.ts
+++ b/ui/swiss/src/xhr.ts
@@ -1,4 +1,4 @@
-import throttle from 'common/throttle';
+import { throttlePromiseDelay } from 'common/throttle';
 import { json, form } from 'common/xhr';
 import SwissCtrl from './ctrl';
 import { isOutcome } from './util';
@@ -54,9 +54,9 @@ const readSheetMin = (str: string) =>
     : [];
 
 export default {
-  join: throttle(1000, join),
-  withdraw: throttle(1000, withdraw),
-  loadPage: throttle(1000, loadPage),
+  join: throttlePromiseDelay(() => 1000, join),
+  withdraw: throttlePromiseDelay(() => 1000, withdraw),
+  loadPage: throttlePromiseDelay(() => 1000, loadPage),
   loadPageOf,
   reloadNow: reload,
   playerInfo,

--- a/ui/tournament/src/xhr.ts
+++ b/ui/tournament/src/xhr.ts
@@ -1,4 +1,4 @@
-import { throttlePromise, finallyDelay } from 'common/throttle';
+import { finallyDelay, throttlePromiseDelay } from 'common/throttle';
 import * as xhr from 'common/xhr';
 import TournamentController from './ctrl';
 
@@ -8,52 +8,46 @@ const onFail = (): void => {
   setTimeout(lichess.reload, Math.floor(Math.random() * 9000));
 };
 
-export const join = throttlePromise(
-  finallyDelay(
-    () => 5000,
-    (ctrl: TournamentController, password?: string, team?: string) =>
-      xhr
-        .textRaw('/tournament/' + ctrl.data.id + '/join', {
-          method: 'POST',
-          // must use JSON body for app compat
-          body: JSON.stringify({
-            p: password || null,
-            team: team || null,
-          }),
-          headers: { 'Content-Type': 'application/json' },
-        })
-        .then(res => {
-          if (!res.ok)
-            res.json().then(t => {
-              if (t.error) alert(t.error);
-              else lichess.reload();
-            });
-        }, onFail)
-  )
-);
-
-export const withdraw = throttlePromise(
-  finallyDelay(
-    () => 1000,
-    (ctrl: TournamentController) =>
-      xhr
-        .text('/tournament/' + ctrl.data.id + '/withdraw', {
-          method: 'POST',
-        })
-        .then(_ => {}, onFail)
-  )
-);
-
-export const loadPage = throttlePromise(
-  finallyDelay(
-    () => 1000,
-    (ctrl: TournamentController, p: number, callback?: () => void) =>
-      xhr.json(`/tournament/${ctrl.data.id}/standing/${p}`).then(data => {
-        ctrl.loadPage(data);
-        callback?.();
-        ctrl.redraw();
+export const join = throttlePromiseDelay(
+  () => 5000,
+  (ctrl: TournamentController, password?: string, team?: string) =>
+    xhr
+      .textRaw('/tournament/' + ctrl.data.id + '/join', {
+        method: 'POST',
+        // must use JSON body for app compat
+        body: JSON.stringify({
+          p: password || null,
+          team: team || null,
+        }),
+        headers: { 'Content-Type': 'application/json' },
+      })
+      .then(res => {
+        if (!res.ok)
+          res.json().then(t => {
+            if (t.error) alert(t.error);
+            else lichess.reload();
+          });
       }, onFail)
-  )
+);
+
+export const withdraw = throttlePromiseDelay(
+  () => 1000,
+  (ctrl: TournamentController) =>
+    xhr
+      .text('/tournament/' + ctrl.data.id + '/withdraw', {
+        method: 'POST',
+      })
+      .then(() => {}, onFail)
+);
+
+export const loadPage = throttlePromiseDelay(
+  () => 1000,
+  (ctrl: TournamentController, p: number, callback?: () => void) =>
+    xhr.json(`/tournament/${ctrl.data.id}/standing/${p}`).then(data => {
+      ctrl.loadPage(data);
+      callback?.();
+      ctrl.redraw();
+    }, onFail)
 );
 
 export const loadPageOf = (ctrl: TournamentController, userId: string) =>
@@ -94,7 +88,7 @@ export const reloadNow: (ctrl: TournamentController) => Promise<void> = finallyD
       )
 );
 
-export const reloadSoon = throttlePromise(finallyDelay(() => 4000 + Math.floor(Math.random() * 1000), reloadNow));
+export const reloadSoon = throttlePromiseDelay(() => 4000 + Math.floor(Math.random() * 1000), reloadNow);
 
 export const playerInfo = (ctrl: TournamentController, userId: string) =>
   xhr.json(`/tournament/${ctrl.data.id}/player/${userId}`).then(data => {


### PR DESCRIPTION
Resolves #10266. In the past, we've used `throttle` on async functions, which will throttle without respecting the length of time that it takes for the promise to resolve. Implement `throttlePromiseDelay` that will correctly throttle async functions by first waiting for the promise to resolve/reject, then tacking on a delay.