### PR TITLE
Change "given name" to "first name"

### DIFF
--- a/translation/source/site.xml
+++ b/translation/source/site.xml
@@ -490,7 +490,7 @@ computer analysis, game chat and shareable URL.</string>
   <string name="ifNoneLeaveEmpty">If none, leave empty</string>
   <string name="profile">Profile</string>
   <string name="editProfile">Edit profile</string>
-  <string name="firstName">Given name</string>
+  <string name="firstName">First name</string>
   <string name="lastName">Surname</string>
   <string name="biography">Biography</string>
   <string name="countryOrFlag" comment="countryOrFlag&#10;Appears when you edit your profile. Lets a player add a country/flag (not all flags are for countries) to their profile">Country or flag</string>


### PR DESCRIPTION
This is just a tiny change I thought would be nice to have.
There's already a transgender flag, this change further accommodates trans people (and all people with chosen names!), because "given name" usually implies it's the name assigned at birth
The term "first name" is just as common in British English as it is in American English (even though "last name" isn't)