### PR TITLE
Fix puzzle/analysis layout for 1260px<width<1400px

### DIFF
--- a/ui/common/css/abstract/_uniboard.scss
+++ b/ui/common/css/abstract/_uniboard.scss
@@ -12,7 +12,7 @@ $col3-uniboard-side: minmax(230px, 350px);
 $col3-uniboard-table: minmax(240px, 400px);
 $col3-uniboard-controls: 3rem;
 
-$col3-uniboard-min-width: calc(70vmin * var(--board-scale));
+$col3-uniboard-min-width: calc(58vmin * var(--board-scale));
 $col3-uniboard-max-width: calc(100vh * var(--board-scale) - #{$site-header-outer-height} - #{$col3-uniboard-controls});
 $col3-uniboard-width: minmax($col3-uniboard-min-width, $col3-uniboard-max-width);
 


### PR DESCRIPTION
When the browser window is set to a width between 1260px and about 1400px, the right side of the analysis column is not properly visible in most views (puzzle, analysis, TV,...). 

I believe the root of the issue is in the table column width calculation which according to my browser looks like this in CSS:
```
@media (min-width: 1260px) {
    .puzzle {
        grid-template-areas: "side    . board   gauge tools" "side    . session .     controls" "side    . kb-move .     controls" "side    . .       .     .";
        grid-template-columns:minmax(230px, 350px) 2vmin minmax(calc(70vmin * var(--board-scale)), calc(100vh * var(--board-scale) - calc(var(--site-header-height) + var(--site-header-margin)) - 3rem)) var(--gauge-gap) minmax(240px, 400px)
    }
}
```
The table consists of 4 columns, which together should sum up to 100vmin or 1260px in the worst case (probably even a little less to leave some margin on the right).  They are however: 230px + 2vmin + 70vmin + 17px + 240px = 1394.2px (@ 1260px, where 1vmin=12.6px) window width which explains the overflow.

I am not very familiar with SCSS, but in my local browser, changing the size from 70vmin to 58vmin fixes the issue in Learn/Analysis/Play/Puzzle without affecting the layout in other views or window sizes where this problem does not occur.  My solution is probably not ideal since it doesn't seem to fix the same problem from occuring in e.g. Lichess TV, but it is a start.  

Maybe someone has an idea or alternate proposal to fix the layout in a less "ad-hoc" way. For example, we could change the min-width from 1260px to 1400px, however I don't know how to do this in SCSS.

Since I usually have my window set to 2560/2=1280px, this issue had been bothering me quite a bit :-), would be great if we could fix it! Thanks for this cool project and lmk if there is anything I should change!