### PR TITLE
Added a link to accuracy description

### DIFF
--- a/ui/analyse/src/roundTraining.ts
+++ b/ui/analyse/src/roundTraining.ts
@@ -48,7 +48,7 @@ function playerTable(ctrl: AnalyseCtrl, color: Color): VNode {
     h('div.advice-summary__player', [h(`i.is.color-icon.${color}`), renderPlayer(ctrl, color)]),
     ...advices.map(a => error(ctrl, d.analysis![color][a.kind], color, a)),
     h('div.advice-summary__acpl', [h('strong', sideData.acpl), h('span', ctrl.trans.noarg('averageCentipawnLoss'))]),
-    h('div.advice-summary__accuracy', [h('strong', [sideData.accuracy, '%']), h('span', ctrl.trans.noarg('accuracy'))]),
+    h('div.advice-summary__accuracy', [h('strong', [sideData.accuracy, '%']), h("a", { props: { href: "https://lichess.org/page/accuracy" } }, "?"), h('span', ctrl.trans.noarg('accuracy'))]),
   ]);
 }
 


### PR DESCRIPTION
Closes #11567

Added a link to the page the issue mentioned in a [?](https://lichess.org/page/accuracy) next to accuracy in case the user wonders what accuracy is.