### PR TITLE
refactor: optional maxDepth | millis

### DIFF
--- a/ui/@types/lichess/index.d.ts
+++ b/ui/@types/lichess/index.d.ts
@@ -378,8 +378,8 @@ declare namespace Tree {
   }
   export interface CloudEval extends ClientEvalBase {
     cloud: true;
-    maxDepth: undefined;
-    millis: undefined;
+    maxDepth?: undefined;
+    millis?: undefined;
   }
   export interface LocalEval extends ClientEvalBase {
     cloud?: false;

--- a/ui/analyse/src/evalCache.ts
+++ b/ui/analyse/src/evalCache.ts
@@ -49,8 +49,7 @@ function toPutData(variant: VariantKey, ev: Tree.ClientEval): EvalPutData {
 
 // from server eval to client eval
 function toCeval(e: Tree.ServerEval): Tree.ClientEval {
-  // TODO: this type is not quite right
-  const res: any = {
+  const res: Tree.ClientEval = {
     fen: e.fen,
     nodes: e.knodes * 1000,
     depth: e.depth,


### PR DESCRIPTION
The main difference between `prop: undefined` and `prop?: undefined` is that even though that they are (without reflection) the same, `prop?: undefined` removes the necessity to explicitly define the type.