### PR TITLE
Add side padding to patron-info in blog footer

### DIFF
--- a/ui/site/css/_blog.scss
+++ b/ui/site/css/_blog.scss
@@ -212,7 +212,7 @@
     }
 
     .patron-info {
-      margin-top: 2em;
+      margin: 2em 2em 0;
       font-size: 0.85em;
     }
   }


### PR DESCRIPTION
The patron link [gets added to Lichess blog posts](https://lichess.org/blog/ZK7htxEAACUAYgoX/womens-world-chess-championship-half-way-done)

Visual UI tweak so it's not so close to the sides

| Before                                                                                           | After                                                                                            |
|--------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------|
| ![image](https://github.com/lichess-org/lila/assets/271432/33bcd59c-2bab-4fdc-9d23-2bb8f5e1a2e4) | ![image](https://github.com/lichess-org/lila/assets/271432/6ea4b332-36b7-426b-bc83-70a47455d4ed) |