### PR TITLE
feat: add keyboardMove command for moving to next puzzle

### DIFF
--- a/app/views/site/keyboardMoveHelp.scala
+++ b/app/views/site/keyboardMoveHelp.scala
@@ -114,6 +114,7 @@ object helpModal {
           row(kbd("who"), readOutOpponentName()),
           row(kbd("draw"), offerOrAcceptDraw()),
           row(kbd("resign"), trans.resignTheGame()),
+          row(kbd("next"), trans.puzzle.nextPuzzle()),
           row(frag(kbd("help"), or, kbd("?")), trans.showHelpDialog()),
           header(tips()),
           tr(

--- a/ui/keyboardMove/src/main.ts
+++ b/ui/keyboardMove/src/main.ts
@@ -28,7 +28,7 @@ export interface KeyboardMove {
   justSelected(): boolean;
   clock(): ClockController | undefined;
   draw(): void;
-  next?(): void;
+  next(): void;
   resign(v: boolean, immediately?: boolean): void;
   helpModalOpen: Prop<boolean>;
 }
@@ -136,7 +136,7 @@ export function ctrl(root: RootController, step: Step): KeyboardMove {
     clock: () => root.clock,
     draw: () => (root.offerDraw ? root.offerDraw(true, true) : null),
     resign: (v, immediately) => (root.resign ? root.resign(v, immediately) : null),
-    next: root.next,
+    next: () => root.next?.(),
     helpModalOpen,
     isFocused,
   };

--- a/ui/keyboardMove/src/main.ts
+++ b/ui/keyboardMove/src/main.ts
@@ -28,6 +28,7 @@ export interface KeyboardMove {
   justSelected(): boolean;
   clock(): ClockController | undefined;
   draw(): void;
+  next?(): void;
   resign(v: boolean, immediately?: boolean): void;
   helpModalOpen: Prop<boolean>;
 }
@@ -61,6 +62,7 @@ export interface RootController {
   submitMove?: (v: boolean) => void;
   userJumpPlyDelta?: (plyDelta: Ply) => void;
   redraw: Redraw;
+  next?: () => void;
 }
 interface Step {
   fen: string;
@@ -134,6 +136,7 @@ export function ctrl(root: RootController, step: Step): KeyboardMove {
     clock: () => root.clock,
     draw: () => (root.offerDraw ? root.offerDraw(true, true) : null),
     resign: (v, immediately) => (root.resign ? root.resign(v, immediately) : null),
+    next: root.next,
     helpModalOpen,
     isFocused,
   };

--- a/ui/keyboardMove/src/plugins/keyboardMove.test.ts
+++ b/ui/keyboardMove/src/plugins/keyboardMove.test.ts
@@ -79,6 +79,23 @@ describe('keyboardMove', () => {
     expect(input.value).toBe('');
   });
 
+  test('next command', () => {
+    input.value = 'next';
+    const mockNext = jest.fn();
+    const keyboardMovePlugin = keyboardMove({
+      input,
+      ctrl: {
+        ...defaultCtrl,
+        next: mockNext,
+      },
+    }) as any;
+
+    keyboardMovePlugin(startingFen, toMap({}), true);
+
+    expect(mockNext).toHaveBeenCalledTimes(1);
+    expect(input.value).toBe('');
+  });
+
   test('reads out clock', () => {
     input.value = 'clock';
     const mockMillisOf = jest.fn(_ => 1000);

--- a/ui/keyboardMove/src/plugins/keyboardMove.test.ts
+++ b/ui/keyboardMove/src/plugins/keyboardMove.test.ts
@@ -21,6 +21,7 @@ const defaultCtrl = {
   clock: unexpectedErrorThrower('clock'),
   confirmMove: () => null,
   draw: unexpectedErrorThrower('draw'),
+  next: unexpectedErrorThrower('next'),
   drop: unexpectedErrorThrower('drop'),
   hasSelected: () => undefined,
   jump: () => null,
@@ -79,7 +80,7 @@ describe('keyboardMove', () => {
     expect(input.value).toBe('');
   });
 
-  test('next command', () => {
+  test('goes to next puzzle', () => {
     input.value = 'next';
     const mockNext = jest.fn();
     const keyboardMovePlugin = keyboardMove({

--- a/ui/keyboardMove/src/plugins/keyboardMove.ts
+++ b/ui/keyboardMove/src/plugins/keyboardMove.ts
@@ -90,6 +90,11 @@ export default (opts: Opts) => {
         opts.ctrl.draw();
         clear();
       }
+    } else if (v.length > 0 && 'next'.startsWith(v.toLowerCase())) {
+      if ('next' === v.toLowerCase()) {
+        opts.ctrl.next && opts.ctrl.next();
+        clear();
+      }
     } else if (v.length > 0 && ('help'.startsWith(v.toLowerCase()) || v === '?')) {
       if (['help', '?'].includes(v.toLowerCase())) {
         opts.ctrl.helpModalOpen(true);

--- a/ui/keyboardMove/src/plugins/keyboardMove.ts
+++ b/ui/keyboardMove/src/plugins/keyboardMove.ts
@@ -92,7 +92,7 @@ export default (opts: Opts) => {
       }
     } else if (v.length > 0 && 'next'.startsWith(v.toLowerCase())) {
       if ('next' === v.toLowerCase()) {
-        opts.ctrl.next && opts.ctrl.next();
+        opts.ctrl.next?.();
         clear();
       }
     } else if (v.length > 0 && ('help'.startsWith(v.toLowerCase()) || v === '?')) {

--- a/ui/puzzle/src/ctrl.ts
+++ b/ui/puzzle/src/ctrl.ts
@@ -445,7 +445,6 @@ export default function (opts: PuzzleOpts, redraw: Redraw): Controller {
   }
 
   function jump(path: Tree.Path): void {
-    console.log('jump');
     const pathChanged = path !== vm.path,
       isForwardStep = pathChanged && path.length === vm.path.length + 2;
     setPath(path);

--- a/ui/puzzle/src/ctrl.ts
+++ b/ui/puzzle/src/ctrl.ts
@@ -99,6 +99,7 @@ export default function (opts: PuzzleOpts, redraw: Redraw): Controller {
           sendMove: playUserMove,
           redraw: this.redraw,
           userJumpPlyDelta,
+          next: nextPuzzle,
         },
         { fen: this.vm.node.fen }
       );
@@ -344,6 +345,7 @@ export default function (opts: PuzzleOpts, redraw: Redraw): Controller {
 
   function nextPuzzle(): void {
     if (streak && vm.lastFeedback != 'win') return;
+    if (vm.mode !== 'view') return;
 
     ceval.stop();
     vm.next.promise.then(n => {
@@ -443,6 +445,7 @@ export default function (opts: PuzzleOpts, redraw: Redraw): Controller {
   }
 
   function jump(path: Tree.Path): void {
+    console.log('jump');
     const pathChanged = path !== vm.path,
       isForwardStep = pathChanged && path.length === vm.path.length + 2;
     setPath(path);

--- a/ui/puzzle/src/keyboard.ts
+++ b/ui/puzzle/src/keyboard.ts
@@ -33,9 +33,7 @@ export default (ctrl: KeyboardController) =>
     .bind('z', () => lichess.pubsub.emit('zen'))
     .bind('?', () => ctrl.keyboardHelp(!ctrl.keyboardHelp()))
     .bind('f', ctrl.flip)
-    .bind('n', () => {
-      if (ctrl.vm.mode === 'view') ctrl.nextPuzzle();
-    });
+    .bind('n', ctrl.nextPuzzle);
 
 export const view = (ctrl: Controller): VNode =>
   snabModal({


### PR DESCRIPTION
This is a first take on #11338 please let me know if I'm on the right track.
If I understand correctly the KeyboardMove interface is designed so different ctrl's can implement different functionality. So I made the command `next` optional given that not all controls are likely to implement it.
The next step would be to add it to the `?` documentation. However I'm not sure if I should always display this command or only if inside a Puzzle context (is there precedent for contextual keyboardMove documentation?)