### PR TITLE
Change empty message on explorer max depth

### DIFF
--- a/app/views/board/userAnalysisI18n.scala
+++ b/app/views/board/userAnalysisI18n.scala
@@ -169,6 +169,7 @@ object userAnalysisI18n:
     trans.lossOr50MovesByPriorMistake,
     trans.unknownDueToRounding,
     trans.noGameFound,
+    trans.maxDepthReached,
     trans.maybeIncludeMoreGamesFromThePreferencesMenu,
     trans.winPreventedBy50MoveRule,
     trans.lossSavedBy50MoveRule,

--- a/modules/i18n/src/main/I18nKeys.scala
+++ b/modules/i18n/src/main/I18nKeys.scala
@@ -88,6 +88,7 @@ object I18nKeys:
   val `masterDbExplanation` = I18nKey("masterDbExplanation")
   val `dtzWithRounding` = I18nKey("dtzWithRounding")
   val `noGameFound` = I18nKey("noGameFound")
+  val `maxDepthReached` = I18nKey("maxDepthReached")
   val `maybeIncludeMoreGamesFromThePreferencesMenu` = I18nKey("maybeIncludeMoreGamesFromThePreferencesMenu")
   val `openings` = I18nKey("openings")
   val `openingExplorer` = I18nKey("openingExplorer")

--- a/translation/source/site.xml
+++ b/translation/source/site.xml
@@ -93,6 +93,7 @@
   </plurals>
   <string name="dtzWithRounding">DTZ50'' with rounding, based on number of half-moves until next capture or pawn move</string>
   <string name="noGameFound">No game found</string>
+  <string name="maxDepthReached">Max depth reached!</string>
   <string name="maybeIncludeMoreGamesFromThePreferencesMenu">Maybe include more games from the preferences menu?</string>
   <string name="openings">Openings</string>
   <string name="openingExplorer">Opening explorer</string>

--- a/ui/analyse/src/explorer/explorerCtrl.ts
+++ b/ui/analyse/src/explorer/explorerCtrl.ts
@@ -12,6 +12,8 @@ import { Hovering, ExplorerData, ExplorerDb, OpeningData, SimpleTablebaseHit, Ex
 import { ExplorerConfigCtrl } from './explorerConfig';
 import { clearLastShow } from './explorerView';
 
+export const MAX_DEPTH = 50;
+
 function pieceCount(fen: Fen) {
   const parts = fen.split(/\s/);
   return parts[0].split(/[nbrqkp]/i).length - 1;
@@ -149,7 +151,7 @@ export default class ExplorerCtrl {
     if (!this.enabled()) return;
     this.gameMenu(null);
     const node = this.root.node;
-    if (node.ply >= 50 && !this.tablebaseRelevant(this.effectiveVariant, node.fen)) {
+    if (node.ply >= MAX_DEPTH && !this.tablebaseRelevant(this.effectiveVariant, node.fen)) {
       this.cache[node.fen] = this.empty;
     }
     const cached = this.cache[node.fen];

--- a/ui/analyse/src/explorer/explorerView.ts
+++ b/ui/analyse/src/explorer/explorerView.ts
@@ -14,7 +14,7 @@ import {
   OpeningGame,
   ExplorerDb,
 } from './interfaces';
-import ExplorerCtrl from './explorerCtrl';
+import ExplorerCtrl, { MAX_DEPTH } from './explorerCtrl';
 import { showTablebase } from './tablebaseView';
 
 function resultBar(move: OpeningMoveStats): VNode {
@@ -247,7 +247,7 @@ const showEmpty = (ctrl: AnalyseCtrl, data?: OpeningData): VNode =>
     explorerTitle(ctrl.explorer),
     openingTitle(ctrl, data),
     h('div.message', [
-      h('strong', ctrl.trans.noarg('noGameFound')),
+      h('strong', ctrl.trans.noarg(ctrl.explorer.root.node.ply >= MAX_DEPTH ? 'maxDepthReached' : 'noGameFound')),
       data?.queuePosition
         ? h('p.explanation', `Indexing ${data.queuePosition} other players first ...`)
         : !ctrl.explorer.config.fullHouse()


### PR DESCRIPTION
Fixes #12775 

This changes the error message when we get to the max depth of explorer analysis to the message mentioned in the linked issue.

![image](https://github.com/lichess-org/lila/assets/2817895/5d287c40-125a-4db2-a171-91d068c9e23d)
