### PR TITLE
Make description set via Tournament Manager scroll on overflow

### DIFF
--- a/app/views/tournament/side.scala
+++ b/app/views/tournament/side.scala
@@ -48,7 +48,7 @@ object side {
         ),
         tour.teamBattle map teamBattle(tour),
         tour.spotlight map { s =>
-          st.section(
+          st.section(cls := "description")(
             markdownLinksOrRichText(s.description),
             shieldOwner map { owner =>
               p(cls := "defender", dataIcon := "")(


### PR DESCRIPTION
Tested with shield tournaments as well

This also gives them a max-height of 20vh which means medium-length descriptions that previously fit will now scroll but otoh if there are a few streamers, the chat is currently basically unusable with longer descriptions.