### PR TITLE
Fix timeline json response for mobile app

### DIFF
--- a/app/controllers/Timeline.scala
+++ b/app/controllers/Timeline.scala
@@ -32,7 +32,7 @@ final class Timeline(env: Env) extends LilaController(env):
             entries <- env.timeline.entryApi
               .moreUserEntries(me.id, Max(getInt("nb") | 0 atMost env.apiTimelineSetting.get()))
             users <- env.user.lightUserApi.asyncManyFallback(entries.flatMap(_.userIds).distinct)
-            userMap = users.view.map { u => u.id -> u }.toMap
+            userMap = users.view.map { u => u.id.value -> u }.toMap
           } yield Ok(Json.obj("entries" -> entries, "users" -> userMap))
       )
     }


### PR DESCRIPTION
FIxes lichess-org/lichobile#2264

Using `UserId`s as keys causes a different serialization (as list of pairs instead of an object). Not sure there's a better way to fix this.