### PR TITLE
Don't punish players in swiss when opponent resigns before turn 1

### DIFF
--- a/modules/game/src/main/Game.scala
+++ b/modules/game/src/main/Game.scala
@@ -520,10 +520,11 @@ case class Game(
       Centis.ofMillis(movedAt.getMillis - nowMillis + timeForFirstMove.millis).nonNeg
     }
 
-  def playerWhoDidNotMove: Option[Player] =
+  def playerWhoDidNotMove: Option[Player] = {
     if playedTurns == Ply(0) then player(startColor).some
     else if playedTurns == Ply(1) then player(!startColor).some
     else none
+  } filterNot { player => winnerColor contains player.color }
 
   def onePlayerHasMoved    = playedTurns > 0
   def bothPlayersHaveMoved = playedTurns > 1


### PR DESCRIPTION
https://lichess.org/forum/lichess-feedback/bug-about-because-you-missed-your-last-swiss-game-you-cannot-enter-a-new-swiss-tournament

Players will no longer get a temp ban or get recorded as absent when their opponent resigns before they can make their first move.

This change also affects arena: it should prevent you from being withdrawn if your opponent resigns before your turn 1.

Was tempted to write this as `} filterNot winner.contains`, but ended up going the wordier and slightly more efficient route.

Small downside: this lets no-shows go scot-free if their opponent resigns in frustration. I think this is fine since this change only applies to tournaments, where opponents should prefer to take the free points rather than resign.