### PR TITLE
~Fix 2nd part of #12544 : Screen shake/scroll problem

### DIFF
--- a/ui/analyse/src/serverSideUnderboard.ts
+++ b/ui/analyse/src/serverSideUnderboard.ts
@@ -40,11 +40,12 @@ export default function (element: HTMLElement, ctrl: AnalyseCtrl) {
   if (!window.LichessAnalyseNvui) {
     lichess.pubsub.on('theme.change', () => updateGifLinks(inputFen.value));
     lichess.pubsub.on('analysis.comp.toggle', (v: boolean) => {
-      setTimeout(
-        () => (v ? $menu.find('.computer-analysis') : $menu.find('span:not(.computer-analysis)').first()).trigger('mousedown'),
-        50
-      );
-      if (v) advChart?.reflow();
+      if (v) {
+        setTimeout(() => $menu.find('.computer-analysis').first().trigger('mousedown'), 50);
+        advChart?.reflow();
+      } else {
+        $menu.find('span:not(.computer-analysis)').first().trigger('mousedown');
+      }
     });
     lichess.pubsub.on('analysis.change', (fen: Fen, _) => {
       const nextInputHash = `${fen}${ctrl.bottomColor()}`;


### PR DESCRIPTION
After https://github.com/lichess-org/lila/commit/103771011a3926f4f9449bdec1947b52cb67ccd4 @ #12544 , which mentions two problems, the first problem was solved (error console), but not the second one (mentioned as 6a & 6b in the Issue + videos @ https://github.com/lichess-org/lila/issues/12544#issuecomment-1474872958 ) : screen shake under certain resolutions (2560x1440 for me).

After the first fix, when scrolling and pressing/spamming z; the issue's 2nd sub-bug is still present : 

https://user-images.githubusercontent.com/2840135/226924187-bf9df795-4de6-47df-82f7-b7a189c6d8c0.mp4

After this PR : 

https://user-images.githubusercontent.com/2840135/226924249-463acdaf-4c1e-43e3-bce4-05f8488a3a83.mp4

Should I create a new issue for this ?
