### PR TITLE
Add link into accuracy report

### DIFF
--- a/ui/analyse/src/view/roundTraining.ts
+++ b/ui/analyse/src/view/roundTraining.ts
@@ -54,9 +54,8 @@ function playerTable(ctrl: AnalyseCtrl, color: Color): VNode {
         'a.text',
         {
           attrs: {
-            'data-color': '#999',
             'data-icon': '',
-            href: 'https://lichess.org/page/accuracy',
+            href: '/page/accuracy',
             target: '_blank',
           },
         },

--- a/ui/analyse/src/view/roundTraining.ts
+++ b/ui/analyse/src/view/roundTraining.ts
@@ -48,14 +48,6 @@ function playerTable(ctrl: AnalyseCtrl, color: Color): VNode {
     h('div.advice-summary__player', [h(`i.is.color-icon.${color}`), renderPlayer(ctrl, color)]),
     ...advices.map(a => error(ctrl, d.analysis![color][a.kind], color, a)),
     h('div.advice-summary__acpl', [h('strong', sideData.acpl), h('span', ctrl.trans.noarg('averageCentipawnLoss'))]),
-    // h('div.advice-summary__accuracy', [h('strong', [sideData.accuracy, '%']), h('span.user-link.ulpt', [ctrl.trans.noarg('accuracy'),
-    //                                                                                       h('good',{attrs:{'data-icon': '',
-    //                                                                                       href: '/page/accuracy',
-    //                                                                                       target: '_blank',}},
-    //                                                                                       )
-    //                                                                                     ]),
-
-    //                                   ]),
     h('div.advice-summary__accuracy', [
       h('strong', [sideData.accuracy, '%']),
       h('span', [

--- a/ui/analyse/src/view/roundTraining.ts
+++ b/ui/analyse/src/view/roundTraining.ts
@@ -48,19 +48,27 @@ function playerTable(ctrl: AnalyseCtrl, color: Color): VNode {
     h('div.advice-summary__player', [h(`i.is.color-icon.${color}`), renderPlayer(ctrl, color)]),
     ...advices.map(a => error(ctrl, d.analysis![color][a.kind], color, a)),
     h('div.advice-summary__acpl', [h('strong', sideData.acpl), h('span', ctrl.trans.noarg('averageCentipawnLoss'))]),
+    // h('div.advice-summary__accuracy', [h('strong', [sideData.accuracy, '%']), h('span.user-link.ulpt', [ctrl.trans.noarg('accuracy'),
+    //                                                                                       h('good',{attrs:{'data-icon': '',
+    //                                                                                       href: '/page/accuracy',
+    //                                                                                       target: '_blank',}},
+    //                                                                                       )
+    //                                                                                     ]),
+
+    //                                   ]),
     h('div.advice-summary__accuracy', [
       h('strong', [sideData.accuracy, '%']),
-      h(
-        'a.text',
-        {
+      h('span', [
+        ctrl.trans.noarg('accuracy'),
+        ' ',
+        h('a', {
           attrs: {
             'data-icon': '',
             href: '/page/accuracy',
             target: '_blank',
           },
-        },
-        ctrl.trans.noarg('accuracy')
-      ),
+        }),
+      ]),
     ]),
   ]);
 }

--- a/ui/analyse/src/view/roundTraining.ts
+++ b/ui/analyse/src/view/roundTraining.ts
@@ -48,7 +48,21 @@ function playerTable(ctrl: AnalyseCtrl, color: Color): VNode {
     h('div.advice-summary__player', [h(`i.is.color-icon.${color}`), renderPlayer(ctrl, color)]),
     ...advices.map(a => error(ctrl, d.analysis![color][a.kind], color, a)),
     h('div.advice-summary__acpl', [h('strong', sideData.acpl), h('span', ctrl.trans.noarg('averageCentipawnLoss'))]),
-    h('div.advice-summary__accuracy', [h('strong', [sideData.accuracy, '%']), h('span', ctrl.trans.noarg('accuracy'))]),
+    h('div.advice-summary__accuracy', [
+      h('strong', [sideData.accuracy, '%']),
+      h(
+        'a.text',
+        {
+          attrs: {
+            'data-color': '#999',
+            'data-icon': '',
+            href: 'https://lichess.org/page/accuracy',
+            target: '_blank',
+          },
+        },
+        ctrl.trans.noarg('accuracy')
+      ),
+    ]),
   ]);
 }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/81013338/193752204-7e9d842c-d8b1-43eb-953a-0d03e37e0777.png)
I added a link and information simple before "accuracy" text, when user click on it, a link to description will be opened in new tab.

Closes #11567
Closes #11593