### PR TITLE
Add link to gift Patron wings from player profile

### DIFF
--- a/app/views/plan/index.scala
+++ b/app/views/plan/index.scala
@@ -134,6 +134,7 @@ object index:
                       cls          := "user-autocomplete",
                       placeholder  := trans.clas.lichessUsername.txt(),
                       autocomplete := "off",
+                      spellcheck   := false,
                       dataTag      := "span",
                       autofocus
                     )

--- a/app/views/relation/actions.scala
+++ b/app/views/relation/actions.scala
@@ -32,6 +32,12 @@ object actions:
               cls      := "btn-rack__btn",
               dataIcon := licon.BubbleSpeech
             ),
+            (!blocked && !user.isPatron) option a(
+              titleOrText(trans.patron.giftPatronWingsShort.txt()),
+              href     := s"${routes.Plan.index}?dest=gift&giftUsername=${user.name}",
+              cls      := "btn-rack__btn",
+              dataIcon := licon.Wings
+            ),
             relation match
               case None =>
                 frag(

--- a/modules/i18n/src/main/I18nKeys.scala
+++ b/modules/i18n/src/main/I18nKeys.scala
@@ -1505,6 +1505,7 @@ object I18nKeys:
     val `nextPayment` = I18nKey("patron:nextPayment")
     val `youWillBeChargedXOnY` = I18nKey("patron:youWillBeChargedXOnY")
     val `makeAdditionalDonation` = I18nKey("patron:makeAdditionalDonation")
+    val `giftPatronWingsShort` = I18nKey("patron:giftPatronWingsShort")
     val `giftPatronWings` = I18nKey("patron:giftPatronWings")
     val `update` = I18nKey("patron:update")
     val `changeMonthlyAmount` = I18nKey("patron:changeMonthlyAmount")

--- a/translation/source/patron.xml
+++ b/translation/source/patron.xml
@@ -61,6 +61,7 @@ However, Patrons get bragging rights with a cool new profile icon.</string>
   <string name="nextPayment">Next payment</string>
   <string name="youWillBeChargedXOnY">You will be charged %1$s on %2$s.</string>
   <string name="makeAdditionalDonation">Make an additional donation</string>
+  <string name="giftPatronWingsShort">Gift Patron wings</string>
   <string name="giftPatronWings">Gift Patron wings to a player</string>
   <string name="update">Update</string>
   <string name="changeMonthlyAmount">Change the monthly amount (%s)</string>

--- a/ui/site/src/checkout.ts
+++ b/ui/site/src/checkout.ts
@@ -119,6 +119,10 @@ export default (window as any).checkoutStart = function (stripePublicKey: string
     if (queryParams.has(name))
       $(`input[name=${name}][value=${queryParams.get(name)?.replace(/[^a-z_-]/gi, '')}]`).trigger('click');
   }
+  for (const name of ['giftUsername']) {
+    if (queryParams.has(name))
+      $(`input[name=${name}]`).val(queryParams.get(name)!.replace(/[^a-z0-9_-]/gi, ''));
+  }
 
   payPalOrderStart($checkout, pricing, getAmountToCharge);
   payPalSubscriptionStart($checkout, pricing, getAmountToCharge);


### PR DESCRIPTION
This would add a new button on player profiles that links to `https://lichess.org/patron?dest=gift&giftUsername=Elizabeth`

![image](https://github.com/lichess-org/lila/assets/271432/b4ee53c5-af14-43b6-8b52-a7af5e139a87)

Will prefill the donation form

![image](https://github.com/lichess-org/lila/assets/271432/be43b7e8-ef06-46d7-9059-e84a70a92f3f)
