### PR TITLE
Narrow logic for computer time control check

### DIFF
--- a/modules/setup/src/main/AiConfig.scala
+++ b/modules/setup/src/main/AiConfig.scala
@@ -51,7 +51,7 @@ case class AiConfig(
 
   def pov(user: Option[User])(implicit idGenerator: IdGenerator) = game(user) dmap { Pov(_, creatorColor) }
 
-  def timeControlFromPosition = variant != chess.variant.FromPosition || time >= 1
+  def timeControlFromPosition = timeMode != TimeMode.RealTime || variant != chess.variant.FromPosition || time >= 1
 }
 
 object AiConfig extends BaseConfig {


### PR DESCRIPTION
Resolves #11377. Even when the user wanted to start an unlimited time mode game with the computer, we were enforcing the rule that the time (their last entered real time "time" setting) be greater than or equal to one minute. Make sure that we only enforce that rule when we are in the real time time mode.