### PR TITLE
Don't apply report accuracy to non-cheat reports

### DIFF
--- a/modules/report/src/main/ReportApi.scala
+++ b/modules/report/src/main/ReportApi.scala
@@ -31,7 +31,7 @@ final class ReportApi(
   import BSONHandlers._
   import Report.Candidate
 
-  private lazy val accuracyOf = accuracy.of _
+  private lazy val accuracyOf = accuracy.apply _
 
   private lazy val scorer = wire[ReportScore]
 
@@ -510,11 +510,11 @@ final class ReportApi(
           }
       }
 
-    def of(reporter: ReporterId): Fu[Option[Accuracy]] =
+    private def of(reporter: ReporterId): Fu[Option[Accuracy]] =
       cache get reporter.value
 
     def apply(candidate: Candidate): Fu[Option[Accuracy]] =
-      (candidate.reason == Reason.Cheat) ?? of(candidate.reporter.id)
+      candidate.isCheat ?? of(candidate.reporter.id)
 
     def invalidate(selector: Bdoc): Funit =
       coll

--- a/modules/report/src/main/ReportScore.scala
+++ b/modules/report/src/main/ReportScore.scala
@@ -1,11 +1,11 @@
 package lila.report
 
 final private class ReportScore(
-    getAccuracy: ReporterId => Fu[Option[Accuracy]]
+    getAccuracy: Report.Candidate => Fu[Option[Accuracy]]
 )(implicit ec: scala.concurrent.ExecutionContext) {
 
   def apply(candidate: Report.Candidate): Fu[Report.Candidate.Scored] =
-    getAccuracy(candidate.reporter.id) map { accuracy =>
+    getAccuracy(candidate) map { accuracy =>
       impl.baseScore +
         impl.accuracyScore(accuracy) +
         impl.reporterScore(candidate.reporter) +


### PR DESCRIPTION
https://hq.lichess.ovh/#narrow/stream/34-mod-dev/topic/report.20accuracy

Not sure if this might have been intentional, definitely seems weird though, see linked discussion