### PR TITLE
fast track streamer applications for trolls

### DIFF
--- a/app/controllers/Streamer.scala
+++ b/app/controllers/Streamer.scala
@@ -88,11 +88,9 @@ final class Streamer(env: Env, apiC: => Api) extends LilaController(env) {
     AuthBody { implicit ctx => me =>
       ctx.noKid ?? {
         NoLameOrBot {
-          NoShadowban {
-            api find me flatMap {
-              case None => api.create(me) inject Redirect(routes.Streamer.edit)
-              case _    => Redirect(routes.Streamer.edit).fuccess
-            }
+          api find me flatMap {
+            case None => api.create(me) inject Redirect(routes.Streamer.edit)
+            case _    => Redirect(routes.Streamer.edit).fuccess
           }
         }
       }
@@ -119,7 +117,9 @@ final class Streamer(env: Env, apiC: => Api) extends LilaController(env) {
 
   def editApply =
     AuthBody { implicit ctx => me =>
-      AsStreamer { s =>
+      if (ctx.me.exists(_.marks.troll))
+        fuccess(Redirect(s"${routes.Streamer.edit.url}").flashSuccess)
+      else AsStreamer { s =>
         env.streamer.liveStreamApi of s flatMap { sws =>
           implicit val req = ctx.body
           StreamerForm

--- a/app/controllers/Streamer.scala
+++ b/app/controllers/Streamer.scala
@@ -117,9 +117,7 @@ final class Streamer(env: Env, apiC: => Api) extends LilaController(env) {
 
   def editApply =
     AuthBody { implicit ctx => me =>
-      if (ctx.me.exists(_.marks.troll))
-        fuccess(Redirect(s"${routes.Streamer.edit.url}").flashSuccess)
-      else AsStreamer { s =>
+      AsStreamer { s =>
         env.streamer.liveStreamApi of s flatMap { sws =>
           implicit val req = ctx.body
           StreamerForm

--- a/app/views/streamer/edit.scala
+++ b/app/views/streamer/edit.scala
@@ -25,7 +25,6 @@ object edit {
       main(cls := "page-menu")(
         bits.menu("edit", s.withoutStream.some),
         div(cls := "page-menu__content box streamer-edit")(
-          standardFlash(), // success for trolls, their submit was discarded.
           if (ctx.is(s.user))
             div(cls := "streamer-header")(
               if (s.streamer.hasPicture)

--- a/app/views/streamer/edit.scala
+++ b/app/views/streamer/edit.scala
@@ -25,6 +25,7 @@ object edit {
       main(cls := "page-menu")(
         bits.menu("edit", s.withoutStream.some),
         div(cls := "page-menu__content box streamer-edit")(
+          standardFlash(), // success for trolls, their submit was discarded.
           if (ctx.is(s.user))
             div(cls := "streamer-header")(
               if (s.streamer.hasPicture)

--- a/modules/streamer/src/main/Streamer.scala
+++ b/modules/streamer/src/main/Streamer.scala
@@ -47,7 +47,7 @@ object Streamer {
       approval = Approval(
         requested = false,
         granted = false,
-        ignored = false,
+        ignored = user.marks.troll,
         tier = 0,
         chatEnabled = true,
         lastGrantedAt = none


### PR DESCRIPTION
gave them a pretty green success banner.  don't think they will buy it.

Removes the 404 preventing db object creation to maximize their frustration a few minutes later.  if that's not desired, put the NoShadowban guard back in.  But apparently there are a ton of trolls applying for streamer who visited the your streamer page (creating their streamer object) prior to being marked.