### PR TITLE
Don't prefer appeals with old read responses

### DIFF
--- a/modules/appeal/src/main/Appeal.scala
+++ b/modules/appeal/src/main/Appeal.scala
@@ -15,6 +15,7 @@ case class Appeal(
     firstUnrepliedAt: DateTime
 ) {
   def id       = _id
+  def isRead = status == Appeal.Status.Read
   def isMuted  = status == Appeal.Status.Muted
   def isUnread = status == Appeal.Status.Unread
 
@@ -30,11 +31,11 @@ case class Appeal(
       msgs = msgs :+ msg,
       updatedAt = DateTime.now,
       status =
-        if (isByMod(msg) && status == Appeal.Status.Unread) Appeal.Status.Read
-        else if (!isByMod(msg) && status == Appeal.Status.Read) Appeal.Status.Unread
+        if (isByMod(msg) && isUnread) Appeal.Status.Read
+        else if (!isByMod(msg) && isRead) Appeal.Status.Unread
         else status,
       firstUnrepliedAt =
-        if (isByMod(msg) || msgs.lastOption.exists(msg => isByMod(msg) || msg.at.isBefore(DateTime.now.minusWeeks(2)))) DateTime.now
+        if (isByMod(msg) || msgs.lastOption.exists(isByMod) || isRead) DateTime.now
         else firstUnrepliedAt
     )
   }


### PR DESCRIPTION
Follow up/better version of #11432

Just realized it makes much more sense to just consider whether the last msg was read already.