### PR TITLE
Cancel premove on jump in practice

### DIFF
--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -397,6 +397,7 @@ export default class AnalyseCtrl {
       const prev = this.path;
       this.practice.preUserJump(prev, path);
       this.jump(path);
+      this.withCg(cg => cg.cancelPremove());
       this.practice.postUserJump(prev, this.path);
     } else this.jump(path);
   };


### PR DESCRIPTION
Premoves should be cancelled on user jump in practice (same behavior as in real games)

1. Go to any practice lesson
2. Make a move
3. Jump backwards and make a premove
4. The premove highlighted squares stick around

Otherwise you end up with stuff like this:
![image](https://user-images.githubusercontent.com/30640147/181953338-5359c1fa-9b55-447b-b7f0-f189d95a7046.png)
