### PR TITLE
Fix move number in link preview if white moved last

### DIFF
--- a/app/templating/GameHelper.scala
+++ b/app/templating/GameHelper.scala
@@ -70,7 +70,7 @@ trait GameHelper:
           case chess.variant.Crazyhouse    => "Drop captured pieces on the board"
           case _                           => "Variant ending"
       case _ => "Game is still being played"
-    val moves = game.chess.ply.value / 2
+    val moves = (game.chess.ply.value + 1) / 2
     s"$p1 plays $p2 in a $mode $speedAndClock game of $variant. $result after ${pluralize("move", moves)}. Click to replay, analyse, and discuss the game!".pp
 
   def shortClockName(clock: Option[Clock.Config])(using lang: Lang): Frag =


### PR DESCRIPTION
`game.chess.ply.value / 2` gives the wrong value if white moved last:

![opengraph](https://user-images.githubusercontent.com/54592274/213866185-a5410c55-932a-42aa-a605-f50c726d0ea4.png)

I've tested `(game.chess.ply.value + 1) / 2`  and it works correctly for games where either side moved last as well as games that were aborted before any moves were played.