### PR TITLE
harden regexes to prevent failed game db lookups

### DIFF
--- a/modules/api/src/main/TextLpvExpand.scala
+++ b/modules/api/src/main/TextLpvExpand.scala
@@ -91,8 +91,8 @@ final class LpvGameRegex(domain: String):
 
 // linkified forum hrefs are relative but this regex runs pre-linkify, match path & id
   val linkRenderRe =
-    raw"(?m)^(?:https?://)?(?:$domain)?(/(\w{8})(?:(?:/(?:white|black))|\w{4}|)(?:#\d+)?)\b".r
+    raw"(?m)^(?:(?:https?://)?$domain)?(/(\w{8})(?:/(?:white|black)|\w{4}|)(?:#(?:last|\d+))?)\b".r
 
 // for blogs, only allow absolute links and match id
   val gamePgnsRe =
-    raw"(?:https?://)?$domain/(\w{8})(?:(?:/(?:white|black))|\w{4}|)(?:#(?:last|\d+))?\b".r
+    raw"(?:https?://)?$domain/(\w{8})(?:/(?:white|black)|\w{4}|)(?:#(?:last|\d+))?\b".r

--- a/modules/api/src/main/TextLpvExpand.scala
+++ b/modules/api/src/main/TextLpvExpand.scala
@@ -7,7 +7,6 @@ import scala.concurrent.ExecutionContext
 import scalatags.Text.all.*
 
 import lila.analyse.AnalysisRepo
-import lila.common.config
 import lila.game.{ Game, GameRepo }
 import lila.memo.CacheApi
 import chess.format.pgn.PgnStr
@@ -16,19 +15,22 @@ final class TextLpvExpand(
     gameRepo: GameRepo,
     analysisRepo: AnalysisRepo,
     pgnDump: PgnDump,
-    cacheApi: CacheApi
+    cacheApi: CacheApi,
+    net: lila.common.config.NetConfig
 )(using ec: ExecutionContext):
 
   def getPgn(id: GameId) = pgnCache get id
 
+  // forum linkRenderFromText builds a mapper from relative game urls -> lpv div tags
+  //
   def linkRenderFromText(text: String): Fu[lila.base.RawHtml.LinkRender] =
-    gameRegex
+    regex.linkRenderRe
       .findAllMatchIn(text)
       .toList
       .flatMap { m =>
-        Option(m group 1) filter { id =>
+        Option(m.group(2)) filter { id =>
           !notGames(id)
-        } map (m.matched -> _)
+        } map (m.group(1) -> _)
       }
       .map { case (matched, id) =>
         pgnCache.get(GameId(id)) map2 { matched -> _ }
@@ -42,25 +44,26 @@ final class TextLpvExpand(
             cls                      := "lpv--autostart is2d",
             attr("data-pgn")         := pgn.toString,
             attr("data-orientation") := chess.Color.fromWhite(!url.contains("black")).name,
-            attr("data-ply")         := plyRegex.findFirstIn(url).fold("last")(_.substring(1))
+            attr("data-ply")         := plyRe.findFirstIn(url).fold("last")(_.substring(1))
           )
         }
     }
 
+  // gamePgnsFromText is used by blogs & ublogs to build game id -> pgn maps but the
+  // substitution happens in blog/BlogApi (blogs) and common/MarkdownRender for ublogs
   def gamePgnsFromText(text: String): Fu[Map[GameId, PgnStr]] =
-    val gameIds = gameRegex
+    val gameIds = regex.gamePgnsRe
       .findAllMatchIn(text)
       .toList
-      .flatMap { m => Option(m group 1) filterNot notGames.contains }
+      .flatMap { m => Option(m.group(1)) filterNot notGames.contains }
       .distinct
       .map(GameId(_))
     pgnCache getAll gameIds map {
       _.collect { case (gameId, Some(pgn)) => gameId -> pgn }
     }
 
-  private val gameRegex = """/(?:embed/)?(?:game/)?(\w{8})(?:/(white|black)|\w{4}|)(#\d+)?\b""".r
-
-  private val plyRegex = raw"#(\d+)\z".r
+  private val regex = LpvGameRegex(net.domain.toString)
+  private val plyRe = raw"#(\d+)\z".r
 
   private val notGames =
     Set("training", "analysis", "insights", "practice", "features", "password", "streamer", "timeline")
@@ -83,3 +86,13 @@ final class TextLpvExpand(
         }
       }
     }
+
+final class LpvGameRegex(domain: String):
+
+// linkified forum hrefs are relative but this regex runs pre-linkify, match path & id
+  val linkRenderRe =
+    raw"(?m)^(?:https?://)?(?:$domain)?(/(\w{8})(?:(?:/(?:white|black))|\w{4}|)(?:#\d+)?)\b".r
+
+// for blogs, only allow absolute links and match id
+  val gamePgnsRe =
+    raw"(?:https?://)?$domain/(\w{8})(?:(?:/(?:white|black))|\w{4}|)(?:#(?:last|\d+))?\b".r

--- a/modules/api/src/main/TextLpvExpand.scala
+++ b/modules/api/src/main/TextLpvExpand.scala
@@ -21,8 +21,8 @@ final class TextLpvExpand(
 
   def getPgn(id: GameId) = pgnCache get id
 
-  // forum linkRenderFromText builds a mapper from relative game urls -> lpv div tags
-  //
+  // forum linkRenderFromText builds a LinkRender from relative game urls -> lpv div tags.
+  // substitution occurs in common/../RawHtml.scala addLinks
   def linkRenderFromText(text: String): Fu[lila.base.RawHtml.LinkRender] =
     regex.linkRenderRe
       .findAllMatchIn(text)

--- a/modules/api/src/test/LpvGameRegexTest.scala
+++ b/modules/api/src/test/LpvGameRegexTest.scala
@@ -1,0 +1,98 @@
+package lila.api
+
+import org.specs2.mutable.Specification
+import chess.format.pgn.PgnStr
+
+class LpvGameRegexTest extends Specification {
+
+  val re = LpvGameRegex("boo.org:8080")
+
+  def group(r: scala.util.matching.Regex, t: String, g: Int) = r.findFirstMatchIn(t).map(_.group(g))
+
+  "forum links" >> {
+    "match basic" >> re.linkRenderRe.matches("https://boo.org:8080/1234abcd")
+
+    "match color" >> re.linkRenderRe.matches("https://boo.org:8080/abcd1234/white")
+
+    "match relative" >> re.linkRenderRe.matches("/12345678/black#123")
+
+    "match no scheme" >> re.linkRenderRe.matches("boo.org:8080/abcdefgh#123")
+
+    "match full game id" >> re.linkRenderRe.matches("boo.org:8080/12345678abcd#12")
+
+    "fail wrong host" >> !re.linkRenderRe.matches("boo.org:1234/zyxwvuts")
+
+    "fail too long" >> !re.linkRenderRe.matches("/abcdefghijkl1234")
+
+    "fail bad ply" >> !re.linkRenderRe.matches("/abcdefgh#12noes")
+
+    "fail bad color" >> !re.linkRenderRe.matches("https://boo.org:8080/12345678/red#22")
+
+    "fail tournaments" >> !re.linkRenderRe.matches("https://boo.org:8080/tournament/ABCD1234")
+
+    "fail studies" >> !re.linkRenderRe.matches("https://boo.org:8080/study/abcd1234/bcde2345")
+
+    "fail site header" >> !re.linkRenderRe.matches("[Site=\"https://boo.org:8080/abcd1234\"]")
+
+    "fail mid-line" >> !re.linkRenderRe.matches("once upon a time /1234abcd/white#4")
+
+    "fail usernames" >> !re.linkRenderRe.matches("/@/thibault")
+
+    "fail full id AND color" >> !re.linkRenderRe.matches("/12345678abcd/black")
+
+    "extract game id 1" >> group(re.linkRenderRe, "/1234abcd", 2).contains("1234abcd")
+
+    "extract game id 2" >>
+      group(re.linkRenderRe, "https://boo.org:8080/abcd1234/black#12", 2).contains("abcd1234")
+
+    "extract game id 3" >>
+      group(re.linkRenderRe, "boo.org:8080/abcd1234wxyz#44", 2).contains("abcd1234")
+  }
+  "blog links" >> {
+    "match basic" >> re.gamePgnsRe.matches("https://boo.org:8080/abcdefgh")
+
+    "match no scheme" >> re.gamePgnsRe.matches("boo.org:8080/12345678/white#123")
+
+    "match full id" >> re.gamePgnsRe.matches("boo.org:8080/1234abcd1234#22")
+
+    "fail wrong host" >> !re.gamePgnsRe.matches("boo.org:1234/abcdefgh")
+
+    "fail relative" >> !re.gamePgnsRe.matches("/12345678")
+
+    "fail mid-line" >> !re.gamePgnsRe.matches("oompa loompa https://boo.org:8080/abcd1234")
+
+    "fail site header" >> !re.gamePgnsRe.matches("[Site=\"https://boo.org:8080/1234abcd\"]")
+
+    "fail tournaments" >> !re.gamePgnsRe.matches("https://boo.org:8080/tournament/ABCD1234")
+
+    "fail usernames" >> !re.gamePgnsRe.matches("boo.org:8080/@/thibault")
+
+    "fail wrong length" >> !re.gamePgnsRe.matches("boo.org:8080/12345678bad/black")
+
+    "extract game id 1" >>
+      group(re.gamePgnsRe, "boo.org:8080/zyxwvuts/black", 1).contains("zyxwvuts")
+
+    "extract game id 2" >>
+      group(re.gamePgnsRe, "boo.org:8080/1234abcd1234#123", 1).contains("1234abcd")
+
+  }
+}
+/*
+"extract color 1" >>
+      group(re.gamePgnsRe, "boo.org:8080/abcdefgh/white#2", "color").contains("white")
+
+"fail extract color" >>
+  group(re.gamePgnsRe, "https://boo.org:8080/abcd1234#white", "color").contains(null)
+
+"extract ply 1" >>
+  group(re.gamePgnsRe, "https://boo.org:8080/12345678/black#0", "ply").contains("0")
+
+"extract ply 2" >>
+  group(re.gamePgnsRe, "https://boo.org:8080/abcd12345678#222", "ply").contains("222")
+
+"extract ply 3" >>
+  group(re.gamePgnsRe, "boo.org:8080/12345678#last", "ply").contains("last")
+
+"fail extract ply" >>
+  group(re.gamePgnsRe, "boo.org:8080/zyxwvuts#l23", "ply").contains(null)
+ */

--- a/modules/api/src/test/LpvGameRegexTest.scala
+++ b/modules/api/src/test/LpvGameRegexTest.scala
@@ -1,7 +1,6 @@
 package lila.api
 
 import org.specs2.mutable.Specification
-import chess.format.pgn.PgnStr
 
 class LpvGameRegexTest extends Specification {
 
@@ -74,25 +73,5 @@ class LpvGameRegexTest extends Specification {
 
     "extract game id 2" >>
       group(re.gamePgnsRe, "boo.org:8080/1234abcd1234#123", 1).contains("1234abcd")
-
   }
 }
-/*
-"extract color 1" >>
-      group(re.gamePgnsRe, "boo.org:8080/abcdefgh/white#2", "color").contains("white")
-
-"fail extract color" >>
-  group(re.gamePgnsRe, "https://boo.org:8080/abcd1234#white", "color").contains(null)
-
-"extract ply 1" >>
-  group(re.gamePgnsRe, "https://boo.org:8080/12345678/black#0", "ply").contains("0")
-
-"extract ply 2" >>
-  group(re.gamePgnsRe, "https://boo.org:8080/abcd12345678#222", "ply").contains("222")
-
-"extract ply 3" >>
-  group(re.gamePgnsRe, "boo.org:8080/12345678#last", "ply").contains("last")
-
-"fail extract ply" >>
-  group(re.gamePgnsRe, "boo.org:8080/zyxwvuts#l23", "ply").contains(null)
- */

--- a/modules/blog/src/main/BlogApi.scala
+++ b/modules/blog/src/main/BlogApi.scala
@@ -117,7 +117,7 @@ final class BlogApi(
 
   // match the entire <a.../> tag with scheme & domain.  href value should be identical to inner text
   private val expandGameRegex =
-    """<a href="https://lichess\.org/(\w{8})(?:/(white|black)|\w{4}|)(?:#(last|\d+))?">https://lichess\.org/[^<]{8,18}</a>""".r
+    """<a href="https://lichess\.org/(\w{8})(?:/(white|black)|\w{4}|)(?:#(last|\d+))?">https://lichess\.org/[^<]{8,19}</a>""".r
 
   private val pgnCache = cacheApi.notLoadingSync[GameId, PgnStr](256, "prisblog.markup.pgn") {
     _.expireAfterWrite(1 second).build()

--- a/modules/blog/src/main/BlogApi.scala
+++ b/modules/blog/src/main/BlogApi.scala
@@ -59,7 +59,9 @@ final class BlogApi(
     one(prismic.api, prismic.ref.some, id).collect { case Some(doc) =>
       doc.getHtml("blog.body", prismic.linkResolver) match {
         case Some(html) =>
-          Bus.ask("lpv")(GamePgnsFromText(html, _)).map(pgnCache.putAll(_)) inject doc.some
+          Bus
+            .ask("lpv")(GamePgnsFromText(html, _))
+            .map(pgnCache.putAll) inject doc.some
         case _ => fuccess(doc.some)
       }
     }.flatten
@@ -107,14 +109,15 @@ final class BlogApi(
         pgnCache.getIfPresent(GameId(m.group(1))).fold(m.matched) { pgn =>
           val esc   = lila.common.base.StringUtils.escapeHtmlRaw(pgn.value)
           val color = Option(m.group(2)).getOrElse("white")
-          val ply   = Option(m.group(3)).getOrElse("0")
+          val ply   = Option(m.group(3)).getOrElse("last")
           s"""<div class="lpv--autostart" data-pgn="$esc" data-orientation="$color" data-ply="$ply"></div>"""
         }
     )
   )
 
+  // match the entire <a.../> tag with scheme & domain.  href value should be identical to inner text
   private val expandGameRegex =
-    """<a href="https://lichess\.org/(\w{8})(?:/(white|black)|\w{4}|)(?:#(\d+))?">https://lichess\.org/[^<]{8,18}</a>""".r
+    """<a href="https://lichess\.org/(\w{8})(?:/(white|black)|\w{4}|)(?:#(last|\d+))?">https://lichess\.org/[^<]{8,18}</a>""".r
 
   private val pgnCache = cacheApi.notLoadingSync[GameId, PgnStr](256, "prisblog.markup.pgn") {
     _.expireAfterWrite(1 second).build()


### PR DESCRIPTION
split TextLpvExpand regex into two to better suit each purpose, and add tests and comments to illustrate how these regexes are expected to work.

don't expand links inside site header of pasted pgn.  allow 'last' as a valid value for ply.  tested ublogs, forums, prismic.

Closes #11450
Closes #11951