### PR TITLE
Show web:mod scope to mods on API token creation page again

### DIFF
--- a/modules/oauth/src/main/OAuthScope.scala
+++ b/modules/oauth/src/main/OAuthScope.scala
@@ -94,7 +94,7 @@ object OAuthScope:
   )
 
   val classified: List[(I18nKey, List[OAuthScope])] = List(
-    I18nKey("User account")    -> List(Email.Read, Preference.Read, Preference.Write),
+    I18nKey("User account")    -> List(Email.Read, Preference.Read, Preference.Write, Web.Mod),
     I18nKey("Interactions")    -> List(Follow.Read, Follow.Write, Msg.Write),
     I18nKey("Play games")      -> List(Challenge.Read, Challenge.Write, Challenge.Bulk, Tournament.Write),
     I18nKey("Teams")           -> List(Team.Read, Team.Write, Team.Lead),


### PR DESCRIPTION
Hidden to regular users by: https://github.com/lichess-org/lila/blob/461b6bb7f1d7966128fa1cb52ca6ac5196223b67/app/views/oAuth/token/create.scala#L43-L46