### PR TITLE
streamer live and granular notification control

### DIFF
--- a/app/templating/SetupHelper.scala
+++ b/app/templating/SetupHelper.scala
@@ -6,7 +6,7 @@ import chess.variant.Variant
 import play.api.i18n.Lang
 
 import lila.i18n.{ I18nKeys => trans }
-import lila.pref.Pref
+import lila.pref.{ NotificationPref, Pref }
 import lila.report.Reason
 import lila.setup.TimeMode
 
@@ -69,6 +69,12 @@ trait SetupHelper { self: I18nHelper =>
     ("1", "One day", none) :: List(2, 3, 5, 7, 10, 14).map { d =>
       (d.toString, s"$d days", none)
     }
+
+  def translatedBooleanIntChoices(implicit lang: Lang) =
+    Seq(
+      0 -> trans.no.txt(),
+      1 -> trans.yes.txt()
+    )
 
   def translatedTimeModeChoices(implicit lang: Lang) =
     List(
@@ -215,6 +221,25 @@ trait SetupHelper { self: I18nHelper =>
       (Pref.MoveEvent.DRAG, trans.preferences.dragPiece.txt()),
       (Pref.MoveEvent.BOTH, trans.preferences.bothClicksAndDrag.txt())
     )
+
+  def translatedNotifyChoices(implicit lang: Lang): Seq[(Int, String)] =
+    Seq(
+      NotificationPref.NONE           -> trans.preferences.notifyNone.txt(),
+      NotificationPref.WEB            -> trans.preferences.notifyWeb.txt(),
+      NotificationPref.DEVICE         -> trans.preferences.notifyDevice.txt(),
+      NotificationPref.WEB_AND_DEVICE -> trans.preferences.notifyEverything.txt()
+    )
+
+  def translatedNotifyMoreChoices(implicit lang: Lang): Seq[(Int, String)] =
+    Seq(
+      NotificationPref.BELL            -> trans.preferences.notifyBell.txt(),
+      NotificationPref.BELL_AND_WEB    -> trans.preferences.notifyWeb.txt(),
+      NotificationPref.BELL_AND_DEVICE -> trans.preferences.notifyDevice.txt(),
+      NotificationPref.ALL             -> trans.preferences.notifyEverything.txt()
+    )
+
+  def translatedNotifyNoneMoreChoices(implicit lang: Lang): Seq[(Int, String)] =
+    (NotificationPref.NONE -> trans.preferences.notifyNone.txt()) +: translatedNotifyMoreChoices(lang)
 
   def translatedTakebackChoices(implicit lang: Lang) =
     List(

--- a/app/templating/SetupHelper.scala
+++ b/app/templating/SetupHelper.scala
@@ -222,25 +222,6 @@ trait SetupHelper { self: I18nHelper =>
       (Pref.MoveEvent.BOTH, trans.preferences.bothClicksAndDrag.txt())
     )
 
-  def translatedNotifyChoices(implicit lang: Lang): Seq[(Int, String)] =
-    Seq(
-      NotificationPref.NONE           -> trans.preferences.notifyNone.txt(),
-      NotificationPref.WEB            -> trans.preferences.notifyWeb.txt(),
-      NotificationPref.DEVICE         -> trans.preferences.notifyDevice.txt(),
-      NotificationPref.WEB_AND_DEVICE -> trans.preferences.notifyEverything.txt()
-    )
-
-  def translatedNotifyMoreChoices(implicit lang: Lang): Seq[(Int, String)] =
-    Seq(
-      NotificationPref.BELL            -> trans.preferences.notifyBell.txt(),
-      NotificationPref.BELL_AND_WEB    -> trans.preferences.notifyWeb.txt(),
-      NotificationPref.BELL_AND_DEVICE -> trans.preferences.notifyDevice.txt(),
-      NotificationPref.ALL             -> trans.preferences.notifyEverything.txt()
-    )
-
-  def translatedNotifyNoneMoreChoices(implicit lang: Lang): Seq[(Int, String)] =
-    (NotificationPref.NONE -> trans.preferences.notifyNone.txt()) +: translatedNotifyMoreChoices(lang)
-
   def translatedTakebackChoices(implicit lang: Lang) =
     List(
       (Pref.Takeback.NEVER, trans.never.txt()),

--- a/app/views/account/bits.scala
+++ b/app/views/account/bits.scala
@@ -29,5 +29,26 @@ object bits {
       case PrefCateg.ChessClock   => trans.preferences.chessClock.txt()
       case PrefCateg.GameBehavior => trans.preferences.gameBehavior.txt()
       case PrefCateg.Privacy      => trans.preferences.privacy.txt()
+      case PrefCateg.Notification => trans.preferences.notifications.txt()
     }
+
+  def setting(name: Frag, body: Frag) = st.section(h2(name), body)
+
+  def radios(field: play.api.data.Field, options: Iterable[(Any, String)], prefix: String = "ir") =
+    st.group(cls := "radio")(
+      options.map { v =>
+        val id      = s"${field.id}_${v._1}"
+        val checked = field.value has v._1.toString
+        div(
+          input(
+            st.id := s"$prefix$id",
+            checked option st.checked,
+            tpe   := "radio",
+            value := v._1.toString,
+            name  := field.name
+          ),
+          label(`for` := s"$prefix$id")(v._2)
+        )
+      }.toList
+    )
 }

--- a/app/views/account/notification.scala
+++ b/app/views/account/notification.scala
@@ -1,0 +1,49 @@
+package views.html
+package account
+
+import lila.api.Context
+import lila.app.templating.Environment._
+import lila.app.ui.ScalatagsTemplate._
+
+object notification {
+  import bits._
+  import trans.preferences._
+
+  def fieldSet(form: play.api.data.Form[_], inactive: Boolean)(implicit ctx: Context) =
+    div(cls := List("none" -> inactive))(
+      setting(
+        notifyInboxMsg(),
+        radios(form("notification.inboxMsg"), translatedNotifyMoreChoices)
+      ),
+      setting(
+        notifyForumMention(),
+        radios(form("notification.forumMention"), translatedNotifyNoneMoreChoices)
+      ),
+      setting(
+        notifyStreamStart(),
+        radios(form("notification.streamStart"), translatedNotifyNoneMoreChoices)
+      ),
+      setting(
+        notifyChallenge(),
+        radios(form("notification.challenge"), translatedNotifyChoices)
+      ),
+      setting(
+        notifyTournamentSoon(),
+        radios(form("notification.tournamentSoon"), translatedNotifyChoices)
+      ),
+      setting(
+        notifyGameEvent(),
+        radios(form("notification.gameEvent"), translatedNotifyChoices)
+      ),
+      setting(
+        notifyTimeAlarm(),
+        radios(form("notification.timeAlarm"), translatedNotifyChoices)
+      ),
+      div(id := "correspondence-email-notif")(
+        setting(
+          correspondenceEmailNotification(),
+          radios(form("notification.correspondenceEmail"), translatedBooleanIntChoices)
+        )
+      )
+    )
+}

--- a/app/views/account/notification.scala
+++ b/app/views/account/notification.scala
@@ -11,39 +11,55 @@ object notification {
 
   def fieldSet(form: play.api.data.Form[_], inactive: Boolean)(implicit ctx: Context) =
     div(cls := List("none" -> inactive))(
-      setting(
-        notifyInboxMsg(),
-        radios(form("notification.inboxMsg"), translatedNotifyMoreChoices)
-      ),
-      setting(
-        notifyForumMention(),
-        radios(form("notification.forumMention"), translatedNotifyNoneMoreChoices)
-      ),
-      setting(
-        notifyStreamStart(),
-        radios(form("notification.streamStart"), translatedNotifyNoneMoreChoices)
-      ),
-      setting(
-        notifyChallenge(),
-        radios(form("notification.challenge"), translatedNotifyChoices)
-      ),
-      setting(
-        notifyTournamentSoon(),
-        radios(form("notification.tournamentSoon"), translatedNotifyChoices)
-      ),
-      setting(
-        notifyGameEvent(),
-        radios(form("notification.gameEvent"), translatedNotifyChoices)
-      ),
-      setting(
-        notifyTimeAlarm(),
-        radios(form("notification.timeAlarm"), translatedNotifyChoices)
-      ),
-      div(id := "correspondence-email-notif")(
-        setting(
-          correspondenceEmailNotification(),
-          radios(form("notification.correspondenceEmail"), translatedBooleanIntChoices)
+      table( cls := "allows-grid")(
+        thead(
+          tr(th, th(notifyBell()), th(notifyPush()))
+        ),
+        tbody(
+          makeRow(form, notifyStreamStart(),filterName="streamStart"),
+          makeRow(form, notifyForumMention(), "forumMention"),
+          makeRow(form, notifyInboxMsg(), "inboxMsg"),
+          makeRow(form, notifyChallenge(), "challenge"),
+          makeRow(form, notifyTournamentSoon(), filterName="tournamentSoon"),
+          makeRow(form, notifyGameEvent(), "gameEvent"),
         )
+      ),
+      setting(
+        correspondenceEmailNotification(),
+        radios(form("notification.correspondenceEmail"), translatedBooleanIntChoices)
       )
     )
+
+  private def makeRow(form: play.api.data.Form[_], transTxt: Frag, filterName: String) =
+    tr(
+      td(transTxt),
+      Seq("bell", "push") map { allow =>
+        val name = s"notification.$filterName.$allow"
+        val checked = form.data(name).contains("true")
+        td(
+          if (editable(s"$filterName.$allow"))
+            div(cls := "toggle", form3.cmnToggle(name, name, checked))
+          else if (!checked)
+            div(iconTag('\ue03f'))
+          else
+            div(
+              cls := "always-on",
+              form3.hidden(name, "true"), // force form value
+              filterName match {
+                case "challenge" => iconTag('\ue048')
+                case "inboxMsg" => iconTag( '\ue00f')
+                case _ => emptyFrag
+              }
+            )
+        )
+      }
+    )
+
+  private def editable(name: String) = name match {
+    case "inboxMsg.bell" => false
+    case "tournamentSoon.bell" => false
+    case "gameEvent.bell" => false
+    case "challenge.bell" => false
+    case _ => true
+  }
 }

--- a/app/views/account/pref.scala
+++ b/app/views/account/pref.scala
@@ -9,31 +9,11 @@ import lila.pref.PrefCateg
 import controllers.routes
 
 object pref {
-
+  import bits._
   import trans.preferences._
 
   private def categFieldset(categ: lila.pref.PrefCateg, active: lila.pref.PrefCateg) =
     div(cls := List("none" -> (categ != active)))
-
-  private def setting(name: Frag, body: Frag) = st.section(h2(name), body)
-
-  private def radios(field: play.api.data.Field, options: Iterable[(Any, String)], prefix: String = "ir") =
-    st.group(cls := "radio")(
-      options.map { v =>
-        val id      = s"${field.id}_${v._1}"
-        val checked = field.value has v._1.toString
-        div(
-          input(
-            st.id := s"$prefix$id",
-            checked option st.checked,
-            tpe   := "radio",
-            value := v._1.toString,
-            name  := field.name
-          ),
-          label(`for` := s"$prefix$id")(v._2)
-        )
-      }.toList
-    )
 
   def apply(u: lila.user.User, form: play.api.data.Form[_], categ: lila.pref.PrefCateg)(implicit
       ctx: Context
@@ -46,6 +26,7 @@ object pref {
       div(cls := "account box box-pad")(
         h1(bits.categName(categ)),
         postForm(cls := "autosubmit", action := routes.Pref.formApply)(
+          notification.fieldSet(form, categ != PrefCateg.Notification),
           categFieldset(PrefCateg.Display, categ)(
             setting(
               pieceAnimation(),
@@ -153,12 +134,6 @@ object pref {
               castleByMovingTheKingTwoSquaresOrOntoTheRook(),
               radios(form("behavior.rookCastle"), translatedRookCastleChoices)
             ),
-            div(id := "correspondence-email-notif")(
-              setting(
-                correspondenceEmailNotification(),
-                radios(form("behavior.corresEmailNotif"), booleanChoices)
-              )
-            ),
             setting(
               inputMovesWithTheKeyboard(),
               radios(form("behavior.keyboardMove"), booleanChoices)
@@ -192,10 +167,6 @@ object pref {
             setting(
               trans.letOtherPlayersInviteYouToStudy(),
               radios(form("studyInvite"), translatedStudyInviteChoices)
-            ),
-            setting(
-              trans.receiveForumNotifications(),
-              radios(form("mention"), booleanChoices)
             ),
             setting(
               trans.shareYourInsightsData(),

--- a/build.sbt
+++ b/build.sbt
@@ -336,7 +336,7 @@ lazy val playban = module("playban",
 )
 
 lazy val push = module("push",
-  Seq(common, db, user, game, challenge, msg),
+  Seq(common, db, user, game, challenge, msg, pref, forum),
   Seq(googleOAuth) ++ reactivemongo.bundle
 )
 
@@ -416,7 +416,7 @@ lazy val explorer = module("explorer",
 )
 
 lazy val notifyModule = module("notify",
-  Seq(common, db, game, user, hub, relation),
+  Seq(common, db, game, user, hub, relation, pref, timeline),
   reactivemongo.bundle
 )
 

--- a/modules/activity/src/main/Env.scala
+++ b/modules/activity/src/main/Env.scala
@@ -75,9 +75,9 @@ final class Env(
     case lila.study.actorApi.StartStudy(id)               =>
       // wait some time in case the study turns private
       scheduler.scheduleOnce(5 minutes) { write.study(id).unit }.unit
-    case lila.hub.actorApi.team.CreateTeam(id, _, userId) => write.team(id, userId).unit
-    case lila.hub.actorApi.team.JoinTeam(id, userId)      => write.team(id, userId).unit
-    case lila.hub.actorApi.streamer.StreamStart(userId)   => write.streamStart(userId).unit
-    case lila.swiss.SwissFinish(swissId, ranking)         => write.swiss(swissId, ranking).unit
+    case lila.hub.actorApi.team.CreateTeam(id, _, userId)  => write.team(id, userId).unit
+    case lila.hub.actorApi.team.JoinTeam(id, userId)       => write.team(id, userId).unit
+    case lila.hub.actorApi.streamer.StreamStart(userId, _) => write.streamStart(userId).unit
+    case lila.swiss.SwissFinish(swissId, ranking)          => write.swiss(swissId, ranking).unit
   }
 }

--- a/modules/common/src/main/mon.scala
+++ b/modules/common/src/main/mon.scala
@@ -649,12 +649,14 @@ object mon {
           .increment()
         ()
       }
-      val move        = send("move") _
-      val takeback    = send("takeback") _
-      val corresAlarm = send("corresAlarm") _
-      val finish      = send("finish") _
-      val message     = send("message") _
-      val tourSoon    = send("tourSoon") _
+      val move         = send("move") _
+      val takeback     = send("takeback") _
+      val corresAlarm  = send("corresAlarm") _
+      val streamStart  = send("streamStart") _
+      val forumMention = send("forumMention") _
+      val finish       = send("finish") _
+      val message      = send("message") _
+      val tourSoon     = send("tourSoon") _
       object challenge {
         val create = send("challengeCreate") _
         val accept = send("challengeAccept") _

--- a/modules/hub/src/main/actorApi.scala
+++ b/modules/hub/src/main/actorApi.scala
@@ -16,7 +16,7 @@ package streamer {
       userId: String,
       streamerName: String,
       text: String,
-      filter: Int,
+      allows: Int,
       lang: Lang,
       recentlyOnline: Boolean = false
   )

--- a/modules/hub/src/main/actorApi.scala
+++ b/modules/hub/src/main/actorApi.scala
@@ -4,13 +4,22 @@ package actorApi
 import chess.format.Uci
 import org.joda.time.{ DateTime, Period }
 import play.api.libs.json._
+import play.api.i18n.Lang
 import scala.concurrent.Promise
 
 // announce something to all clients
 case class Announce(msg: String, date: DateTime, json: JsObject)
 
 package streamer {
-  case class StreamStart(userId: String)
+  case class StreamStart(streamerId: String, pushTo: List[NotifiableFollower])
+  case class NotifiableFollower(
+      userId: String,
+      streamerName: String,
+      text: String,
+      filter: Int,
+      lang: Lang,
+      recentlyOnline: Boolean = false
+  )
 }
 
 package map {
@@ -317,4 +326,5 @@ package plan {
 
 package push {
   case class TourSoon(tourId: String, tourName: String, userIds: Iterable[String], swiss: Boolean)
+  case class ForumMention(userId: String, title: String, postId: String)
 }

--- a/modules/i18n/src/main/I18nKeys.scala
+++ b/modules/i18n/src/main/I18nKeys.scala
@@ -1669,11 +1669,10 @@ val `notifyGameEvent` = new I18nKey("preferences:notifyGameEvent")
 val `notifyChallenge` = new I18nKey("preferences:notifyChallenge")
 val `notifyTournamentSoon` = new I18nKey("preferences:notifyTournamentSoon")
 val `notifyTimeAlarm` = new I18nKey("preferences:notifyTimeAlarm")
-val `notifyNone` = new I18nKey( "preferences:notifyNone")
 val `notifyBell` = new I18nKey("preferences:notifyBell")
+val `notifyPush` = new I18nKey("preferences:notifyPush")
 val `notifyWeb` = new I18nKey("preferences:notifyWeb")
 val `notifyDevice` = new I18nKey("preferences:notifyDevice")
-val `notifyEverything` = new I18nKey("preferences:notifyEverything")
 }
 
 object team {

--- a/modules/i18n/src/main/I18nKeys.scala
+++ b/modules/i18n/src/main/I18nKeys.scala
@@ -1614,6 +1614,7 @@ object preferences {
 val `preferences` = new I18nKey("preferences:preferences")
 val `display` = new I18nKey("preferences:display")
 val `privacy` = new I18nKey("preferences:privacy")
+val `notifications` = new I18nKey("preferences:notifications")
 val `pieceAnimation` = new I18nKey("preferences:pieceAnimation")
 val `materialDifference` = new I18nKey("preferences:materialDifference")
 val `boardHighlights` = new I18nKey("preferences:boardHighlights")
@@ -1661,7 +1662,18 @@ val `sayGgWpAfterLosingOrDrawing` = new I18nKey("preferences:sayGgWpAfterLosingO
 val `yourPreferencesHaveBeenSaved` = new I18nKey("preferences:yourPreferencesHaveBeenSaved")
 val `scrollOnTheBoardToReplayMoves` = new I18nKey("preferences:scrollOnTheBoardToReplayMoves")
 val `correspondenceEmailNotification` = new I18nKey("preferences:correspondenceEmailNotification")
-
+val `notifyStreamStart` = new I18nKey("preferences:notifyStreamStart")
+val `notifyInboxMsg` = new I18nKey("preferences:notifyInboxMsg")
+val `notifyForumMention` = new I18nKey("preferences:notifyForumMention")
+val `notifyGameEvent` = new I18nKey("preferences:notifyGameEvent")
+val `notifyChallenge` = new I18nKey("preferences:notifyChallenge")
+val `notifyTournamentSoon` = new I18nKey("preferences:notifyTournamentSoon")
+val `notifyTimeAlarm` = new I18nKey("preferences:notifyTimeAlarm")
+val `notifyNone` = new I18nKey( "preferences:notifyNone")
+val `notifyBell` = new I18nKey("preferences:notifyBell")
+val `notifyWeb` = new I18nKey("preferences:notifyWeb")
+val `notifyDevice` = new I18nKey("preferences:notifyDevice")
+val `notifyEverything` = new I18nKey("preferences:notifyEverything")
 }
 
 object team {

--- a/modules/notify/src/main/BSONHandlers.scala
+++ b/modules/notify/src/main/BSONHandlers.scala
@@ -44,11 +44,12 @@ private object BSONHandlers {
   implicit val PlanStartHandler  = Macros.handler[PlanStart]
   implicit val PlanExpireHandler = Macros.handler[PlanExpire]
 
-  implicit val RatingRefundHandler = Macros.handler[RatingRefund]
-  implicit val CorresAlarmHandler  = Macros.handler[CorresAlarm]
-  implicit val IrwinDoneHandler    = Macros.handler[IrwinDone]
-  implicit val KaladinDoneHandler  = Macros.handler[KaladinDone]
-  implicit val GenericLinkHandler  = Macros.handler[GenericLink]
+  implicit val RatingRefundHandler    = Macros.handler[RatingRefund]
+  implicit val CorresAlarmHandler     = Macros.handler[CorresAlarm]
+  implicit val IrwinDoneHandler       = Macros.handler[IrwinDone]
+  implicit val KaladinDoneHandler     = Macros.handler[KaladinDone]
+  implicit val GenericLinkHandler     = Macros.handler[GenericLink]
+  implicit val StreamStartNoteHandler = Macros.handler[StreamStartNote]
 
   implicit val ColorBSONHandler = BSONBooleanHandler.as[Color](Color.fromWhite, _.white)
 
@@ -79,6 +80,7 @@ private object BSONHandlers {
         case x: IrwinDone                  => IrwinDoneHandler.writeTry(x).get
         case x: KaladinDone                => KaladinDoneHandler.writeTry(x).get
         case x: GenericLink                => GenericLinkHandler.writeTry(x).get
+        case x: StreamStartNote            => StreamStartNoteHandler.writeTry(x).get
       }
     } ++ $doc("type" -> notificationContent.key)
 
@@ -117,6 +119,7 @@ private object BSONHandlers {
         case "irwinDone"      => IrwinDoneHandler.readTry(reader.doc).get
         case "kaladinDone"    => KaladinDoneHandler.readTry(reader.doc).get
         case "genericLink"    => GenericLinkHandler.readTry(reader.doc).get
+        case "streamStart"    => StreamStartNoteHandler.readTry(reader.doc).get
       }
 
     def writes(writer: Writer, n: NotificationContent): dsl.Bdoc = writeNotificationContent(n)

--- a/modules/notify/src/main/Env.scala
+++ b/modules/notify/src/main/Env.scala
@@ -15,7 +15,10 @@ final class Env(
     userRepo: lila.user.UserRepo,
     getLightUser: lila.common.LightUser.Getter,
     getLightUserSync: lila.common.LightUser.GetterSync,
-    cacheApi: lila.memo.CacheApi
+    cacheApi: lila.memo.CacheApi,
+    prefApi: lila.pref.PrefApi,
+    relationApi: lila.relation.RelationApi,
+    timeline: lila.hub.actors.Timeline
 )(implicit
     ec: scala.concurrent.ExecutionContext,
     system: ActorSystem
@@ -28,6 +31,8 @@ final class Env(
   private val maxPerPage = MaxPerPage(7)
 
   lazy val api = wire[NotifyApi]
+
+  private lazy val streamStarter = wire[StreamStartHelper]
 
   // api actor
   Bus.subscribeFun("notify") {

--- a/modules/notify/src/main/JsonHandlers.scala
+++ b/modules/notify/src/main/JsonHandlers.scala
@@ -21,6 +21,12 @@ final class JSONHandlers(getLightUser: LightUser.GetterSync) {
             "category"    -> category.value,
             "postId"      -> postId.value
           )
+        case StreamStartNote(streamerId, streamerName, text) =>
+          Json.obj(
+            "sid"  -> streamerId,
+            "name" -> streamerName,
+            "text" -> text
+          )
         case InvitedToStudy(invitedBy, studyName, studyId) =>
           Json.obj(
             "invitedBy" -> getLightUser(invitedBy.value),
@@ -94,12 +100,6 @@ final class JSONHandlers(getLightUser: LightUser.GetterSync) {
   }
   implicit val andUnreadWrites: OWrites[Notification.AndUnread] = Json.writes[Notification.AndUnread]
 
-  implicit val newNotificationWrites: Writes[NewNotification] = (newNotification: NewNotification) =>
-    Json.obj(
-      "notification" -> newNotification.notification,
-      "unread"       -> newNotification.unreadNotifications
-    )
-
   private val i18nKeys: List[lila.i18n.MessageKey] = List(
     trans.mentionedYouInX,
     trans.xMentionedYouInY,
@@ -125,5 +125,11 @@ final class JSONHandlers(getLightUser: LightUser.GetterSync) {
   def apply(notify: Notification.AndUnread)(implicit lang: Lang) =
     andUnreadWrites.writes(notify) ++ Json.obj(
       "i18n" -> JsDump.keysToObject(i18nKeys, lang)
+    )
+
+  def apply(notify: Notification.SingleAndUnread)(implicit lang: Lang) =
+    Json.obj(
+      "note"   -> notify.note,
+      "unread" -> notify.unread
     )
 }

--- a/modules/notify/src/main/JsonHandlers.scala
+++ b/modules/notify/src/main/JsonHandlers.scala
@@ -124,12 +124,14 @@ final class JSONHandlers(getLightUser: LightUser.GetterSync) {
 
   def apply(notify: Notification.AndUnread)(implicit lang: Lang) =
     andUnreadWrites.writes(notify) ++ Json.obj(
-      "i18n" -> JsDump.keysToObject(i18nKeys, lang)
+      "i18n" -> JsDump.keysToObject(i18nKeys, lang),
+      "alert" -> false
     )
 
   def apply(notify: Notification.SingleAndUnread)(implicit lang: Lang) =
     Json.obj(
       "note"   -> notify.note,
-      "unread" -> notify.unread
+      "unread" -> notify.unread,
+      "alert" -> notify.alert
     )
 }

--- a/modules/notify/src/main/Notification.scala
+++ b/modules/notify/src/main/Notification.scala
@@ -9,7 +9,7 @@ case class Notification(
     notifies: Notification.Notifies,
     content: NotificationContent,
     read: Notification.NotificationRead,
-    createdAt: DateTime
+    createdAt: DateTime,
 ) {
   def id = _id
 
@@ -26,7 +26,7 @@ object Notification {
 
   case class UnreadCount(value: Int) extends AnyVal
   case class AndUnread(pager: Paginator[Notification], unread: UnreadCount)
-  case class SingleAndUnread(note: Notification, unread: UnreadCount)
+  case class SingleAndUnread(note: Notification, unread: UnreadCount, alert: Boolean)
   case class Notifies(value: String)          extends AnyVal with StringValue
   case class NotificationRead(value: Boolean) extends AnyVal
 
@@ -55,8 +55,11 @@ object MentionedInThread {
   case class PostId(value: String)      extends AnyVal with StringValue
 }
 
-case class StreamStartNote(streamerId: lila.user.User.ID, streamerName: String, text: String)
-    extends NotificationContent("streamStart")
+case class StreamStartNote(
+    streamerId: String,
+    streamerName: String,
+    text: String
+) extends NotificationContent("streamStart")
 
 object StreamStartNote {
   def make(userId: String, streamerId: String, streamerName: String, text: String): Notification =

--- a/modules/notify/src/main/Notification.scala
+++ b/modules/notify/src/main/Notification.scala
@@ -4,8 +4,6 @@ import lila.common.paginator.Paginator
 import lila.notify.MentionedInThread.PostId
 import org.joda.time.DateTime
 
-case class NewNotification(notification: Notification, unreadNotifications: Int)
-
 case class Notification(
     _id: String,
     notifies: Notification.Notifies,
@@ -28,6 +26,7 @@ object Notification {
 
   case class UnreadCount(value: Int) extends AnyVal
   case class AndUnread(pager: Paginator[Notification], unread: UnreadCount)
+  case class SingleAndUnread(note: Notification, unread: UnreadCount)
   case class Notifies(value: String)          extends AnyVal with StringValue
   case class NotificationRead(value: Boolean) extends AnyVal
 
@@ -54,6 +53,14 @@ object MentionedInThread {
   case class TopicId(value: String)     extends AnyVal with StringValue
   case class Category(value: String)    extends AnyVal with StringValue
   case class PostId(value: String)      extends AnyVal with StringValue
+}
+
+case class StreamStartNote(streamerId: lila.user.User.ID, streamerName: String, text: String)
+    extends NotificationContent("streamStart")
+
+object StreamStartNote {
+  def make(userId: String, streamerId: String, streamerName: String, text: String): Notification =
+    Notification.make(Notification.Notifies(userId), new StreamStartNote(streamerId, streamerName, text))
 }
 
 case class InvitedToStudy(

--- a/modules/notify/src/main/NotificationRepo.scala
+++ b/modules/notify/src/main/NotificationRepo.scala
@@ -34,14 +34,14 @@ final private class NotificationRepo(val coll: Coll)(implicit ec: scala.concurre
     $doc(
       "read" -> false,
       $or(
-        $doc("content.type" -> $ne("streamStart"), "createdAt" $gt DateTime.now.minusDays(3)),
-        $doc("content.type" -> "streamStart", "createdAt" $gt DateTime.now.minusHours(2))
+        $doc("content.type" -> "streamStart", "createdAt" $gt DateTime.now.minusHours(2)),
+        $doc("content.type" -> $ne("streamStart"), "createdAt" $gt DateTime.now.minusDays(3))
       )
     )
 
   private def hasUnread =
     $doc( // recent, read
-      "createdAt" $gt DateTime.now.minusMinutes(10)
+      "createdAt" $gt DateTime.now.minusMinutes(10) // wtf?
     )
 
   private def hasOldOrUnread =
@@ -97,6 +97,9 @@ final private class NotificationRepo(val coll: Coll)(implicit ec: scala.concurre
     coll.exists(userNotificationsQuery(notifies) ++ selector)
 
   val recentSort = $sort desc "createdAt"
+
+  def mostRecentUnread(userId: Notification.Notifies) =
+    coll.find($doc("notifies" -> userId, "read" -> false)).sort($sort.createdDesc).one[Notification]
 
   def userNotificationsQuery(userId: Notification.Notifies) = $doc("notifies" -> userId)
 

--- a/modules/notify/src/main/NotifyApi.scala
+++ b/modules/notify/src/main/NotifyApi.scala
@@ -1,29 +1,31 @@
 package lila.notify
 
 import scala.concurrent.duration._
+import scala.concurrent.Future
 
 import lila.common.Bus
 import lila.common.config.MaxPerPage
 import lila.common.paginator.Paginator
 import lila.db.dsl._
 import lila.db.paginator.Adapter
-import lila.hub.actorApi.socket.SendTo
+import lila.hub.actorApi.socket.{ SendTo, SendTos }
 import lila.memo.CacheApi._
 import lila.user.UserRepo
-import lila.i18n.I18nLangPicker
+import lila.i18n._
 
 final class NotifyApi(
     jsonHandlers: JSONHandlers,
     repo: NotificationRepo,
     userRepo: UserRepo,
     cacheApi: lila.memo.CacheApi,
+    streamStarter: StreamStartHelper,
     maxPerPage: MaxPerPage
 )(implicit ec: scala.concurrent.ExecutionContext) {
 
   import BSONHandlers.{ NotificationBSONHandler, NotifiesHandler }
-  import jsonHandlers._
+  import Notification._
 
-  def getNotifications(userId: Notification.Notifies, page: Int): Fu[Paginator[Notification]] =
+  def getNotifications(userId: Notifies, page: Int): Fu[Paginator[Notification]] =
     Paginator(
       adapter = new Adapter(
         collection = repo.coll,
@@ -35,30 +37,31 @@ final class NotifyApi(
       maxPerPage = maxPerPage
     )
 
-  def getNotificationsAndCount(userId: Notification.Notifies, page: Int): Fu[Notification.AndUnread] =
+  def getNotificationsAndCount(userId: Notifies, page: Int): Fu[Notification.AndUnread] =
     getNotifications(userId, page) zip unreadCount(userId) dmap (Notification.AndUnread.apply _).tupled
 
-  def markAllRead(userId: Notification.Notifies) =
+  def markAllRead(userId: Notifies) =
     repo.markAllRead(userId) >>- unreadCountCache.put(userId, fuccess(0))
 
-  def markAllRead(userIds: Iterable[Notification.Notifies]) =
+  def markAllRead(userIds: Iterable[Notifies]) =
     repo.markAllRead(userIds) >>- userIds.foreach {
       unreadCountCache.put(_, fuccess(0))
     }
 
-  private val unreadCountCache = cacheApi[Notification.Notifies, Int](32768, "notify.unreadCountCache") {
+  private val unreadCountCache = cacheApi[Notifies, Int](32768, "notify.unreadCountCache") {
     _.expireAfterAccess(15 minutes)
       .buildAsyncFuture(repo.unreadNotificationsCount)
   }
 
-  def unreadCount(userId: Notification.Notifies): Fu[Notification.UnreadCount] =
-    unreadCountCache get userId dmap Notification.UnreadCount.apply
+  def unreadCount(userId: Notifies): Fu[UnreadCount] =
+    unreadCountCache get userId dmap UnreadCount.apply
 
   def addNotification(notification: Notification): Funit =
     // Add to database and then notify any connected clients of the new notification
     insertOrDiscardNotification(notification) map {
       _ foreach { notif =>
         notifyUser(notif.notifies)
+        pushToUser(notif)
       }
     }
 
@@ -68,14 +71,71 @@ final class NotifyApi(
   def addNotifications(notifications: List[Notification]): Funit =
     notifications.map(addNotification).sequenceFu.void
 
-  def remove(notifies: Notification.Notifies, selector: Bdoc = $empty): Funit =
+  def remove(notifies: Notifies, selector: Bdoc = $empty): Funit =
     repo.remove(notifies, selector) >>- unreadCountCache.invalidate(notifies)
 
-  def markRead(notifies: Notification.Notifies, selector: Bdoc): Funit =
+  def markRead(notifies: Notifies, selector: Bdoc): Funit =
     repo.markManyRead(selector ++ $doc("notifies" -> notifies, "read" -> false)) >>-
       unreadCountCache.invalidate(notifies)
 
   def exists = repo.exists _
+
+  /*
+  look up the followers, filter by notification pref, push web/firebase if necessary,
+  and assemble a NotiflowerViews (see StreamStartHelper) where the text is translated
+  for all recipients. bulk lookup the unread counts for users and update the unread cache.
+  group notes by unique (lang, unreadCount) tuples to determine the user set for SendTos.
+  each SendTos message contains a single notification (no pager) with the translated text,
+  streamer name/id, and unread count.
+
+  meanwhile, the typescript has been modified to handle these slimmed down messages
+  (see ui/notify/_.ts).  a full page of notifications won't be delivered until they
+  actually click the bell.  there is no per-user db access in this entire flow and
+  it's streamlined wrt lila-ws tells.  magnus, please stay retired.
+   */
+
+  def notifyStreamStart(streamerId: String, streamerName: String): Funit =
+    streamStarter.getNotiflowersAndPush(streamerId, streamerName) flatMap { res =>
+      val views = streamStarter.NotiflowerViews(res, streamerId, streamerName)
+
+      repo.bulkUnreadCount(views.users) flatMap { countList => // before insert is intentional
+        bumpCountCache(countList filter (recents => views.byUser(recents._1).recentlyOnline))
+
+        repo.insertMany(views.noteList) andThen { case _ =>
+          views.notesByLang map { case (lang, sameLangNotes) =>
+            notesByCount(sameLangNotes, countList.toMap) map { case (count, (users, note)) =>
+
+              Bus.publish(
+                SendTos(
+                  users,
+                  "notifications",
+                  jsonHandlers(Notification.SingleAndUnread(note, UnreadCount(count + 1)))(lang)
+                ),
+                "socketUsers"
+              )
+            }
+          }
+        }
+      }
+    }
+
+  private def notesByCount(
+      notes: Iterable[Option[Notification]],
+      countMap: Map[String, Int]
+  ) =
+    notes
+      .collect { case Some(note) =>
+        (countMap.getOrElse(note.notifies.value, 0), note) // (count, note) tuple list
+      }
+      .groupMapReduce(_._1)                     // group list by count
+      { t => (Set(t._2.notifies.value), t._2) } // wrap note.userId in set
+      { (a, b) => (a._1 | b._1, a._2) }         // join userId sets and discard identical note
+
+  private def bumpCountCache(countList: List[(String, Int)]) =
+    countList map { case (userId, veryRecentCount) =>
+      // we have the accurate count.  and everyone in countList is recently online
+      unreadCountCache.put(Notifies(userId), Future({ veryRecentCount + 1 })) // +1 for the streamStart
+    }
 
   private def shouldSkip(notification: Notification) =
     (!notification.isMsg ?? userRepo.isKid(notification.notifies.value)) >>| {
@@ -97,7 +157,7 @@ final class NotifyApi(
       _ ?? addNotificationWithoutSkipOrEvent(notification) inject notification.some
     }
 
-  private def notifyUser(notifies: Notification.Notifies): Funit =
+  private def notifyUser(notifies: Notifies): Funit =
     getNotificationsAndCount(notifies, 1) map { msg =>
       Bus.publish(
         SendTo.async(
@@ -111,5 +171,23 @@ final class NotifyApi(
         ),
         "socketUsers"
       )
+    }
+
+  private def pushToUser(note: Notification) =
+    note.content match {
+      case MentionedInThread(commenter, topic, _, _, postId) =>
+        userRepo.byId(note.notifies.value) collect { case Some(user) =>
+          implicit val lang: play.api.i18n.Lang = user.realLang.getOrElse(defaultLang)
+          Bus.publish(
+            lila.hub.actorApi.push.ForumMention(
+              commenter.value,
+              I18nKeys.xMentionedYouInY.txt(commenter, topic),
+              postId.value
+            ),
+            "forumMention"
+          )
+        }
+      case _ =>
+      // only pushing forum mention and stream start notifications from notify
     }
 }

--- a/modules/notify/src/main/NotifyApi.scala
+++ b/modules/notify/src/main/NotifyApi.scala
@@ -2,13 +2,12 @@ package lila.notify
 
 import scala.concurrent.duration._
 import scala.concurrent.Future
-
 import lila.common.Bus
 import lila.common.config.MaxPerPage
 import lila.common.paginator.Paginator
 import lila.db.dsl._
 import lila.db.paginator.Adapter
-import lila.hub.actorApi.socket.{ SendTo, SendTos }
+import lila.hub.actorApi.socket.{SendTo, SendTos}
 import lila.memo.CacheApi._
 import lila.user.UserRepo
 import lila.i18n._
@@ -19,7 +18,8 @@ final class NotifyApi(
     userRepo: UserRepo,
     cacheApi: lila.memo.CacheApi,
     streamStarter: StreamStartHelper,
-    maxPerPage: MaxPerPage
+    maxPerPage: MaxPerPage,
+    prefApi : lila.pref.PrefApi
 )(implicit ec: scala.concurrent.ExecutionContext) {
 
   import BSONHandlers.{ NotificationBSONHandler, NotifiesHandler }
@@ -60,8 +60,7 @@ final class NotifyApi(
     // Add to database and then notify any connected clients of the new notification
     insertOrDiscardNotification(notification) map {
       _ foreach { notif =>
-        notifyUser(notif.notifies)
-        pushToUser(notif)
+        notifyUser(notif)
       }
     }
 
@@ -82,11 +81,13 @@ final class NotifyApi(
 
   /*
   look up the followers, filter by notification pref, push web/firebase if necessary,
-  and assemble a NotiflowerViews (see StreamStartHelper) where the text is translated
+  and assemble a NotiflowerView (see StreamStartHelper) where the text is translated
   for all recipients. bulk lookup the unread counts for users and update the unread cache.
-  group notes by unique (lang, unreadCount) tuples to determine the user set for SendTos.
+  group notes by unique (lang, unreadCount, alert) tuples to determine the user set for SendTos.
   each SendTos message contains a single notification (no pager) with the translated text,
-  streamer name/id, and unread count.
+  streamer name/id, unread count, and either true/false whether to use Notification API if
+  backgrounded (sigh..  yes we further group SendTos based on whether the user set has push
+  enabled on streamStart)
 
   meanwhile, the typescript has been modified to handle these slimmed down messages
   (see ui/notify/_.ts).  a full page of notifications won't be delivered until they
@@ -96,28 +97,35 @@ final class NotifyApi(
 
   def notifyStreamStart(streamerId: String, streamerName: String): Funit =
     streamStarter.getNotiflowersAndPush(streamerId, streamerName) flatMap { res =>
-      val views = streamStarter.NotiflowerViews(res, streamerId, streamerName)
+      val views = streamStarter.NotiflowerView(res, streamerId, streamerName)
 
-      repo.bulkUnreadCount(views.users) flatMap { countList => // before insert is intentional
+      repo.bulkUnreadCount(views.users) flatMap { countList => // count before insert is intentional
         bumpCountCache(countList filter (recents => views.byUser(recents._1).recentlyOnline))
 
         repo.insertMany(views.noteList) andThen { case _ =>
           views.notesByLang map { case (lang, sameLangNotes) =>
             notesByCount(sameLangNotes, countList.toMap) map { case (count, (users, note)) =>
-
-              Bus.publish(
-                SendTos(
-                  users,
-                  "notifications",
-                  jsonHandlers(Notification.SingleAndUnread(note, UnreadCount(count + 1)))(lang)
-                ),
-                "socketUsers"
-              )
+              val (alertUsers, obliviousUsers) = views.alertPartition(users)
+              sendTos(alertUsers, note, count, true, lang)
+              sendTos(obliviousUsers, note, count, false, lang)
+              // at this point, terrified to look at lila-ws.  what if grouping these msgs
+              // into identical sendTos doesn't optimize traffic compared to many single sendTo
+              // calls? (it kind of snowballed on me)...
             }
           }
         }
       }
     }
+
+  private def sendTos(users: Set[String], note: Notification, count: Int, alert: Boolean, lang: play.api.i18n.Lang) =
+    Bus.publish(
+      SendTos(
+        users,
+        "notifications",
+        jsonHandlers(Notification.SingleAndUnread(note, UnreadCount(count + 1), alert = alert))(lang)
+      ),
+      "socketUsers"
+    )
 
   private def notesByCount(
       notes: Iterable[Option[Notification]],
@@ -157,23 +165,25 @@ final class NotifyApi(
       _ ?? addNotificationWithoutSkipOrEvent(notification) inject notification.some
     }
 
-  private def notifyUser(notifies: Notifies): Funit =
-    getNotificationsAndCount(notifies, 1) map { msg =>
-      Bus.publish(
-        SendTo.async(
-          notifies.value,
-          "notifications",
-          () => {
-            userRepo langOf notifies.value map I18nLangPicker.byStrOrDefault map { implicit lang =>
-              jsonHandlers(msg)
-            }
-          }
-        ),
-        "socketUsers"
-      )
-    }
+  private def notifyUser(note: Notification) =
+      getAllows(note.notifies.value, note) zip unreadCountCache.get(note.notifies) collect {
+        case (allows, count) =>
+          if (allows.push) pushToUser(note)
+          if (allows.bell) Bus.publish(
+            SendTo.async(
+              note.notifies.value,
+              "notifications",
+              () => {
+                userRepo langOf note.notifies.value map I18nLangPicker.byStrOrDefault map { implicit lang =>
+                  jsonHandlers(SingleAndUnread(note, UnreadCount(count), allows.web))
+                }
+              }
+            ),
+            "socketUsers"
+          )
+      }
 
-  private def pushToUser(note: Notification) =
+  private def pushToUser(note: Notification) = {
     note.content match {
       case MentionedInThread(commenter, topic, _, _, postId) =>
         userRepo.byId(note.notifies.value) collect { case Some(user) =>
@@ -188,6 +198,16 @@ final class NotifyApi(
           )
         }
       case _ =>
-      // only pushing forum mention and stream start notifications from notify
+    }
+  }
+
+  import lila.pref.NotificationPref._
+  private def getAllows(uid: String, note: Notification): Fu[Allows] =
+    prefApi.getNotificationPref(uid) map { pref =>
+      note.content match {
+        case _: PrivateMessage => pref.allows(InboxMsg)
+        case _: MentionedInThread => pref.allows(ForumMention)
+        case _ => Allows(BELL)
+      }
     }
 }

--- a/modules/notify/src/main/StreamStartHelper.scala
+++ b/modules/notify/src/main/StreamStartHelper.scala
@@ -1,0 +1,96 @@
+package lila.notify
+
+import reactivemongo.api.ReadPreference
+import org.joda.time.DateTime
+
+import lila.common.Bus
+import lila.db.dsl._
+import lila.hub.actorApi.streamer.NotifiableFollower
+import lila.i18n._
+import lila.user.User
+
+/* a helper class to encapsulate pref, timeline, and relation dependencies
+   so that we may violate them in secret.
+ */
+
+final private class StreamStartHelper(
+    userRepo: lila.user.UserRepo,
+    prefApi: lila.pref.PrefApi,
+    timeline: lila.hub.actors.Timeline,
+    relationApi: lila.relation.RelationApi
+)(implicit
+    ec: scala.concurrent.ExecutionContext
+) {
+  def getNotiflowersAndPush(streamerId: User.ID, streamerName: String): Fu[Iterable[NotifiableFollower]] =
+    relationApi.freshFollowersFromSecondary(streamerId, 14).flatMap { followers =>
+      timeline ! {
+        import lila.hub.actorApi.timeline.{ Propagate, StreamStart }
+        Propagate(StreamStart(streamerId, streamerName)) toUsers followers
+      }
+      lookupNotifiable(streamerName, followers) andThen { pushList =>
+        Bus.publish(
+          lila.hub.actorApi.streamer.StreamStart(streamerId, pushList.get),
+          "streamStart"
+        )
+      }
+    }
+
+  case class NotiflowerViews(notiflowers: Iterable[NotifiableFollower], sid: String, name: String) {
+
+    val noteList: List[Notification] =
+      notiflowers map { x => StreamStartNote.make(x.userId, sid, name, x.text) } toList
+
+    val byUser: Map[String, NotifiableFollower] =
+      notiflowers.groupMapReduce(_.userId)(identity)((x, _) => x)
+
+    val users: Iterable[String] = byUser.keys
+
+    val notesByUser: Map[String, Notification] =
+      noteList.groupMapReduce(_.notifies.value)(identity)((x, _) => x)
+
+    val notesByLang: Map[play.api.i18n.Lang, Iterable[Option[Notification]]] =
+      notiflowers.groupMap(_.lang)(nf => notesByUser.get(nf.userId))
+  }
+
+  private def lookupNotifiable(
+      streamerName: String,
+      followers: List[User.ID]
+  ): Fu[List[NotifiableFollower]] = {
+    prefApi.coll
+      .aggregateList(-1, ReadPreference.secondaryPreferred) { framework =>
+        import framework._
+        Match($inIds(followers) ++ $doc("notification.streamStart" -> $doc("$gt" -> 0))) ->
+          List(
+            Project($doc("notification.streamStart" -> true)),
+            PipelineOperator(
+              $lookup.pipeline(
+                from = userRepo.coll,
+                as = "u",
+                local = "_id",
+                foreign = "_id",
+                pipe = List(
+                  $doc("$match"   -> $doc("enabled" -> true)),
+                  $doc("$project" -> $doc("lang" -> true, "seenAt" -> true, "_id" -> false))
+                )
+              )
+            ),
+            Unwind("u"),
+            Sort(Descending("u.seenAt"))
+          )
+      }
+      .map { docs =>
+        for {
+          doc     <- docs
+          id      <- doc string "_id"
+          filter  <- doc child "notification" map (_ int "streamStart")
+          langStr <- doc child "u" map (_ string "lang")
+          seenAt  <- doc child "u" map (_.getAsOpt[DateTime]("seenAt"))
+
+          // doing language translation here hurts me more than it hurts you.
+          lang           = I18nLangPicker.byStrOrDefault(langStr)
+          text           = I18nKeys.xStartedStreaming.txt(streamerName)(lang)
+          recentlyOnline = seenAt.fold(false)(_.compareTo(DateTime.now().minusMinutes(15)) > 0)
+        } yield NotifiableFollower(id, streamerName, text, ~filter, lang, recentlyOnline)
+      }
+  }
+}

--- a/modules/pref/src/main/JsonView.scala
+++ b/modules/pref/src/main/JsonView.scala
@@ -35,7 +35,7 @@ object JsonView {
       "message"          -> p.message,
       "submitMove"       -> p.submitMove,
       "confirmResign"    -> p.confirmResign,
-      "mention"          -> (p.notification.forumMention != 0), // back compat
+      "mention"          -> p.notification.forumMention.any, // back compat
       "corresEmailNotif" -> (p.notification.correspondenceEmail != 0), // back compat
       "notification"     -> p.notification,
       "insightShare"     -> p.insightShare,

--- a/modules/pref/src/main/JsonView.scala
+++ b/modules/pref/src/main/JsonView.scala
@@ -35,8 +35,9 @@ object JsonView {
       "message"          -> p.message,
       "submitMove"       -> p.submitMove,
       "confirmResign"    -> p.confirmResign,
-      "mention"          -> p.mention,
-      "corresEmailNotif" -> p.corresEmailNotif,
+      "mention"          -> (p.notification.forumMention != 0), // back compat
+      "corresEmailNotif" -> (p.notification.correspondenceEmail != 0), // back compat
+      "notification"     -> p.notification,
       "insightShare"     -> p.insightShare,
       "keyboardMove"     -> p.keyboardMove,
       "zen"              -> p.zen,

--- a/modules/pref/src/main/NotificationPref.scala
+++ b/modules/pref/src/main/NotificationPref.scala
@@ -1,0 +1,101 @@
+package lila.pref
+
+import play.api.libs.json.{ Json, OWrites }
+import reactivemongo.api.bson.{ BSONDocumentHandler, Macros }
+
+case class NotificationPref(
+    inboxMsg: Int,
+    challenge: Int,
+    gameEvent: Int,
+    tournamentSoon: Int,
+    timeAlarm: Int,
+    streamStart: Int,
+    forumMention: Int,
+    correspondenceEmail: Int
+) {
+
+  import NotificationPref._
+
+  def filter(notification: Type): Int =
+    notification match {
+      case InboxMsg       => inboxMsg
+      case Challenge      => challenge
+      case GameEvent      => gameEvent
+      case TournamentSoon => tournamentSoon
+      case TimeAlarm      => timeAlarm
+      case StreamStart    => streamStart
+      case ForumMention   => forumMention
+    }
+}
+
+object NotificationPref {
+  val NONE            = 0
+  val BELL            = 1
+  val WEB             = 2 // web push
+  val BELL_AND_WEB    = BELL | WEB
+  val DEVICE          = 4 // firebase
+  val BELL_AND_DEVICE = BELL | DEVICE
+  val WEB_AND_DEVICE  = WEB | DEVICE
+  val ALL             = BELL | WEB | DEVICE
+
+  val choices: Seq[Int]     = Seq(NONE, WEB, DEVICE, WEB_AND_DEVICE)        // non-bell push notifications
+  val moreChoices: Seq[Int] = Seq(BELL, BELL_AND_WEB, BELL_AND_DEVICE, ALL) // inbox
+  val noneMoreChoices: Seq[Int] = NONE +: moreChoices // stream start & forum mention
+
+  sealed trait Type {
+    override def toString: String = { // to match db fields
+      val typeName = getClass.getSimpleName
+      s"${typeName.charAt(0).toLower}${typeName.substring(1, typeName.length - 1)}" // strip object class $
+    }
+  }
+
+  case object InboxMsg       extends Type
+  case object GameEvent      extends Type
+  case object Challenge      extends Type
+  case object TournamentSoon extends Type
+  case object TimeAlarm      extends Type
+  case object StreamStart    extends Type
+  case object ForumMention   extends Type
+
+  lazy val default: NotificationPref = NotificationPref(
+    inboxMsg = ALL,
+    challenge = WEB_AND_DEVICE,
+    gameEvent = WEB_AND_DEVICE,
+    tournamentSoon = WEB_AND_DEVICE,
+    timeAlarm = WEB_AND_DEVICE,
+    streamStart = NONE,
+    forumMention = BELL,
+    correspondenceEmail = 0
+  )
+  /* example within a pref json view:
+    ...
+    "notification": {
+      "correspondenceEmail": true,
+      "streamStart": "bell|web|device",
+      "gameEvent": "web",
+      "inboxMsg": "",
+      ...
+   */
+  implicit val notificationDataJsonWriter: OWrites[NotificationPref] =
+    OWrites[NotificationPref] { ndata =>
+      Json.obj(
+        "inboxMsg"            -> filterToString(ndata.inboxMsg),
+        "challenge"           -> filterToString(ndata.challenge),
+        "gameEvent"           -> filterToString(ndata.gameEvent),
+        "tournamentSoon"      -> filterToString(ndata.tournamentSoon),
+        "timeAlarm"           -> filterToString(ndata.timeAlarm),
+        "streamStart"         -> filterToString(ndata.streamStart),
+        "forumMention"        -> filterToString(ndata.forumMention),
+        "correspondenceEmail" -> (ndata.correspondenceEmail != 0)
+      )
+    }
+
+  private def filterToString(filter: Int): String = (
+    Map(BELL -> "bell", WEB -> "web", DEVICE -> "device") collect {
+      case (tpe, str) if (filter & tpe) != 0 => str
+    }
+  ).mkString("|")
+
+  implicit val NotificationDataBSONHandler: BSONDocumentHandler[NotificationPref] =
+    Macros.handler[NotificationPref]
+}

--- a/modules/pref/src/main/Pref.scala
+++ b/modules/pref/src/main/Pref.scala
@@ -35,8 +35,6 @@ case class Pref(
     studyInvite: Int,
     submitMove: Int,
     confirmResign: Int,
-    mention: Boolean,
-    corresEmailNotif: Boolean,
     insightShare: Int,
     keyboardMove: Int,
     zen: Int,
@@ -46,6 +44,7 @@ case class Pref(
     pieceNotation: Int,
     resizeHandle: Int,
     agreement: Int,
+    notification: NotificationPref,
     tags: Map[String, String] = Map.empty
 ) {
 
@@ -231,10 +230,6 @@ object Pref {
       EVERYBODY -> "With everybody"
     )
   }
-
-  object Mention extends BooleanPref
-
-  object CorresEmailNotif extends BooleanPref
 
   object KeyboardMove extends BooleanPref
 
@@ -473,8 +468,6 @@ object Pref {
     studyInvite = StudyInvite.ALWAYS,
     submitMove = SubmitMove.CORRESPONDENCE_ONLY,
     confirmResign = ConfirmResign.YES,
-    mention = true,
-    corresEmailNotif = false,
     insightShare = InsightShare.FRIENDS,
     keyboardMove = KeyboardMove.NO,
     zen = Zen.NO,
@@ -484,6 +477,7 @@ object Pref {
     pieceNotation = PieceNotation.SYMBOL,
     resizeHandle = ResizeHandle.INITIAL,
     agreement = Agreement.current,
+    notification = NotificationPref.default,
     tags = Map.empty
   )
 

--- a/modules/pref/src/main/PrefCateg.scala
+++ b/modules/pref/src/main/PrefCateg.scala
@@ -8,8 +8,9 @@ object PrefCateg {
   case object ChessClock   extends PrefCateg("chess-clock")
   case object GameBehavior extends PrefCateg("game-behavior")
   case object Privacy      extends PrefCateg("privacy")
+  case object Notification extends PrefCateg("notification")
 
-  val all: List[PrefCateg] = List(Display, ChessClock, GameBehavior, Privacy)
+  val all: List[PrefCateg] = List(Display, ChessClock, GameBehavior, Privacy, Notification)
 
   def apply(slug: String) = all.find(_.slug == slug)
 }

--- a/modules/pref/src/main/PrefForm.scala
+++ b/modules/pref/src/main/PrefForm.scala
@@ -13,6 +13,9 @@ object PrefForm {
   private def checkedNumber(choices: Seq[(Int, String)]) =
     number.verifying(containedIn(choices))
 
+  private def checkedInteger(choices: Seq[Int]) =
+    number.verifying(choice => choices.contains(choice))
+
   private lazy val booleanNumber =
     number.verifying(Pref.BooleanPref.verify)
 
@@ -31,16 +34,15 @@ object PrefForm {
         "blindfold"     -> checkedNumber(Pref.Blindfold.choices)
       )(DisplayData.apply)(DisplayData.unapply),
       "behavior" -> mapping(
-        "moveEvent"        -> optional(numberIn(Set(0, 1, 2))),
-        "premove"          -> booleanNumber,
-        "takeback"         -> checkedNumber(Pref.Takeback.choices),
-        "autoQueen"        -> checkedNumber(Pref.AutoQueen.choices),
-        "autoThreefold"    -> checkedNumber(Pref.AutoThreefold.choices),
-        "submitMove"       -> checkedNumber(Pref.SubmitMove.choices),
-        "corresEmailNotif" -> optional(booleanNumber),
-        "confirmResign"    -> checkedNumber(Pref.ConfirmResign.choices),
-        "keyboardMove"     -> optional(booleanNumber),
-        "rookCastle"       -> optional(booleanNumber)
+        "moveEvent"     -> optional(numberIn(Set(0, 1, 2))),
+        "premove"       -> booleanNumber,
+        "takeback"      -> checkedNumber(Pref.Takeback.choices),
+        "autoQueen"     -> checkedNumber(Pref.AutoQueen.choices),
+        "autoThreefold" -> checkedNumber(Pref.AutoThreefold.choices),
+        "submitMove"    -> checkedNumber(Pref.SubmitMove.choices),
+        "confirmResign" -> checkedNumber(Pref.ConfirmResign.choices),
+        "keyboardMove"  -> optional(booleanNumber),
+        "rookCastle"    -> optional(booleanNumber)
       )(BehaviorData.apply)(BehaviorData.unapply),
       "clock" -> mapping(
         "tenths"   -> checkedNumber(Pref.ClockTenths.choices),
@@ -48,11 +50,20 @@ object PrefForm {
         "sound"    -> booleanNumber,
         "moretime" -> checkedNumber(Pref.Moretime.choices)
       )(ClockData.apply)(ClockData.unapply),
+      "notification" -> mapping(
+        "inboxMsg"            -> checkedInteger(NotificationPref.moreChoices),
+        "challenge"           -> checkedInteger(NotificationPref.choices),
+        "tournamentSoon"      -> checkedInteger(NotificationPref.choices),
+        "gameEvent"           -> checkedInteger(NotificationPref.choices),
+        "timeAlarm"           -> checkedInteger(NotificationPref.choices),
+        "streamStart"         -> checkedInteger(NotificationPref.noneMoreChoices),
+        "forumMention"        -> checkedInteger(NotificationPref.noneMoreChoices),
+        "correspondenceEmail" -> booleanNumber
+      )(NotificationPref.apply)(NotificationPref.unapply),
       "follow"       -> booleanNumber,
       "challenge"    -> checkedNumber(Pref.Challenge.choices),
       "message"      -> checkedNumber(Pref.Message.choices),
       "studyInvite"  -> optional(checkedNumber(Pref.StudyInvite.choices)),
-      "mention"      -> optional(booleanNumber),
       "insightShare" -> numberIn(Set(0, 1, 2)),
       "ratings"      -> optional(booleanNumber)
     )(PrefData.apply)(PrefData.unapply)
@@ -78,7 +89,6 @@ object PrefForm {
       autoQueen: Int,
       autoThreefold: Int,
       submitMove: Int,
-      corresEmailNotif: Option[Int],
       confirmResign: Int,
       keyboardMove: Option[Int],
       rookCastle: Option[Int]
@@ -95,11 +105,11 @@ object PrefForm {
       display: DisplayData,
       behavior: BehaviorData,
       clock: ClockData,
+      notification: NotificationPref,
       follow: Int,
       challenge: Int,
       message: Int,
       studyInvite: Option[Int],
-      mention: Option[Int],
       insightShare: Int,
       ratings: Option[Int]
   ) {
@@ -125,8 +135,6 @@ object PrefForm {
         premove = behavior.premove == 1,
         animation = display.animation,
         submitMove = behavior.submitMove,
-        corresEmailNotif = behavior.corresEmailNotif.fold(Pref.default.corresEmailNotif)(_ == 1),
-        mention = mention.fold(Pref.default.mention)(_ == 1),
         insightShare = insightShare,
         confirmResign = behavior.confirmResign,
         captured = display.captured == 1,
@@ -136,7 +144,8 @@ object PrefForm {
         resizeHandle = display.resizeHandle | pref.resizeHandle,
         rookCastle = behavior.rookCastle | pref.rookCastle,
         pieceNotation = display.pieceNotation | pref.pieceNotation,
-        moveEvent = behavior.moveEvent | pref.moveEvent
+        moveEvent = behavior.moveEvent | pref.moveEvent,
+        notification = notification
       )
   }
 
@@ -162,7 +171,6 @@ object PrefForm {
           autoQueen = pref.autoQueen,
           autoThreefold = pref.autoThreefold,
           submitMove = pref.submitMove,
-          corresEmailNotif = (if (pref.corresEmailNotif) 1 else 0).some,
           confirmResign = pref.confirmResign,
           keyboardMove = pref.keyboardMove.some,
           rookCastle = pref.rookCastle.some
@@ -173,11 +181,11 @@ object PrefForm {
           sound = if (pref.clockSound) 1 else 0,
           moretime = pref.moretime
         ),
+        notification = pref.notification,
         follow = if (pref.follow) 1 else 0,
         challenge = pref.challenge,
         message = pref.message,
         studyInvite = pref.studyInvite.some,
-        mention = (if (pref.mention) 1 else 0).some,
         insightShare = pref.insightShare,
         ratings = pref.ratings.some
       )

--- a/modules/pref/src/main/PrefForm.scala
+++ b/modules/pref/src/main/PrefForm.scala
@@ -4,9 +4,9 @@ import play.api.data._
 import play.api.data.Forms._
 
 import lila.common.Form.{ numberIn, stringIn }
+import NotificationPref._
 
 object PrefForm {
-
   private def containedIn(choices: Seq[(Int, String)]): Int => Boolean =
     choice => choices.exists(_._1 == choice)
 
@@ -18,6 +18,11 @@ object PrefForm {
 
   private lazy val booleanNumber =
     number.verifying(Pref.BooleanPref.verify)
+
+  private val allowsMapping = mapping(
+    "bell" -> boolean,
+    "push" -> boolean,
+  )(Allows.fromForm)(Allows.toForm)
 
   val pref = Form(
     mapping(
@@ -51,13 +56,12 @@ object PrefForm {
         "moretime" -> checkedNumber(Pref.Moretime.choices)
       )(ClockData.apply)(ClockData.unapply),
       "notification" -> mapping(
-        "inboxMsg"            -> checkedInteger(NotificationPref.moreChoices),
-        "challenge"           -> checkedInteger(NotificationPref.choices),
-        "tournamentSoon"      -> checkedInteger(NotificationPref.choices),
-        "gameEvent"           -> checkedInteger(NotificationPref.choices),
-        "timeAlarm"           -> checkedInteger(NotificationPref.choices),
-        "streamStart"         -> checkedInteger(NotificationPref.noneMoreChoices),
-        "forumMention"        -> checkedInteger(NotificationPref.noneMoreChoices),
+        "inboxMsg"            -> allowsMapping,
+        "challenge"           -> allowsMapping,
+        "forumMention"        -> allowsMapping,
+        "streamStart"         -> allowsMapping,
+        "tournamentSoon"      -> allowsMapping,
+        "gameEvent"           -> allowsMapping,
         "correspondenceEmail" -> booleanNumber
       )(NotificationPref.apply)(NotificationPref.unapply),
       "follow"       -> booleanNumber,

--- a/modules/pref/src/main/PrefHandlers.scala
+++ b/modules/pref/src/main/PrefHandlers.scala
@@ -6,7 +6,6 @@ import lila.db.BSON
 import lila.db.dsl._
 
 private object PrefHandlers {
-
   implicit val prefBSONHandler = new BSON[Pref] {
 
     def reads(r: BSON.Reader): Pref =
@@ -34,7 +33,6 @@ private object PrefHandlers {
         follow = r.getD("follow", Pref.default.follow),
         highlight = r.getD("highlight", Pref.default.highlight),
         destination = r.getD("destination", Pref.default.destination),
-        corresEmailNotif = r.getD("corresEmailNotif", Pref.default.corresEmailNotif),
         coords = r.getD("coords", Pref.default.coords),
         replay = r.getD("replay", Pref.default.replay),
         challenge = r.getD("challenge", Pref.default.challenge),
@@ -42,7 +40,6 @@ private object PrefHandlers {
         studyInvite = r.getD("studyInvite", Pref.default.studyInvite),
         submitMove = r.getD("submitMove", Pref.default.submitMove),
         confirmResign = r.getD("confirmResign", Pref.default.confirmResign),
-        mention = r.getD("mention", Pref.default.mention),
         insightShare = r.getD("insightShare", Pref.default.insightShare),
         keyboardMove = r.getD("keyboardMove", Pref.default.keyboardMove),
         zen = r.getD("zen", Pref.default.zen),
@@ -52,53 +49,61 @@ private object PrefHandlers {
         resizeHandle = r.getD("resizeHandle", Pref.default.resizeHandle),
         moveEvent = r.getD("moveEvent", Pref.default.moveEvent),
         agreement = r.getD("agreement", 0),
+        notification = r.getD(
+          "notification",
+          NotificationPref.default.copy(
+            // migrate existing settings to new location
+            // delete this copy call after a month or so. 8/2022
+            correspondenceEmail = r.getD("corresEmailNotif", false) ?? 1,
+            forumMention = r.getD("mention", true) ?? NotificationPref.BELL
+          )
+        ),
         tags = r.getD("tags", Pref.default.tags)
       )
 
     def writes(w: BSON.Writer, o: Pref) =
       $doc(
-        "_id"              -> o._id,
-        "bg"               -> o.bg,
-        "bgImg"            -> o.bgImg,
-        "is3d"             -> o.is3d,
-        "theme"            -> o.theme,
-        "pieceSet"         -> o.pieceSet,
-        "theme3d"          -> o.theme3d,
-        "pieceSet3d"       -> o.pieceSet3d,
-        "soundSet"         -> SoundSet.name2key(o.soundSet),
-        "blindfold"        -> o.blindfold,
-        "autoQueen"        -> o.autoQueen,
-        "autoThreefold"    -> o.autoThreefold,
-        "takeback"         -> o.takeback,
-        "moretime"         -> o.moretime,
-        "clockTenths"      -> o.clockTenths,
-        "clockBar"         -> o.clockBar,
-        "clockSound"       -> o.clockSound,
-        "premove"          -> o.premove,
-        "animation"        -> o.animation,
-        "corresEmailNotif" -> o.corresEmailNotif,
-        "captured"         -> o.captured,
-        "follow"           -> o.follow,
-        "highlight"        -> o.highlight,
-        "destination"      -> o.destination,
-        "coords"           -> o.coords,
-        "replay"           -> o.replay,
-        "challenge"        -> o.challenge,
-        "message"          -> o.message,
-        "studyInvite"      -> o.studyInvite,
-        "submitMove"       -> o.submitMove,
-        "confirmResign"    -> o.confirmResign,
-        "mention"          -> o.mention,
-        "insightShare"     -> o.insightShare,
-        "keyboardMove"     -> o.keyboardMove,
-        "zen"              -> o.zen,
-        "ratings"          -> o.ratings,
-        "rookCastle"       -> o.rookCastle,
-        "moveEvent"        -> o.moveEvent,
-        "pieceNotation"    -> o.pieceNotation,
-        "resizeHandle"     -> o.resizeHandle,
-        "agreement"        -> o.agreement,
-        "tags"             -> o.tags
+        "_id"           -> o._id,
+        "bg"            -> o.bg,
+        "bgImg"         -> o.bgImg,
+        "is3d"          -> o.is3d,
+        "theme"         -> o.theme,
+        "pieceSet"      -> o.pieceSet,
+        "theme3d"       -> o.theme3d,
+        "pieceSet3d"    -> o.pieceSet3d,
+        "soundSet"      -> SoundSet.name2key(o.soundSet),
+        "blindfold"     -> o.blindfold,
+        "autoQueen"     -> o.autoQueen,
+        "autoThreefold" -> o.autoThreefold,
+        "takeback"      -> o.takeback,
+        "moretime"      -> o.moretime,
+        "clockTenths"   -> o.clockTenths,
+        "clockBar"      -> o.clockBar,
+        "clockSound"    -> o.clockSound,
+        "premove"       -> o.premove,
+        "animation"     -> o.animation,
+        "captured"      -> o.captured,
+        "follow"        -> o.follow,
+        "highlight"     -> o.highlight,
+        "destination"   -> o.destination,
+        "coords"        -> o.coords,
+        "replay"        -> o.replay,
+        "challenge"     -> o.challenge,
+        "message"       -> o.message,
+        "studyInvite"   -> o.studyInvite,
+        "submitMove"    -> o.submitMove,
+        "confirmResign" -> o.confirmResign,
+        "insightShare"  -> o.insightShare,
+        "keyboardMove"  -> o.keyboardMove,
+        "zen"           -> o.zen,
+        "ratings"       -> o.ratings,
+        "rookCastle"    -> o.rookCastle,
+        "moveEvent"     -> o.moveEvent,
+        "pieceNotation" -> o.pieceNotation,
+        "resizeHandle"  -> o.resizeHandle,
+        "agreement"     -> o.agreement,
+        "notification"  -> o.notification,
+        "tags"          -> o.tags
       )
   }
 }

--- a/modules/push/src/main/Env.scala
+++ b/modules/push/src/main/Env.scala
@@ -28,7 +28,9 @@ final class Env(
     userRepo: lila.user.UserRepo,
     getLightUser: lila.common.LightUser.Getter,
     proxyRepo: lila.round.GameProxyRepo,
-    gameRepo: lila.game.GameRepo
+    gameRepo: lila.game.GameRepo,
+    prefApi: lila.pref.PrefApi,
+    postApi: lila.forum.PostApi
 )(implicit
     ec: scala.concurrent.ExecutionContext,
     scheduler: akka.actor.Scheduler
@@ -75,6 +77,8 @@ final class Env(
     "msgUnread",
     "challenge",
     "corresAlarm",
+    "streamStart",
+    "forumMention",
     "offerEventCorres",
     "tourSoon"
   ) {
@@ -94,6 +98,10 @@ final class Env(
       logUnit { pushApi.challengeAccept(c, joinerId) }
     case lila.game.actorApi.CorresAlarmEvent(pov) =>
       logUnit { pushApi corresAlarm pov }
+    case lila.hub.actorApi.streamer.StreamStart(streamerId, notifyList) =>
+      logUnit { pushApi streamStart (streamerId, notifyList) }
+    case lila.hub.actorApi.push.ForumMention(commenter, title, postId) =>
+      logUnit { pushApi forumMention (commenter, title, postId) }
     case t: lila.hub.actorApi.push.TourSoon =>
       logUnit { pushApi tourSoon t }
   }

--- a/modules/push/src/main/PushApi.scala
+++ b/modules/push/src/main/PushApi.scala
@@ -253,7 +253,7 @@ final private class PushApi(
           body = target.text,
           stacking = Stacking.StreamStart,
           payload = Json.obj(
-            "userId"   -> streamerId,
+            "userId"   -> target.userId,
             "userData" -> Json.obj("type" -> "streamStart", "streamerId" -> streamerId)
           )
         )

--- a/modules/push/src/main/Stacking.scala
+++ b/modules/push/src/main/Stacking.scala
@@ -11,6 +11,8 @@ private object Stacking {
   case object GameDrawOffer   extends Stacking("gameDrawOffer", "Draw offers in $[notif_count] games")
   case object NewMessage      extends Stacking("newMessage", "You have $[notif_count] new messages")
   case object ChallengeCreate extends Stacking("challengeCreate", "You have $[notif_count] new challenges")
+  case object ForumMention    extends Stacking("forumMention", "You have been mentioned $[notif_count] times")
+  case object StreamStart     extends Stacking("streamStart", "$[notif_count] streamers streaming")
   case object ChallengeAccept
       extends Stacking("challengeAccept", "$[notif_count] players accepted your challenges")
   case object TourSoon extends Stacking("tourSoon", "$[notif_count] tournaments are starting")

--- a/modules/relation/src/main/RelationApi.scala
+++ b/modules/relation/src/main/RelationApi.scala
@@ -38,7 +38,8 @@ final class RelationApi(
 
   def fetchFollowing = repo following _
 
-  def freshFollowersFromSecondary = repo.freshFollowersFromSecondary _
+  def freshFollowersFromSecondary(userId: ID, daysAgo: Int = 10) =
+    repo.freshFollowersFromSecondary(userId, daysAgo)
 
   def fetchBlocking = repo blocking _
 

--- a/modules/relation/src/main/RelationRepo.scala
+++ b/modules/relation/src/main/RelationRepo.scala
@@ -18,7 +18,7 @@ final private class RelationRepo(coll: Coll, userRepo: lila.user.UserRepo)(impli
   def blockers(userId: ID) = relaters(userId, Block)
   def blocking(userId: ID) = relating(userId, Block)
 
-  def freshFollowersFromSecondary(userId: ID): Fu[List[User.ID]] =
+  def freshFollowersFromSecondary(userId: ID, daysAgo: Int): Fu[List[User.ID]] =
     coll
       .aggregateOne(readPreference = ReadPreference.secondaryPreferred) { implicit framework =>
         import framework._
@@ -30,7 +30,7 @@ final private class RelationRepo(coll: Coll, userRepo: lila.user.UserRepo)(impli
               local = "u1",
               foreign = "_id",
               pipe = List(
-                $doc("$match"   -> $expr($doc("$gt" -> $arr("$seenAt", DateTime.now.minusDays(10))))),
+                $doc("$match"   -> $expr($doc("$gt" -> $arr("$seenAt", DateTime.now.minusDays(daysAgo))))),
                 $doc("$project" -> $id(true))
               )
             )

--- a/modules/round/src/main/CorrespondenceEmail.scala
+++ b/modules/round/src/main/CorrespondenceEmail.scala
@@ -39,7 +39,7 @@ final private class CorrespondenceEmail(gameRepo: GameRepo, userRepo: UserRepo, 
         import framework._
         // hit partial index
         List(
-          Match($doc("corresEmailNotif" -> true)),
+          Match($doc("notification.correspondenceEmail" -> 1)),
           Project($id(true)),
           PipelineOperator(
             $lookup.pipeline(

--- a/modules/streamer/src/main/Env.scala
+++ b/modules/streamer/src/main/Env.scala
@@ -29,6 +29,8 @@ final class Env(
     notifyApi: lila.notify.NotifyApi,
     userRepo: lila.user.UserRepo,
     timeline: lila.hub.actors.Timeline,
+    relationApi: lila.relation.RelationApi,
+    prefApi: lila.pref.PrefApi,
     db: lila.db.Db
 )(implicit
     ec: scala.concurrent.ExecutionContext,
@@ -73,7 +75,8 @@ final class Env(
     keyword = config.keyword,
     alwaysFeatured = alwaysFeaturedSetting.get _,
     googleApiKey = config.googleApiKey,
-    twitchApi = twitchApi
+    twitchApi = twitchApi,
+    notifyApi = notifyApi
   )
 
   lazy val liveStreamApi = wire[LiveStreamApi]

--- a/translation/source/preferences.xml
+++ b/translation/source/preferences.xml
@@ -58,9 +58,8 @@
   <string name="notifyChallenge">Challenges</string>
   <string name="notifyTournamentSoon">Tournament starting soon</string>
   <string name="notifyTimeAlarm">Correspondence clock running out</string>
-  <string name="notifyNone">No Push</string>
-  <string name="notifyBell">Bell Only</string>
-  <string name="notifyWeb">Web Push</string>
-  <string name="notifyDevice">Device Push</string>
-  <string name="notifyEverything">All</string>
+  <string name="notifyBell">Bell</string>
+  <string name="notifyPush">Push</string>
+  <string name="notifyWeb">Browser</string>
+  <string name="notifyDevice">Device</string>
 </resources>

--- a/translation/source/preferences.xml
+++ b/translation/source/preferences.xml
@@ -3,6 +3,7 @@
   <string name="preferences">Preferences</string>
   <string name="display">Display</string>
   <string name="privacy">Privacy</string>
+  <string name="notifications">Notifications</string>
   <string name="pieceAnimation">Piece animation</string>
   <string name="materialDifference">Material difference</string>
   <string name="boardHighlights">Board highlights (last move and check)</string>
@@ -49,5 +50,17 @@
   <string name="sayGgWpAfterLosingOrDrawing" comment="sayGgWpAfterLosingOrDrawing&#10;&#10;When enabled, this setting will automatically send 'Good game, well played' to your opponent if you are lose or draw the game. It's meant as a courtesy message.&#10;&#10;The message will be sent in ENGLISH.&#10;&#10;It is up to you how to deal with this. For example, you may want to put '(message will be sent in English)' in your translated text as one example. Or you can leave the actual English text and put a brief translation in your own language.">Say "Good game, well played" upon defeat or draw</string>
   <string name="yourPreferencesHaveBeenSaved">Your preferences have been saved.</string>
   <string name="scrollOnTheBoardToReplayMoves">Scroll on the board to replay moves</string>
-  <string name="correspondenceEmailNotification">Daily mail notification listing your correspondence games</string>
+  <string name="correspondenceEmailNotification">Daily email listing your correspondence games</string>
+  <string name="notifyStreamStart">Someone you follow begins streaming</string>
+  <string name="notifyInboxMsg">New inbox message</string>
+  <string name="notifyForumMention">Forum comment mentions you</string>
+  <string name="notifyGameEvent">Correspondence game updates</string>
+  <string name="notifyChallenge">Challenges</string>
+  <string name="notifyTournamentSoon">Tournament starting soon</string>
+  <string name="notifyTimeAlarm">Correspondence clock running out</string>
+  <string name="notifyNone">No Push</string>
+  <string name="notifyBell">Bell Only</string>
+  <string name="notifyWeb">Web Push</string>
+  <string name="notifyDevice">Device Push</string>
+  <string name="notifyEverything">All</string>
 </resources>

--- a/ui/common/css/theme/_default.scss
+++ b/ui/common/css/theme/_default.scss
@@ -51,6 +51,7 @@ $c-secondary-over: #fff;
 /* Accent: orange */
 $c-accent: hsl(22, 100%, 42%);
 $c-accent-dim: c-dimmer($c-accent);
+$c-accent-faint: hsla(22, 100%, 42%, 0.4);
 $c-accent-clear: c-clearer($c-accent);
 $c-accent-over: #fff;
 

--- a/ui/notify/src/interfaces.ts
+++ b/ui/notify/src/interfaces.ts
@@ -19,6 +19,7 @@ export interface NotifyData {
 export interface SingleNotifyData {
   note: Notification;
   unread: number;
+  alert: boolean;
 }
 
 interface NotificationUser {

--- a/ui/notify/src/interfaces.ts
+++ b/ui/notify/src/interfaces.ts
@@ -1,7 +1,7 @@
 import { VNode } from 'snabbdom';
 
 export interface NotifyOpts {
-  data?: NotifyData;
+  data?: NotifyData | SingleNotifyData;
   incoming: boolean;
   isVisible(): boolean;
   setCount(nb: number): void;
@@ -14,6 +14,11 @@ export interface NotifyData {
   pager: Paginator<Notification>;
   unread: number;
   i18n: I18nDict;
+}
+
+export interface SingleNotifyData {
+  note: Notification;
+  unread: number;
 }
 
 interface NotificationUser {
@@ -36,7 +41,7 @@ export interface Notification {
 }
 
 export interface Ctrl {
-  update(data: NotifyData, incoming: boolean): void;
+  update(data: NotifyData | SingleNotifyData, incoming: boolean): void;
   data(): NotifyData | undefined;
   initiating(): boolean;
   scrolling(): boolean;

--- a/ui/notify/src/renderers.ts
+++ b/ui/notify/src/renderers.ts
@@ -7,7 +7,7 @@ export default function makeRenderers(trans: Trans): Renderers {
   return {
     streamStart: {
       html: n =>
-        generic(n, '/streamer/' + n.content.sid, '\ue006', [
+        generic(n, `/streamer/${n.content.sid}/redirect`, '\ue006', [
           h('span', [h('strong', n.content.name), drawTime(n)]),
           h('span', n.content.text),
         ]),
@@ -23,7 +23,7 @@ export default function makeRenderers(trans: Trans): Renderers {
     },
     mention: {
       html: n =>
-        generic(n, '/forum/redirect/post/' + n.content.postId, '', [
+        generic(n, `/forum/redirect/post/${n.content.postId}`, '', [
           h('span', [h('strong', userFullName(n.content.mentionedBy)), drawTime(n)]),
           h('span', trans('mentionedYouInX', n.content.topic)),
         ]),

--- a/ui/notify/src/renderers.ts
+++ b/ui/notify/src/renderers.ts
@@ -5,6 +5,14 @@ import { Notification, Renderer, Renderers } from './interfaces';
 // function generic(n: Notification, url: string | undefined, icon: string, content: VNode[]): VNode {
 export default function makeRenderers(trans: Trans): Renderers {
   return {
+    streamStart: {
+      html: n =>
+        generic(n, '/streamer/' + n.content.sid, '\ue006', [
+          h('span', [h('strong', n.content.name), drawTime(n)]),
+          h('span', n.content.text),
+        ]),
+      text: n => n.content.text, // streamStarts are pre-translated
+    },
     genericLink: {
       html: n =>
         generic(n, n.content.url, n.content.icon, [

--- a/ui/serviceWorker/src/main.ts
+++ b/ui/serviceWorker/src/main.ts
@@ -34,6 +34,8 @@ async function handleNotificationClick(event: NotificationEvent) {
   if (data.fullId) url = '/' + data.fullId;
   else if (data.threadId) url = '/inbox/' + data.threadId;
   else if (data.challengeId) url = '/' + data.challengeId;
+  else if (data.streamerId) url = '/streamer/' + data.streamerId;
+  else if (data.forumMention) url = '/forum/redirect/post/' + data.postId;
 
   // focus open window with same url
   for (const client of windowClients) {

--- a/ui/serviceWorker/src/main.ts
+++ b/ui/serviceWorker/src/main.ts
@@ -34,8 +34,8 @@ async function handleNotificationClick(event: NotificationEvent) {
   if (data.fullId) url = '/' + data.fullId;
   else if (data.threadId) url = '/inbox/' + data.threadId;
   else if (data.challengeId) url = '/' + data.challengeId;
-  else if (data.streamerId) url = '/streamer/' + data.streamerId;
-  else if (data.forumMention) url = '/forum/redirect/post/' + data.postId;
+  else if (data.streamerId) url = `/streamer/${data.streamerId}/redirect`;
+  else if (data.forumMention) url = `/forum/redirect/post/${data.postId}`;
 
   // focus open window with same url
   for (const client of windowClients) {

--- a/ui/site/css/_account.scss
+++ b/ui/site/css/_account.scss
@@ -150,6 +150,50 @@
     }
   }
 
+  table.allows-grid {
+    width: 100%;
+    margin: 2em 0 4em 0;
+    font-size: 1.1em;
+    table-layout: fixed;
+    border-collapse: collapse;
+
+    tr:nth-child(odd) td {
+      background-color: $c-bg-zebra;
+    }
+
+    th,
+    td {
+      width: 15%;
+      padding: 1em;
+      text-align: center;
+      border: solid $c-accent-faint;
+      border-width: 0 1px 1px 0;
+
+      &:first-child {
+        width: 55%;
+        text-align: left;
+      }
+
+      &:last-child {
+        border-right: 0;
+      }
+
+      div {
+        background: transparent;
+        color: c-dimmer($c-font-dimmer);
+      }
+
+      div.always-on {
+        color: $c-good;
+      }
+
+      div.toggle {
+        display: flex;
+        justify-content: center;
+      }
+    }
+  }
+
   .saved {
     @extend %box-radius;
 


### PR DESCRIPTION
notify followers when streamer goes live, add optional web/firebase push for forum mentions, add pane to preferences allowing customization of bell/web/push for other notification types.  not attached to the UI at all.  tried (and failed) to make things relatively coherent with the radio group system.  streamer live notifications are tied to follows in this commit, but that can be changed easily.  for example, if a "subscribe" button on every streamer's page is desired (independent of relations).

note - by all means take a chainsaw to that preference pane.  I already hate it.

closes #11230, closes #5012

related lichobile commit pending (just to launch browser on firebase push stream start & forum mention)

