### PR TITLE
API: Allow to retrieve pending simuls when authenticated

### DIFF
--- a/app/controllers/Simul.scala
+++ b/app/controllers/Simul.scala
@@ -23,8 +23,8 @@ final class Simul(env: Env) extends LilaController(env):
       Ok(html.simul.home(pending, created, started, finished)).toFuccess
     }
 
-  val apiList = Anon:
-    fetchSimuls(none) flatMap { case (((pending, created), started), finished) =>
+  val apiList = OpenOrScoped(): me =>
+    fetchSimuls(me) flatMap { case (((pending, created), started), finished) =>
       env.simul.jsonView.apiAll(pending, created, started, finished) map JsonOk
     }
 


### PR DESCRIPTION
I think not requiring any scope is fine because simuls are public (similar to export game endpoints), but otherwise can create a new scope.

Will edit api docs