### PR TITLE
Set prettier log level to `warning`

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "typescript": "^4.9.4"
   },
   "scripts": {
-    "format": "prettier --write .",
-    "check-format": "prettier --check .",
+    "format": "prettier --write . --loglevel warn",
+    "check-format": "prettier --check . --loglevel warn",
     "lint": "eslint . --ext .ts",
     "journal": "journalctl --user -fu lila -o cat",
     "metals": "tail -F .metals/metals.log | stdbuf -oL cut -c 21- | rg -v '(notification for request|handleCancellation)'",


### PR DESCRIPTION
By default `prettier` will output a line for every file it will format, this definitely remove a sense of speed, but preserve your terminal output from spam.

Maybe break someone's workflow so made a PR.