### PR TITLE
Don't linkify period with nothing after it

### DIFF
--- a/ui/mod/src/inquiry.ts
+++ b/ui/mod/src/inquiry.ts
@@ -54,7 +54,7 @@ lichess.load.then(() => {
       expandMentions(
         $(this)
           .html()
-          .replace(/(?:https:\/\/)?lichess\.org\/([\w\/:(&;)?=@\.]+)/gi, '<a href="/$1">lichess.org/$1</a>')
+          .replace(/(?:https:\/\/)?lichess\.org\/((?:[\w\/:(&;)?=@]|\.\w)+)/gi, '<a href="/$1">lichess.org/$1</a>')
       )
     );
   });


### PR DESCRIPTION
i.e. when it's just ending a sentence instead of doing a field access like "sort.order" in an advanced serach URL