### PR TITLE
Analysis page settings slider styling

### DIFF
--- a/ui/analyse/css/_action-menu.scss
+++ b/ui/analyse/css/_action-menu.scss
@@ -102,14 +102,10 @@
 
     input[type='range'] {
       flex: 1 4 auto;
-      padding-#{$start-direction}: 1em;
+      padding: 0;
       height: 1.6em;
       width: 100%;
       margin: 0 1ch;
-
-      &[min='0'] {
-        padding: 0;
-      }
     }
 
     .range_value {


### PR DESCRIPTION
On the [Analysis page](https://lichess.org/analysis) options, the CPUs and Memory range sliders don't show as 100% when you max out the values.

Before:
![before](https://user-images.githubusercontent.com/271432/202078703-1c9fb6ac-538e-4134-a145-e1177aa95473.png)

After:
![after](https://user-images.githubusercontent.com/271432/202078714-1a7fccb8-358a-4fca-925a-1699b2128ec8.png)
