### PR TITLE
don't empty document when unsetting an empty list of fields

### DIFF
--- a/modules/db/src/main/dsl.scala
+++ b/modules/db/src/main/dsl.scala
@@ -104,18 +104,15 @@ trait dsl {
     $doc("$setOnInsert" -> $doc((Seq(item) ++ items): _*))
   }
 
-  def $set(item: ElementProducer, items: ElementProducer*): Bdoc = {
-    $doc("$set" -> $doc((Seq(item) ++ items): _*))
-  }
+  def $set(items: ElementProducer*): Bdoc =
+    $doc("$set" -> items.nonEmpty ?? $doc(items: _*))
+
+  def $unset(fields: Iterable[String]): Bdoc =
+    $doc("$unset" -> fields.nonEmpty ?? $doc(fields.map(k => (k, BSONString("")))))
 
   def $unset(field: String, fields: String*): Bdoc = {
     $doc("$unset" -> $doc((Seq(field) ++ fields).map(k => (k, BSONString("")))))
   }
-
-  def $unset(fields: Seq[String]): Bdoc =
-    fields.nonEmpty ?? {
-      $doc("$unset" -> $doc(fields.map(k => (k, BSONString("")))))
-    }
 
   def $setBoolOrUnset(field: String, value: Boolean): Bdoc = {
     if (value) $set(field -> true) else $unset(field)


### PR DESCRIPTION
i'm assuming that behavior is not intended.

also change `set` so that it can be safely invoked with no arguments (to support building `ElementProducer` sequences programmatically that might end up empty)

neither of these should break anything - the `set` change can save a bit of boilerplate but isn't really needed per se