### PR TITLE
~Fix draw offers missing when reloading (Fixes #13183)

### DIFF
--- a/modules/game/src/main/JsonView.scala
+++ b/modules/game/src/main/JsonView.scala
@@ -35,6 +35,7 @@ final class JsonView(rematches: Rematches):
       .add("winner" -> game.winnerColor)
       .add("rematch" -> rematches.getAcceptedId(game.id))
       .add("rules" -> game.metadata.nonEmptyRules)
+      .add("drawOffers" -> (!game.drawOffers.isEmpty).option(game.drawOffers.normalizedPlies))
 
     // adds fields that could be computed by the client instead
   def baseWithChessDenorm(game: Game, initialFen: Option[Fen.Epd]) =


### PR DESCRIPTION
Fixes #13183

It may be tempting to, following this, use that "drawOffers" array (well, "Set"), to replace the use of the variable "lastDrawOfferAtPly" (added to JSON to fix #13139) in "ui/round/src/ctrl.ts". However "lastDrawOfferAtPly" is not normalized, while the Set are, meaning the value risk being +- 1 off.