### PR TITLE
Two bugs with PGN imports on analysis board

### DIFF
--- a/ui/analyse/css/_analyse.free.scss
+++ b/ui/analyse/css/_analyse.free.scss
@@ -14,13 +14,13 @@
       #{$end-direction}: 0;
       top: 100%;
       text-align: right;
-      opacity: 0;
+      visibility: hidden;
 
       @include transition;
     }
 
     textarea:focus ~ .action {
-      opacity: 1;
+      visibility: visible;
     }
   }
 

--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -446,6 +446,7 @@ export default class AnalyseCtrl {
       if (andReload) {
         this.reloadData(data, false);
         this.userJump(this.mainlinePathToPly(this.tree.lastPly()));
+        this.chessground.set({ fen: this.node.fen });
         this.redraw();
       }
       return data;


### PR DESCRIPTION
**Importing a PGN doesn't update material difference until the next time the board is updated**

1. Go to the analysis board and **make sure computer eval is off**
2. Set the PGN to `1. d4 e5 2. dxe5`
3. The one pawn material difference doesn't appear unless you reload the board

This happens because the [material diffs are calculated using chessground's current state](https://github.com/lichess-org/lila/blob/7b92fe1f60d338761bf88cbedcc02ede689b9aeb/ui/analyse/src/view.ts#L313). During the redraw, this calculation happens before chessground gets updated to the new PGN so the material diffs end up not correctly reflecting the game state.

My fix here just manually sets chessground's board state before the redraw happens so the calculation proceeds as expected.

---

**Import PGN button is not hidden properly**

The "Import PGN" button is meant to only visible when the textbox is focused but it's actually still clickable even when not there. Moving the cursor over the button also causes the cursor to change to a pointer. This is just because the button has `opacity: 0` which does not remove the button.

The fix here is to just switch to `visibility: hidden`. I checked around and seems like nothing else uses this styling and would be otherwise affected.