### PR TITLE
don't stop timeline for large threads

### DIFF
--- a/modules/forum/src/main/ForumPostApi.scala
+++ b/modules/forum/src/main/ForumPostApi.scala
@@ -59,7 +59,7 @@ final class ForumPostApi(
                 else lila.hub.actorApi.shutup.RecordPublicForumMessage(me.id, post.text)
               }
               if (anonMod) logAnonPost(me.id, post, edit = false)
-              else if (!post.troll && !categ.quiet && !topic.isTooBig)
+              else if (!post.troll && !categ.quiet)
                 timeline ! Propagate(TimelinePost(me.id, topic.id, topic.name, post.id)).pipe {
                   _ toFollowersOf me.id toUsers topicUserIds exceptUser me.id withTeam categ.team
                 }


### PR DESCRIPTION
Since the topic is no longer bumped, it becomes hard to find. So the only way to continue a conversation is for remaining participants to aggressively ping each other

This has made it difficult for me to troubleshoot issues on long running feedback forum threads. I feel like it's overkill.