### PR TITLE
Fix shapes in studies

### DIFF
--- a/modules/tree/src/main/tree.scala
+++ b/modules/tree/src/main/tree.scala
@@ -193,9 +193,10 @@ object Node:
     )
   }
 
-  // private given Writes[Pos] = Writes[Pos] { p =>
-  //   JsString(p.key)
-  // }
+  @annotation.nowarn("msg=unused")
+  private given Writes[Pos] = Writes[Pos] { p =>
+    JsString(p.key)
+  }
   private val shapeCircleWrites = Json.writes[Shape.Circle]
   private val shapeArrowWrites  = Json.writes[Shape.Arrow]
   given shapeWrites: Writes[Shape] = Writes[Shape] {


### PR DESCRIPTION
Without the Writes given, it writes them as ints which breaks chessground i.e. doesn't show any shapes in studies and for users without animations, doesn't update the board anymore after an attempt to draw a shape.

Probably also should deny the default opaque writer to avoid this but forgot how exactly to do that again. I guess maybe then it also wouldn't warn that it's unused anymore.

Fix https://github.com/lichess-org/lila/issues/12617