### PR TITLE
fix reactivemongo exceptions in lila log on dev instance startup

### DIFF
--- a/modules/db/src/main/Db.scala
+++ b/modules/db/src/main/Db.scala
@@ -50,7 +50,7 @@ final class Db(
         if (devMode)
           driver
             .connect(
-              parsedUri.hosts.map(_._1).toSeq,
+              parsedUri.hosts.map(hostAndPort => s"${hostAndPort._1}:${hostAndPort._2}").toSeq,
               MongoConnectionOptions.default.copy(failoverStrategy = FailoverStrategy(1.second, 5, _ * 1.5)),
               name
             )

--- a/modules/db/src/main/Env.scala
+++ b/modules/db/src/main/Env.scala
@@ -16,7 +16,8 @@ trait YoloDb
 @Module
 final class Env(
     appConfig: Configuration,
-    shutdown: CoordinatedShutdown
+    shutdown: CoordinatedShutdown,
+    mode: play.api.Mode
 )(implicit ec: ExecutionContext) {
 
   private val driver = new AsyncDriver(appConfig.get[Config]("mongodb").some)
@@ -24,7 +25,8 @@ final class Env(
   lazy val mainDb = new Db(
     name = "main",
     uri = appConfig.get[String]("mongodb.uri"),
-    driver = driver
+    driver = driver,
+    mode != play.api.Mode.Prod
   )
 
   lazy val yoloDb = new AsyncDb(


### PR DESCRIPTION
Increase backoff delay in failover strategy (just for dev mode).  It's one way to get rid of 30KB or so of stack traces on startup.  Don't want to get desensitized to exceptions in logs if you can help it.