### PR TITLE
Domains in Portugal

### DIFF
--- a/modules/security/src/main/DisposableEmailDomain.scala
+++ b/modules/security/src/main/DisposableEmailDomain.scala
@@ -205,6 +205,9 @@ private object DisposableEmailDomain:
     "globo.com",
     "globomail.com",
     "oi.com.br",
+    /* Domains used in Portugal */
+    "sapo.pt",
+    "outlook.pt",
     /* Domains without an A record */
     "cabletv.on.ca",
     "live.ca",


### PR DESCRIPTION
sapo.pt: https://mail.sapo.pt/
outlook.pt: Microsoft email in Portugal