### PR TITLE
Fix $mq-not-... media queries

### DIFF
--- a/ui/common/css/abstract/_media-queries.scss
+++ b/ui/common/css/abstract/_media-queries.scss
@@ -1,28 +1,35 @@
 /* Widths */
 
-$mq-xx-small: min-width 500px;
-$mq-x-small: min-width 650px;
-$mq-small: min-width 800px;
-$mq-medium: min-width 980px;
-$mq-large: min-width 1120px;
-$mq-x-large: min-width 1260px;
+$mq-width-xx-small: 500px;
+$mq-width-x-small: 650px;
+$mq-width-small: 800px;
+$mq-width-medium: 980px;
+$mq-width-large: 1120px;
+$mq-width-x-large: 1260px;
 
-$mq-less-than-400: max-width 399.99px;
-$mq-not-xx-small: max-width 499.99px;
-$mq-not-x-small: max-width 649.99px;
-$mq-not-small: max-width 799.99px;
-$mq-not-medium: max-width 979.99px;
-$mq-not-large: max-width 1119.99px;
-$mq-not-x-large: max-width 1259.99px;
+$mq-xx-small: min-width ($mq-width-xx-small - 0.7px);
+$mq-x-small: min-width ($mq-width-x-small - 0.7px);
+$mq-small: min-width ($mq-width-small - 0.7px);
+$mq-medium: min-width ($mq-width-medium - 0.7px);
+$mq-large: min-width ($mq-width-large - 0.7px);
+$mq-x-large: min-width ($mq-width-x-large - 0.7px);
+
+$mq-less-than-400: max-width 400px;
+$mq-not-xx-small: max-width ($mq-width-xx-small - 0.71px);
+$mq-not-x-small: max-width ($mq-width-x-small - 0.71px);
+$mq-not-small: max-width ($mq-width-small - 0.71px);
+$mq-not-medium: max-width ($mq-width-medium - 0.71px);
+$mq-not-large: max-width ($mq-width-large - 0.71px);
+$mq-not-x-large: max-width ($mq-width-x-large - 0.71px);
 
 /* Heights */
 
-$mq-x-short: min-height 400px;
+$mq-x-short: min-height 399.3px;
 $mq-short: min-height 500px;
 $mq-tall: min-height 600px;
 $mq-x-tall: min-height 700px;
 
-$mq-not-x-short: max-height 399.99px;
+$mq-not-x-short: max-height 399.29px;
 
 /* Orientations */
 


### PR DESCRIPTION
Tested in FF and Chrome, they now both show the small layout on 799px and 800px. I went for slightly below since I think we want to keep the current layout on 800px screens.