### PR TITLE
Use mini-game for broadcast multi-boards

### DIFF
--- a/app/views/game/mini.scala
+++ b/app/views/game/mini.scala
@@ -22,33 +22,36 @@ object mini:
       ownerLink: Boolean = false,
       tv: Boolean = false,
       withLink: Boolean = true
-  )(implicit ctx: Context): Tag =
+  )(using ctx: Context): Tag =
+    renderMini(
+      pov,
+      withLink.option(gameLink(pov.game, pov.color, ownerLink, tv)),
+      showRatings = ctx.pref.showRatings
+    )
+
+  def noCtx(pov: Pov, tv: Boolean = false): Tag =
+    val link = if (tv) routes.Tv.index else routes.Round.watcher(pov.gameId, pov.color.name)
+    renderMini(pov, link.url.some)(using
+      defaultLang
+    )
+
+  private def renderMini(
+      pov: Pov,
+      link: Option[String] = None,
+      showRatings: Boolean = true
+  )(using Lang): Tag =
     val game   = pov.game
     val isLive = game.isBeingPlayed
-    val tag    = if (withLink) a else span
+    val tag    = if (link.isDefined) a else span
     tag(
-      href     := withLink.option(gameLink(game, pov.color, ownerLink, tv)),
+      href     := link,
       cls      := s"mini-game mini-game-${game.id} mini-game--init ${game.variant.key} is2d",
       dataLive := isLive.option(game.id),
       renderState(pov)
     )(
-      renderPlayer(!pov, withRating = ctx.pref.showRatings),
+      renderPlayer(!pov, withRating = showRatings),
       cgWrap,
-      renderPlayer(pov, withRating = ctx.pref.showRatings)
-    )
-
-  def noCtx(pov: Pov, tv: Boolean = false): Tag =
-    val game   = pov.game
-    val isLive = game.isBeingPlayed
-    a(
-      href := (if (tv) routes.Tv.index else routes.Round.watcher(pov.gameId, pov.color.name)),
-      cls := s"mini-game mini-game-${game.id} mini-game--init is2d ${isLive ?? "mini-game--live"} ${game.variant.key}",
-      dataLive := isLive.option(game.id),
-      renderState(pov)
-    )(
-      renderPlayer(!pov, withRating = true)(using defaultLang),
-      cgWrap,
-      renderPlayer(pov, withRating = true)(using defaultLang)
+      renderPlayer(pov, withRating = showRatings)
     )
 
   def renderState(pov: Pov) =

--- a/app/views/user/show/gamesContent.scala
+++ b/app/views/user/show/gamesContent.scala
@@ -54,7 +54,7 @@ object gamesContent:
           )(
             if (filterName == "playing" && pager.nbResults > 2)
               pager.currentPageResults.flatMap { Pov(_, u) }.map { pov =>
-                views.html.game.mini(pov)(ctx)(cls := "paginated")
+                views.html.game.mini(pov)(cls := "paginated")
               }
             else
               views.html.game.widgets(pager.currentPageResults, notes, user = u.some, ownerLink = ctx is u),

--- a/ui/@types/lichess/index.d.ts
+++ b/ui/@types/lichess/index.d.ts
@@ -47,7 +47,7 @@ interface Lichess {
   miniGame: {
     init(node: HTMLElement): string | null;
     initAll(parent?: HTMLElement): void;
-    update(node: HTMLElement, data: MiniBoardUpdate): void;
+    update(node: HTMLElement, data: MiniGameUpdateData): void;
     finish(node: HTMLElement, win?: Color): void;
   };
   ab?: any;
@@ -482,7 +482,7 @@ declare namespace Tree {
   export interface Shape {}
 }
 
-interface MiniBoardUpdate {
+interface MiniGameUpdateData {
   fen: Fen;
   lm: Uci;
   wc?: number;

--- a/ui/@types/lichess/index.d.ts
+++ b/ui/@types/lichess/index.d.ts
@@ -47,7 +47,7 @@ interface Lichess {
   miniGame: {
     init(node: HTMLElement): string | null;
     initAll(parent?: HTMLElement): void;
-    update(node: HTMLElement, data: GameUpdate): void;
+    update(node: HTMLElement, data: MiniBoardUpdate): void;
     finish(node: HTMLElement, win?: Color): void;
   };
   ab?: any;
@@ -482,8 +482,7 @@ declare namespace Tree {
   export interface Shape {}
 }
 
-interface GameUpdate {
-  id: string;
+interface MiniBoardUpdate {
   fen: Fen;
   lm: Uci;
   wc?: number;

--- a/ui/analyse/css/study/panel/_multiboard.scss
+++ b/ui/analyse/css/study/panel/_multiboard.scss
@@ -77,28 +77,5 @@
         box-shadow: none;
       }
     }
-
-    .player {
-      @extend %flex-between-nowrap, %roboto;
-      gap: 0.5em;
-
-      height: 1.5em;
-      white-space: nowrap;
-
-      result {
-        font-weight: bold;
-        margin-#{$end-direction}: 0.5em;
-      }
-      rating {
-        font-size: 0.9em;
-      }
-    }
-
-    .name {
-      @extend %flex-center;
-
-      justify-content: center;
-      height: 3em;
-    }
   }
 }

--- a/ui/analyse/src/socket.ts
+++ b/ui/analyse/src/socket.ts
@@ -26,6 +26,14 @@ export interface ReqPosition {
   path: string;
 }
 
+interface GameUpdate {
+  id: string;
+  fen: Fen;
+  lm: Uci;
+  wc?: number;
+  bc?: number;
+}
+
 export type StudySocketSendParams =
   | [t: 'setPath', d: ReqPosition]
   | [t: 'deleteNode', d: ReqPosition & { jumpTo: string }]

--- a/ui/analyse/src/study/multiBoard.ts
+++ b/ui/analyse/src/study/multiBoard.ts
@@ -140,7 +140,6 @@ const makePreview = (study: StudyCtrl) => (preview: ChapterPreview) =>
     {
       attrs: {
         'data-state': `${preview.fen},${preview.orientation},${preview.lastMove}`,
-        'data-live': preview.id,
       },
       class: {
         active: !study.multiBoard.loading && study.vm.chapterId == preview.id && !study.relay?.tourShow.active,

--- a/ui/analyse/src/study/multiBoard.ts
+++ b/ui/analyse/src/study/multiBoard.ts
@@ -134,44 +134,38 @@ function pagerButton(text: string, icon: string, click: () => void, enable: bool
   });
 }
 
-const makePreview = (study: StudyCtrl) => {
-  return (preview: ChapterPreview) => {
-    return h(
-      `a.${preview.id}.mini-game.mini-game-${preview.id}.mini-game--init.is2d`,
-      {
-        attrs: {
-          'data-state': `${preview.fen},${preview.orientation},${preview.lastMove}`,
-          'data-live': preview.id,
+const makePreview = (study: StudyCtrl) => (preview: ChapterPreview) =>
+  h(
+    `a.mini-game.mini-game-${preview.id}.mini-game--init.is2d`,
+    {
+      attrs: {
+        'data-state': `${preview.fen},${preview.orientation},${preview.lastMove}`,
+        'data-live': preview.id,
+      },
+      class: {
+        active: !study.multiBoard.loading && study.vm.chapterId == preview.id && !study.relay?.tourShow.active,
+      },
+      hook: {
+        insert(vnode) {
+          const el = vnode.elm as HTMLElement;
+          lichess.miniGame.init(el);
+          vnode.data!.fen = preview.fen;
+          el.addEventListener('mousedown', _ => study.setChapter(preview.id));
         },
-        class: {
-          active: !study.multiBoard.loading && study.vm.chapterId == preview.id && !study.relay?.tourShow.active,
-        },
-        hook: {
-          insert(vnode) {
-            const el = vnode.elm as HTMLElement;
-            lichess.miniGame.init(el);
-            vnode.data!.fen = preview.fen;
-            el.addEventListener('mousedown', _ => study.setChapter(preview.id));
-          },
-          postpatch(old, vnode) {
-            if (old.data!.fen !== preview.fen) {
-              lichess.miniGame.update(vnode.elm as HTMLElement, {
-                lm: preview.lastMove!,
-                fen: preview.fen,
-              });
-            }
-            vnode.data!.fen = preview.fen;
-          },
+        postpatch(old, vnode) {
+          if (old.data!.fen !== preview.fen) {
+            lichess.miniGame.update(vnode.elm as HTMLElement, {
+              lm: preview.lastMove!,
+              fen: preview.fen,
+            });
+          }
+          vnode.data!.fen = preview.fen;
         },
       },
-      [
-        boardPlayer(preview, opposite(preview.orientation)),
-        h('span.cg-wrap'),
-        boardPlayer(preview, preview.orientation),
-      ]
-    );
-  };
-};
+    },
+    [boardPlayer(preview, opposite(preview.orientation)), h('span.cg-wrap'), boardPlayer(preview, preview.orientation)]
+  );
+
 const userName = (u: ChapterPreviewPlayer) => (u.title ? [h('span.utitle', u.title), ' ' + u.name] : [u.name]);
 
 function renderPlayer(player: ChapterPreviewPlayer | undefined): VNode | undefined {

--- a/ui/analyse/src/study/multiBoard.ts
+++ b/ui/analyse/src/study/multiBoard.ts
@@ -1,4 +1,3 @@
-//import * as domData from 'common/data';
 import debounce from 'common/debounce';
 import { bind, MaybeVNodes } from 'common/snabbdom';
 import { spinnerVdom as spinner } from 'common/spinner';

--- a/ui/analyse/src/study/multiBoard.ts
+++ b/ui/analyse/src/study/multiBoard.ts
@@ -155,13 +155,10 @@ const makePreview = (study: StudyCtrl) => {
           },
           postpatch(old, vnode) {
             if (old.data!.fen !== preview.fen) {
-              lichess.miniGame.update(
-                vnode.elm as HTMLElement,
-                {
-                  lm: preview.lastMove!,
-                  fen: preview.fen,
-                }
-              );
+              lichess.miniGame.update(vnode.elm as HTMLElement, {
+                lm: preview.lastMove!,
+                fen: preview.fen,
+              });
             }
             vnode.data!.fen = preview.fen;
           },

--- a/ui/analyse/src/study/multiBoard.ts
+++ b/ui/analyse/src/study/multiBoard.ts
@@ -181,7 +181,7 @@ function renderPlayer(player: ChapterPreviewPlayer | undefined): VNode | undefin
 
 const boardPlayer = (preview: ChapterPreview, color: Color) => {
   const player = preview.players && preview.players[color];
-  const result = preview.outcome && preview.outcome.split('-')[color === 'white' ? 0 : 1];
+  const result = preview.outcome?.split('-')[color === 'white' ? 0 : 1];
   return h('span.mini-game__player', [
     h('span.mini-game__user', [renderPlayer(player)]),
     result && h('span.mini-game__result', result.replace('1/2', '½')),

--- a/ui/analyse/src/study/multiBoard.ts
+++ b/ui/analyse/src/study/multiBoard.ts
@@ -161,7 +161,7 @@ const makePreview = (study: StudyCtrl) => {
                 {
                   lm: preview.lastMove!,
                   fen: preview.fen,
-                } as any
+                }
               );
             }
             vnode.data!.fen = preview.fen;

--- a/ui/analyse/src/study/multiBoard.ts
+++ b/ui/analyse/src/study/multiBoard.ts
@@ -1,11 +1,11 @@
-import * as domData from 'common/data';
+//import * as domData from 'common/data';
 import debounce from 'common/debounce';
 import { bind, MaybeVNodes } from 'common/snabbdom';
 import { spinnerVdom as spinner } from 'common/spinner';
 import { h, VNode } from 'snabbdom';
 import { multiBoard as xhrLoad } from './studyXhr';
-import { opposite, uciToMove } from 'chessground/util';
-import { StudyCtrl, ChapterPreview, Position } from './interfaces';
+import { opposite } from 'chessground/util';
+import { StudyCtrl, ChapterPreview, ChapterPreviewPlayer, Position } from './interfaces';
 
 export class MultiBoardCtrl {
   loading = false;
@@ -135,60 +135,66 @@ function pagerButton(text: string, icon: string, click: () => void, enable: bool
   });
 }
 
-function makePreview(study: StudyCtrl) {
+const makePreview = (study: StudyCtrl) => {
   return (preview: ChapterPreview) => {
-    const contents = preview.players
-      ? [makePlayer(preview, opposite(preview.orientation)), makeCg(preview), makePlayer(preview, preview.orientation)]
-      : [h('div.name', preview.name), makeCg(preview)];
     return h(
-      'a.' + preview.id,
+      `a.${preview.id}.mini-game.mini-game-${preview.id}.mini-game--init.is2d`,
       {
-        attrs: { title: preview.name },
+        attrs: {
+          'data-state': `${preview.fen},${preview.orientation},${preview.lastMove}`,
+          'data-live': preview.id,
+        },
         class: {
           active: !study.multiBoard.loading && study.vm.chapterId == preview.id && !study.relay?.tourShow.active,
         },
-        hook: bind('mousedown', _ => study.setChapter(preview.id)),
+        hook: {
+          insert(vnode) {
+            const el = vnode.elm as HTMLElement;
+            lichess.miniGame.init(el);
+            vnode.data!.fen = preview.fen;
+            el.addEventListener('mousedown', _ => study.setChapter(preview.id));
+          },
+          postpatch(old, vnode) {
+            if (old.data!.fen !== preview.fen) {
+              lichess.miniGame.update(
+                vnode.elm as HTMLElement,
+                {
+                  lm: preview.lastMove!,
+                  fen: preview.fen,
+                } as any
+              );
+            }
+            vnode.data!.fen = preview.fen;
+          },
+        },
       },
-      contents
+      [
+        boardPlayer(preview, opposite(preview.orientation)),
+        h('span.cg-wrap'),
+        boardPlayer(preview, preview.orientation),
+      ]
     );
   };
-}
+};
+const userName = (u: ChapterPreviewPlayer) => (u.title ? [h('span.utitle', u.title), ' ' + u.name] : [u.name]);
 
-function makePlayer(preview: ChapterPreview, color: Color): VNode | undefined {
-  const player = preview.players && preview.players[color];
-  const result = preview.outcome && preview.outcome.split('-')[color === 'white' ? 0 : 1];
+function renderPlayer(player: ChapterPreviewPlayer | undefined): VNode | undefined {
   return (
     player &&
-    h('span.player', [
-      h('span', [
-        result && h('result', result.replace('1/2', '½')),
-        player.title ? `${player.title} ${player.name}` : player.name,
+    h('span.mini-game__player', [
+      h('span.mini-game__user', [
+        h('span.name', userName(player)),
+        player.rating && h('span.rating', ' ' + player.rating),
       ]),
-      player.rating && h('rating', '' + player.rating),
     ])
   );
 }
 
-function makeCg(preview: ChapterPreview): VNode {
-  return h('span.mini-board.cg-wrap.is2d', {
-    attrs: {
-      'data-state': `${preview.fen},${preview.orientation},${preview.lastMove}`,
-    },
-    hook: {
-      insert(vnode) {
-        lichess.miniBoard.init(vnode.elm as HTMLElement);
-        vnode.data!.fen = preview.fen;
-      },
-      postpatch(old, vnode) {
-        if (old.data!.fen !== preview.fen) {
-          const lm = preview.lastMove!;
-          domData.get(vnode.elm as HTMLElement, 'chessground').set({
-            fen: preview.fen,
-            lastMove: uciToMove(lm),
-          });
-        }
-        vnode.data!.fen = preview.fen;
-      },
-    },
-  });
-}
+const boardPlayer = (preview: ChapterPreview, color: Color) => {
+  const player = preview.players && preview.players[color];
+  const result = preview.outcome && preview.outcome.split('-')[color === 'white' ? 0 : 1];
+  return h('span.mini-game__player', [
+    h('span.mini-game__user', [renderPlayer(player)]),
+    result && h('span.mini-game__result', result.replace('1/2', '½')),
+  ]);
+};

--- a/ui/site/src/component/mini-game.ts
+++ b/ui/site/src/component/mini-game.ts
@@ -3,13 +3,6 @@ import * as domData from 'common/data';
 import clockWidget from './clock-widget';
 import StrongSocket from './socket';
 
-interface UpdateData {
-  lm: string;
-  fen: string;
-  wc?: number;
-  bc?: number;
-}
-
 const fenColor = (fen: string) => (fen.indexOf(' b') > 0 ? 'black' : 'white');
 
 export const init = (node: HTMLElement) => {
@@ -52,7 +45,7 @@ export const initAll = (parent?: HTMLElement) => {
   if (ids.length) StrongSocket.firstConnect.then(send => send('startWatching', ids.join(' ')));
 };
 
-export const update = (node: HTMLElement, data: UpdateData) => {
+export const update = (node: HTMLElement, data: MiniBoardUpdate) => {
   const $el = $(node),
     lm = data.lm,
     cg = domData.get(node.querySelector('.cg-wrap')!, 'chessground');

--- a/ui/site/src/component/mini-game.ts
+++ b/ui/site/src/component/mini-game.ts
@@ -45,7 +45,7 @@ export const initAll = (parent?: HTMLElement) => {
   if (ids.length) StrongSocket.firstConnect.then(send => send('startWatching', ids.join(' ')));
 };
 
-export const update = (node: HTMLElement, data: MiniBoardUpdate) => {
+export const update = (node: HTMLElement, data: MiniGameUpdateData) => {
   const $el = $(node),
     lm = data.lm,
     cg = domData.get(node.querySelector('.cg-wrap')!, 'chessground');


### PR DESCRIPTION
The snabbdom code was mainly taken from the code in swiss/arena to show ongoing games.

Tested on both finished and ongoing games, as well as update via ws. Should allow "easy" integration in a 2nd time (even though for now mini-game has a limitation about clock, re-putting it at the beginning of the turn at every refresh, that should be fixed for classical)

before:

<img width="824" alt="image" src="https://user-images.githubusercontent.com/56031107/233865273-b543cb7e-4664-465c-b519-30f442be8836.png">
after
<img width="826" alt="image-2" src="https://user-images.githubusercontent.com/56031107/233865278-cbe6fd75-1252-4c9e-8bc6-7bf612e8c099.png">

