### PR TITLE
persist user's pov for study chapters

### DIFF
--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -232,6 +232,7 @@ export default class AnalyseCtrl {
 
   flip = () => {
     this.flipped = !this.flipped;
+    this.study?.onFlip();
     this.chessground.set({
       orientation: this.bottomColor(),
     });

--- a/ui/analyse/src/study/interfaces.ts
+++ b/ui/analyse/src/study/interfaces.ts
@@ -45,6 +45,7 @@ export interface StudyCtrl {
   isChapterOwner(): boolean;
   canJumpTo(path: Tree.Path): boolean;
   onJump(): void;
+  onFlip(): void;
   withPosition<T>(obj: T): T & { ch: string; path: string };
   setPath(path: Tree.Path, node: Tree.Node): void;
   deleteNode(path: Tree.Path): void;

--- a/ui/analyse/src/study/studyCtrl.ts
+++ b/ui/analyse/src/study/studyCtrl.ts
@@ -87,6 +87,7 @@ export default function (
 
   const relayRecProp = storedBooleanProp('relay.rec', true);
   const nonRelayRecMapProp = storedMap<boolean>('study.rec', 100, () => true);
+  const chapterFlipMapProp = storedMap<boolean>('chapter.flip', 400, () => false);
 
   const vm: StudyVm = (() => {
     const isManualChapter = data.chapter.id !== data.position.chapterId;
@@ -264,7 +265,7 @@ export default function (
     document.title = data.name;
     members.dict(s.members);
     chapters.list(s.chapters);
-    ctrl.flipped = false;
+    ctrl.flipped = chapterFlipMapProp(data.chapter.id);
 
     const merge = !vm.mode.write && sameChapter;
     ctrl.reloadData(d.analysis, merge);
@@ -296,7 +297,6 @@ export default function (
     configurePractice();
     serverEval.reset();
     commentForm.onSetPath(data.chapter.id, ctrl.path, ctrl.node);
-
     redraw();
     ctrl.startCeval();
   }
@@ -649,6 +649,9 @@ export default function (
       if (gamebookPlay) gamebookPlay.onJump();
       else chapters.localPaths[vm.chapterId] = ctrl.path; // don't remember position on gamebook
       if (practice) practice.onJump();
+    },
+    onFlip() {
+      chapterFlipMapProp(data.chapter.id, ctrl.flipped);
     },
     withPosition,
     setPath(path, node) {


### PR DESCRIPTION
no longer reset them to chapter's original orientation when they toggle a sync/rec button.  probably less desirable is that their pov now persists across manual page reloads.  it's straightforward to fix that and limit this to button toggles but...  i figured it's a good time to find out whether this change would completely ruin all of our lives before going any further.

this PR is just a question in source code form.  i choose not to dip into my stash of unused thibault discord pings at this time.