### PR TITLE
Use webkitAudioContext as a fallback for iOS Safari < 14.5

### DIFF
--- a/ui/@types/lichess/index.d.ts
+++ b/ui/@types/lichess/index.d.ts
@@ -316,6 +316,7 @@ interface Window {
   readonly Tagify: unknown;
   readonly paypalOrder: unknown;
   readonly paypalSubscription: unknown;
+  readonly webkitAudioContext?: typeof AudioContext;
 }
 
 interface Study {

--- a/ui/site/src/component/mic.ts
+++ b/ui/site/src/component/mic.ts
@@ -229,7 +229,7 @@ export const mic = new (class implements Voice.Microphone {
         deviceId: this.micId,
       },
     });
-    this.audioCtx = new AudioContext({
+    this.audioCtx = new (AudioContext || window.webkitAudioContext)({
       sampleRate: this.mediaStream.getAudioTracks()[0].getSettings().sampleRate,
     });
     this.micSource = this.audioCtx.createMediaStreamSource(this.mediaStream);

--- a/ui/site/src/component/sound.ts
+++ b/ui/site/src/component/sound.ts
@@ -10,7 +10,7 @@ type Path = string;
 export type SoundMove = (node?: { san?: string; uci?: string }) => void;
 
 export default new (class implements SoundI {
-  ctx = new AudioContext();
+  ctx = new (AudioContext || window.webkitAudioContext)();
   sounds = new Map<Path, Sound>(); // All loaded sounds and their instances
   paths = new Map<Name, Path>(); // sound names to paths
   theme = $('body').data('sound-set');
@@ -22,7 +22,7 @@ export default new (class implements SoundI {
   async context() {
     if (this.ctx.state !== 'running' && this.ctx.state !== 'suspended') {
       // in addition to 'closed', iOS has 'interrupted'. who knows what else is out there
-      this.ctx = new AudioContext();
+      this.ctx = new (AudioContext || window.webkitAudioContext)();
       for (const s of this.sounds.values()) s.rewire(this.ctx);
     }
     if (this.ctx.state === 'suspended') await this.ctx.resume();


### PR DESCRIPTION
Maybe would be nicer to just set `AudioContext` on the window object but not super sure where a good place to do that would be 🤔 Maybe in `site.liches.globals.ts`?