### PR TITLE
fix path to font file on oops page

### DIFF
--- a/public/oops/font.html
+++ b/public/oops/font.html
@@ -3,7 +3,7 @@
     <style>
       @font-face {
         font-family: 'lichess';
-        src: url('../_qFOQpH/font/lichess.woff2') format('woff2');
+        src: url('../assets/font/lichess.woff2') format('woff2');
         font-display: block;
         font-weight: normal;
         font-style: normal;


### PR DESCRIPTION
Path to font file is returning a 404 on https://lichess.org/oops/font.html