### PR TITLE
Show i18n string for scopes

### DIFF
--- a/app/views/account/security.scala
+++ b/app/views/account/security.scala
@@ -93,7 +93,7 @@ object security {
               if (client.scopes.nonEmpty)
                 frag(
                   "Third party application with permissions: ",
-                  client.scopes.map(_.name).mkString(", ")
+                  client.scopes.map(_.toString).mkString(", ")
                 )
               else
                 frag("Third party application using only public data.")


### PR DESCRIPTION
I tried the new team:lead scope (and team:read), and noticed on the security page https://lichess.org/account/security that the scopes were not being rendered correctly:
![scope-object](https://user-images.githubusercontent.com/4084220/195407785-4e59e4c9-9860-4315-8da4-25f0e7d8a12b.png)

With fix in pull request,
![scope-string](https://user-images.githubusercontent.com/4084220/195407784-68651943-bc61-4622-b0fd-84a2038de8b8.png)

Maybe the descriptions of the scopes are supposed to be there instead of the names...?
