### PR TITLE
Verify website on Mastodon

### DIFF
--- a/app/ui/scalatags.scala
+++ b/app/ui/scalatags.scala
@@ -161,6 +161,7 @@ trait ScalatagsExtensions:
   }
 
   val noFollow = rel := "nofollow"
+  val me       = rel := "me"
 
   def ariaTitle(v: String): Modifier = (t: Builder) => {
     val value = Builder.GenericAttrValueSource(v)

--- a/app/ui/scalatags.scala
+++ b/app/ui/scalatags.scala
@@ -161,7 +161,6 @@ trait ScalatagsExtensions:
   }
 
   val noFollow = rel := "nofollow"
-  val me       = rel := "me"
 
   def ariaTitle(v: String): Modifier = (t: Builder) => {
     val value = Builder.GenericAttrValueSource(v)

--- a/app/views/base/bits.scala
+++ b/app/views/base/bits.scala
@@ -43,7 +43,7 @@ z-index: 99;
 
   val connectLinks =
     div(cls := "connect-links")(
-      a(href := "https://mastodon.online/@lichess", targetBlank, me)("Mastodon"),
+      a(href := "https://mastodon.online/@lichess", targetBlank, rel := "me")("Mastodon"),
       a(href := "https://twitter.com/lichess", targetBlank, noFollow)("Twitter"),
       a(href := "https://discord.gg/lichess", targetBlank, noFollow)("Discord"),
       a(href := "https://www.youtube.com/c/LichessDotOrg", targetBlank, noFollow)("YouTube"),

--- a/app/views/base/bits.scala
+++ b/app/views/base/bits.scala
@@ -43,7 +43,7 @@ z-index: 99;
 
   val connectLinks =
     div(cls := "connect-links")(
-      a(href := "https://mastodon.online/@lichess", targetBlank)("Mastodon"),
+      a(href := "https://mastodon.online/@lichess", targetBlank, me)("Mastodon"),
       a(href := "https://twitter.com/lichess", targetBlank, noFollow)("Twitter"),
       a(href := "https://discord.gg/lichess", targetBlank, noFollow)("Discord"),
       a(href := "https://www.youtube.com/c/LichessDotOrg", targetBlank, noFollow)("YouTube"),


### PR DESCRIPTION
Mastodon requires `<a rel="me" href="https://mastodon.online/@lichess">Mastodon</a>` in the page(s) linked.
Further info/discussion: https://hq.lichess.ovh/#narrow/stream/63-content-social/topic/Mastodon/near/2505256 and following.