### PR TITLE
Enable source maps in prod

### DIFF
--- a/ui/@build/src/esbuild.ts
+++ b/ui/@build/src/esbuild.ts
@@ -17,7 +17,7 @@ export async function esbuild(): Promise<void> {
   }
   try {
     await es.build({
-      sourcemap: env.prod ? false : 'inline',
+      sourcemap: true,
       define: {
         __info__: JSON.stringify({
           date: new Date(new Date().toUTCString()).toISOString().split('.')[0] + '+00:00',

--- a/ui/@build/src/sass.ts
+++ b/ui/@build/src/sass.ts
@@ -116,7 +116,7 @@ function compile(sources: string[], tellTheWorld = true) {
   const proc = cps.spawn(
     sassExec,
     sassArgs.concat(
-      env.prod ? ['--style=compressed', '--no-source-map'] : ['--embed-sources'],
+      env.prod ? ['--style=compressed', '--embed-sources'] : ['--embed-sources'],
       sources.map(
         (src: string) =>
           `${src}:${path.join(


### PR DESCRIPTION
Closes #6774.

This enables source maps for prod builds. Prod and dev builds now both use source maps separated from the minified sources. (Dev build no longer use inline source maps). Separate source maps like this don't get loaded unless the user opens the dev console.

Tested with `net.asset.minified = true` and `ui/build -p`.

There is one small imperfection: In prod builds, we combine deps.min.js and site.min.js into lichess.min.js. This means lichess.min.js is out of sync with the source map, so setting breakpoints in site.ts does not work. You can still see the original file though, so it is better than no source map at all.