### PR TITLE
Disallow claiming draw if my turn

### DIFF
--- a/modules/round/src/main/RoundAsyncActor.scala
+++ b/modules/round/src/main/RoundAsyncActor.scala
@@ -283,7 +283,7 @@ final private[round] class RoundAsyncActor(
 
     case DrawForce(playerId) =>
       handle(playerId) { pov =>
-        (pov.game.forceDrawable && !pov.game.hasAi && pov.game.hasClock) ?? {
+        (pov.game.forceDrawable && !pov.game.hasAi && pov.game.hasClock && !pov.isMyTurn) ?? {
           getPlayer(!pov.color).isLongGone flatMap {
             case true => finisher.rageQuit(pov.game, None)
             case _    => fuccess(List(Event.Reload))


### PR DESCRIPTION
I guess this has niche relevance bc you can generally just make a move first but e.g. in Antichess, it's possible that making your move forces stalemate i.e. your loss in which case it's probably fair to allow the opponent to quit the game and still win.