### PR TITLE
Broadcast preview: add live clocks

### DIFF
--- a/modules/study/src/main/StudyMultiBoard.scala
+++ b/modules/study/src/main/StudyMultiBoard.scala
@@ -70,10 +70,10 @@ final class StudyMultiBoard(
                     |tags = tags.filter(t => t.startsWith('White') || t.startsWith('Black') || t.startsWith('Result'));
                     |const node = tags.length
                     |  ? Object.keys(root).reduce(
-                    |      ([path, node], i) =>
-                    |        root[i].p > node.p && i.startsWith(path) ? [i, root[i]] : [path, node],
-                    |      ['', root['_']]
-                    |    )[1]
+                    |      ([node, path], i) =>
+                    |        root[i].p > node.p && i.startsWith(path) ? [root[i], i] : [node, path],
+                    |      [root['_'], '']
+                    |    )[0]
                     |  : root['_'];
                     |return {node:{fen:node.f,uci:node.u},tags} }""".stripMargin
                     )

--- a/modules/study/src/main/StudyMultiBoard.scala
+++ b/modules/study/src/main/StudyMultiBoard.scala
@@ -110,25 +110,22 @@ final class StudyMultiBoard(
         }
         .map { r =>
           for
-            doc    <- r
-            id     <- doc.getAsOpt[StudyChapterId]("_id")
-            name   <- doc.getAsOpt[StudyChapterName]("name").pp
-            lastMoveAt = doc.getAsOpt[Instant]("lastMoveAt").pp
+            doc  <- r
+            id   <- doc.getAsOpt[StudyChapterId]("_id")
+            name <- doc.getAsOpt[StudyChapterName]("name")
+            lastMoveAt = doc.getAsOpt[Instant]("lastMoveAt")
             comp   <- doc.getAsOpt[Bdoc]("comp")
             node   <- comp.getAsOpt[Bdoc]("node")
-            _ = node.getAsOpt[Centis]("clockDebug").pp
-            fen    <- node.getAsOpt[Fen.Epd]("fen").pp
-            sideToPlay <- node.getAsOpt[Ply]("ply").map(_.color)
+            fen    <- node.getAsOpt[Fen.Epd]("fen")
             clocks <- comp.getAsOpt[Bdoc]("clocks")
-            lastMove   = node.getAsOpt[Uci]("uci").pp
-            tags       = comp.getAsOpt[Tags]("tags").pp
-            blackClock = clocks.getAsOpt[Centis]("black").pp
-            whiteClock = clocks.getAsOpt[Centis]("white").pp
+            lastMove   = node.getAsOpt[Uci]("uci")
+            tags       = comp.getAsOpt[Tags]("tags")
+            blackClock = clocks.getAsOpt[Centis]("black")
+            whiteClock = clocks.getAsOpt[Centis]("white")
           yield ChapterPreview(
             id = id,
             name = name,
-            players = tags flatMap ChapterPreview.players(blackClock=blackClock, whiteClock=whiteClock),
-            sideToPlay = sideToPlay,
+            players = tags flatMap ChapterPreview.players(blackClock = blackClock, whiteClock = whiteClock),
             orientation = doc.getAsOpt[Color]("orientation") | Color.White,
             fen = fen,
             lastMove = lastMove,
@@ -162,7 +159,6 @@ object StudyMultiBoard:
       id: StudyChapterId,
       name: StudyChapterName,
       players: Option[ChapterPreview.Players],
-      sideToPlay: Color,
       orientation: Color,
       fen: Fen.Epd,
       lastMove: Option[Uci],

--- a/modules/study/src/main/StudyMultiBoard.scala
+++ b/modules/study/src/main/StudyMultiBoard.scala
@@ -68,7 +68,13 @@ final class StudyMultiBoard(
                       "args" -> $arr("$root", "$tags"),
                       "body" -> """function(root, tags) {
                     |tags = tags.filter(t => t.startsWith('White') || t.startsWith('Black') || t.startsWith('Result'));
-                    |const node = tags.length ? Object.keys(root).reduce(([path, node], i) => (root[i].p > node.p && i.startsWith(path)) ? [i, root[i]] : [path, node], ['', root['_']])[1] : root['_'];
+                    |const node = tags.length
+                    |  ? Object.keys(root).reduce(
+                    |      ([path, node], i) =>
+                    |        root[i].p > node.p && i.startsWith(path) ? [i, root[i]] : [path, node],
+                    |      ['', root['_']]
+                    |    )[1]
+                    |  : root['_'];
                     |return {node:{fen:node.f,uci:node.u},tags} }""".stripMargin
                     )
                   ),

--- a/modules/study/src/main/StudyMultiBoard.scala
+++ b/modules/study/src/main/StudyMultiBoard.scala
@@ -149,7 +149,7 @@ final class StudyMultiBoard(
     Json.obj("white" -> players.white, "black" -> players.black)
   }
 
-  given Writes[Outcome] = writeAs(_.toString)
+  given Writes[Outcome] = writeAs(_.toString.replace("1/2", "½"))
 
   given Writes[ChapterPreview] = Json.writes
 

--- a/ui/analyse/src/explorer/explorerCtrl.ts
+++ b/ui/analyse/src/explorer/explorerCtrl.ts
@@ -1,10 +1,11 @@
 import { Prop, prop, defined } from 'common';
 import { storedBooleanProp } from 'common/storage';
+import { fenColor } from 'common/mini-game';
 import debounce from 'common/debounce';
 import { sync, Sync } from 'common/sync';
 import { opposite } from 'chessground/util';
 import * as xhr from './explorerXhr';
-import { winnerOf, colorOf } from './explorerUtil';
+import { winnerOf } from './explorerUtil';
 import * as gameUtil from 'game';
 import AnalyseCtrl from '../ctrl';
 import { Hovering, ExplorerData, ExplorerDb, OpeningData, SimpleTablebaseHit, ExplorerOpts } from './interfaces';
@@ -217,7 +218,7 @@ export default class ExplorerCtrl {
     return {
       fen,
       best: move && move.uci,
-      winner: res.checkmate ? opposite(colorOf(fen)) : res.stalemate ? undefined : winnerOf(fen, move!),
+      winner: res.checkmate ? opposite(fenColor(fen)) : res.stalemate ? undefined : winnerOf(fen, move!),
     } as SimpleTablebaseHit;
   };
 }

--- a/ui/analyse/src/explorer/explorerUtil.ts
+++ b/ui/analyse/src/explorer/explorerUtil.ts
@@ -1,14 +1,11 @@
 import { TablebaseMoveStats } from './interfaces';
 import { opposite } from 'chessops/util';
+import { fenColor } from 'common/mini-game';
 import { VNode } from 'snabbdom';
 import AnalyseCtrl from '../ctrl';
 
-export function colorOf(fen: Fen): Color {
-  return fen.split(' ')[1] === 'w' ? 'white' : 'black';
-}
-
 export function winnerOf(fen: Fen, move: TablebaseMoveStats): Color | undefined {
-  const stm = colorOf(fen);
+  const stm = fenColor(fen);
   if (move.checkmate || move.variant_loss || (move.dtz && move.dtz < 0)) return stm;
   if (move.variant_win || (move.dtz && move.dtz > 0)) return opposite(stm);
   return undefined;

--- a/ui/analyse/src/study/interfaces.ts
+++ b/ui/analyse/src/study/interfaces.ts
@@ -231,7 +231,6 @@ export interface ChapterPreview {
     white: ChapterPreviewPlayer;
     black: ChapterPreviewPlayer;
   };
-  sideToPlay: Color;
   orientation: Color;
   fen: string;
   lastMove?: string;

--- a/ui/analyse/src/study/interfaces.ts
+++ b/ui/analyse/src/study/interfaces.ts
@@ -231,9 +231,11 @@ export interface ChapterPreview {
     white: ChapterPreviewPlayer;
     black: ChapterPreviewPlayer;
   };
+  sideToPlay: Color;
   orientation: Color;
   fen: string;
   lastMove?: string;
+  lastMoveAt?: number;
   playing: boolean;
   outcome?: '1-0' | '0-1' | '1/2-1/2';
 }
@@ -242,6 +244,7 @@ export interface ChapterPreviewPlayer {
   name: string;
   title?: string;
   rating?: number;
+  clock?: number;
 }
 
 export type Orientation = 'black' | 'white' | 'auto';

--- a/ui/analyse/src/study/interfaces.ts
+++ b/ui/analyse/src/study/interfaces.ts
@@ -236,7 +236,7 @@ export interface ChapterPreview {
   lastMove?: string;
   lastMoveAt?: number;
   playing: boolean;
-  outcome?: '1-0' | '0-1' | '1/2-1/2';
+  outcome?: '1-0' | '0-1' | '½-½';
 }
 
 export interface ChapterPreviewPlayer {

--- a/ui/analyse/src/study/interfaces.ts
+++ b/ui/analyse/src/study/interfaces.ts
@@ -158,7 +158,7 @@ export interface StudyChapterMeta {
   id: string;
   name: string;
   ongoing?: boolean;
-  res?: string;
+  res?: '1-0' | '0-1' | '½-½' | '*';
 }
 
 export interface StudyChapterConfig extends StudyChapterMeta {

--- a/ui/analyse/src/study/multiBoard.ts
+++ b/ui/analyse/src/study/multiBoard.ts
@@ -1,4 +1,5 @@
 import debounce from 'common/debounce';
+import { renderClock } from 'common/mini-game';
 import { bind, MaybeVNodes } from 'common/snabbdom';
 import { spinnerVdom as spinner } from 'common/spinner';
 import { h, VNode } from 'snabbdom';
@@ -178,14 +179,6 @@ function renderPlayer(player: ChapterPreviewPlayer | undefined): VNode | undefin
     ])
   );
 }
-
-const renderClock = (color: Color, time: number) =>
-  h(`span.mini-game__clock.mini-game__clock--${color}`, {
-    attrs: {
-      'data-time': time,
-      'data-managed': 1,
-    },
-  });
 
 const computeTimeLeft = (
   preview: ChapterPreview,

--- a/ui/analyse/src/study/multiBoard.ts
+++ b/ui/analyse/src/study/multiBoard.ts
@@ -179,11 +179,36 @@ function renderPlayer(player: ChapterPreviewPlayer | undefined): VNode | undefin
   );
 }
 
+const renderClock = (color: Color, time: number) =>
+  h(`span.mini-game__clock.mini-game__clock--${color}`, {
+    attrs: {
+      'data-time': time,
+      'data-managed': 1,
+    },
+  });
+
+const computeTimeLeft = (
+  preview: ChapterPreview,
+  player: ChapterPreviewPlayer | undefined,
+  color: Color
+): number | undefined => {
+  if (player && player.clock) {
+    if (preview.lastMoveAt && preview.sideToPlay == color) {
+      const spent = (Date.now() - preview.lastMoveAt) / 1000;
+      return Math.max(0, player.clock / 100 - spent);
+    } else {
+      return player.clock / 100;
+    }
+  } else {
+    return;
+  }
+};
+
 const boardPlayer = (preview: ChapterPreview, color: Color) => {
   const player = preview.players && preview.players[color];
   const result = preview.outcome?.split('-')[color === 'white' ? 0 : 1];
-  return h('span.mini-game__player', [
-    h('span.mini-game__user', [renderPlayer(player)]),
-    result && h('span.mini-game__result', result.replace('1/2', '½')),
-  ]);
+  const resultNode = result && h('span.mini-game__result', result.replace('1/2', '½'));
+  const timeleft = computeTimeLeft(preview, player, color);
+  const clock = timeleft && renderClock(color, timeleft);
+  return h('span.mini-game__player', [h('span.mini-game__user', [renderPlayer(player)]), resultNode ?? clock]);
 };

--- a/ui/analyse/src/study/multiBoard.ts
+++ b/ui/analyse/src/study/multiBoard.ts
@@ -1,5 +1,5 @@
 import debounce from 'common/debounce';
-import { renderClock } from 'common/mini-game';
+import { renderClock, fenColor } from 'common/mini-game';
 import { bind, MaybeVNodes } from 'common/snabbdom';
 import { spinnerVdom as spinner } from 'common/spinner';
 import { h, VNode } from 'snabbdom';
@@ -21,8 +21,7 @@ export class MultiBoardCtrl {
     if (cp?.playing) {
       cp.fen = node.fen;
       cp.lastMove = node.uci;
-      cp.sideToPlay = node.ply % 2 === 0 ? 'white' : 'black'; // TODO, does it work when the first position is black to move?
-      let playerWhoMoved = cp.players && cp.players[oppositeColor(cp.sideToPlay)];
+      let playerWhoMoved = cp.players && cp.players[oppositeColor(fenColor(cp.fen))];
       playerWhoMoved && (playerWhoMoved.clock = node.clock);
       // at this point `(cp: ChapterPreview).lastMoveAt` becomes outdated but should be ok since not in use anymore
       // to mitigate bad usage, setting it as `undefined`
@@ -196,7 +195,7 @@ function renderPlayer(player: ChapterPreviewPlayer | undefined): VNode | undefin
 const computeTimeLeft = (preview: ChapterPreview, color: Color): number | undefined => {
   const player = preview.players && preview.players[color];
   if (player && player.clock) {
-    if (preview.lastMoveAt && preview.sideToPlay == color) {
+    if (preview.lastMoveAt && fenColor(preview.fen) == color) {
       const spent = (Date.now() - preview.lastMoveAt) / 1000;
       return Math.max(0, player.clock / 100 - spent);
     } else {

--- a/ui/analyse/src/study/multiBoard.ts
+++ b/ui/analyse/src/study/multiBoard.ts
@@ -21,7 +21,7 @@ export class MultiBoardCtrl {
     if (cp?.playing) {
       cp.fen = node.fen;
       cp.lastMove = node.uci;
-      let playerWhoMoved = cp.players && cp.players[oppositeColor(fenColor(cp.fen))];
+      const playerWhoMoved = cp.players && cp.players[oppositeColor(fenColor(cp.fen))];
       playerWhoMoved && (playerWhoMoved.clock = node.clock);
       // at this point `(cp: ChapterPreview).lastMoveAt` becomes outdated but should be ok since not in use anymore
       // to mitigate bad usage, setting it as `undefined`

--- a/ui/analyse/src/study/studyCtrl.ts
+++ b/ui/analyse/src/study/studyCtrl.ts
@@ -530,6 +530,7 @@ export default function (
     },
     chapters(d) {
       chapters.list(d);
+      if (vm.toolTab() == 'multiBoard' || (relay && relay.tourShow.active)) multiBoard.addResult(d);
       if (!currentChapter()) {
         vm.chapterId = d[0].id;
         if (!vm.mode.sticky) xhrReload();

--- a/ui/common/src/mini-game.ts
+++ b/ui/common/src/mini-game.ts
@@ -1,5 +1,7 @@
 import { h } from 'snabbdom';
 
+export const fenColor = (fen: string) => (fen.includes(' w') ? 'white' : 'black');
+
 export const renderClock = (color: Color, time: number) =>
   h(`span.mini-game__clock.mini-game__clock--${color}`, {
     attrs: {

--- a/ui/common/src/mini-game.ts
+++ b/ui/common/src/mini-game.ts
@@ -1,0 +1,9 @@
+import { h } from 'snabbdom';
+
+export const renderClock = (color: Color, time: number) =>
+  h(`span.mini-game__clock.mini-game__clock--${color}`, {
+    attrs: {
+      'data-time': time,
+      'data-managed': 1,
+    },
+  });

--- a/ui/simul/src/view/pairings.ts
+++ b/ui/simul/src/view/pairings.ts
@@ -1,5 +1,6 @@
 import { h } from 'snabbdom';
 import { onInsert } from 'common/snabbdom';
+import { renderClock } from 'common/mini-game';
 import SimulCtrl from '../ctrl';
 import { Pairing } from '../interfaces';
 import { opposite } from 'chessground/util';
@@ -7,14 +8,6 @@ import { opposite } from 'chessground/util';
 export default function (ctrl: SimulCtrl) {
   return h('div.game-list.now-playing.box__pad', ctrl.data.pairings.map(miniPairing(ctrl)));
 }
-
-const renderClock = (color: Color, time: number) =>
-  h(`span.mini-game__clock.mini-game__clock--${color}`, {
-    attrs: {
-      'data-time': time,
-      'data-managed': 1,
-    },
-  });
 
 const miniPairing = (ctrl: SimulCtrl) => (pairing: Pairing) => {
   const game = pairing.game,

--- a/ui/site/src/component/mini-game.ts
+++ b/ui/site/src/component/mini-game.ts
@@ -55,15 +55,15 @@ export const update = (node: HTMLElement, data: MiniGameUpdateData) => {
       lastMove: uciToMove(lm),
     });
   const turnColor = fenColor(data.fen);
-  const renderClock = (time: number | undefined, color: Color) => {
+  const updateClock = (time: number | undefined, color: Color) => {
     if (!isNaN(time!))
       clockWidget($el[0]?.querySelector('.mini-game__clock--' + color) as HTMLElement, {
         time: time!,
         pause: color != turnColor || !clockIsRunning(data.fen, color),
       });
   };
-  renderClock(data.wc, 'white');
-  renderClock(data.bc, 'black');
+  updateClock(data.wc, 'white');
+  updateClock(data.bc, 'black');
 };
 
 export const finish = (node: HTMLElement, win?: string) =>

--- a/ui/site/src/component/mini-game.ts
+++ b/ui/site/src/component/mini-game.ts
@@ -1,9 +1,8 @@
 import { uciToMove } from 'chessground/util';
+import { fenColor } from 'common/mini-game';
 import * as domData from 'common/data';
 import clockWidget from './clock-widget';
 import StrongSocket from './socket';
-
-const fenColor = (fen: string) => (fen.indexOf(' b') > 0 ? 'black' : 'white');
 
 export const init = (node: HTMLElement) => {
   if (!window.Chessground) setTimeout(() => init(node), 200);

--- a/ui/site/src/component/mini-game.ts
+++ b/ui/site/src/component/mini-game.ts
@@ -65,10 +65,10 @@ export const update = (node: HTMLElement, data: MiniGameUpdateData) => {
   updateClock(data.bc, 'black');
 };
 
-export const finish = (node: HTMLElement, win?: string) =>
+export const finish = (node: HTMLElement, win?: 'black' | 'white') =>
   ['white', 'black'].forEach(color => {
     const $clock = $(node).find('.mini-game__clock--' + color);
     // don't interfere with snabbdom clocks
     if (!$clock.data('managed'))
-      $clock.replaceWith(`<span class="mini-game__result">${win ? (win == color[0] ? 1 : 0) : '½'}</span>`);
+      $clock.replaceWith(`<span class="mini-game__result">${win ? (win === color[0] ? 1 : 0) : '½'}</span>`);
   });

--- a/ui/swiss/src/view/boards.ts
+++ b/ui/swiss/src/view/boards.ts
@@ -1,4 +1,5 @@
 import { Board, SwissOpts } from '../interfaces';
+import { renderClock } from 'common/mini-game';
 import { h, VNode } from 'snabbdom';
 import { opposite } from 'chessground/util';
 import { player as renderPlayer } from './util';
@@ -44,12 +45,7 @@ function boardPlayer(board: Board, color: Color, opts: SwissOpts) {
   return h('span.mini-game__player', [
     h('span.mini-game__user', [h('strong', '#' + player.rank), renderPlayer(player, true, opts.showRatings)]),
     board.clock
-      ? h(`span.mini-game__clock.mini-game__clock--${color}`, {
-          attrs: {
-            'data-time': board.clock[color],
-            'data-managed': 1,
-          },
-        })
+      ? renderClock(color, board.clock[color])
       : h('span.mini-game__result', board.winner ? (board.winner == color ? 1 : 0) : '½'),
   ]);
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/56031107/236626413-de42f7e0-3df9-4316-8d01-fd53a11e96a9.png)

close https://github.com/lichess-org/lila/issues/12106

The change to the aggregation query has been isolated to this commit: https://github.com/lichess-org/lila/commit/24936cd48173b52ed002a1e2fb6a12cd6305c9c4. The change in size is mostly due to reformatting.

Globally I think the integration is quite clean and doesn't add that much complexity, beside the query being slightly more expensive.

Testing on the other end is hard because of complete lack of type checking and errors only happening at runtime. I've tested to the best of my abilities:
- Tested on real broadcast (pic above)
- Tested on Lichess game from start to end
- Tested on Lichess game from position where black start first (which permitted do discover a bug with the query)

Worst case scenario the query fail and the overview cannot be shown, but I don't know if it'd harm the servers (since I guess the results wouldn't be cached anymore, every view on a broadcast would be expensive).

Maybe stage testing with the broadcast would be appropriate.
