### PR TITLE
Adjust variant draw streak thresholds

### DIFF
--- a/app/views/tournament/faq.scala
+++ b/app/views/tournament/faq.scala
@@ -70,15 +70,11 @@ object faq:
             td(30)
           ),
           tr(
-            td("Crazyhouse, King of the Hill"),
-            td(25)
-          ),
-          tr(
-            td("Antichess, Racing Kings"),
+            td("Antichess, Crazyhouse, King of the Hill"),
             td(20)
           ),
           tr(
-            td("Three check, Atomic"),
+            td("Three check, Atomic, Racing Kings"),
             td(10)
           )
         )

--- a/modules/tournament/src/main/Pairing.scala
+++ b/modules/tournament/src/main/Pairing.scala
@@ -39,10 +39,9 @@ case class Pairing(
   def quickDraw        = draw && turns.exists(20 >)
   def notSoQuickFinish = finished && turns.exists(14 <=)
   def longGame(variant: Variant) = turns.exists(_ >= (variant match {
-    case Standard | Chess960 | Horde => 60
-    case Crazyhouse | KingOfTheHill  => 50
-    case Antichess | RacingKings     => 40
-    case ThreeCheck | Atomic         => 20
+    case Standard | Chess960 | Horde            => 60
+    case Antichess | Crazyhouse | KingOfTheHill => 40
+    case ThreeCheck | Atomic | RacingKings      => 20
   }))
 
   def wonBy(user: UserId): Boolean     = winner.has(user)


### PR DESCRIPTION
Follow up to #11580

RK 20 => 10
ZH/KOTH 25 => 20

Some members of the RK community have pointed out that 20 is still way too high. Checking some stats again, the vast majority (~90%) of RK games and draws are shorter than 20 moves. Looks like originally, 15 was the suggested value but then it got bumped to 20 for consistency.

The ZH and KOTH adjustment is mostly for increased consistency. But checking some games, they do seem to have legitimate draws in that move range and are ofc generally shorter than standard games.