### PR TITLE
Close various dialogs when the keyboard help comes up

### DIFF
--- a/public/javascripts/study/tour-chapter.js
+++ b/public/javascripts/study/tour-chapter.js
@@ -88,10 +88,10 @@ lichess.studyTourChapter = function (study) {
     });
     tour.start();
 
-    lichess.pubsub.on('tour.stop', tour.cancel);
+    lichess.pubsub.on('analyse.close-all', tour.cancel);
 
     Shepherd.once('inactive', _ => {
-      lichess.pubsub.off('tour.stop', tour.cancel);
+      lichess.pubsub.off('analyse.close-all', tour.cancel);
     });
   });
 };

--- a/public/javascripts/study/tour.js
+++ b/public/javascripts/study/tour.js
@@ -126,10 +126,10 @@ lichess.studyTour = function (study) {
       });
     tour.start();
 
-    lichess.pubsub.on('tour.stop', tour.cancel);
+    lichess.pubsub.on('analyse.close-all', tour.cancel);
 
     Shepherd.once('inactive', _ => {
-      lichess.pubsub.off('tour.stop', tour.cancel);
+      lichess.pubsub.off('analyse.close-all', tour.cancel);
     });
   });
 };

--- a/ui/analyse/src/keyboard.ts
+++ b/ui/analyse/src/keyboard.ts
@@ -59,6 +59,10 @@ export const bind = (ctrl: AnalyseCtrl) => {
     .bind('f', ctrl.flip)
     .bind('?', () => {
       ctrl.keyboardHelp = !ctrl.keyboardHelp;
+      if (ctrl.keyboardHelp) {
+        lichess.pubsub.emit('tour.stop');
+        lichess.pubsub.emit('dialog.close');
+      }
       ctrl.redraw();
     })
     .bind('l', ctrl.toggleCeval)

--- a/ui/analyse/src/keyboard.ts
+++ b/ui/analyse/src/keyboard.ts
@@ -59,10 +59,7 @@ export const bind = (ctrl: AnalyseCtrl) => {
     .bind('f', ctrl.flip)
     .bind('?', () => {
       ctrl.keyboardHelp = !ctrl.keyboardHelp;
-      if (ctrl.keyboardHelp) {
-        lichess.pubsub.emit('tour.stop');
-        lichess.pubsub.emit('dialog.close');
-      }
+      if (ctrl.keyboardHelp) lichess.pubsub.emit('analyse.close-all');
       ctrl.redraw();
     })
     .bind('l', ctrl.toggleCeval)

--- a/ui/analyse/src/study/chapterNewForm.ts
+++ b/ui/analyse/src/study/chapterNewForm.ts
@@ -72,20 +72,17 @@ export function ctrl(
       });
   }
 
-  function open() {
-    // end tour and prepare to close if asked
-    lichess.pubsub.on('dialog.close', close);
-    lichess.pubsub.emit('tour.stop');
-
+  const open = () => {
+    lichess.pubsub.emit('analyse.close-all');
     vm.open = true;
     loadVariants();
     vm.initial(false);
-  }
-  function close() {
-    lichess.pubsub.off('dialog.close', close);
-    lichess.pubsub.emit('tour.stop');
+  };
+  const close = () => {
     vm.open = false;
-  }
+  };
+
+  lichess.pubsub.on('analyse.close-all', close);
 
   return {
     vm,

--- a/ui/analyse/src/study/chapterNewForm.ts
+++ b/ui/analyse/src/study/chapterNewForm.ts
@@ -73,12 +73,16 @@ export function ctrl(
   }
 
   function open() {
+    // end tour and prepare to close if asked
+    lichess.pubsub.on('dialog.close', close);
     lichess.pubsub.emit('tour.stop');
+
     vm.open = true;
     loadVariants();
     vm.initial(false);
   }
   function close() {
+    lichess.pubsub.off('dialog.close', close);
     lichess.pubsub.emit('tour.stop');
     vm.open = false;
   }

--- a/ui/analyse/src/study/inviteForm.ts
+++ b/ui/analyse/src/study/inviteForm.ts
@@ -28,17 +28,25 @@ export function makeCtrl(
   const open = prop(false),
     spectators = prop<string[]>([]);
 
+  const toggle = function () {
+    if (!open()) {
+      lichess.pubsub.emit('tour.stop');
+      lichess.pubsub.on('dialog.close', () => {
+        // use toggle to close the dialog
+        if (open()) toggle();
+      });
+    } else {
+      lichess.pubsub.off('dialog.close', close);
+    }
+    open(!open());
+  };
+
   const previouslyInvited = storedSet<string>('study.previouslyInvited', 10);
   return {
     open,
     members,
     spectators,
-    toggle() {
-      if (!open()) {
-        lichess.pubsub.emit('tour.stop');
-      }
-      open(!open());
-    },
+    toggle,
     invite(titleName: string) {
       const userId = titleNameToId(titleName);
       send('invite', userId);

--- a/ui/analyse/src/study/inviteForm.ts
+++ b/ui/analyse/src/study/inviteForm.ts
@@ -31,6 +31,7 @@ export function makeCtrl(
   const toggle = () => {
     if (!open()) lichess.pubsub.emit('analyse.close-all');
     open(!open());
+    redraw();
   };
 
   lichess.pubsub.on('analyse.close-all', () => open(false));

--- a/ui/analyse/src/study/inviteForm.ts
+++ b/ui/analyse/src/study/inviteForm.ts
@@ -28,18 +28,12 @@ export function makeCtrl(
   const open = prop(false),
     spectators = prop<string[]>([]);
 
-  const toggle = function () {
-    if (!open()) {
-      lichess.pubsub.emit('tour.stop');
-      lichess.pubsub.on('dialog.close', () => {
-        // use toggle to close the dialog
-        if (open()) toggle();
-      });
-    } else {
-      lichess.pubsub.off('dialog.close', close);
-    }
+  const toggle = () => {
+    if (!open()) lichess.pubsub.emit('analyse.close-all');
     open(!open());
   };
+
+  lichess.pubsub.on('analyse.close-all', () => open(false));
 
   const previouslyInvited = storedSet<string>('study.previouslyInvited', 10);
   return {

--- a/ui/analyse/src/study/studyMembers.ts
+++ b/ui/analyse/src/study/studyMembers.ts
@@ -292,7 +292,7 @@ export function view(ctrl: StudyCtrl): VNode {
             'div.add',
             {
               key: 'add',
-              hook: bind('click', members.inviteForm.toggle, ctrl.redraw),
+              hook: bind('click', members.inviteForm.toggle),
             },
             [h('div.left', [h('span.status', iconTag('')), h('div.user-link', ctrl.trans.noarg('addMembers'))])]
           )

--- a/ui/analyse/src/study/studyMembers.ts
+++ b/ui/analyse/src/study/studyMembers.ts
@@ -62,22 +62,13 @@ export function ctrl(opts: Opts): StudyMemberCtrl {
   let spectatorIds: string[] = [];
   const max = 30;
 
-  function owner() {
-    return dict()[opts.ownerId];
-  }
+  const owner = () => dict()[opts.ownerId];
 
-  function isOwner() {
-    return opts.myId === opts.ownerId || (opts.admin && canContribute());
-  }
+  const isOwner = () => opts.myId === opts.ownerId || (opts.admin && canContribute());
 
-  function myMember() {
-    return opts.myId ? dict()[opts.myId] : undefined;
-  }
+  const myMember = () => (opts.myId ? dict()[opts.myId] : undefined);
 
-  function canContribute(): boolean {
-    const m = myMember();
-    return !!m && m.role === 'w';
-  }
+  const canContribute = (): boolean => myMember()?.role === 'w';
 
   const inviteForm = inviteFormCtrl(opts.send, dict, () => opts.tab('members'), opts.redraw, opts.trans);
 


### PR DESCRIPTION
If you do Shift+? to open the keyboard dialog with any of
- Study/chapter tour
- Add member dialog
- Add chapter dialog
open, 

You get weird overlapping dialogs which is generally bad ux. Since Shift+? is the most recent action from the user, it should take priority and other dialogs should close. Since the keyboard cheat sheet is owned by `AnalyseCtrl` and the various dialogs are owned by subcontrollers the only reasonable way I can think of to close those subdialogs is [with `pubsub` like in this PR](https://github.com/lichess-org/lila/pull/11081). Plus if there's any other dialogs on the site with the same issue we could use the same socket message.

As an example:
![image](https://user-images.githubusercontent.com/30640147/182076200-e5a09e10-af00-4c02-985f-5f3e3d9c8677.png)
