### PR TITLE
Inquiry: make "view games" a link to the mod game tables again

### DIFF
--- a/app/views/mod/inquiry.scala
+++ b/app/views/mod/inquiry.scala
@@ -108,8 +108,8 @@ object inquiry:
         isGranted(_.MarkBooster) option {
           val searchUrl = routes.User.games(in.user.username, "search")
           div(cls := "dropper view-games")(
-            span("View", br, "Games"),
-            div(
+            a(href := routes.GameMod.index(in.user.username))("View", br, "Games"),
+            div(cls := "view-games-dropdown")(
               a(
                 cls := "fbt",
                 href := s"$searchUrl?turnsMax=5&mode=1&players.loser=${in.user.id}&sort.field=d&sort.order=desc"
@@ -118,9 +118,6 @@ object inquiry:
                 cls := "fbt",
                 href := s"$searchUrl?turnsMax=5&mode=1&players.winner=${in.user.id}&sort.field=d&sort.order=desc"
               )("Quick rated wins"),
-              isGranted(_.CheatHunter) option a(cls := "fbt", href := routes.GameMod.index(in.user.username))(
-                "Hunter game list"
-              ),
               boostOpponents(in.report, in.allReports, in.user) map { opponents =>
                 a(
                   cls  := "fbt",

--- a/ui/site/css/mod/_inquiry.scss
+++ b/ui/site/css/mod/_inquiry.scss
@@ -371,17 +371,17 @@ body.no-inquiry {
   }
 
   .view-games {
-    > span {
-      display: flex;
-      flex-flow: column;
-      justify-content: center;
-      text-align: center;
-    }
-    a {
-      display: block;
-      padding: 0.5em 1.3em;
-      text-transform: initial;
-      text-align: left;
+    display: flex;
+    flex-flow: column;
+    justify-content: center;
+    text-align: center;
+    .view-games-dropdown {
+      a {
+        display: block;
+        padding: 0.5em 1.3em;
+        text-transform: initial;
+        text-align: left;
+      }
     }
   }
 


### PR DESCRIPTION
https://hq.lichess.ovh/#narrow/stream/34-mod-dev/topic/advance.20game.20search.20presets.20for.20boost.20reports/near/2781136


<img width="159" alt="image-5" src="https://github.com/lichess-org/lila/assets/56031107/eef5da3b-1bd6-4f69-b639-87f4ed0c25f1">

