### PR TITLE
Include activities for unlimited correspondence games on profile

### DIFF
--- a/modules/activity/src/main/ActivityWriteApi.scala
+++ b/modules/activity/src/main/ActivityWriteApi.scala
@@ -26,7 +26,7 @@ final class ActivityWriteApi(
         ActivityFields.games -> a.games.orZero
           .add(game.perfType, Score.make(game wonBy player.color, RatingProg make player.light))
       )
-      val setCorres = game.hasCorrespondenceClock so $doc(
+      val setCorres = game.isCorrespondence so $doc(
         ActivityFields.corres -> a.corres.orZero.add(game.id, moved = false, ended = true)
       )
       setGames ++ setCorres

--- a/modules/activity/src/main/Env.scala
+++ b/modules/activity/src/main/Env.scala
@@ -69,7 +69,7 @@ final class Env(
     case lila.ublog.UblogPost.Create(post)                => write.ublogPost(post)
     case prog: lila.practice.PracticeProgress.OnComplete  => write.practice(prog)
     case lila.simul.Simul.OnStart(simul)                  => write.simul(simul)
-    case CorresMoveEvent(move, Some(userId), _, _, false) => write.corresMove(move.gameId, userId)
+    case CorresMoveEvent(move, Some(userId), _, _, _)     => write.corresMove(move.gameId, userId)
     case lila.hub.actorApi.plan.MonthInc(userId, months)  => write.plan(userId, months)
     case lila.hub.actorApi.relation.Follow(from, to)      => write.follow(from, to)
     case lila.study.actorApi.StartStudy(id)               =>


### PR DESCRIPTION
Includes activities for unlimited time correspondence games. I didn't immediately see a reason why unlimited correspondence games were omitted, but I'll close this PR if there is one.

Resolves #12908 