### PR TITLE
Reposition 'Your team boards' text

### DIFF
--- a/app/views/forum/categ.scala
+++ b/app/views/forum/categ.scala
@@ -30,7 +30,9 @@ object categ {
         showCategs(categs.filterNot(_.categ.isTeam)),
         if (categs.exists(_.categ.isTeam))
           frag(
-            h1(cls := "box__top")("Your Team Boards"),
+            boxTop(
+              h1("Your Team Boards")
+            ),
             showCategs(categs.filter(_.categ.isTeam))
           )
       )

--- a/modules/plan/src/main/Currency.scala
+++ b/modules/plan/src/main/Currency.scala
@@ -68,7 +68,7 @@ final class CurrencyApi(
 
   def currencyByCountryCodeOrLang(countryCode: Option[String], lang: Lang): Currency =
     countryCode
-      .flatMap { code => scala.util.Try(new java.util.Locale("", code)).toOption }
+      .flatMap { code => scala.util.Try(new Locale.Builder().setRegion(code).build()).toOption }
       .flatMap(currencyOption)
       .orElse(currencyOption(lang.locale))
       .getOrElse(USD)

--- a/modules/swiss/src/main/SwissNotify.scala
+++ b/modules/swiss/src/main/SwissNotify.scala
@@ -13,7 +13,7 @@ import lila.user.User
 
 final private class SwissNotify(
     swissColl: Coll @@ SwissColl,
-    playerColl: Coll @@ PlayerColl,
+    playerColl: Coll @@ PlayerColl
 )(implicit
     ec: ExecutionContext,
     scheduler: akka.actor.Scheduler


### PR DESCRIPTION
Resolves #11826 

The change here
```
.flatMap { code => scala.util.Try(new Locale.Builder().setRegion(code).build()).toOption }
```

Prevents the deprecation error on JDK 19. `Locale.of` was an alternative but it breaks compatibility with JDK 18