### PR TITLE
Fix uniboard overflow with fallback

### DIFF
--- a/ui/analyse/css/_layout.scss
+++ b/ui/analyse/css/_layout.scss
@@ -80,6 +80,7 @@ body {
     'uchat';
 
   @include breakpoint($mq-col2) {
+    grid-template-columns: $col2-uniboard-fallback-width var(--gauge-gap) $col2-uniboard-table;
     grid-template-columns: $col2-uniboard-width var(--gauge-gap) $col2-uniboard-table;
     grid-template-rows: fit-content(0);
     grid-template-areas:
@@ -111,6 +112,7 @@ body {
   }
 
   @include breakpoint($mq-col3) {
+    grid-template-columns: $col3-uniboard-side $block-gap $col3-uniboard-fallback-width var(--gauge-gap) $col3-uniboard-table;
     grid-template-columns: $col3-uniboard-side $block-gap $col3-uniboard-width var(--gauge-gap) $col3-uniboard-table;
     grid-template-rows: $meta-height $chat-height 2.5em 1fr;
     grid-template-areas:

--- a/ui/common/css/abstract/_uniboard.scss
+++ b/ui/common/css/abstract/_uniboard.scss
@@ -49,3 +49,19 @@ $col2-uniboard-squeeze-table: minmax(200px, 240px);
 $col2-uniboard-squeeze-width: minmax(calc(55vmin), calc(100vh - #{$site-header-outer-height} - #{$block-gap}));
 
 $col1-uniboard-controls: 5rem;
+
+// fallbacks for really old browsers that don't support css min() and max() functions
+$col3-uniboard-fallback-min-width: calc(70vmin * var(--board-scale));
+$col3-uniboard-fallback-max-width: calc(
+  100vh * var(--board-scale) - #{$site-header-outer-height} - #{$col3-uniboard-controls}
+);
+$col3-uniboard-fallback-width: minmax($col3-uniboard-fallback-min-width, $col3-uniboard-fallback-max-width);
+$col3-uniboard-fallback-default-max-width: calc(
+  100vh * #{$uniboard-default-scale} - #{$site-header-outer-height} - #{$col3-uniboard-controls}
+);
+$col3-uniboard-fallback-default-width: minmax(
+  #{$col3-uniboard-default-min-width},
+  #{$col3-uniboard-fallback-default-max-width}
+);
+$col2-uniboard-fallback-width: $col3-uniboard-fallback-width;
+$col2-uniboard-fallback-default-width: $col3-uniboard-fallback-default-width;

--- a/ui/common/css/abstract/_uniboard.scss
+++ b/ui/common/css/abstract/_uniboard.scss
@@ -25,7 +25,7 @@ $col3-uniboard-max-height: calc(100vh - #{$site-header-outer-height} - #{$col3-m
 $col3-uniboard-max-size: min(#{$col3-uniboard-max-width}, #{$col3-uniboard-max-height});
 $col3-uniboard-width: calc(#{$col3-uniboard-max-size} * var(--board-scale));
 
-// default zoom setting is 85% which gives a board-scale of 0.85*0.7+0.3 = 0.895 ≈ 0.9 (coincidence)
+// default zoom setting is 85% which gives a board-scale of 0.85*0.75+0.25 = 0,8875 ≈ 0.9 (coincidence)
 // this is used for 3-col pages that don't actually have a board, e.g. tournament pages
 // on these pages, the height is irrelevant, so we just use the width
 $uniboard-default-scale: 0.9;

--- a/ui/common/css/abstract/_uniboard.scss
+++ b/ui/common/css/abstract/_uniboard.scss
@@ -8,27 +8,42 @@ $mq-col3-uniboard: $mq-x-large;
 /* when the width is appropriate for col1, but landscape prevents it */
 $mq-col2-uniboard-squeeze: $mq-not-small $mq-landscape;
 
-$col3-uniboard-side: minmax(230px, 350px);
-$col3-uniboard-table: minmax(240px, 400px);
+$scrollbar-width: 20px;
+
+$col3-uniboard-side-min: 250px;
+$col3-uniboard-table-min: 240px;
+$col3-uniboard-side: minmax(#{$col3-uniboard-side-min}, 350px);
+$col3-uniboard-table: minmax(#{$col3-uniboard-table-min}, 400px);
 $col3-uniboard-controls: 3rem;
+$col3-min-bottom-margin: 1rem;
 
-$col3-uniboard-min-width: calc(max(720px, 50vmin) * var(--board-scale));
-$col3-uniboard-max-width: calc(100vh * var(--board-scale) - #{$site-header-outer-height} - #{$col3-uniboard-controls});
-$col3-uniboard-width: minmax($col3-uniboard-min-width, $col3-uniboard-max-width);
-
-$col3-uniboard-default-scale: 0.9;
-
-// zoom: 85%
-$col3-uniboard-default-min-width: 500px;
-$col3-uniboard-default-max-width: calc(
-  100vh * #{$col3-uniboard-default-scale} - #{$site-header-outer-height} - #{$col3-uniboard-controls}
+$col3-uniboard-max-width: calc(
+  100vw - #{$col3-uniboard-side-min} - #{$block-gap} - var(--gauge-gap, #{$block-gap}) - #{$col3-uniboard-table-min} - 2 *
+    var(--main-margin, 0px) - #{$scrollbar-width}
 );
+$col3-uniboard-max-height: calc(100vh - #{$site-header-outer-height} - #{$col3-min-bottom-margin});
+$col3-uniboard-max-size: min(#{$col3-uniboard-max-width}, #{$col3-uniboard-max-height});
+$col3-uniboard-width: calc(#{$col3-uniboard-max-size} * var(--board-scale));
+
+// default zoom setting is 85% which gives a board-scale of 0.85*0.7+0.3 = 0.895 ≈ 0.9 (coincidence)
+// this is used for 3-col pages that don't actually have a board, e.g. tournament pages
+// on these pages, the height is irrelevant, so we just use the width
+$uniboard-default-scale: 0.9;
+$col3-uniboard-default-min-width: 500px;
+$col3-uniboard-default-max-width: calc(#{$col3-uniboard-max-width} * #{$uniboard-default-scale});
 $col3-uniboard-default-width: minmax(#{$col3-uniboard-default-min-width}, #{$col3-uniboard-default-max-width});
 
 $col2-uniboard-table: $col3-uniboard-table;
 $col2-uniboard-controls: $col3-uniboard-controls;
-$col2-uniboard-width: $col3-uniboard-width;
-$col2-uniboard-default-width: $col3-uniboard-default-width;
+
+$col2-uniboard-max-width: calc(
+  100vw - var(--gauge-gap, #{$block-gap}) - #{$col3-uniboard-table-min} - 2 * var(--main-margin, 0px) - #{$scrollbar-width}
+);
+$col2-uniboard-max-height: $col3-uniboard-max-height;
+$col2-uniboard-max-size: min(#{$col2-uniboard-max-width}, #{$col2-uniboard-max-height});
+$col2-uniboard-width: calc(#{$col2-uniboard-max-size} * var(--board-scale));
+
+$col2-uniboard-default-width: calc(#{$col2-uniboard-max-width} * #{$uniboard-default-scale});
 
 $col2-uniboard-squeeze-table: minmax(200px, 240px);
 $col2-uniboard-squeeze-width: minmax(calc(55vmin), calc(100vh - #{$site-header-outer-height} - #{$block-gap}));

--- a/ui/common/css/abstract/_uniboard.scss
+++ b/ui/common/css/abstract/_uniboard.scss
@@ -25,7 +25,7 @@ $col3-uniboard-max-height: calc(100vh - #{$site-header-outer-height} - #{$col3-m
 $col3-uniboard-max-size: min(#{$col3-uniboard-max-width}, #{$col3-uniboard-max-height});
 $col3-uniboard-width: calc(#{$col3-uniboard-max-size} * var(--board-scale));
 
-// default zoom setting is 85% which gives a board-scale of 0.85*0.75+0.25 = 0,8875 ≈ 0.9 (coincidence)
+// default zoom setting is 85% which gives a board-scale of 0.85*0.75+0.25 = 0,8875 ≈ 0.9
 // this is used for 3-col pages that don't actually have a board, e.g. tournament pages
 // on these pages, the height is irrelevant, so we just use the width
 $uniboard-default-scale: 0.9;

--- a/ui/common/css/abstract/_uniboard.scss
+++ b/ui/common/css/abstract/_uniboard.scss
@@ -30,7 +30,7 @@ $col3-uniboard-width: calc(#{$col3-uniboard-max-size} * var(--board-scale));
 // on these pages, the height is irrelevant, so we just use the width
 $uniboard-default-scale: 0.9;
 $col3-uniboard-default-min-width: 500px;
-$col3-uniboard-default-max-width: calc(#{$col3-uniboard-max-width} * #{$uniboard-default-scale});
+$col3-uniboard-default-max-width: calc(#{$col3-uniboard-max-size} * #{$uniboard-default-scale});
 $col3-uniboard-default-width: minmax(#{$col3-uniboard-default-min-width}, #{$col3-uniboard-default-max-width});
 
 $col2-uniboard-table: $col3-uniboard-table;
@@ -43,7 +43,8 @@ $col2-uniboard-max-height: $col3-uniboard-max-height;
 $col2-uniboard-max-size: min(#{$col2-uniboard-max-width}, #{$col2-uniboard-max-height});
 $col2-uniboard-width: calc(#{$col2-uniboard-max-size} * var(--board-scale));
 
-$col2-uniboard-default-width: calc(#{$col2-uniboard-max-width} * #{$uniboard-default-scale});
+$col2-uniboard-default-max-width: calc(#{$col2-uniboard-max-size} * #{$uniboard-default-scale});
+$col2-uniboard-default-width: minmax(#{$col3-uniboard-default-min-width}, #{$col2-uniboard-default-max-width});
 
 $col2-uniboard-squeeze-table: minmax(200px, 240px);
 $col2-uniboard-squeeze-width: minmax(calc(55vmin), calc(100vh - #{$site-header-outer-height} - #{$block-gap}));

--- a/ui/common/css/layout/_uniboard.scss
+++ b/ui/common/css/layout/_uniboard.scss
@@ -3,7 +3,7 @@ body {
 
   @include breakpoint($mq-zoom-enabled) {
     // --zoom: 80; defined in the HTML, loaded from server
-    --board-scale: calc((var(--zoom) / 100) * 0.7 + 0.3);
+    --board-scale: calc((var(--zoom) / 100) * 0.75 + 0.25);
   }
 }
 

--- a/ui/coordinateTrainer/css/_layout.scss
+++ b/ui/coordinateTrainer/css/_layout.scss
@@ -44,6 +44,7 @@ $mq-col3: $mq-x-large;
   grid-row-gap: $block-gap;
 
   @include breakpoint($mq-col2) {
+    grid-template-columns: $col2-uniboard-fallback-width $block-gap $col2-uniboard-table;
     grid-template-columns: $col2-uniboard-width $block-gap $col2-uniboard-table;
     grid-template-rows: fit-content(0);
     grid-template-areas:
@@ -60,6 +61,7 @@ $mq-col3: $mq-x-large;
       'side . progress . .'
       'side . co-input . .'
       'side . .        . .';
+    grid-template-columns: $col3-uniboard-side $block-gap $col3-uniboard-fallback-width $block-gap $col3-uniboard-table;
     grid-template-columns: $col3-uniboard-side $block-gap $col3-uniboard-width $block-gap $col3-uniboard-table;
   }
 }

--- a/ui/learn/css/_layout.scss
+++ b/ui/learn/css/_layout.scss
@@ -37,6 +37,7 @@ $mq-col3: $mq-col3-uniboard;
 
   @include breakpoint($mq-col2) {
     &--run {
+      grid-template-columns: $col2-uniboard-fallback-width $col2-uniboard-table;
       grid-template-columns: $col2-uniboard-width $col2-uniboard-table;
       grid-template-rows: fit-content(0);
       grid-template-areas: 'main table' 'side .';
@@ -54,6 +55,7 @@ $mq-col3: $mq-col3-uniboard;
 
   @include breakpoint($mq-col3) {
     &--run {
+      grid-template-columns: $col3-uniboard-side $col3-uniboard-fallback-width $col3-uniboard-table;
       grid-template-columns: $col3-uniboard-side $col3-uniboard-width $col3-uniboard-table;
       grid-template-areas: 'side main table';
     }

--- a/ui/puzzle/css/_layout.scss
+++ b/ui/puzzle/css/_layout.scss
@@ -62,6 +62,7 @@
   }
 
   @include breakpoint($mq-col2) {
+    grid-template-columns: $col2-uniboard-fallback-width var(--gauge-gap) $col2-uniboard-table;
     grid-template-columns: $col2-uniboard-width var(--gauge-gap) $col2-uniboard-table;
     grid-template-rows: fit-content(0);
     grid-template-areas:
@@ -81,6 +82,7 @@
       'side    . session .     controls'
       'side    . kb-move .     controls'
       'side    . .       .     .';
+    grid-template-columns: $col3-uniboard-side $block-gap $col3-uniboard-fallback-width var(--gauge-gap) $col3-uniboard-table;
     grid-template-columns: $col3-uniboard-side $block-gap $col3-uniboard-width var(--gauge-gap) $col3-uniboard-table;
   }
 

--- a/ui/racer/css/_racer.scss
+++ b/ui/racer/css/_racer.scss
@@ -14,6 +14,7 @@
   grid-template-areas: 'board' 'race' 'side' 'history';
 
   @include breakpoint($mq-col2) {
+    grid-template-columns: $col2-uniboard-fallback-width $col2-uniboard-table;
     grid-template-columns: $col2-uniboard-width $col2-uniboard-table;
     grid-template-rows: auto fit-content(0);
     grid-template-areas:

--- a/ui/round/css/_app-layout.scss
+++ b/ui/round/css/_app-layout.scss
@@ -82,6 +82,7 @@
 
   @include breakpoint($mq-col2) {
     grid-template-areas: 'board voice' 'board .' 'board mat-top' 'board clock-top' 'board expi-top' 'board user-top' 'board moves' 'board controls' 'board user-bot' 'board expi-bot' 'board clock-bot' 'board mat-bot' 'board .' 'kb-move .';
+    grid-template-columns: $col2-uniboard-fallback-width $col2-uniboard-table;
     grid-template-columns: $col2-uniboard-width $col2-uniboard-table;
     grid-template-rows: 0; // prevent voice from pushing the table off center
     grid-column-gap: $block-gap;
@@ -116,6 +117,7 @@
   }
 
   @include breakpoint($mq-col3) {
+    grid-template-columns: $col3-uniboard-fallback-width $col3-uniboard-table;
     grid-template-columns: $col3-uniboard-width $col3-uniboard-table;
   }
 

--- a/ui/round/css/_app-layout.scss
+++ b/ui/round/css/_app-layout.scss
@@ -115,6 +115,10 @@
     }
   }
 
+  @include breakpoint($mq-col3) {
+    grid-template-columns: $col3-uniboard-width $col3-uniboard-table;
+  }
+
   @include breakpoint($mq-col2-uniboard-squeeze) {
     grid-template-columns: $col2-uniboard-squeeze-width $col2-uniboard-squeeze-table;
     grid-column-gap: #{$block-gap * 3 / 2};

--- a/ui/round/css/_layout.scss
+++ b/ui/round/css/_layout.scss
@@ -46,6 +46,7 @@
   }
 
   @include breakpoint($mq-col3) {
+    grid-template-columns: $col3-uniboard-side $col3-uniboard-fallback-width $col3-uniboard-table;
     grid-template-columns: $col3-uniboard-side $col3-uniboard-width $col3-uniboard-table;
     grid-template-rows: fit-content(0);
     grid-template-areas: 'side  app   app' 'uchat under .';

--- a/ui/simul/css/_layout.scss
+++ b/ui/simul/css/_layout.scss
@@ -18,6 +18,7 @@
 
   @include breakpoint($mq-col2) {
     &:not(.simul-created) {
+      grid-template-columns: $col2-uniboard-fallback-default-width $col2-uniboard-table;
       grid-template-columns: $col2-uniboard-default-width $col2-uniboard-table;
       grid-template-rows: auto max-content;
       grid-template-areas: 'main side' 'main uchat' '.    uchat';
@@ -26,6 +27,7 @@
 
   @include breakpoint($mq-col3) {
     &.simul {
+      grid-template-columns: $col3-uniboard-side $col3-uniboard-fallback-default-width $col3-uniboard-table;
       grid-template-columns: $col3-uniboard-side $col3-uniboard-default-width $col3-uniboard-table;
       grid-template-rows: auto fit-content(0);
       grid-template-areas: 'side  main main' 'uchat main main' 'uchat .    .';

--- a/ui/site/css/tv/_single.scss
+++ b/ui/site/css/tv/_single.scss
@@ -18,6 +18,7 @@ $mq-col3: $mq-col3-uniboard;
   }
 
   @include breakpoint($mq-col3) {
+    grid-template-columns: $col3-uniboard-side $col3-uniboard-fallback-width $col3-uniboard-table;
     grid-template-columns: $col3-uniboard-side $col3-uniboard-width $col3-uniboard-table;
     grid-template-rows: fit-content(0);
     grid-template-areas: 'side app   app' 'side under .';

--- a/ui/storm/css/_play.scss
+++ b/ui/storm/css/_play.scss
@@ -7,6 +7,7 @@
     grid-template-areas: 'board' 'side';
 
     @include breakpoint($mq-col2) {
+      grid-template-columns: $col2-uniboard-fallback-width $col2-uniboard-table;
       grid-template-columns: $col2-uniboard-width $col2-uniboard-table;
       grid-template-rows: fit-content(0);
       grid-template-areas: 'board   side';

--- a/ui/swiss/css/_layout.scss
+++ b/ui/swiss/css/_layout.scss
@@ -33,6 +33,7 @@ $chat-optimal-size: calc(100vh - #{$site-header-outer-height} - #{$block-gap} - 
   grid-gap: $block-gap;
 
   @include breakpoint($mq-col2) {
+    grid-template-columns: $col2-uniboard-fallback-default-width $col2-uniboard-table;
     grid-template-columns: $col2-uniboard-default-width $col2-uniboard-table;
     grid-template-rows: $chat-optimal-size min-content;
     grid-template-areas: 'main  side' 'main  uchat' 'table table';
@@ -43,6 +44,7 @@ $chat-optimal-size: calc(100vh - #{$site-header-outer-height} - #{$block-gap} - 
   }
 
   @include breakpoint($mq-col3) {
+    grid-template-columns: $col3-uniboard-side $col3-uniboard-fallback-default-width $col3-uniboard-table;
     grid-template-columns: $col3-uniboard-side $col3-uniboard-default-width $col3-uniboard-table;
     grid-template-rows: $chat-optimal-size auto;
     grid-template-areas: 'side  main table' 'uchat main table';

--- a/ui/tournament/css/_layout.scss
+++ b/ui/tournament/css/_layout.scss
@@ -31,6 +31,7 @@ $chat-optimal-size: calc(100vh - #{$site-header-outer-height} - #{$block-gap} - 
   grid-gap: $block-gap;
 
   @include breakpoint($mq-col2) {
+    grid-template-columns: $col2-uniboard-fallback-default-width $col2-uniboard-table;
     grid-template-columns: $col2-uniboard-default-width $col2-uniboard-table;
     grid-template-rows: $chat-optimal-size min-content;
     grid-template-areas: 'main  side' 'main  uchat' 'table table';
@@ -49,6 +50,7 @@ $chat-optimal-size: calc(100vh - #{$site-header-outer-height} - #{$block-gap} - 
   }
 
   @include breakpoint($mq-col3) {
+    grid-template-columns: $col3-uniboard-side $col3-uniboard-fallback-default-width $col3-uniboard-table;
     grid-template-columns: $col3-uniboard-side $col3-uniboard-default-width $col3-uniboard-table;
     grid-template-rows: $chat-optimal-size auto;
     grid-template-areas: 'side  main table' 'uchat main table';


### PR DESCRIPTION
Same as #12837 but uses the old layout (before schlawg's changes) for browsers that don't support the min()/max() CSS functions. Though I ofc wasn't able to test the fallback part properly.

Not sure whether this actually makes sense. It's kinda ugly and such browsers are quite severely outdated and probably quite insecure. So far, I've also only seen one complaint. But Google doesn't seem to provide updates to Chromebooks for very long so I guess this applies to moderately old Chromebooks (roughly 7-8 years old it seems).