### PR TITLE
PGN import: warn that variations will be lost and redirect to study

### DIFF
--- a/app/views/game/importGame.scala
+++ b/app/views/game/importGame.scala
@@ -10,10 +10,10 @@ import controllers.routes
 
 object importGame:
 
-  private def analyseHelp(implicit ctx: Context) =
+  private def analyseHelp(using ctx: Context) =
     ctx.isAnon option a(cls := "blue", href := routes.Auth.signup)(trans.youNeedAnAccountToDoThat())
 
-  def apply(form: play.api.data.Form[?])(implicit ctx: Context) =
+  def apply(form: play.api.data.Form[?])(using ctx: Context) =
     views.html.base.layout(
       title = trans.importGame.txt(),
       moreCss = cssTag("importer"),
@@ -29,7 +29,9 @@ object importGame:
       main(cls := "importer page-small box box-pad")(
         h1(cls := "box__top")(trans.importGame()),
         p(cls := "explanation")(trans.importGameExplanation()),
-        standardFlash,
+        standardFlash | flashMessage("warning")(
+          trans.importGameCaveat(a(href := routes.Study.allDefault(1))(trans.toStudy()))
+        ),
         postForm(cls := "form3 import", action := routes.Importer.sendGame)(
           form3.group(form("pgn"), trans.pasteThePgnStringHere())(form3.textarea(_)()),
           form("pgn").value flatMap { pgn =>

--- a/app/views/game/importGame.scala
+++ b/app/views/game/importGame.scala
@@ -29,9 +29,12 @@ object importGame:
       main(cls := "importer page-small box box-pad")(
         h1(cls := "box__top")(trans.importGame()),
         p(cls := "explanation")(trans.importGameExplanation()),
-        standardFlash | flashMessage("warning")(
-          trans.importGameCaveat(a(href := routes.Study.allDefault(1))(trans.toStudy()))
+        p(
+          a(cls := "text", dataIcon := "", href := routes.Study.allDefault(1))(
+            trans.importGameCaveat()
+          )
         ),
+        standardFlash,
         postForm(cls := "form3 import", action := routes.Importer.sendGame)(
           form3.group(form("pgn"), trans.pasteThePgnStringHere())(form3.textarea(_)()),
           form("pgn").value flatMap { pgn =>

--- a/modules/i18n/src/main/I18nKeys.scala
+++ b/modules/i18n/src/main/I18nKeys.scala
@@ -289,6 +289,7 @@ object I18nKeys:
   val `toStudy` = I18nKey("toStudy")
   val `importGame` = I18nKey("importGame")
   val `importGameExplanation` = I18nKey("importGameExplanation")
+  val `importGameCaveat` = I18nKey("importGameCaveat")
   val `thisIsAChessCaptcha` = I18nKey("thisIsAChessCaptcha")
   val `clickOnTheBoardToMakeYourMove` = I18nKey("clickOnTheBoardToMakeYourMove")
   val `captcha.fail` = I18nKey("captcha.fail")

--- a/translation/source/site.xml
+++ b/translation/source/site.xml
@@ -391,6 +391,7 @@
   <string name="importGame">Import game</string>
   <string name="importGameExplanation">Paste a game PGN to get a browsable replay,
 computer analysis, game chat and shareable URL.</string>
+  <string name="importGameCaveat">Variations will be erased. To keep them, import the PGN through a %s.</string>
   <plurals name="nbImportedGames">
     <item quantity="one">%s imported game</item>
     <item quantity="other">%s imported games</item>

--- a/translation/source/site.xml
+++ b/translation/source/site.xml
@@ -391,7 +391,7 @@
   <string name="importGame">Import game</string>
   <string name="importGameExplanation">Paste a game PGN to get a browsable replay,
 computer analysis, game chat and shareable URL.</string>
-  <string name="importGameCaveat">Variations will be erased. To keep them, import the PGN through a %s.</string>
+  <string name="importGameCaveat">Variations will be erased. To keep them, import the PGN via a study.</string>
   <plurals name="nbImportedGames">
     <item quantity="one">%s imported game</item>
     <item quantity="other">%s imported games</item>


### PR DESCRIPTION
Current design:
<img width="880" alt="image" src="https://user-images.githubusercontent.com/56031107/222885641-0bdb3e21-b4e0-4884-b132-8a869c7b8e5f.png">



Prior was a bit too intrusive.
<img width="916" alt="image" src="https://user-images.githubusercontent.com/56031107/222821371-c6bfdec9-3078-46dc-a893-03a0ec2a5be6.png">

Another option was to display this warning only if the pasted PGN contained variations but was more complex to implement (rendering warning with forms)
