### PR TITLE
Enhanced better user feedback when max depth reached

### DIFF
--- a/translation/source/site.xml
+++ b/translation/source/site.xml
@@ -92,7 +92,7 @@
     <item quantity="other">Mate in %s half-moves</item>
   </plurals>
   <string name="dtzWithRounding">DTZ50'' with rounding, based on number of half-moves until next capture or pawn move</string>
-  <string name="noGameFound">No game found</string>
+  <string name="maxDepthReached">Max depth reached!</string>
   <string name="maybeIncludeMoreGamesFromThePreferencesMenu">Maybe include more games from the preferences menu?</string>
   <string name="openings">Openings</string>
   <string name="openingExplorer">Opening explorer</string>


### PR DESCRIPTION
Currently when the max depth of 25 is reached, it shows as if no games were found: 
Replaced with a better message would be to show something like "Max depth reached!"

closes issue #12775 