### PR TITLE
Use zipWithIndex.traverse for traverseIndexM

### DIFF
--- a/modules/analyse/src/main/Info.scala
+++ b/modules/analyse/src/main/Info.scala
@@ -78,7 +78,8 @@ object Info:
     str
       .split(listSeparator)
       .toList
-      .traverseWithIndexM((infoStr, index) => decode(fromPly + index + 1, infoStr))
+      .zipWithIndex
+      .traverse((infoStr, index) => decode(fromPly + index + 1, infoStr))
 
   def encodeList(infos: List[Info]): String = infos.map(_.encode) mkString listSeparator
 


### PR DESCRIPTION
`traverseIndexM` is slower and building up stack

I did my benchmark [here](https://gist.github.com/lenguyenthanh/5d6f51c1678db2072236c5fab9d4195c) with results:
```
[info] CatsTraverseWithIndex.traverseWithIndexM               50  thrpt       232250.931          ops/s
[info] CatsTraverseWithIndex.traverseWithIndexM             1000  thrpt         9221.258          ops/s
[info] CatsTraverseWithIndex.traverseWithIndexM           100000  thrpt           61.646          ops/s
[info] CatsTraverseWithIndex.traverseWithIndexM         10000000  thrpt            0.329          ops/s
[info] CatsTraverseWithIndex.zipMapSequence                   50  thrpt       495305.959          ops/s
[info] CatsTraverseWithIndex.zipMapSequence                 1000  thrpt        16892.090          ops/s
[info] CatsTraverseWithIndex.zipMapSequence               100000  thrpt          110.555          ops/s
[info] CatsTraverseWithIndex.zipMapSequence             10000000  thrpt            0.358          ops/s
[info] CatsTraverseWithIndex.zipTraverse                      50  thrpt       546814.666          ops/s
[info] CatsTraverseWithIndex.zipTraverse                    1000  thrpt        19551.344          ops/s
[info] CatsTraverseWithIndex.zipTraverse                  100000  thrpt          109.362          ops/s
[info] CatsTraverseWithIndex.zipTraverse                10000000  thrpt            0.394          ops/s
```

Edit: I wrote a short blog for this: https://www.thanh.se/posts/2023-07-30-you-should-not-use-traverseWithIndexM.html