### PR TITLE
Better display how to remove imported games 

### DIFF
--- a/app/views/analyse/jsI18n.scala
+++ b/app/views/analyse/jsI18n.scala
@@ -69,8 +69,6 @@ object jsI18n:
         trans.multipleLines,
         trans.cpus,
         trans.memory,
-        trans.delete,
-        trans.deleteThisImportedGame,
         trans.replayMode,
         trans.slow,
         trans.fast,

--- a/app/views/game/side.scala
+++ b/app/views/game/side.scala
@@ -60,9 +60,20 @@ object side:
                 ),
                 game.pgnImport.flatMap(_.date).map(frag(_)) | momentFromNowWithPreload(game.createdAt)
               ),
-              game.pgnImport.flatMap(_.user).map { user =>
-                small(
-                  trans.importedByX(userIdLink(user.some, None, withOnline = false))
+              game.pgnImport.flatMap(_.user).map { importUser =>
+                frag(
+                  small(
+                    trans.importedByX(userIdLink(importUser.some, None, withOnline = false))
+                  ),
+                  ctx.me.filter(_.id is importUser).map { _ =>
+                    form(cls := "delete", method := "post", action := routes.Game.delete(game.id)) {
+                      button(
+                        cls          := "link text button-thin confirm",
+                        attr("type") := "submit",
+                        title        := trans.deleteThisImportedGame.txt()
+                      )(trans.delete.txt())
+                    }
+                  }
                 )
               }
             )

--- a/app/views/game/side.scala
+++ b/app/views/game/side.scala
@@ -65,7 +65,7 @@ object side:
                   small(
                     trans.importedByX(userIdLink(importUser.some, None, withOnline = false))
                   ),
-                  ctx.me.is(importUser) option
+                  ctx.isUserId(importUser) option
                     form(cls := "delete", method := "post", action := routes.Game.delete(game.id)):
                       button(
                         cls          := "link text button-thin confirm",

--- a/app/views/game/side.scala
+++ b/app/views/game/side.scala
@@ -60,20 +60,18 @@ object side:
                 ),
                 game.pgnImport.flatMap(_.date).map(frag(_)) | momentFromNowWithPreload(game.createdAt)
               ),
-              game.pgnImport.flatMap(_.user).map { importUser =>
-                frag(
+              game.pgnImport
+                .flatMap(_.user)
+                .map: importedBy =>
                   small(
-                    trans.importedByX(userIdLink(importUser.some, None, withOnline = false))
-                  ),
-                  ctx.isUserId(importUser) option
-                    form(cls := "delete", method := "post", action := routes.Game.delete(game.id)):
-                      button(
-                        cls          := "link text button-thin confirm",
-                        attr("type") := "submit",
-                        title        := trans.deleteThisImportedGame.txt()
-                      )(trans.delete.txt())
-                )
-              }
+                    trans.importedByX(userIdLink(importedBy.some, None, withOnline = false)),
+                    ctx.isUserId(importedBy) option
+                      form(cls := "delete", method := "post", action := routes.Game.delete(game.id)):
+                        submitButton(
+                          cls   := "button-link confirm",
+                          title := trans.deleteThisImportedGame.txt()
+                        )(trans.delete.txt())
+                  )
             )
           ),
           div(cls := "game__meta__players")(

--- a/app/views/game/side.scala
+++ b/app/views/game/side.scala
@@ -65,15 +65,13 @@ object side:
                   small(
                     trans.importedByX(userIdLink(importUser.some, None, withOnline = false))
                   ),
-                  ctx.me.filter(_.id is importUser).map { _ =>
-                    form(cls := "delete", method := "post", action := routes.Game.delete(game.id)) {
+                  ctx.me.is(importUser) option
+                    form(cls := "delete", method := "post", action := routes.Game.delete(game.id)):
                       button(
                         cls          := "link text button-thin confirm",
                         attr("type") := "submit",
                         title        := trans.deleteThisImportedGame.txt()
                       )(trans.delete.txt())
-                    }
-                  }
                 )
               }
             )

--- a/modules/user/src/main/UserContext.scala
+++ b/modules/user/src/main/UserContext.scala
@@ -64,13 +64,12 @@ final case class HeaderUserContext(r: RequestHeader, m: Option[User], i: Option[
 
 trait UserContextWrapper extends UserContext:
   val userContext: UserContext
-  val req                                  = userContext.req
-  val me                                   = userContext.me
-  val impersonatedBy                       = userContext.impersonatedBy
-  def isBot                                = me.exists(_.isBot)
-  def noBot                                = !isBot
-  def isAppealUser                         = me.exists(_.enabled.no)
-  def is[U](u: U)(using idOf: UserIdOf[U]) = me.exists(_.id == idOf(u))
+  val req            = userContext.req
+  val me             = userContext.me
+  val impersonatedBy = userContext.impersonatedBy
+  def isBot          = me.exists(_.isBot)
+  def noBot          = !isBot
+  def isAppealUser   = me.exists(_.enabled.no)
 
 object UserContext:
 

--- a/modules/user/src/main/UserContext.scala
+++ b/modules/user/src/main/UserContext.scala
@@ -64,12 +64,13 @@ final case class HeaderUserContext(r: RequestHeader, m: Option[User], i: Option[
 
 trait UserContextWrapper extends UserContext:
   val userContext: UserContext
-  val req            = userContext.req
-  val me             = userContext.me
-  val impersonatedBy = userContext.impersonatedBy
-  def isBot          = me.exists(_.isBot)
-  def noBot          = !isBot
-  def isAppealUser   = me.exists(_.enabled.no)
+  val req                                  = userContext.req
+  val me                                   = userContext.me
+  val impersonatedBy                       = userContext.impersonatedBy
+  def isBot                                = me.exists(_.isBot)
+  def noBot                                = !isBot
+  def isAppealUser                         = me.exists(_.enabled.no)
+  def is[U](u: U)(using idOf: UserIdOf[U]) = me.exists(_.id == idOf(u))
 
 object UserContext:
 

--- a/ui/analyse/src/view/actionMenu.ts
+++ b/ui/analyse/src/view/actionMenu.ts
@@ -1,6 +1,6 @@
 import { isEmpty } from 'common';
 import modal from 'common/modal';
-import { bind, bindNonPassive, dataIcon, MaybeVNodes } from 'common/snabbdom';
+import { bind, dataIcon, MaybeVNodes } from 'common/snabbdom';
 import { h, VNode } from 'snabbdom';
 import { AutoplayDelay } from '../autoplay';
 import { config as externalEngineConfig } from './externalEngine';
@@ -36,34 +36,6 @@ const cplSpeed: AutoplaySpeed = {
 };
 
 const ctrlToggle = (t: ToggleSettings, ctrl: AnalyseCtrl) => toggle(t, ctrl.trans, ctrl.redraw);
-
-function deleteButton(ctrl: AnalyseCtrl, userId?: string): VNode | undefined {
-  const g = ctrl.data.game;
-  if (g.source === 'import' && g.importedBy && g.importedBy === userId)
-    return h(
-      'form.delete',
-      {
-        attrs: {
-          method: 'post',
-          action: `/${g.id}/delete`,
-        },
-        hook: bindNonPassive('submit', _ => confirm(ctrl.trans.noarg('deleteThisImportedGame'))),
-      },
-      [
-        h(
-          'button.button.text.button-thin.button-red',
-          {
-            attrs: {
-              type: 'submit',
-              'data-icon': '',
-            },
-          },
-          ctrl.trans.noarg('delete')
-        ),
-      ]
-    );
-  return;
-}
 
 function autoplayButtons(ctrl: AnalyseCtrl): VNode {
   const d = ctrl.data;
@@ -361,7 +333,6 @@ export function view(ctrl: AnalyseCtrl): VNode {
     ...cevalConfig,
     ...externalEngineConfig(ctrl),
     ...(ctrl.mainline.length > 4 ? [h('h2', noarg('replayMode')), autoplayButtons(ctrl)] : []),
-    deleteButton(ctrl, ctrl.opts.userId),
     canContinue
       ? h('div.continue-with.none.g_' + d.game.id, [
           h(

--- a/ui/round/css/_meta.scss
+++ b/ui/round/css/_meta.scss
@@ -31,14 +31,7 @@
     }
 
     form.delete button {
-      @extend %button-none;
-      padding: 0;
-      color: $c-error;
-
-      &:hover,
-      &:focus {
-        color: $c-error-over;
-      }
+      color: $c-bad;
     }
   }
 

--- a/ui/round/css/_meta.scss
+++ b/ui/round/css/_meta.scss
@@ -29,6 +29,17 @@
     time {
       opacity: 1;
     }
+
+    form.delete button {
+      @extend %button-none;
+      padding: 0;
+      color: $c-error;
+
+      &:hover,
+      &:focus {
+        color: $c-error-over;
+      }
+    }
   }
 
   .status {


### PR DESCRIPTION
Fixes #12562.

This is my proposal for a new "Delete" button location for imported games.

![Screenshot of game info area. Underneath "Imported by LM Lichess", there is a red "Delete" link](https://github.com/lichess-org/lila/assets/1116815/899517cb-ce4e-47f9-b538-90166c7ba33d)

![Screenshot of a browser-rendered confirmation dialog asking "Delete this imported game?" and showing "Cancel" and "OK" buttons](https://github.com/lichess-org/lila/assets/1116815/71288c2c-5386-40a1-adcc-81af9ae9c8a0)

The changes remove the existing button (pictured below) from the analysis menu.

![Screenshot of bottom area of the analysis menu on a game on lichess. A red "Delete" button is shown aligned to the right underneath "replay mode" settings](https://github.com/lichess-org/lila/assets/1116815/952427f1-0604-40b0-a140-9591b48fbf0c)
