### PR TITLE
Continuing friend racers will keep the same owner as the original

### DIFF
--- a/modules/racer/src/main/RacerApi.scala
+++ b/modules/racer/src/main/RacerApi.scala
@@ -32,6 +32,12 @@ final class RacerApi(
     case Some(u) => RacerPlayer.Id.User(u.id)
     case None    => RacerPlayer.Id.Anon(sessionId)
 
+  def createKeepOwnerAndJoin(race: RacerRace, player: RacerPlayer.Id): Fu[RacerRace.Id] =
+    create(race.owner, 10).map { id =>
+      join(id, player)
+      id
+    }
+
   def createAndJoin(player: RacerPlayer.Id): Fu[RacerRace.Id] =
     create(player, 10).map { id =>
       join(id, player)
@@ -64,7 +70,7 @@ final class RacerApi(
       fuccess(found.id)
     case None =>
       rematchQueue {
-        createAndJoin(player) map { rematchId =>
+        createKeepOwnerAndJoin(race, player) map { rematchId =>
           save(race.copy(rematch = rematchId.some))
           rematchId
         }


### PR DESCRIPTION
The idea behind this change is to make life easier for streamers hosting racers for their viewers. For this purpose it is important that the streamer is the owner of the racer so they have control over when it is started, while currently after the first racer has finished, the first user to click "Join rematch" will be the owner of the next racer and the only real way to get around this is to just create a new racer every time and not use the rematch feature.

The functionality that will be lost with this change is if the group wants to keep playing even after the original owner drops out, but I would consider this to be less important than what is gained. Presumably the friendly racers are generally used by streamers and actual friends who communicate frequently, so the problem of the original owner not joining a rematch without telling anyone thus nobody can start the racer seems like it would be very rare.

A different way to address this would be to add an option when creating/starting a friendly racer whether to keep the owner, but I am not convinced the extra complexity both in implementation and UI is worth it.