### PR TITLE
Fix Copy PGN for chrome

### DIFF
--- a/ui/analyse/src/study/studyShare.ts
+++ b/ui/analyse/src/study/studyShare.ts
@@ -90,7 +90,7 @@ async function writePgnClipboard(url: string): Promise<void> {
     return navigator.clipboard.writeText(pgn);
   } else {
     const clipboardItem = new ClipboardItem({
-      'text/plain': xhrText(url).then(pgn => new Blob([pgn])),
+      'text/plain': xhrText(url).then(pgn => new Blob([pgn], { type: 'text/plain' })),
     });
     return navigator.clipboard.write([clipboardItem]);
   }
@@ -169,7 +169,10 @@ export function view(ctrl: StudyShareCtrl): VNode {
                   };
                   writePgnClipboard(`/study/${studyId}/${ctrl.chapter().id}.pgn`).then(
                     () => iconFeedback(true),
-                    () => iconFeedback(false)
+                    err => {
+                      console.log(err);
+                      iconFeedback(false);
+                    }
                   );
                 }),
               },


### PR DESCRIPTION
Apparently on Chrome you need to specify the type of the Blob `{ type: 'text/plain' }`. 

I've left the `console.log` since it's useful in the future since it should only be triggered when something on our end is not working as expected.

Tested on Chrome, Safari and Firefox

fix #12737