### PR TITLE
move user popup to the side of challenge menu item

### DIFF
--- a/ui/challenge/src/view.ts
+++ b/ui/challenge/src/view.ts
@@ -166,7 +166,7 @@ function renderUser(u: ChallengeUser | undefined, showRatings: boolean): VNode {
   return h(
     'a.ulpt.user-link',
     {
-      attrs: { href: `/@/${u.name}` },
+      attrs: { href: `/@/${u.name}`, 'data-pt-pos': 'w' },
       class: { online: !!u.online },
     },
     [


### PR DESCRIPTION
Right now, it's kind of an obstacle that can obscure the accept/decline buttons unless you know what you're doing.