### PR TITLE
Study chapter: fix PGN to clipboard for Safari

### DIFF
--- a/ui/analyse/src/study/studyShare.ts
+++ b/ui/analyse/src/study/studyShare.ts
@@ -83,6 +83,19 @@ export function ctrl(
   };
 }
 
+async function writePgnClipboard(url: string): Promise<void> {
+  // Firefox does not support `ClipboardItem`
+  if (typeof ClipboardItem === 'undefined') {
+    const pgn = await xhrText(url);
+    return navigator.clipboard.writeText(pgn);
+  } else {
+    const clipboardItem = new ClipboardItem({
+      'text/plain': xhrText(url).then(pgn => new Blob([pgn])),
+    });
+    return navigator.clipboard.write([clipboardItem]);
+  }
+}
+
 export function view(ctrl: StudyShareCtrl): VNode {
   const studyId = ctrl.studyId,
     chapter = ctrl.chapter();
@@ -150,12 +163,11 @@ export function view(ctrl: StudyShareCtrl): VNode {
                   title: ctrl.trans.noarg('copyChapterPgnDescription'),
                 },
                 hook: bind('click', async event => {
-                  const pgn = await xhrText(`/study/${studyId}/${ctrl.chapter().id}.pgn`);
                   const iconFeedback = (success: boolean) => {
                     (event.target as HTMLElement).setAttribute('data-icon', success ? '' : '');
                     setTimeout(() => (event.target as HTMLElement).setAttribute('data-icon', ''), 1000);
                   };
-                  navigator.clipboard.writeText(pgn).then(
+                  writePgnClipboard(`/study/${studyId}/${ctrl.chapter().id}.pgn`).then(
                     () => iconFeedback(true),
                     () => iconFeedback(false)
                   );

--- a/ui/analyse/src/study/studyShare.ts
+++ b/ui/analyse/src/study/studyShare.ts
@@ -151,9 +151,14 @@ export function view(ctrl: StudyShareCtrl): VNode {
                 },
                 hook: bind('click', async event => {
                   const pgn = await xhrText(`/study/${studyId}/${ctrl.chapter().id}.pgn`);
-                  await navigator.clipboard.writeText(pgn);
-                  (event.target as HTMLElement).setAttribute('data-icon', '');
-                  setTimeout(() => (event.target as HTMLElement).setAttribute('data-icon', ''), 1000);
+                  const iconFeedback = (success: boolean) => {
+                    (event.target as HTMLElement).setAttribute('data-icon', success ? '' : '');
+                    setTimeout(() => (event.target as HTMLElement).setAttribute('data-icon', ''), 1000);
+                  };
+                  navigator.clipboard.writeText(pgn).then(
+                    () => iconFeedback(true),
+                    () => iconFeedback(false)
+                  );
                 }),
               },
               ctrl.trans.noarg('copyChapterPgn')


### PR DESCRIPTION
The issue was that we waited for the PGN http request to return before calling the clipboard API, and at that time it was already disabled back by the browser.
Safari fix is a simplified version of https://developer.apple.com/forums/thread/691873. Unfortunately, Firefox does not support the `ClipboardItem` so made a workaround.

Tested on Safari and Firefox.