### PR TITLE
prepare bringing back mobile timeline after lichess-org/lichobile#2230

### DIFF
--- a/modules/api/src/main/Mobile.scala
+++ b/modules/api/src/main/Mobile.scala
@@ -21,9 +21,9 @@ object Mobile {
 
   object Api {
 
-    val currentVersion = ApiVersion(6)
+    val currentVersion = ApiVersion(7)
 
-    val acceptedVersions: Set[ApiVersion] = Set(1, 2, 3, 4, 5, 6) map ApiVersion.apply
+    val acceptedVersions: Set[ApiVersion] = Set(1, 2, 3, 4, 5, 6, 7) map ApiVersion.apply
 
     def requestVersion(req: RequestHeader): Option[ApiVersion] =
       HTTPRequest apiVersion req filter acceptedVersions.contains


### PR DESCRIPTION
The timeline API is currently disabled using the `API timeline entries to serve` runtime setting, because there was an XSS vulnerability in the mobile app (lichess-org/lichobile#2212).

After lichess-org/lichobile#2230 we can now bring it back, but only on the fixed version. So some breaking change is required that keeps it disabled on older versions. For example, this.

cc @jas14 