### PR TITLE
fix  game abort time disappearance for opponent in mobile view

### DIFF
--- a/ui/round/css/_app-layout.scss
+++ b/ui/round/css/_app-layout.scss
@@ -67,10 +67,6 @@
       box-shadow: none;
     }
 
-    .expiration-top {
-      display: none;
-    }
-
     &__table {
       display: none;
     }
@@ -116,5 +112,18 @@
 
   &__board {
     grid-area: board;
+  }
+}
+
+.round__app__expi_top {
+  display: grid;
+
+  @include breakpoint($mq-col1) {
+    grid-template-rows: auto auto $col1-user-height $col1-mat-height auto auto auto $col1-mat-height $col1-user-height auto;
+    grid-template-areas: 'moves' 'pocket-top' 'user-top' 'mat-top' 'expi-top' 'board' 'expi-bot' 'mat-bot' 'user-bot' 'pocket-bot' 'kb-move' 'controls';
+
+    .rclock-bottom {
+      grid-area: 8 / 1 / 10 / 2;
+    }
   }
 }

--- a/ui/round/src/view/main.ts
+++ b/ui/round/src/view/main.ts
@@ -8,6 +8,7 @@ import { render as renderKeyboardMove } from 'keyboardMove';
 import { render as renderGround } from '../ground';
 import { renderTable } from './table';
 import { renderMaterialDiffs } from 'game/view/material';
+import { isPlayerTurn, playable } from 'game';
 
 export function main(ctrl: RoundController): VNode {
   const d = ctrl.data,
@@ -22,35 +23,40 @@ export function main(ctrl: RoundController): VNode {
       ctrl.ply
     );
 
+  const showExpiTop = playable(ctrl.data) && ctrl.data.expiration && !isPlayerTurn(ctrl.data);
+
   return ctrl.nvui
     ? ctrl.nvui.render(ctrl)
-    : h('div.round__app.variant-' + d.game.variant.key, [
-        h(
-          'div.round__app__board.main-board' + (ctrl.data.pref.blindfold ? '.blindfold' : ''),
-          {
-            hook:
-              'ontouchstart' in window || !lichess.storage.boolean('scrollMoves').getOrDefault(true)
-                ? undefined
-                : util.bind(
-                    'wheel',
-                    stepwiseScroll((e: WheelEvent, scroll: boolean) => {
-                      if (!ctrl.isPlaying()) {
-                        e.preventDefault();
-                        if (e.deltaY > 0 && scroll) keyboard.next(ctrl);
-                        else if (e.deltaY < 0 && scroll) keyboard.prev(ctrl);
-                        ctrl.redraw();
-                      }
-                    }),
-                    undefined,
-                    false
-                  ),
-          },
-          [renderGround(ctrl), ctrl.promotion.view(ctrl.data.game.variant.key === 'antichess')]
-        ),
-        ctrl.keyboardHelp ? keyboard.view(ctrl) : null,
-        crazyView(ctrl, topColor, 'top') || materialDiffs[0],
-        ...renderTable(ctrl),
-        crazyView(ctrl, bottomColor, 'bottom') || materialDiffs[1],
-        ctrl.keyboardMove ? renderKeyboardMove(ctrl.keyboardMove) : null,
-      ]);
+    : h(
+        (showExpiTop ? 'div.round__app.round__app__expi_top.variant-' : 'div.round__app.variant-') + d.game.variant.key,
+        [
+          h(
+            'div.round__app__board.main-board' + (ctrl.data.pref.blindfold ? '.blindfold' : ''),
+            {
+              hook:
+                'ontouchstart' in window || !lichess.storage.boolean('scrollMoves').getOrDefault(true)
+                  ? undefined
+                  : util.bind(
+                      'wheel',
+                      stepwiseScroll((e: WheelEvent, scroll: boolean) => {
+                        if (!ctrl.isPlaying()) {
+                          e.preventDefault();
+                          if (e.deltaY > 0 && scroll) keyboard.next(ctrl);
+                          else if (e.deltaY < 0 && scroll) keyboard.prev(ctrl);
+                          ctrl.redraw();
+                        }
+                      }),
+                      undefined,
+                      false
+                    ),
+            },
+            [renderGround(ctrl), ctrl.promotion.view(ctrl.data.game.variant.key === 'antichess')]
+          ),
+          ctrl.keyboardHelp ? keyboard.view(ctrl) : null,
+          crazyView(ctrl, topColor, 'top') || materialDiffs[0],
+          ...renderTable(ctrl),
+          crazyView(ctrl, bottomColor, 'bottom') || materialDiffs[1],
+          ctrl.keyboardMove ? renderKeyboardMove(ctrl.keyboardMove) : null,
+        ]
+      );
 }


### PR DESCRIPTION
This PR fixes the issue in which opponents first move countdown timer is not visible in mobile view.

---

Update:

I created an new CSS class `round__app__expi_top` to show expiration timer of the opponent in mobile view. This class adds one more row in grid view to show the expiration timer.

I added this class because changing the class `round__app` to add one more row for `expiration-top` class in grid view messed up the square selection (user has to tap below the desired square in order to select it) when the expiration timer went away after first move.

This change only adds `round__app__expi_top` class when expiration timer of the opponent is needed to be shown otherwise `round__app` is added.

https://user-images.githubusercontent.com/69393483/225615864-a496ff71-a67f-4d46-b236-417dfa69f50e.mp4




other solution could be adding `grid-area: 4 / 1 / 5 / 2;` in `.expiration-top` class instead of `display: none;`, but I think it not very good solution as it will overlap with opponent name and time if we adjust `z-index`. 


---
before changes:
![image](https://user-images.githubusercontent.com/69393483/221927300-ef11d5fc-5f27-4cf7-a11f-a0e3ca9cc26f.png)

after changes:

![image](https://user-images.githubusercontent.com/69393483/221928352-e90bd46c-6ce8-459c-a880-ebd1fa210da6.png)

https://user-images.githubusercontent.com/69393483/222522626-2b14e161-a60d-4123-b9ef-c0d205ee3e7b.mp4


---

Without clock grid area change clock is misplaced:

![css-row-add](https://user-images.githubusercontent.com/69393483/222523783-5b81d615-b76e-4d15-a86e-6fc81f4aa256.png)

---





 may fix #9974