### PR TITLE
Fix: move-dest dark board background

### DIFF
--- a/ui/common/css/vendor/chessground/_dark-board.scss
+++ b/ui/common/css/vendor/chessground/_dark-board.scss
@@ -20,5 +20,9 @@
     cg-board piece {
       filter: brightness(calc(1 - 0.6 * var(--dark-factor)));
     }
+
+    cg-board square.move-dest {
+      background: radial-gradient(rgba(8, 46, 8, 0.8) 19%, rgba(0, 0, 0, 0) 20%);
+    }
   }
 }


### PR DESCRIPTION
Fixes #12508
This pull request addresses and resolves the issue related to legal moves for the dark board background theme. The changes only affect the dark board background theme and should also make them more visible for other board themes.

![Screenshot 2023-07-21 at 21-59-10 Chess tactic #CpB7V - Black to play](https://github.com/lichess-org/lila/assets/78294042/224ea318-c387-4910-bf97-d70a80909ac2)