### PR TITLE
Add embed route for puzzles with zen mode enforced

### DIFF
--- a/app/views/base/layout.scala
+++ b/app/views/base/layout.scala
@@ -113,6 +113,14 @@ object layout:
   <a data-icon="" id="zentog" class="text fbt active">${trans.preferences.zenMode.txt()}</a>
 </div>""")
 
+  private def getZenZone(zen: Boolean)(implicit ctx: Context): Option[scalatags.Text.RawFrag] =
+  {
+    if (zen)
+      return None
+    else
+      return Some(zenZone)
+  }
+
   private def dasher(me: lila.user.User) =
     div(cls := "dasher")(
       a(id := "user_tag", cls := "toggle link", href := routes.Auth.logoutGet)(me.username),
@@ -232,6 +240,7 @@ object layout:
       chessground: Boolean = true,
       zoomable: Boolean = false,
       zenable: Boolean = false,
+      zen: Boolean = false,
       csp: Option[ContentSecurityPolicy] = None,
       wrapClass: String = "",
       atomLinkTag: Option[Tag] = None,
@@ -291,7 +300,7 @@ object layout:
               baseClass              -> true,
               "dark-board"           -> (ctx.pref.bg == lila.pref.Pref.Bg.DARKBOARD),
               "piece-letter"         -> ctx.pref.pieceNotationIsLetter,
-              "zen"                  -> ctx.pref.isZen,
+              "zen"                  -> (if (zen) zen else ctx.pref.isZen),
               "blind-mode"           -> ctx.blind,
               "kid"                  -> ctx.kid,
               "mobile"               -> ctx.isMobileBrowser,
@@ -322,7 +331,7 @@ object layout:
             .get(ctx.req)
             .ifTrue(ctx.isAnon)
             .map(views.html.auth.bits.checkYourEmailBanner(_)),
-          zenable option zenZone,
+          zenable option getZenZone(zen),
           siteHeader.apply,
           div(
             id := "main-wrap",

--- a/app/views/lobby/home.scala
+++ b/app/views/lobby/home.scala
@@ -122,7 +122,7 @@ object home:
           )
         },
         puzzle map { p =>
-          views.html.puzzle.embed.dailyLink(p)(ctx.lang)(cls := "lobby__puzzle")
+          views.html.puzzle.dailyEmbed.dailyLink(p)(ctx.lang)(cls := "lobby__puzzle")
         },
         ctx.noBot option bits.underboards(tours, simuls, leaderboard, tournamentWinners),
         bits.lastPosts(lastPost, ublogPosts),

--- a/app/views/puzzle/dailyEmbed.scala
+++ b/app/views/puzzle/dailyEmbed.scala
@@ -1,0 +1,35 @@
+package views.html.puzzle
+
+import controllers.routes
+import play.api.i18n.Lang
+
+import lila.app.templating.Environment.{ given, * }
+import lila.app.ui.EmbedConfig
+import lila.app.ui.ScalatagsTemplate.{ *, given }
+import lila.puzzle.DailyPuzzle
+
+object embed:
+
+  import EmbedConfig.implicits.*
+
+  def apply(daily: DailyPuzzle.WithHtml)(implicit config: EmbedConfig) =
+    views.html.base.embed(
+      title = "lichess.org chess puzzle",
+      cssModule = "tv.embed"
+    )(
+      dailyLink(daily)(config.lang)(
+        targetBlank,
+        id  := "daily-puzzle",
+        cls := "embedded"
+      ),
+      jsModule("puzzle.embed")
+    )
+
+  def dailyLink(daily: DailyPuzzle.WithHtml)(implicit lang: Lang) = a(
+    href  := routes.Puzzle.daily,
+    title := trans.puzzle.clickToSolve.txt()
+  )(
+    span(cls := "text")(trans.puzzle.puzzleOfTheDay()),
+    raw(daily.html),
+    span(cls := "text")(daily.puzzle.color.fold(trans.whitePlays, trans.blackPlays)())
+  )

--- a/conf/routes
+++ b/conf/routes
@@ -152,6 +152,7 @@ GET   /training/new                    controllers.Puzzle.mobileBcNew
 GET   /training/$numericalId<\d{6,}>/load      controllers.Puzzle.mobileBcLoad(numericalId: Long)
 POST  /training/$numericalId<\d{6,}>/vote      controllers.Puzzle.mobileBcVote(numericalId: Long)
 GET   /training/:angleOrId             controllers.Puzzle.show(angleOrId)
+GET   /training/embed/:angleOrId              controllers.Puzzle.embed(angleOrId)
 GET   /training/:angle/$color<white|black|random> controllers.Puzzle.angleAndColor(angle, color)
 GET   /training/:angle/$id<\w{5}>      controllers.Puzzle.showWithAngle(angle, id)
 POST  /training/$numericalId<\d{6,}>/round2    controllers.Puzzle.mobileBcRound(numericalId: Long)


### PR DESCRIPTION
In response to #11337 , @JBaker05 and I created a route, controller, and view for embedding puzzles. Much of the controller and view was recycled from the controller and view for the existing puzzles page. After this, we developed a way to enforce zen mode for this route so that many of the extraneous elements that one would not want to see on the embedded version of this page will not be visible. The following is a screen recording of how the iframe behaves locally:
https://user-images.githubusercontent.com/59403072/204429083-0452b0be-91e1-4dc1-a871-ded2dd5b9919.mov

We are looking for some feedback on the work we have done so far, particularly with regards to the route, controller, and view for the embed endpoint. Moreover, we understand that while this works locally, we will need to set the x-frame-options of this route to SAMEORIGIN in order for this to work in production. Additionally, while zen mode masks many of the extraneous elements, it might not be the preferred method for handling this, so we would appreciate guidance in the form of a general plan and/or code pointers on how to handle this more robustly by modifying CSS and/or TS files. For instance, such a method could remove the black bars at the top and bottom of the view as seen in the above recording.
