### PR TITLE
revoke device tokens on pwd change & 2fa in addition to logout

### DIFF
--- a/app/controllers/Account.scala
+++ b/app/controllers/Account.scala
@@ -163,6 +163,7 @@ final class Account(
   private def refreshSessionId(me: UserModel, result: Result)(implicit ctx: Context): Fu[Result] =
     env.security.store.closeAllSessionsOf(me.id) >>
       env.push.webSubscriptionApi.unsubscribeByUser(me) >>
+      env.push.unregisterDevices(me) >>
       env.security.api.saveAuthentication(me.id, ctx.mobileApiVersion) map { sessionId =>
         result.withCookies(env.lilaCookie.session(env.security.api.sessionIdKey, sessionId))
       }


### PR DESCRIPTION
force reauth device to continue getting push messages, discussed by jas14, lakin, benedikt in lila-development discord.  they concluded revoking token(s) "seems reasonable".