### PR TITLE
Add styling for account status on Appeal page

### DIFF
--- a/app/views/appeal/tree.scala
+++ b/app/views/appeal/tree.scala
@@ -281,9 +281,10 @@ object tree {
   def apply(me: User, playban: Boolean)(implicit ctx: Context) =
     bits.layout("Appeal a moderation decision") {
       val query = isGranted(_.Appeals) ?? ctx.req.queryString.toMap
+      val isMarked = playban || me.marks.engine || me.marks.boost || me.marks.troll || me.marks.rankban
       main(cls := "page page-small box box-pad appeal")(
         h1("Appeal"),
-        div(cls := "nav-tree")(
+        div(cls := s"nav-tree${if (isMarked) " marked" else ""}")(
           if (me.disabled || query.contains("alt")) altScreen
           else
             renderNode(

--- a/ui/site/css/_appeal.scss
+++ b/ui/site/css/_appeal.scss
@@ -76,6 +76,18 @@
     font-size: 1.2em;
   }
 
+  .root h2 {
+    padding: 0.7em;
+    text-align: center;
+    background: $c-good;
+    color: $c-good-over;
+  }
+
+  .marked .root h2 {
+    background: $c-bad;
+    color: $c-bad-over;
+  }
+
   .appeal-presets {
     margin-#{$end-direction}: 1em;
   }


### PR DESCRIPTION
On the Appeal page, it may not be immediately clear that the h2 is dynamic text. It looks like a normal page/section header, so it may be skipped over.

| Before | After |
| - | - |
| ![Screenshot from 2022-10-09 14-27-46](https://user-images.githubusercontent.com/271432/194773965-b704e4e1-cf81-4151-820d-e323b0d17b97.png) | ![Screenshot from 2022-10-10 18-05-02](https://user-images.githubusercontent.com/271432/194959563-f5bcaf7a-9d8b-4804-8f06-021d653aedb9.png) |
| ![Screenshot from 2022-10-09 14-30-06](https://user-images.githubusercontent.com/271432/194773991-d0548cfb-afdd-4e4d-9bb4-594bc1ff791b.png) | ![Screenshot from 2022-10-10 18-04-23](https://user-images.githubusercontent.com/271432/194959589-09b284b6-48ab-4049-abab-7e2172622c39.png) |
| ![Screenshot from 2022-10-09 14-28-42](https://user-images.githubusercontent.com/271432/194773996-a79a79ea-1085-43db-9aac-75b778cbfe42.png) | ![Screenshot from 2022-10-10 18-05-15](https://user-images.githubusercontent.com/271432/194959621-3a9006fe-b7ad-4610-96d0-4b8cc8f47cb1.png) |
| ![Screenshot from 2022-10-09 14-30-36](https://user-images.githubusercontent.com/271432/194774000-2a3f3ddb-caa3-4173-b7c8-b35e59d59fa3.png) | ![Screenshot from 2022-10-10 18-04-38](https://user-images.githubusercontent.com/271432/194959640-71023c19-da1e-4d87-b59f-1873c47bc10e.png) |
