### PR TITLE
Fix typo in 'tryEnPassant' string

### DIFF
--- a/app/views/site/contact.scala
+++ b/app/views/site/contact.scala
@@ -181,7 +181,7 @@ object contact {
               illegalPawnCapture(),
               frag(
                 p(calledEnPassant()),
-                p(a(href := "/learn#/15")(tryEnPassant()), ".")
+                p(a(href := "/learn#/15")(tryEnPassant()))
               )
             ),
             Leaf(

--- a/translation/source/contact.xml
+++ b/translation/source/contact.xml
@@ -41,7 +41,7 @@
   <string name="howToReportBug">Please describe what the bug looks like, what you expected to happen instead, and the steps to reproduce the bug.</string>
   <string name="illegalPawnCapture">Illegal pawn capture</string>
   <string name="calledEnPassant">It is called "en passant" and is one of the rules of chess.</string>
-  <string name="tryEnPassant">Try this little interactive game to learn more about "en passant"</string>
+  <string name="tryEnPassant">Try this little interactive game to learn more about "en passant".</string>
   <string name="illegalCastling">Illegal or impossible castling</string>
   <string name="castlingPrevented">Castling is only prevented if the king goes through a controlled square.</string>
   <string name="castlingRules">Make sure you understand the castling rules</string>

--- a/translation/source/contact.xml
+++ b/translation/source/contact.xml
@@ -41,7 +41,7 @@
   <string name="howToReportBug">Please describe what the bug looks like, what you expected to happen instead, and the steps to reproduce the bug.</string>
   <string name="illegalPawnCapture">Illegal pawn capture</string>
   <string name="calledEnPassant">It is called "en passant" and is one of the rules of chess.</string>
-  <string name="tryEnPassant">Try this little interactive game to learn more about "en passant".</string>
+  <string name="tryEnPassant">Try this little interactive game to learn more about "en passant"</string>
   <string name="illegalCastling">Illegal or impossible castling</string>
   <string name="castlingPrevented">Castling is only prevented if the king goes through a controlled square.</string>
   <string name="castlingRules">Make sure you understand the castling rules</string>


### PR DESCRIPTION
The full stop was duplicated in the UI:
![A duplicate full stop on the Contact page for "en passant" bug reporting](https://user-images.githubusercontent.com/13908946/201089806-4852775f-b777-409b-b576-d61be087339e.png)

Notably, this change will also have to be applied in the translations.

Alternatively, it could also be removed in the UI code:
<https://github.com/lichess-org/lila/blob/fdeaca9529c9038e758a9294ff2ae31af56affa8/app/views/site/contact.scala#L184>

However, not including the full stop in the URL seems to be more consistent with the other pages.