### PR TITLE
Remove players from opening explorer

### DIFF
--- a/app/views/board/userAnalysisI18n.scala
+++ b/app/views/board/userAnalysisI18n.scala
@@ -176,6 +176,7 @@ object userAnalysisI18n:
     trans.lossSavedBy50MoveRule,
     trans.allSet,
     trans.study.searchByUsername,
+    trans.study.removeRecentlySearchedPlayer,
     trans.mode,
     trans.rated,
     trans.casual,

--- a/app/views/study/jsI18n.scala
+++ b/app/views/study/jsI18n.scala
@@ -33,6 +33,7 @@ object jsI18n:
       inviteToTheStudy,
       pleaseOnlyInvitePeopleYouKnow,
       searchByUsername,
+      removeRecentlySearchedPlayer,
       spectator,
       contributor,
       kick,

--- a/modules/i18n/src/main/I18nKeys.scala
+++ b/modules/i18n/src/main/I18nKeys.scala
@@ -1138,6 +1138,7 @@ object I18nKeys:
     val `inviteToTheStudy` = I18nKey("study:inviteToTheStudy")
     val `pleaseOnlyInvitePeopleYouKnow` = I18nKey("study:pleaseOnlyInvitePeopleYouKnow")
     val `searchByUsername` = I18nKey("study:searchByUsername")
+    val `removeRecentlySearchedPlayer` = I18nKey("study:removeRecentlySearchedPlayer")
     val `spectator` = I18nKey("study:spectator")
     val `contributor` = I18nKey("study:contributor")
     val `kick` = I18nKey("study:kick")

--- a/translation/source/study.xml
+++ b/translation/source/study.xml
@@ -33,6 +33,7 @@
   <string name="inviteToTheStudy">Invite to the study</string>
   <string name="pleaseOnlyInvitePeopleYouKnow">Please only invite people you know, and who actively want to join this study.</string>
   <string name="searchByUsername">Search by username</string>
+  <string name="removeRecentlySearchedPlayer">Remove recently searched player</string>
   <string name="spectator">Spectator</string>
   <string name="contributor">Contributor</string>
   <string name="kick">Kick</string>

--- a/ui/analyse/css/explorer/_config.scss
+++ b/ui/analyse/css/explorer/_config.scss
@@ -120,6 +120,11 @@
       .button {
         margin: 0.3em 0.2em;
         text-transform: none;
+
+        .remove {
+          position: relative;
+          left: 18%;
+        }
       }
     }
   }

--- a/ui/analyse/src/explorer/explorerConfig.ts
+++ b/ui/analyse/src/explorer/explorerConfig.ts
@@ -335,7 +335,13 @@ const playerModal = (ctrl: ExplorerConfigCtrl) => {
       ]),
       h(
         'div.previous',
-        [...(ctrl.myName ? [ctrl.myName] : []), ...ctrl.participants, ...ctrl.data.playerName.previous()].map(name =>
+        [
+          ...(ctrl.myName ? [ctrl.myName] : []),
+          ...ctrl.participants.filter(
+            name => !ctrl?.myName || name?.localeCompare(ctrl.myName, undefined, { sensitivity: 'accent' })
+          ),
+          ...ctrl.data.playerName.previous(),
+        ].map(name =>
           h(
             `button.button${name == ctrl.myName ? '.button-green' : ''}`,
             {

--- a/ui/analyse/src/explorer/explorerConfig.ts
+++ b/ui/analyse/src/explorer/explorerConfig.ts
@@ -341,15 +341,30 @@ const playerModal = (ctrl: ExplorerConfigCtrl) => {
             name => !ctrl?.myName || name?.localeCompare(ctrl.myName, undefined, { sensitivity: 'accent' })
           ),
           ...ctrl.data.playerName.previous(),
-        ].map(name =>
-          h(
-            `button.button${name == ctrl.myName ? '.button-green' : ''}`,
+        ].map(name => {
+          const selfButton = name == ctrl.myName;
+          return h(
+            `button.button${selfButton ? '.button-green' : ''}`,
             {
               hook: bind('click', () => onSelect(name)),
             },
-            name
-          )
-        )
+            selfButton || ctrl.participants.includes(name)
+              ? name
+              : [
+                  name,
+                  h('button.remove', {
+                    attrs: {
+                      'aria-label': 'Remove player',
+                      title: ctrl.root.trans.noarg('removeRecentlySearchedPlayer'),
+                      ...dataIcon(''),
+                    },
+                    hook: bind('click', e => {
+                      e.stopPropagation();
+                    }),
+                  }),
+                ]
+          );
+        })
       ),
     ],
   });


### PR DESCRIPTION
Addresses #12869

This PR addresses the aforementioned issue by allowing players in the opening explorer to remove recently searched players from that list.

UI: 
![image](https://github.com/lichess-org/lila/assets/2817895/cbb3649a-975c-4114-9026-d8d02f908ffc)


Also, there was a potential issue with caps showing the logged-in user twice if they participated in the game which daa177fc12b37ba6db524ca825db772e07a9a5b1 addresses.