### PR TITLE
404 - Community Blogs - when (re-)selecting "All Languages"

### DIFF
--- a/app/views/ublog/index.scala
+++ b/app/views/ublog/index.scala
@@ -97,7 +97,10 @@ object index {
                 langSelections
                   .map { case (language, name) =>
                     a(
-                      href := routes.Ublog.communityLang(language),
+                      href := ( language match {
+                        case "all" => routes.Ublog.communityAll()
+                        case _     => routes.Ublog.communityLang(language)
+                      }),
                       cls  := (language == lang.fold("all")(_.language)).option("current")
                     )(name)
                   }

--- a/app/views/ublog/index.scala
+++ b/app/views/ublog/index.scala
@@ -97,11 +97,11 @@ object index {
                 langSelections
                   .map { case (language, name) =>
                     a(
-                      href := ( language match {
+                      href := (language match {
                         case "all" => routes.Ublog.communityAll()
                         case _     => routes.Ublog.communityLang(language)
                       }),
-                      cls  := (language == lang.fold("all")(_.language)).option("current")
+                      cls := (language == lang.fold("all")(_.language)).option("current")
                     )(name)
                   }
               ),


### PR DESCRIPTION
1. Browse to https://lichess.org/blog/community
`/blog/community`
2. Optional - Click the Language filter drop-down box and then select "English"
`/en/blog/community`
3. Click the Language filter drop-down box and then select "All languages"
`/all/blog/community` 404

This fix proposal routes 'language' "all" to the base route `/blog/community`