### PR TITLE
Fix: PGNs transparent background

### DIFF
--- a/ui/common/css/component/_lichess-pgn-viewer.scss
+++ b/ui/common/css/component/_lichess-pgn-viewer.scss
@@ -5,7 +5,7 @@ $lpv-bg: $c-bg-zebra;
 $lpv-bg-controls: $lpv-bg;
 $lpv-bg-movelist: $lpv-bg;
 $lpv-bg-variation: $c-bg-zebra2;
-$lpv-bg-pane: fade-out($lpv-bg, 0.01);
+$lpv-bg-pane: fade-out($c-bg-zebra2, 0.01);
 $lpv-font: $c-font;
 $lpv-font-shy: $c-font-dim;
 $lpv-font-accent: mix($lpv-bg, $c-font, 20%);


### PR DESCRIPTION
Fixes #12393
This commit fixes the issue by adding a background around the text, similar to dark mode.

**Before:**  ![before](https://user-images.githubusercontent.com/78294042/232368353-4a149583-6865-4494-8fd9-b940878a101f.png) **After:**  ![after](https://user-images.githubusercontent.com/78294042/232368363-6ce5cd7c-ca91-4e9e-a5d2-bea2951f987e.png)