### PR TITLE
Fix incorrect I18nKey for en passant puzzle theme.

### DIFF
--- a/modules/puzzle/src/main/PuzzleTheme.scala
+++ b/modules/puzzle/src/main/PuzzleTheme.scala
@@ -38,7 +38,7 @@ object PuzzleTheme:
     PuzzleTheme(Key("dovetailMate"), i.dovetailMate, i.dovetailMateDescription)
   val equality       = PuzzleTheme(Key("equality"), i.equality, i.equalityDescription)
   val endgame        = PuzzleTheme(Key("endgame"), i.endgame, i.endgameDescription)
-  val enPassant      = PuzzleTheme(Key("enPassant"), I18nKey("En passant"), i.enPassantDescription)
+  val enPassant      = PuzzleTheme(Key("enPassant"), trans.learn.enPassant, i.enPassantDescription)
   val exposedKing    = PuzzleTheme(Key("exposedKing"), i.exposedKing, i.exposedKingDescription)
   val fork           = PuzzleTheme(Key("fork"), i.fork, i.forkDescription)
   val hangingPiece   = PuzzleTheme(Key("hangingPiece"), i.hangingPiece, i.hangingPieceDescription)


### PR DESCRIPTION
Due to an incorrect key, the en passant puzzle theme was not localized

![image](https://user-images.githubusercontent.com/11248241/224686407-47cc0e19-2e8d-40f6-9d2a-108abf2310b9.png)

Re-using the string from `trans.learn`, as it should be the same, and I believe this was the original intention.

Please test; I don't have the dev setup locally, and i don't know scala lmao

https://lichess.org/training/themes