### PR TITLE
Add user hosted simuls page

### DIFF
--- a/app/LilaComponents.scala
+++ b/app/LilaComponents.scala
@@ -154,6 +154,7 @@ final class LilaComponents(
   lazy val user: User                     = wire[User]
   lazy val userAnalysis: UserAnalysis     = wire[UserAnalysis]
   lazy val userTournament: UserTournament = wire[UserTournament]
+  lazy val userSimul: UserSimul           = wire[UserSimul]
   lazy val video: Video                   = wire[Video]
   lazy val swiss: Swiss                   = wire[Swiss]
   lazy val dgt: DgtCtrl                   = wire[DgtCtrl]

--- a/app/controllers/UserSimul.scala
+++ b/app/controllers/UserSimul.scala
@@ -1,0 +1,18 @@
+package controllers
+
+import lila.app.{ given, * }
+import views.*
+
+final class UserSimul(env: Env) extends LilaController(env):
+
+  def path(username: UserStr, path: String, page: Int) = Open:
+    Reasonable(page):
+      val userOption =
+        env.user.repo.byId(username).map { _.filter(_.enabled.yes || isGranted(_.SeeReport)) }
+      OptionFuResult(userOption): user =>
+        path match
+          case "hosted" =>
+            env.simul.api.hostedByUser(user.id, page).map { entries =>
+              Ok(html.userSimul.hosted(user, entries))
+            }
+          case _ => notFound

--- a/app/views/user/show/header.scala
+++ b/app/views/user/show/header.scala
@@ -51,6 +51,12 @@ object header:
           )(
             splitNumber(trans.nbTournamentPoints.pluralSame(u.toints))
           ),
+          u.noBot option a(
+            href := routes.UserSimul.path(u.username, "hosted"),
+            cls  := "nm-item simul_stats"
+          )(
+            splitNumber(trans.nbSimuls.pluralSame(info.nbSimuls))
+          ),
           a(href := routes.Study.byOwnerDefault(u.username), cls := "nm-item")(
             splitNumber(trans.`nbStudies`.pluralSame(info.nbStudies))
           ),

--- a/app/views/userSimul/hosted.scala
+++ b/app/views/userSimul/hosted.scala
@@ -1,0 +1,51 @@
+package views.html
+package userSimul
+
+import lila.api.Context
+import lila.app.templating.Environment.{ given, * }
+import lila.app.ui.ScalatagsTemplate.{ *, given }
+import lila.user.User
+import lila.common.paginator.Paginator
+
+import controllers.routes
+
+object hosted:
+
+  def apply(user: User, pager: Paginator[lila.simul.Simul])(using Context) =
+    views.html.base.layout(
+      title = s"${user.username} hosted simuls",
+      moreCss = cssTag("user-simul"),
+      moreJs = infiniteScrollTag
+    ) {
+      if (pager.nbResults == 0) div(cls := "box-pad")(user.username, " hasn't hosted any simuls yet!")
+      else
+        div(cls := "simul-list")(
+          table(cls := "slist")(
+            thead(
+              tr(
+                th(cls := "count")(pager.nbResults),
+                th(colspan := 3)(h1(userLink(user, withOnline = true), " simuls")),
+                th(s"${trans.wins.txt()}/${trans.draws.txt()}/${trans.losses.txt()}"),
+                th(trans.side())
+              )
+            ),
+            tbody(cls := "infinite-scroll")(
+              pager.currentPageResults.map { s =>
+                val hostColor = s.color match
+                  case Some(color) => color
+                  case None        => "random"
+
+                tr(cls := "paginated")(
+                  td(cls := "icon")(iconTag(s.mainPerfType.icon)),
+                  td(cls := "name")(s.fullName),
+                  td(s.clock.config.toString),
+                  td(momentFromNow(s.createdAt)),
+                  td(s"${s.wins} / ${s.draws} / ${s.losses}"),
+                  td(i(cls := s"color-icon $hostColor"))
+                )
+              },
+              pagerNextTable(pager, np => routes.UserSimul.path(user.username, "hosted", np).url)
+            )
+          )
+        )
+    }

--- a/conf/routes
+++ b/conf/routes
@@ -61,6 +61,7 @@ GET   /insights/:username/:metric/:dimension/*filters controllers.Insight.path(u
 
 # User subpages
 GET   /@/:username/tournaments/:path   controllers.UserTournament.path(username, path, page: Int ?= 1)
+GET   /@/:username/simuls/:path        controllers.UserSimul.path(username, path, page: Int ?= 1)
 
 # User blog
 GET   /@/:username/blog                controllers.Ublog.index(username, page: Int ?= 1)

--- a/modules/i18n/src/main/I18nKeys.scala
+++ b/modules/i18n/src/main/I18nKeys.scala
@@ -815,6 +815,7 @@ object I18nKeys:
   val `giveNbSeconds` = I18nKey("giveNbSeconds")
   val `nbTournamentPoints` = I18nKey("nbTournamentPoints")
   val `nbStudies` = I18nKey("nbStudies")
+  val `nbSimuls` = I18nKey("nbSimuls")
   val `moreThanNbRatedGames` = I18nKey("moreThanNbRatedGames")
   val `moreThanNbPerfRatedGames` = I18nKey("moreThanNbPerfRatedGames")
   val `needNbMorePerfGames` = I18nKey("needNbMorePerfGames")

--- a/modules/simul/src/main/SimulApi.scala
+++ b/modules/simul/src/main/SimulApi.scala
@@ -18,6 +18,8 @@ import lila.hub.LeaderTeam
 import lila.gathering.Condition
 import lila.gathering.Condition.GetUserTeamIds
 import lila.rating.PerfType
+import lila.common.paginator.Paginator
+import lila.common.config.MaxPerPage
 
 final class SimulApi(
     userRepo: UserRepo,
@@ -224,6 +226,15 @@ final class SimulApi(
 
   def teamOf(id: SimulId): Fu[Option[TeamId]] =
     repo.coll.primitiveOne[TeamId]($id(id), "team")
+
+  def hostedByUser(userId: UserId, page: Int): Fu[Paginator[Simul]] =
+    Paginator(
+      adapter = repo.byHostAdapter(userId),
+      currentPage = page,
+      maxPerPage = MaxPerPage(20)
+    )
+
+  def nbHostedByUser(userId: UserId): Fu[Int] = repo.byHostAdapter(userId).nbResults
 
   private def makeGame(simul: Simul, host: User)(
       pairing: SimulPairing,

--- a/modules/simul/src/main/SimulCondition.scala
+++ b/modules/simul/src/main/SimulCondition.scala
@@ -36,11 +36,6 @@ object SimulCondition:
         "team"      -> teamMember(leaderTeams)
       )(All.apply)(unapply).verifying("Invalid ratings", _.validRatings)
 
-  import reactivemongo.api.bson.*
-  given bsonHandler: BSONDocumentHandler[All] =
-    import lila.gathering.ConditionHandlers.BSONHandlers.given
-    Macros.handler
-
   final class Verify(historyApi: lila.history.HistoryApi):
     def apply(simul: Simul, user: User, pt: PerfType)(using
         ex: Executor,

--- a/translation/source/site.xml
+++ b/translation/source/site.xml
@@ -346,6 +346,10 @@
     <item quantity="one">%s study</item>
     <item quantity="other">%s studies</item>
   </plurals>
+  <plurals name="nbSimuls">
+    <item quantity="one">%s simul</item>
+    <item quantity="other">%s simuls</item>
+  </plurals>
   <string name="viewTournament">View tournament</string>
   <string name="backToTournament">Back to tournament</string>
   <string name="noDrawBeforeSwissLimit">You cannot draw before 30 moves are played in a Swiss tournament.</string>

--- a/ui/site/css/_user-simul.scss
+++ b/ui/site/css/_user-simul.scss
@@ -1,0 +1,47 @@
+.simul-list {
+  .slist {
+    white-space: nowrap;
+
+    .count {
+      @extend %roboto;
+
+      vertical-align: center;
+      color: $c-brag;
+      font-size: 40px;
+      text-align: center;
+      line-height: 72px;
+      width: 80px;
+    }
+
+    .icon {
+      text-align: center;
+      font-size: 3em;
+      color: $c-brag;
+    }
+
+    .color-icon {
+      display: block;
+      width: 50px;
+      height: 50px;
+      background-size: 50px;
+
+      &.white {
+        background-image: url(../piece/cburnett/wK.svg);
+      }
+
+      &.random {
+        background-image: url(../images/wbK.svg);
+      }
+
+      &.black {
+        background-image: url(../piece/cburnett/bK.svg);
+      }
+    }
+
+    .name {
+      letter-spacing: 3px;
+      font-size: 1.7em;
+      display: block;
+    }
+  }
+}

--- a/ui/site/css/build/_user-simul.scss
+++ b/ui/site/css/build/_user-simul.scss
@@ -1,0 +1,3 @@
+@import '../../../common/css/plugin';
+@import '../../../common/css/component/slist';
+@import '../user-simul';

--- a/ui/site/css/build/user-simul.ltr.dark.scss
+++ b/ui/site/css/build/user-simul.ltr.dark.scss
@@ -1,0 +1,3 @@
+@import '../../../common/css/dir/ltr';
+@import '../../../common/css/theme/dark';
+@import 'user-simul';

--- a/ui/site/css/build/user-simul.ltr.light.scss
+++ b/ui/site/css/build/user-simul.ltr.light.scss
@@ -1,0 +1,3 @@
+@import '../../../common/css/dir/ltr';
+@import '../../../common/css/theme/light';
+@import 'user-simul';

--- a/ui/site/css/build/user-simul.ltr.transp.scss
+++ b/ui/site/css/build/user-simul.ltr.transp.scss
@@ -1,0 +1,3 @@
+@import '../../../common/css/dir/ltr';
+@import '../../../common/css/theme/transp';
+@import 'user-simul';

--- a/ui/site/css/build/user-simul.rtl.dark.scss
+++ b/ui/site/css/build/user-simul.rtl.dark.scss
@@ -1,0 +1,3 @@
+@import '../../../common/css/dir/rtl';
+@import '../../../common/css/theme/dark';
+@import 'user-simul';

--- a/ui/site/css/build/user-simul.rtl.light.scss
+++ b/ui/site/css/build/user-simul.rtl.light.scss
@@ -1,0 +1,3 @@
+@import '../../../common/css/dir/rtl';
+@import '../../../common/css/theme/light';
+@import 'user-simul';

--- a/ui/site/css/build/user-simul.rtl.transp.scss
+++ b/ui/site/css/build/user-simul.rtl.transp.scss
@@ -1,0 +1,3 @@
+@import '../../../common/css/dir/rtl';
+@import '../../../common/css/theme/transp';
+@import 'user-simul';


### PR DESCRIPTION
Closes #6554 

The simuls overview page is functional, but ugly (sorry, styling is not my forte). Besides, I was not sure which information is really useful there and how to present it.

I added a kinda-hack to the SimulRepo so that old simuls which do not have a "conditions" field in the db could still be loaded and processed.

I wish there were icons signifying player side, i.e., "WhitePieces", "BlackPieces", "RandomColor", but in the Licon.scala there is only the random one. Therefore, I had to load them as svg, which is fine, I think, but a bit off stylistically.