### PR TITLE
Fix automatic selection of external engine on Analysis board

### DIFF
--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -169,8 +169,13 @@ export default class AnalyseCtrl {
 
     const urlEngine = new URLSearchParams(location.search).get('engine');
     if (urlEngine) {
-      this.getCeval().selectedEngine(urlEngine);
-      if (!this.ceval.enabled()) this.toggleCeval();
+      try {
+        this.getCeval().selectedEngine(urlEngine);
+        this.ensureCevalRunning();
+      } catch (e) {
+        console.info(e);
+      }
+      lichess.redirect('/analysis');
     }
 
     lichess.pubsub.on('jump', (ply: string) => {
@@ -710,6 +715,12 @@ export default class AnalyseCtrl {
       } else this.ceval.stop();
     }
   });
+
+  ensureCevalRunning = () => {
+    if (!this.showComputer()) this.toggleComputer();
+    if (!this.ceval.enabled()) this.toggleCeval();
+    if (this.threatMode()) this.toggleThreatMode();
+  };
 
   toggleCeval = () => {
     if (!this.showComputer()) return;

--- a/ui/analyse/src/practice/practiceCtrl.ts
+++ b/ui/analyse/src/practice/practiceCtrl.ts
@@ -57,12 +57,6 @@ export function make(root: AnalyseCtrl, playableDepth: () => number): PracticeCt
     hinting = prop<Hinting | null>(null),
     played = prop(false);
 
-  function ensureCevalRunning() {
-    if (!root.showComputer()) root.toggleComputer();
-    if (!root.ceval.enabled()) root.toggleCeval();
-    if (root.threatMode()) root.toggleThreatMode();
-  }
-
   function commentable(node: Tree.Node, bonus = 0): boolean {
     if (node.tbhit || root.outcome(node)) return true;
     const ceval = node.ceval;
@@ -148,7 +142,7 @@ export function make(root: AnalyseCtrl, playableDepth: () => number): PracticeCt
       return root.redraw();
     }
     if (tablebaseGuaranteed(variant, node.fen) && !defined(node.tbhit)) return;
-    ensureCevalRunning();
+    root.ensureCevalRunning();
     if (isMyTurn()) {
       const h = hinting();
       if (h) {


### PR DESCRIPTION
When opening `/analysis?engine=eei_12345`, from an external client, the first load would have a console error and not activate the engine sidebar until you refresh the page.

I helped introduce the original bug in #12574

I also noticed there was an `ensureCevalRunning()` function so I used that instead because it will ensure that the computer option is enabled, running, and in a good state to start evaluating.

#### Before this PR:

https://github.com/lichess-org/lila/assets/271432/865cd386-117d-4e50-9513-810991047fda

#### After this PR:

https://github.com/lichess-org/lila/assets/271432/f0b5ce1f-ceb1-4be6-a404-b1ebe7b88034