### PR TITLE
Allow custom domain email domains pointing to anonaddy.me.

### DIFF
--- a/modules/security/src/main/DisposableEmailDomain.scala
+++ b/modules/security/src/main/DisposableEmailDomain.scala
@@ -46,7 +46,8 @@ private object DisposableEmailDomain:
 
   def whitelisted(domain: Domain) = whitelist.contains(domain.withoutSubdomain.|(domain).lower)
 
-  private val mxRecordPasslist = Set(Domain("simplelogin.co"), Domain("simplelogin.com"))
+  private val mxRecordPasslist =
+    Set(Domain("simplelogin.co"), Domain("simplelogin.com"), Domain("anonaddy.me"))
 
   private val staticBlacklist = Set(
     "lichess.org",


### PR DESCRIPTION
anonaddy.com is an email forwarder just the same as simplelogin.io, that allows to create unique email addresses in order to protect privacy, increase security in case of data leak and provide some degree of anonymity.