### PR TITLE
Redirect click on "Learn" top nav button to Chess basics

### DIFF
--- a/app/views/base/topnav.scala
+++ b/app/views/base/topnav.scala
@@ -50,7 +50,7 @@ object topnav:
         )
       },
       st.section(
-        linkTitle(routes.Practice.index.url, trans.learnMenu()),
+        linkTitle(routes.Learn.index.url, trans.learnMenu()),
         div(role := "group")(
           ctx.noBot option frag(
             a(href := langHref(routes.Learn.index))(trans.chessBasics()),


### PR DESCRIPTION
Close #12336. I agree with the OP that it makes more sense for beginners and lead to better consistency. The "Practice" link was chosen in f3fa4dd70c7bd78ef8133baa6430ddd3bf754bec.