### PR TITLE
limit impact of explorer hickups on fishnet

### DIFF
--- a/modules/fishnet/src/main/FishnetOpeningBook.scala
+++ b/modules/fishnet/src/main/FishnetOpeningBook.scala
@@ -29,6 +29,7 @@ final private class FishnetOpeningBook(
   def apply(game: Game, level: Int): Fu[Option[Uci]] =
     (game.ply < depth.get() && !outOfBook.get(game.id)) ?? {
       ws.url(s"${config.explorerEndpoint}/lichess")
+        .withRequestTimeout(800.millis)
         .withQueryStringParameters(
           "variant"     -> game.variant.key.value,
           "fen"         -> Fen.write(game.chess).value,


### PR DESCRIPTION
We could consider adding a timeout like this. There are tail latencies, and with so many requests even p99 would happen a lot, so this would probably also need something to reduce noisy logs like
```
[info] [info] fishnet - Request timeout to explorer.lichess.ovh:443 after 800 ms
```