### PR TITLE
Graph and clean build.sbt module inter-dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ ui/*/npm-debug.log
 ui/*/tsconfig.tsbuildinfo
 hs_*.log
 yarn-error.log
+dependency-graph.png
 
 RUNNING_PID
 

--- a/bin/dependency-graph
+++ b/bin/dependency-graph
@@ -1,0 +1,125 @@
+#!/usr/bin/env python
+
+# Analyzes module dependencies in build.sbt
+# Outputs all and essential dependencies for each module to stdout
+# Generates a png graph in the repo root folder
+
+import os
+import re
+import networkx as nx
+import pydot
+
+buildfile_path = os.path.join(os.path.dirname(__file__), os.pardir,
+                              'build.sbt')
+output_path = os.path.join(os.path.dirname(__file__), os.pardir,
+                           'dependency-graph.png')
+
+def_module_pattern = r'^lazy val (\w+) = module\(.*'
+
+G = nx.DiGraph()
+
+with open(buildfile_path, 'r') as f:
+    lines = iter(f)
+    for line in lines:
+        match = re.match(def_module_pattern, line)
+        if match:
+            module = match.group(1)
+            if module != 'api':
+                next_line = next(lines).strip()
+                dependencies = [
+                    dep for dep in next_line[4:-2].split(', ') if dep != ""
+                ]
+                for dependency in dependencies:
+                    G.add_edge(dependency, module)
+
+topological_generations = list(nx.topological_generations(G))
+transitive_closure = nx.transitive_closure(G)
+
+
+def build_providers_dict(dependencies):
+
+    def add(res, subdependency, provider):
+        if subdependency in res:
+            res[subdependency].append(provider)
+        else:
+            res[subdependency] = [provider]
+
+    providers_dict = {}
+    for dependency, subdependencies in dependencies:
+        add(providers_dict, dependency, dependency)
+        for dep in subdependencies:
+            add(providers_dict, dep, dependency)
+    return providers_dict
+
+
+def pick_essential_dependencies(providers_dict):
+
+    def pick(essentials, providers_dict):
+        if len(providers_dict) == 0:
+            return essentials, providers_dict
+
+        candidate = min(providers_dict.values(), key=len)
+        if len(candidate) > 1:
+            return essentials, providers_dict
+
+        new = candidate[0]
+        essentials.append(new)
+
+        leftovers = {
+            dependency: providers
+            for dependency, providers in providers_dict.items()
+            if new not in providers
+        }
+
+        return pick(essentials, leftovers)
+
+    return pick([], providers_dict)
+
+
+essentials_dict = {}
+for node in G.nodes:
+    all_dependencies = list(transitive_closure.predecessors(node))
+    providers_dict = build_providers_dict([
+        (dep, transitive_closure.predecessors(dep)) for dep in all_dependencies
+    ])
+    essentials, leftover = pick_essential_dependencies(providers_dict)
+    essentials_dict[node] = essentials
+
+    print("Module:", node)
+    print("All dependencies:", all_dependencies)
+    print("Essential dependencies:", essentials)
+    if len(leftover) > 0:
+        print("Leftover dependencies:", [dep for dep in leftover])
+    print()
+
+pydot_graph = nx.drawing.nx_pydot.to_pydot(G)
+pydot_graph.set_rankdir('LR')
+# pydot_graph.set_ratio(1)
+
+sink_nodes = pydot.Subgraph(rank="same")
+
+for generation in topological_generations:
+    layer = pydot.Subgraph(rank="same")
+    for node_name in generation:
+        node = pydot_graph.get_node(node_name)[0]
+        if G.out_degree(node_name) == 0:
+            sink_nodes.add_node(node)
+        else:
+            layer.add_node(node)
+    pydot_graph.add_subgraph(layer)
+
+pydot_graph.add_subgraph(sink_nodes)
+
+original_edges = set(G.edges())
+for module in essentials_dict:
+    for dependency in essentials_dict[module]:
+        if (dependency, module) in original_edges:
+            edge = pydot_graph.get_edge(dependency, module)[0]
+        else:
+            edge = pydot.Edge(dependency, module)
+            pydot_graph.add_edge(edge)
+
+        edge.set_color('red')
+        edge.set_penwidth(2)
+
+pydot_graph.write_png(output_path)

--- a/build.sbt
+++ b/build.sbt
@@ -80,7 +80,7 @@ lazy val api = module("api",
 ) aggregate (moduleRefs: _*)
 
 lazy val i18n = module("i18n",
-  Seq(common, db, hub),
+  Seq(db, hub),
   tests.bundle ++ Seq(scalatags, jodaTime)
 ).settings(
   Compile / sourceGenerators += Def.task {
@@ -94,52 +94,52 @@ lazy val i18n = module("i18n",
 )
 
 lazy val puzzle = module("puzzle",
-  Seq(common, memo, hub, history, db, user, rating, pref, tree, game),
+  Seq(history, pref),
   reactivemongo.bundle ++ tests.bundle
 )
 
 lazy val storm = module("storm",
-  Seq(common, memo, hub, puzzle, db, user, pref, tree),
+  Seq(puzzle),
   reactivemongo.bundle
 )
 
 lazy val racer = module("racer",
-  Seq(common, memo, hub, puzzle, storm, db, user, pref, tree, room),
+  Seq(storm, room),
   reactivemongo.bundle
 )
 
 lazy val video = module("video",
-  Seq(common, memo, hub, db, user),
+  Seq(user),
   reactivemongo.bundle ++ macwire.bundle
 )
 
 lazy val coach = module("coach",
-  Seq(common, hub, db, user, security, notifyModule),
+  Seq(notifyModule),
   reactivemongo.bundle
 )
 
 lazy val streamer = module("streamer",
-  Seq(common, hub, db, user, notifyModule),
+  Seq(notifyModule),
   reactivemongo.bundle
 )
 
 lazy val coordinate = module("coordinate",
-  Seq(common, db, user),
+  Seq(user),
   reactivemongo.bundle ++ macwire.bundle
 )
 
 lazy val blog = module("blog",
-  Seq(common, memo, timeline),
+  Seq(timeline),
   Seq(prismic) ++ tests.bundle ++ reactivemongo.bundle
 )
 
 lazy val ublog = module("ublog",
-  Seq(common, memo, timeline, irc),
+  Seq(timeline),
   Seq(bloomFilter) ++ tests.bundle ++ reactivemongo.bundle
 )
 
 lazy val evaluation = module("evaluation",
-  Seq(common, hub, db, user, game, analyse),
+  Seq(analyse),
   tests.bundle ++ reactivemongo.bundle
 )
 
@@ -152,17 +152,17 @@ lazy val common = module("common",
 )
 
 lazy val rating = module("rating",
-  Seq(common, db, memo, i18n),
+  Seq(i18n, memo),
   reactivemongo.bundle ++ tests.bundle
 ).dependsOn(common % "test->test")
 
 lazy val perfStat = module("perfStat",
-  Seq(common, db, user, game, rating),
+  Seq(game),
   reactivemongo.bundle
 )
 
 lazy val history = module("history",
-  Seq(common, db, memo, game, user),
+  Seq(game),
   Seq(scalatags) ++ reactivemongo.bundle
 )
 
@@ -172,282 +172,282 @@ lazy val db = module("db",
 )
 
 lazy val memo = module("memo",
-  Seq(common, db),
+  Seq(db),
   Seq(scaffeine) ++ reactivemongo.bundle ++ playWs.bundle
 )
 
 lazy val search = module("search",
-  Seq(common, hub),
+  Seq(hub),
   playWs.bundle
 )
 
 lazy val chat = module("chat",
-  Seq(common, db, user, security, i18n, socket),
+  Seq(security),
   Seq(scalatags) ++ reactivemongo.bundle
 )
 
 lazy val room = module("room",
-  Seq(common, socket, chat),
+  Seq(chat),
   Seq(lettuce) ++ reactivemongo.bundle
 )
 
 lazy val timeline = module("timeline",
-  Seq(common, db, game, user, hub, security, relation, team),
+  Seq(team),
   reactivemongo.bundle
 )
 
 lazy val event = module("event",
-  Seq(common, db, memo, i18n, user),
+  Seq(user),
   Seq(scalatags) ++ reactivemongo.bundle
 )
 
 lazy val mod = module("mod",
-  Seq(common, db, user, hub, security, tournament, swiss, game, analyse, evaluation, report, notifyModule, history, perfStat, irc),
+  Seq(evaluation, perfStat, tournament, swiss, report),
   reactivemongo.bundle
 )
 
 lazy val user = module("user",
-  Seq(common, memo, db, hub, rating, socket),
+  Seq(rating, socket),
   Seq(hasher, galimatias) ++ tests.bundle ++ playWs.bundle ++ reactivemongo.bundle
 )
 
 lazy val game = module("game",
-  Seq(common, memo, db, hub, user, chat),
+  Seq(chat),
   Seq(compression) ++ tests.bundle ++ reactivemongo.bundle
 )
 
 lazy val gameSearch = module("gameSearch",
-  Seq(common, hub, search, game),
+  Seq(game, search),
   reactivemongo.bundle
 )
 
 lazy val tv = module("tv",
-  Seq(common, db, hub, socket, game, round, user),
+  Seq(round),
   Seq(hasher) ++ reactivemongo.bundle
 )
 
 lazy val bot = module("bot",
-  Seq(common, db, hub, game, user, challenge, chat, socket),
+  Seq(challenge),
   reactivemongo.bundle
 )
 
 lazy val analyse = module("analyse",
-  Seq(common, hub, game, user, notifyModule, evalCache),
+  Seq(notifyModule, evalCache),
   tests.bundle ++ reactivemongo.bundle
 )
 
 lazy val round = module("round",
-  Seq(common, db, memo, hub, socket, game, user, i18n, fishnet, pref, chat, history, playban, room, irc),
+  Seq(history, room, fishnet, playban),
   Seq(scalatags, hasher, kamon.core, lettuce) ++ reactivemongo.bundle
 )
 
 lazy val pool = module("pool",
-  Seq(common, game, user, playban),
+  Seq(playban),
   reactivemongo.bundle
 )
 
 lazy val activity = module("activity",
-  Seq(common, game, analyse, user, forum, study, pool, puzzle, tournament, simul, swiss, practice, team, ublog),
+  Seq(pool, puzzle, simul, practice, ublog),
   reactivemongo.bundle
 )
 
 lazy val lobby = module("lobby",
-  Seq(common, db, memo, hub, socket, game, user, round, timeline, relation, playban, security, pool),
+  Seq(timeline, pool),
   Seq(lettuce) ++ reactivemongo.bundle
 )
 
 lazy val setup = module("setup",
-  Seq(common, db, memo, hub, socket, game, user, lobby, pref, relation, oauth),
+  Seq(lobby),
   reactivemongo.bundle
 )
 
 lazy val importer = module("importer",
-  Seq(common, game, round),
+  Seq(round),
   tests.bundle ++ reactivemongo.bundle
 )
 
 lazy val insight = module("insight",
-  Seq(common, game, user, analyse, relation, pref, socket, round, security),
+  Seq(round),
   Seq(scalatags, apacheMath) ++ reactivemongo.bundle
 )
 
 lazy val tutor = module("tutor",
-  Seq(common, game, user, analyse, round, insight),
+  Seq(insight),
   tests.bundle ++ reactivemongo.bundle
 )
 
 lazy val opening = module("opening",
-  Seq(common, memo, game),
+  Seq(game),
   tests.bundle
 )
 
 lazy val gathering = module("gathering",
-  Seq(common, user, rating, history),
+  Seq(history),
   Seq.empty
 )
 
 lazy val tournament = module("tournament",
-  Seq(common, hub, socket, gathering, game, round, security, chat, memo, history, notifyModule, i18n, room),
+  Seq(gathering, round),
   Seq(scalatags, lettuce) ++ tests.bundle ++ reactivemongo.bundle
 )
 
 lazy val swiss = module("swiss",
-  Seq(common, hub, socket, gathering, game, round, security, chat, memo, i18n, room),
+  Seq(gathering, round),
   Seq(scalatags, lettuce) ++ reactivemongo.bundle
 )
 
 lazy val simul = module("simul",
-  Seq(common, hub, socket, gathering, game, round, chat, memo, room),
+  Seq(gathering, round),
   Seq(lettuce) ++ reactivemongo.bundle
 )
 
 lazy val fishnet = module("fishnet",
-  Seq(common, game, analyse, db, evalCache),
+  Seq(analyse),
   Seq(lettuce) ++ tests.bundle ++ reactivemongo.bundle
 )
 
 lazy val irwin = module("irwin",
-  Seq(common, db, user, game, tournament, mod, insight),
+  Seq(mod, insight),
   reactivemongo.bundle
 )
 
 lazy val oauth = module("oauth",
-  Seq(common, db, user),
+  Seq(user),
   reactivemongo.bundle
 )
 
 lazy val security = module("security",
-  Seq(common, hub, db, user, i18n, irc, oauth, mailer),
+  Seq(irc, oauth, mailer),
   Seq(maxmind, hasher, uaparser) ++ tests.bundle ++ reactivemongo.bundle
 )
 
 lazy val shutup = module("shutup",
-  Seq(common, db, hub, game, relation),
+  Seq(relation),
   tests.bundle ++ reactivemongo.bundle
 )
 
 lazy val challenge = module("challenge",
-  Seq(common, db, hub, setup, game, relation, pref, socket, room, msg),
+  Seq(setup),
   Seq(scalatags, lettuce) ++ tests.bundle ++ reactivemongo.bundle
 )
 
 lazy val study = module("study",
-  Seq(common, db, hub, socket, game, round, importer, notifyModule, relation, evalCache, explorer, i18n, room),
+  Seq(explorer),
   Seq(scalatags, lettuce) ++ tests.bundle ++ reactivemongo.bundle
 ).dependsOn(common % "test->test")
 
 lazy val relay = module("relay",
-  Seq(common, study),
+  Seq(study),
   Seq(galimatias) ++ reactivemongo.bundle
 )
 
 lazy val studySearch = module("studySearch",
-  Seq(common, hub, study, search),
+  Seq(study, search),
   reactivemongo.bundle
 )
 
 lazy val learn = module("learn",
-  Seq(common, db, user),
+  Seq(user),
   reactivemongo.bundle
 )
 
 lazy val evalCache = module("evalCache",
-  Seq(common, db, user, security, socket, tree),
+  Seq(security),
   reactivemongo.bundle
 )
 
 lazy val practice = module("practice",
-  Seq(common, db, memo, user, study),
+  Seq(study),
   reactivemongo.bundle
 )
 
 lazy val playban = module("playban",
-  Seq(common, db, game, msg, chat),
+  Seq(msg),
   reactivemongo.bundle
 )
 
 lazy val push = module("push",
-  Seq(common, db, user, game, challenge, msg, pref, notifyModule),
+  Seq(challenge),
   Seq(googleOAuth) ++ reactivemongo.bundle
 )
 
 lazy val irc = module("irc",
-  Seq(common, hub, user),
+  Seq(user),
   reactivemongo.bundle
 )
 
 lazy val mailer = module("mailer",
-  Seq(common, user),
+  Seq(user),
   reactivemongo.bundle ++ Seq(scalatags, hasher)
 )
 
 lazy val plan = module("plan",
-  Seq(common, user, security),
+  Seq(security),
   tests.bundle ++ reactivemongo.bundle
 )
 
 lazy val relation = module("relation",
-  Seq(common, db, memo, hub, user, game, pref),
+  Seq(game, pref),
   reactivemongo.bundle
 )
 
 lazy val pref = module("pref",
-  Seq(common, db, user),
+  Seq(user),
   reactivemongo.bundle
 )
 
 lazy val msg = module("msg",
-  Seq(common, db, user, hub, relation, security, shutup, notifyModule, chat),
+  Seq(shutup, notifyModule),
   reactivemongo.bundle
 )
 
 lazy val forum = module("forum",
-  Seq(common, db, user, security, hub, mod, notifyModule),
+  Seq(mod),
   reactivemongo.bundle
 )
 
 lazy val forumSearch = module("forumSearch",
-  Seq(common, hub, forum, search),
+  Seq(forum, search),
   reactivemongo.bundle
 )
 
 lazy val team = module("team",
-  Seq(common, memo, db, user, forum, security, hub, notifyModule),
+  Seq(forum),
   reactivemongo.bundle
 )
 
 lazy val teamSearch = module("teamSearch",
-  Seq(common, hub, team, search),
+  Seq(team, search),
   reactivemongo.bundle
 )
 
 lazy val clas = module("clas",
-  Seq(common, memo, db, user, security, msg, history, puzzle),
+  Seq(msg, puzzle),
   reactivemongo.bundle ++ Seq(bloomFilter)
 )
 
 lazy val bookmark = module("bookmark",
-  Seq(common, memo, db, hub, user, game, round),
+  Seq(round),
   reactivemongo.bundle
 )
 
 lazy val report = module("report",
-  Seq(common, db, user, game, security, playban),
+  Seq(playban),
   reactivemongo.bundle
 )
 
 lazy val appeal = module("appeal",
-  Seq(common, db, user),
+  Seq(user),
   reactivemongo.bundle
 )
 
 lazy val explorer = module("explorer",
-  Seq(common, db, game, importer),
+  Seq(importer),
   reactivemongo.bundle
 )
 
 lazy val notifyModule = module("notify",
-  Seq(common, db, game, user, hub, relation, pref),
+  Seq(relation),
   reactivemongo.bundle
 )
 
@@ -457,7 +457,7 @@ lazy val tree = module("tree",
 )
 
 lazy val socket = module("socket",
-  Seq(common, hub, memo, tree),
+  Seq(hub, memo, tree),
   Seq(lettuce)
 )
 


### PR DESCRIPTION
There were no issue regarding this PR, but maybe it may still be useful.
While working on lila I was advised not to add module dependencies to the build.sbt because it may lead to circular dependencies and break the build. However, I could not find any easy way to check this except try it out. Moreover, I could not answer: 
- Which module depends on which? 
- Is there a way to easily see if some dependency relation is no longer needed?
- What is the general structure/architecture of lila at all?

This PR adds a `bin/dependency-graph` script that for each module outputs all dependencies (explicit and transitive) and attempts to build a minimal set of essential explicit dependencies while preserving the overall structure. It also generates the graph as a png for better visual understanding.

In the second commit I cleaned up all non-essential dependencies from build.sbt to make it look cleaner (so, for example, teamSearch module now depends only on team and search, which is easy to understand). However, perhaps some non-essential dependencies can be kept because they help with understanding.