### PR TITLE
Hide the puzzle difficulty toggle for anonymous players

### DIFF
--- a/ui/puzzle/src/view/side.ts
+++ b/ui/puzzle/src/view/side.ts
@@ -226,7 +226,7 @@ export function config(ctrl: Controller): MaybeVNode {
       ]),
       h('label', { attrs: { for: autoNextId } }, noarg('jumpToNextPuzzleImmediately')),
     ]),
-    data.replay || ctrl.streak ? null : renderDifficultyForm(ctrl),
+    !data.user || data.replay || ctrl.streak ? null : renderDifficultyForm(ctrl),
     h('div.puzzle__side__config__toggles', [
       h(
         'a.puzzle__side__config__zen.button.button-empty',


### PR DESCRIPTION
<img width="1432" alt="image" src="https://user-images.githubusercontent.com/56031107/233414768-2b73d167-dccb-4ab7-98b9-a32699811f2a.png">

The other solution was to disable the button, but then it was only added clutter for anonymous players. 

Close https://github.com/lichess-org/lila/issues/12673