### PR TITLE
Update value in TournamentForm

### DIFF
--- a/modules/tournament/src/main/TournamentForm.scala
+++ b/modules/tournament/src/main/TournamentForm.scala
@@ -129,7 +129,7 @@ object TournamentForm:
   val clockIncrementDefault = IncrementSeconds(0)
   val clockIncrementChoices = options(IncrementSeconds raw clockIncrements, "%d second{s}")
 
-  val minutes       = (20 to 60 by 5) ++ (70 to 120 by 10) ++ (150 to 360 by 30) ++ (420 to 600 by 60) :+ 720
+  val minutes       = (20 to 60 by 5) ++ (70 to 120 by 10) ++ (150 to 360 by 30) ++ (420 to 600 by 60) :+ 720 :+ 1440
   val minuteDefault = 45
   val minuteChoices = options(minutes, "%d minute{s}")
 


### PR DESCRIPTION
In TournamentForm the max value for 'minutes' is 720 while in the tournament CrudForm it is 1440. There is no reason for it to be set at 1440 if it's not possible to go beyond 720.