### PR TITLE
disable local storage on lichess.org/analysis

### DIFF
--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -135,7 +135,10 @@ export default class AnalyseCtrl {
 
     this.initialize(this.data, false);
 
-    this.persistence = this.embed || opts.study ? undefined : new Persistence(this, this.synthetic);
+    this.persistence =
+      this.embed || opts.study || this.synthetic // just for now
+        ? undefined
+        : new Persistence(this, this.synthetic);
 
     this.instanciateCeval();
 


### PR DESCRIPTION
one dude actually thinks lichess is pressuring him to make a study with the pane reappearing the way it does.  maybe your first impression was the right one?  if you're firm on keeping temp storage live on tools board, we'll definitely want to flush the synthetic local moves before importing PGN or FEN as that is currently broken.