### PR TITLE
Remember puzzle difficulty

### DIFF
--- a/app/views/base/topnav.scala
+++ b/app/views/base/topnav.scala
@@ -37,7 +37,7 @@ object topnav:
         )
       ),
       ctx.noBot option {
-        val puzzleUrl = langHref(routes.Puzzle.home.url)
+        val puzzleUrl = langHref(routes.Puzzle.home().url)
         st.section(
           linkTitle(puzzleUrl, trans.puzzles()),
           div(role := "group")(

--- a/app/views/plan/features.scala
+++ b/app/views/plan/features.scala
@@ -82,7 +82,7 @@ object features:
               a(href := routes.Learn.index)("All chess basics lessons")
             ),
             tr(unlimited)(
-              a(href := routes.Puzzle.home)("Tactical puzzles from user games")
+              a(href := routes.Puzzle.home())("Tactical puzzles from user games")
             ),
             tr(unlimited)(
               a(href := routes.Puzzle.streak)("Puzzle Streak"),
@@ -148,7 +148,7 @@ object features:
               "Board editor and analysis board with Stockfish 14+"
             ),
             tr(unlimited)(
-              a(href := routes.Puzzle.home)("Tactics puzzles")
+              a(href := routes.Puzzle.home())("Tactics puzzles")
             ),
             tr(check)(
               "Available in 80+ languages"

--- a/app/views/puzzle/bits.scala
+++ b/app/views/puzzle/bits.scala
@@ -38,7 +38,7 @@ object bits:
   def pageMenu(active: String, user: Option[User], days: Int = 30)(implicit ctx: Context) =
     val u = user.filterNot(ctx.is).map(_.username)
     st.nav(cls := "page-menu__menu subnav")(
-      a(href := routes.Puzzle.home)(
+      a(href := routes.Puzzle.home())(
         trans.puzzles()
       ),
       a(cls := active.active("themes"), href := routes.Puzzle.themes)(

--- a/app/views/puzzle/dashboard.scala
+++ b/app/views/puzzle/dashboard.scala
@@ -129,7 +129,7 @@ object dashboard:
           ),
           dashOpt.flatMap(body) |
             div(cls := s"${baseClass}__empty")(
-              a(href := routes.Puzzle.home)(trans.puzzle.noPuzzlesToShow())
+              a(href := routes.Puzzle.home())(trans.puzzle.noPuzzlesToShow())
             )
         )
       )

--- a/app/views/puzzle/theme.scala
+++ b/app/views/puzzle/theme.scala
@@ -50,7 +50,7 @@ object theme:
       div(cls := s"puzzle-themes__list ${cat.value.replace(":", "-")}")(
         themes.map { pt =>
           val url =
-            if (pt.theme == PuzzleTheme.mix) routes.Puzzle.home
+            if (pt.theme == PuzzleTheme.mix) routes.Puzzle.home()
             else routes.Puzzle.show(pt.theme.key.value)
           a(cls := "puzzle-themes__link", href := (pt.count > 0).option(langHref(url)))(
             span(

--- a/app/views/user/show/newPlayer.scala
+++ b/app/views/user/show/newPlayer.scala
@@ -34,7 +34,7 @@ object newPlayer:
       ),
       ul(
         li(a(href := routes.Learn.index)("Learn chess rules")),
-        li(a(href := routes.Puzzle.home)("Improve with chess tactics puzzles")),
+        li(a(href := routes.Puzzle.home())("Improve with chess tactics puzzles")),
         li(a(href := s"${routes.Lobby.home}#ai")("Play the artificial intelligence")),
         li(a(href := s"${routes.Lobby.home}#hook")("Play opponents from around the world")),
         li(a(href := routes.User.list)("Follow your friends on Lichess")),

--- a/conf/routes
+++ b/conf/routes
@@ -134,7 +134,7 @@ POST  /training/coordinate/score       controllers.Coordinate.score
 GET   /$lang<\w\w\w?>/training/coordinate controllers.Coordinate.homeLang(lang)
 
 # Training - Puzzle
-GET   /training                        controllers.Puzzle.home
+GET   /training                        controllers.Puzzle.home(difficulty: Option[String] ?= Some("normal"))
 GET   /training/daily                  controllers.Puzzle.daily
 GET   /training/frame                  controllers.Puzzle.frame
 GET   /training/help                   controllers.Puzzle.help

--- a/ui/puzzle/src/ctrl.ts
+++ b/ui/puzzle/src/ctrl.ts
@@ -33,7 +33,7 @@ import { parseSquare, parseUci, makeSquare, makeUci, opposite } from 'chessops/u
 import { pgnToTree, mergeSolution } from './moveTree';
 import { PromotionCtrl } from 'chess/promotion';
 import { Role, Move, Outcome } from 'chessops/types';
-import { storedBooleanProp } from 'common/storage';
+import { storedBooleanProp, storedStringProp } from 'common/storage';
 import { fromNodeList } from 'tree/dist/path';
 import { last } from 'tree/dist/ops';
 import { uciToMove } from 'chessground/util';
@@ -46,6 +46,7 @@ export default function (opts: PuzzleOpts, redraw: Redraw): Controller {
   const hasStreak = !!opts.data.streak;
   const autoNext = storedBooleanProp(`puzzle.autoNext${hasStreak ? '.streak' : ''}`, hasStreak);
   const rated = storedBooleanProp('puzzle.rated', true);
+  const difficulty = storedStringProp('puzzle.difficulty', 'normal');
   const ground = prop<CgApi | undefined>(undefined) as Prop<CgApi>;
   const threatMode = prop(false);
   const streak = opts.data.streak ? new PuzzleStreak(opts.data) : undefined;
@@ -635,6 +636,7 @@ export default function (opts: PuzzleOpts, redraw: Redraw): Controller {
       rated(!rated());
       redraw();
     },
+    setDifficulty: (diff: string) => difficulty(diff),
     outcome,
     toggleCeval,
     toggleThreatMode,

--- a/ui/puzzle/src/interfaces.ts
+++ b/ui/puzzle/src/interfaces.ts
@@ -72,6 +72,7 @@ export interface Controller extends KeyboardController {
   autoNexting: () => boolean;
   rated: StoredProp<boolean>;
   toggleRated: () => void;
+  setDifficulty: (diff: string) => void;
   session: PuzzleSession;
   allThemes?: AllThemes;
   showRatings: boolean;

--- a/ui/puzzle/src/view/side.ts
+++ b/ui/puzzle/src/view/side.ts
@@ -274,7 +274,13 @@ export const renderDifficultyForm = (ctrl: Controller): VNode =>
         'select#puzzle-difficulty.puzzle__difficulty__selector',
         {
           attrs: { name: 'difficulty' },
-          hook: onInsert(elm => elm.addEventListener('change', () => (elm.parentNode as HTMLFormElement).submit())),
+          hook: onInsert(elm =>
+            elm.addEventListener('change', e => {
+              let diff = (e.target as HTMLInputElement).value;
+              ctrl.setDifficulty(diff);
+              (elm.parentNode as HTMLFormElement).submit();
+            })
+          ),
         },
         difficulties.map(([key, delta]) =>
           h(

--- a/ui/site/src/site.ts
+++ b/ui/site/src/site.ts
@@ -26,6 +26,11 @@ lichess.info = info;
 lichess.load.then(() => {
   $('#user_tag').removeAttr('href');
 
+  let puzzleDifficulty = lichess.storage.get('analyse.puzzle.difficulty') ?? 'normal';
+  if (puzzleDifficulty !== 'normal') {
+    $("a[href='/training']").attr('href', `/training?difficulty=${puzzleDifficulty}`);
+  }
+
   requestAnimationFrame(() => {
     miniBoard.initAll();
     miniGame.initAll();


### PR DESCRIPTION
Fixes #12173 

The difficulty is stored in `localStorage` and is provided as query params. If the current user's `PuzzleSession` does not exist, or has a different difficulty level, a new one is created with the provided difficulty.

I'm not sure if all links leading to the puzzles have been covered. They are currently modified via jquery.

Please do provide feedback and let me know if any changes are required.

