### PR TITLE
Add download button to advanced search

### DIFF
--- a/app/views/search/index.scala
+++ b/app/views/search/index.scala
@@ -81,7 +81,9 @@ object index:
                 div(cls := "search__status box__pad")(
                   strong(xGamesFound(pager.nbResults.localize, pager.nbResults)),
                   " • ",
-                  permalink
+                  permalink,
+                  " • ",
+                  a(cls := "button", href := routes.Game.exportByIds)(trans.download())
                 ),
                 div(cls := "search__rows infinite-scroll")(
                   views.html.game.widgets(pager.currentPageResults),


### PR DESCRIPTION
The change solves #12066.

I couldn't complete the feature because I don't know how to pass game IDs to the `exportByIds` API endpoint. I appreciate an explanation on how the latter can be done.