### PR TITLE
Remove quote border on transparent theme

### DIFF
--- a/ui/common/css/component/_quote.scss
+++ b/ui/common/css/component/_quote.scss
@@ -6,22 +6,25 @@
     position: relative;
     margin: 0 0.7em;
     padding: 1em 0;
-    border: $border;
-    border-width: 1px 0;
     font-style: italic;
     font-size: 1.1rem;
 
-    &:after {
-      content: '';
-      position: absolute;
-      bottom: -9px;
-      #{$start-direction}: 42px;
-      width: 15px;
-      height: 15px;
-      background: $c-bg-box;
-      border-#{$start-direction}: 2px solid $c-border;
-      border-bottom: 1px solid $c-border;
-      transform: skew(45deg) rotate(-45deg);
+    @if $theme != 'transp' {
+      border: $border;
+      border-width: 1px 0;
+
+      &:after {
+        content: '';
+        position: absolute;
+        bottom: -9px;
+        #{$start-direction}: 42px;
+        width: 15px;
+        height: 15px;
+        background: $c-bg-box;
+        border-#{$start-direction}: 2px solid $c-border;
+        border-bottom: 1px solid $c-border;
+        transform: skew(45deg) rotate(-45deg);
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #11769

Doesn't seem like there's a nice way to make this work with transparency and seems like the border doesn't show up well on most backgrounds anyway so seems best to just remove it.