### PR TITLE
game api: Move accuracy into analyisis object

### DIFF
--- a/modules/api/src/main/GameApiV2.scala
+++ b/modules/api/src/main/GameApiV2.scala
@@ -299,11 +299,10 @@ final class GameApiV2(
           .add("aiLevel" -> p.aiLevel)
           .add(
             "analysis" -> analysisOption.flatMap(
-              analysisJson.player(g.pov(p.color).sideAndStart)(_, accuracy = none)
+              analysisJson.player(g.pov(p.color).sideAndStart)(_, accuracy)
             )
           )
           .add("team" -> teams.map(_(p.color)))
-          .add("accuracy" -> accuracy.map(_(p.color)).map(_.toInt))
       })
     )
     .add("initialFen" -> initialFen)


### PR DESCRIPTION
For consistency (acpl is also there) and less code duplication. Since the field is brand new, was added for the app and the output isn't documented yet (only the accuracy query param), it should be fine to still change it?