### PR TITLE
Avoid huge margins around ubloc cards on large monitors

### DIFF
--- a/ui/site/css/ublog/_card.scss
+++ b/ui/site/css/ublog/_card.scss
@@ -2,7 +2,7 @@
   &-cards {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(22em, 1fr));
-    grid-gap: 3vmin;
+    grid-gap: 1.5em;
   }
   &-card {
     @extend %box-neat-force;


### PR DESCRIPTION
`3vmin` creates comparatively huge margins around the cards on high-res monitors with downscaling which leads to 2-column layouts and ridiculously oversized cards compared to everything else.

`1.5em` seems about a reasonable amount for pretty much all screen sizes.