### PR TITLE
Always show bookmark game star

### DIFF
--- a/ui/round/css/_meta.scss
+++ b/ui/round/css/_meta.scss
@@ -81,13 +81,3 @@
     margin-top: 0.2em;
   }
 }
-
-@media (hover: hover) {
-  .game__meta .bookmark {
-    display: none;
-  }
-
-  .game__meta:hover .bookmark {
-    display: block;
-  }
-}


### PR DESCRIPTION
Change to always show to bookmark game star as the icon is only shown on hover which makes it difficult to find if you don't know where to look. The bookmark star is already always shown by default for mobile web players.

Context:
![Screenshot from 2023-08-12 19-50-55](https://github.com/lichess-org/lila/assets/3620552/c8bbe6f8-133f-4b7d-914a-ec5b163d5c2f)


Resolves #10149
Closes #13275