### PR TITLE
Fix a typo on Learn page

### DIFF
--- a/translation/source/learn.xml
+++ b/translation/source/learn.xml
@@ -213,7 +213,7 @@ in two moves!</string>
   <string name="register">Register</string>
   <string name="getAFreeLichessAccount">Get a free Lichess account</string>
   <string name="practice">Practise</string>
-  <string name="learnCommonChessPositions">Learn common chess.Positions</string>
+  <string name="learnCommonChessPositions">Learn common chess positions</string>
   <string name="puzzles">Puzzles</string>
   <string name="exerciseYourTacticalSkills">Exercise your tactical skills</string>
   <string name="videos">Videos</string>


### PR DESCRIPTION
Change "Learn common chess.Positions" - > "Learn common chess positions"