### PR TITLE
Scalachess 15.6.2

### DIFF
--- a/modules/analyse/src/main/Annotator.scala
+++ b/modules/analyse/src/main/Annotator.scala
@@ -37,7 +37,7 @@ final class Annotator(netDomain: lila.common.config.NetDomain):
   // 1. e4 { [%eval 0.17] } { [%clk 0:00:30] }
   // 1. e4 { [%eval 0.17] [%clk 0:00:30] }
   def toPgnString(pgn: Pgn): PgnStr = PgnStr:
-    s"$pgn\n\n\n".replaceIf("] } { [", "] [")
+    s"${pgn.render}\n\n\n".replaceIf("] } { [", "] [")
 
   private def annotateStatus(winner: Option[Color], status: Status)(p: Pgn) =
     lila.game.StatusText(status, winner, chess.variant.Standard) match

--- a/modules/api/src/main/PgnDump.scala
+++ b/modules/api/src/main/PgnDump.scala
@@ -8,6 +8,8 @@ import lila.game.Game
 import lila.game.PgnDump.WithFlags
 import lila.team.GameTeams
 import play.api.i18n.Lang
+import chess.ByColor
+import chess.format.EpdFen
 
 final class PgnDump(
     val dumper: lila.game.PgnDump,
@@ -43,7 +45,7 @@ final class PgnDump(
       realPlayers.fold(pgn)(_.update(game, pgn))
     }
 
-  def formatter(flags: WithFlags) =
+  def formatter(flags: WithFlags): (Game, Option[EpdFen], Option[Analysis], Option[ByColor[TeamId]], Option[RealPlayers]) => Future[String] =
     (
         game: Game,
         initialFen: Option[Fen.Epd],

--- a/modules/api/src/main/TextLpvExpand.scala
+++ b/modules/api/src/main/TextLpvExpand.scala
@@ -1,12 +1,11 @@
 package lila.api
 
-import chess.format.pgn.Pgn
 import scalatags.Text.all.*
 
 import lila.analyse.{ Analysis, AnalysisRepo }
 import lila.game.GameRepo
 import lila.memo.CacheApi
-import chess.format.pgn.PgnStr
+import chess.format.pgn.{ Pgn, PgnStr }
 import lila.common.config.NetDomain
 
 final class TextLpvExpand(
@@ -50,7 +49,7 @@ final class TextLpvExpand(
       .map: pgn =>
         div(
           cls              := "lpv--autostart is2d",
-          attr("data-pgn") := pgn.toString,
+          attr("data-pgn") := pgn.value,
           plyRe.findFirstIn(url).map(_.substring(1)).map(ply => attr("data-ply") := ply),
           (url contains "/black").option(attr("data-orientation") := "black")
         )

--- a/modules/game/src/main/PgnDump.scala
+++ b/modules/game/src/main/PgnDump.scala
@@ -55,7 +55,7 @@ final class PgnDump(
 
   private def rating(p: Player) = p.rating.orElse(p.nameSplit.flatMap(_._2)).fold("?")(_.toString)
 
-  def player(p: Player, u: Option[LightUser]) =
+  def player(p: Player, u: Option[LightUser]): String | UserName =
     p.aiLevel.fold(u.fold(p.nameSplit.map(_._1).orElse(p.name) | lila.user.User.anonymous)(_.name))(
       "lichess AI level " + _
     )
@@ -163,7 +163,7 @@ object PgnDump:
       san = san,
       secondsLeft = clocks.lift(index - clockOffset).map(_.roundSeconds)
     )
-    Tree.build(moves.zipWithIndex, f)
+    Tree.buildWithIndex(moves, f)
 
   case class WithFlags(
       clocks: Boolean = true,

--- a/modules/game/src/main/PgnStorage.scala
+++ b/modules/game/src/main/PgnStorage.scala
@@ -45,7 +45,7 @@ private object PgnStorage:
           positionHashes = PositionHash(decoded.positionHashes),
           unmovedRooks = UnmovedRooks(decoded.board.castlingRights),
           lastMove = Option(decoded.lastUci) flatMap Uci.apply,
-          castles = Castles(Bitboard(decoded.board.castlingRights)),
+          castles = Castles(decoded.board.castlingRights),
           halfMoveClock = HalfMoveClock(decoded.halfMoveClock)
         )
 

--- a/modules/game/src/test/PgnDumpTest.scala
+++ b/modules/game/src/test/PgnDumpTest.scala
@@ -8,13 +8,17 @@ class PgnDumpTest extends munit.FunSuite:
 
   def assertPgnDump(pgn: String) =
     val sanStrs = pgn.split(' ').toList.map(SanStr(_))
-    val output  = PgnDump.makeTree(sanStrs, Ply.initial, Vector.empty, Color.White).fold("")(_.render)
+    val builder = new StringBuilder
+    PgnDump.makeTree(sanStrs, Ply.initial, Vector.empty, Color.White).foreach(_.render(builder))
+    val output = builder.toString
     val clean   = output.split(' ').grouped(3).map(_.tail).flatten.mkString(" ") // remove ply number
     assertEquals(clean, pgn)
 
   def assertPgnDumpWithMoveNumbers(pgn: String) =
     val sanStrs = pgn.split(' ').toList.grouped(3).map(_.drop(1)).flatten.map(SanStr(_)).toList
-    val output  = PgnDump.makeTree(sanStrs, Ply.initial, Vector.empty, Color.White).fold("")(_.render)
+    val builder = new StringBuilder
+    PgnDump.makeTree(sanStrs, Ply.initial, Vector.empty, Color.White).foreach(_.render(builder))
+    val output = builder.toString
     assertEquals(output, pgn)
 
   test("roundtrip pgns"):

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
   val scalalib    = "com.github.ornicar"           %% "scalalib"                        % "9.5.5"
   val hasher      = "com.roundeights"              %% "hasher"                          % "1.3.1"
   val jodaTime    = "joda-time"                     % "joda-time"                       % "2.12.5"
-  val chess       = "org.lichess"                  %% "scalachess"                      % "15.6.2"
+  val chess       = "org.lichess"                  %% "scalachess"                      % "15.6.3"
   val compression = "org.lichess"                  %% "compression"                     % "1.10"
   val maxmind     = "com.maxmind.geoip2"            % "geoip2"                          % "4.0.1"
   val prismic     = "io.prismic"                   %% "scala-kit"                       % "1.2.19_lila-3.1"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
   val scalalib    = "com.github.ornicar"           %% "scalalib"                        % "9.5.5"
   val hasher      = "com.roundeights"              %% "hasher"                          % "1.3.1"
   val jodaTime    = "joda-time"                     % "joda-time"                       % "2.12.5"
-  val chess       = "org.lichess"                  %% "scalachess"                      % "15.6.1"
+  val chess       = "org.lichess"                  %% "scalachess"                      % "15.6.2"
   val compression = "org.lichess"                  %% "compression"                     % "1.10"
   val maxmind     = "com.maxmind.geoip2"            % "geoip2"                          % "4.0.1"
   val prismic     = "io.prismic"                   %% "scala-kit"                       % "1.2.19_lila-3.1"


### PR DESCRIPTION
With https://github.com/lichess-org/scalachess/pull/464

The PR above, removed `Pgn.toString`, so, something like `s"something$pgn"` will not work anymore. 

I reviewed all the places, we use `Pgn` but it's possible that I missed some.

Edit: I found one place using `Pgn.toString`: https://github.com/lichess-org/lila/blob/af19a5cef1cbb7e44c7240619790526d66f83c99/app/controllers/Analyse.scala#L81

So, I'll revert `toString` for Pgn to be safe.

Edit2: Fixed