### PR TITLE
copy study chapter PGN into clipboard

### DIFF
--- a/app/Env.scala
+++ b/app/Env.scala
@@ -247,7 +247,7 @@ final class EnvBoot(
   lazy val storm: lila.storm.Env             = wire[lila.storm.Env]
   lazy val racer: lila.racer.Env             = wire[lila.racer.Env]
   lazy val ublog: lila.ublog.Env             = wire[lila.ublog.Env]
-  lazy val opening: lila.opening.Env           = wire[lila.opening.Env]
+  lazy val opening: lila.opening.Env         = wire[lila.opening.Env]
   lazy val tutor: lila.tutor.Env             = wire[lila.tutor.Env]
   lazy val api: lila.api.Env                 = wire[lila.api.Env]
   lazy val lilaCookie                        = wire[lila.common.LilaCookie]

--- a/app/controllers/Study.scala
+++ b/app/controllers/Study.scala
@@ -479,6 +479,19 @@ final class Study(
       }
     }
 
+  def chapterPgnPlainText(id: String, chapterId: String) =
+    Open { implicit ctx =>
+      env.study.api.byIdWithChapter(id, chapterId) flatMap {
+        _.fold(notFound) { case WithChapter(study, chapter) =>
+          CanView(study, ctx.me) {
+            env.study.pgnDump.ofChapter(study, requestPgnFlags(ctx.req))(chapter) map { pgn =>
+              Ok(pgn.toString).as("text/plain")
+            }
+          }(privateUnauthorizedFu(study), privateForbiddenFu(study))
+        }
+      }
+    }
+
   def exportPgn(username: String) =
     OpenOrScoped(_.Study.Read)(
       open = ctx => handleExport(username, ctx.me, ctx.req),

--- a/conf/routes
+++ b/conf/routes
@@ -191,6 +191,7 @@ POST  /study                           controllers.Study.create
 POST  /study/as                        controllers.Study.createAs
 GET   /study/$id<\w{8}>.pgn            controllers.Study.pgn(id: String)
 GET   /study/$id<\w{8}>/$chapterId<\w{8}>.pgn controllers.Study.chapterPgn(id: String, chapterId: String)
+GET   /study/$id<\w{8}>/$chapterId<\w{8}>.txt controllers.Study.chapterPgnPlainText(id: String, chapterId: String)
 GET   /study/$id<\w{8}>/$chapterId<\w{8}>.gif controllers.Study.chapterGif(id: String, chapterId: String)
 POST  /study/$id<\w{8}>/delete         controllers.Study.delete(id: String)
 GET   /study/$id<\w{8}>/clone          controllers.Study.cloneStudy(id: String)

--- a/ui/analyse/src/patch.ts
+++ b/ui/analyse/src/patch.ts
@@ -1,3 +1,3 @@
-import { attributesModule, classModule, init } from 'snabbdom';
+import { attributesModule, classModule, eventListenersModule, init } from 'snabbdom';
 
-export default init([classModule, attributesModule]);
+export default init([classModule, attributesModule, eventListenersModule]);

--- a/ui/analyse/src/study/studyShare.ts
+++ b/ui/analyse/src/study/studyShare.ts
@@ -1,6 +1,6 @@
 import { prop, Prop } from 'common';
 import { bind } from 'common/snabbdom';
-import { url as xhrUrl } from 'common/xhr';
+import { text as xhrText, url as xhrUrl } from 'common/xhr';
 import { h, VNode } from 'snabbdom';
 import { renderIndexAndMove } from '../moveView';
 import { baseUrl } from '../util';
@@ -136,6 +136,25 @@ export function view(ctrl: StudyShareCtrl): VNode {
           },
         },
         ctrl.trans.noarg(ctrl.relay ? 'downloadGame' : 'chapterPgn')
+      ),
+      h(
+        'a.button.text',
+        {
+          attrs: {
+            'data-icon': '',
+          },
+          on: {
+            click: () => {
+              xhrText(`/study/${studyId}/${chapter.id}.txt`).then(pgnAsText => {
+                navigator.clipboard.writeText(pgnAsText).then(() => {
+                  alert('PGN copied into clipboard.');
+                });
+
+              });
+            },
+          },
+        },
+        'Copy PGN'
       ),
       h(
         'a.button.text',


### PR DESCRIPTION
My proposal to copy chapter PGN into clipboard for pasting (instead of downloading a file to local file system).

It involves:

1. a new route and a new funtion to get PGN from server without triggering a browser download
2. placing the PGN text into clipboard
3. confirmation via a javascript alert (for now)

![copy chapter PGN](https://user-images.githubusercontent.com/12477220/183264533-43d1e534-a353-49ce-b15f-6b0bdd0aa532.PNG)

![PGN copied](https://user-images.githubusercontent.com/12477220/183264545-f27f123a-c372-48eb-a4a6-0ca0532b0d42.PNG)

2 things I would need help on if you like the approach:

1. The icon should be a copy/paste icon 
2. The confirmation is a very rough javascript alert. Is there something more elegant already used elsewhere ? (I could not find anything)

I will add translation if it is a go