### PR TITLE
Display swiss ban end time with client time zone

### DIFF
--- a/app/views/swiss/side.scala
+++ b/app/views/swiss/side.scala
@@ -83,9 +83,13 @@ object side:
                     "refused"   -> (ctx.isAuth && !v.verdict.accepted)
                   ),
                   title := v.verdict.reason.map(_(ctx.lang))
-                )(v.condition match {
-                  case SwissCondition.PlayYourGames if !v.verdict.accepted =>
-                    v.verdict.reason.map(_(ctx.lang))
+                )(v.verdict match {
+                  case SwissCondition.RefusedUntil(until) =>
+                    frag(
+                      "Because you missed your last swiss game, you cannot enter a new swiss tournament until",
+                      absClientDateTime(until),
+                      "."
+                    )
                   case c => c.name(s.perfType)
                 })
               }

--- a/modules/swiss/src/main/SwissCondition.scala
+++ b/modules/swiss/src/main/SwissCondition.scala
@@ -27,18 +27,14 @@ object SwissCondition:
   sealed abstract class Verdict(val accepted: Boolean, val reason: Option[Lang => String])
   case object Accepted                        extends Verdict(true, none)
   case class Refused(because: Lang => String) extends Verdict(false, because.some)
+  case class RefusedUntil(until: DateTime)    extends Verdict(false, none)
 
   case class WithVerdict(condition: SwissCondition, verdict: Verdict)
 
   case object PlayYourGames extends SwissCondition:
     def name(perf: PerfType)(using lang: Lang) = "Play your games"
     def withBan(bannedUntil: Option[DateTime]) = withVerdict {
-      bannedUntil.fold[Verdict](Accepted) { until =>
-        Refused { lang =>
-          val showUntil = DateTimeFormat.forStyle("MS").withLocale(lang.toLocale) print until
-          s"Because you missed your last swiss game, you cannot enter a new swiss tournament until $showUntil."
-        }
-      }
+      bannedUntil.fold[Verdict](Accepted)(RefusedUntil)
     }
 
   case object Titled extends SwissCondition with FlatCond:


### PR DESCRIPTION
Would probably be nicer to use relative times but then it would get translated and getting the wording to match properly seems tricky.