### PR TITLE
add lichess profile link and change subscribe button style

### DIFF
--- a/app/views/streamer/bits.scala
+++ b/app/views/streamer/bits.scala
@@ -110,7 +110,7 @@ object bits:
   def subscribeButtonFor(s: lila.streamer.Streamer.WithContext)(using ctx: Context, lang: Lang): Option[Tag] =
     ctx.isAuth option {
       val id = s"streamer-subscribe-${s.streamer.userId}"
-      label(cls := "streamer-subscribe button button-metal")(
+      label(cls := "streamer-subscribe")(
         `for`          := id,
         data("action") := s"${routes.Streamer.subscribe(s.streamer.userId, !s.subscribed)}"
       )(
@@ -124,3 +124,7 @@ object bits:
         trans.subscribe()
       )
     }
+  def streamerProfile(s: lila.streamer.Streamer.WithContext)(using ctx: Context, lang: Lang) =
+    span(cls := "streamer-profile")(
+      userLink(s.user)
+    )

--- a/app/views/streamer/header.scala
+++ b/app/views/streamer/header.scala
@@ -62,6 +62,9 @@ object header:
             }
           )
         ),
-        !modView option bits.subscribeButtonFor(s)
+        div(cls := "streamer-footer")(
+          !modView option bits.subscribeButtonFor(s),
+          bits.streamerProfile(s)
+        )
       )
     )

--- a/app/views/streamer/index.scala
+++ b/app/views/streamer/index.scala
@@ -54,7 +54,10 @@ object index:
               }
             )
           ),
-          !requests option bits.subscribeButtonFor(s)
+          div(cls := "streamer-footer")(
+            !requests option bits.subscribeButtonFor(s),
+            bits.streamerProfile(s)
+          )
         )
       )
 

--- a/ui/common/css/form/_cmn-toggle.scss
+++ b/ui/common/css/form/_cmn-toggle.scss
@@ -2,6 +2,7 @@
   @extend %double-tap;
   position: absolute;
   margin-#{$start-direction}: -99999px;
+  visibility: hidden;
 }
 
 .cmn-toggle + label {

--- a/ui/site/css/streamer/_header.scss
+++ b/ui/site/css/streamer/_header.scss
@@ -126,7 +126,12 @@
   @extend %flex-center-nowrap;
   gap: 1em;
   align-self: flex-start;
-  z-index: 2;
+  font-weight: bold;
+  z-index: z('link-overlay');
+}
+
+.streamer-profile{
+  z-index: z('link-overlay');
 }
 
 .live .streamer-lang {
@@ -135,4 +140,10 @@
   @include breakpoint($mq-not-xx-small) {
     margin-right: 50px;
   }
+}
+
+.streamer-footer{
+  @extend%flex-wrap;
+  align-items: center;
+  gap: 3em;
 }

--- a/ui/site/css/streamer/_list.scss
+++ b/ui/site/css/streamer/_list.scss
@@ -68,7 +68,7 @@ $mq-picture: $mq-medium;
   }
 
   .overview {
-    margin: 20px 10px 0 2.5vw;
+    margin: 20px 10px 10px 2.5vw;
     display: flex;
     flex: auto;
     flex-flow: column;
@@ -110,5 +110,10 @@ $mq-picture: $mq-medium;
       margin-#{$end-direction}: 0.4em;
       opacity: 0.7;
     }
+  }
+  .streamer-footer{
+    @extend%flex-wrap;
+    align-items: center;
+    gap: 3em;
   }
 }


### PR DESCRIPTION
References #12164

Adds a profile link in the streamer's overview and styles the subscribe button a bit, to make it consistent with the other toggle switch buttons.

**Old:**
![imagen](https://user-images.githubusercontent.com/47272450/236030775-dc27d069-bb07-42d6-a913-6819beb03f8b.png)

![imagen](https://user-images.githubusercontent.com/47272450/236035446-6200b37c-fa8d-4cfe-9178-e30e49fbebbb.png)

**New:**
![imagen](https://user-images.githubusercontent.com/47272450/236030378-1085b716-114e-4705-aecc-523e4af56fcf.png)

![imagen](https://user-images.githubusercontent.com/47272450/236035322-7ad6fc89-d44b-402b-98ef-1b9936f02f32.png)

I think that the toggle switch button shouldn't be inside of a regular button, it feels to crowded. Furthemore it's consistent with the other switch buttons like the ones in "Edit streamer page".

![imagen](https://user-images.githubusercontent.com/47272450/236033083-76711766-38d2-41d2-a0d6-6333b9710a40.png)
