### PR TITLE
Fix typo in crawler matcher regex

### DIFF
--- a/modules/common/src/main/HTTPRequest.scala
+++ b/modules/common/src/main/HTTPRequest.scala
@@ -61,7 +61,7 @@ object HTTPRequest:
     // spiders/crawlers
     """Googlebot|AdsBot|Google-Read-Aloud|bingbot|BingPreview|facebookexternalhit|SemrushBot|AhrefsBot|PetalBot|Applebot|YandexBot|YandexAdNet|Twitterbot|Baiduspider""" +
       // http libs
-      """|HeadlessChrome|okhttp|axios|wget|curl|python-requests|aiohttp|commons-httpclient|python-urllib|python-httpx|Nessus|"""
+      """|HeadlessChrome|okhttp|axios|wget|curl|python-requests|aiohttp|commons-httpclient|python-urllib|python-httpx|Nessus"""
 
   final class UaMatcher(rStr: String):
     private val pattern                    = rStr.r.pattern


### PR DESCRIPTION
Started getting login errors today. When submitting the login form, the POST request was getting a 404.

I did a git bisect and tracked it down to 51a47677e67bc1fb34d8e92f6487656e34737e0e