### PR TITLE
Signup: disable weak password protection on dev instances

### DIFF
--- a/modules/security/src/main/PasswordCheck.scala
+++ b/modules/security/src/main/PasswordCheck.scala
@@ -1,6 +1,7 @@
 package lila.security
 
 import lila.user.User.ClearPassword
+import play.api.Mode
 import play.api.data.validation.{ Valid, Invalid, ValidationError, Constraint }
 
 object PasswordCheck:
@@ -11,13 +12,13 @@ object PasswordCheck:
   def isWeak(p: ClearPassword, login: String) =
     login == p.value || commonPasswords(p.value)
 
-  val newConstraint = Constraint[String] { (pass: String) =>
-    if commonPasswords(pass) then Invalid(ValidationError(errorWeak))
+  def newConstraint(using mode: Mode) = Constraint[String] { (pass: String) =>
+    if mode == Mode.Prod && commonPasswords(pass) then Invalid(ValidationError(errorWeak))
     else Valid
   }
 
-  def sameConstraint(user: UserStr) = Constraint[String] { (pass: String) =>
-    if pass == user.value then Invalid(ValidationError(errorSame))
+  def sameConstraint(user: UserStr)(using mode: Mode) = Constraint[String] { (pass: String) =>
+    if mode == Mode.Prod && pass == user.value then Invalid(ValidationError(errorSame))
     else Valid
   }
 

--- a/modules/security/src/main/SecurityForm.scala
+++ b/modules/security/src/main/SecurityForm.scala
@@ -115,12 +115,6 @@ final class SecurityForm(
     )
   )
 
-  def newPasswordFor(user: User) = Form(
-    single(
-      "password" -> newPasswordFieldFor(user)
-    )
-  )
-
   case class PasswordResetConfirm(newPasswd1: String, newPasswd2: String):
     def samePasswords = newPasswd1 == newPasswd2
 

--- a/modules/security/src/main/SecurityForm.scala
+++ b/modules/security/src/main/SecurityForm.scala
@@ -1,5 +1,6 @@
 package lila.security
 
+import play.api.Mode
 import play.api.data.*
 import play.api.data.Forms.*
 import play.api.data.validation.Constraints
@@ -16,7 +17,7 @@ final class SecurityForm(
     emailValidator: EmailAddressValidator,
     lameNameCheck: LameNameCheck,
     hcaptcha: Hcaptcha
-)(using Executor):
+)(using ec: Executor, mode: play.api.Mode):
 
   import SecurityForm.*
 
@@ -94,7 +95,7 @@ final class SecurityForm(
           "agreement" -> agreement,
           "fp"        -> optional(nonEmptyText)
         )(SignupData.apply)(_ => None)
-          .verifying(PasswordCheck.errorSame, x => x.password != x.username.value)
+          .verifying(PasswordCheck.errorSame, x => mode != Mode.Prod || x.password != x.username.value)
       )
     )
 
@@ -104,7 +105,7 @@ final class SecurityForm(
         "password" -> newPasswordField,
         "email"    -> emailField
       )(MobileSignupData.apply)(_ => None)
-        .verifying(PasswordCheck.errorSame, x => x.password != x.username.value)
+        .verifying(PasswordCheck.errorSame, x => mode != Mode.Prod || x.password != x.username.value)
     )
 
   def passwordReset(implicit req: RequestHeader) = hcaptcha.form(


### PR DESCRIPTION
Not sure If it pass the utility/complexity threshold but still convenient to add users with easy to use pwd via the UI instead of fiddling with the db.