### PR TITLE
also maintain POV across page loads

### DIFF
--- a/ui/analyse/src/study/studyCtrl.ts
+++ b/ui/analyse/src/study/studyCtrl.ts
@@ -321,6 +321,7 @@ export default function (
       );
   });
 
+  ctrl.flipped = chapterFlipMapProp(data.chapter.id);
   if (members.canContribute()) form.openIfNew();
 
   const currentNode = () => ctrl.node;


### PR DESCRIPTION
Otherwise after manually refreshing a chapter, you get the chapter orientation but as soon as you toggle a mode button it could potentially flip your POV to whatever value the map had.

A different fix would be to use an in-memory map.  This would preserve POV across mode toggles but reset POV to chapter orientation on page loads.

In this commit the POV is just always preserved (for consistency sake).