### PR TITLE
Prevent duplicate browser confirm() when creating token

### DIFF
--- a/ui/site/src/account.ts
+++ b/ui/site/src/account.ts
@@ -49,7 +49,7 @@ lichess.load.then(() => {
     let isDanger = false;
     const checkDanger = () => {
       isDanger = !!form.find('.danger input:checked').length;
-      submit.toggleClass('button-red confirm', isDanger);
+      submit.toggleClass('button-red', isDanger);
       submit.attr('data-icon', isDanger ? licon.CautionTriangle : licon.Checkmark);
       submit.attr('title', isDanger ? submit.data('danger-title') : '');
     };


### PR DESCRIPTION
Creating an API token can trigger duplicate browser `confirm()`s.

To recreate:

1. Go to http://lichess.org/account/oauth/token/create?scopes[]=team:lead&description=Test+Token
2. The URL automatically checks the `team:lead` permission (1 of the `isDanger` permissions)
3. Click Submit
4. You will get 2 browser `confirm()`s

This PR prevents [the handler in site.ts](https://github.com/lichess-org/lila/blob/71369a95062403e21780787fbd49994976ec06d6/ui/site/src/site.ts#L107-L109) from also being added for this form.