### PR TITLE
fix controller refactor & esm collision bug

### DIFF
--- a/app/views/practice/show.scala
+++ b/app/views/practice/show.scala
@@ -19,7 +19,7 @@ object show:
       moreJs = frag(
         analyseNvuiTag,
         jsModuleInit(
-          "analysisBoard.practice",
+          "analysisBoard.study",
           Json.obj(
             "practice" -> data.practice,
             "study"    -> data.study,


### PR DESCRIPTION
Found another. Back when embed studies were actually embedded (and not pgn viewers), there was actual mode parameter (relay, practice, embed, etc.) passed to the study initModule to differentiate site studies from embeds. During the controller refactor conflicts, I for some reason decided it was a good idea to create entirely fictional modules with those parameters embedded in the name.