### PR TITLE
Rename source 'Tournament' to 'Arena' in advanced game search

### DIFF
--- a/modules/game/src/main/Source.scala
+++ b/modules/game/src/main/Source.scala
@@ -8,7 +8,7 @@ enum Source(val id: Int):
   case Friend     extends Source(id = 2)
   case Ai         extends Source(id = 3)
   case Api        extends Source(id = 4)
-  case Tournament extends Source(id = 5)
+  case Arena      extends Source(id = 5)
   case Position   extends Source(id = 6)
   case Import     extends Source(id = 7)
   case ImportLive extends Source(id = 9)
@@ -21,7 +21,7 @@ object Source:
 
   val byId = values.mapBy(_.id)
 
-  val searchable = List(Lobby, Friend, Ai, Position, Import, Tournament, Simul, Pool, Swiss)
-  val expirable  = Set(Lobby, Tournament, Pool, Swiss)
+  val searchable = List(Lobby, Friend, Ai, Position, Import, Arena, Simul, Pool, Swiss)
+  val expirable  = Set(Lobby, Arena, Pool, Swiss)
 
   def apply(id: Int): Option[Source] = byId get id

--- a/modules/mod/src/main/AssessApi.scala
+++ b/modules/mod/src/main/AssessApi.scala
@@ -173,7 +173,7 @@ final class AssessApi(
     }
 
   private val assessableSources: Set[Source] =
-    Set(Source.Lobby, Source.Pool, Source.Tournament, Source.Swiss, Source.Simul)
+    Set(Source.Lobby, Source.Pool, Source.Arena, Source.Swiss, Source.Simul)
 
   private def randomPercent(percent: Int): Boolean =
     ThreadLocalRandom.nextInt(100) < percent

--- a/modules/playban/src/main/PlaybanApi.scala
+++ b/modules/playban/src/main/PlaybanApi.scala
@@ -28,7 +28,7 @@ final class PlaybanApi(
   private given BSONDocumentHandler[TempBan]    = Macros.handler
   private given BSONDocumentHandler[UserRecord] = Macros.handler
 
-  private val blameableSources: Set[Source] = Set(Source.Lobby, Source.Pool, Source.Tournament)
+  private val blameableSources: Set[Source] = Set(Source.Lobby, Source.Pool, Source.Arena)
 
   private def blameable(game: Game): Fu[Boolean] =
     (game.source.exists(blameableSources.contains) && game.hasClock) ?? {
@@ -237,7 +237,7 @@ final class PlaybanApi(
         lila.mon.playban.ban.mins.record(ban.mins)
         Bus.publish(
           lila.hub.actorApi.playban
-            .Playban(record.userId, ban.mins, inTournament = source has Source.Tournament),
+            .Playban(record.userId, ban.mins, inTournament = source has Source.Arena),
           "playban"
         )
         coll

--- a/modules/tournament/src/main/AutoPairing.scala
+++ b/modules/tournament/src/main/AutoPairing.scala
@@ -28,7 +28,7 @@ final class AutoPairing(
         whitePlayer = makePlayer(White, pairing.player1),
         blackPlayer = makePlayer(Black, pairing.player2),
         mode = tour.mode,
-        source = Source.Tournament,
+        source = Source.Arena,
         pgnImport = None
       )
       .withId(pairing.pairing.gameId)


### PR DESCRIPTION
Fixes https://github.com/lichess-org/lila/issues/12932 according to the comments section.
![dropdown-rename-arena-lichess](https://github.com/lichess-org/lila/assets/6975572/059f140d-ef4e-42bb-b095-e321ed10b88a)

The fix only affects the Scala 'Source' enum name used to populate the front-end 'Source' dropdown select list. 
Because the 'Source' int mapping remains equal to 5, no back-end update are required (URL path of tournament and arena search = /games/search?source=5").