### PR TITLE
Use start instead of left to align ruser

### DIFF
--- a/ui/round/css/_user.scss
+++ b/ui/round/css/_user.scss
@@ -2,7 +2,7 @@
   @extend %zen;
 
   display: flex;
-  justify-content: left;
+  justify-content: start;
   font-size: 1.2em;
   padding: 0 0.3em;
 


### PR DESCRIPTION
Fixes #11485 by placing the username in the right spot for rtl languages.

Pun intended.