### PR TITLE
Fix: typo in modal.ts

### DIFF
--- a/ui/common/src/modal.ts
+++ b/ui/common/src/modal.ts
@@ -58,7 +58,7 @@ export function snabModal(opts: SnabModal): VNode {
     opts.noClickAway
       ? {}
       : {
-          hook: bind('click', (event: MouseEvent) => {
+          hook: bind('mousedown', (event: MouseEvent) => {
             if ((event.target as HTMLElement).id == overlayId) close();
           }),
         },


### PR DESCRIPTION
I would like to apologize for accidentally undoing one of my changes while formatting the code. Specifically, I reverted the event from `'mousedown'` back to `'click'`. However, I'd like to clarify that the correct event is `'mousedown'` as opposed to `'click'` because of known issues with `'click'` events in Chrome since version 73.