### PR TITLE
Fix rating refund notification

### DIFF
--- a/translation/source/site.xml
+++ b/translation/source/site.xml
@@ -873,7 +873,7 @@ computer analysis, game chat and shareable URL.</string>
   <string name="resVsX">%1$s vs %2$s</string>
   <string name="someoneReviewedYourCoachProfile">Someone reviewed your coach profile.</string>
   <string name="newPendingReview">New pending review</string>
-  <string name="lostAgainstTOSViolator">You lost to someone who violated the Lichess TOS</string>
+  <string name="lostAgainstTOSViolator">You lost rating points to someone who violated the Lichess TOS</string>
   <string name="refundXpointsTimeControlY">Refund: %1$s %2$s rating points.</string>
   <string name="timeAlmostUp">Time is almost up!</string>
   <string name="clickToRevealEmailAddress">[Click to reveal email address]</string>


### PR DESCRIPTION
See #12124 

This fixes the notification for British English (translation/source), the other translations will have to be updated on Crowdin, I presume.