### PR TITLE
Couple lichess study chapter names w/ PGN Event tag

### DIFF
--- a/modules/study/src/main/StudyApi.scala
+++ b/modules/study/src/main/StudyApi.scala
@@ -415,18 +415,7 @@ final class StudyApi(
     sequenceStudyWithChapter(studyId, setTag.chapterId):
       case Study.WithChapter(study, chapter) =>
         Contribute(who.u, study):
-          if (setTag.tag.name == Tag.Event) {
-            val data: ChapterMaker.EditData = ChapterMaker.EditData(
-              chapter.id,
-              StudyChapterName(setTag.tag.value),
-              ChapterMaker.Orientation.Auto,
-              ChapterMaker.Mode.Normal,
-              chapter.description.getOrElse("-")
-            )
-            editChapter(studyId, data)(who)
-          } else {
-            doSetTags(study, chapter, PgnTags(chapter.tags + setTag.tag), who)
-          }
+          doSetTags(study, chapter, PgnTags(chapter.tags + setTag.tag), who)
 
   def setTags(studyId: StudyId, chapterId: StudyChapterId, tags: Tags)(who: Who) =
     sequenceStudyWithChapter(studyId, chapterId):
@@ -625,8 +614,6 @@ final class StudyApi(
           )
           if (chapter == newChapter) funit
           else
-            var eventTag = Tag(Tag.Event, newChapter.name.toString)
-            doSetTags(study, newChapter, PgnTags(newChapter.tags + eventTag), who)
             chapterRepo.update(newChapter) >> {
               if (chapter.conceal != newChapter.conceal)
                 (newChapter.conceal.isDefined && study.position.chapterId == chapter.id).?? {


### PR DESCRIPTION
Currently lichess study chapter names are only partially related to the PGN Event tags. When exporting a lichess study, if a chapter _does not_ have an Event tag associated with it, an Event tag is automatically added with the form <Study Name> - <Chapter Name>. However, if an Event tag is associated with a chapter that is used instead. Additionally, when importing a PGN into a lichess study the Event tag is not used to initialize a chapter title. Instead, a default chapter title of the form "Chatper <N>" is used. Combined this creates a non-intuitive user experience for users that frequently import & export PGNs into lichess studies as edits to chapter titles are not reflected back in the exported PGN.

This commit addresses these issues by coupling the PGN Event tag with the lichess study chapter. When importing a PGN, the chapter is now initialized from the Event tag when present. When the Event tag is not present, import behaves as it did previously. Additionally, when editing a lichess study chapter name, the Event tag is simultaneously updated (and vice-versa). This means that a subsequent PGN export will populate the Event tag with the name of the lichess study chapter.

This commit implements proposal 1 in my comment on https://github.com/lichess-org/lila/issues/12883