### PR TITLE
Add grey background to the .pocket class

### DIFF
--- a/ui/chess/css/_zh-pocket.scss
+++ b/ui/chess/css/_zh-pocket.scss
@@ -3,11 +3,11 @@
 
   display: flex;
   width: 62.5%;
+  background: #888;
 
   @include breakpoint($mq-col2-uniboard) {
     width: 100%;
     box-shadow: 0 3px 5px rgba(0, 0, 0, 0.3) inset;
-    background: #888;
   }
 
   &-c1 {


### PR DESCRIPTION
CSS background for .pocket class was only working for "min-width: 800px".
The background was black, making pieces almost invisible.