### PR TITLE
remove window.unload listener from StrongSocket

### DIFF
--- a/ui/round/src/socket.ts
+++ b/ui/round/src/socket.ts
@@ -49,6 +49,7 @@ function backoff(delay: number, factor: number, callback: Callback): Callback {
 
 export function make(send: SocketSend, ctrl: RoundController): RoundSocket {
   lichess.socket.sign(ctrl.sign);
+  if (ctrl.isPlaying()) window.addEventListener('unload', lichess.socket.destroy);
 
   const reload = (o?: Incoming, isRetry?: boolean) => {
     // avoid reload if possible!

--- a/ui/site/src/component/socket.ts
+++ b/ui/site/src/component/socket.ts
@@ -97,7 +97,6 @@ export default class StrongSocket {
     };
     this.version = version;
     this.pubsub.on('socket.send', this.send);
-    window.addEventListener('unload', this.destroy);
     this.connect();
   }
 


### PR DESCRIPTION
I don't think explicitly closing the socket on `unload` does anything, but having an unload listener [prevents some browser optimizations](https://developer.mozilla.org/en-US/docs/Web/API/Window/unload_event#usage_notes).