### PR TITLE
Fix a couple of practice toggle bugs

### DIFF
--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -687,7 +687,7 @@ export default class AnalyseCtrl {
     this.startCeval();
     if (!this.ceval.enabled()) {
       this.threatMode(false);
-      if (this.practice) this.togglePractice();
+      if (this.practice) this.practice = undefined;
     }
     this.redraw();
   };
@@ -780,10 +780,10 @@ export default class AnalyseCtrl {
   }
 
   toggleComputer = () => {
+    if (this.showComputer() && this.opts.practice) this.togglePractice();
     if (this.ceval.enabled()) this.toggleCeval();
     const value = !this.showComputer();
     this.showComputer(value);
-    if (!value && this.practice) this.togglePractice();
     this.onToggleComputer();
     lichess.pubsub.emit('analysis.comp.toggle', value);
   };

--- a/ui/analyse/src/study/practice/studyPracticeCtrl.ts
+++ b/ui/analyse/src/study/practice/studyPracticeCtrl.ts
@@ -44,7 +44,7 @@ export default function (root: AnalyseCtrl, studyData: StudyData, data: StudyPra
     if (!root.study!.data.chapter.practice) {
       return saveNbMoves();
     }
-    if (success() !== null) return;
+    if (!root.practice || success() !== null) return;
     nbMoves(computeNbMoves());
     const res = success(makeSuccess(root, goal(), nbMoves()));
     if (res) onVictory();


### PR DESCRIPTION
The [`z` hotkey to turn off all computer analyses](https://github.com/lichess-org/lila/blob/da3a6af82c8cea46b1911fab3f1390407b15b23e/ui/analyse/src/keyboard.ts#L49) does some weird stuff to the practice mode.

1. `togglePractice` function really only turns practice off once
a. Go to any [practice lesson](https://lichess.org/practice/checkmates/checkmate-patterns-ii/8yadFPpU/APLob5jh) 
b. Press `z` to turn off computer eval. The only way to turn practice back on now is to refresh.

This was happening because `toggleComputer` sets `practice = undefined` but after that it doesn't know that `practice` should be toggled back on later. I use `opts` to make that decision. 
Also there were included 2 calls to `togglePractice` (once in `toggleCeval` and once in `toggleComputer`) so even if not for the bug above the toggle wouldn't work.

---

2. (Minor) Console errors once practice is off
a. Turn off practice like above
b. Make a move and check the consol
![image](https://user-images.githubusercontent.com/30640147/181996585-96b22d57-7cfd-4502-9efb-e492c35a3656.png)

---

P.S.
Honestly my take is that this "turn off computers" hotkey should be disabled entirely on the practice mode but that's for a higher power to decide