### PR TITLE
Fix for auto orientation when adding a chapter using PGN

### DIFF
--- a/modules/study/src/main/ChapterMaker.scala
+++ b/modules/study/src/main/ChapterMaker.scala
@@ -77,9 +77,7 @@ final private class ChapterMaker(
       case Orientation.Fixed(color)      => color
       case _ if isMe(tags.players.white) => Color.white
       case _ if isMe(tags.players.black) => Color.black
-      case _ if tags.outcome.isDefined   => Color.white
-      case _ if data.isGamebook          => !root.lastMainlineNode.color
-      case _                             => root.lastMainlineNode.color
+      case _                             => root.fen.colorOrWhite
 
   private def fromFenOrBlank(study: Study, data: Data, order: Int, userId: UserId): Chapter =
     val variant = data.variant | Variant.default


### PR DESCRIPTION
When adding a chapter to a study using a PGN and setting "Automatic" board orientation, the board orientation was being set off the last mainline node instead of who's turn it is as indicated by the starting FEN. Additionally, the previous code automatically set the orientation to white on any result.

These changes set the orientation (when set to Automatic) to use the orientation of who's turn it is based off the PGNs FEN, not based off the last move.

Considering the existing code was hard-coded to White on any set outcome, the changes in this PR might be undesired - but I figured I'd leave that up for debate on review.

Tested using PGNs that were provided in the bug report.

https://github.com/lichess-org/lila/assets/3620552/465aaa11-523f-4ea0-9cf8-fce235c27eba

Resolves #13309 