### PR TITLE
Don't prefer appeals with old responses

### DIFF
--- a/modules/appeal/src/main/Appeal.scala
+++ b/modules/appeal/src/main/Appeal.scala
@@ -34,7 +34,7 @@ case class Appeal(
         else if (!isByMod(msg) && status == Appeal.Status.Read) Appeal.Status.Unread
         else status,
       firstUnrepliedAt =
-        if (isByMod(msg) || msgs.lastOption.exists(isByMod)) DateTime.now
+        if (isByMod(msg) || msgs.lastOption.exists(msg => isByMod(msg) || msg.at.isBefore(DateTime.now.minusWeeks(2)))) DateTime.now
         else firstUnrepliedAt
     )
   }


### PR DESCRIPTION
Avoid bumping appeals with old replies after the mod response to the top by using a new message as the new sort date if the previous one was older than 2 weeks.

2 weeks is kinda arbitrary but seems like a safe amount to be very certain old appeals don't get lost.