### PR TITLE
ui register web push fix

### DIFF
--- a/app/views/base/layout.scala
+++ b/app/views/base/layout.scala
@@ -302,7 +302,7 @@ object layout {
             )
           },
           dataDev,
-          dataVapid    := vapidPublicKey,
+          dataVapid    := ctx.isAuth option vapidPublicKey,
           dataUser     := ctx.userId,
           dataSoundSet := ctx.currentSoundSet.toString,
           dataSocketDomains,

--- a/ui/site/src/component/serviceWorker.ts
+++ b/ui/site/src/component/serviceWorker.ts
@@ -39,8 +39,8 @@ export default function () {
                       },
                       body: JSON.stringify(sub),
                     }).then(res => {
-                      if (res.ok) store.set('' + Date.now());
-                      else console.log('submitting push subscription failed', res.statusText);
+                      if (res.ok && !res.redirected) store.set('' + Date.now());
+                      else sub.unsubscribe();
                     }),
                   err => {
                     console.log('push subscribe failed', err.message);


### PR DESCRIPTION
The problem:  **Anyone who logs out does not receive web push notifications until up to 12 hours after they log back in (including new users).**  

When the most recent 12 hour localStorage-based WebSubscription reup timer has expired, a client calls /push/subscribe first thing on site load. If they are not logged in, AuthBody redirects the xhr fetch to /signup which returns 200 OK so the client thinks it has succeeded, causing it to reset the 12 hour reup timer.  Meanwhile, the user has no valid web subscription as far as lila is concerned.  If their session survives at least 12 hours beyond that, they will subscribe on the next reload.

This change requires a no redirect 200 to reset the timer.  It would be smart to also not call /push/subscribe unless/until there's a user session.  It is my hope that fixing my sloppy fix will make a great first issue for a new(er) contributor.