### PR TITLE
Adjust ui/build script to allow Node.js versions 14.20.*

### DIFF
--- a/ui/build
+++ b/ui/build
@@ -8,7 +8,7 @@ nodever="$(node --version)"
 echo "node: $nodever"
 echo "yarn: $(yarn --version)"
 
-[[ "$nodever" =~ ^(v14\.1[3-9]\.[0-9]+)|(v1[5-8]\.[0-9]+\.[0-9]+)$ ]] || { echo "Node version >=14.13 and <=18 required. Found: $nodever"; exit 1; }
+[[ "$nodever" =~ ^(v14\.((1[3-9])|(2[0-9]+))\.[0-9]+)|(v1[5-8]\.[0-9]+\.[0-9]+)$ ]] || { echo "Node version >=14.13 and <=18 required. Found: $nodever"; exit 1; }
 
 cd "$(git rev-parse --show-toplevel)"
 


### PR DESCRIPTION
When I was setting up my local environment for the first time `ui/build` script failed with:
`Node version >=14.13 and <=18 required. Found: 14.20.1`

The version I have matches the criteria. The problem was that the regular expression we use does not work correctly with two digits numbers. I adjusted it to allow versions `14.2*.*`
