### PR TITLE
Use proper name for Vasyl Ivanchuk

### DIFF
--- a/modules/common/src/main/GreatPlayer.scala
+++ b/modules/common/src/main/GreatPlayer.scala
@@ -205,7 +205,7 @@ object GreatPlayer:
     ("Ilyin-Genevsky", "Alexander_Ilyin-Genevsky"),
     ("Inarkiev", "Ernesto_Inarkiev"),
     ("Ioseliani", "Nana_Ioseliani"),
-    ("Ivanchuk", "Vassily_Ivanchuk"),
+    ("Ivanchuk", "Vasyl_Ivanchuk"),
     ("Ivanov", "Alexander_Ivanov_(chess_player)"),
     ("Ivkov", "Borislav_Ivkov"),
     ("Jaffé", "Charles_Jaffe"),


### PR DESCRIPTION
I noticed that for some reason the incorrect/old/russian name was used for Vasyl Ivanchuk. I changed it to the proper one used on [Wikipedia](https://en.wikipedia.org/wiki/Vasyl_Ivanchuk) and the [official fide page](https://ratings.fide.com/profile/14100010).