### PR TITLE
Fix team page forum section not showing new posts

### DIFF
--- a/modules/forum/src/main/PostRepo.scala
+++ b/modules/forum/src/main/PostRepo.scala
@@ -50,14 +50,14 @@ final class PostRepo(val coll: Coll, filter: Filter = Safe)(implicit
 
   def recentInCategs(nb: Int)(categIds: List[String], langs: List[String]): Fu[List[Post]] =
     coll
-      .find(selectCategs(categIds) ++ selectLangs(langs) ++ selectNotHidden ++ selectNotErased)
+      .find(selectCategs(categIds) ++ selectLangs(langs) ++ selectNotErased)
       .sort($sort.createdDesc)
       .cursor[Post]()
       .list(nb)
 
   def recentInCateg(categId: String, nb: Int): Fu[List[Post]] =
     coll
-      .find(selectCateg(categId) ++ selectNotHidden ++ selectNotErased)
+      .find(selectCateg(categId) ++ selectNotErased)
       .sort($sort.createdDesc)
       .cursor[Post]()
       .list(nb)
@@ -81,7 +81,6 @@ final class PostRepo(val coll: Coll, filter: Filter = Safe)(implicit
   def selectCateg(categId: String)         = $doc("categId" -> categId) ++ trollFilter
   def selectCategs(categIds: List[String]) = $doc("categId" $in categIds) ++ trollFilter
 
-  val selectNotHidden = $doc("hidden" -> false)
   val selectNotErased = $doc("erasedAt" $exists false)
 
   def selectLangs(langs: List[String]) =


### PR DESCRIPTION
Due to #11759 (specifically https://github.com/lichess-org/lila/pull/11759/files#diff-7cf58bc48ad004db530d19f1e8c89de585979ceefbed0e592fdc5a737497cfb5L100)

This means it will now just show the same top posts as the team forum page instead of hiding topics after 10 posts like it was before that PR. And I guess the "feature" button allowed Lichess mods to control what showed up there.

But not sure how much that matters? I guess we could also partially revert that PR and maybe have a feature button for team leaders as well but maybe too much of a niche feature and imo also hard to understand?

I guess an alternative if we do want to keep only showing the first few posts in a topic would be to just limit by the post number in the query but tbh it's not clear to me whether we actually want to do this in the first place. It seems to me that people generally like to see the actual latest posts, at least in team forums.