### PR TITLE
Use full domain when setting cookie from JS

### DIFF
--- a/ui/site/src/component/reload.ts
+++ b/ui/site/src/component/reload.ts
@@ -11,12 +11,11 @@ export const redirect = (opts: string | Opts) => {
   else {
     url = opts.url;
     if (opts.cookie) {
-      const domain = document.domain.replace(/^.+(\.[^.]+\.[^.]+)$/, '$1');
       const cookie = [
         encodeURIComponent(opts.cookie.name) + '=' + opts.cookie.value,
         '; max-age=' + opts.cookie.maxAge,
         '; path=/',
-        '; domain=' + domain,
+        '; domain=' + location.hostname,
       ].join('');
       document.cookie = cookie;
     }


### PR DESCRIPTION
Otherwise, this causes issues when hosting Lichess with a subdomain, e.g. on gitpod, because the JS cookie will be set for a different domain than the cookies set via headers.

I assume this was originally there when we used language subdomains but I don't think we're doing anything like that anymore? Otherwise, I guess we could just send the correct domain with the cookie json.