### PR TITLE
Temporarily read any mod stuff from primary

### DIFF
--- a/modules/db/src/main/dsl.scala
+++ b/modules/db/src/main/dsl.scala
@@ -405,7 +405,11 @@ object dsl extends dsl with Handlers:
 
     def secondaryPreferred = coll withReadPreference ReadPreference.secondaryPreferred
     def secondary          = coll withReadPreference ReadPreference.secondary
-    def temporarilyPrimary = coll withReadPreference temporarilyPrimary
+
+    // #TODO FIXME
+    // should be secondaryPreferred
+    // https://github.com/ReactiveMongo/ReactiveMongo/issues/1185
+    def temporarilyPrimary = coll withReadPreference ReadPreference.primary
 
     def ext = this
 

--- a/modules/db/src/main/dsl.scala
+++ b/modules/db/src/main/dsl.scala
@@ -409,7 +409,7 @@ object dsl extends dsl with Handlers:
     // #TODO FIXME
     // should be secondaryPreferred
     // https://github.com/ReactiveMongo/ReactiveMongo/issues/1185
-    def temporarilyPrimary = coll withReadPreference ReadPreference.primary
+    def tempPrimary = coll withReadPreference ReadPreference.primary
 
     def ext = this
 

--- a/modules/db/src/main/dsl.scala
+++ b/modules/db/src/main/dsl.scala
@@ -405,6 +405,7 @@ object dsl extends dsl with Handlers:
 
     def secondaryPreferred = coll withReadPreference ReadPreference.secondaryPreferred
     def secondary          = coll withReadPreference ReadPreference.secondary
+    def temporarilyPrimary = coll withReadPreference temporarilyPrimary
 
     def ext = this
 

--- a/modules/irwin/src/main/IrwinApi.scala
+++ b/modules/irwin/src/main/IrwinApi.scala
@@ -55,7 +55,7 @@ final class IrwinApi(
     def withPovs(user: User): Fu[Option[IrwinReport.WithPovs]] =
       get(user) flatMap {
         _ ?? { report =>
-          gameRepo.gamesFromSecondary(report.games.map(_.gameId)) dmap { games =>
+          gameRepo.gamesTemporarilyFromPrimary(report.games.map(_.gameId)) dmap { games =>
             val povs = games.flatMap { g =>
               Pov(g, user) map { g.id -> _ }
             }.toMap

--- a/modules/mod/src/main/Gamify.scala
+++ b/modules/mod/src/main/Gamify.scala
@@ -104,7 +104,7 @@ final class Gamify(
 
   private def actionLeaderboard(after: DateTime, before: Option[DateTime]): Fu[List[ModCount]] =
     logRepo.coll
-      .aggregateList(maxDocs = 100, readPreference = ReadPreference.secondaryPreferred) { framework =>
+      .aggregateList(maxDocs = 100, readPreference = temporarilyPrimary) { framework =>
         import framework.*
         Match(
           $doc(
@@ -128,7 +128,7 @@ final class Gamify(
     reportApi.coll
       .aggregateList(
         maxDocs = Int.MaxValue,
-        readPreference = ReadPreference.secondaryPreferred
+        readPreference = temporarilyPrimary
       ) { framework =>
         import framework.*
         Match(

--- a/modules/mod/src/main/ModActivity.scala
+++ b/modules/mod/src/main/ModActivity.scala
@@ -44,7 +44,7 @@ final class ModActivity(repo: ModlogRepo, reportApi: lila.report.ReportApi, cach
     repo.coll
       .aggregateList(
         maxDocs = maxDocs,
-        readPreference = ReadPreference.secondaryPreferred
+        readPreference = temporarilyPrimary
       ) { framework =>
         import framework.*
         def dateToString(field: String): Bdoc =

--- a/modules/mod/src/main/ModQueueStats.scala
+++ b/modules/mod/src/main/ModQueueStats.scala
@@ -38,7 +38,7 @@ final class ModQueueStats(
   private def compute(period: Period): Fu[Result] =
     repo.coll
       .find($doc("_id" $gte dateFormat.print(Period dateSince period)))
-      .cursor[Bdoc](ReadPreference.secondaryPreferred)
+      .cursor[Bdoc](temporarilyPrimary)
       .listAll()
       .map { docs =>
         for {

--- a/modules/mod/src/main/ModlogApi.scala
+++ b/modules/mod/src/main/ModlogApi.scala
@@ -332,14 +332,14 @@ final class ModlogApi(repo: ModlogRepo, userRepo: UserRepo, ircApi: IrcApi)(usin
     )
 
   def recentBy(mod: Mod) =
-    coll.secondaryPreferred
+    coll.temporarilyPrimary
       .find($doc("mod" -> mod.id))
       .sort($sort desc "date")
       .cursor[Modlog]()
       .list(100)
 
   def addModlog(users: List[User]): Fu[List[UserWithModlog]] =
-    coll.secondaryPreferred
+    coll.temporarilyPrimary
       .find(
         $doc(
           "user" $in users.filter(_.marks.value.nonEmpty).map(_.id),

--- a/modules/mod/src/main/ModlogApi.scala
+++ b/modules/mod/src/main/ModlogApi.scala
@@ -332,14 +332,14 @@ final class ModlogApi(repo: ModlogRepo, userRepo: UserRepo, ircApi: IrcApi)(usin
     )
 
   def recentBy(mod: Mod) =
-    coll.temporarilyPrimary
+    coll.tempPrimary
       .find($doc("mod" -> mod.id))
       .sort($sort desc "date")
       .cursor[Modlog]()
       .list(100)
 
   def addModlog(users: List[User]): Fu[List[UserWithModlog]] =
-    coll.temporarilyPrimary
+    coll.tempPrimary
       .find(
         $doc(
           "user" $in users.filter(_.marks.value.nonEmpty).map(_.id),

--- a/modules/playban/src/main/PlaybanApi.scala
+++ b/modules/playban/src/main/PlaybanApi.scala
@@ -168,7 +168,7 @@ final class PlaybanApi(
   def hasCurrentBan(userId: UserId): Fu[Boolean] = currentBan(userId).map(_.isDefined)
 
   def bans(userIds: List[UserId]): Fu[Map[UserId, Int]] =
-    coll.aggregateList(Int.MaxValue, ReadPreference.secondaryPreferred) { framework =>
+    coll.aggregateList(Int.MaxValue, temporarilyPrimary) { framework =>
       import framework.*
       Match($inIds(userIds) ++ $doc("b" $exists true)) -> List(
         Project($doc("bans" -> $doc("$size" -> "$b")))

--- a/modules/report/src/main/ReportApi.scala
+++ b/modules/report/src/main/ReportApi.scala
@@ -407,9 +407,9 @@ final class ReportApi(
         coll
           .find($doc("atoms.by" -> user.id))
           .sort(sortLastAtomAt)
-          .cursor[Report](ReadPreference.secondaryPreferred)
+          .cursor[Report](temporarilyPrimary)
           .list(nb)
-      about <- recent(Suspect(user), nb, ReadPreference.secondaryPreferred)
+      about <- recent(Suspect(user), nb, temporarilyPrimary)
     } yield Report.ByAndAbout(by, Room.filterGranted(mod, about))
 
   def currentCheatScore(suspect: Suspect): Fu[Option[Report.Score]] =

--- a/modules/security/src/main/UserLogins.scala
+++ b/modules/security/src/main/UserLogins.scala
@@ -100,7 +100,7 @@ final class UserLoginsApi(
       max: Int
   ): Fu[List[OtherUser[User]]] =
     ipSet.nonEmpty ?? store.coll
-      .aggregateList(max, readPreference = ReadPreference.secondaryPreferred) { implicit framework =>
+      .aggregateList(max, readPreference = temporarilyPrimary) { implicit framework =>
         import framework.*
         import FingerHash.given
         Match(

--- a/modules/user/src/main/UserRepo.scala
+++ b/modules/user/src/main/UserRepo.scala
@@ -483,7 +483,7 @@ final class UserRepo(val coll: Coll)(using ec: scala.concurrent.ExecutionContext
       users: List[U]
   )(using idOf: UserIdOf[U], r: BSONHandler[User]): Fu[List[User.WithEmails]] =
     coll
-      .list[Bdoc]($inIds(users.map(idOf.apply)), ReadPreference.secondaryPreferred)
+      .list[Bdoc]($inIds(users.map(idOf.apply)), temporarilyPrimary)
       .map { docs =>
         for {
           doc  <- docs
@@ -503,7 +503,7 @@ final class UserRepo(val coll: Coll)(using ec: scala.concurrent.ExecutionContext
         $inIds(ids),
         $doc(F.verbatimEmail -> true, F.email -> true, F.prevEmail -> true).some
       )
-      .cursor[Bdoc](ReadPreference.secondaryPreferred)
+      .cursor[Bdoc](temporarilyPrimary)
       .listAll()
       .map { docs =>
         for


### PR DESCRIPTION
Primarily to fix all the sporadic mod zone failures.

I also changed it for some `aggregateList` calls but in hindsight, not sure if those actually do have failures like the cursors?

Though on the other hand, not sure if https://github.com/lichess-org/lila/blob/master/modules/mod/src/main/ModQueueStats.scala/#L41 alone explains all the mod stats/hall of fame issues.

Also, there are still a few irwin/kaladin related cursors but I don't know if there actually have been any issues with those.