### PR TITLE
Use "coep: credentialless" with credentialless iframes on all pages on Chrome 110+

### DIFF
--- a/app/http/HttpFilter.scala
+++ b/app/http/HttpFilter.scala
@@ -26,7 +26,12 @@ final class HttpFilter(env: Env)(using val mat: Materializer) extends Filter:
       redirectWrongDomain(req) map fuccess getOrElse {
         nextFilter(req) dmap addApiResponseHeaders(req) dmap { result =>
           monitoring(req, startTime, result)
-          result
+          if req.isChrome110Plus then
+            result.withHeaders(
+              "Cross-Origin-Opener-Policy"   -> "same-origin",
+              "Cross-Origin-Embedder-Policy" -> "credentialless"
+            )
+          else result
         }
       }
 

--- a/app/http/HttpFilter.scala
+++ b/app/http/HttpFilter.scala
@@ -26,7 +26,7 @@ final class HttpFilter(env: Env)(using val mat: Materializer) extends Filter:
       redirectWrongDomain(req) map fuccess getOrElse {
         nextFilter(req) dmap addApiResponseHeaders(req) dmap { result =>
           monitoring(req, startTime, result)
-          if HTTPRequest.isChrome110Plus(req) then
+          if HTTPRequest.isChrome113Plus(req) then
             result.withHeaders(
               "Cross-Origin-Opener-Policy"   -> "same-origin",
               "Cross-Origin-Embedder-Policy" -> "credentialless"

--- a/app/http/HttpFilter.scala
+++ b/app/http/HttpFilter.scala
@@ -26,7 +26,7 @@ final class HttpFilter(env: Env)(using val mat: Materializer) extends Filter:
       redirectWrongDomain(req) map fuccess getOrElse {
         nextFilter(req) dmap addApiResponseHeaders(req) dmap { result =>
           monitoring(req, startTime, result)
-          if req.isChrome110Plus then
+          if HTTPRequest.isChrome110Plus(req) then
             result.withHeaders(
               "Cross-Origin-Opener-Policy"   -> "same-origin",
               "Cross-Origin-Embedder-Policy" -> "credentialless"

--- a/app/ui/scalatags.scala
+++ b/app/ui/scalatags.scala
@@ -35,6 +35,7 @@ trait ScalatagsAttrs:
   object frame:
     val scrolling       = attr("scrolling")
     val allowfullscreen = attr("allowfullscreen").empty
+    val credentialless  = attr("credentialless").empty
 
   val dataSortNumberTh = th(attr("data-sort-method") := "number")
   val dataSort         = attr("data-sort")

--- a/app/views/base/notFound.scala
+++ b/app/views/base/notFound.scala
@@ -33,7 +33,8 @@ object notFound:
             src            := assetUrl(s"vendor/ChessPursuit/bin-release/index.html"),
             st.frameborder := 0,
             widthA         := 400,
-            heightA        := 500
+            heightA        := 500,
+            frame.credentialless
           ),
           p(cls := "credits")(
             a(href := "https://github.com/Saturnyn/ChessPursuit")("ChessPursuit"),

--- a/app/views/coach/show.scala
+++ b/app/views/coach/show.scala
@@ -101,6 +101,7 @@ object show:
                   heightA             := "192",
                   src                 := url.value,
                   attr("frameborder") := "0",
+                  frame.credentialless,
                   frame.allowfullscreen
                 )
               }

--- a/app/views/site/bits.scala
+++ b/app/views/site/bits.scala
@@ -16,7 +16,8 @@ object bits:
         iframe(
           src := "https://docs.google.com/forms/d/e/1FAIpQLSeGgDHgWGP0uobQknF92eCMXqebyNBTyzJoJqbeGjRezlbWOw/viewform?embedded=true",
           style          := "width:100%;height:1400px",
-          st.frameborder := 0
+          st.frameborder := 0,
+          frame.credentialless
         )(spinner)
       )
     }

--- a/app/views/streamer/show.scala
+++ b/app/views/streamer/show.scala
@@ -37,6 +37,7 @@ object show:
             s.stream match {
               case Some(YouTube.Stream(_, _, videoId, _, _)) =>
                 iframe(
+                  frame.credentialless,
                   st.frameborder  := "0",
                   frame.scrolling := "no",
                   src := s"https://www.youtube.com/live_chat?v=$videoId&embed_domain=${netConfig.domain}"
@@ -44,6 +45,7 @@ object show:
               case _ =>
                 s.streamer.twitch.map { twitch =>
                   iframe(
+                    frame.credentialless,
                     st.frameborder  := "0",
                     frame.scrolling := "yes",
                     src := s"https://twitch.tv/embed/${twitch.userId}/chat?${(ctx.currentBg != "light") ?? "darkpopout&"}parent=${netConfig.domain}"
@@ -60,7 +62,8 @@ object show:
                 iframe(
                   src            := s"https://www.youtube.com/embed/$videoId?autoplay=1",
                   st.frameborder := "0",
-                  frame.allowfullscreen
+                  frame.allowfullscreen,
+                  frame.credentialless
                 )
               )
             case _ =>
@@ -68,7 +71,8 @@ object show:
                 div(cls := "box embed twitch")(
                   iframe(
                     src := s"https://player.twitch.tv/?channel=${twitch.userId}&parent=${netConfig.domain}",
-                    frame.allowfullscreen
+                    frame.allowfullscreen,
+                    frame.credentialless
                   )
                 )
               } getOrElse div(cls := "box embed")(div(cls := "nostream")(offline()))

--- a/app/views/video/show.scala
+++ b/app/views/video/show.scala
@@ -35,7 +35,8 @@ object show:
             tpe := "text/html",
             src := s"https://www.youtube.com/embed/${video.id}?autoplay=1&origin=https://lichess.org&start=${video.startTime}",
             st.frameborder := "0",
-            frame.allowfullscreen
+            frame.allowfullscreen,
+            frame.credentialless
           )
         ),
         h1(cls := "box__pad")(

--- a/modules/common/src/main/HTTPRequest.scala
+++ b/modules/common/src/main/HTTPRequest.scala
@@ -47,7 +47,7 @@ object HTTPRequest:
   }
 
   val isChrome96Plus   = UaMatcher("""Chrome/(?:\d{3,}|9[6-9])""")
-  val isChrome110Plus  = UaMatcher("""Chrome/(?:1[1-9]\d)""")
+  val isChrome113Plus  = UaMatcher("""Chrome/(?:11[3-9]|1[2-9]\d)""")
   val isFirefox112Plus = UaMatcher("""Firefox/(?:11[2-9]|1[2-9]\d)""")
   val isMobile         = UaMatcher("""(?i)iphone|ipad|ipod|android.+mobile""")
   val isLichessMobile  = UaMatcher("""Lichess Mobile/""")

--- a/modules/common/src/main/HTTPRequest.scala
+++ b/modules/common/src/main/HTTPRequest.scala
@@ -47,6 +47,7 @@ object HTTPRequest:
   }
 
   val isChrome96Plus   = UaMatcher("""Chrome/(?:\d{3,}|9[6-9])""")
+  val isChrome110Plus  = UaMatcher("""Chrome/(?:1[1-9]\d)""")
   val isFirefox112Plus = UaMatcher("""Firefox/(?:11[2-9]|1[2-9]\d)""")
   val isMobile         = UaMatcher("""(?i)iphone|ipad|ipod|android.+mobile""")
   val isLichessMobile  = UaMatcher("""Lichess Mobile/""")

--- a/public/oops/scheduled-maintenance.html
+++ b/public/oops/scheduled-maintenance.html
@@ -104,6 +104,7 @@
             frameborder="0"
             width="400"
             height="500"
+            credentialless
           >
           </iframe>
         </div>

--- a/public/oops/toomanyrequests.html
+++ b/public/oops/toomanyrequests.html
@@ -51,6 +51,7 @@
         frameborder="0"
         width="400"
         height="500"
+        credentialless
       >
       </iframe>
     </div>

--- a/ui/common/src/richText.ts
+++ b/ui/common/src/richText.ts
@@ -101,7 +101,7 @@ function toYouTubeEmbedUrl(url: string) {
 export function toYouTubeEmbed(url: string): string | undefined {
   const embedUrl = toYouTubeEmbedUrl(url);
   return embedUrl
-    ? `<div class="embed"><iframe width="100%" src="${embedUrl}" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>`
+    ? `<div class="embed"><iframe width="100%" src="${embedUrl}" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen credentialless></iframe></div>`
     : undefined;
 }
 
@@ -114,6 +114,6 @@ function toTwitchEmbedUrl(url: string) {
 export function toTwitchEmbed(url: string): string | undefined {
   const embedUrl = toTwitchEmbedUrl(url);
   return embedUrl
-    ? `<div class="embed"><iframe width="100%" src="${embedUrl}" frameborder=0 allowfullscreen></iframe></div>`
+    ? `<div class="embed"><iframe width="100%" src="${embedUrl}" frameborder=0 allowfullscreen credentialless></iframe></div>`
     : undefined;
 }

--- a/ui/site/src/expandText.ts
+++ b/ui/site/src/expandText.ts
@@ -98,6 +98,17 @@ lichess.load.then(() => {
     );
     if (!twitterLoaded) {
       twitterLoaded = true;
+
+      // polyfill document.createElement so that iframes created by twitter get the `credentialless` attribute
+      const originalCreateElement = document.createElement;
+      document.createElement = function () {
+        const element = originalCreateElement.apply(this, arguments as any);
+        if (element instanceof HTMLIFrameElement) {
+          (element as any).credentialless = true;
+        }
+        return element;
+      };
+
       xhr.script('https://platform.twitter.com/widgets.js');
     }
   }

--- a/ui/site/src/expandText.ts
+++ b/ui/site/src/expandText.ts
@@ -73,7 +73,7 @@ lichess.load.then(() => {
   }
 
   function expandYoutube(a: Candidate) {
-    const $iframe = $('<div class="embed"><iframe src="' + a.src + '"></iframe></div>');
+    const $iframe = $('<div class="embed"><iframe src="' + a.src + '" credentialless></iframe></div>');
     $(a.element).replaceWith($iframe);
     return $iframe;
   }


### PR DESCRIPTION
Second attempt at #11614

Using the "credentialless" (formerly called "anonymous") attribute on iframes new in Chrome 110 to make YT/Twitch embeds work:
- https://developer.chrome.com/blog/anonymous-iframe-origin-trial/
- https://chromestatus.com/feature/5729461725036544
- https://developer.mozilla.org/en-US/docs/Web/Security/IFrame_credentialless

Chrome 110 just got released on the dev channel and should become stable in 4 weeks so probably still a bit early to merge but from cursory testing, everything seems to work. Probably still should be tested on .dev a bit once 110 is stable.

Also, I guess might make sense to create a custom iframe tag or something to always set the attribute?