### PR TITLE
Fix (one of) the default setting(s) for playBellSound

### DIFF
--- a/ui/site/src/account.ts
+++ b/ui/site/src/account.ts
@@ -5,7 +5,7 @@ lichess.load.then(() => {
     ['behavior', 'arrowSnap', 'arrow.snap', true],
     ['behavior', 'courtesy', 'courtesy', false],
     ['behavior', 'scrollMoves', 'scrollMoves', true],
-    ['notification', 'playBellSound', 'playBellSound', false],
+    ['notification', 'playBellSound', 'playBellSound', true],
   ];
 
   $('.security table form').on('submit', function (this: HTMLFormElement) {


### PR DESCRIPTION
I think that default got mangled in a merge somewhere, but this is a PR just to make sure.

I wonder if there's a better way to handle defaults for boolean prefs.  I appreciate the explicit nature of getOrDefault obviating the need for things like (x !== false) but it would be nice to have a single authoritative list of defaults for local prefs.