### PR TITLE
Update OAuth code flow link

### DIFF
--- a/app/views/oAuth/token/index.scala
+++ b/app/views/oAuth/token/index.scala
@@ -23,7 +23,7 @@ object index:
         standardFlash.map(div(cls := "box__pad")(_)),
         p(cls := "box__pad force-ltr")(
           "You can make OAuth requests without going through the ",
-          a(href := s"${routes.Api.index}#section/Authentication")("authorization code flow"),
+          a(href := s"${routes.Api.index}#tag/OAuth/operation/oauth")("authorization code flow"),
           ".",
           br,
           br,


### PR DESCRIPTION
The `authorization code flow` link currently listed on the [OAuth Token](https://lichess.org/account/oauth/token) page points to an old section link. This pull request updates the link to point to the new location.