### PR TITLE
Fix uniboard layout fallback for old browsers

### DIFF
--- a/ui/analyse/css/_layout.scss
+++ b/ui/analyse/css/_layout.scss
@@ -80,8 +80,7 @@ body {
     'uchat';
 
   @include breakpoint($mq-col2) {
-    grid-template-columns: $col2-uniboard-fallback-width var(--gauge-gap) $col2-uniboard-table;
-    grid-template-columns: $col2-uniboard-width var(--gauge-gap) $col2-uniboard-table;
+    grid-template-columns: var(--col2-uniboard-width) var(--gauge-gap) $col2-uniboard-table;
     grid-template-rows: fit-content(0);
     grid-template-areas:
       'board      gauge tools'
@@ -112,8 +111,7 @@ body {
   }
 
   @include breakpoint($mq-col3) {
-    grid-template-columns: $col3-uniboard-side $block-gap $col3-uniboard-fallback-width var(--gauge-gap) $col3-uniboard-table;
-    grid-template-columns: $col3-uniboard-side $block-gap $col3-uniboard-width var(--gauge-gap) $col3-uniboard-table;
+    grid-template-columns: $col3-uniboard-side $block-gap var(--col3-uniboard-width) var(--gauge-gap) $col3-uniboard-table;
     grid-template-rows: $meta-height $chat-height 2.5em 1fr;
     grid-template-areas:
       'side    . board gauge tools'

--- a/ui/ceval/css/_eval-gauge.scss
+++ b/ui/ceval/css/_eval-gauge.scss
@@ -1,4 +1,4 @@
-main {
+body {
   @include fluid-size('--gauge-gap', 8px, 17px);
 }
 

--- a/ui/common/css/layout/_uniboard.scss
+++ b/ui/common/css/layout/_uniboard.scss
@@ -5,6 +5,19 @@ body {
     // --zoom: 80; defined in the HTML, loaded from server
     --board-scale: calc((var(--zoom) / 100) * 0.75 + 0.25);
   }
+
+  // use old fallback values for browsers that don't support min()
+  --col2-uniboard-width: #{$col2-uniboard-fallback-width};
+  --col3-uniboard-width: #{$col3-uniboard-fallback-width};
+  --col2-uniboard-default-width: #{$col2-uniboard-fallback-default-width};
+  --col3-uniboard-default-width: #{$col3-uniboard-fallback-default-width};
+
+  @supports (width: min(1px, 2px)) {
+    --col2-uniboard-width: #{$col2-uniboard-width};
+    --col3-uniboard-width: #{$col3-uniboard-width};
+    --col2-uniboard-default-width: #{$col2-uniboard-default-width};
+    --col3-uniboard-default-width: #{$col3-uniboard-default-width};
+  }
 }
 
 @include breakpoint($mq-col1-uniboard) {

--- a/ui/coordinateTrainer/css/_layout.scss
+++ b/ui/coordinateTrainer/css/_layout.scss
@@ -44,8 +44,7 @@ $mq-col3: $mq-x-large;
   grid-row-gap: $block-gap;
 
   @include breakpoint($mq-col2) {
-    grid-template-columns: $col2-uniboard-fallback-width $block-gap $col2-uniboard-table;
-    grid-template-columns: $col2-uniboard-width $block-gap $col2-uniboard-table;
+    grid-template-columns: var(--col2-uniboard-width) $block-gap $col2-uniboard-table;
     grid-template-rows: fit-content(0);
     grid-template-areas:
       'board    . table'
@@ -61,8 +60,7 @@ $mq-col3: $mq-x-large;
       'side . progress . .'
       'side . co-input . .'
       'side . .        . .';
-    grid-template-columns: $col3-uniboard-side $block-gap $col3-uniboard-fallback-width $block-gap $col3-uniboard-table;
-    grid-template-columns: $col3-uniboard-side $block-gap $col3-uniboard-width $block-gap $col3-uniboard-table;
+    grid-template-columns: $col3-uniboard-side $block-gap var(--col3-uniboard-width) $block-gap $col3-uniboard-table;
   }
 }
 

--- a/ui/learn/css/_layout.scss
+++ b/ui/learn/css/_layout.scss
@@ -37,8 +37,7 @@ $mq-col3: $mq-col3-uniboard;
 
   @include breakpoint($mq-col2) {
     &--run {
-      grid-template-columns: $col2-uniboard-fallback-width $col2-uniboard-table;
-      grid-template-columns: $col2-uniboard-width $col2-uniboard-table;
+      grid-template-columns: var(--col2-uniboard-width) $col2-uniboard-table;
       grid-template-rows: fit-content(0);
       grid-template-areas: 'main table' 'side .';
     }
@@ -55,8 +54,7 @@ $mq-col3: $mq-col3-uniboard;
 
   @include breakpoint($mq-col3) {
     &--run {
-      grid-template-columns: $col3-uniboard-side $col3-uniboard-fallback-width $col3-uniboard-table;
-      grid-template-columns: $col3-uniboard-side $col3-uniboard-width $col3-uniboard-table;
+      grid-template-columns: $col3-uniboard-side var(--col3-uniboard-width) $col3-uniboard-table;
       grid-template-areas: 'side main table';
     }
   }

--- a/ui/puzzle/css/_layout.scss
+++ b/ui/puzzle/css/_layout.scss
@@ -62,8 +62,7 @@
   }
 
   @include breakpoint($mq-col2) {
-    grid-template-columns: $col2-uniboard-fallback-width var(--gauge-gap) $col2-uniboard-table;
-    grid-template-columns: $col2-uniboard-width var(--gauge-gap) $col2-uniboard-table;
+    grid-template-columns: var(--col2-uniboard-width) var(--gauge-gap) $col2-uniboard-table;
     grid-template-rows: fit-content(0);
     grid-template-areas:
       'board   gauge tools'
@@ -82,8 +81,7 @@
       'side    . session .     controls'
       'side    . kb-move .     controls'
       'side    . .       .     .';
-    grid-template-columns: $col3-uniboard-side $block-gap $col3-uniboard-fallback-width var(--gauge-gap) $col3-uniboard-table;
-    grid-template-columns: $col3-uniboard-side $block-gap $col3-uniboard-width var(--gauge-gap) $col3-uniboard-table;
+    grid-template-columns: $col3-uniboard-side $block-gap var(--col3-uniboard-width) var(--gauge-gap) $col3-uniboard-table;
   }
 
   &__side {

--- a/ui/racer/css/_racer.scss
+++ b/ui/racer/css/_racer.scss
@@ -14,8 +14,7 @@
   grid-template-areas: 'board' 'race' 'side' 'history';
 
   @include breakpoint($mq-col2) {
-    grid-template-columns: $col2-uniboard-fallback-width $col2-uniboard-table;
-    grid-template-columns: $col2-uniboard-width $col2-uniboard-table;
+    grid-template-columns: var(--col2-uniboard-width) $col2-uniboard-table;
     grid-template-rows: auto fit-content(0);
     grid-template-areas:
       'board  side'

--- a/ui/round/css/_app-layout.scss
+++ b/ui/round/css/_app-layout.scss
@@ -82,8 +82,7 @@
 
   @include breakpoint($mq-col2) {
     grid-template-areas: 'board voice' 'board .' 'board mat-top' 'board clock-top' 'board expi-top' 'board user-top' 'board moves' 'board controls' 'board user-bot' 'board expi-bot' 'board clock-bot' 'board mat-bot' 'board .' 'kb-move .';
-    grid-template-columns: $col2-uniboard-fallback-width $col2-uniboard-table;
-    grid-template-columns: $col2-uniboard-width $col2-uniboard-table;
+    grid-template-columns: var(--col2-uniboard-width) $col2-uniboard-table;
     grid-template-rows: 0; // prevent voice from pushing the table off center
     grid-column-gap: $block-gap;
 
@@ -117,8 +116,7 @@
   }
 
   @include breakpoint($mq-col3) {
-    grid-template-columns: $col3-uniboard-fallback-width $col3-uniboard-table;
-    grid-template-columns: $col3-uniboard-width $col3-uniboard-table;
+    grid-template-columns: var(--col3-uniboard-width) $col3-uniboard-table;
   }
 
   @include breakpoint($mq-col2-uniboard-squeeze) {

--- a/ui/round/css/_layout.scss
+++ b/ui/round/css/_layout.scss
@@ -46,8 +46,7 @@
   }
 
   @include breakpoint($mq-col3) {
-    grid-template-columns: $col3-uniboard-side $col3-uniboard-fallback-width $col3-uniboard-table;
-    grid-template-columns: $col3-uniboard-side $col3-uniboard-width $col3-uniboard-table;
+    grid-template-columns: $col3-uniboard-side var(--col3-uniboard-width) $col3-uniboard-table;
     grid-template-rows: fit-content(0);
     grid-template-areas: 'side  app   app' 'uchat under .';
 

--- a/ui/simul/css/_layout.scss
+++ b/ui/simul/css/_layout.scss
@@ -18,8 +18,7 @@
 
   @include breakpoint($mq-col2) {
     &:not(.simul-created) {
-      grid-template-columns: $col2-uniboard-fallback-default-width $col2-uniboard-table;
-      grid-template-columns: $col2-uniboard-default-width $col2-uniboard-table;
+      grid-template-columns: var(--col2-uniboard-default-width) $col2-uniboard-table;
       grid-template-rows: auto max-content;
       grid-template-areas: 'main side' 'main uchat' '.    uchat';
     }
@@ -27,8 +26,7 @@
 
   @include breakpoint($mq-col3) {
     &.simul {
-      grid-template-columns: $col3-uniboard-side $col3-uniboard-fallback-default-width $col3-uniboard-table;
-      grid-template-columns: $col3-uniboard-side $col3-uniboard-default-width $col3-uniboard-table;
+      grid-template-columns: $col3-uniboard-side var(--col3-uniboard-default-width) $col3-uniboard-table;
       grid-template-rows: auto fit-content(0);
       grid-template-areas: 'side  main main' 'uchat main main' 'uchat .    .';
     }

--- a/ui/site/css/tv/_single.scss
+++ b/ui/site/css/tv/_single.scss
@@ -18,8 +18,7 @@ $mq-col3: $mq-col3-uniboard;
   }
 
   @include breakpoint($mq-col3) {
-    grid-template-columns: $col3-uniboard-side $col3-uniboard-fallback-width $col3-uniboard-table;
-    grid-template-columns: $col3-uniboard-side $col3-uniboard-width $col3-uniboard-table;
+    grid-template-columns: $col3-uniboard-side var(--col3-uniboard-width) $col3-uniboard-table;
     grid-template-rows: fit-content(0);
     grid-template-areas: 'side app   app' 'side under .';
 

--- a/ui/storm/css/_play.scss
+++ b/ui/storm/css/_play.scss
@@ -7,8 +7,7 @@
     grid-template-areas: 'board' 'side';
 
     @include breakpoint($mq-col2) {
-      grid-template-columns: $col2-uniboard-fallback-width $col2-uniboard-table;
-      grid-template-columns: $col2-uniboard-width $col2-uniboard-table;
+      grid-template-columns: var(--col2-uniboard-width) $col2-uniboard-table;
       grid-template-rows: fit-content(0);
       grid-template-areas: 'board   side';
     }

--- a/ui/swiss/css/_layout.scss
+++ b/ui/swiss/css/_layout.scss
@@ -33,8 +33,7 @@ $chat-optimal-size: calc(100vh - #{$site-header-outer-height} - #{$block-gap} - 
   grid-gap: $block-gap;
 
   @include breakpoint($mq-col2) {
-    grid-template-columns: $col2-uniboard-fallback-default-width $col2-uniboard-table;
-    grid-template-columns: $col2-uniboard-default-width $col2-uniboard-table;
+    grid-template-columns: var(--col2-uniboard-default-width) $col2-uniboard-table;
     grid-template-rows: $chat-optimal-size min-content;
     grid-template-areas: 'main  side' 'main  uchat' 'table table';
 
@@ -44,8 +43,7 @@ $chat-optimal-size: calc(100vh - #{$site-header-outer-height} - #{$block-gap} - 
   }
 
   @include breakpoint($mq-col3) {
-    grid-template-columns: $col3-uniboard-side $col3-uniboard-fallback-default-width $col3-uniboard-table;
-    grid-template-columns: $col3-uniboard-side $col3-uniboard-default-width $col3-uniboard-table;
+    grid-template-columns: $col3-uniboard-side var(--col3-uniboard-default-width) $col3-uniboard-table;
     grid-template-rows: $chat-optimal-size auto;
     grid-template-areas: 'side  main table' 'uchat main table';
 

--- a/ui/tournament/css/_layout.scss
+++ b/ui/tournament/css/_layout.scss
@@ -31,8 +31,7 @@ $chat-optimal-size: calc(100vh - #{$site-header-outer-height} - #{$block-gap} - 
   grid-gap: $block-gap;
 
   @include breakpoint($mq-col2) {
-    grid-template-columns: $col2-uniboard-fallback-default-width $col2-uniboard-table;
-    grid-template-columns: $col2-uniboard-default-width $col2-uniboard-table;
+    grid-template-columns: var(--col2-uniboard-default-width) $col2-uniboard-table;
     grid-template-rows: $chat-optimal-size min-content;
     grid-template-areas: 'main  side' 'main  uchat' 'table table';
 
@@ -50,8 +49,7 @@ $chat-optimal-size: calc(100vh - #{$site-header-outer-height} - #{$block-gap} - 
   }
 
   @include breakpoint($mq-col3) {
-    grid-template-columns: $col3-uniboard-side $col3-uniboard-fallback-default-width $col3-uniboard-table;
-    grid-template-columns: $col3-uniboard-side $col3-uniboard-default-width $col3-uniboard-table;
+    grid-template-columns: $col3-uniboard-side var(--col3-uniboard-default-width) $col3-uniboard-table;
     grid-template-rows: $chat-optimal-size auto;
     grid-template-areas: 'side  main table' 'uchat main table';
 


### PR DESCRIPTION
Since they apparently can't figure out on there own that they don't understand `min` in nested expressions (see also #12841).