### PR TITLE
Fix API response when game isn't abortableByUser

### DIFF
--- a/app/controllers/Challenge.scala
+++ b/app/controllers/Challenge.scala
@@ -215,7 +215,7 @@ final class Challenge(
               } flatMap {
                 _ ?? { p => env.round.proxyRepo.upgradeIfPresent(p) dmap some }
               } flatMap {
-                case Some(pov) if pov.game.abortable =>
+                case Some(pov) if pov.game.abortableByUser =>
                   lila.common.Bus.publish(Tell(id, Abort(pov.playerId)), "roundSocket")
                   jsonOkResult.fuccess
                 case Some(pov) if pov.game.playable =>

--- a/modules/bot/src/main/BotPlayer.scala
+++ b/modules/bot/src/main/BotPlayer.scala
@@ -75,14 +75,16 @@ final class BotPlayer(
     Bus.publish(Tell(id, msg), "roundSocket")
 
   def abort(pov: Pov): Funit =
-    if (!pov.game.abortable) clientError("This game can no longer be aborted")
+    if (!pov.game.abortableByUser) clientError("This game can no longer be aborted")
     else
       fuccess {
         tellRound(pov.gameId, Abort(pov.playerId))
       }
 
   def resign(pov: Pov): Funit =
-    if (pov.game.abortable) abort(pov)
+    if (pov.game.abortableByUser) fuccess {
+      tellRound(pov.gameId, Abort(pov.playerId))
+    }
     else if (pov.game.resignable) fuccess {
       tellRound(pov.gameId, Resign(pov.playerId))
     }

--- a/modules/round/src/main/Env.scala
+++ b/modules/round/src/main/Env.scala
@@ -207,7 +207,7 @@ final class Env(
   val apiMoveStream = wire[ApiMoveStream]
 
   def resign(pov: Pov): Unit =
-    if (pov.game.abortable) tellRound(pov.gameId, Abort(pov.playerId))
+    if (pov.game.abortableByUser) tellRound(pov.gameId, Abort(pov.playerId))
     else if (pov.game.resignable) tellRound(pov.gameId, Resign(pov.playerId))
 }
 


### PR DESCRIPTION
Due to https://github.com/lichess-org/lila/commit/41ae99507ce16dcb156d8eb89df9c1cbc8546ddb

As far as I can tell, games only are `abortable` but not `abortableByUser` if they were created via the bulk pairings API.