### PR TITLE
Reduce the size of tournament shields on mobile devices

### DIFF
--- a/ui/tournament/css/_leaderboard.scss
+++ b/ui/tournament/css/_leaderboard.scss
@@ -74,6 +74,13 @@ $user-list-width: 35ch;
   color: #333;
   text-shadow: 0 0 6px #fff;
   filter: drop-shadow(0 0 10px $c-brag);
+
+  @include breakpoint($mq-not-small) {
+    width: 50.25px;
+    height: 60px;
+    font-size: 30px;
+    line-height: 57px;
+  }
 }
 
 .tournament-categ-shields {


### PR DESCRIPTION
Resolves #11591
# Preview
## Mobile view
![Screen Shot 2022-09-22 at 01 06 15](https://user-images.githubusercontent.com/18627392/191630816-cd7d0f4d-1419-4075-ae7f-1097b37a9fc5.png)
## Desktop view
![image](https://user-images.githubusercontent.com/18627392/191630860-ff874268-19be-4778-b90e-31411bc7e709.png)
