### PR TITLE
make conditional premoves clickable

### DIFF
--- a/ui/analyse/css/_forecast.scss
+++ b/ui/analyse/css/_forecast.scss
@@ -28,6 +28,12 @@
   .entry {
     @extend %flex-center-nowrap;
 
+    cursor: pointer;
+    &:hover {
+      background: $c-primary;
+      color: $c-primary-over;
+    }
+
     @include padding-direction(0.7em, 0.1em, 0.7em, 0.6em);
 
     margin-#{$start-direction}: -0.1em;

--- a/ui/analyse/src/forecast/forecastView.ts
+++ b/ui/analyse/src/forecast/forecastView.ts
@@ -5,6 +5,8 @@ import AnalyseCtrl from '../ctrl';
 import { renderNodesHtml } from '../pgnExport';
 import { spinnerVdom as spinner } from 'common/spinner';
 import { fixCrazySan } from 'chess';
+import { scalachessCharPair } from 'chessops/compat';
+import { parseUci } from 'chessops';
 
 function onMyTurn(ctrl: AnalyseCtrl, fctrl: ForecastCtrl, cNodes: ForecastStep[]): VNode | undefined {
   const firstNode = cNodes[0];
@@ -63,6 +65,19 @@ export default function (ctrl: AnalyseCtrl, fctrl: ForecastCtrl): VNode {
               'div.entry.text',
               {
                 attrs: dataIcon(''),
+                hook: bind(
+                  'click',
+                  () => {
+                    const path = [];
+                    for (const node of nodes) {
+                      const move = parseUci(node.uci);
+                      if (!move) return;
+                      path.push(scalachessCharPair(move));
+                    }
+                    ctrl.userJump(`/?WG${path.join('')}`);
+                  },
+                  ctrl.redraw
+                ),
               },
               [
                 h('button.del', {


### PR DESCRIPTION
This PR Attempts to fix #12707

Looks like this

https://user-images.githubusercontent.com/10794178/236216034-da95b880-5def-4766-ac71-0eac538a8ba1.mp4

I'm not really sure about the styling, and there is an existing issue where in if a premove is edited later, clicking on it doesn't use the updated node list. There is a `redraw` argument in `ui/analyse/src/forecast/forecastCtrl.ts` but I still haven't been able to figure out how to make that work.