### PR TITLE
Add existing metal type BG for blog posts in lobby

### DIFF
--- a/ui/lobby/css/_lobby.scss
+++ b/ui/lobby/css/_lobby.scss
@@ -162,6 +162,8 @@ body {
 }
 
 .lobby__blog {
+  @include metal-bg;
+
   grid-template-columns: repeat(auto-fill, minmax(190px, 1fr));
   grid-gap: 0 2%;
   grid-template-rows: auto; /* first row auto */


### PR DESCRIPTION
Addresses #12836

Here is the original:
![image](https://github.com/lichess-org/lila/assets/2817895/506310e5-f3d1-4d4b-9860-2925dfb62282)

Here is the difference with this PR:
![image](https://github.com/lichess-org/lila/assets/2817895/e09f856f-9f12-419e-97ee-e9d813328002)

And as discussed in the issue, here is the change with #12761 reverted:
![image](https://github.com/lichess-org/lila/assets/2817895/e1c91a9c-43ee-4bfa-992b-5f0739c8d4e8)
