### PR TITLE
Fix uniboard overflow

### DIFF
--- a/ui/common/css/abstract/_uniboard.scss
+++ b/ui/common/css/abstract/_uniboard.scss
@@ -8,27 +8,42 @@ $mq-col3-uniboard: $mq-x-large;
 /* when the width is appropriate for col1, but landscape prevents it */
 $mq-col2-uniboard-squeeze: $mq-not-small $mq-landscape;
 
-$col3-uniboard-side: minmax(230px, 350px);
-$col3-uniboard-table: minmax(240px, 400px);
+$scrollbar-width: 20px;
+
+$col3-uniboard-side-min: 250px;
+$col3-uniboard-table-min: 240px;
+$col3-uniboard-side: minmax(#{$col3-uniboard-side-min}, 350px);
+$col3-uniboard-table: minmax(#{$col3-uniboard-table-min}, 400px);
 $col3-uniboard-controls: 3rem;
+$col3-min-bottom-margin: 1rem;
 
-$col3-uniboard-min-width: calc(max(720px, 50vmin) * var(--board-scale));
-$col3-uniboard-max-width: calc(100vh * var(--board-scale) - #{$site-header-outer-height} - #{$col3-uniboard-controls});
-$col3-uniboard-width: minmax($col3-uniboard-min-width, $col3-uniboard-max-width);
-
-$col3-uniboard-default-scale: 0.9;
-
-// zoom: 85%
-$col3-uniboard-default-min-width: 500px;
-$col3-uniboard-default-max-width: calc(
-  100vh * #{$col3-uniboard-default-scale} - #{$site-header-outer-height} - #{$col3-uniboard-controls}
+$col3-uniboard-max-width: calc(
+  100vw - #{$col3-uniboard-side-min} - #{$block-gap} - var(--gauge-gap, #{$block-gap}) - #{$col3-uniboard-table-min} - 2 *
+    var(--main-margin, 0px) - #{$scrollbar-width}
 );
+$col3-uniboard-max-height: calc(100vh - #{$site-header-outer-height} - #{$col3-min-bottom-margin});
+$col3-uniboard-max-size: min(#{$col3-uniboard-max-width}, #{$col3-uniboard-max-height});
+$col3-uniboard-width: calc(#{$col3-uniboard-max-size} * var(--board-scale));
+
+// default zoom setting is 85% which gives a board-scale of 0.85*0.7+0.3 = 0.895 ≈ 0.9 (coincidence)
+// this is used for 3-col pages that don't actually have a board, e.g. tournament pages
+// on these pages, the height is irrelevant, so we just use the width
+$uniboard-default-scale: 0.9;
+$col3-uniboard-default-min-width: 500px;
+$col3-uniboard-default-max-width: calc(#{$col3-uniboard-max-width} * #{$uniboard-default-scale});
 $col3-uniboard-default-width: minmax(#{$col3-uniboard-default-min-width}, #{$col3-uniboard-default-max-width});
 
 $col2-uniboard-table: $col3-uniboard-table;
 $col2-uniboard-controls: $col3-uniboard-controls;
-$col2-uniboard-width: $col3-uniboard-width;
-$col2-uniboard-default-width: $col3-uniboard-default-width;
+
+$col2-uniboard-max-width: calc(
+  100vw - var(--gauge-gap, #{$block-gap}) - #{$col3-uniboard-table-min} - 2 * var(--main-margin, 0px) - #{$scrollbar-width}
+);
+$col2-uniboard-max-height: $col3-uniboard-max-height;
+$col2-uniboard-max-size: min(#{$col2-uniboard-max-width}, #{$col2-uniboard-max-height});
+$col2-uniboard-width: calc(#{$col2-uniboard-max-size} * var(--board-scale));
+
+$col2-uniboard-default-width: calc(#{$col2-uniboard-max-width} * #{$uniboard-default-scale});
 
 $col2-uniboard-squeeze-table: minmax(200px, 240px);
 $col2-uniboard-squeeze-width: minmax(calc(55vmin), calc(100vh - #{$site-header-outer-height} - #{$block-gap}));

--- a/ui/common/css/abstract/_uniboard.scss
+++ b/ui/common/css/abstract/_uniboard.scss
@@ -30,7 +30,7 @@ $col3-uniboard-width: calc(#{$col3-uniboard-max-size} * var(--board-scale));
 // on these pages, the height is irrelevant, so we just use the width
 $uniboard-default-scale: 0.9;
 $col3-uniboard-default-min-width: 500px;
-$col3-uniboard-default-max-width: calc(#{$col3-uniboard-max-width} * #{$uniboard-default-scale});
+$col3-uniboard-default-max-width: calc(#{$col3-uniboard-max-size} * #{$uniboard-default-scale});
 $col3-uniboard-default-width: minmax(#{$col3-uniboard-default-min-width}, #{$col3-uniboard-default-max-width});
 
 $col2-uniboard-table: $col3-uniboard-table;
@@ -43,7 +43,8 @@ $col2-uniboard-max-height: $col3-uniboard-max-height;
 $col2-uniboard-max-size: min(#{$col2-uniboard-max-width}, #{$col2-uniboard-max-height});
 $col2-uniboard-width: calc(#{$col2-uniboard-max-size} * var(--board-scale));
 
-$col2-uniboard-default-width: calc(#{$col2-uniboard-max-width} * #{$uniboard-default-scale});
+$col2-uniboard-default-max-width: calc(#{$col2-uniboard-max-size} * #{$uniboard-default-scale});
+$col2-uniboard-default-width: minmax(#{$col3-uniboard-default-min-width}, #{$col2-uniboard-default-max-width});
 
 $col2-uniboard-squeeze-table: minmax(200px, 240px);
 $col2-uniboard-squeeze-width: minmax(calc(55vmin), calc(100vh - #{$site-header-outer-height} - #{$block-gap}));

--- a/ui/round/css/_app-layout.scss
+++ b/ui/round/css/_app-layout.scss
@@ -115,6 +115,10 @@
     }
   }
 
+  @include breakpoint($mq-col3) {
+    grid-template-columns: $col3-uniboard-width $col3-uniboard-table;
+  }
+
   @include breakpoint($mq-col2-uniboard-squeeze) {
     grid-template-columns: $col2-uniboard-squeeze-width $col2-uniboard-squeeze-table;
     grid-column-gap: #{$block-gap * 3 / 2};


### PR DESCRIPTION
Adapted from #9659

See #12839 for the same PR but with additional fallbacks to support really old browsers that don't support the CSS min() function.

Still the same idea:

Instead of guessing which values might work, calculate the maximum available space for the board by calculating the max height (basically as before) and the max width (100vw - everything left and right of the board if it's as small as possible). The board shouldn't be larger than the smaller of those two. This is our 100% scaling and everything else is just scaled from there. By moving the scaling to the outside, it's not really necessary to have an extra minimum since the scaling is already capped at 30%. Although I guess in theory, an extra minimum could be added.

I also increased the max-height slightly by not requiring space for the controls below the right sidebar (i.e. only 1rem min margin on the bottom instead of the previous 3rem). On the round page, these controls don't even show up and it seems more logical to allow the user to maximize the board size if they want.

~~I also adjusted the default-width which is used on the overview page of a tournament or simul. They use the same layout but don't have a board. It doesn't make sense to consider the height for the maximum width here, there's no reason why the tournament overview should get slimmer and get margin on the left and right if you decrease the window height, so the max width is now only based on the max board width. On most regular sizes, this doesn't make a difference though.~~

Edit: Reverted this for now since it doesn't leave margins on the left and right on wide screens and isn't really that important rn.