### PR TITLE
Add "More blogs" link in Lobby view (Solves  #12535)

### DIFF
--- a/app/views/lobby/bits.scala
+++ b/app/views/lobby/bits.scala
@@ -84,25 +84,28 @@ object bits:
       )
     )
 
-  def lastPosts(lichess: Option[lila.blog.MiniPost], uposts: List[lila.ublog.UblogPost.PreviewPost])(using
-      ctx: Context
-  ): Frag =
-    div(cls := "lobby__blog ublog-post-cards")(
-      lichess map { post =>
-        a(cls := "ublog-post-card ublog-post-card--link", href := routes.Blog.show(post.id, post.slug))(
-          img(
-            src     := post.image,
-            cls     := "ublog-post-card__image",
-            widthA  := UblogPost.thumbnail.Small.width,
-            heightA := UblogPost.thumbnail.Small.height
-          ),
-          span(cls := "ublog-post-card__content")(
-            h2(cls := "ublog-post-card__title")(post.title),
-            semanticDate(post.date)(using ctx.lang)(cls := "ublog-post-card__over-image")
+  def lastPosts(
+    lichess: Option[lila.blog.MiniPost], uposts: List[lila.ublog.UblogPost.PreviewPost]
+  )(using ctx: Context) =
+    frag(
+      div(cls := "lobby__blog ublog-post-cards")(
+        lichess map { post =>
+          a(cls := "ublog-post-card ublog-post-card--link", href := routes.Blog.show(post.id, post.slug))(
+            img(
+              src     := post.image,
+              cls     := "ublog-post-card__image",
+              widthA  := UblogPost.thumbnail.Small.width,
+              heightA := UblogPost.thumbnail.Small.height
+            ),
+            span(cls := "ublog-post-card__content")(
+              h2(cls := "ublog-post-card__title")(post.title),
+              semanticDate(post.date)(using ctx.lang)(cls := "ublog-post-card__over-image")
+            )
           )
-        )
-      },
-      ctx.noKid option (uposts map { views.html.ublog.post.card(_, showAuthor = false, showIntro = false) })
+        },
+        ctx.noKid option (uposts map { views.html.ublog.post.card(_, showAuthor = false, showIntro = false) }),
+        a(cls := "ublog-community-blogs--link", href := routes.Ublog.communityAll())(trans.moreBlogs()," »")
+      )
     )
 
   def showUnreadLichessMessage(using Context) =

--- a/modules/i18n/src/main/I18nKeys.scala
+++ b/modules/i18n/src/main/I18nKeys.scala
@@ -310,6 +310,7 @@ object I18nKeys:
   val `followsYou` = I18nKey("followsYou")
   val `xStartedFollowingY` = I18nKey("xStartedFollowingY")
   val `more` = I18nKey("more")
+  val `moreBlogs` = I18nKey("moreBlogs")
   val `memberSince` = I18nKey("memberSince")
   val `lastSeenActive` = I18nKey("lastSeenActive")
   val `player` = I18nKey("player")

--- a/translation/source/site.xml
+++ b/translation/source/site.xml
@@ -428,6 +428,7 @@ computer analysis, game chat and shareable URL.</string>
     <item quantity="other">%s following</item>
   </plurals>
   <string name="more">More</string>
+  <string name="moreBlogs">More blogs</string>
   <string name="memberSince">Member since</string>
   <string name="lastSeenActive">Active %s</string>
   <string name="player">Player</string>

--- a/ui/lobby/css/_lobby.scss
+++ b/ui/lobby/css/_lobby.scss
@@ -165,12 +165,24 @@ body {
   grid-template-columns: repeat(auto-fill, minmax(190px, 1fr));
   grid-gap: 0 2%;
   grid-template-rows: auto; /* first row auto */
-  grid-auto-rows: 0; /* all the other rows 0 */
   font-size: 0.9em;
   h2 {
     font-size: 1.2em;
   }
   .ublog-post-card:hover {
     box-shadow: none;
+  }
+}
+
+.ublog-community-blogs--link {
+  grid-area: blog;
+  grid-column: 1 / 1;
+  margin-top: 10px;
+  padding-left: 5px;
+  font-weight: bold;
+  color: #999999;
+
+  @include breakpoint($mq-col3) {
+    padding-left: 0px;
   }
 }


### PR DESCRIPTION
This adds a link directly below the blogs posts in the lobby view, solving #12535. I took the liberty to choose the position, margin and padding of the new link, please let me know if this works for you.

The link on desktop:
![2023-03-23T00:59:27,020398874+01:00](https://user-images.githubusercontent.com/4669964/227065937-e8106d72-7662-48a9-81b2-d29f6c99c7ff.png)

The link on mobile break-point (added a small padding for readability):
![2023-03-23T00:59:42,774939402+01:00](https://user-images.githubusercontent.com/4669964/227065935-75d61cdc-b19d-4185-8b0b-314e6d419741.png)
