### PR TITLE
Show input error if attempting to report yourself

### DIFF
--- a/app/controllers/Report.scala
+++ b/app/controllers/Report.scala
@@ -158,7 +158,7 @@ final class Report(
             page <- renderPage(html.report.form(err, user))
           yield BadRequest(page),
         data =>
-          if me.is(data.user.id) then notFound
+          if me.is(data.user.id) then BadRequest("You cannot report yourself")
           else
             api.create(data, Reporter(me)) inject
               Redirect(routes.Report.thanks).flashing("reported" -> data.user.name.value)

--- a/modules/report/src/main/ReportForm.scala
+++ b/modules/report/src/main/ReportForm.scala
@@ -6,7 +6,7 @@ import play.api.data.validation.*
 
 import lila.common.{ config, LightUser }
 import lila.common.Form.given
-import lila.user.User
+import lila.user.{ User, Me }
 
 final private[report] class ReportForm(
     lightUserAsync: LightUser.Getter,
@@ -17,10 +17,14 @@ final private[report] class ReportForm(
     then Valid
     else Invalid(Seq(ValidationError("error.provideOneCheatedGameLink")))
 
-  val create = Form:
+  def create(using me: Me) = Form:
     mapping(
       "username" -> lila.user.UserForm.historicalUsernameField
         .verifying("Unknown username", { blockingFetchUser(_).isDefined })
+        .verifying(
+          "You cannot report yourself",
+          u => !me.is(u.id)
+        )
         .verifying(
           "Don't report Lichess. Use lichess.org/contact instead.",
           u => !User.isOfficial(u)


### PR DESCRIPTION
Show input error instead of 404 page when attempting to report yourself. Thanks to fitztrev for the initial work on the draft pr.

Self report error (new):
![image](https://github.com/lichess-org/lila/assets/3620552/abd8276c-519d-49c1-8965-2d509256b3fe)

Fixes #13078