### PR TITLE
Use cats for LilaFuture & Refactor RelayAsync

### DIFF
--- a/app/controllers/ForumCateg.scala
+++ b/app/controllers/ForumCateg.scala
@@ -1,5 +1,6 @@
 package controllers
 
+import cats.syntax.all.*
 import lila.app.{ given, * }
 import views.*
 import lila.common.config
@@ -12,7 +13,7 @@ final class ForumCateg(env: Env) extends LilaController(env) with ForumControlle
       pageHit
       for
         allTeamIds <- ctx.userId so teamCache.teamIdsList
-        teamIds <- lila.common.LilaFuture.filter(allTeamIds):
+        teamIds <- allTeamIds.filterA:
           teamCache.forumAccess.get(_).map(_ != Team.Access.NONE)
         categs <- postApi.categsForUser(teamIds, ctx.me)
         _      <- env.user.lightUserApi preloadMany categs.flatMap(_.lastPostUserId)

--- a/modules/forum/src/main/MentionNotifier.scala
+++ b/modules/forum/src/main/MentionNotifier.scala
@@ -39,18 +39,12 @@ final class MentionNotifier(
   /** Checks the database to make sure that the users mentioned exist, and removes any users that do not exist
     * or block the mentioner from the returned list.
     */
-  private def filterValidUsers(
-      candidates: Set[UserId],
-      mentionedBy: UserId
-  ): Fu[List[UserId]] =
-    for {
-      existingUsers <-
-        userRepo
-          .filterExists(candidates take 10)
-          .map(_.take(5).toSet)
+  private def filterValidUsers(candidates: Set[UserId], mentionedBy: UserId): Fu[List[UserId]] =
+    for
+      existingUsers    <- userRepo.filterExists(candidates take 10).map(_.take(5).toSet)
       mentionableUsers <- prefApi.mentionableIds(existingUsers)
-      users            <- mentionableUsers.toList.filterA(relationApi.fetchBlocks(_, mentionedBy))
-    } yield users
+      users            <- mentionableUsers.toList.filterA(!relationApi.fetchBlocks(_, mentionedBy))
+    yield users
 
   private def extractMentionedUsers(post: ForumPost): Set[UserId] =
     post.text.contains('@') so {

--- a/modules/forum/src/main/MentionNotifier.scala
+++ b/modules/forum/src/main/MentionNotifier.scala
@@ -1,6 +1,6 @@
 package lila.forum
 
-import lila.common.LilaFuture
+import cats.syntax.all.*
 import lila.notify.MentionedInThread
 
 /** Notifier to inform users if they have been mentioned in a post
@@ -49,7 +49,7 @@ final class MentionNotifier(
           .filterExists(candidates take 10)
           .map(_.take(5).toSet)
       mentionableUsers <- prefApi.mentionableIds(existingUsers)
-      users <- LilaFuture.filterNot(mentionableUsers.toList) { relationApi.fetchBlocks(_, mentionedBy) }
+      users            <- mentionableUsers.toList.filterA(relationApi.fetchBlocks(_, mentionedBy))
     } yield users
 
   private def extractMentionedUsers(post: ForumPost): Set[UserId] =

--- a/modules/puzzle/src/main/PuzzleFinisher.scala
+++ b/modules/puzzle/src/main/PuzzleFinisher.scala
@@ -27,17 +27,15 @@ final private[puzzle] class PuzzleFinisher(
   )
 
   def batch(me: User, angle: PuzzleAngle, solutions: List[Solution]): Fu[List[(PuzzleRound, IntRatingDiff)]] =
-    lila.common.LilaFuture
-      .fold(solutions)((me.perfs.puzzle, List.empty[(PuzzleRound, IntRatingDiff)])) {
+    solutions
+      .foldM((me.perfs.puzzle, List.empty[(PuzzleRound, IntRatingDiff)])):
         case ((perf, rounds), sol) =>
-          apply(sol.id, angle, me, sol.win, sol.mode) map {
+          apply(sol.id, angle, me, sol.win, sol.mode).map:
             case Some((round, newPerf)) =>
               val rDiff = IntRatingDiff(newPerf.intRating.value - perf.intRating.value)
               (newPerf, (round, rDiff) :: rounds)
             case None => (perf, rounds)
-          }
-      }
-      .map { (_, rounds) => rounds.reverse }
+      .map((_, rounds) => rounds.reverse)
 
   def apply(
       id: PuzzleId,

--- a/modules/relay/src/main/RelayFormat.scala
+++ b/modules/relay/src/main/RelayFormat.scala
@@ -1,5 +1,6 @@
 package lila.relay
 
+import cats.syntax.all.*
 import io.mola.galimatias.URL
 import play.api.libs.json.*
 import play.api.libs.ws.StandaloneWSClient
@@ -41,26 +42,25 @@ final private class RelayFormatApi(ws: StandaloneWSClient, cacheApi: CacheApi)(u
         case _ => fuccess(none)
 
     def guessSingleFile(url: URL): Fu[Option[RelayFormat]] =
-      lila.common.LilaFuture.find(
-        List(
-          url.some,
-          !url.pathSegments.contains(mostCommonSingleFileName) option addPart(url, mostCommonSingleFileName)
-        ).flatten.distinct
-      )(looksLikePgn) dmap2 { (u: URL) =>
+      List(
+        url.some,
+        !url.pathSegments.contains(mostCommonSingleFileName) option addPart(url, mostCommonSingleFileName)
+      ).flatten.distinct.findM(looksLikePgn) dmap2 { (u: URL) =>
         SingleFile(pgnDoc(u))
       }
 
     def guessManyFiles(url: URL): Fu[Option[RelayFormat]] =
-      lila.common.LilaFuture.find(
-        List(url) ::: mostCommonIndexNames.filterNot(url.pathSegments.contains).map(addPart(url, _))
-      )(looksLikeJson) flatMapz { index =>
-        val jsonUrl = (n: Int) => jsonDoc(replaceLastPart(index, s"game-$n.json"))
-        val pgnUrl  = (n: Int) => pgnDoc(replaceLastPart(index, s"game-$n.pgn"))
-        looksLikeJson(jsonUrl(1).url).map(_ option jsonUrl) orElse
-          looksLikePgn(pgnUrl(1).url).map(_ option pgnUrl) dmap2 {
-            ManyFiles(index, _)
-          }
-      }
+      (List(url) ::: mostCommonIndexNames
+        .filterNot(url.pathSegments.contains)
+        .map(addPart(url, _)))
+        .findM(looksLikeJson)
+        .flatMapz: index =>
+          val jsonUrl = (n: Int) => jsonDoc(replaceLastPart(index, s"game-$n.json"))
+          val pgnUrl  = (n: Int) => pgnDoc(replaceLastPart(index, s"game-$n.pgn"))
+          looksLikeJson(jsonUrl(1).url).map(_ option jsonUrl) orElse
+            looksLikePgn(pgnUrl(1).url).map(_ option pgnUrl) dmap2 {
+              ManyFiles(index, _)
+            }
 
     guessLcc(originalUrl) orElse
       guessSingleFile(originalUrl) orElse

--- a/modules/relay/src/main/RelaySync.scala
+++ b/modules/relay/src/main/RelaySync.scala
@@ -1,6 +1,7 @@
 package lila.relay
 
 import cats.syntax.traverse.*
+import cats.syntax.foldable.*
 import chess.format.pgn.{ Tag, Tags }
 import chess.format.UciPath
 import lila.socket.Socket.Sri
@@ -100,21 +101,20 @@ final private class RelaySync(
             toMainline = true
           )(who) >> chapterRepo.setRelayPath(chapter.id, path)
         } >> newNode.so { node =>
-          lila.common.LilaFuture.fold(node.mainline.toList)(Position(chapter, path).ref) {
-            case (position, n) =>
-              studyApi.addNode(
-                studyId = study.id,
-                position = position,
-                node = n,
-                opts = moveOpts.copy(clock = n.clock),
-                relay = Chapter
-                  .Relay(
-                    index = game.index,
-                    path = position.path + n.id,
-                    lastMoveAt = nowInstant
-                  )
-                  .some
-              )(who) inject position + n
+          node.mainline.foldM(Position(chapter, path).ref) { case (position, n) =>
+            studyApi.addNode(
+              studyId = study.id,
+              position = position,
+              node = n,
+              opts = moveOpts.copy(clock = n.clock),
+              relay = Chapter
+                .Relay(
+                  index = game.index,
+                  path = position.path + n.id,
+                  lastMoveAt = nowInstant
+                )
+                .some
+            )(who) inject position + n
           } inject {
             if (chapter.root.children.nodes.isEmpty && node.mainline.nonEmpty)
               studyApi.reloadChapters(study)

--- a/modules/report/src/main/ReportScore.scala
+++ b/modules/report/src/main/ReportScore.scala
@@ -1,5 +1,6 @@
 package lila.report
 
+import cats.syntax.all.*
 import lila.game.GameRepo
 
 final private class ReportScore(
@@ -50,8 +51,9 @@ final private class ReportScore(
       if (c.candidate.isCheat & !c.candidate.isIrwinCheat & !c.candidate.isKaladinCheat)
         val gameIds = gameRegex.findAllMatchIn(c.candidate.text).toList.take(20).map(m => GameId(m.group(1)))
         def isUsable(gameId: GameId) = gameRepo analysed gameId map { _.exists(_.ply > 30) }
-        lila.common.LilaFuture.exists(gameIds)(isUsable) map {
-          if _ then c
-          else c.withScore(_.map(_ / 3))
-        }
+        gameIds
+          .existsM(isUsable)
+          .map:
+            if _ then c
+            else c.withScore(_.map(_ / 3))
       else fuccess(c)

--- a/modules/security/src/main/GarbageCollector.scala
+++ b/modules/security/src/main/GarbageCollector.scala
@@ -1,5 +1,6 @@
 package lila.security
 
+import cats.syntax.all.*
 import play.api.mvc.RequestHeader
 import ornicar.scalalib.ThreadLocalRandom
 
@@ -75,8 +76,8 @@ final class GarbageCollector(
               case _ =>
                 badOtherAccounts(spy.otherUsers.map(_.user)).so: others =>
                   logger.debug(s"other ${data.user.username} others=${others.map(_.username)}")
-                  lila.common.LilaFuture
-                    .exists(spy.ips)(ipTrust.isSuspicious)
+                  spy.ips
+                    .existsM(ipTrust.isSuspicious)
                     .map:
                       _ so collect(
                         user,

--- a/modules/study/src/main/ServerEval.scala
+++ b/modules/study/src/main/ServerEval.scala
@@ -1,5 +1,6 @@
 package lila.study
 
+import cats.syntax.all.*
 import chess.format.pgn.Glyphs
 import chess.format.{ Fen, Uci, UciCharPair, UciPath }
 import play.api.libs.json.*
@@ -7,9 +8,9 @@ import play.api.libs.json.*
 import lila.analyse.{ Analysis, Info }
 import lila.hub.actorApi.fishnet.StudyChapterRequest
 import lila.security.Granter
-import lila.tree.Node.Comment
 import lila.user.{ User, UserRepo }
 import lila.tree.{ Node, Root, Branch }
+import lila.tree.Node.Comment
 import lila.db.dsl.bsonWriteOpt
 
 object ServerEval:
@@ -64,49 +65,49 @@ object ServerEval:
         sequencer.sequenceStudyWithChapter(studyId, analysis.id into StudyChapterId) {
           case Study.WithChapter(_, chapter) =>
             (complete so chapterRepo.completeServerEval(chapter)) >> {
-              lila.common.LilaFuture
-                .fold(chapter.root.mainline.zip(analysis.infoAdvices).toList)(UciPath.root) {
-                  case (path, (node, (info, advOpt))) =>
-                    chapter.root
-                      .nodeAt(path)
-                      .flatMap: parent =>
-                        analysisLine(parent, chapter.setup.variant, info).map: subTree =>
-                          parent.addChild(subTree) -> subTree
-                      .so { (newParent, subTree) =>
-                        chapterRepo.addSubTree(subTree, newParent, path)(chapter)
-                      } >> {
-                      import BSONHandlers.given
-                      import lila.db.dsl.given
-                      import lila.study.Node.{ BsonFields as F }
-                      ((info.eval.score.isDefined && node.eval.isEmpty) || (advOpt.isDefined && !node.comments.hasLichessComment)) so
-                        chapterRepo
-                          .setNodeValues(
-                            chapter,
-                            path + node.id,
-                            List(
-                              F.score -> info.eval.score
-                                .ifTrue {
-                                  node.eval.isEmpty ||
-                                  advOpt.isDefined && node.comments.findBy(Comment.Author.Lichess).isEmpty
-                                }
-                                .flatMap(bsonWriteOpt),
-                              F.comments -> advOpt
-                                .map { adv =>
-                                  node.comments + Comment(
-                                    Comment.Id.make,
-                                    adv.makeComment(withEval = false, withBestMove = true) into Comment.Text,
-                                    Comment.Author.Lichess
-                                  )
-                                }
-                                .flatMap(bsonWriteOpt),
-                              F.glyphs -> advOpt
-                                .map { adv =>
-                                  node.glyphs merge Glyphs.fromList(List(adv.judgment.glyph))
-                                }
-                                .flatMap(bsonWriteOpt)
-                            )
+              chapter.root.mainline
+                .zip(analysis.infoAdvices)
+                .foldM(UciPath.root) { case (path, (node, (info, advOpt))) =>
+                  chapter.root
+                    .nodeAt(path)
+                    .flatMap: parent =>
+                      analysisLine(parent, chapter.setup.variant, info).map: subTree =>
+                        parent.addChild(subTree) -> subTree
+                    .so { (newParent, subTree) =>
+                      chapterRepo.addSubTree(subTree, newParent, path)(chapter)
+                    } >> {
+                    import BSONHandlers.given
+                    import lila.db.dsl.given
+                    import lila.study.Node.{ BsonFields as F }
+                    ((info.eval.score.isDefined && node.eval.isEmpty) || (advOpt.isDefined && !node.comments.hasLichessComment)) so
+                      chapterRepo
+                        .setNodeValues(
+                          chapter,
+                          path + node.id,
+                          List(
+                            F.score -> info.eval.score
+                              .ifTrue {
+                                node.eval.isEmpty ||
+                                advOpt.isDefined && node.comments.findBy(Comment.Author.Lichess).isEmpty
+                              }
+                              .flatMap(bsonWriteOpt),
+                            F.comments -> advOpt
+                              .map { adv =>
+                                node.comments + Comment(
+                                  Comment.Id.make,
+                                  adv.makeComment(withEval = false, withBestMove = true) into Comment.Text,
+                                  Comment.Author.Lichess
+                                )
+                              }
+                              .flatMap(bsonWriteOpt),
+                            F.glyphs -> advOpt
+                              .map { adv =>
+                                node.glyphs merge Glyphs.fromList(List(adv.judgment.glyph))
+                              }
+                              .flatMap(bsonWriteOpt)
                           )
-                    } inject path + node.id
+                        )
+                  } inject path + node.id
                 } void
             } >>- {
               chapterRepo


### PR DESCRIPTION
Most of LilaFuture functions are already exists in cats. Either with A (for [Applicative](https://typelevel.org/cats/typeclasses/applicative.html)) or M (for [Monad](https://typelevel.org/cats/typeclasses/monad.html)) suffix:

- filter => filterA
- fold => foldM
- find => findM
- exists => existsM

This also refactor `RelaySync.apply` function using for comprehension to make it easier to read.