### PR TITLE
Add ratingDiff to /api/stream/event

### DIFF
--- a/modules/game/src/main/JsonView.scala
+++ b/modules/game/src/main/JsonView.scala
@@ -65,6 +65,7 @@ final class JsonView(rematches: Rematches):
               .playerTextBlocking(pov.opponent, withRating = false)
           )
           .add("rating" -> pov.opponent.rating)
+          .add("ratingDiff" -> pov.opponent.ratingDiff)
           .add("ai" -> pov.opponent.aiLevel),
         "isMyTurn" -> pov.isMyTurn
       )
@@ -73,6 +74,7 @@ final class JsonView(rematches: Rematches):
       .add("swissId" -> pov.game.swissId)
       .add("orientation" -> pov.game.variant.racingKings.option(chess.White))
       .add("winner" -> pov.game.winnerColor)
+      .add("ratingDiff" -> pov.player.ratingDiff)
 
   def player(p: Player, user: Option[LightUser]) =
     Json


### PR DESCRIPTION
Adds `ratingDiff` to `/api/stream/event`. The ratingDiff is only displayed when the type is `gameFinish`.

I considered adding the [player method](https://github.com/lichess-org/lila/blob/master/modules/game/src/main/JsonView.scala#L77-L85) to the `ownerPreview` but thought adding the ratingDiff directly was more of a straightforward addition, and doesn't repeat data. If there is a better approach to handling this I'll gladly update the PR.

Resolves #12491 