### PR TITLE
Refactor typescript trans.plural to mimic the scala codebase

### DIFF
--- a/ui/@types/lichess/index.d.ts
+++ b/ui/@types/lichess/index.d.ts
@@ -142,6 +142,7 @@ interface Trans {
   (key: string, ...args: Array<string | number>): string;
   noarg: TransNoArg;
   plural(key: string, count: number, ...args: Array<string | number>): string;
+  pluralSame(key: string, count: number, ...args: Array<string | number>): string;
   vdom<T>(key: string, ...args: T[]): Array<string | T>;
   vdomPlural<T>(key: string, count: number, countArg: T, ...args: T[]): Array<string | T>;
 }

--- a/ui/analyse/src/explorer/tablebaseView.ts
+++ b/ui/analyse/src/explorer/tablebaseView.ts
@@ -38,7 +38,7 @@ function showDtm(ctrl: AnalyseCtrl, fen: Fen, move: TablebaseMoveStats) {
       'result.' + winnerOf(fen, move),
       {
         attrs: {
-          title: ctrl.trans.plural('mateInXHalfMoves', Math.abs(move.dtm)) + ' (Depth To Mate)',
+          title: ctrl.trans.pluralSame('mateInXHalfMoves', Math.abs(move.dtm)) + ' (Depth To Mate)',
         },
       },
       'DTM ' + Math.abs(move.dtm)

--- a/ui/analyse/src/forecast/forecastView.ts
+++ b/ui/analyse/src/forecast/forecastView.ts
@@ -24,7 +24,7 @@ function onMyTurn(ctrl: AnalyseCtrl, fctrl: ForecastCtrl, cNodes: ForecastStep[]
       h('span', [
         h('strong', ctrl.trans('playX', fixCrazySan(cNodes[0].san))),
         lines.length
-          ? h('span', ctrl.trans.plural('andSaveNbPremoveLines', lines.length))
+          ? h('span', ctrl.trans.pluralSame('andSaveNbPremoveLines', lines.length))
           : h('span', ctrl.trans.noarg('noConditionalPremoves')),
       ]),
     ]

--- a/ui/analyse/src/study/chapterNewForm.ts
+++ b/ui/analyse/src/study/chapterNewForm.ts
@@ -293,7 +293,7 @@ export function view(ctrl: StudyChapterNewFormCtrl): VNode {
           activeTab === 'pgn'
             ? h('div.form-group', [
                 h('textarea#chapter-pgn.form-control', {
-                  attrs: { placeholder: trans.plural('pasteYourPgnTextHereUpToNbGames', ctrl.multiPgnMax) },
+                  attrs: { placeholder: trans.pluralSame('pasteYourPgnTextHereUpToNbGames', ctrl.multiPgnMax) },
                 }),
                 h(
                   'a.button.button-empty',

--- a/ui/analyse/src/study/studyView.ts
+++ b/ui/analyse/src/study/studyView.ts
@@ -209,13 +209,13 @@ export function side(ctrl: StudyCtrl): VNode {
   const chaptersTab =
     tourShow && ctrl.looksNew() && !ctrl.members.canContribute()
       ? null
-      : makeTab('chapters', ctrl.trans.plural(ctrl.relay ? 'nbGames' : 'nbChapters', ctrl.chapters.size()));
+      : makeTab('chapters', ctrl.trans.pluralSame(ctrl.relay ? 'nbGames' : 'nbChapters', ctrl.chapters.size()));
 
   const tabs = h('div.tabs-horiz', { attrs: { role: 'tablist' } }, [
     tourTab,
     chaptersTab,
     !tourTab || ctrl.members.canContribute() || ctrl.data.admin
-      ? makeTab('members', ctrl.trans.plural('nbMembers', ctrl.members.size()))
+      ? makeTab('members', ctrl.trans.pluralSame('nbMembers', ctrl.members.size()))
       : null,
     ctrl.members.isOwner()
       ? h(

--- a/ui/lobby/src/view/correspondence.ts
+++ b/ui/lobby/src/view/correspondence.ts
@@ -29,7 +29,7 @@ function renderSeek(ctrl: LobbyController, seek: Seek): VNode {
           )
         : 'Anonymous',
       seek.rating && !ctrl.opts.hideRatings ? seek.rating + (seek.provisional ? '?' : '') : '',
-      seek.days ? ctrl.trans.plural('nbDays', seek.days) : '∞',
+      seek.days ? ctrl.trans.pluralSame('nbDays', seek.days) : '∞',
       h('span', [
         h('span.varicon', {
           attrs: { 'data-icon': perfIcons[seek.perf.key] },

--- a/ui/puzzle/src/view/side.ts
+++ b/ui/puzzle/src/view/side.ts
@@ -283,7 +283,7 @@ export const renderDifficultyForm = (ctrl: Controller): VNode =>
                 selected: key == ctrl.settings.difficulty,
                 title:
                   !!delta &&
-                  ctrl.trans.plural(
+                  ctrl.trans.pluralSame(
                     delta < 0 ? 'nbPointsBelowYourPuzzleRating' : 'nbPointsAboveYourPuzzleRating',
                     Math.abs(delta)
                   ),

--- a/ui/round/src/corresClock/corresClockView.ts
+++ b/ui/round/src/corresClock/corresClockView.ts
@@ -18,8 +18,8 @@ function formatClockTime(trans: Trans, time: Millis) {
     // days : hours
     const days = date.getUTCDate() - 1;
     hours = date.getUTCHours();
-    str += (days === 1 ? trans('oneDay') : trans.plural('nbDays', days)) + ' ';
-    if (hours !== 0) str += trans.plural('nbHours', hours);
+    str += (days === 1 ? trans('oneDay') : trans.pluralSame('nbDays', days)) + ' ';
+    if (hours !== 0) str += trans.pluralSame('nbHours', hours);
   } else if (time >= 3600 * 1000) {
     // hours : minutes
     hours = date.getUTCHours();

--- a/ui/simul/src/view/results.ts
+++ b/ui/simul/src/view/results.ts
@@ -36,4 +36,4 @@ const splitNumber = (s: string) => {
 };
 
 const trans = (ctrl: SimulCtrl, key: string, cond: (pairing: Pairing) => boolean) =>
-  splitNumber(ctrl.trans.plural(key, ctrl.data.pairings.filter(cond).length));
+  splitNumber(ctrl.trans.pluralSame(key, ctrl.data.pairings.filter(cond).length));

--- a/ui/site/src/component/friends.ts
+++ b/ui/site/src/component/friends.ts
@@ -49,7 +49,7 @@ export default class OnlineFriends {
     if (this.loaded)
       requestAnimationFrame(() => {
         const ids = Array.from(this.users.keys()).sort();
-        this.titleEl.innerHTML = siteTrans.plural(
+        this.titleEl.innerHTML = siteTrans.pluralSame(
           'nbFriendsOnline',
           ids.length,
           this.loaded ? `<strong>${ids.length}</strong>` : '-'

--- a/ui/site/src/component/timeago.ts
+++ b/ui/site/src/component/timeago.ts
@@ -26,7 +26,7 @@ const toDate = (input: DateLike): Date =>
 const formatDiff = (seconds: number): string => {
   const absSeconds = Math.abs(seconds);
   const unit = units.find(unit => absSeconds >= unit[2] * unit[3])!;
-  return siteTrans.plural(unit[seconds < 0 ? 1 : 0], Math.floor(absSeconds / unit[2]));
+  return siteTrans.pluralSame(unit[seconds < 0 ? 1 : 0], Math.floor(absSeconds / unit[2]));
 };
 
 let formatterInst: (date: Date) => string;

--- a/ui/site/src/component/trans.ts
+++ b/ui/site/src/component/trans.ts
@@ -27,7 +27,7 @@ export const trans = (i18n: I18nDict) => {
   };
 
   trans.pluralSame = (key: I18nKey, count: number, ...args: Array<string | number>) =>
-    trans.plural(key, count, count, args);
+    trans.plural(key, count, count, ...args);
 
   trans.plural = function (key: I18nKey, count: number, ...args: Array<string | number>) {
     const pluralKey = `${key}:${lichess.quantity(count)}`;

--- a/ui/site/src/component/trans.ts
+++ b/ui/site/src/component/trans.ts
@@ -25,13 +25,11 @@ export const trans = (i18n: I18nDict) => {
     const str = i18n[key];
     return str ? format(str, args) : key;
   };
-  trans.pluralSame = function (key: I18nKey, count: number) {
-    const pluralKey = `${key}:${lichess.quantity(count)}`;
-    const str = i18n[pluralKey] || i18n[key];
-    return str ? format(str, Array.prototype.slice.call(arguments, 1)) : key;
-  };
 
-  trans.plural = function (key: I18nKey, count: number, ...args: string[]) {
+  trans.pluralSame = (key: I18nKey, count: number, ...args: Array<string | number>) =>
+    trans.plural(key, count, count, args);
+
+  trans.plural = function (key: I18nKey, count: number, ...args: Array<string | number>) {
     const pluralKey = `${key}:${lichess.quantity(count)}`;
     const str = i18n[pluralKey] || i18n[key];
     return str ? format(str, args) : key;

--- a/ui/site/src/component/trans.ts
+++ b/ui/site/src/component/trans.ts
@@ -25,10 +25,16 @@ export const trans = (i18n: I18nDict) => {
     const str = i18n[key];
     return str ? format(str, args) : key;
   };
-  trans.plural = function (key: I18nKey, count: number) {
+  trans.pluralSame = function (key: I18nKey, count: number) {
     const pluralKey = `${key}:${lichess.quantity(count)}`;
     const str = i18n[pluralKey] || i18n[key];
     return str ? format(str, Array.prototype.slice.call(arguments, 1)) : key;
+  };
+
+  trans.plural = function (key: I18nKey, count: number, ...args: string[]) {
+    const pluralKey = `${key}:${lichess.quantity(count)}`;
+    const str = i18n[pluralKey] || i18n[key];
+    return str ? format(str, args) : key;
   };
   // optimisation for translations without arguments
   trans.noarg = (key: I18nKey) => i18n[key] || key;

--- a/ui/swiss/src/view/header.ts
+++ b/ui/swiss/src/view/header.ts
@@ -34,7 +34,7 @@ function clock(ctrl: SwissCtrl): VNode | undefined {
 
 function ongoing(ctrl: SwissCtrl): VNode | undefined {
   const nb = ctrl.data.nbOngoing;
-  return nb ? h('div.ongoing', [h('span.nb', [nb]), h('span.shy', ctrl.trans.plural('ongoingGames', nb))]) : undefined;
+  return nb ? h('div.ongoing', [h('span.nb', [nb]), h('span.shy', ctrl.trans.pluralSame('ongoingGames', nb))]) : undefined;
 }
 
 export default function (ctrl: SwissCtrl): VNode {

--- a/ui/swiss/src/view/header.ts
+++ b/ui/swiss/src/view/header.ts
@@ -34,7 +34,9 @@ function clock(ctrl: SwissCtrl): VNode | undefined {
 
 function ongoing(ctrl: SwissCtrl): VNode | undefined {
   const nb = ctrl.data.nbOngoing;
-  return nb ? h('div.ongoing', [h('span.nb', [nb]), h('span.shy', ctrl.trans.pluralSame('ongoingGames', nb))]) : undefined;
+  return nb
+    ? h('div.ongoing', [h('span.nb', [nb]), h('span.shy', ctrl.trans.pluralSame('ongoingGames', nb))])
+    : undefined;
 }
 
 export default function (ctrl: SwissCtrl): VNode {


### PR DESCRIPTION
Currently, there is no equivalent for the scala `plural` function in the typescript code and `trans.plural` performs what the scala `pluralSame` function does. This renames the typescript `trans.plural` function to `trans.pluralSame` and creates a `trans.plural` function that has a similar interface to the scala code. If merged, the [wiki page for translation](https://github.com/lichess-org/lila/wiki/How-translations-work) should be updated.

Resolves #11587