### PR TITLE
Fix ply cursor in study movetime charts

### DIFF
--- a/ui/analyse/css/study/panel/_server-eval.scss
+++ b/ui/analyse/css/study/panel/_server-eval.scss
@@ -10,6 +10,7 @@
 
   &.ready {
     height: 15em;
+    cursor: pointer;
   }
 }
 

--- a/ui/analyse/src/serverSideUnderboard.ts
+++ b/ui/analyse/src/serverSideUnderboard.ts
@@ -1,19 +1,10 @@
-import type Highcharts from 'highcharts';
+import type { PlyChartHTMLElement } from 'chart/dist/interface';
 
 import AnalyseCtrl from './ctrl';
 import { baseUrl } from './util';
 import modal from 'common/modal';
 import { url as xhrUrl, textRaw as xhrTextRaw } from 'common/xhr';
 import { AnalyseData } from './interfaces';
-
-interface HighchartsHTMLElement extends HTMLElement {
-  highcharts: Highcharts.ChartObject;
-}
-
-interface PlyChart extends Highcharts.ChartObject {
-  lastPly?: Ply | false;
-  selectPly(ply: number): void;
-}
 
 export default function (element: HTMLElement, ctrl: AnalyseCtrl) {
   $(element).replaceWith(ctrl.opts.$underboard!);
@@ -26,8 +17,7 @@ export default function (element: HTMLElement, ctrl: AnalyseCtrl) {
     $timeChart = $('#movetimes-chart'),
     inputFen = document.querySelector('.analyse__underboard__fen') as HTMLInputElement,
     gameGifLink = document.querySelector('.game-gif') as HTMLAnchorElement,
-    positionGifLink = document.querySelector('.position-gif') as HTMLAnchorElement,
-    unselect = (chart: Highcharts.ChartObject) => chart.getSelectedPoints().forEach(point => point.select(false));
+    positionGifLink = document.querySelector('.position-gif') as HTMLAnchorElement;
   let lastInputHash: string;
 
   const updateGifLinks = (fen: Fen) => {
@@ -53,7 +43,7 @@ export default function (element: HTMLElement, ctrl: AnalyseCtrl) {
         () => (v ? $menu.find('[data-panel="computer-analysis"]') : $menu.find('span:eq(1)')).trigger('mousedown'),
         50
       );
-      if (v) $('#acpl-chart').each((_, e) => (e as HighchartsHTMLElement).highcharts.reflow());
+      if (v) $('#acpl-chart').each((_, e) => (e as PlyChartHTMLElement).highcharts.reflow());
     });
     lichess.pubsub.on('analysis.change', (fen: Fen, _, mainlinePly: Ply | false) => {
       const $chart = $('#acpl-chart');
@@ -63,26 +53,8 @@ export default function (element: HTMLElement, ctrl: AnalyseCtrl) {
         updateGifLinks(fen);
         lastInputHash = nextInputHash;
       }
-      if ($chart.length) {
-        const chart = ($chart[0] as HighchartsHTMLElement).highcharts as PlyChart;
-        if (chart) {
-          if (mainlinePly != chart.lastPly) {
-            if (mainlinePly === false) unselect(chart);
-            else chart.selectPly(mainlinePly);
-          }
-          chart.lastPly = mainlinePly;
-        }
-      }
-      if ($timeChart.length) {
-        const chart = ($timeChart[0] as HighchartsHTMLElement).highcharts as PlyChart;
-        if (chart) {
-          if (mainlinePly != chart.lastPly) {
-            if (mainlinePly === false) unselect(chart);
-            else chart.selectPly(mainlinePly);
-          }
-          chart.lastPly = mainlinePly;
-        }
-      }
+      if ($chart.length) ($chart[0] as PlyChartHTMLElement).highcharts?.selectPly(mainlinePly);
+      if ($timeChart.length) ($timeChart[0] as PlyChartHTMLElement).highcharts?.selectPly(mainlinePly);
     });
     lichess.pubsub.on('analysis.server.progress', (d: AnalyseData) => {
       if (!window.LichessChartGame) startAdvantageChart();

--- a/ui/analyse/src/study/serverEval.ts
+++ b/ui/analyse/src/study/serverEval.ts
@@ -1,45 +1,25 @@
-import { defined, prop } from 'common';
+import { prop } from 'common';
 import { bind, onInsert } from 'common/snabbdom';
 import { spinnerVdom } from 'common/spinner';
-import Highcharts from 'highcharts';
+import type { PlyChartHTMLElement } from 'chart/dist/interface';
 import { h, VNode } from 'snabbdom';
 import AnalyseCtrl from '../ctrl';
 
-interface HighchartsHTMLElement extends HTMLElement {
-  highcharts: Highcharts.ChartObject;
-}
-
 export default class ServerEval {
   requested = prop(false);
-  lastPly = prop<number | false>(false);
-  chartEl = prop<HighchartsHTMLElement | null>(null);
+  chartEl = prop<PlyChartHTMLElement | null>(null);
 
   constructor(readonly root: AnalyseCtrl, readonly chapterId: () => string) {
     lichess.pubsub.on('analysis.change', (_fen: string, _path: string, mainlinePly: number | false) => {
-      if (!window.LichessChartGame || this.lastPly() === mainlinePly) return;
-      const lp = this.lastPly(typeof mainlinePly === 'undefined' ? this.lastPly() : mainlinePly),
-        el = this.chartEl(),
-        chart = el && el.highcharts;
-      if (chart) {
-        if (lp === false) this.unselect(chart);
-        else {
-          const point = chart.series[0].data[lp - 1 - root.tree.root.ply];
-          if (defined(point)) point.select();
-          else this.unselect(chart);
-        }
-      } else this.lastPly(false);
+      if (window.LichessChartGame) this.chartEl()?.highcharts?.selectPly(mainlinePly);
     });
   }
 
-  unselect = (chart: Highcharts.ChartObject) => chart.getSelectedPoints().forEach(p => p.select(false));
-
   reset = () => {
     this.requested(false);
-    this.lastPly(false);
   };
 
-  onMergeAnalysisData = () =>
-    window.LichessChartGame?.acpl.update && window.LichessChartGame.acpl.update(this.root.data, this.root.mainline);
+  onMergeAnalysisData = () => window.LichessChartGame?.acpl.update?.(this.root.data, this.root.mainline);
 
   request = () => {
     this.root.socket.send('requestAnalysis', this.chapterId());
@@ -57,11 +37,10 @@ export function view(ctrl: ServerEval): VNode {
     'div.study__server-eval.ready.' + analysis.id,
     {
       hook: onInsert(el => {
-        ctrl.lastPly(false);
         lichess.requestIdleCallback(async () => {
           await lichess.loadModule('chart.game');
           window.LichessChartGame!.acpl(ctrl.root.data, ctrl.root.mainline, ctrl.root.trans, el, false);
-          ctrl.chartEl(el as HighchartsHTMLElement);
+          ctrl.chartEl(el as PlyChartHTMLElement);
         }, 800);
       }),
     },

--- a/ui/build
+++ b/ui/build
@@ -14,12 +14,12 @@ cd "$(git rev-parse --show-toplevel)"
 
 mkdir -p public/compiled
 
-apps1="common"
+apps1="common chart"
 apps2="chess palantir"
 apps3="ceval game tree chat nvui puz keyboardMove"
 apps4="site analyse swiss msg tutor opening cli challenge notify learn insight editor puzzle round lobby tournament tournamentSchedule tournamentCalendar simul dasher serviceWorker dgt storm racer coordinateTrainer"
 site_plugins="ublogForm ublog tvEmbed puzzleEmbed analyseEmbed lpv lpvEmbed user clas captcha expandText team forum account coachShow coachForm challengePage checkout plan login passwordComplexity tourForm teamBattleForm gameSearch userComplete infiniteScroll flatpickr appeal publicChats contact userGamesDownload tvGames speech"
-other_plugins="analyse:study analyse:nvui analyse:studyTopicForm round:nvui puzzle:nvui puzzle:dashboard puzzle:opening chart:ratingDistribution chart:ratingHistory chart:game mod:user mod:inquiry mod:search mod:games mod:activity mod:teamAdmin "
+other_plugins="analyse:study analyse:nvui analyse:studyTopicForm round:nvui puzzle:nvui puzzle:dashboard puzzle:opening mod:user mod:inquiry mod:search mod:games mod:activity mod:teamAdmin "
 
 if [ $mode == "upgrade" ]; then
   yarn upgrade --non-interactive

--- a/ui/chart/package.json
+++ b/ui/chart/package.json
@@ -13,9 +13,10 @@
     "typescript": "^4.5"
   },
   "scripts": {
-    "dev": "rollup --failAfterWarnings --config --config-all",
-    "prod": "rollup --failAfterWarnings --config --config-all --config-prod",
-    "plugin-dev": "rollup --failAfterWarnings --config --config-plugin",
-    "plugin-prod": "rollup --failAfterWarnings --config --config-prod --config-plugin"
+    "compile": "tsc --incremental --declaration --emitDeclarationOnly",
+    "dev": "$npm_execpath run compile && rollup --failAfterWarnings --config --config-all",
+    "prod": "$npm_execpath run compile && rollup --failAfterWarnings --config --config-all --config-prod",
+    "plugin-dev": "$npm_execpath run compile && rollup --failAfterWarnings --config --config-plugin",
+    "plugin-prod": "$npm_execpath run compile && rollup --failAfterWarnings --config --config-prod --config-plugin"
   }
 }

--- a/ui/chart/package.json
+++ b/ui/chart/package.json
@@ -13,8 +13,8 @@
     "typescript": "^4.5"
   },
   "scripts": {
-    "dev": "rollup --failAfterWarnings --config",
-    "prod": "rollup --failAfterWarnings --config --config-prod",
+    "dev": "rollup --failAfterWarnings --config --config-all",
+    "prod": "rollup --failAfterWarnings --config --config-all --config-prod",
     "plugin-dev": "rollup --failAfterWarnings --config --config-plugin",
     "plugin-prod": "rollup --failAfterWarnings --config --config-prod --config-plugin"
   }

--- a/ui/chart/src/acpl.ts
+++ b/ui/chart/src/acpl.ts
@@ -1,7 +1,13 @@
-import { ChartElm, loadHighcharts, MovePoint } from './common';
+import { loadHighcharts, MovePoint, selectPly } from './common';
 import divisionLines from './division';
+import { PlyChartHTMLElement } from './interface';
 
-const acpl: Window['LichessChartGame']['acpl'] = async (data: any, mainline: any[], trans: Trans, el: ChartElm) => {
+const acpl: Window['LichessChartGame']['acpl'] = async (
+  data: any,
+  mainline: any[],
+  trans: Trans,
+  el: PlyChartHTMLElement
+) => {
   await loadHighcharts('highchart');
   acpl.update = (d: any, mainline: any[]) =>
     el.highcharts && el.highcharts.series[0].setData(makeSerieData(d, mainline));
@@ -25,7 +31,7 @@ const acpl: Window['LichessChartGame']['acpl'] = async (data: any, mainline: any
         if (d.game.variant.key === 'antichess') cp = -cp;
       } else if (node.eval && typeof node.eval.cp !== 'undefined') {
         cp = node.eval.cp;
-      } else return { y: null };
+      } else return { y: undefined };
 
       const turn = Math.floor((node.ply - 1) / 2) + 1;
       const dots = isWhite ? '.' : '...';
@@ -148,11 +154,8 @@ const acpl: Window['LichessChartGame']['acpl'] = async (data: any, mainline: any
       ],
     },
   });
-  el.highcharts.selectPly = (ply: number) => {
-    const plyline = el.highcharts.xAxis[0].plotLinesAndBands[0];
-    plyline.options.value = ply - 1 - data.game.startedAtTurn;
-    plyline.render();
-  };
+  el.highcharts.firstPly = data.treeParts[0].ply;
+  el.highcharts.selectPly = selectPly;
   lichess.pubsub.emit('analysis.change.trigger');
 };
 

--- a/ui/chart/src/common.ts
+++ b/ui/chart/src/common.ts
@@ -1,6 +1,4 @@
-export interface ChartElm extends HTMLElement {
-  highcharts: any;
-}
+import { PlyChart } from './interface';
 
 export interface MovePoint {
   y: number;
@@ -10,6 +8,14 @@ export interface MovePoint {
 }
 
 let highchartsPromise: Promise<any> | undefined;
+
+export function selectPly(this: PlyChart, ply: number | false) {
+  if (this.lastPly === ply) return;
+  this.lastPly = ply;
+  const plyline = (this.xAxis[0] as any).plotLinesAndBands[0];
+  plyline.options.value = ply === false ? -1 : ply - 1 - this.firstPly;
+  plyline.render();
+}
 
 export async function loadHighcharts(tpe: string) {
   if (highchartsPromise) return highchartsPromise;

--- a/ui/chart/src/division.ts
+++ b/ui/chart/src/division.ts
@@ -9,7 +9,7 @@ export default function (div: Division, trans: Trans) {
     color: window.Highcharts.theme.lichess.line.accent,
     width: 1,
     value: 0,
-    zIndex: 5,
+    zIndex: 6,
   });
   const textWeak = window.Highcharts.theme.lichess.text.weak;
   if (div.middle) {

--- a/ui/chart/src/interface.ts
+++ b/ui/chart/src/interface.ts
@@ -1,0 +1,15 @@
+import type Highcharts from 'highcharts';
+
+export interface HighchartsHTMLElement extends HTMLElement {
+  highcharts: Highcharts.ChartObject;
+}
+
+export interface PlyChart extends Highcharts.ChartObject {
+  lastPly?: number | false;
+  firstPly: number;
+  selectPly(ply: number | false): void;
+}
+
+export interface PlyChartHTMLElement extends HTMLElement {
+  highcharts: PlyChart;
+}

--- a/ui/chart/src/movetime.ts
+++ b/ui/chart/src/movetime.ts
@@ -100,15 +100,7 @@ const movetime: Window['LichessChartGame']['movetime'] = async (data: any, trans
       const clickableOptions = {
         events: {
           click: (event: any) => {
-            if (event.point) {
-              const x = event.point.x;
-              const p =
-                chartElm.highcharts.series[(showTotal ? 4 : 0) + (((tree[x] ? tree[x].ply : undefined) || x) % 2)].data[
-                  x >> 1
-                ];
-              if (p) p.select(true);
-              lichess.pubsub.emit('analysis.chart.click', x);
-            }
+            if (event.point) lichess.pubsub.emit('analysis.chart.click', event.point.x);
           },
         },
       };
@@ -196,7 +188,6 @@ const movetime: Window['LichessChartGame']['movetime'] = async (data: any, trans
           events: {
             click(e: any) {
               let ply = Math.round(e.xAxis[0].value);
-              chartElm.highcharts.series[(showTotal ? 4 : 0) + (ply & 1)].data[ply >> 1]?.select(true);
               // if the parity of the ply doesn't match the quadrant of the click,
               // we add the x residual rounded away from zero to correct it
               if (e.yAxis[0].value < 0 == !(ply & 1)) ply += e.xAxis[0].value < ply ? -1 : 1;

--- a/ui/chart/src/movetime.ts
+++ b/ui/chart/src/movetime.ts
@@ -254,6 +254,7 @@ const movetime: Window['LichessChartGame']['movetime'] = async (data: any, trans
           lineWidth: 0,
           tickWidth: 0,
           plotLines: divisionLines(data.game.division, trans),
+          minPadding: showTotal ? -0.015 : 0.01,
         },
         yAxis: [
           {

--- a/ui/chart/src/movetime.ts
+++ b/ui/chart/src/movetime.ts
@@ -1,11 +1,12 @@
 import divisionLines from './division';
-import { ChartElm, loadHighcharts, MovePoint } from './common';
+import { loadHighcharts, MovePoint, selectPly } from './common';
+import { PlyChartHTMLElement } from './interface';
 
 const movetime: Window['LichessChartGame']['movetime'] = async (data: any, trans: Trans, hunter: boolean) => {
   if (!data.game.moveCentis) return; // imported games
   await loadHighcharts('highchart');
   movetime.render = () => {
-    $('#movetimes-chart:not(.rendered)').each(function (this: ChartElm) {
+    $('#movetimes-chart:not(.rendered)').each(function (this: PlyChartHTMLElement) {
       const chartElm = this;
       $(chartElm).addClass('rendered');
 
@@ -281,17 +282,8 @@ const movetime: Window['LichessChartGame']['movetime'] = async (data: any, trans
           },
         ],
       });
-      chartElm.highcharts.selectPly = (ply: number) => {
-        const plyline = chartElm.highcharts.xAxis[0].plotLinesAndBands[0];
-        plyline.options.value = ply - 1 - data.game.startedAtTurn;
-        plyline.render();
-        const white = ply % 2 !== 0;
-        const serie = (white ? 0 : 1) + (showTotal ? 4 : 0);
-        const turn = Math.floor((ply - 1 - data.game.startedAtTurn) / 2);
-        const point = chartElm.highcharts.series[serie].data[turn];
-        if (point) point.select(true);
-        else chartElm.highcharts.getSelectedPoints().forEach((point: any) => point.select(false));
-      };
+      chartElm.highcharts.firstPly = data.treeParts[0].ply;
+      chartElm.highcharts.selectPly = selectPly;
     });
     lichess.pubsub.emit('analysis.change.trigger');
   };


### PR DESCRIPTION
And also make it a bit more typesafe + some other small chart adjustments (see commit messages).

The chart module now builds type declarations but without js (--emitDeclarationOnly) to avoid accidentally importing stuff. The "dist" imports are kinda annoying but not sure how to make that work properly. Using "exports" in package.json didn't seem to work. I guess maybe it's not possible to do this without js files 🤔

Fixes #11617