### PR TITLE
Add PUT method to Access-Control-Allow-Methods for API endpoints

### DIFF
--- a/app/http/ResponseHeaders.scala
+++ b/app/http/ResponseHeaders.scala
@@ -28,4 +28,4 @@ object ResponseHeaders:
       )
     )
 
-  val allowMethods = List("OPTIONS", "GET", "POST", "DELETE") mkString ", "
+  val allowMethods = List("OPTIONS", "GET", "POST", "PUT", "DELETE") mkString ", "


### PR DESCRIPTION
The [endpoint to update an external engine](https://lichess.org/api#tag/External-engine/operation/apiExternalEnginePut) looks like the first API endpoint that uses PUT so adding that method to `Access-Control-Allow-Methods`

Fixes this error that I am getting:

![image](https://user-images.githubusercontent.com/271432/229327299-58f80388-22d5-46de-946f-2bd0fb06b13f.png)
