### PR TITLE
Add two buttons for random selection of piece set and board theme

### DIFF
--- a/ui/dasher/src/piece.ts
+++ b/ui/dasher/src/piece.ts
@@ -59,7 +59,17 @@ export function view(ctrl: PieceCtrl): VNode {
 
   return h('div.sub.piece.' + ctrl.dimension(), [
     header(ctrl.trans.noarg('pieceSet'), () => ctrl.open('links')),
-    h('div.list', d.list.map(pieceView(d.current, ctrl.set, ctrl.dimension() == 'd3'))),
+    h('div.list', [
+      h(
+        'button.text',
+        {
+          hook: bind('click', () => ctrl.set(randomPiece(d.list))),
+          attrs: { title: 'Random', type: 'button' },
+        },
+        'Random'
+      ),
+      h('div.list', d.list.map(pieceView(d.current, ctrl.set, ctrl.dimension() == 'd3'))),
+    ]),
   ]);
 }
 
@@ -97,4 +107,12 @@ function applyPiece(t: Piece, list: Piece[], is3d: boolean) {
     document.body.dataset.pieceSet = t;
   }
   lichess.pubsub.emit('theme.change');
+}
+
+function randomInt(min: number, max: number) {
+  return Math.floor(min + Math.random() * (max - min));
+}
+
+function randomPiece(list: Piece[]) {
+  return list[randomInt(0, list.length)];
 }

--- a/ui/dasher/src/theme.ts
+++ b/ui/dasher/src/theme.ts
@@ -59,7 +59,17 @@ export function view(ctrl: ThemeCtrl): VNode {
 
   return h('div.sub.theme.' + ctrl.dimension(), [
     header(ctrl.trans.noarg('boardTheme'), () => ctrl.open('links')),
-    h('div.list', d.list.map(themeView(d.current, ctrl.set))),
+    h('div.list', [
+      h(
+        'button.text',
+        {
+          hook: bind('click', () => ctrl.set(randomTheme(d.list))),
+          attrs: { title: 'Random', type: 'button' },
+        },
+        'Random'
+      ),
+      h('div.list', d.list.map(themeView(d.current, ctrl.set))),
+    ]),
   ]);
 }
 
@@ -80,4 +90,12 @@ function applyTheme(t: Theme, list: Theme[], is3d: boolean) {
   $('body').removeClass(list.join(' ')).addClass(t);
   if (!is3d) document.body.dataset.boardTheme = t;
   lichess.pubsub.emit('theme.change');
+}
+
+function randomInt(min: number, max: number) {
+  return Math.floor(min + Math.random() * (max - min));
+}
+
+function randomTheme(list: Theme[]) {
+  return list[randomInt(0, list.length)];
 }


### PR DESCRIPTION
The change closes #11912.

The user must click on the button if he wants to have a new random board theme or piece set. Reloading the page does not generate a new random board theme or piece set. 

There are two UI issues. 

1. The buttons don't use the whole available space in the horizontal direction. 
2. The two buttons look different.

![random_board_theme](https://user-images.githubusercontent.com/38296271/206908067-6a2901b7-cb9b-46a1-8dfc-baae30a0f664.png)
![random_piece_set](https://user-images.githubusercontent.com/38296271/206908076-4b37fe7a-6c01-4bb8-89ae-011e6fc80cd1.png)
