### PR TITLE
Show "more time" button on smaller screens

### DIFF
--- a/ui/round/css/_clock.scss
+++ b/ui/round/css/_clock.scss
@@ -187,15 +187,11 @@
   .berserked {
     @extend %flex-center, %zen;
 
-    display: none;
-
-    @include breakpoint($mq-xx-small) {
-      order: -1;
-      display: flex;
-      flex: 0 1 auto;
-      font-size: 1.7em;
-      padding: 0 0.3em;
-    }
+    order: -1;
+    display: flex;
+    flex: 0 1 auto;
+    font-size: 1.7em;
+    padding: 0 0.3em;
 
     @include breakpoint($mq-col2) {
       order: inherit;


### PR DESCRIPTION
## Advantages

Well... the gift 15s button is back on the mobile interface, which is IMHO a quite important button for casually playing with friends.

## Disadvantages:

When the screen is really small, and the name is long enough, this happens: (this is at [320px](https://ux.stackexchange.com/questions/74798/are-there-devices-narrower-than-320px-and-data-on-their-usage-for-web-browsing))
![image](https://user-images.githubusercontent.com/86106200/222827183-9c4c52a9-ce84-4c5e-94b9-43d77976e9bb.png)

Note that the above name is far longer than most I've encountered (I don't know about the average / 95percentile etc name length), and the screen width is 320px. ([Why is this a decent cutoff?](https://ux.stackexchange.com/questions/74798/are-there-devices-narrower-than-320px-and-data-on-their-usage-for-web-browsing)) And also a "3:00:00" clock is one of the largest you can have.

Compare that to a more decent version (here on 270px wide!):
![image](https://user-images.githubusercontent.com/86106200/222828859-2fcf5f6c-4605-4762-829b-c932ec034942.png)

For reference, the previous breakpoint to hide this button was 500px.

Possible solutions:
 - Introduce another mediaquery for even smaller sizes (only kicks problems down the screen size)
 - Truncate name length

Let me know if you'd prefer me to implement one of these options.

## References

See also: #12445 