### PR TITLE
lpv:  keyboard nav, ublog ply & orientation, and light theme fixes

### DIFF
--- a/app/templating/AssetHelper.scala
+++ b/app/templating/AssetHelper.scala
@@ -76,7 +76,7 @@ trait AssetHelper { self: I18nHelper with SecurityHelper =>
     }
 
   def basicCsp(implicit req: RequestHeader): ContentSecurityPolicy = {
-    val assets = assetDomain.value
+    val assets  = assetDomain.value
     val sockets = socketDomains map { x => s"wss://$x${!req.secure ?? s" ws://$x"}" }
     // include both ws and wss when insecure because requests may come through a secure proxy
     val localDev = !req.secure ?? List("http://127.0.0.1:3000")

--- a/modules/api/src/main/TextLpvExpand.scala
+++ b/modules/api/src/main/TextLpvExpand.scala
@@ -37,11 +37,13 @@ final class TextLpvExpand(
       matches
         .get(url)
         .map { pgn =>
-          div(
-            cls                      := "lpv--autostart",
-            attr("data-pgn")         := pgn.toString,
-            attr("data-orientation") := chess.Color.fromWhite(!url.contains("black")).name,
-            attr("data-ply") := plyRegex.findFirstIn(url).fold("last")(_.substring(1))
+          div( // added div for viewport calculations (pgn-viewer hoses its initializer element). site/lpv.ts
+            div(
+              cls                      := "lpv--autostart",
+              attr("data-pgn")         := pgn.toString,
+              attr("data-orientation") := chess.Color.fromWhite(!url.contains("black")).name,
+              attr("data-ply")         := plyRegex.findFirstIn(url).fold("last")(_.substring(1))
+            )
           )
         }
     }

--- a/modules/appeal/src/main/Appeal.scala
+++ b/modules/appeal/src/main/Appeal.scala
@@ -34,7 +34,10 @@ case class Appeal(
         else if (!isByMod(msg) && status == Appeal.Status.Read) Appeal.Status.Unread
         else status,
       firstUnrepliedAt =
-        if (isByMod(msg) || msgs.lastOption.exists(msg => isByMod(msg) || msg.at.isBefore(DateTime.now.minusWeeks(2)))) DateTime.now
+        if (
+          isByMod(msg) || msgs.lastOption
+            .exists(msg => isByMod(msg) || msg.at.isBefore(DateTime.now.minusWeeks(2)))
+        ) DateTime.now
         else firstUnrepliedAt
     )
   }

--- a/modules/common/src/main/MarkdownRender.scala
+++ b/modules/common/src/main/MarkdownRender.scala
@@ -262,8 +262,8 @@ object MarkdownRender {
       html
         .tag("div") // this div needed for viewport calculations in site/lpv.ts
         .attr("data-pgn", pgn)
-        .attr("data-orientation", if (color != null) color else "white")
-        .attr("data-ply", if (ply != null) ply.substring(1) else "0")
+        .attr("data-orientation", Option(color) | "white")
+        .attr("data-ply", Option(ply) | "0")
         .attr("class", "lpv--autostart")
         .srcPos(node.getChars())
         .withAttr(link)

--- a/modules/common/src/test/MarkdownTest.scala
+++ b/modules/common/src/test/MarkdownTest.scala
@@ -35,14 +35,14 @@ class MarkdownTest extends Specification {
       val md = Markdown(s"foo [game](http://l.org/$gameId) bar")
       gameRender(
         md
-      ) must_== s"""<p>foo <div data-pgn="$pgn" class="lpv--autostart">http://l.org/$gameId</div> bar</p>
+      ) must_== s"""<p>foo <div><div data-pgn="$pgn" data-orientation="white" data-ply="0" class="lpv--autostart">http://l.org/$gameId</div></div> bar</p>
 """
     }
     "auto link" in {
       val md = Markdown(s"foo http://l.org/$gameId bar")
       gameRender(
         md
-      ) must_== s"""<p>foo <div data-pgn="$pgn" class="lpv--autostart">http://l.org/$gameId</div> bar</p>
+      ) must_== s"""<p>foo <div><div data-pgn="$pgn" data-orientation="white" data-ply="0" class="lpv--autostart">http://l.org/$gameId</div></div> bar</p>
 """
     }
   }

--- a/ui/common/css/component/_lichess-pgn-viewer.scss
+++ b/ui/common/css/component/_lichess-pgn-viewer.scss
@@ -4,8 +4,9 @@ $c-bg-controls: $c-bg;
 $c-bg-movelist: $c-bg;
 $c-bg-variation: hsl($c-site-hue, 5%, 15%) !default;
 $c-bg-pane: hsla(0, 0%, 0%, 0.9);
-$c-accent: $c-secondary;
-$c-accent-over: $c-secondary-over;
+$c-accent: $c-primary;
+$c-accent-over: $c-primary-over;
+$c-font-accent: mix($c-bg, hsl(0, 0%, 65%), 20%);
 $c-font-shy: $c-font-dim;
 
 @import '../../../../node_modules/lichess-pgn-viewer/scss/lichess-pgn-viewer.lib';

--- a/ui/common/css/theme/_dark.scss
+++ b/ui/common/css/theme/_dark.scss
@@ -77,6 +77,7 @@ $c-link-hover: c-clearer(saturate($c-primary, 100%), 25%);
 $c-bg-box: $c-bg-high;
 $c-bg-box-opaque: $c-bg-box;
 $c-bg-input: c-light($c-bg-page, 13%);
+$c-bg-variation: hsl($c-site-hue, 5%, 15%);
 
 $c-bg-popup: $c-bg-low;
 $c-popup: $c-font-clear;

--- a/ui/common/css/theme/_default.scss
+++ b/ui/common/css/theme/_default.scss
@@ -110,6 +110,7 @@ $c-link-over: $c-primary-over;
 $c-bg-box: $c-bg-high;
 $c-bg-box-opaque: $c-bg-box;
 $c-bg-input: c-light($c-bg-page, 98%);
+$c-bg-variation: $c-bg-zebra2;
 
 $c-border: hsl(0, 0%, 85%);
 $c-border-page: hsl(0, 0%, 80%);

--- a/ui/learn/src/mithrilFix.ts
+++ b/ui/learn/src/mithrilFix.ts
@@ -4,7 +4,7 @@ import m from 'mithril';
 
 type OneOrMany<T> = T | T[];
 
-type Children<T> = OneOrMany<
+type Children<T extends _mithril.MithrilController> = OneOrMany<
   | string
   | number
   | null

--- a/ui/site/src/lpv.ts
+++ b/ui/site/src/lpv.ts
@@ -4,16 +4,42 @@ import { Opts } from 'lichess-pgn-viewer/interfaces';
 import { text as xhrText } from 'common/xhr';
 
 export function autostart() {
+  const lpvs = new Map<Element, Element>();
+
   $('.lpv--autostart').each(function (this: HTMLElement) {
-    loadCssPath('lpv').then(() => {
-      Lpv(this, {
-        pgn: this.dataset['pgn']!.replace(/<br>/g, '\n'),
-        orientation: this.dataset['orientation'] as Color | undefined,
-        lichess: location.origin,
-        initialPly: this.dataset['ply'] as number | 'last',
-      });
+    lpvs.set(this.parentElement!, this);
+    Lpv(this, {
+      pgn: this.dataset['pgn']!.replace(/<br>/g, '\n'),
+      orientation: this.dataset['orientation'] as Color | undefined,
+      lichess: location.origin,
+      initialPly: this.dataset['ply'] as number | 'last',
     });
   });
+  if (lpvs.size == 0) return;
+
+  function bindKeyGoto(key: string, goto: string): void {
+    window.Mousetrap.bind(key, () => keyboardTarget()?.dispatchEvent(new Event(goto)));
+  }
+
+  function keyboardTarget(): Element | undefined {
+    let maxExtent = 0,
+      targetLpv;
+    lpvs.forEach((lpv, div, __) => {
+      const r = div.getBoundingClientRect();
+      const extent = Math.min(window.innerHeight, r.bottom) - Math.max(0, r.top);
+      if (extent > maxExtent) {
+        maxExtent = extent;
+        targetLpv = lpv;
+      }
+    });
+    return targetLpv;
+  }
+
+  bindKeyGoto('left', 'prev');
+  bindKeyGoto('right', 'next');
+  bindKeyGoto('up', 'first');
+  bindKeyGoto('down', 'last');
+  bindKeyGoto('f', 'flip');
 }
 
 export const loadPgnAndStart = async (el: HTMLElement, url: string, opts: Opts) => {


### PR DESCRIPTION
Related to PR #4 in pgn-viewer.  There shouldn't be any build-time dependencies but keystrokes won't work until that PR is merged, pushed to npm registry or yarn linked.