### PR TITLE
uniform filename format for ctrl-click in embedded vscode terminals

### DIFF
--- a/ui/@build/src/esbuild.ts
+++ b/ui/@build/src/esbuild.ts
@@ -62,9 +62,11 @@ const onEndPlugin = {
 
 function esbuildMessage(msg: es.Message, error = false) {
   const file = msg.location?.file.replace(/^[./]*/, '') ?? '<unknown>';
-  const line = msg.location?.line ? `line ${msg.location.line} of ` : '';
+  const line = msg.location?.line
+    ? `:${msg.location.line}`
+    : '' + (msg.location?.column ? `:${msg.location.column}` : '');
   const srcText = msg.location?.lineText;
-  env.log(`${error ? errorMark : c.warn('WARNING')} - ${line}'${c.cyan(file)}': ${msg.text}`, {
+  env.log(`${error ? errorMark : c.warn('WARNING')} - '${c.cyan(file + line)}' - ${msg.text}`, {
     ctx: 'esbuild',
   });
   if (srcText) env.log('  ' + c.magenta(srcText), { ctx: 'esbuild' });

--- a/ui/@build/src/tsc.ts
+++ b/ui/@build/src/tsc.ts
@@ -46,9 +46,7 @@ export async function tsc(): Promise<void> {
 function tscLog(text: string): void {
   if (text.includes('File change detected') || text.includes('Starting compilation')) return; // redundant
   text = text.replace(/\d?\d:\d\d:\d\d (PM|AM) - /, '');
-  if (text.match(/: error TS\d\d\d\d/)) {
-    text = fixTscError(text);
-  }
+  if (text.match(/: error TS\d\d\d\d/)) text = fixTscError(text);
   env.log(text.replace('. Watching for file changes.', ` - ${c.grey('Watching')}...`), { ctx: 'tsc' });
 }
 
@@ -57,5 +55,4 @@ const fixTscError = (text: string) =>
     .replace(/^[./]*/, `${errorMark} - '\x1b[36m`)
     .replace(/\.ts\((\d+),(\d+)\):/, ".ts:$1:$2\x1b[0m' -")
     .replace(/error (TS\d{4})/, '$1');
-// strip the ../../../../.. junk, highlight error
-// format location for terminal ctrl click
+// format location for vscode embedded terminal ctrl click

--- a/ui/@build/src/tsc.ts
+++ b/ui/@build/src/tsc.ts
@@ -7,7 +7,6 @@ import { env, colors as c, errorMark, lines } from './main';
 export async function tsc(): Promise<void> {
   return new Promise(resolve => {
     if (!env.tsc) return resolve();
-
     const cfgPath = path.join(env.buildDir, 'dist', 'build.tsconfig.json');
     const cfg: any = { files: [] };
     cfg.references = buildModules
@@ -48,8 +47,15 @@ function tscLog(text: string): void {
   if (text.includes('File change detected') || text.includes('Starting compilation')) return; // redundant
   text = text.replace(/\d?\d:\d\d:\d\d (PM|AM) - /, '');
   if (text.match(/: error TS\d\d\d\d/)) {
-    // strip the ../../../../.. junk, highlight error
-    text = `${errorMark} - ${text.replace(/^[./]*/, '')}`;
+    text = fixTscError(text);
   }
   env.log(text.replace('. Watching for file changes.', ` - ${c.grey('Watching')}...`), { ctx: 'tsc' });
 }
+
+const fixTscError = (text: string) =>
+  text
+    .replace(/^[./]*/, `${errorMark} - '\x1b[36m`)
+    .replace(/\.ts\((\d+),(\d+)\):/, ".ts:$1:$2\x1b[0m' -")
+    .replace(/error (TS\d{4})/, '$1');
+// strip the ../../../../.. junk, highlight error
+// format location for terminal ctrl click


### PR DESCRIPTION
all ui/build tsc and esbuild error message filenames should now be ctrl-clickable with location in embedded terminals