### PR TITLE
Fix acpl chart cursor in studys again

### DIFF
--- a/ui/@types/lichess/index.d.ts
+++ b/ui/@types/lichess/index.d.ts
@@ -67,7 +67,6 @@ interface Lichess {
     update(data: any, mainline: any[]): void;
     (data: any, mainline: any[], trans: Trans, el: HTMLElement): void;
   };
-  movetimeChart: any;
   playMusic(): any;
   quietMode?: boolean;
   analysis?: any; // expose the analysis ctrl
@@ -259,16 +258,6 @@ interface Window {
   readonly LichessPuzzleNvui?: Nvui;
   readonly LichessAnalyseNvui?: (ctrl: any) => {
     render(): any;
-  };
-  readonly LichessChartGame: {
-    acpl: {
-      (data: any, mainline: Tree.Node[], trans: Trans, el: HTMLElement, hunter: boolean): Promise<void>;
-      update?(data: any, mainline: Tree.Node[]): void;
-    };
-    movetime: {
-      (data: any, trans: Trans, hunter: boolean): Promise<void>;
-      render?(): void;
-    };
   };
   readonly LichessChartRatingHistory?: any;
   readonly LichessKeyboardMove?: any;

--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -169,7 +169,9 @@ export default class AnalyseCtrl {
       if (this.music && set !== 'music') this.music = null;
     });
 
-    lichess.pubsub.on('analysis.change.trigger', this.onChange);
+    lichess.pubsub.on('ply.trigger', () =>
+      lichess.pubsub.emit('ply', this.node.ply, this.tree.lastMainlineNode(this.path).ply === this.node.ply)
+    );
     lichess.pubsub.on('analysis.chart.click', index => {
       this.jumpToIndex(index);
       this.redraw();
@@ -389,7 +391,7 @@ export default class AnalyseCtrl {
       if (this.study) this.study.onJump();
     }
     if (this.music) this.music.jump(this.node);
-    lichess.pubsub.emit('ply', this.node.ply, this.tree.lastMainlineNode(this.path).ply);
+    lichess.pubsub.emit('ply', this.node.ply, this.tree.lastMainlineNode(this.path).ply === this.node.ply);
     this.showGround();
   }
 

--- a/ui/chart/src/division.ts
+++ b/ui/chart/src/division.ts
@@ -1,9 +1,6 @@
-interface Division {
-  middle?: number;
-  end?: number;
-}
+import { Division } from './interface';
 
-export default function (div: Division, trans: Trans) {
+export default function (div: Division | undefined, trans: Trans) {
   const lines = [];
   lines.push({
     color: window.Highcharts.theme.lichess.line.accent,
@@ -12,7 +9,7 @@ export default function (div: Division, trans: Trans) {
     zIndex: 6,
   });
   const textWeak = window.Highcharts.theme.lichess.text.weak;
-  if (div.middle) {
+  if (div?.middle) {
     lines.push({
       label: {
         text: trans('opening'),
@@ -44,7 +41,7 @@ export default function (div: Division, trans: Trans) {
       zIndex: 5,
     });
   }
-  if (div.end)
+  if (div?.end)
     lines.push({
       label: {
         text: trans('endgame'),

--- a/ui/chart/src/interface.ts
+++ b/ui/chart/src/interface.ts
@@ -1,14 +1,55 @@
 import type Highcharts from 'highcharts';
 
-export interface HighchartsHTMLElement extends HTMLElement {
-  highcharts: Highcharts.ChartObject;
-}
-
 export interface PlyChart extends Highcharts.ChartObject {
   firstPly: number;
   selectPly(ply: number, isMainline: boolean): void;
 }
 
-export interface PlyChartHTMLElement extends HTMLElement {
-  highcharts: PlyChart;
+export interface AcplChart extends PlyChart {
+  updateData(d: AnalyseData, mainline: Tree.Node[]): void;
+}
+
+export interface Division {
+  middle?: number;
+  end?: number;
+}
+
+export interface Player {
+  color: 'white' | 'black';
+  blurs?: {
+    bits?: string;
+  };
+}
+
+export interface AnalyseData {
+  player: Player;
+  opponent: Player;
+  treeParts: Tree.Node[];
+  game: {
+    division?: Division;
+    variant: {
+      key: string;
+    };
+    moveCentis?: number[];
+    status: {
+      name: string;
+    };
+  };
+  analysis?: {
+    partial: boolean;
+  };
+  clock?: {
+    running: boolean;
+    initial: number;
+    increment: number;
+  };
+}
+
+declare global {
+  interface Window {
+    readonly LichessChartGame: {
+      acpl(el: HTMLElement, data: AnalyseData, mainline: Tree.Node[], trans: Trans): Promise<AcplChart>;
+      movetime(el: HTMLElement, data: AnalyseData, trans: Trans, hunter: boolean): Promise<PlyChart>;
+    };
+  }
 }

--- a/ui/chart/src/movetime.ts
+++ b/ui/chart/src/movetime.ts
@@ -1,284 +1,285 @@
 import divisionLines from './division';
 import { loadHighcharts, MovePoint, selectPly } from './common';
-import { PlyChartHTMLElement } from './interface';
+import { AnalyseData } from './interface';
 
-const movetime: Window['LichessChartGame']['movetime'] = async (data: any, trans: Trans, hunter: boolean) => {
-  if (!data.game.moveCentis) return; // imported games
+const movetime: Window['LichessChartGame']['movetime'] = async (
+  el: HTMLElement,
+  data: AnalyseData,
+  trans: Trans,
+  hunter: boolean
+) => {
+  const moveCentis = data.game.moveCentis;
+  if (!moveCentis) return; // imported games
   await loadHighcharts('highchart');
-  movetime.render = () => {
-    $('#movetimes-chart:not(.rendered)').each(function (this: PlyChartHTMLElement) {
-      const chartElm = this;
-      $(chartElm).addClass('rendered');
 
-      const area = window.Highcharts.theme.lichess.area;
-      const highlightColor = '#3893E8';
-      const xAxisColor = '#cccccc99';
-      const whiteAreaFill = hunter ? area.white : 'rgba(255, 255, 255, 0.2)';
-      const whiteColumnFill = 'rgba(255, 255, 255, 0.9)';
-      const whiteColumnBorder = '#00000044';
-      const blackAreaFill = hunter ? area.black : 'rgba(0, 0, 0, 0.4)';
-      const blackColumnFill = 'rgba(0, 0, 0, 0.9)';
-      const blackColumnBorder = '#ffffff33';
+  const area = window.Highcharts.theme.lichess.area;
+  const highlightColor = '#3893E8';
+  const xAxisColor = '#cccccc99';
+  const whiteAreaFill = hunter ? area.white : 'rgba(255, 255, 255, 0.2)';
+  const whiteColumnFill = 'rgba(255, 255, 255, 0.9)';
+  const whiteColumnBorder = '#00000044';
+  const blackAreaFill = hunter ? area.black : 'rgba(0, 0, 0, 0.4)';
+  const blackColumnFill = 'rgba(0, 0, 0, 0.9)';
+  const blackColumnBorder = '#ffffff33';
 
-      const moveSeries = {
-        white: [] as MovePoint[],
-        black: [] as MovePoint[],
-      };
-      const totalSeries = {
-        white: [] as MovePoint[],
-        black: [] as MovePoint[],
-      };
-      const labels: string[] = [];
-
-      const tree = data.treeParts;
-      let ply = 0,
-        maxMove = 0,
-        maxTotal = 0,
-        showTotal = !hunter;
-
-      const logC = Math.pow(Math.log(3), 2);
-
-      const blurs = [toBlurArray(data.player), toBlurArray(data.opponent)];
-      if (data.player.color === 'white') blurs.reverse();
-
-      data.game.moveCentis.forEach((centis: number, x: number) => {
-        const node = tree[x + 1];
-        ply = node ? node.ply : ply + 1;
-        const san = node ? node.san : '-';
-
-        const turn = (ply + 1) >> 1;
-        const color = ply & 1;
-        const colorName = color ? 'white' : 'black';
-
-        const y = Math.pow(Math.log(0.005 * Math.min(centis, 12e4) + 3), 2) - logC;
-        maxMove = Math.max(y, maxMove);
-
-        let label = turn + (color ? '. ' : '... ') + san;
-        const movePoint: MovePoint = {
-          x,
-          y: color ? y : -y,
-        };
-
-        if (blurs[color].shift() === '1') {
-          movePoint.marker = {
-            symbol: 'square',
-            radius: 3,
-            lineWidth: '1px',
-            lineColor: highlightColor,
-            fillColor: color ? '#fff' : '#333',
-          };
-          label += ' [blur]';
-        }
-
-        const seconds = (centis / 100).toFixed(centis >= 200 ? 1 : 2);
-        label += '<br />' + trans('nbSeconds', '<strong>' + seconds + '</strong>');
-        moveSeries[colorName].push(movePoint);
-
-        let clock = node ? node.clock : undefined;
-        if (clock == undefined) {
-          if (x < data.game.moveCentis.length - 1) showTotal = false;
-          else if (data.game.status.name === 'outoftime') clock = 0;
-          else if (data.clock) {
-            const prevClock = tree[x - 1] ? tree[x - 1].clock : undefined;
-            if (prevClock) clock = prevClock + data.clock.increment - centis;
-          }
-        }
-        if (clock != undefined) {
-          label += '<br />' + formatClock(clock);
-          maxTotal = Math.max(clock, maxTotal);
-          totalSeries[colorName].push({
-            x,
-            y: color ? clock : -clock,
-          });
-        }
-
-        labels.push(label);
-      });
-
-      const disabled = { enabled: false };
-      const noText = { text: null };
-      const clickableOptions = {
-        events: {
-          click: (event: any) => {
-            if (event.point) lichess.pubsub.emit('analysis.chart.click', event.point.x);
-          },
-        },
-      };
-      const foregrondLineOptions = {
-        ...clickableOptions,
-        color: highlightColor,
-        lineWidth: hunter ? 1 : 2,
-        states: {
-          hover: {
-            lineWidth: hunter ? 1 : 2,
-          },
-        },
-        marker: {
-          radius: 1,
-          states: {
-            hover: {
-              radius: 3,
-              lineColor: highlightColor,
-              fillColor: 'white',
-            },
-            select: {
-              radius: 4,
-              lineColor: highlightColor,
-              fillColor: 'white',
-            },
-          },
-        },
-      };
-
-      chartElm.highcharts = window.Highcharts.chart(chartElm, {
-        credits: disabled,
-        legend: disabled,
-        series: [
-          ...(showTotal
-            ? [
-                {
-                  name: 'White Clock Area',
-                  type: 'area',
-                  yAxis: 1,
-                  data: totalSeries.white,
-                },
-                {
-                  name: 'Black Clock Area',
-                  type: 'area',
-                  yAxis: 1,
-                  data: totalSeries.black,
-                },
-              ]
-            : []),
-          {
-            name: 'White Move Time',
-            type: hunter ? 'area' : 'column',
-            yAxis: 0,
-            data: moveSeries.white,
-            borderColor: whiteColumnBorder,
-          },
-          {
-            name: 'Black Move Time',
-            type: hunter ? 'area' : 'column',
-            yAxis: 0,
-            data: moveSeries.black,
-            borderColor: blackColumnBorder,
-          },
-          ...(showTotal
-            ? [
-                {
-                  name: 'White Clock Line',
-                  type: 'line',
-                  yAxis: 1,
-                  data: totalSeries.white,
-                },
-                {
-                  name: 'Black Clock Line',
-                  type: 'line',
-                  yAxis: 1,
-                  data: totalSeries.black,
-                },
-              ]
-            : []),
-        ],
-        chart: {
-          alignTicks: false,
-          spacing: [2, 0, 2, 0],
-          animation: false,
-          events: {
-            click(e: any) {
-              let ply = Math.round(e.xAxis[0].value);
-              // if the parity of the ply doesn't match the quadrant of the click,
-              // we add the x residual rounded away from zero to correct it
-              if (e.yAxis[0].value < 0 == !(ply & 1)) ply += e.xAxis[0].value < ply ? -1 : 1;
-              lichess.pubsub.emit('analysis.chart.click', ply);
-            },
-          },
-        },
-        tooltip: {
-          formatter: function (this: any) {
-            return labels[this.x];
-          },
-        },
-        plotOptions: {
-          series: {
-            animation: false,
-          },
-          area: {
-            ...(hunter
-              ? foregrondLineOptions
-              : {
-                  ...clickableOptions,
-                  lineWidth: 0,
-                  states: {
-                    hover: {
-                      lineWidth: 0,
-                    },
-                  },
-                  marker: disabled,
-                }),
-            trackByArea: true,
-            fillColor: whiteAreaFill,
-            negativeFillColor: blackAreaFill,
-          },
-          line: foregrondLineOptions,
-          column: {
-            ...clickableOptions,
-            color: whiteColumnFill,
-            negativeColor: blackColumnFill,
-            grouping: false,
-            groupPadding: 0,
-            pointPadding: 0,
-            states: {
-              hover: disabled,
-              select: {
-                enabled: !showTotal,
-                color: highlightColor,
-                borderColor: highlightColor,
-              },
-            },
-          },
-        },
-        title: noText,
-        xAxis: {
-          title: noText,
-          labels: disabled,
-          lineWidth: 0,
-          tickWidth: 0,
-          plotLines: divisionLines(data.game.division, trans),
-          minPadding: showTotal ? -0.015 : 0.01,
-        },
-        yAxis: [
-          {
-            title: noText,
-            min: -maxMove,
-            max: maxMove,
-            labels: disabled,
-            gridLineWidth: 0,
-            plotLines: [
-              {
-                color: xAxisColor,
-                width: 1,
-                value: 0,
-                zIndex: 10,
-              },
-            ],
-          },
-          {
-            title: noText,
-            min: -maxTotal,
-            max: maxTotal,
-            labels: disabled,
-            gridLineWidth: 0,
-          },
-        ],
-      });
-      chartElm.highcharts.firstPly = data.treeParts[0].ply;
-      chartElm.highcharts.selectPly = selectPly;
-    });
-    lichess.pubsub.emit('analysis.change.trigger');
+  const moveSeries = {
+    white: [] as MovePoint[],
+    black: [] as MovePoint[],
   };
-  movetime.render();
+  const totalSeries = {
+    white: [] as MovePoint[],
+    black: [] as MovePoint[],
+  };
+  const labels: string[] = [];
+
+  const tree = data.treeParts;
+  let ply = 0,
+    maxMove = 0,
+    maxTotal = 0,
+    showTotal = !hunter;
+
+  const logC = Math.pow(Math.log(3), 2);
+
+  const blurs = [toBlurArray(data.player), toBlurArray(data.opponent)];
+  if (data.player.color === 'white') blurs.reverse();
+
+  moveCentis.forEach((centis: number, x: number) => {
+    const node = tree[x + 1];
+    ply = node ? node.ply : ply + 1;
+    const san = node ? node.san : '-';
+
+    const turn = (ply + 1) >> 1;
+    const color = ply & 1;
+    const colorName = color ? 'white' : 'black';
+
+    const y = Math.pow(Math.log(0.005 * Math.min(centis, 12e4) + 3), 2) - logC;
+    maxMove = Math.max(y, maxMove);
+
+    let label = turn + (color ? '. ' : '... ') + san;
+    const movePoint: MovePoint = {
+      x,
+      y: color ? y : -y,
+    };
+
+    if (blurs[color].shift() === '1') {
+      movePoint.marker = {
+        symbol: 'square',
+        radius: 3,
+        lineWidth: '1px',
+        lineColor: highlightColor,
+        fillColor: color ? '#fff' : '#333',
+      };
+      label += ' [blur]';
+    }
+
+    const seconds = (centis / 100).toFixed(centis >= 200 ? 1 : 2);
+    label += '<br />' + trans('nbSeconds', '<strong>' + seconds + '</strong>');
+    moveSeries[colorName].push(movePoint);
+
+    let clock = node ? node.clock : undefined;
+    if (clock == undefined) {
+      if (x < moveCentis.length - 1) showTotal = false;
+      else if (data.game.status.name === 'outoftime') clock = 0;
+      else if (data.clock) {
+        const prevClock = tree[x - 1] ? tree[x - 1].clock : undefined;
+        if (prevClock) clock = prevClock + data.clock.increment - centis;
+      }
+    }
+    if (clock != undefined) {
+      label += '<br />' + formatClock(clock);
+      maxTotal = Math.max(clock, maxTotal);
+      totalSeries[colorName].push({
+        x,
+        y: color ? clock : -clock,
+      });
+    }
+
+    labels.push(label);
+  });
+
+  const disabled = { enabled: false };
+  const noText = { text: null };
+  const clickableOptions = {
+    events: {
+      click: (event: any) => {
+        if (event.point) lichess.pubsub.emit('analysis.chart.click', event.point.x);
+      },
+    },
+  };
+  const foregrondLineOptions = {
+    ...clickableOptions,
+    color: highlightColor,
+    lineWidth: hunter ? 1 : 2,
+    states: {
+      hover: {
+        lineWidth: hunter ? 1 : 2,
+      },
+    },
+    marker: {
+      radius: 1,
+      states: {
+        hover: {
+          radius: 3,
+          lineColor: highlightColor,
+          fillColor: 'white',
+        },
+        select: {
+          radius: 4,
+          lineColor: highlightColor,
+          fillColor: 'white',
+        },
+      },
+    },
+  };
+
+  const chart = window.Highcharts.chart(el, {
+    credits: disabled,
+    legend: disabled,
+    series: [
+      ...(showTotal
+        ? [
+            {
+              name: 'White Clock Area',
+              type: 'area',
+              yAxis: 1,
+              data: totalSeries.white,
+            },
+            {
+              name: 'Black Clock Area',
+              type: 'area',
+              yAxis: 1,
+              data: totalSeries.black,
+            },
+          ]
+        : []),
+      {
+        name: 'White Move Time',
+        type: hunter ? 'area' : 'column',
+        yAxis: 0,
+        data: moveSeries.white,
+        borderColor: whiteColumnBorder,
+      },
+      {
+        name: 'Black Move Time',
+        type: hunter ? 'area' : 'column',
+        yAxis: 0,
+        data: moveSeries.black,
+        borderColor: blackColumnBorder,
+      },
+      ...(showTotal
+        ? [
+            {
+              name: 'White Clock Line',
+              type: 'line',
+              yAxis: 1,
+              data: totalSeries.white,
+            },
+            {
+              name: 'Black Clock Line',
+              type: 'line',
+              yAxis: 1,
+              data: totalSeries.black,
+            },
+          ]
+        : []),
+    ],
+    chart: {
+      alignTicks: false,
+      spacing: [2, 0, 2, 0],
+      animation: false,
+      events: {
+        click(e: any) {
+          let ply = Math.round(e.xAxis[0].value);
+          // if the parity of the ply doesn't match the quadrant of the click,
+          // we add the x residual rounded away from zero to correct it
+          if (e.yAxis[0].value < 0 == !(ply & 1)) ply += e.xAxis[0].value < ply ? -1 : 1;
+          lichess.pubsub.emit('analysis.chart.click', ply);
+        },
+      },
+    },
+    tooltip: {
+      formatter: function (this: any) {
+        return labels[this.x];
+      },
+    },
+    plotOptions: {
+      series: {
+        animation: false,
+      },
+      area: {
+        ...(hunter
+          ? foregrondLineOptions
+          : {
+              ...clickableOptions,
+              lineWidth: 0,
+              states: {
+                hover: {
+                  lineWidth: 0,
+                },
+              },
+              marker: disabled,
+            }),
+        trackByArea: true,
+        fillColor: whiteAreaFill,
+        negativeFillColor: blackAreaFill,
+      },
+      line: foregrondLineOptions,
+      column: {
+        ...clickableOptions,
+        color: whiteColumnFill,
+        negativeColor: blackColumnFill,
+        grouping: false,
+        groupPadding: 0,
+        pointPadding: 0,
+        states: {
+          hover: disabled,
+          select: {
+            enabled: !showTotal,
+            color: highlightColor,
+            borderColor: highlightColor,
+          },
+        },
+      },
+    },
+    title: noText,
+    xAxis: {
+      title: noText,
+      labels: disabled,
+      lineWidth: 0,
+      tickWidth: 0,
+      plotLines: divisionLines(data.game.division, trans),
+      minPadding: showTotal ? -0.015 : 0.01,
+    },
+    yAxis: [
+      {
+        title: noText,
+        min: -maxMove,
+        max: maxMove,
+        labels: disabled,
+        gridLineWidth: 0,
+        plotLines: [
+          {
+            color: xAxisColor,
+            width: 1,
+            value: 0,
+            zIndex: 10,
+          },
+        ],
+      },
+      {
+        title: noText,
+        min: -maxTotal,
+        max: maxTotal,
+        labels: disabled,
+        gridLineWidth: 0,
+      },
+    ],
+  });
+  chart.firstPly = data.treeParts[0].ply;
+  chart.selectPly = selectPly.bind(chart);
+  lichess.pubsub.on('ply', chart.selectPly);
+  lichess.pubsub.emit('ply.trigger');
+  return chart;
 };
 
 const toBlurArray = (player: any) => (player.blurs && player.blurs.bits ? player.blurs.bits.split('') : []);

--- a/ui/game/src/interfaces.ts
+++ b/ui/game/src/interfaces.ts
@@ -162,6 +162,7 @@ export interface Ctrl {
 export interface Blurs {
   nb: number;
   percent: number;
+  bits?: string;
 }
 
 export interface Trans {


### PR DESCRIPTION
And do some more refactoring for even more typesafety and less attaching stuff to DOM nodes.

Fixes #11679

The main fix is moving `pubsub.on('ply', (..) => chart.selectPly(...))` into the initializers in the chart module so that it's called when setting them up in a study as well.