### PR TITLE
Actually forfeit swiss games on marks

### DIFF
--- a/modules/swiss/src/main/SwissApi.scala
+++ b/modules/swiss/src/main/SwissApi.scala
@@ -340,7 +340,7 @@ final class SwissApi(
     Bus
       .ask[List[TeamID]]("teamJoinedBy")(lila.hub.actorApi.team.TeamIdsJoinedBy(userId, _))
       .flatMap { joinedPlayableSwissIds(userId, _) }
-      .flatMap { kickFromSwissIds(userId, _) }
+      .flatMap { kickFromSwissIds(userId, _, forfeit = true) }
 
   def joinedPlayableSwissIds(userId: User.ID, teamIds: List[TeamID]): Fu[List[Swiss.Id]] =
     colls.swiss
@@ -661,7 +661,7 @@ final class SwissApi(
       }
       .map(_.flatMap(_.getAsOpt[Swiss.Id]("_id")))
       .flatMap {
-        _.map { withdraw(_, user.id, forfeit = false) }.sequenceFu.void
+        _.map { withdraw(_, user.id) }.sequenceFu.void
       }
 
   def isUnfinished(id: Swiss.Id): Fu[Boolean] =


### PR DESCRIPTION
Originally implemented in https://github.com/lichess-org/lila/commit/15cd13d7759a898cc9d5c059dbd912dbe8f05007 but it's never actually called with `forfeit = true`.

Not sure if any other places should use it, mainly kickTeam and account closure.