### PR TITLE
launch correspondence analysis at latest game ply

### DIFF
--- a/ui/analyse/src/persistence.ts
+++ b/ui/analyse/src/persistence.ts
@@ -45,7 +45,7 @@ export default class Persistence {
       if (state) {
         this.isDirty = true;
         this.ctrl.tree.merge(state.root);
-        this.ctrl.jump(this.ctrl.ongoing ? this.ctrl.initialPath : state.path);
+        if (!this.ctrl.ongoing) this.ctrl.jump(state.path);
         if (state.flipped != this.ctrl.flipped) this.ctrl.flip();
       }
       this.ctrl.redraw();

--- a/ui/analyse/src/persistence.ts
+++ b/ui/analyse/src/persistence.ts
@@ -45,7 +45,7 @@ export default class Persistence {
       if (state) {
         this.isDirty = true;
         this.ctrl.tree.merge(state.root);
-        this.ctrl.jump(state.path);
+        this.ctrl.jump(this.ctrl.ongoing ? this.ctrl.initialPath : state.path);
         if (state.flipped != this.ctrl.flipped) this.ctrl.flip();
       }
       this.ctrl.redraw();


### PR DESCRIPTION
Last week, we set the initial path correctly.  This week, we're setting the initial ply correctly.  Next week, we break it all again.

fixes #11423