### PR TITLE
Clipboard action with icon for broadcast sharing 

### DIFF
--- a/ui/analyse/src/study/studyShare.ts
+++ b/ui/analyse/src/study/studyShare.ts
@@ -212,7 +212,17 @@ export function view(ctrl: StudyShareCtrl): VNode {
                       value: `${baseUrl()}${path}`,
                     },
                   }),
-                  h('button.clipboard', 'Copy')
+                  h('a.button.clipboard', {
+                    attrs: {
+                      'data-icon': ''
+                    },
+                    hook: bind('click', async event => {
+                      const text = `${baseUrl()}${path}`;
+                      await navigator.clipboard.writeText(text);
+                      (event.target as HTMLElement).setAttribute('data-icon', '');
+                      setTimeout(() => (event.target as HTMLElement).setAttribute('data-icon', ''), 1000);
+                    })
+                  })
                 ]),
                 ...(pastable ? [fromPly(ctrl), !isPrivate ? youCanPasteThis() : null] : []),
               ])

--- a/ui/analyse/src/study/studyShare.ts
+++ b/ui/analyse/src/study/studyShare.ts
@@ -205,12 +205,15 @@ export function view(ctrl: StudyShareCtrl): VNode {
             ).map(([i18n, path, pastable]: [string, string, boolean]) =>
               h('div.form-group', [
                 h('label.form-label', ctrl.trans.noarg(i18n)),
-                h('input.form-control.autoselect', {
-                  attrs: {
-                    readonly: true,
-                    value: `${baseUrl()}${path}`,
-                  },
-                }),
+                h('div.form-control-with-clipboard', [
+                  h('input.form-control.autoselect', {
+                    attrs: {
+                      readonly: true,
+                      value: `${baseUrl()}${path}`,
+                    },
+                  }),
+                  h('button.clipboard', 'Copy')
+                ]),
                 ...(pastable ? [fromPly(ctrl), !isPrivate ? youCanPasteThis() : null] : []),
               ])
             ),

--- a/ui/analyse/src/study/studyShare.ts
+++ b/ui/analyse/src/study/studyShare.ts
@@ -214,15 +214,15 @@ export function view(ctrl: StudyShareCtrl): VNode {
                   }),
                   h('a.button.clipboard', {
                     attrs: {
-                      'data-icon': ''
+                      'data-icon': '',
                     },
                     hook: bind('click', async event => {
                       const text = `${baseUrl()}${path}`;
                       await navigator.clipboard.writeText(text);
                       (event.target as HTMLElement).setAttribute('data-icon', '');
                       setTimeout(() => (event.target as HTMLElement).setAttribute('data-icon', ''), 1000);
-                    })
-                  })
+                    }),
+                  }),
                 ]),
                 ...(pastable ? [fromPly(ctrl), !isPrivate ? youCanPasteThis() : null] : []),
               ])

--- a/ui/common/css/form/_form3.scss
+++ b/ui/common/css/form/_form3.scss
@@ -36,7 +36,7 @@
 
 .form-control {
   display: block;
-  width: 95%;
+  width: 100%;
   height: calc(2.7em + 2px);
   background-clip: padding-box;
 }
@@ -44,6 +44,10 @@
 .form-control-with-clipboard {
   display: inline-flex;
   width: 100%;
+}
+
+.form-control-with-clipboard > .form-control {
+  width: 95%;
 }
 
 .clipboard {

--- a/ui/common/css/form/_form3.scss
+++ b/ui/common/css/form/_form3.scss
@@ -47,7 +47,6 @@
 }
 
 .clipboard {
-  display: inline;
   float: right;
 }
 

--- a/ui/common/css/form/_form3.scss
+++ b/ui/common/css/form/_form3.scss
@@ -36,9 +36,19 @@
 
 .form-control {
   display: block;
-  width: 100%;
+  width: 95%;
   height: calc(2.7em + 2px);
   background-clip: padding-box;
+}
+
+.form-control-with-clipboard {
+  display: inline-flex;
+  width: 100%;
+}
+
+.clipboard {
+  display: inline;
+  float: right;
 }
 
 textarea.form-control {


### PR DESCRIPTION
Hello,

This PR is attempting to resolve [this issue](https://github.com/lichess-org/lila/issues/12403).

Right now this is how the UI change is looking like (the blue clipboard buttons):
<img width="1118" alt="Screenshot 2023-03-13 at 2 05 15 PM" src="https://user-images.githubusercontent.com/88844579/224790226-00788416-700f-4455-8be2-aa0a7ffaf12a.png">


Feedback would be appreciated.