### PR TITLE
Fix Copy PGN tab navigation

### DIFF
--- a/ui/analyse/src/study/studyShare.ts
+++ b/ui/analyse/src/study/studyShare.ts
@@ -161,7 +161,7 @@ export function view(ctrl: StudyShareCtrl): VNode {
                 attrs: {
                   'data-icon': '',
                   title: ctrl.trans.noarg('copyChapterPgnDescription'),
-                  href: `#`,
+                  tabindex: '0',
                 },
                 hook: bind('click', async event => {
                   const iconFeedback = (success: boolean) => {

--- a/ui/analyse/src/study/studyShare.ts
+++ b/ui/analyse/src/study/studyShare.ts
@@ -161,6 +161,7 @@ export function view(ctrl: StudyShareCtrl): VNode {
                 attrs: {
                   'data-icon': '',
                   title: ctrl.trans.noarg('copyChapterPgnDescription'),
+                  href: `#`,
                 },
                 hook: bind('click', async event => {
                   const iconFeedback = (success: boolean) => {


### PR DESCRIPTION
Adds an empty href to give the Copy PGN button focus for tab navigation.

Resolves #12741
