### PR TITLE
Optimize email and domain regex

### DIFF
--- a/modules/common/src/main/EmailAddress.scala
+++ b/modules/common/src/main/EmailAddress.scala
@@ -39,7 +39,7 @@ object EmailAddress extends OpaqueString[EmailAddress]:
         e.username.count('.' == _) >= 4
 
   private val regex =
-    """^[a-zA-Z0-9\.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$""".r
+    """(?i)^[a-z0-9.!#$%&'*+/=?^_`{|}~\-]+@[a-z0-9](?:[a-z0-9-]{0,62}+(?<!-))?(?:\.[a-z0-9](?:[a-z0-9-]{0,62}+(?<!-))?)*$""".r
 
   val maxLength = 320
 

--- a/modules/common/src/main/model.scala
+++ b/modules/common/src/main/model.scala
@@ -59,7 +59,7 @@ object Domain extends OpaqueString[Domain]:
 
   // https://stackoverflow.com/a/26987741/1744715
   private val regex =
-    """(?i)^(((?!-))(xn--|_{1,1})?[a-z0-9-]{0,61}[a-z0-9]{1,1}\.)*(xn--)?([a-z0-9][a-z0-9\-]{0,60}|[a-z0-9-]{1,30}\.[a-z]{2,})$""".r
+    """(?i)^_?[a-z0-9-]{1,63}+(?:\._?[a-z0-9-]{1,63}+)*$""".r
   def isValid(str: String)              = regex.matches(str)
   def from(str: String): Option[Domain] = isValid(str) option Domain(str)
   def unsafe(str: String): Domain       = Domain(str)


### PR DESCRIPTION
The new email regex should behave exactly the same. The only changes are using `(?i)` and `[a-z]` instead of `[a-zA-Z]` and replacing `[a-zA-Z0-9-]{0,61}[a-zA-Z0-9]` with `[a-z0-9-]{0,62}+(?<!-)` which should match the same stuff but uses non-greedy repetition.

For the domains, it now allows leading hyphens and underscores in the TLD which previously wasn't allowed. The previous regex already allowed quite a lot of weird hyphen and underscore stuff though. But looks like it's only used for email domains which already disallow this stuff anyway? Would be simple to just change it to be like the domain part of the email regex though and disallow all this stuff.