### PR TITLE
Optimize shutup regexes

### DIFF
--- a/modules/shutup/src/main/Analyser.scala
+++ b/modules/shutup/src/main/Analyser.scala
@@ -59,18 +59,18 @@ object Analyser:
 
   private val latinBigRegex = {
     """(?i)\b""" +
-      latinWordsRegexes.mkString("(", "|", ")").replaceAll("(", "(?:") +
+      latinWordsRegexes.mkString("(", "|", ")").replace("(", "(?:") +
       """\b"""
   }.r
 
   private val ruBigRegex = {
     """(?iu)\b""" +
-      Dictionary.ru.mkString("(", "|", ")") .replaceAll("(", "(?:")+
+      Dictionary.ru.mkString("(", "|", ")").replace("(", "(?:")+
       """\b"""
   }.r
 
   private val criticalRegex = {
     """(?i)\b""" +
-      Dictionary.critical.mkString("(", "|", ")").replaceAll("(", "(?:") +
+      Dictionary.critical.mkString("(", "|", ")").replace("(", "(?:") +
       """\b"""
   }.r

--- a/modules/shutup/src/main/Analyser.scala
+++ b/modules/shutup/src/main/Analyser.scala
@@ -41,17 +41,17 @@ object Analyser:
 
   private def latinWordsRegexes =
     Dictionary.en.map { word =>
-      word + (if (word endsWith "e") "s?+" else "(?:es|s|)")
+      word + (if word endsWith "e" then "s?+" else "(es|s|)")
     } ++
       Dictionary.es.map { word =>
-        word + (if (word endsWith "e") "" else "e?+") + "s?+"
+        word + (if word endsWith "e" then "" else "e?+") + "s?+"
       } ++
       Dictionary.hi ++
       Dictionary.fr.map { word =>
         word + "[sx]?+"
       } ++
       Dictionary.de.map { word =>
-        word + (if (word endsWith "e") "" else "e?+") + "[nrs]?+"
+        word + (if word endsWith "e" then "" else "e?+") + "[nrs]?+"
       } ++
       Dictionary.tr ++
       Dictionary.it ++
@@ -59,18 +59,18 @@ object Analyser:
 
   private val latinBigRegex = {
     """(?i)\b""" +
-      latinWordsRegexes.mkString("(", "|", ")") +
+      latinWordsRegexes.mkString("(", "|", ")").replaceAll("(", "(?:") +
       """\b"""
   }.r
 
   private val ruBigRegex = {
     """(?iu)\b""" +
-      Dictionary.ru.mkString("(", "|", ")") +
+      Dictionary.ru.mkString("(", "|", ")") .replaceAll("(", "(?:")+
       """\b"""
   }.r
 
   private val criticalRegex = {
     """(?i)\b""" +
-      Dictionary.critical.mkString("(", "|", ")") +
+      Dictionary.critical.mkString("(", "|", ")").replaceAll("(", "(?:") +
       """\b"""
   }.r

--- a/modules/shutup/src/main/Dictionary.scala
+++ b/modules/shutup/src/main/Dictionary.scala
@@ -7,7 +7,7 @@ package lila.shutup
 private object Dictionary:
 
   def en = dict("""
-(f++|ph)[uae]++c?k(er|r|u|k|t|ing?|ign|en|tard?|face|off?|e?d|)
+(f++|ph)(u++|e++|a++)c?k(er|r|u|k|t|ing?|ign|en|tard?|face|off?|e?d|)
 (f|ph)agg?([oi]t|)
 (kill|hang|neck) my ?self
 [ck]um(shot|)

--- a/modules/shutup/src/main/Dictionary.scala
+++ b/modules/shutup/src/main/Dictionary.scala
@@ -7,7 +7,7 @@ package lila.shutup
 private object Dictionary:
 
   def en = dict("""
-(f+|ph)(u{1,}|a{1,}|e{1,})c?k(er|r|u|k|t|ing?|ign|en|tard?|face|off?|e?d|)
+(f++|ph)[uae]++c?k(er|r|u|k|t|ing?|ign|en|tard?|face|off?|e?d|)
 (f|ph)agg?([oi]t|)
 (kill|hang|neck) my ?self
 [ck]um(shot|)
@@ -24,7 +24,7 @@ ass?(hole|fag)
 autist(ic|)
 aus?c?hwitz
 bastard?
-be[ea]+t?ch
+be[ea]++t?ch
 biy?t?ch
 blow(job|)
 blumpkin
@@ -64,7 +64,7 @@ gobshite?
 gook
 gypo
 handjob
-hitler+
+hitler++
 homm?o(sexual|)
 honkey
 hooker
@@ -78,7 +78,7 @@ kill (you|u)
 labia
 lamer?
 lesbo
-lo+ser
+lo++ser
 masturbat(ed?|ion|ing)
 milf
 molest(er|ed|)
@@ -90,7 +90,7 @@ mthrfckr
 nazi
 nigg?ah?
 nonce
-noo+b
+noo++b
 nutsac?k
 pa?edo((f|ph)ile|)
 paki
@@ -102,7 +102,7 @@ pimp
 piss
 poof
 poon
-poo+p(face|)
+poo++p(face|)
 porn(hub|)
 pric?k
 prostitute
@@ -313,8 +313,9 @@ yarra[gğ][iı] yediniz
   def critical = dict("""
 cancer
 (go|pl(ea)?[sz]e?) (a?nd)? ?(die|burn|suicide)
-((ho?pe|wish) ((yo?)?[uy](r (famil[yi]|m[ou]m|mother))?( and )*)+ (die|burn)s?|((die|burn)s? irl))
-(kill|hang|neck) ?((yo?)?[uyi]r? ?(self|famil[yi]|m[ou]m|mother)( and )?)+
+(ho?pe|wish) ((yo?)?[uy](r (famil[yi]|m[ou]m|mother))?( and )?)++ (die|burn)s?
+(die|burn)s? irl
+(kill|hang|neck) ?(yo?)?[uyi]r? ?(self|famil[yi]|m[ou]m|mother)
 kys
 nigg?er
 rape(d|ing|)


### PR DESCRIPTION
- Make all groups non-capturing
- Make all repetitions possessive (shouldn't change the result if the repetition doesn't contain the next character which is always the case here)
- Remove unnecessary repetition (we don't need to match "kill yourself and .." if "kill yourself" would already match anyways)