### PR TITLE
Create unrated tournaments via the tournament manager

### DIFF
--- a/app/views/tournament/crud.scala
+++ b/app/views/tournament/crud.scala
@@ -104,6 +104,11 @@ object crud:
       form3.group(form("description"), raw("Full description"), help = raw("Link: [text](url)").some)(
         form3.textarea(_)(rows := 6)
       ),
+      form3.checkbox(
+        form("rated"),
+        trans.rated(),
+        help = trans.ratedFormHelp().some
+      ),
       form3.split(
         form3.group(form("variant"), raw("Variant"), half = true) { f =>
           form3.select(f, translatedVariantChoicesWithVariants.map(x => x._1 -> x._2))

--- a/modules/tournament/src/main/crud/CrudApi.scala
+++ b/modules/tournament/src/main/crud/CrudApi.scala
@@ -2,7 +2,7 @@ package lila.tournament
 package crud
 
 import scala.util.chaining.*
-import chess.Clock
+import chess.{ Clock, Mode }
 import chess.format.Fen
 
 import lila.common.config.MaxPerPage
@@ -34,6 +34,7 @@ final class CrudApi(tournamentRepo: TournamentRepo, crudForm: CrudForm):
       description = tour.spotlight.??(_.description),
       conditions = Condition.DataForm.AllSetup(tour.conditions),
       berserkable = !tour.noBerserk,
+      rated = tour.isRated,
       streakable = tour.streakable,
       teamBattle = tour.isTeamBattle,
       hasChat = tour.hasChat
@@ -93,6 +94,7 @@ final class CrudApi(tournamentRepo: TournamentRepo, crudForm: CrudForm):
       clock = clock,
       minutes = minutes,
       variant = realVariant,
+      mode = if (data.rated) Mode.Rated else Mode.Casual,
       startsAt = date.instant,
       schedule = Schedule(
         freq = Schedule.Freq.Unique,

--- a/modules/tournament/src/main/crud/CrudForm.scala
+++ b/modules/tournament/src/main/crud/CrudForm.scala
@@ -29,6 +29,7 @@ final class CrudForm(repo: TournamentRepo):
       "headline"       -> text(minLength = 5, maxLength = 30),
       "description"    -> nonEmptyText,
       "conditions"     -> Condition.DataForm.all(Nil),
+      "rated"          -> boolean,
       "berserkable"    -> boolean,
       "streakable"     -> boolean,
       "teamBattle"     -> boolean,
@@ -51,6 +52,7 @@ final class CrudForm(repo: TournamentRepo):
     description = "",
     conditions = Condition.DataForm.AllSetup.default,
     berserkable = true,
+    rated = true,
     streakable = true,
     teamBattle = false,
     hasChat = true
@@ -74,6 +76,7 @@ object CrudForm:
       headline: String,
       description: String,
       conditions: Condition.DataForm.AllSetup,
+      rated: Boolean,
       berserkable: Boolean,
       streakable: Boolean,
       teamBattle: Boolean,


### PR DESCRIPTION
close https://github.com/lichess-org/lila/issues/12692

I think we could refactor the tournament manager by just wrapping a normal tournament form with the additional fields, would also allow more flexibility. Will look into it in the future.