### PR TITLE
Don't consider tour join pause for tournaments that haven't started yet

### DIFF
--- a/modules/tournament/src/main/Pause.scala
+++ b/modules/tournament/src/main/Pause.scala
@@ -40,7 +40,7 @@ final private class Pause:
     }
 
   def canJoin(userId: UserId, tour: Tournament): Boolean =
-    remainingDelay(userId, tour).isEmpty
+    tour.isCreated || remainingDelay(userId, tour).isEmpty
 
 object Pause:
 


### PR DESCRIPTION
They don't give pauses on leaving so it's from a different earlier tournament.