### PR TITLE
Make stuff called by the mod leaderboard use temporarilyPrimary

### DIFF
--- a/modules/user/src/main/UserRepo.scala
+++ b/modules/user/src/main/UserRepo.scala
@@ -41,7 +41,7 @@ final class UserRepo(val coll: Coll)(using ec: scala.concurrent.ExecutionContext
 
   def enabledByIds[U](us: Iterable[U])(using idOf: UserIdOf[U]): Fu[List[User]] = {
     val ids = us.map(idOf.apply).filter(User.noGhost)
-    coll.list[User](enabledSelect ++ $inIds(ids), ReadPreference.secondaryPreferred)
+    coll.list[User](enabledSelect ++ $inIds(ids), temporarilyPrimary)
   }
 
   def byIdOrGhost(id: UserId): Fu[Option[Either[LightUser.Ghost, User]]] =


### PR DESCRIPTION
I think this is probably the remaining part that's causing only some mods to show up? And it doesn't crash bc it uses Cursor.ContOnError?

Also used by [favorite opponent](https://github.com/lichess-org/lila/blame/master/modules/game/src/main/FavoriteOpponents.scala/#L23) though. Not sure whether that's an issue?