### PR TITLE
Fix: modal close on mouse-up outside modal

### DIFF
--- a/ui/common/src/modal.ts
+++ b/ui/common/src/modal.ts
@@ -17,12 +17,14 @@ interface SnabModal extends BaseModal {
   onClose(): void;
 }
 
+const overlayId = 'modal-overlay';
+
 export default function modal(opts: Modal) {
   modal.close();
   const $wrap = $(
     '<div id="modal-wrap"><span class="close" role="button" aria-label="Close" data-icon="" tabindex="0"></span></div>'
   );
-  const $overlay = $(`<div id="modal-overlay" class="${opts.class}">`);
+  const $overlay = $(`<div id="${overlayId}" class="${opts.class}">`);
   if (!opts.noClickAway) $overlay.on('click', modal.close);
   $('<a href="#"></a>').appendTo($overlay); // guard against focus escaping to window chrome
   $wrap.appendTo($overlay);
@@ -40,7 +42,7 @@ export default function modal(opts: Modal) {
 
 modal.close = () => {
   $('body').removeClass('overlayed');
-  $('#modal-overlay').each(function (this: HTMLElement) {
+  $(`#${overlayId}`).each(function (this: HTMLElement) {
     if (modal.onClose) modal.onClose();
     $(this).remove();
   });
@@ -52,14 +54,12 @@ modal.onClose = undefined as (() => void) | undefined;
 export function snabModal(opts: SnabModal): VNode {
   const close = opts.onClose!;
   return h(
-    'div#modal-overlay',
+    `div#${overlayId}`,
     opts.noClickAway
       ? {}
       : {
           hook: bind('click', (event: MouseEvent) => {
-            if (event.target === document.querySelector('div#modal-overlay')) {
-              close();
-            }
+            if ((event.target as HTMLElement).id == overlayId) close();
           }),
         },
     [

--- a/ui/common/src/modal.ts
+++ b/ui/common/src/modal.ts
@@ -51,33 +51,41 @@ modal.onClose = undefined as (() => void) | undefined;
 
 export function snabModal(opts: SnabModal): VNode {
   const close = opts.onClose!;
-  return h('div#modal-overlay', opts.noClickAway ? {} : { hook: bind('mousedown', (event: MouseEvent) => {
-    if (event.target === document.querySelector('div#modal-overlay')) {
-      close();
-    }
-  }) }, [
-    h(
-      'div#modal-wrap.' + opts.class,
-      {
-        hook: onInsert(el => {
-          bindWrap($(el));
-          opts.onInsert && opts.onInsert($(el));
-        }),
-      },
-      [
-        h('span.close', {
-          attrs: {
-            'data-icon': '',
-            role: 'button',
-            'aria-label': 'Close',
-            tabindex: '0',
-          },
-          hook: onInsert(el => bindClose(el, close)),
-        }),
-        h('div', opts.content),
-      ]
-    ),
-  ]);
+  return h(
+    'div#modal-overlay',
+    opts.noClickAway
+      ? {}
+      : {
+          hook: bind('click', (event: MouseEvent) => {
+            if (event.target === document.querySelector('div#modal-overlay')) {
+              close();
+            }
+          }),
+        },
+    [
+      h(
+        'div#modal-wrap.' + opts.class,
+        {
+          hook: onInsert(el => {
+            bindWrap($(el));
+            opts.onInsert && opts.onInsert($(el));
+          }),
+        },
+        [
+          h('span.close', {
+            attrs: {
+              'data-icon': '',
+              role: 'button',
+              'aria-label': 'Close',
+              tabindex: '0',
+            },
+            hook: onInsert(el => bindClose(el, close)),
+          }),
+          h('div', opts.content),
+        ]
+      ),
+    ]
+  );
 }
 
 const bindClose = (el: HTMLElement, close: () => void) => {

--- a/ui/common/src/modal.ts
+++ b/ui/common/src/modal.ts
@@ -51,7 +51,11 @@ modal.onClose = undefined as (() => void) | undefined;
 
 export function snabModal(opts: SnabModal): VNode {
   const close = opts.onClose!;
-  return h('div#modal-overlay', opts.noClickAway ? {} : { hook: bind('click', close) }, [
+  return h('div#modal-overlay', opts.noClickAway ? {} : { hook: bind('mousedown', (event: MouseEvent) => {
+    if (event.target === document.querySelector('div#modal-overlay')) {
+      close();
+    }
+  }) }, [
     h(
       'div#modal-wrap.' + opts.class,
       {


### PR DESCRIPTION
Fixes #12566
This fix ensures that the modal remains open even if a user clicks outside of it accidentally while the mouse is still down.