### PR TITLE
Voice input partial moves

### DIFF
--- a/ui/input/src/handlerUtil.ts
+++ b/ui/input/src/handlerUtil.ts
@@ -35,7 +35,9 @@ export function sanCandidates(san: string, legalSans: SanToUci): San[] {
 
 export function destsToUcis(dests: Dests): Uci[] {
   const ucis: string[] = [];
-  for (const [orig, d] of dests) d.forEach(dest => ucis.push(orig + dest));
+  for (const [orig, destList] of dests) {
+    for (const dest of destList) ucis.push(orig + dest);
+  }
   return ucis;
 }
 
@@ -76,7 +78,7 @@ const commands = Object.keys(commandFunctions);
 
 export function nonMoveCommand(command: string, ctrl: MoveCtrl, clear?: () => void): boolean {
   if (!commands.includes(command)) {
-    return command.length > 0 && !!commands.find(c => c.startsWith(command.toLowerCase()));
+    return command.length > 0 && commands.some(c => c.startsWith(command.toLowerCase()));
   }
   commandFunctions[command](ctrl);
   clear?.();

--- a/ui/input/src/handlerUtil.ts
+++ b/ui/input/src/handlerUtil.ts
@@ -71,6 +71,7 @@ const commandFunctions: Record<string, (ctrl?: MoveCtrl) => void> = {
   draw: (ctrl: MoveCtrl) => ctrl.draw(),
   resign: (ctrl: MoveCtrl) => ctrl.resign(true, true),
   next: (ctrl: MoveCtrl) => ctrl.next?.(),
+  takeback: (ctrl: MoveCtrl) => ctrl.takeback?.(),
   upv: (ctrl: MoveCtrl) => ctrl.vote?.(true),
   downv: (ctrl: MoveCtrl) => ctrl.vote?.(false),
   help: (ctrl: MoveCtrl) => ctrl.helpModalOpen(true),

--- a/ui/input/src/handlerUtil.ts
+++ b/ui/input/src/handlerUtil.ts
@@ -11,6 +11,7 @@ export const ambiguousPromotionCaptureRegex = /^([a-h][27]?x?)?[a-h](1|8)=?$/;
 export const promotionRegex = /^([a-h]x?)?[a-h](1|8)=?[nbrqkNBRQK]$/;
 export const iccfRegex = /^[1-8][1-8]?[1-5]?$/;
 export const partialMoveRegex = /^[BNRQK]$/;
+export const cancelRegex = /cancel/;
 
 export function iccfToUci(v: string) {
   const chars = v.split('');

--- a/ui/input/src/handlerUtil.ts
+++ b/ui/input/src/handlerUtil.ts
@@ -10,6 +10,7 @@ export const ambiguousPromotionRegex = /^[a-h][27][a-h][18]$/;
 export const ambiguousPromotionCaptureRegex = /^([a-h][27]?x?)?[a-h](1|8)=?$/;
 export const promotionRegex = /^([a-h]x?)?[a-h](1|8)=?[nbrqkNBRQK]$/;
 export const iccfRegex = /^[1-8][1-8]?[1-5]?$/;
+export const partialMoveRegex = /^[BNRQK]$/;
 
 export function iccfToUci(v: string) {
   const chars = v.split('');

--- a/ui/input/src/interfaces.ts
+++ b/ui/input/src/interfaces.ts
@@ -81,6 +81,7 @@ export interface VoiceCtrl {
   readonly isRecording: boolean; // are we recording?
   readonly status: string; // errors, progress, or the most recent voice command
   addListener: (name: string, listener: VoiceListener) => void;
+  partialMove: Prop<string>;
 }
 
 export interface VoskOpts {

--- a/ui/input/src/interfaces.ts
+++ b/ui/input/src/interfaces.ts
@@ -34,6 +34,7 @@ export interface MoveCtrl {
   draw(): void;
   next(): void;
   vote(v: boolean): void;
+  takeback(): void;
   resign(v: boolean, immediately?: boolean): void;
   helpModalOpen: Prop<boolean>;
   voice: VoiceCtrl; // convenience
@@ -59,6 +60,7 @@ export interface RootCtrl {
   crazyValid?: (role: cg.Role, key: cg.Key) => boolean;
   data: RootData;
   offerDraw?: (v: boolean, immediately?: boolean) => void;
+  takebackYes?: () => void;
   resign?: (v: boolean, immediately?: boolean) => void;
   sendMove: (orig: cg.Key, dest: cg.Key, prom: cg.Role | undefined, meta?: cg.MoveMetadata) => void;
   sendNewPiece?: (role: cg.Role, key: cg.Key, isPredrop: boolean) => void;

--- a/ui/input/src/moveCtrl.ts
+++ b/ui/input/src/moveCtrl.ts
@@ -49,7 +49,6 @@ export function makeMoveCtrl(root: RootCtrl, step: { fen: string }): MoveCtrl {
       handlers.forEach(h => h(step.fen, cgState.movable.dests, yourMove));
     },
     addHandler(h: MoveHandler) {
-      if (!h) return;
       handlers.add(h);
       h(initFen, cgState.movable.dests);
     },

--- a/ui/input/src/moveCtrl.ts
+++ b/ui/input/src/moveCtrl.ts
@@ -3,6 +3,7 @@ import { promote } from 'chess/promotion';
 import { propWithEffect } from 'common';
 import { voiceCtrl } from './main';
 import { RootCtrl, MoveHandler, MoveCtrl } from './interfaces';
+import { pieceCharToRole } from './util';
 
 export function makeMoveCtrl(root: RootCtrl, step: { fen: string }): MoveCtrl {
   const isFocused = propWithEffect(false, root.redraw);
@@ -22,7 +23,7 @@ export function makeMoveCtrl(root: RootCtrl, step: { fen: string }): MoveCtrl {
   }
   return {
     drop(key, piece) {
-      const role = sanToRole[piece];
+      const role = pieceCharToRole[piece];
       const crazyData = root.data.crazyhouse;
       const color = root.data.player.color;
       // Crazyhouse not set up properly
@@ -37,7 +38,7 @@ export function makeMoveCtrl(root: RootCtrl, step: { fen: string }): MoveCtrl {
       root.sendNewPiece(role, key, false);
     },
     promote(orig, dest, piece) {
-      const role = sanToRole[piece];
+      const role = pieceCharToRole[piece];
       const variant = root.data.game.variant.key;
       if (!role || role == 'pawn' || (role == 'king' && variant !== 'antichess')) return;
       root.chessground.cancelMove();
@@ -80,13 +81,3 @@ export function makeMoveCtrl(root: RootCtrl, step: { fen: string }): MoveCtrl {
     root,
   };
 }
-
-const sanToRole: { [key: string]: cg.Role } = {
-  // TODO: use functionality available elsewhere or find a better place for this
-  P: 'pawn',
-  N: 'knight',
-  B: 'bishop',
-  R: 'rook',
-  Q: 'queen',
-  K: 'king',
-};

--- a/ui/input/src/moveCtrl.ts
+++ b/ui/input/src/moveCtrl.ts
@@ -73,6 +73,7 @@ export function makeMoveCtrl(root: RootCtrl, step: { fen: string }): MoveCtrl {
     clock: () => root.clock,
     draw: () => (root.offerDraw ? root.offerDraw(true, true) : null),
     resign: (v, immediately) => (root.resign ? root.resign(v, immediately) : null),
+    takeback: () => root.takebackYes?.(),
     next: () => root.next?.(),
     vote: (v: boolean) => root.vote?.(v),
     helpModalOpen,

--- a/ui/input/src/util.ts
+++ b/ui/input/src/util.ts
@@ -1,0 +1,10 @@
+import * as cg from 'chessground/types';
+
+export const pieceCharToRole: { [key: string]: cg.Role } = {
+  P: 'pawn',
+  N: 'knight',
+  B: 'bishop',
+  R: 'rook',
+  Q: 'queen',
+  K: 'king',
+};

--- a/ui/input/src/voiceCtrl.ts
+++ b/ui/input/src/voiceCtrl.ts
@@ -1,6 +1,7 @@
 import { VoiceCtrl, VoiceListener, MsgType } from './interfaces';
 import { objectStorage } from 'common/objectStorage';
 import { prop } from 'common';
+import { pieceCharToRole } from './util';
 
 const speechMap = new Map<string, string>([
   ['a', 'a'],
@@ -164,7 +165,7 @@ export const makeVoiceCtrl = () =>
 
     broadcast(text: string, msgType: MsgType = 'status', forMs = 0) {
       window.clearTimeout(this.broadcastTimeout);
-      this.voskStatus = text;
+      this.voskStatus = this.partialMove() ? `${pieceCharToRole[this.partialMove()]}... ${text}` : text;
       const encoded = msgType === 'command' ? this.encode(text) : text;
       for (const li of this.listeners.values()) li(encoded, msgType);
       this.broadcastTimeout = forMs > 0 ? window.setTimeout(() => this.broadcast(''), forMs) : undefined;

--- a/ui/input/src/voiceCtrl.ts
+++ b/ui/input/src/voiceCtrl.ts
@@ -68,6 +68,7 @@ const speechMap = new Map<string, string>([
 
   // Command words
   ['help', '?'],
+  ['cancel', 'cancel'],
   ['next', 'next'],
   ['continue', 'next'],
   ['next puzzle', 'next'],

--- a/ui/input/src/voiceCtrl.ts
+++ b/ui/input/src/voiceCtrl.ts
@@ -74,6 +74,7 @@ const speechMap = new Map<string, string>([
   ['continue', 'next'],
   ['next puzzle', 'next'],
   ['clock', 'clock'],
+  ['take back', 'takeback'],
   ['draw', 'draw'],
   ['offer draw', 'draw'],
   ['accept draw', 'draw'],

--- a/ui/input/src/voiceMoveHandler.ts
+++ b/ui/input/src/voiceMoveHandler.ts
@@ -14,6 +14,10 @@ export function makeVoiceHandler(ctrl: MoveCtrl): MoveHandler {
       ctrl.voice.partialMove(v);
       return;
     }
+    if (v.match(util.cancelRegex)) {
+      ctrl.voice.partialMove('');
+      return;
+    }
 
     if (legalSans && v.match(util.fullUciRegex)) {
       ctrl.san(v.slice(0, 2) as Key, v.slice(2) as Key);

--- a/ui/input/src/voiceMoveHandler.ts
+++ b/ui/input/src/voiceMoveHandler.ts
@@ -4,12 +4,28 @@ import { Dests } from 'chessground/types';
 import { sanWriter, SanToUci } from 'chess';
 import * as util from './handlerUtil';
 
+const substitutionsMap = {
+  a: ['a8', '8'],
+  '3': ['3e'],
+  '8': ['a8', 'a'],
+  c: ['ce'],
+  d: ['de'],
+  g: ['ge'],
+};
+const closestLegalUci = (input: string, legalSans?: SanToUci): Uci | null => {
+  if (!legalSans) return null;
+  for (const [key, substitutions] of Object.entries(substitutionsMap)) {
+    for (const substitution of substitutions) {
+      const substituted = input.replace(key, substitution);
+      if (legalSans[substituted]) return legalSans[substituted];
+    }
+  }
+  return null;
+};
+
 export function makeVoiceHandler(ctrl: MoveCtrl): MoveHandler {
   let legalSans: SanToUci | undefined;
   function submit(v: string) {
-    const selectedKey = ctrl.hasSelected() || '';
-    const uci = util.sanToUci(v, legalSans);
-
     if (v.match(util.partialMoveRegex)) {
       ctrl.voice.partialMove(v);
       return;
@@ -19,6 +35,10 @@ export function makeVoiceHandler(ctrl: MoveCtrl): MoveHandler {
       return;
     }
 
+    const selectedKey = ctrl.hasSelected() || '';
+    const uci = util.sanToUci(v, legalSans);
+    const closeUci = closestLegalUci(v, legalSans);
+
     if (legalSans && v.match(util.fullUciRegex)) {
       ctrl.san(v.slice(0, 2) as Key, v.slice(2) as Key);
     } else if (legalSans && v.match(util.keyRegex)) {
@@ -26,17 +46,13 @@ export function makeVoiceHandler(ctrl: MoveCtrl): MoveHandler {
       else ctrl.select(v as Key);
     } else if (legalSans && uci) {
       ctrl.san(uci.slice(0, 2) as Key, uci.slice(2) as Key);
+    } else if (closeUci) {
+      ctrl.san(closeUci.slice(0, 2) as Key, closeUci.slice(2) as Key);
     } else if (legalSans && (selectedKey.slice(0, 1) + v).match(util.promotionRegex)) {
       const promotionSan = selectedKey && selectedKey.slice(0, 1) !== v.slice(0, 1) ? selectedKey.slice(0, 1) + v : v;
       const foundUci = util.sanToUci(promotionSan.replace('=', '').slice(0, -1), legalSans);
       if (!foundUci) return;
       ctrl.promote(foundUci.slice(0, 2) as Key, foundUci.slice(2) as Key, v.slice(-1).toUpperCase());
-    } else if (v.match(util.crazyhouseRegex)) {
-      // Incomplete crazyhouse strings such as Q@ or Q@a should do nothing.
-      if (v.length > 3 || (v.length > 2 && v.startsWith('@'))) {
-        if (v.length === 3) v = 'P' + v;
-        ctrl.drop(v.slice(2) as Key, v[0].toUpperCase());
-      }
     } else if (
       !util.nonMoveCommand(v, ctrl) &&
       v.length &&

--- a/ui/input/src/voiceMoveHandler.ts
+++ b/ui/input/src/voiceMoveHandler.ts
@@ -17,7 +17,10 @@ const closestLegalUci = (input: string, legalSans?: SanToUci): Uci | null => {
   for (const [key, substitutions] of Object.entries(substitutionsMap)) {
     for (const substitution of substitutions) {
       const substituted = input.replace(key, substitution);
+      // check if after substitution, we have a legal SAN move
       if (legalSans[substituted]) return legalSans[substituted];
+      // check if after substitution, we have a legal UCI move
+      if (substituted.match(util.fullUciRegex)) return substituted;
     }
   }
   return null;


### PR DESCRIPTION
A pretty simple change to account for the problem that Trevlar brought up where you say "bishop" followed by a pause because you are figuring out the name of the coordinate, but by the time you say the coordinate, it's an entirely new input.

Now you can say "bishop", or the name of any other piece, and we will save it as a partial move, updating the text to show "bishop...". It's kind of subtle, the fact that we have saved that piece name. If you really didn't want that piece, I added a command to "cancel". The cancel command could be useful in other contexts as well perhaps. All in all I think this "partial move" feature needs more improvement, but maybe it's a good starting point?