### PR TITLE
Fix pgn viewer light theme

### DIFF
--- a/ui/common/css/component/_lichess-pgn-viewer.scss
+++ b/ui/common/css/component/_lichess-pgn-viewer.scss
@@ -1,13 +1,22 @@
 $lpv-site-hue: 37;
+$lpv-accent: $c-primary;
+$lpv-accent-over: $c-primary-over;
 $lpv-bg: $c-bg-zebra;
 $lpv-bg-controls: $lpv-bg;
 $lpv-bg-movelist: $lpv-bg;
-$lpv-bg-variation: hsl($c-site-hue, 5%, 15%) !default;
-$lpv-bg-pane: hsla(0, 0%, 0%, 0.9);
-$lpv-accent: $c-primary;
-$lpv-accent-over: $c-primary-over;
-$lpv-font-accent: mix($lpv-bg, hsl(0, 0%, 65%), 20%);
+$lpv-bg-variation: $c-bg-zebra2;
+$lpv-bg-pane: fade-out($lpv-bg, 0.01);
+$lpv-font: $c-font;
 $lpv-font-shy: $c-font-dim;
+$lpv-font-accent: mix($lpv-bg, $c-font, 20%);
+$lpv-border: $c-border;
+
+$lpv-inaccuracy: $c-inaccuracy;
+$lpv-mistake: $c-mistake;
+$lpv-blunder: $c-blunder;
+$lpv-good-move: $c-good;
+$lpv-brilliant: $c-brilliant;
+$lpv-interesting: $c-interesting;
 
 @import '../../node_modules/lichess-pgn-viewer/scss/lichess-pgn-viewer.lib';
 


### PR DESCRIPTION
Primarily to fix the PGN display.

Not sure about the menu background but to make the black text in the light theme work the bg has to be light and to make it clear and readable, it needs to be rather opaque. Alternative would be to give it a separate style in lpv.

Also, in dark mode, the variations and comments are now lighter than the moves (comparing the before and after, it weirdly looks like the colors have been swapped but that's just an illusion, the moves still have the same background color, though the font is slightly lighter). Tbh I think I slightly prefer how it looked before but on the other hand, this is how it looks on the analysis board as well, so not sure.

Also re-ordered the variables to match the definitions in lpv.

|Before|After|
|:--:|:--:|
|<img width="665" alt="dark_before" src="https://user-images.githubusercontent.com/19309705/208640908-4b1a562c-7ca6-4d05-b5b8-86afb8ede603.png">|<img width="667" alt="dark_after" src="https://user-images.githubusercontent.com/19309705/208640812-adcd735f-cc3e-4b16-8a94-3cce7accdc3b.png">|
|<img width="668" alt="dark_panel_before" src="https://user-images.githubusercontent.com/19309705/208640901-dce9d111-9d34-426f-9918-3a644596828a.png">|<img width="666" alt="dark_panel_after" src="https://user-images.githubusercontent.com/19309705/208640802-75412b06-9727-4c2c-b910-5e6a4361fa9a.png">|
|<img width="668" alt="light_before" src="https://user-images.githubusercontent.com/19309705/208640892-d4210608-e12a-4b39-b060-141c829ff525.png">|<img width="668" alt="light_after" src="https://user-images.githubusercontent.com/19309705/208640857-5911a26a-c94d-45a2-a11f-538116e8408a.png">|
|<img width="666" alt="light_pgn_before" src="https://user-images.githubusercontent.com/19309705/208640867-26702245-5937-41ba-b541-3479f8b03afb.png">|<img width="666" alt="light_pgn_after" src="https://user-images.githubusercontent.com/19309705/208640819-16e16194-d10b-4f98-a227-4cc852f64f8b.png">|
|<img width="665" alt="light_panel_before" src="https://user-images.githubusercontent.com/19309705/208640885-ad26af29-4bdc-4f4d-a46e-72ae83fa6500.png">|<img width="666" alt="light_panel_after" src="https://user-images.githubusercontent.com/19309705/208640847-9bddde5d-6a62-4827-8d79-1ca109c60607.png">|
