### PR TITLE
Fix depreciation notice about `java.net.Url`

### DIFF
--- a/app/controllers/I18n.scala
+++ b/app/controllers/I18n.scala
@@ -30,12 +30,12 @@ final class I18n(env: Env) extends LilaController(env):
                 val redir = Redirect {
                   ctx.req.referer.fold(routes.Lobby.home.url) { str =>
                     try
-                      val pageUrl = new java.net.URL(str)
+                      val pageUrl = new java.net.URI(str).parseServerAuthority().toURL()
                       val path    = pageUrl.getPath
                       val query   = pageUrl.getQuery
                       if (query == null) path
                       else path + "?" + query
-                    catch case _: java.net.MalformedURLException => routes.Lobby.home.url
+                    catch case _: Exception => routes.Lobby.home.url
                   }
                 }
                 if (ctx.isAnon) redir.withCookies(env.lilaCookie.session("lang", lang.code))


### PR DESCRIPTION
Constructing raw URLs is deprecated since Java20, this is the recommended way to handle it: https://download.java.net/java/early_access/jdk20/docs/api/java.base/java/net/URL.html#constructor-deprecation

The new version can throw several exceptions: `URISyntaxException`, `MalformedURLException` or `IllegalArgumentException` so thought it was better to handle general exceptions.