### PR TITLE
Fix: Improve legibility by adding a text shadow

### DIFF
--- a/ui/lobby/css/_lobby.scss
+++ b/ui/lobby/css/_lobby.scss
@@ -168,6 +168,7 @@ body {
   grid-auto-rows: 0; /* all the other rows 0 */
   font-size: 0.9em;
   h2 {
+    @extend %page-text-shadow !optional;
     font-size: 1.2em;
   }
   .ublog-post-card:hover {


### PR DESCRIPTION
I've enhanced the legibility of text on lighter backgrounds for lobby blog cards by adding a subtle text shadow.

Before:
![before](https://user-images.githubusercontent.com/78294042/235341487-8d444c08-7a62-46b0-905a-02c681bf2715.png)

After:
![after](https://user-images.githubusercontent.com/78294042/235341495-0099f42f-e9f6-4ed7-9ec8-73b729702a23.png)
