### PR TITLE
Disable spellcheck for username search

### DIFF
--- a/ui/tournament/src/search.ts
+++ b/ui/tournament/src/search.ts
@@ -17,6 +17,9 @@ export function input(ctrl: TournamentController): VNode {
   return h(
     'div.search',
     h('input', {
+      attrs: {
+        spellcheck: 'false',
+      },
       hook: onInsert((el: HTMLInputElement) => {
         lichess.userComplete().then(uac => {
           uac({


### PR DESCRIPTION
When searching players on tournament standing, this was before:

![before](https://user-images.githubusercontent.com/271432/189560007-5068d5a3-4808-4602-8824-f9459f70493e.png)

And after this change:

![after](https://user-images.githubusercontent.com/271432/189560023-0cd2d2e0-a7e0-4594-a898-aa1192910d53.png)
