### PR TITLE
Make mod timeouts in teams work again

### DIFF
--- a/modules/chat/src/main/ChatApi.scala
+++ b/modules/chat/src/main/ChatApi.scala
@@ -158,6 +158,7 @@ final class ChatApi(
           busChan = data.chan match {
             case "tournament" => _.Tournament
             case "swiss"      => _.Swiss
+            case "team"       => _.Team
             case _            => _.Study
           }
         )

--- a/modules/chat/src/main/ChatTimeout.scala
+++ b/modules/chat/src/main/ChatTimeout.scala
@@ -89,7 +89,7 @@ object ChatTimeout:
   val form = Form(
     mapping(
       "roomId" -> of[RoomId],
-      "chan"   -> lila.common.Form.stringIn(Set("tournament", "swiss", "study")),
+      "chan"   -> lila.common.Form.stringIn(Set("tournament", "swiss", "team", "study")),
       "userId" -> lila.user.UserForm.historicalUsernameField,
       "reason" -> nonEmptyText,
       "text"   -> nonEmptyText

--- a/ui/chat/src/moderation.ts
+++ b/ui/chat/src/moderation.ts
@@ -42,15 +42,17 @@ export function moderationCtrl(opts: ModerationOpts): ModerationCtrl {
     opts,
     open,
     close,
-    timeout(reason: ModerationReason, text: string) {
+    async timeout(reason: ModerationReason, text: string) {
       if (data) {
         const body = {
           userId: data.id,
           reason: reason.key,
           text,
         };
-        if (new URLSearchParams(window.location.search).get('mod') === 'true') timeout(opts.resourceId, body);
-        else lichess.pubsub.emit('socket.send', 'timeout', body);
+        if (new URLSearchParams(window.location.search).get('mod') === 'true') {
+          await timeout(opts.resourceId, body);
+          window.location.reload(); // to load new state since it won't be sent over the socket
+        } else lichess.pubsub.emit('socket.send', 'timeout', body);
       }
       close();
       opts.redraw();

--- a/ui/chat/src/moderation.ts
+++ b/ui/chat/src/moderation.ts
@@ -3,7 +3,7 @@ import { bind } from 'common/snabbdom';
 import userLink from 'common/userLink';
 import { ModerationCtrl, ModerationOpts, ModerationData, ModerationReason, Ctrl } from './interfaces';
 import { numberFormat } from 'common/number';
-import { userModInfo, flag } from './xhr';
+import { userModInfo, flag, timeout } from './xhr';
 
 export function moderationCtrl(opts: ModerationOpts): ModerationCtrl {
   let data: ModerationData | undefined;
@@ -43,12 +43,15 @@ export function moderationCtrl(opts: ModerationOpts): ModerationCtrl {
     open,
     close,
     timeout(reason: ModerationReason, text: string) {
-      data &&
-        lichess.pubsub.emit('socket.send', 'timeout', {
+      if (data) {
+        const body = {
           userId: data.id,
           reason: reason.key,
           text,
-        });
+        };
+        if (new URLSearchParams(window.location.search).get('mod') === 'true') timeout(opts.resourceId, body);
+        else lichess.pubsub.emit('socket.send', 'timeout', body);
+      }
       close();
       opts.redraw();
     },

--- a/ui/chat/src/xhr.ts
+++ b/ui/chat/src/xhr.ts
@@ -27,7 +27,7 @@ export const timeout = (
   }
 ) => {
   const [chan, roomId] = resourceId.split('/');
-  text(`/mod/public-chat/timeout`, {
+  return text(`/mod/public-chat/timeout`, {
     method: 'post',
     body: form({
       ...body,

--- a/ui/chat/src/xhr.ts
+++ b/ui/chat/src/xhr.ts
@@ -17,3 +17,22 @@ export const setNote = (id: string, text: string) =>
   });
 
 const noteUrl = (id: string) => `/${id}/note`;
+
+export const timeout = (
+  resourceId: string,
+  body: {
+    userId: string;
+    reason: string;
+    text: string;
+  }
+) => {
+  const [chan, roomId] = resourceId.split('/');
+  text(`/mod/public-chat/timeout`, {
+    method: 'post',
+    body: form({
+      ...body,
+      chan,
+      roomId,
+    }),
+  });
+};


### PR DESCRIPTION
Via the HTTP endpoint since non-team-members can't connect to the room anymore so timeout msgs via the socket don't work.

Not exactly the cleanest solution but at least makes it work. Letting mods connect to the socket would be nicer but seems a bit tricky to avoid showing their names.