### PR TITLE
Fix ban button on IP/print pages

### DIFF
--- a/app/views/mod/search.scala
+++ b/app/views/mod/search.scala
@@ -69,6 +69,7 @@ object search:
                 )(if (blocked) "Banned" else "Ban this print")
               )
             else if (blocked) div(cls := "banned")("BANNED")
+            else emptyFrag
           ),
           isGranted(_.Admin) option div(cls := "box__pad")(
             h2("User agents"),
@@ -110,6 +111,7 @@ object search:
                 )(if (blocked) "Banned" else "Ban this IP")
               )
             else if (blocked) div(cls := "banned")("BANNED")
+            else emptyFrag
           ),
           isGranted(_.Admin) option div(cls := "box__pad")(
             h2("User agents"),


### PR DESCRIPTION
I guess this is some obscure Scala 3 change that `if`s without an `else` are now statements/return unit or something?

Did a cursory search and didn't find any other cases like this in `app/views`.