### PR TITLE
Fix rtl alignment in /games

### DIFF
--- a/ui/site/css/tv/_side.scss
+++ b/ui/site/css/tv/_side.scss
@@ -15,7 +15,7 @@
     }
 
     > span {
-      text-align: right;
+      text-align: end;
 
       strong {
         display: block;


### PR DESCRIPTION
Before:
<img width="262" alt="Screen Shot 2022-09-15 at 2 06 27 PM" src="https://user-images.githubusercontent.com/7917791/190809552-b47bb992-a6e0-45d2-863c-291121a10825.png">
After:
<img width="262" alt="Screen Shot 2022-09-15 at 2 05 51 PM" src="https://user-images.githubusercontent.com/7917791/190809611-a07d2d02-670f-4e46-bba3-dde50ce03afe.png">
