### PR TITLE
Update OAuth code flow link

### DIFF
--- a/app/views/oAuth/token/index.scala
+++ b/app/views/oAuth/token/index.scala
@@ -23,7 +23,7 @@ object index:
         standardFlash.map(div(cls := "box__pad")(_)),
         p(cls := "box__pad force-ltr")(
           "You can make OAuth requests without going through the ",
-          a(href := s"${routes.Api.index}#section/Authentication")("authorization code flow"),
+          a(href := s"${routes.Api.index}#section/Introduction/Authentication")("authorization code flow"),
           ".",
           br,
           br,


### PR DESCRIPTION
Updates the the `authorization code flow` link on the [OAuth Token page](https://lichess.org/account/oauth/token) to point to the new section link.

This section was restored yesterday here: https://github.com/lichess-org/api/commit/0a6f9f4517a76d00683ad6067f18d4393bcbfc8e but it's now under the `/Introduction` section.