### PR TITLE
allow optional config values

### DIFF
--- a/modules/common/src/main/AutoConfig.scala
+++ b/modules/common/src/main/AutoConfig.scala
@@ -65,6 +65,16 @@ object AutoConfig:
 
             // Get the type of this class member
             TypeRepr.of[T].memberType(param).asType match
+              case '[Option[t]] =>
+                Expr.summon[ConfigLoader[t]] match
+                  case None =>
+                    report.errorAndAbort(
+                      s"Could not find an instance of ConfigLoader for type ${TypeRepr.of[t].show}"
+                    )
+                  case Some(value) =>
+                    '{
+                      optionalConfig[t](using $value).load($confTerm, $nameOverride)
+                    }
               case '[t] =>
                 // summon ConfigLoader for the type of this parameter
                 Expr.summon[ConfigLoader[t]] match


### PR DESCRIPTION
Mostly to override default behavior that cannot be accurately represented by a single value. For example, a developer may override the delay calculation in FishnetPlayer with some value. This change allows us to rely on None for default behavior rather than nonsense sentinel values in base.conf.