### PR TITLE
Fix snabbdom false attributes

### DIFF
--- a/ui/analyse/src/explorer/explorerConfig.ts
+++ b/ui/analyse/src/explorer/explorerConfig.ts
@@ -318,7 +318,10 @@ const playerModal = (ctrl: ExplorerConfigCtrl) => {
       h('h2', 'Personal opening explorer'),
       h('div.input-wrapper', [
         h('input', {
-          attrs: { placeholder: ctrl.root.trans.noarg('searchByUsername') },
+          attrs: {
+            placeholder: ctrl.root.trans.noarg('searchByUsername'),
+            spellcheck: 'false',
+          },
           hook: onInsert<HTMLInputElement>(input =>
             lichess.userComplete().then(uac => {
               uac({

--- a/ui/analyse/src/study/inviteForm.ts
+++ b/ui/analyse/src/study/inviteForm.ts
@@ -70,7 +70,10 @@ export function view(ctrl: ReturnType<typeof makeCtrl>): VNode {
       h('div.input-wrapper', [
         // because typeahead messes up with snabbdom
         h('input', {
-          attrs: { placeholder: ctrl.trans.noarg('searchByUsername') },
+          attrs: {
+            placeholder: ctrl.trans.noarg('searchByUsername'),
+            spellcheck: 'false',
+          },
           hook: onInsert<HTMLInputElement>(input =>
             lichess.userComplete().then(uac => {
               uac({

--- a/ui/analyse/src/study/studyTags.ts
+++ b/ui/analyse/src/study/studyTags.ts
@@ -16,7 +16,7 @@ function editable(value: string, submit: (v: string, el: HTMLInputElement) => vo
   return h('input', {
     key: value, // force to redraw on change, to visibly update the input value
     attrs: {
-      spellcheck: false,
+      spellcheck: 'false',
       value,
     },
     hook: onInsert<HTMLInputElement>(el => {

--- a/ui/analyse/src/view.ts
+++ b/ui/analyse/src/view.ts
@@ -83,7 +83,7 @@ function inputs(ctrl: AnalyseCtrl): VNode | undefined {
     h('div.pair', [
       h('label.name', 'FEN'),
       h('input.copyable.autoselect.analyse__underboard__fen', {
-        attrs: { spellCheck: false },
+        attrs: { spellcheck: 'false' },
         hook: {
           insert: vnode => {
             const el = vnode.elm as HTMLInputElement;
@@ -110,7 +110,7 @@ function inputs(ctrl: AnalyseCtrl): VNode | undefined {
       h('div.pair', [
         h('label.name', 'PGN'),
         h('textarea.copyable', {
-          attrs: { spellCheck: false },
+          attrs: { spellcheck: 'false' },
           hook: {
             ...onInsert((el: HTMLTextAreaElement) => {
               el.value = defined(ctrl.pgnInput) ? ctrl.pgnInput : pgnExport.renderFullTxt(ctrl);

--- a/ui/editor/src/view.ts
+++ b/ui/editor/src/view.ts
@@ -310,7 +310,7 @@ function inputs(ctrl: EditorCtrl, fen: string): VNode | undefined {
       h('strong', 'FEN'),
       h('input.copyable', {
         attrs: {
-          spellcheck: false,
+          spellcheck: 'false',
         },
         props: {
           value: fen,
@@ -339,7 +339,7 @@ function inputs(ctrl: EditorCtrl, fen: string): VNode | undefined {
       h('input.copyable.autoselect', {
         attrs: {
           readonly: true,
-          spellcheck: false,
+          spellcheck: 'false',
           value: ctrl.makeEditorUrl(fen, ctrl.bottomColor()),
         },
       }),

--- a/ui/keyboardMove/src/main.ts
+++ b/ui/keyboardMove/src/main.ts
@@ -149,8 +149,8 @@ export function render(ctrl: KeyboardMove) {
   return h('div.keyboard-move', [
     h('input', {
       attrs: {
-        spellcheck: false,
-        autocomplete: false,
+        spellcheck: 'false',
+        autocomplete: 'off',
       },
       hook: onInsert(input =>
         lichess

--- a/ui/racer/src/view/main.ts
+++ b/ui/racer/src/view/main.ts
@@ -146,7 +146,7 @@ const renderLink = (ctrl: RacerCtrl) =>
     h('div', [
       h(`input#racer-url-${ctrl.race.id}.copyable.autoselect`, {
         attrs: {
-          spellcheck: false,
+          spellcheck: 'false',
           readonly: 'readonly',
           value: `${window.location.protocol}//${window.location.host}/racer/${ctrl.race.id}`,
         },

--- a/ui/swiss/src/search.ts
+++ b/ui/swiss/src/search.ts
@@ -17,6 +17,9 @@ export function input(ctrl: TournamentController): VNode {
   return h(
     'div.search',
     h('input', {
+      attrs: {
+        spellcheck: 'false',
+      },
       hook: onInsert((el: HTMLInputElement) => {
         lichess.userComplete().then(uac => {
           uac({


### PR DESCRIPTION
Snabbdom removes `false` attributes, so to get `<input spellcheck="false" />` we'll pass `(string) 'false'` instead of `(bool) false`.

I also found some other username inputs so I disabled spellcheck for those too.

Related to my previous PR #11530 