### PR TITLE
sbt 1.6.0 changes behaviour regarding sbt.TrapExit, need to fork to r…

### DIFF
--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -25,7 +25,7 @@ object BuildSettings {
       Compile / doc / sources                := Seq.empty,
       Compile / packageDoc / publishArtifact := false,
       Compile / packageSrc / publishArtifact := false,
-      Compile / run / fork := true,
+      Compile / run / fork                   := true,
       javaOptions ++= Seq("-Xms64m", "-Xmx256m"),
       // com.typesafe.play:play-ahc-ws-standalone_2.13:2.1.3 brings in 0.9.0, but we want 1.0.0:
       libraryDependencySchemes += "org.scala-lang.modules" %% "scala-java8-compat" % "always"

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -25,6 +25,7 @@ object BuildSettings {
       Compile / doc / sources                := Seq.empty,
       Compile / packageDoc / publishArtifact := false,
       Compile / packageSrc / publishArtifact := false,
+      Compile / run / fork := true,
       javaOptions ++= Seq("-Xms64m", "-Xmx256m"),
       // com.typesafe.play:play-ahc-ws-standalone_2.13:2.1.3 brings in 0.9.0, but we want 1.0.0:
       libraryDependencySchemes += "org.scala-lang.modules" %% "scala-java8-compat" % "always"


### PR DESCRIPTION
From https://github.com/sbt/sbt/releases/tag/v1.6.0:

> sbt.TrapExit is dropped due to Security Manager being deprecated in JDK 17. Calling sys.exit in run or test would shutdown the sbt session. Use [forking](https://www.scala-sbt.org/1.x/docs/Forking.html) to prevent it https://github.com/sbt/sbt/pull/6665 by [@eed3si9n](https://github.com/eed3si9n)

and the recommendation is this change, which seems to fix it.