### PR TITLE
Fix regression: missing parentheses around rating

### DIFF
--- a/app/templating/GameHelper.scala
+++ b/app/templating/GameHelper.scala
@@ -98,11 +98,12 @@ trait GameHelper { self: I18nHelper with UserHelper with AiHelper with StringHel
           titleTag(user.title ifTrue withTitle map Title.apply),
           user.name,
           withRating option frag(
-            " ",
+            " (",
             player.rating.fold(frag("?")) { rating =>
               if (player.provisional) abbr(title := trans.perfStat.notEnoughRatedGames.txt())(rating, "?")
               else rating
-            }
+            },
+            ")"
           )
         )
       }


### PR DESCRIPTION
Adds parentheses back to player rating in the sidebar ([issue explanation with screenshots in forums](https://lichess.org/forum/lichess-feedback/please-return-back-the-parentheses-around-the-rating)).