### PR TITLE
fix fenThumbnail from cdn redirected to lila

### DIFF
--- a/app/views/analyse/replay.scala
+++ b/app/views/analyse/replay.scala
@@ -60,7 +60,7 @@ object replay {
         href := cdnUrl(
           routes.Export
             .fenThumbnail(
-              Forsyth.>>(pov.game.situation).value.replace(" ", "_"),
+              Forsyth.>>(pov.game.situation).value,
               pov.color.name,
               None,
               pov.game.variant.key.some

--- a/app/views/opening/show.scala
+++ b/app/views/opening/show.scala
@@ -38,7 +38,7 @@ object show {
         .OpenGraph(
           `type` = "article",
           image = cdnUrl(
-            s"${routes.Export.fenThumbnail(opening.ref.fen.replace(" ", "_"), chess.White.name, opening.ref.uci.split(" ").lastOption, none).url}"
+            s"${routes.Export.fenThumbnail(opening.ref.fen, chess.White.name, opening.ref.uci.split(" ").lastOption, none).url}"
           ).some,
           title = name,
           url = s"$netBaseUrl${routes.Opening.show(opening.key.value)}",

--- a/conf/routes
+++ b/conf/routes
@@ -425,7 +425,7 @@ GET   /game/export/png/$gameId<\w{8}>.png                     controllers.Export
 GET   /game/export/gif/thumbnail/$gameId<\w{8}>.gif           controllers.Export.gameThumbnail(gameId: String)
 GET   /game/export/gif/$gameId<\w{8}>.gif                     controllers.Export.gif(gameId: String, color: String = "white")
 GET   /game/export/gif/$color<white|black>/$gameId<\w{8}>.gif controllers.Export.gif(gameId: String, color: String)
-GET   /export/gif/*fen                                        controllers.Export.fenThumbnail(fen: String, color: String ?= "white", lastMove: Option[String], variant: Option[String])
+GET   /export/fen.gif                                         controllers.Export.fenThumbnail(fen: String, color: String ?= "white", lastMove: Option[String], variant: Option[String])
 
 # Fishnet
 GET   /fishnet                                controllers.Main.movedPermanently(to: String = "https://github.com/lichess-org/fishnet")

--- a/ui/analyse/src/serverSideUnderboard.ts
+++ b/ui/analyse/src/serverSideUnderboard.ts
@@ -43,7 +43,8 @@ export default function (element: HTMLElement, ctrl: AnalyseCtrl) {
       const nextInputHash = `${fen}${ctrl.bottomColor()}`;
       if (fen && nextInputHash !== lastInputHash) {
         inputFen.value = fen;
-        positionGifLink.href = xhrUrl(`/export/gif/${fen.replace(/ /g, '_')}`, {
+        positionGifLink.href = xhrUrl(document.body.getAttribute('data-asset-url') + '/export/fen.gif', {
+          fen,
           color: ctrl.bottomColor(),
           lastMove: ctrl.node.uci,
           variant: ctrl.data.game.variant.key,

--- a/ui/analyse/src/study/studyShare.ts
+++ b/ui/analyse/src/study/studyShare.ts
@@ -142,7 +142,8 @@ export function view(ctrl: StudyShareCtrl): VNode {
         {
           attrs: {
             'data-icon': '',
-            href: xhrUrl(`/export/gif/${ctrl.currentNode().fen.replace(/ /g, '_')}`, {
+            href: xhrUrl(document.body.getAttribute('data-asset-url') + '/export/fen.gif', {
+              fen: ctrl.currentNode().fen,
               color: ctrl.bottomColor(),
               lastMove: ctrl.currentNode().uci,
               variant: ctrl.variantKey,


### PR DESCRIPTION
As observed by @brollin in https://github.com/lichess-org/lila/pull/11455#discussion_r961084894, https://lichess1.org/export/fen always redirects to https://lichess.org/export/fen.

That's because:
* We forgot to add nginx config when adding this route, so nginx redirects
* lila itself also [redirects unexpected domains](https://github.com/lichess-org/lila/blob/9e87d11d8b0bd19aa2818cc248b536370ce25375/app/http/HttpFilter.scala#L48). In particular these gifs don't have a file extension in the URL

We could add another exception there, but I like just changing `/export/gif/<fen>` to `/export/fen.gif?fen=...`.