### PR TITLE
Priorite visible mark over account closure in user appeal view

### DIFF
--- a/app/views/appeal/tree.scala
+++ b/app/views/appeal/tree.scala
@@ -281,7 +281,7 @@ object tree:
       main(cls := "page page-small box box-pad appeal force-ltr")(
         h1(cls := "box__top")("Appeal"),
         div(cls := s"nav-tree${if (isMarked) " marked" else ""}")(
-          if (me.enabled.no || query.contains("alt")) altScreen
+          if ((me.enabled.no && !me.marks.anyVisible) || query.contains("alt")) altScreen
           else
             renderNode(
               {

--- a/modules/user/src/main/UserMark.scala
+++ b/modules/user/src/main/UserMark.scala
@@ -29,9 +29,10 @@ object UserMarks extends TotalWrapper[UserMarks, List[UserMark]]:
     def rankban: Boolean             = has(UserMark.Rankban)
     def alt: Boolean                 = has(UserMark.Alt)
 
-    def nonEmpty = a.value.nonEmpty option a
-    def dirty    = a.value.exists(UserMark.bannable.contains)
-    def clean    = !a.dirty
+    def nonEmpty   = a.value.nonEmpty option a
+    def dirty      = a.value.exists(UserMark.bannable.contains)
+    def clean      = !a.dirty
+    def anyVisible = a.boost || a.engine
 
     def set(sel: UserMark.type => UserMark, v: Boolean) = UserMarks {
       if (v) sel(UserMark) :: a.value


### PR DESCRIPTION
Since the policy is to close marked account with a higher chance to sue, the appeal page can be misleading to those users if we show the alt-closed screen.

close https://github.com/lichess-org/lila/issues/12553