### PR TITLE
Add /api/study/<id>/<chapter>.pgn endpoint

### DIFF
--- a/conf/routes
+++ b/conf/routes
@@ -230,6 +230,7 @@ GET   /study/topic/autocomplete        controllers.Study.topicAutocomplete
 GET   /study/glyphs/:lang.json         controllers.Study.glyphs(lang)
 GET   /$lang<\w\w\w?>/study            controllers.Study.homeLang(lang)
 GET   /api/study/$id<\w{8}>.pgn        controllers.Study.apiPgn(id)
+GET   /api/study/$id<\w{8}>/$chapterId<\w{8}>.pgn controllers.Study.apiChapterPgn(id, chapterId)
 
 # Relay
 GET   /broadcast                              controllers.RelayTour.index(page: Int ?= 1)


### PR DESCRIPTION
Closes #12548

Mirrored the all chapters API endpoint but I wonder if it really makes sense to return error JSON here 🤔

Not doing it certainly would make things cleaner. Though I guess maybe it also just makes sense to duplicate the bit of code instead of having a fairly small function with a lot of parameters 🤔