### PR TITLE
Fix iPad faking Mac detection and handle limited max wasm memory better

### DIFF
--- a/ui/ceval/src/platform.ts
+++ b/ui/ceval/src/platform.ts
@@ -56,13 +56,13 @@ export function detectPlatform(
     : 1;
 
   // the numbers returned by maxHashMB seem small, but who knows if wasm stockfish performance even
-  // scales like native stockfish with increasing hash.  prefer smaller, non-crashing values
+  // scales like native stockfish with increasing hash. prefer smaller, non-crashing values
   // steer the high performance crowd towards external engine as it gets better
   const maxHashMB = (): number => {
     let maxHash = 256; // this is conservative but safe, mostly desktop firefox / mac safari users here
     if (navigator.deviceMemory) maxHash = pow2floor(navigator.deviceMemory * 128); // chrome/edge/opera
     else if (isAndroid()) maxHash = 64; // budget androids are easy to crash @ 128
-    else if (isIPad()) maxHash = 64; // ipados safari pretends to be desktop but acts more like iphone
+    else if (isIPad()) maxHash = 64; // iPadOS safari pretends to be desktop but acts more like iphone
     else if (isIOS()) maxHash = 32;
     return maxHash;
   };

--- a/ui/ceval/src/util.ts
+++ b/ui/ceval/src/util.ts
@@ -24,8 +24,18 @@ export const pow2floor = (n: number) => {
   return pow2;
 };
 
-export const sharedWasmMemory = (initial: number, maximum: number): WebAssembly.Memory =>
-  new WebAssembly.Memory({ shared: true, initial, maximum });
+export const sharedWasmMemory = (initial: number, maximum: number): WebAssembly.Memory => {
+  while (true) {
+    try {
+      return new WebAssembly.Memory({ shared: true, initial, maximum });
+    } catch (e) {
+      if (e instanceof RangeError) {
+        if (initial === maximum) throw e;
+        maximum = Math.max(initial, Math.floor(maximum / 2));
+      } else throw e;
+    }
+  }
+};
 
 export function defaultDepth(technology: CevalTechnology, threads: number, multiPv: number): number {
   const extraDepth = Math.min(Math.max(threads - multiPv, 0), 6);

--- a/ui/common/src/mobile.ts
+++ b/ui/common/src/mobile.ts
@@ -48,9 +48,10 @@ export const isMobile = (): boolean => isAndroid() || isIOS();
 
 export const isAndroid = (): boolean => /Android/.test(navigator.userAgent);
 
-export const isIOS = (): boolean => /iPad|iPhone|iPod/.test(navigator.userAgent) || isIPad();
+export const isIOS = (): boolean => /iPhone|iPod/.test(navigator.userAgent) || isIPad();
 
-export const isIPad = (): boolean => navigator?.maxTouchPoints > 2 && /MacIntel/.test(navigator.userAgent);
+// some newer iPads pretend to be Macs, hence checking for "Macintosh"
+export const isIPad = (): boolean => navigator?.maxTouchPoints > 2 && /iPad|Macintosh/.test(navigator.userAgent);
 
 const hasMouse = memoize<boolean>(() => window.matchMedia('(hover: hover) and (pointer: fine)').matches);
 


### PR DESCRIPTION
Broken by #12005 (changed navigator.platform to userAgent which needs to check for "Macintosh" instead of "MacIntel")
Fixes #12049

