### PR TITLE
Lpv 1.0.0 with icon font for portability, has inline SVG requiring a CSP change

### DIFF
--- a/app/templating/AssetHelper.scala
+++ b/app/templating/AssetHelper.scala
@@ -91,6 +91,7 @@ trait AssetHelper { self: I18nHelper with SecurityHelper =>
       workerSrc = List("'self'", assets),
       imgSrc = List("data:", "*"),
       scriptSrc = List("'self'", assets),
+      fontSrc = List("'self'", assets),
       baseUri = List("'none'")
     )
   }

--- a/app/views/forum/topic.scala
+++ b/app/views/forum/topic.scala
@@ -90,7 +90,8 @@ object topic {
           url = s"$netBaseUrl${routes.ForumTopic.show(categ.slug, topic.slug, posts.currentPage).url}",
           description = shorten(posts.currentPageResults.headOption.??(_.post.text), 152)
         )
-        .some
+        .some,
+      csp = defaultCsp.withInlineIconFont.some
     ) {
       val teamOnly = categ.team.filterNot(isMyTeamSync)
       val pager = views.html.base.bits

--- a/app/views/msg.scala
+++ b/app/views/msg.scala
@@ -24,6 +24,7 @@ object msg {
         )
       ),
       title = trans.inbox.txt(),
+      csp = defaultCsp.withInlineIconFont.some
     ) {
       main(cls := "box msg-app")
     }

--- a/app/views/msg.scala
+++ b/app/views/msg.scala
@@ -23,7 +23,7 @@ object msg {
             )})"""
         )
       ),
-      title = "Lichess Inbox"
+      title = trans.inbox.txt(),
     ) {
       main(cls := "box msg-app")
     }

--- a/app/views/ublog/post.scala
+++ b/app/views/ublog/post.scala
@@ -44,7 +44,7 @@ object post {
         st.title := trans.ublog.xBlog.txt(user.username)
       ).some,
       robots = netConfig.crawlable && blog.listed && (post.indexable || blog.tier >= UblogBlog.Tier.HIGH),
-      csp = defaultCsp.withTwitter.some
+      csp = defaultCsp.withTwitter.withInlineIconFont.some
     ) {
       main(cls := "page-menu page-small")(
         views.html.blog.bits.menu(none, (if (ctx is user) "mine" else "community").some),

--- a/modules/common/src/main/ContentSecurityPolicy.scala
+++ b/modules/common/src/main/ContentSecurityPolicy.scala
@@ -8,6 +8,7 @@ case class ContentSecurityPolicy(
     workerSrc: List[String],
     imgSrc: List[String],
     scriptSrc: List[String],
+    fontSrc: List[String],
     baseUri: List[String]
 ) {
 
@@ -82,6 +83,8 @@ case class ContentSecurityPolicy(
 
   def withLilaHttp = copy(connectSrc = "http.lichess.org" :: connectSrc)
 
+  def withInlineIconFont = copy(fontSrc = "data:" :: fontSrc)
+
   override def toString: String =
     List(
       "default-src " -> defaultSrc,
@@ -91,6 +94,7 @@ case class ContentSecurityPolicy(
       "worker-src "  -> workerSrc,
       "img-src "     -> imgSrc,
       "script-src "  -> scriptSrc,
+      "font-src "    -> fontSrc,
       "base-uri "    -> baseUri
     ) collect {
       case (directive, sources) if sources.nonEmpty =>

--- a/ui/common/package.json
+++ b/ui/common/package.json
@@ -32,7 +32,7 @@
     "tablesort": "^5.3",
     "chessground": "^8.3.5",
     "snabbdom": "^3.3.1",
-    "lichess-pgn-viewer": "^0.3.11"
+    "lichess-pgn-viewer": "^1"
   },
   "devDependencies": {
     "@types/cash": "8.0.0",

--- a/ui/opening/package.json
+++ b/ui/opening/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "chart.js": "^3.8",
     "common": "2.0.0",
-    "lichess-pgn-viewer": "^0.3.11"
+    "lichess-pgn-viewer": "^1"
   },
   "scripts": {
     "dev": "rollup --config",

--- a/ui/site/package.json
+++ b/ui/site/package.json
@@ -34,7 +34,7 @@
     "stockfish.js": "^10.0.2",
     "stockfish.wasm": "^0.10.0",
     "zxcvbn": "^4.4.2",
-    "lichess-pgn-viewer": "^0.3.11"
+    "lichess-pgn-viewer": "^1"
   },
   "scripts": {
     "deps": "cat ../../public/javascripts/vendor/cash.min.js ./dep/powertip.min.js ./dep/howler.min.js ./dep/mousetrap.min.js > ../../public/compiled/deps.min.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5456,10 +5456,10 @@ levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-lichess-pgn-viewer@^0.3.11:
-  version "0.3.11"
-  resolved "https://registry.yarnpkg.com/lichess-pgn-viewer/-/lichess-pgn-viewer-0.3.11.tgz#ad56563534536e1055b5e7f78b92f1e307f389a8"
-  integrity sha512-f5H3JhPCEJ9hidDcbijF5TtN4osB9xNds1w7jHqAU2vsZJzZq2b+rA5/hZFWLTZhvf5MPmCK5RKIhCUwebWHmQ==
+lichess-pgn-viewer@^1:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/lichess-pgn-viewer/-/lichess-pgn-viewer-1.0.0.tgz#e345d879d5745ee95cd4f775e1fe10dc0ed7962f"
+  integrity sha512-HGHWE6xe2geWq3pmUnC6bFKaEwFqEZh1V5Y4nB113dGXDl+IGZdIsJweHAH451eOeIF1vtBLr7HemKHHFuqauA==
   dependencies:
     chessground "^8.3.4"
     chessops "^0.12.4"


### PR DESCRIPTION
I think it's secure? Couldn't find a way to be more precise than `data:` in the new `font-src` CSP header.