### PR TITLE
Puzzle replay: redirect to dashboard only after voting

### DIFF
--- a/ui/puzzle/src/ctrl.ts
+++ b/ui/puzzle/src/ctrl.ts
@@ -347,9 +347,7 @@ export default function (opts: PuzzleOpts, redraw: Redraw): Controller {
     }
     redraw();
     if (!next) {
-      if (data.replay) {
-        lichess.redirect(`/training/dashboard/${data.replay.days}`);
-      } else {
+      if (!data.replay) {
         alert('No more puzzles available! Try another theme.');
         lichess.redirect('/training/themes');
       }
@@ -367,8 +365,12 @@ export default function (opts: PuzzleOpts, redraw: Redraw): Controller {
       if (isPuzzleData(n)) {
         initiate(n);
         redraw();
-      } else lichess.redirect(`/training/dashboard/${n.days}`);
+      }
     });
+
+    if (data.replay && vm.round === undefined) {
+      lichess.redirect(`/training/dashboard/${data.replay.days}`);
+    }
 
     if (!streak && !data.replay) {
       const path = router.withLang(`/training/${data.angle.key}`);


### PR DESCRIPTION
Fixes https://github.com/lichess-org/lila/issues/12717
With this fix, the redirect will only take place when the user clicks on the green "thumbs up" or red "thumbs down" icon, indicating that they have completed the puzzle.