### PR TITLE
Fix racing kings goal being blurred with transp bg

### DIFF
--- a/ui/chess/css/_variant-style.scss
+++ b/ui/chess/css/_variant-style.scss
@@ -1,7 +1,6 @@
 .variant-racingKings .cg-wrap {
   &.cg-wrap cg-container::before {
-    @extend %popup-shadow;
-
+    box-shadow: 0 14px 28px rgba(0, 0, 0, 0.25), 0 10px 10px rgba(0, 0, 0, 0.22);
     background: hsla(0, 0%, 90%, 0.2);
     width: 100%;
     height: 12.5%;


### PR DESCRIPTION
`%popup-shadow` got a blur in #13196 