### PR TITLE
Don't make cmn-toggle button transparent in transp theme

### DIFF
--- a/ui/common/css/form/_cmn-toggle.scss
+++ b/ui/common/css/form/_cmn-toggle.scss
@@ -37,7 +37,11 @@
   }
 
   &::after {
-    @extend %metal;
+    @if $theme == 'transp' {
+      background: linear-gradient(to bottom, hsl($c-site-hue, 7%, 22), hsl($c-site-hue, 5%, 19) 100%);
+    } @else {
+      @extend %metal;
+    }
 
     border-radius: 100%;
     box-shadow: 0 1px 2.5px rgba(0, 0, 0, 0.3);
@@ -75,7 +79,11 @@
     }
 
     &::after {
-      @extend %metal-hover;
+      @if $theme == 'transp' {
+        background: linear-gradient(to bottom, hsl($c-site-hue, 7%, 25), hsl($c-site-hue, 5%, 22) 100%);
+      } @else {
+        @extend %metal;
+      }
       @include transition(margin);
     }
   }


### PR DESCRIPTION
Before: <img width="47" alt="image" src="https://user-images.githubusercontent.com/19309705/192150908-026d57d5-2860-48ee-b21e-e976f1d64882.png">
After: <img width="40" alt="image" src="https://user-images.githubusercontent.com/19309705/192150913-1847ea5c-f57d-4830-b4c8-40160a137f42.png">
