### PR TITLE
Copy chapter PGN in study

### DIFF
--- a/ui/analyse/src/study/studyShare.ts
+++ b/ui/analyse/src/study/studyShare.ts
@@ -231,6 +231,17 @@ export function view(ctrl: StudyShareCtrl): VNode {
           },
         }),
       ]),
+      h('div.pgn', [
+        h('div.pair', [
+          h('label.name', 'PGN'),
+          h('textarea.copyable.autoselect', {
+            attrs: {
+              spellCheck: false,
+              download: `/study/${studyId}/${chapter.id}.pgn`,
+            },
+          }),
+        ]),
+      ]),
     ]),
   ]);
 }


### PR DESCRIPTION
The change solves #11311 by adding a text box element below the FEN one. We use https://github.com/lichess-org/lila/blob/19bd7a0bafb87520125cd0e883467747ca67fa69/ui/analyse/src/view.ts#L134-L137 for the structure of the element. To get the PGN data we use the same technique as in https://github.com/lichess-org/pgn-viewer/blob/4019ef209acefef52b8e0b96f0c36aa51f5d0dbd/src/view/main.ts#L43-L50.