### PR TITLE
Add extra time per player in simul

### DIFF
--- a/app/views/simul/form.scala
+++ b/app/views/simul/form.scala
@@ -111,6 +111,16 @@ object form:
         )(
           form3.select(_, clockExtraChoices)
         ),
+        form3.group(
+          form("clockExtraPerPlayer"),
+          trans.simulHostExtraTimePerPlayer(),
+          help = trans.simulAddExtraTimePerPlayer().some,
+          half = true
+        )(
+          form3.select(_, clockExtraPerPlayerChoices)
+        )
+      ),
+      form3.split(
         form3.group(form("color"), trans.simulHostcolor(), half = true)(
           form3.select(_, colorChoices)
         )

--- a/app/views/simul/show.scala
+++ b/app/views/simul/show.scala
@@ -10,6 +10,7 @@ import lila.common.String.html.safeJsonValue
 import lila.common.Json.given
 import lila.socket.SocketVersion
 import lila.socket.SocketVersion.given
+import chess.Clock.LimitMinutes
 
 object show:
 
@@ -69,6 +70,10 @@ object show:
               trans.simulHostExtraTime(),
               ": ",
               pluralize("minute", sim.clock.hostExtraMinutes),
+              br,
+              trans.simulHostExtraTimePerPlayer(),
+              ": ",
+              pluralize("minute", LimitMinutes raw sim.clock.hostExtraTimePerPlayer),
               br,
               trans.hostColorX(sim.color match {
                 case Some("white") => trans.white()

--- a/modules/i18n/src/main/I18nKeys.scala
+++ b/modules/i18n/src/main/I18nKeys.scala
@@ -525,6 +525,8 @@ object I18nKeys:
   val `simulClockHint` = I18nKey("simulClockHint")
   val `simulAddExtraTime` = I18nKey("simulAddExtraTime")
   val `simulHostExtraTime` = I18nKey("simulHostExtraTime")
+  val `simulAddExtraTimePerPlayer` = I18nKey("simulAddExtraTimePerPlayer")
+  val `simulHostExtraTimePerPlayer` = I18nKey("simulHostExtraTimePerPlayer")
   val `lichessTournaments` = I18nKey("lichessTournaments")
   val `tournamentFAQ` = I18nKey("tournamentFAQ")
   val `timeBeforeTournamentStarts` = I18nKey("timeBeforeTournamentStarts")

--- a/modules/simul/src/main/Simul.scala
+++ b/modules/simul/src/main/Simul.scala
@@ -81,6 +81,7 @@ case class Simul(
       status = SimulStatus.Started,
       startedAt = nowDate.some,
       applicants = Nil,
+      clock = clock.adjustedForPlayers(nbAccepted),
       pairings = applicants collect {
         case a if a.accepted => SimulPairing(a.player)
       },

--- a/modules/simul/src/main/SimulClock.scala
+++ b/modules/simul/src/main/SimulClock.scala
@@ -1,11 +1,13 @@
 package lila.simul
 
 import chess.{ Centis, Clock, Color }
+import chess.Clock.LimitMinutes
 
 // All durations are expressed in seconds
 case class SimulClock(
     config: Clock.Config,
-    hostExtraTime: Int
+    hostExtraTime: Int,
+    hostExtraTimePerPlayer: LimitMinutes
 ):
 
   def chessClockOf(hostColor: Color) =
@@ -17,6 +19,9 @@ case class SimulClock(
     )
 
   def hostExtraMinutes = hostExtraTime / 60
+
+  def adjustedForPlayers(numberOfPlayers: Int) =
+    copy(hostExtraTime = hostExtraTime + numberOfPlayers * (LimitMinutes raw hostExtraTimePerPlayer) * 60)
 
   def valid =
     if (config.limitSeconds.value + hostExtraTime == 0) config.incrementSeconds >= 10

--- a/translation/source/site.xml
+++ b/translation/source/site.xml
@@ -663,6 +663,8 @@ computer analysis, game chat and shareable URL.</string>
   <string name="simulClockHint">Fischer Clock setup. The more players you take on, the more time you may need.</string>
   <string name="simulAddExtraTime">You may add extra time to your clock to help you cope with the simul.</string>
   <string name="simulHostExtraTime">Host extra clock time</string>
+  <string name="simulAddExtraTimePerPlayer">Add time to your clock per player joined the simul.</string>
+  <string name="simulHostExtraTimePerPlayer">Host extra clock time per player</string>
   <string name="lichessTournaments">Lichess tournaments</string>
   <string name="tournamentFAQ">Arena tournament FAQ</string>
   <string name="timeBeforeTournamentStarts">Time before tournament starts</string>


### PR DESCRIPTION
Implements one of the suggestions in #6554 

This adds an option to add extra time per player on the simul screen.