### PR TITLE
git hooks for linting and formatting pre-commit and pre-push

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -39,3 +39,6 @@ eea12a89f8550d74518f19ec9cda404e3f73b3d0
 
 # Scala Steward: Reformat with scalafmt 3.7.12
 6fb1e4363f3ed03acbf7aaffa10c63bc591a099f
+
+# prettier 3.0.1 update from 2.x
+72d993c45d9b9d17395e0f0a2726af325ef0621c

--- a/bin/git-hooks/pre-commit
+++ b/bin/git-hooks/pre-commit
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+pnpm lint-staged

--- a/bin/git-hooks/pre-push
+++ b/bin/git-hooks/pre-push
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+pnpm format-check && pnpm lint

--- a/bin/git-hooks/pre-push
+++ b/bin/git-hooks/pre-push
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-pnpm format-check && pnpm lint
+pnpm check-format && pnpm lint

--- a/bin/mongodb/active-players-since.js
+++ b/bin/mongodb/active-players-since.js
@@ -37,7 +37,7 @@ var result = db.game5.aggregate(
   },
   {
     $limit: 10,
-  }
+  },
 );
 
 printjson(result);

--- a/bin/mongodb/agad-arena-resume.js
+++ b/bin/mongodb/agad-arena-resume.js
@@ -10,5 +10,5 @@ db.tournament2.update(
       startsAt: ISODate('2022-01-11T19:00:00.000Z'),
     },
     $unset: { winner: 1 },
-  }
+  },
 );

--- a/bin/mongodb/clas_v2.js
+++ b/bin/mongodb/clas_v2.js
@@ -4,7 +4,7 @@ db.clas_clas.find({ createdAt: { $exists: 1 } }).forEach(clas => {
     {
       $unset: { updatedAt: 1, createdAt: 1 },
       $set: { created: { by: clas.teachers[0], at: clas.createdAt } },
-    }
+    },
   );
 });
 db.clas_student.find({ createdAt: { $exists: 1 } }).forEach(stu => {
@@ -14,7 +14,7 @@ db.clas_student.find({ createdAt: { $exists: 1 } }).forEach(stu => {
     {
       $unset: { updatedAt: 1, createdAt: 1 },
       $set: { created: { by: teacher, at: stu.createdAt } },
-    }
+    },
   );
 });
 db.clas_student.find({ realName: { $exists: 0 } }).forEach(stu => {
@@ -22,6 +22,6 @@ db.clas_student.find({ realName: { $exists: 0 } }).forEach(stu => {
     { _id: stu._id },
     {
       $set: { realName: stu.userId, notes: '' },
-    }
+    },
   );
 });

--- a/bin/mongodb/clean-settings.js
+++ b/bin/mongodb/clean-settings.js
@@ -6,5 +6,5 @@ db.user2.update(
       'settings.sound': 1,
     },
   },
-  { multi: 1 }
+  { multi: 1 },
 );

--- a/bin/mongodb/config-timemode.js
+++ b/bin/mongodb/config-timemode.js
@@ -15,7 +15,7 @@
       {
         $set: sets,
         $unset: unsets,
-      }
+      },
     );
   });
 });

--- a/bin/mongodb/donor-patron.js
+++ b/bin/mongodb/donor-patron.js
@@ -16,7 +16,7 @@ db.user4.update(
   },
   {
     multi: true,
-  }
+  },
 );
 
 var userIds = [];
@@ -61,7 +61,7 @@ function donationToPatron(donation) {
           since: donation.date,
         },
       },
-    }
+    },
   );
 }
 

--- a/bin/mongodb/fix-normalized-emails.js
+++ b/bin/mongodb/fix-normalized-emails.js
@@ -20,6 +20,6 @@ db.user4
           email: normalized,
           verbatimEmail: verbatim,
         },
-      }
+      },
     );
   });

--- a/bin/mongodb/forum-fix-int.js
+++ b/bin/mongodb/forum-fix-int.js
@@ -18,7 +18,7 @@ db.f_categ
           nbTopicsTroll: 1,
           nbPostsTroll: 1,
         },
-      }
+      },
     );
     db.f_categ.update(
       {
@@ -32,6 +32,6 @@ db.f_categ
           nbTopicsTroll: NumberInt(o.nbTopicsTroll),
           nbPostsTroll: NumberInt(o.nbPostsTroll),
         },
-      }
+      },
     );
   });

--- a/bin/mongodb/gm-bootstrap.js
+++ b/bin/mongodb/gm-bootstrap.js
@@ -21,6 +21,6 @@ userIds.forEach(id => {
     db.tournament_player.update(
       { uid: id, r: 1500, m: 1500 },
       { $set: { r: NumberInt(perf.gl.r), m: NumberInt(perf.gl.r) } },
-      { multi: 1 }
+      { multi: 1 },
     );
 });

--- a/bin/mongodb/horde.js
+++ b/bin/mongodb/horde.js
@@ -9,7 +9,7 @@
           $push: {
             'filter.v': NumberInt(8),
           },
-        }
+        },
       );
     }
   });

--- a/bin/mongodb/indexes.js
+++ b/bin/mongodb/indexes.js
@@ -1,6 +1,6 @@
 db.challenge.createIndex(
   { seenAt: 1 },
-  { partialFilterExpression: { status: 10, timeControl: { $exists: true }, seenAt: { $exists: true } } }
+  { partialFilterExpression: { status: 10, timeControl: { $exists: true }, seenAt: { $exists: true } } },
 );
 
 db.simul.createIndex({ hostId: 1 }, { partialFilterExpression: { status: 10 } });

--- a/bin/mongodb/mod-progress.js
+++ b/bin/mongodb/mod-progress.js
@@ -1,7 +1,7 @@
 db.modlog.update(
   { human: { $ne: true }, mod: { $ne: 'lichess' } },
   { $set: { human: true } },
-  { multi: true }
+  { multi: true },
 );
 db.modlog.createIndex({ mod: 1, date: -1 }, { partialFilterExpression: { human: true } });
 
@@ -16,7 +16,7 @@ db.report2.find({ processedBy: { $exists: 1 } }).forEach(r =>
           at: r.atoms[0].at,
         },
       },
-    }
-  )
+    },
+  ),
 );
 db.report2.createIndex({ 'done.at': -1 }, { partialFilterExpression: { open: false } });

--- a/bin/mongodb/msg_import.js
+++ b/bin/mongodb/msg_import.js
@@ -5,7 +5,7 @@ function makeIndexes() {
   db.msg_thread.ensureIndex({ users: 1, 'lastMsg.date': -1 }, { background: 1 });
   db.msg_thread.ensureIndex(
     { users: 1 },
-    { partialFilterExpression: { 'lastMsg.read': false }, background: 1 }
+    { partialFilterExpression: { 'lastMsg.read': false }, background: 1 },
   );
   db.msg_msg.ensureIndex({ tid: 1, date: -1 }, { background: 1 });
 }

--- a/bin/mongodb/note-search.js
+++ b/bin/mongodb/note-search.js
@@ -8,11 +8,11 @@ db.note
       from: { $nin: ['watcherbot', 'lichess'] },
       text: { $not: /^Appeal reply:/ },
     },
-    { _id: 1 }
+    { _id: 1 },
   )
   .forEach(n => db.note.updateOne(n, { $set: { s: true } }));
 
 db.note.createIndex(
   { text: 'text', from: 'text', to: 'text', dox: 1, date: -1 },
-  { name: 'search', partialFilterExpression: { s: true } }
+  { name: 'search', partialFilterExpression: { s: true } },
 );

--- a/bin/mongodb/patron-lifetime-mods.js
+++ b/bin/mongodb/patron-lifetime-mods.js
@@ -4,7 +4,7 @@ db.user4
       enabled: true,
       roles: { $in: ['ROLE_SUPER_ADMIN', 'ROLE_ADMIN', 'ROLE_HUNTER', 'ROLE_SEE_REPORT'] },
     },
-    { _id: 1, plan: 1 }
+    { _id: 1, plan: 1 },
   )
   .forEach(user => {
     var userId = user._id;
@@ -22,7 +22,7 @@ db.user4
             since: prev.since || new Date(),
           },
         },
-      }
+      },
     );
 
     db.plan_patron.update(
@@ -31,6 +31,6 @@ db.user4
         lastLevelUp: new Date(),
         lifetime: true,
       },
-      { upsert: true }
+      { upsert: true },
     );
   });

--- a/bin/mongodb/patron-lifetime.js
+++ b/bin/mongodb/patron-lifetime.js
@@ -12,7 +12,7 @@ db.user4.update(
         since: prev.since || new Date(),
       },
     },
-  }
+  },
 );
 
 db.plan_patron.update(
@@ -21,5 +21,5 @@ db.plan_patron.update(
     lastLevelUp: new Date(),
     lifetime: true,
   },
-  { upsert: true }
+  { upsert: true },
 );

--- a/bin/mongodb/patron-since.js
+++ b/bin/mongodb/patron-since.js
@@ -7,5 +7,5 @@ function monthDiff(dateFrom, dateTo) {
 
 db.user4.update(
   { _id: u },
-  { $set: { 'plan.months': NumberInt(monthDiff(since, new Date()) + 1), 'plan.since': since } }
+  { $set: { 'plan.months': NumberInt(monthDiff(since, new Date()) + 1), 'plan.since': since } },
 );

--- a/bin/mongodb/play21.js
+++ b/bin/mongodb/play21.js
@@ -22,7 +22,7 @@ db.f_topic.find().forEach(function (topic) {
         nbPostsTroll: topic['nbPosts'],
         lastPostIdTroll: topic['lastPostId'],
       },
-    }
+    },
   );
 });
 
@@ -36,7 +36,7 @@ db.f_categ.find().forEach(function (categ) {
         nbPostsTroll: categ['nbPosts'],
         lastPostIdTroll: categ['lastPostId'],
       },
-    }
+    },
   );
 });
 
@@ -44,7 +44,7 @@ print('remove useless author names in forum posts');
 db.f_post.update(
   { author: { $exists: true }, userId: { $exists: true } },
   { $unset: { author: true } },
-  { multi: true }
+  { multi: true },
 );
 
 print('mark all forum posts as not troll');

--- a/bin/mongodb/practice-fen-fix.js
+++ b/bin/mongodb/practice-fen-fix.js
@@ -33,7 +33,7 @@ var chapters = db.study_chapter
           $set: {
             'root.f': fixed,
           },
-        }
+        },
       );
     }
 
@@ -48,7 +48,7 @@ var chapters = db.study_chapter
           $set: {
             'root.p': NumberInt(ply),
           },
-        }
+        },
       );
     }
   });

--- a/bin/mongodb/practice-pinned.js
+++ b/bin/mongodb/practice-pinned.js
@@ -1,6 +1,6 @@
 const ids =
   'BJy6fEDf fE4k21MW 8yadFPpU PDkQDt6u 96Lij7wH Rg2cMBZ6 9ogFv8Ac tuoBxVE5 Qj281y1p MnsJEWnI RUQASaZm o734CNqp ITWY4GN2 9cKgYrHb g1fxVZu9 s5pLU7Of xebrDvFe A4ujYOer pt20yRkT MkDViieT 9c6GrCTk Z1DKk4Rl'.split(
-    ' '
+    ' ',
   );
 
 ids.forEach(id => {
@@ -15,7 +15,7 @@ ids.forEach(id => {
       print('  - ' + chapter._id + ' ' + chapter.name);
       db.study_chapter.update(
         { _id: chapter._id },
-        { $set: { description: chapter.root.co[0].text }, $unset: { 'root.co': 1 } }
+        { $set: { description: chapter.root.co[0].text }, $unset: { 'root.co': 1 } },
       );
     });
 });

--- a/bin/mongodb/pref.js
+++ b/bin/mongodb/pref.js
@@ -15,7 +15,7 @@ db.pref.find().forEach(function (p) {
     },
     {
       $unset: set,
-    }
+    },
   );
   db.pref.update(
     {
@@ -23,7 +23,7 @@ db.pref.find().forEach(function (p) {
     },
     {
       $set: set,
-    }
+    },
   );
 });
 

--- a/bin/mongodb/puzzle-disable-broken-mate.js
+++ b/bin/mongodb/puzzle-disable-broken-mate.js
@@ -42,7 +42,7 @@ puzzles
               sum: NumberInt(-9000),
             },
           },
-        }
+        },
       );
       print(p._id);
     }

--- a/bin/mongodb/puzzle-fen-turn.js
+++ b/bin/mongodb/puzzle-fen-turn.js
@@ -27,6 +27,6 @@ puzzles
         $set: {
           fen: newFen,
         },
-      }
+      },
     );
   });

--- a/bin/mongodb/puzzle-mate.js
+++ b/bin/mongodb/puzzle-mate.js
@@ -10,6 +10,6 @@ db.puzzle.find({ tags: { $exists: true } }).forEach(function (o) {
       $unset: {
         tags: true,
       },
-    }
+    },
   );
 });

--- a/bin/mongodb/puzzle-migrate-vote-disable.js
+++ b/bin/mongodb/puzzle-migrate-vote-disable.js
@@ -19,7 +19,7 @@ puzzles
         $unset: {
           'vote.sum': true,
         },
-      }
+      },
     );
     modified += 1;
   });

--- a/bin/mongodb/puzzle-perf.js
+++ b/bin/mongodb/puzzle-perf.js
@@ -19,7 +19,7 @@ db.puzzle
         $unset: {
           rating: true,
         },
-      }
+      },
     );
   });
 db.puzzle
@@ -41,6 +41,6 @@ db.puzzle
             sum: NumberInt(0),
           },
         },
-      }
+      },
     );
   });

--- a/bin/mongodb/puzzle-vote-ratio.js
+++ b/bin/mongodb/puzzle-vote-ratio.js
@@ -64,7 +64,7 @@ db.puzzle2_round
     ],
     {
       allowDiskUse: true,
-    }
+    },
   )
   .forEach(r => {
     db.puzzle2_puzzle.update(
@@ -75,12 +75,12 @@ db.puzzle2_round
           vd: NumberInt(r.vd),
           vu: NumberInt(r.vu),
         },
-      }
+      },
     );
   });
 
 db.puzzle2_puzzle.update(
   { vu: { $exists: 0 }, vd: { $exists: 0 } },
   { $set: { vote: 1, vu: NumberInt(1), vd: NumberInt(0) } },
-  { multi: 1 }
+  { multi: 1 },
 );

--- a/bin/mongodb/ranking-fix.js
+++ b/bin/mongodb/ranking-fix.js
@@ -8,7 +8,7 @@ ranking
     {},
     {
       user: 1,
-    }
+    },
   )
   .forEach(function (r) {
     if (

--- a/bin/mongodb/rapid-filter-update.js
+++ b/bin/mongodb/rapid-filter-update.js
@@ -3,6 +3,6 @@ var speedId = 5;
   coll.update(
     { 'filter.s.2': { $exists: true } },
     { $push: { 'filter.s': NumberInt(speedId) } },
-    { multi: true }
+    { multi: true },
   );
 });

--- a/bin/mongodb/relay-tour-migration.js
+++ b/bin/mongodb/relay-tour-migration.js
@@ -33,6 +33,6 @@ db.relay.find().forEach(relay => {
         markup: true,
         credit: true,
       },
-    }
+    },
   );
 });

--- a/bin/mongodb/relay-tour-tier.js
+++ b/bin/mongodb/relay-tour-tier.js
@@ -1,11 +1,11 @@
 db.relay_tour.update(
   { official: true },
   { $set: { tier: NumberInt(3) }, $unset: { official: true } },
-  { multi: 1 }
+  { multi: 1 },
 );
 db.relay_tour.dropIndex('active_1_official_1_syncedAt_-1');
 db.relay_tour.createIndex(
   { active: 1, tier: 1 },
-  { partialFilterExpression: { active: true, tier: { $exists: true } } }
+  { partialFilterExpression: { active: true, tier: { $exists: true } } },
 );
 db.relay_tour.createIndex({ syncedAt: -1 }, { partialFilterExpression: { tier: { $exists: true } } });

--- a/bin/mongodb/set-ratings.js
+++ b/bin/mongodb/set-ratings.js
@@ -39,7 +39,7 @@ for (k of Object.keys(ratings)) {
             re: [],
           },
         },
-      }
+      },
     );
   }
 }

--- a/bin/mongodb/simul-end.js
+++ b/bin/mongodb/simul-end.js
@@ -28,5 +28,5 @@ db.simul.update(
   },
   {
     multi: 1,
-  }
+  },
 );

--- a/bin/mongodb/streamer-auto-demote.js
+++ b/bin/mongodb/streamer-auto-demote.js
@@ -11,5 +11,5 @@ db.streamer.update(
   },
   {
     multi: 1,
-  }
+  },
 );

--- a/bin/mongodb/study-chapter-tags.js
+++ b/bin/mongodb/study-chapter-tags.js
@@ -18,6 +18,6 @@ db.study_chapter
         $unset: {
           'setup.fromPgn': !!c.setup.fromPgn,
         },
-      }
+      },
     );
   });

--- a/bin/mongodb/study-flat-chapter-migrate.js
+++ b/bin/mongodb/study-flat-chapter-migrate.js
@@ -87,8 +87,8 @@ db.study_chapter_backup
         `${i} ${percent.toFixed(2)}% ${perSecond}/s ETA ${minutesLeft} minutes | size:${(
           sumSizeFrom / batchSize
         ).toFixed(0)}->${(sumSizeTo / batchSize).toFixed(0)} moves:${(sumMoves / batchSize).toFixed(
-          0
-        )} big:${tooBigNb} deep:${tooDeepNb}`
+          0,
+        )} big:${tooBigNb} deep:${tooDeepNb}`,
       );
       lastAt = at;
       sumSizeFrom = 0;

--- a/bin/mongodb/study-topic-index.js
+++ b/bin/mongodb/study-topic-index.js
@@ -1,20 +1,20 @@
 db.study.createIndex(
   { topics: 1, rank: -1 },
-  { partialFilterExpression: { topics: { $exists: 1 } }, background: 1 }
+  { partialFilterExpression: { topics: { $exists: 1 } }, background: 1 },
 );
 db.study.createIndex(
   { topics: 1, createdAt: -1 },
-  { partialFilterExpression: { topics: { $exists: 1 } }, background: 1 }
+  { partialFilterExpression: { topics: { $exists: 1 } }, background: 1 },
 );
 db.study.createIndex(
   { topics: 1, updatedAt: -1 },
-  { partialFilterExpression: { topics: { $exists: 1 } }, background: 1 }
+  { partialFilterExpression: { topics: { $exists: 1 } }, background: 1 },
 );
 db.study.createIndex(
   { topics: 1, likes: -1 },
-  { partialFilterExpression: { topics: { $exists: 1 } }, background: 1 }
+  { partialFilterExpression: { topics: { $exists: 1 } }, background: 1 },
 );
 db.study.createIndex(
   { uids: 1, rank: -1 },
-  { partialFilterExpression: { topics: { $exists: 1 } }, background: 1 }
+  { partialFilterExpression: { topics: { $exists: 1 } }, background: 1 },
 );

--- a/bin/mongodb/survivor.js
+++ b/bin/mongodb/survivor.js
@@ -31,7 +31,7 @@ db.tournament
           $gte: 5,
         },
       },
-    }
+    },
   )
   .result.forEach(function (r) {
     db.trophy.insert({

--- a/bin/mongodb/swiss-fix.js
+++ b/bin/mongodb/swiss-fix.js
@@ -18,7 +18,7 @@ db.swiss
           nextRoundAt: 1,
           featurable: 1,
         },
-      }
+      },
     );
   });
 

--- a/bin/mongodb/swiss-remove-number.js
+++ b/bin/mongodb/swiss-remove-number.js
@@ -15,7 +15,7 @@ db.swiss.find().forEach(swiss => {
           p: [index[p.p[0]], index[p.p[1]]],
           t: p.t == p.p[0] ? NumberInt(0) : p.t == p.p[1] ? NumberInt(1) : p.t,
         },
-      }
+      },
     );
   });
 
@@ -24,5 +24,5 @@ db.swiss.find().forEach(swiss => {
 
 db.swiss.ensureIndex(
   { nbPlayers: -1 },
-  { partialFilterExpression: { featurable: true, 'settings.i': { $lte: 600 } } }
+  { partialFilterExpression: { featurable: true, 'settings.i': { $lte: 600 } } },
 );

--- a/bin/mongodb/team-tournaments.js
+++ b/bin/mongodb/team-tournaments.js
@@ -2,7 +2,7 @@ db.tournament2.dropIndex('teamBattle.teams_1_startsAt_-1');
 db.tournament2.dropIndex('conditions.teamMember.teamId_1_startsAt_-1');
 db.tournament2.ensureIndex(
   { forTeams: 1, startsAt: -1 },
-  { partialFilterExpression: { forTeams: { $exists: 1 } } }
+  { partialFilterExpression: { forTeams: { $exists: 1 } } },
 );
 
 db.tournament2
@@ -12,5 +12,5 @@ db.tournament2
 db.tournament2
   .find({ 'conditions.teamMember.teamId': { $exists: 1 } })
   .forEach(t =>
-    db.tournament2.update({ _id: t._id }, { $set: { forTeams: [t.conditions.teamMember.teamId] } })
+    db.tournament2.update({ _id: t._id }, { $set: { forTeams: [t.conditions.teamMember.teamId] } }),
   );

--- a/bin/mongodb/tournament-lichess.js
+++ b/bin/mongodb/tournament-lichess.js
@@ -2,5 +2,5 @@ db.tournament2.update({ createdBy: 'lichess' }, { $unset: { createdBy: 1 } }, { 
 db.tournament2.dropIndex('createdBy_1_startsAt_-1');
 db.tournament2.createIndex(
   { createdBy: 1, startsAt: -1, status: 1 },
-  { partialFilterExpression: { createdBy: { $exists: true } } }
+  { partialFilterExpression: { createdBy: { $exists: true } } },
 );

--- a/bin/mongodb/tournament-randomize-start.js
+++ b/bin/mongodb/tournament-randomize-start.js
@@ -6,7 +6,7 @@ db.tournament2
     {
       id: 1,
       startsAt: 1,
-    }
+    },
   )
   .forEach(d => {
     if (d.startsAt.getSeconds() === 0) {
@@ -18,7 +18,7 @@ db.tournament2
           $set: {
             startsAt: d.startsAt,
           },
-        }
+        },
       );
     }
   });

--- a/bin/mongodb/tournament-team-indexes.js
+++ b/bin/mongodb/tournament-team-indexes.js
@@ -1,13 +1,13 @@
 db.tournament2.createIndex(
   { 'conditions.teamMember.teamId': 1, startsAt: -1 },
-  { partialFilterExpression: { 'conditions.teamMember': { $exists: 1 } } }
+  { partialFilterExpression: { 'conditions.teamMember': { $exists: 1 } } },
 );
 db.tournament2.createIndex(
   { 'teamBattle.teams': 1, startsAt: -1 },
-  { partialFilterExpression: { teamBattle: { $exists: 1 } } }
+  { partialFilterExpression: { teamBattle: { $exists: 1 } } },
 );
 db.tournament_player.createIndex(
   { tid: 1, t: 1, m: -1 },
   { partialFilterExpression: { t: { $exists: true } } },
-  { background: true }
+  { background: true },
 );

--- a/bin/mongodb/ublog-blog.js
+++ b/bin/mongodb/ublog-blog.js
@@ -7,7 +7,7 @@ db.ublog_post.createIndex(
   {
     partialFilterExpression: { live: true },
     name: 'liveByBlog',
-  }
+  },
 );
 db.ublog_post.createIndex(
   {
@@ -17,21 +17,21 @@ db.ublog_post.createIndex(
   {
     partialFilterExpression: { live: false },
     name: 'draftByBlog',
-  }
+  },
 );
 db.ublog_post.createIndex({ rank: -1 }, { partialFilterExpression: { live: true }, name: 'liveByRank' });
 db.ublog_post.dropIndex('liveByLang');
 db.ublog_post.createIndex(
   { language: 1, rank: -1 },
-  { partialFilterExpression: { live: true }, name: 'liveByLanguage' }
+  { partialFilterExpression: { live: true }, name: 'liveByLanguage' },
 );
 db.ublog_post.createIndex(
   { likers: 1, rank: -1 },
-  { partialFilterExpression: { live: true }, name: 'liveByLiked' }
+  { partialFilterExpression: { live: true }, name: 'liveByLiked' },
 );
 db.ublog_post.createIndex(
   { topic: 1, rank: -1 },
-  { partialFilterExpression: { live: true }, name: 'liveByTopic' }
+  { partialFilterExpression: { live: true }, name: 'liveByTopic' },
 );
 
 db.ublog_post.find({ blog: { $exists: false } }).forEach(p => {
@@ -77,6 +77,6 @@ db.ublog_post.find({ blog: { $exists: false } }).forEach(p => {
         liveAt: 1,
         troll: 1,
       },
-    }
+    },
   );
 });

--- a/bin/mongodb/user-count.js
+++ b/bin/mongodb/user-count.js
@@ -29,6 +29,6 @@ db.user2.find().forEach(function (user) {
           winH: user.nbWinsH || 0,
         },
       },
-    }
+    },
   );
 });

--- a/bin/mongodb/user-dedup-createdAt.js
+++ b/bin/mongodb/user-dedup-createdAt.js
@@ -16,7 +16,7 @@ db.user4
         $unset: {
           createdAt: true,
         },
-      }
+      },
     );
 
     db.user4.update(
@@ -27,7 +27,7 @@ db.user4
         $set: {
           createdAt: u.createdAt,
         },
-      }
+      },
     );
 
     ++it;

--- a/bin/mongodb/user-delete-forever.js
+++ b/bin/mongodb/user-delete-forever.js
@@ -23,8 +23,8 @@ print(
       },
       $unset: { p1: true },
     },
-    multi
-  ).nModified + ' done'
+    multi,
+  ).nModified + ' done',
 );
 
 print('Set white games as anon');
@@ -40,8 +40,8 @@ print(
       },
       $unset: { p0: true },
     },
-    multi
-  ).nModified + ' done'
+    multi,
+  ).nModified + ' done',
 );
 print('done');
 
@@ -49,42 +49,42 @@ print('Delete old PMs');
 print(
   db.m_thread.remove({
     visibleByUserIds: userId,
-  }).nRemoved + ' done'
+  }).nRemoved + ' done',
 );
 
 print('Delete new PMs');
 print(
   db.msg_thread.remove({
     users: userId,
-  }).nRemoved + ' done'
+  }).nRemoved + ' done',
 );
 
 print('Delete mod log');
 print(
   db.modlog.remove({
     user: userId,
-  }).nRemoved + ' done'
+  }).nRemoved + ' done',
 );
 
 print('Delete rating history');
 print(
   db.history3.remove({
     _id: userId,
-  }).nRemoved + ' done'
+  }).nRemoved + ' done',
 );
 
 print('Delete bookmarks');
 print(
   db.bookmark.remove({
     u: userId,
-  }).nRemoved + ' done'
+  }).nRemoved + ' done',
 );
 
 print('Delete learn progress');
 print(
   db.learn_progress.remove({
     _id: userId,
-  }).nRemoved + ' done'
+  }).nRemoved + ' done',
 );
 
 print('Delete perf stats');
@@ -99,70 +99,70 @@ print('Delete prefs');
 print(
   db.pref.remove({
     _id: userId,
-  }).nRemoved + ' done'
+  }).nRemoved + ' done',
 );
 
 print('Delete relations from');
 print(
   db.relation.remove({
     u1: userId,
-  }).nRemoved + ' done'
+  }).nRemoved + ' done',
 );
 
 print('Delete relations to');
 print(
   db.relation.remove({
     u2: userId,
-  }).nRemoved + ' done'
+  }).nRemoved + ' done',
 );
 
 print('Delete security data');
 print(
   db.security.remove({
     user: userId,
-  }).nRemoved + ' done'
+  }).nRemoved + ' done',
 );
 
 print('Delete team membership');
 print(
   db.team_member.remove({
     user: userId,
-  }).nRemoved + ' done'
+  }).nRemoved + ' done',
 );
 
 print('Delete playbans');
 print(
   db.playban.remove({
     _id: userId,
-  }).nRemoved + ' done'
+  }).nRemoved + ' done',
 );
 
 print('Delete perf stats');
 print(
   db.perf_stat.remove({
     _id: new RegExp('^' + userId + '/'),
-  }).nRemoved + ' done'
+  }).nRemoved + ' done',
 );
 
 print('Delete activity');
 print(
   db.activity.remove({
     _id: new RegExp('^' + userId + ':'),
-  }).nRemoved + ' done'
+  }).nRemoved + ' done',
 );
 
 print('Delete assessments');
 print(
   db.player_assessment.remove({
     userId: userId,
-  }).nRemoved + ' done'
+  }).nRemoved + ' done',
 );
 
 print('Delete user');
 print(
   db.user4.remove({
     _id: userId,
-  }).nRemoved + ' done'
+  }).nRemoved + ' done',
 );
 
 print('\n complete.');

--- a/bin/mongodb/user-id-size.js
+++ b/bin/mongodb/user-id-size.js
@@ -7,7 +7,7 @@ coll
     {},
     {
       _id: 1,
-    }
+    },
   )
   .forEach(function (u) {
     coll.update(
@@ -18,6 +18,6 @@ coll
         $set: {
           len: NumberInt(u._id.length),
         },
-      }
+      },
     );
   });

--- a/bin/mongodb/variant-filter-update.js
+++ b/bin/mongodb/variant-filter-update.js
@@ -3,6 +3,6 @@ var variantId = 10;
   coll.update(
     { 'filter.v.1': { $exists: true } },
     { $push: { 'filter.v': NumberInt(variantId) } },
-    { multi: true }
+    { multi: true },
   );
 });

--- a/bin/mongodb/wid.js
+++ b/bin/mongodb/wid.js
@@ -16,7 +16,7 @@ var gamesToMigrate = db.game5.find(
   {
     us: 1,
     w: 1,
-  }
+  },
 );
 
 gamesToMigrate.forEach(function (g) {
@@ -29,7 +29,7 @@ gamesToMigrate.forEach(function (g) {
         $set: {
           wid: g.us[0],
         },
-      }
+      },
     );
   } else if (!g.w && typeof g.us[1] != 'undefined' && g.us[1]) {
     db.game5.update(
@@ -40,7 +40,7 @@ gamesToMigrate.forEach(function (g) {
         $set: {
           wid: g.us[1],
         },
-      }
+      },
     );
   }
 });

--- a/bin/mongodb/winner.js
+++ b/bin/mongodb/winner.js
@@ -12,7 +12,7 @@ var gamesToMigrate = db.game5
     },
     {
       'p0.w': true,
-    }
+    },
   )
   .sort({ ca: -1 });
 
@@ -37,7 +37,7 @@ gamesToMigrate.forEach(function (g) {
     {
       _id: g._id,
     },
-    update
+    update,
   );
 });
 

--- a/package.json
+++ b/package.json
@@ -21,21 +21,26 @@
     "node": ">=14",
     "pnpm": "^8.6"
   },
+  "lint-staged": {
+    "*.{js,ts,md,json,scss}": "prettier --write"
+  },
   "dependencies": {
-    "@types/node": "^18.16.18",
+    "@types/node": "^18.17.5",
     "@types/web": "^0.0.84",
-    "@typescript-eslint/eslint-plugin": "^5.60.1",
-    "@typescript-eslint/parser": "^5.60.1",
+    "@typescript-eslint/eslint-plugin": "^6.4.0",
+    "@typescript-eslint/parser": "^6.4.0",
     "ab": "github:lichess-org/ab-stub",
-    "chessground": "^8.3.11",
-    "eslint": "^8.43.0",
-    "eslint-config-prettier": "^8.8.0",
-    "prettier": "2.8.1",
-    "typescript": "^5.1.5"
+    "chessground": "^8.4.0",
+    "eslint": "^8.47.0",
+    "lint-staged": "^13.3.0",
+    "prettier": "^3.0.1",
+    "typescript": "^5.1.6"
   },
   "scripts": {
-    "format": "prettier --write . --loglevel warn",
-    "check-format": "prettier --check . --loglevel warn",
+    "format": "prettier --write .",
+    "check-format": "prettier --check .",
+    "add-hooks": "git config --add core.hooksPath bin/git-hooks",
+    "remove-hooks": "git config --unset core.hooksPath bin/git-hooks",
     "lint": "eslint . --ext .ts",
     "journal": "journalctl --user -fu lila -o cat",
     "metals": "tail -F .metals/metals.log | stdbuf -oL cut -c 21- | rg -v '(notification for request|handleCancellation)'",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,35 +9,35 @@ importers:
   .:
     dependencies:
       '@types/node':
-        specifier: ^18.16.18
-        version: 18.16.18
+        specifier: ^18.17.5
+        version: 18.17.5
       '@types/web':
         specifier: ^0.0.84
         version: 0.0.84
       '@typescript-eslint/eslint-plugin':
-        specifier: ^5.60.1
-        version: 5.60.1(@typescript-eslint/parser@5.60.1)(eslint@8.43.0)(typescript@5.1.5)
+        specifier: ^6.4.0
+        version: 6.4.0(@typescript-eslint/parser@6.4.0)(eslint@8.47.0)(typescript@5.1.6)
       '@typescript-eslint/parser':
-        specifier: ^5.60.1
-        version: 5.60.1(eslint@8.43.0)(typescript@5.1.5)
+        specifier: ^6.4.0
+        version: 6.4.0(eslint@8.47.0)(typescript@5.1.6)
       ab:
         specifier: github:lichess-org/ab-stub
         version: github.com/lichess-org/ab-stub/94236bf34dbc9c05daf50f4c9842d859b9142be0
       chessground:
-        specifier: ^8.3.11
-        version: 8.3.11
+        specifier: ^8.4.0
+        version: 8.4.0
       eslint:
-        specifier: ^8.43.0
-        version: 8.43.0
-      eslint-config-prettier:
-        specifier: ^8.8.0
-        version: 8.8.0(eslint@8.43.0)
+        specifier: ^8.47.0
+        version: 8.47.0
+      lint-staged:
+        specifier: ^13.3.0
+        version: 13.3.0
       prettier:
-        specifier: 2.8.1
-        version: 2.8.1
+        specifier: ^3.0.1
+        version: 3.0.1
       typescript:
-        specifier: ^5.1.5
-        version: 5.1.5
+        specifier: ^5.1.6
+        version: 5.1.6
 
   bin:
     dependencies:
@@ -61,13 +61,13 @@ importers:
         version: 2.7.1
       jest:
         specifier: ^28.1.3
-        version: 28.1.3(@types/node@18.16.18)
+        version: 28.1.3(@types/node@18.17.5)
       jest-environment-jsdom:
         specifier: ^28.1.3
         version: 28.1.3
       ts-jest:
         specifier: ^28.0.7
-        version: 28.0.8(@babel/core@7.20.5)(jest@28.1.3)(typescript@5.1.5)
+        version: 28.0.8(@babel/core@7.20.5)(jest@28.1.3)(typescript@5.1.6)
 
   ui/@build:
     dependencies:
@@ -2379,29 +2379,29 @@ packages:
     dev: false
     optional: true
 
-  /@eslint-community/eslint-utils@4.4.0(eslint@8.43.0):
+  /@eslint-community/eslint-utils@4.4.0(eslint@8.47.0):
     resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
     dependencies:
-      eslint: 8.43.0
-      eslint-visitor-keys: 3.4.1
+      eslint: 8.47.0
+      eslint-visitor-keys: 3.4.3
     dev: false
 
-  /@eslint-community/regexpp@4.5.1:
-    resolution: {integrity: sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==}
+  /@eslint-community/regexpp@4.6.2:
+    resolution: {integrity: sha512-pPTNuaAG3QMH+buKyBIGJs3g/S5y0caxw0ygM3YyE6yJFySwiGGSzA+mM3KJ8QQvzeLh3blwgSonkFjgQdxzMw==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
     dev: false
 
-  /@eslint/eslintrc@2.0.3:
-    resolution: {integrity: sha512-+5gy6OQfk+xx3q0d6jGZZC3f3KzAkXc/IanVxd1is/VIIziRqqt3ongQz0FiTUXqTk0c7aDB3OaFuKnuSoJicQ==}
+  /@eslint/eslintrc@2.1.2:
+    resolution: {integrity: sha512-+wvgpDsrB1YqAMdEUCcnTlpfVBH7Vqn6A/NT3D8WVXFIaKMlErPIZT3oCIAVCOtarRpMtelZLqJeU3t7WY6X6g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
       debug: 4.3.4
-      espree: 9.5.2
-      globals: 13.20.0
+      espree: 9.6.1
+      globals: 13.21.0
       ignore: 5.2.4
       import-fresh: 3.3.0
       js-yaml: 4.1.0
@@ -2411,8 +2411,8 @@ packages:
       - supports-color
     dev: false
 
-  /@eslint/js@8.43.0:
-    resolution: {integrity: sha512-s2UHCoiXfxMvmfzqoN+vrQ84ahUSYde9qNO1MdxmoEhyHWsfmwOpFlwYV+ePJEVc7gFnATGUi376WowX1N7tFg==}
+  /@eslint/js@8.47.0:
+    resolution: {integrity: sha512-P6omY1zv5MItm93kLM8s2vr1HICJH8v0dvddDhysbIuZ+vcjOHg5Zbkf1mTkcmi2JA9oBG2anOkRnW8WJTS8Og==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: false
 
@@ -2461,7 +2461,7 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
       '@jest/types': 28.1.3
-      '@types/node': 20.3.2
+      '@types/node': 20.5.0
       chalk: 4.1.2
       jest-message-util: 28.1.3
       jest-util: 28.1.3
@@ -2482,14 +2482,14 @@ packages:
       '@jest/test-result': 28.1.3
       '@jest/transform': 28.1.3
       '@jest/types': 28.1.3
-      '@types/node': 20.3.2
+      '@types/node': 20.5.0
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.7.0
       exit: 0.1.2
       graceful-fs: 4.2.10
       jest-changed-files: 28.1.3
-      jest-config: 28.1.3(@types/node@20.3.2)
+      jest-config: 28.1.3(@types/node@20.5.0)
       jest-haste-map: 28.1.3
       jest-message-util: 28.1.3
       jest-regex-util: 28.0.2
@@ -2517,7 +2517,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 28.1.3
       '@jest/types': 28.1.3
-      '@types/node': 20.3.2
+      '@types/node': 20.5.0
       jest-mock: 28.1.3
     dev: false
 
@@ -2527,7 +2527,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 29.3.1
       '@jest/types': 29.3.1
-      '@types/node': 20.3.2
+      '@types/node': 20.5.0
       jest-mock: 29.3.1
     dev: false
 
@@ -2571,7 +2571,7 @@ packages:
     dependencies:
       '@jest/types': 28.1.3
       '@sinonjs/fake-timers': 9.1.2
-      '@types/node': 20.3.2
+      '@types/node': 20.5.0
       jest-message-util: 28.1.3
       jest-mock: 28.1.3
       jest-util: 28.1.3
@@ -2583,7 +2583,7 @@ packages:
     dependencies:
       '@jest/types': 29.3.1
       '@sinonjs/fake-timers': 9.1.2
-      '@types/node': 20.3.2
+      '@types/node': 20.5.0
       jest-message-util: 29.3.1
       jest-mock: 29.3.1
       jest-util: 29.3.1
@@ -2627,7 +2627,7 @@ packages:
       '@jest/transform': 28.1.3
       '@jest/types': 28.1.3
       '@jridgewell/trace-mapping': 0.3.17
-      '@types/node': 20.3.2
+      '@types/node': 20.5.0
       chalk: 4.1.2
       collect-v8-coverage: 1.0.1
       exit: 0.1.2
@@ -2746,7 +2746,7 @@ packages:
       '@jest/schemas': 28.1.3
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 20.3.2
+      '@types/node': 20.5.0
       '@types/yargs': 17.0.17
       chalk: 4.1.2
     dev: false
@@ -2758,7 +2758,7 @@ packages:
       '@jest/schemas': 29.0.0
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 20.3.2
+      '@types/node': 20.5.0
       '@types/yargs': 17.0.17
       chalk: 4.1.2
     dev: false
@@ -2916,7 +2916,7 @@ packages:
   /@types/graceful-fs@4.1.5:
     resolution: {integrity: sha512-anKkLmZZ+xm4p8JWBf4hElkM4XR+EZeA2M9BAkkTldmcyDY4mbdIJnRghDJH3Ov5ooY7/UAoENtmdMSkaAd7Cw==}
     dependencies:
-      '@types/node': 20.3.2
+      '@types/node': 20.5.0
     dev: false
 
   /@types/highcharts@4.2.57:
@@ -2951,7 +2951,7 @@ packages:
   /@types/jsdom@16.2.15:
     resolution: {integrity: sha512-nwF87yjBKuX/roqGYerZZM0Nv1pZDMAT5YhOHYeM/72Fic+VEqJh4nyoqoapzJnW3pUlfxPY5FhgsJtM+dRnQQ==}
     dependencies:
-      '@types/node': 20.3.2
+      '@types/node': 20.5.0
       '@types/parse5': 6.0.3
       '@types/tough-cookie': 4.0.2
     dev: false
@@ -2960,12 +2960,12 @@ packages:
     resolution: {integrity: sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==}
     dev: false
 
-  /@types/node@18.16.18:
-    resolution: {integrity: sha512-/aNaQZD0+iSBAGnvvN2Cx92HqE5sZCPZtx2TsK+4nvV23fFe09jVDvpArXr2j9DnYlzuU9WuoykDDc6wqvpNcw==}
+  /@types/node@18.17.5:
+    resolution: {integrity: sha512-xNbS75FxH6P4UXTPUJp/zNPq6/xsfdJKussCWNOnz4aULWIRwMgP1LgaB5RiBnMX1DPCYenuqGZfnIAx5mbFLA==}
     dev: false
 
-  /@types/node@20.3.2:
-    resolution: {integrity: sha512-vOBLVQeCQfIcF/2Y7eKFTqrMnizK5lRNQ7ykML/5RuwVXVWxYkgwS7xbt4B6fKCUPgbSL5FSsjHQpaGQP/dQmw==}
+  /@types/node@20.5.0:
+    resolution: {integrity: sha512-Mgq7eCtoTjT89FqNoTzzXg2XvCi5VMhRV6+I2aYanc6kQCBImeNaAYRs/DyoVqk1YEUJK5gN9VO7HRIdz4Wo3Q==}
     dev: false
 
   /@types/parse5@6.0.3:
@@ -3032,134 +3032,135 @@ packages:
     resolution: {integrity: sha512-3NoqvZC2W5gAC5DZbTpCeJ251vGQmgcWIHQJGq2J240HY6ErQ9aWKkwfoKJlHLx+A83WPNTZ9+3cd2ILxbvr1w==}
     dev: false
 
-  /@typescript-eslint/eslint-plugin@5.60.1(@typescript-eslint/parser@5.60.1)(eslint@8.43.0)(typescript@5.1.5):
-    resolution: {integrity: sha512-KSWsVvsJsLJv3c4e73y/Bzt7OpqMCADUO846bHcuWYSYM19bldbAeDv7dYyV0jwkbMfJ2XdlzwjhXtuD7OY6bw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+  /@typescript-eslint/eslint-plugin@6.4.0(@typescript-eslint/parser@6.4.0)(eslint@8.47.0)(typescript@5.1.6):
+    resolution: {integrity: sha512-62o2Hmc7Gs3p8SLfbXcipjWAa6qk2wZGChXG2JbBtYpwSRmti/9KHLqfbLs9uDigOexG+3PaQ9G2g3201FWLKg==}
+    engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^5.0.0
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      '@typescript-eslint/parser': ^6.0.0 || ^6.0.0-alpha
+      eslint: ^7.0.0 || ^8.0.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@eslint-community/regexpp': 4.5.1
-      '@typescript-eslint/parser': 5.60.1(eslint@8.43.0)(typescript@5.1.5)
-      '@typescript-eslint/scope-manager': 5.60.1
-      '@typescript-eslint/type-utils': 5.60.1(eslint@8.43.0)(typescript@5.1.5)
-      '@typescript-eslint/utils': 5.60.1(eslint@8.43.0)(typescript@5.1.5)
+      '@eslint-community/regexpp': 4.6.2
+      '@typescript-eslint/parser': 6.4.0(eslint@8.47.0)(typescript@5.1.6)
+      '@typescript-eslint/scope-manager': 6.4.0
+      '@typescript-eslint/type-utils': 6.4.0(eslint@8.47.0)(typescript@5.1.6)
+      '@typescript-eslint/utils': 6.4.0(eslint@8.47.0)(typescript@5.1.6)
+      '@typescript-eslint/visitor-keys': 6.4.0
       debug: 4.3.4
-      eslint: 8.43.0
-      grapheme-splitter: 1.0.4
+      eslint: 8.47.0
+      graphemer: 1.4.0
       ignore: 5.2.4
-      natural-compare-lite: 1.4.0
-      semver: 7.5.3
-      tsutils: 3.21.0(typescript@5.1.5)
-      typescript: 5.1.5
+      natural-compare: 1.4.0
+      semver: 7.5.4
+      ts-api-utils: 1.0.1(typescript@5.1.6)
+      typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@typescript-eslint/parser@5.60.1(eslint@8.43.0)(typescript@5.1.5):
-    resolution: {integrity: sha512-pHWlc3alg2oSMGwsU/Is8hbm3XFbcrb6P5wIxcQW9NsYBfnrubl/GhVVD/Jm/t8HXhA2WncoIRfBtnCgRGV96Q==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+  /@typescript-eslint/parser@6.4.0(eslint@8.47.0)(typescript@5.1.6):
+    resolution: {integrity: sha512-I1Ah1irl033uxjxO9Xql7+biL3YD7w9IU8zF+xlzD/YxY6a4b7DYA08PXUUCbm2sEljwJF6ERFy2kTGAGcNilg==}
+    engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      eslint: ^7.0.0 || ^8.0.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/scope-manager': 5.60.1
-      '@typescript-eslint/types': 5.60.1
-      '@typescript-eslint/typescript-estree': 5.60.1(typescript@5.1.5)
+      '@typescript-eslint/scope-manager': 6.4.0
+      '@typescript-eslint/types': 6.4.0
+      '@typescript-eslint/typescript-estree': 6.4.0(typescript@5.1.6)
+      '@typescript-eslint/visitor-keys': 6.4.0
       debug: 4.3.4
-      eslint: 8.43.0
-      typescript: 5.1.5
+      eslint: 8.47.0
+      typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@typescript-eslint/scope-manager@5.60.1:
-    resolution: {integrity: sha512-Dn/LnN7fEoRD+KspEOV0xDMynEmR3iSHdgNsarlXNLGGtcUok8L4N71dxUgt3YvlO8si7E+BJ5Fe3wb5yUw7DQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+  /@typescript-eslint/scope-manager@6.4.0:
+    resolution: {integrity: sha512-TUS7vaKkPWDVvl7GDNHFQMsMruD+zhkd3SdVW0d7b+7Zo+bd/hXJQ8nsiUZMi1jloWo6c9qt3B7Sqo+flC1nig==}
+    engines: {node: ^16.0.0 || >=18.0.0}
     dependencies:
-      '@typescript-eslint/types': 5.60.1
-      '@typescript-eslint/visitor-keys': 5.60.1
+      '@typescript-eslint/types': 6.4.0
+      '@typescript-eslint/visitor-keys': 6.4.0
     dev: false
 
-  /@typescript-eslint/type-utils@5.60.1(eslint@8.43.0)(typescript@5.1.5):
-    resolution: {integrity: sha512-vN6UztYqIu05nu7JqwQGzQKUJctzs3/Hg7E2Yx8rz9J+4LgtIDFWjjl1gm3pycH0P3mHAcEUBd23LVgfrsTR8A==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+  /@typescript-eslint/type-utils@6.4.0(eslint@8.47.0)(typescript@5.1.6):
+    resolution: {integrity: sha512-TvqrUFFyGY0cX3WgDHcdl2/mMCWCDv/0thTtx/ODMY1QhEiyFtv/OlLaNIiYLwRpAxAtOLOY9SUf1H3Q3dlwAg==}
+    engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
-      eslint: '*'
+      eslint: ^7.0.0 || ^8.0.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.60.1(typescript@5.1.5)
-      '@typescript-eslint/utils': 5.60.1(eslint@8.43.0)(typescript@5.1.5)
+      '@typescript-eslint/typescript-estree': 6.4.0(typescript@5.1.6)
+      '@typescript-eslint/utils': 6.4.0(eslint@8.47.0)(typescript@5.1.6)
       debug: 4.3.4
-      eslint: 8.43.0
-      tsutils: 3.21.0(typescript@5.1.5)
-      typescript: 5.1.5
+      eslint: 8.47.0
+      ts-api-utils: 1.0.1(typescript@5.1.6)
+      typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@typescript-eslint/types@5.60.1:
-    resolution: {integrity: sha512-zDcDx5fccU8BA0IDZc71bAtYIcG9PowaOwaD8rjYbqwK7dpe/UMQl3inJ4UtUK42nOCT41jTSCwg76E62JpMcg==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+  /@typescript-eslint/types@6.4.0:
+    resolution: {integrity: sha512-+FV9kVFrS7w78YtzkIsNSoYsnOtrYVnKWSTVXoL1761CsCRv5wpDOINgsXpxD67YCLZtVQekDDyaxfjVWUJmmg==}
+    engines: {node: ^16.0.0 || >=18.0.0}
     dev: false
 
-  /@typescript-eslint/typescript-estree@5.60.1(typescript@5.1.5):
-    resolution: {integrity: sha512-hkX70J9+2M2ZT6fhti5Q2FoU9zb+GeZK2SLP1WZlvUDqdMbEKhexZODD1WodNRyO8eS+4nScvT0dts8IdaBzfw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+  /@typescript-eslint/typescript-estree@6.4.0(typescript@5.1.6):
+    resolution: {integrity: sha512-iDPJArf/K2sxvjOR6skeUCNgHR/tCQXBsa+ee1/clRKr3olZjZ/dSkXPZjG6YkPtnW6p5D1egeEPMCW6Gn4yLA==}
+    engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
       typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/types': 5.60.1
-      '@typescript-eslint/visitor-keys': 5.60.1
+      '@typescript-eslint/types': 6.4.0
+      '@typescript-eslint/visitor-keys': 6.4.0
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.5.3
-      tsutils: 3.21.0(typescript@5.1.5)
-      typescript: 5.1.5
+      semver: 7.5.4
+      ts-api-utils: 1.0.1(typescript@5.1.6)
+      typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@typescript-eslint/utils@5.60.1(eslint@8.43.0)(typescript@5.1.5):
-    resolution: {integrity: sha512-tiJ7FFdFQOWssFa3gqb94Ilexyw0JVxj6vBzaSpfN/8IhoKkDuSAenUKvsSHw2A/TMpJb26izIszTXaqygkvpQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+  /@typescript-eslint/utils@6.4.0(eslint@8.47.0)(typescript@5.1.6):
+    resolution: {integrity: sha512-BvvwryBQpECPGo8PwF/y/q+yacg8Hn/2XS+DqL/oRsOPK+RPt29h5Ui5dqOKHDlbXrAeHUTnyG3wZA0KTDxRZw==}
+    engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      eslint: ^7.0.0 || ^8.0.0
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@8.43.0)
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.47.0)
       '@types/json-schema': 7.0.12
       '@types/semver': 7.5.0
-      '@typescript-eslint/scope-manager': 5.60.1
-      '@typescript-eslint/types': 5.60.1
-      '@typescript-eslint/typescript-estree': 5.60.1(typescript@5.1.5)
-      eslint: 8.43.0
-      eslint-scope: 5.1.1
-      semver: 7.5.3
+      '@typescript-eslint/scope-manager': 6.4.0
+      '@typescript-eslint/types': 6.4.0
+      '@typescript-eslint/typescript-estree': 6.4.0(typescript@5.1.6)
+      eslint: 8.47.0
+      semver: 7.5.4
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: false
 
-  /@typescript-eslint/visitor-keys@5.60.1:
-    resolution: {integrity: sha512-xEYIxKcultP6E/RMKqube11pGjXH1DCo60mQoWhVYyKfLkwbIVVjYxmOenNMxILx0TjCujPTjjnTIVzm09TXIw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+  /@typescript-eslint/visitor-keys@6.4.0:
+    resolution: {integrity: sha512-yJSfyT+uJm+JRDWYRYdCm2i+pmvXJSMtPR9Cq5/XQs4QIgNoLcoRtDdzsLbLsFM/c6um6ohQkg/MLxWvoIndJA==}
+    engines: {node: ^16.0.0 || >=18.0.0}
     dependencies:
-      '@typescript-eslint/types': 5.60.1
-      eslint-visitor-keys: 3.4.1
+      '@typescript-eslint/types': 6.4.0
+      eslint-visitor-keys: 3.4.3
     dev: false
 
   /@yaireo/tagify@4.17.6(prop-types@15.8.1):
@@ -3181,12 +3182,12 @@ packages:
       acorn-walk: 7.2.0
     dev: false
 
-  /acorn-jsx@5.3.2(acorn@8.9.0):
+  /acorn-jsx@5.3.2(acorn@8.10.0):
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      acorn: 8.9.0
+      acorn: 8.10.0
     dev: false
 
   /acorn-walk@7.2.0:
@@ -3200,14 +3201,14 @@ packages:
     hasBin: true
     dev: false
 
-  /acorn@8.8.1:
-    resolution: {integrity: sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==}
+  /acorn@8.10.0:
+    resolution: {integrity: sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
     dev: false
 
-  /acorn@8.9.0:
-    resolution: {integrity: sha512-jaVNAFBHNLXspO543WnNNPZFRtavh3skAkITqD0/2aeMkKZTN+254PyhwxFYrk3vQ1xfY+2wbesJMs/JC8/PwQ==}
+  /acorn@8.8.1:
+    resolution: {integrity: sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==}
     engines: {node: '>=0.4.0'}
     hasBin: true
     dev: false
@@ -3237,9 +3238,21 @@ packages:
       type-fest: 0.21.3
     dev: false
 
+  /ansi-escapes@5.0.0:
+    resolution: {integrity: sha512-5GFMVX8HqE/TB+FuBJGuO5XG0WrsA6ptUqoODaT/n9mmUaZFkqnBueB4leqGBCmrUHnCnC4PCZTCd0E7QQ83bA==}
+    engines: {node: '>=12'}
+    dependencies:
+      type-fest: 1.4.0
+    dev: false
+
   /ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
+    dev: false
+
+  /ansi-regex@6.0.1:
+    resolution: {integrity: sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==}
+    engines: {node: '>=12'}
     dev: false
 
   /ansi-styles@3.2.1:
@@ -3259,6 +3272,11 @@ packages:
   /ansi-styles@5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
+    dev: false
+
+  /ansi-styles@6.2.1:
+    resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
+    engines: {node: '>=12'}
     dev: false
 
   /anymatch@3.1.3:
@@ -3497,6 +3515,11 @@ packages:
       supports-color: 7.2.0
     dev: false
 
+  /chalk@5.3.0:
+    resolution: {integrity: sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+    dev: false
+
   /char-regex@1.0.2:
     resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
     engines: {node: '>=10'}
@@ -3521,12 +3544,8 @@ packages:
       mithril: github.com/ornicar/mithril.js/d99d36d445fad1b22f4b285963ea065291d99ad4
     dev: false
 
-  /chessground@8.3.11:
-    resolution: {integrity: sha512-t/kL/WK5KOkHx/EGON2/sTkKMLeKfZtg3zDPabzt8HCesYQuWHXcsXIMMKzltc8Tyv5VNXDwKd8d5JeoU++ucA==}
-    dev: false
-
-  /chessground@8.3.13:
-    resolution: {integrity: sha512-H063phgP0OWXNOwu24Zm+HmW8aDCjBobdbZDVM3N3exDZ3cClfttH6nr4vc8XEcNUFt8mM+2L09OZvWtIwaAlA==}
+  /chessground@8.4.0:
+    resolution: {integrity: sha512-0LPdp2Ln/EzeH/T63fDO4Hn9KcSExoMOqkgz3fPjPiY1mSHDBqVuU3drbctHIdorl6hkyQC3qZPMmNHYgZjnsA==}
     dev: false
 
   /chessops@0.12.7:
@@ -3542,6 +3561,21 @@ packages:
 
   /cjs-module-lexer@1.2.2:
     resolution: {integrity: sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==}
+    dev: false
+
+  /cli-cursor@4.0.0:
+    resolution: {integrity: sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      restore-cursor: 4.0.0
+    dev: false
+
+  /cli-truncate@3.1.0:
+    resolution: {integrity: sha512-wfOBkjXteqSnI59oPcJkcPl/ZmwvMMOj340qUIY1SKZCv0B9Cf4D4fAucRkIKQmsIuYK3x1rrgU7MeGRruiuiA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      slice-ansi: 5.0.0
+      string-width: 5.1.2
     dev: false
 
   /cliui@8.0.1:
@@ -3583,11 +3617,20 @@ packages:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
     dev: false
 
+  /colorette@2.0.20:
+    resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
+    dev: false
+
   /combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
     dependencies:
       delayed-stream: 1.0.0
+    dev: false
+
+  /commander@11.0.0:
+    resolution: {integrity: sha512-9HMlXtt/BNoYr8ooyjjNRdIilOTkVJXB+GhxMTtOKwk0R4j4lS4NpjuqmRxroBfnfTSHQIHQB7wryHhXarNjmQ==}
+    engines: {node: '>=16'}
     dev: false
 
   /concat-map@0.0.1:
@@ -3732,6 +3775,10 @@ packages:
     resolution: {integrity: sha512-nMrx/KErHpEkiKZlrghcT/nLWCj8vEJgv6s6TF84gmgn6uROPx2wRvClkcnjSEyvppYY9okOI1DIv573Toql1w==}
     dev: false
 
+  /eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+    dev: false
+
   /electron-to-chromium@1.4.284:
     resolution: {integrity: sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==}
     dev: false
@@ -3743,6 +3790,10 @@ packages:
 
   /emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+    dev: false
+
+  /emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
     dev: false
 
   /error-ex@1.3.2:
@@ -3814,45 +3865,28 @@ packages:
       source-map: 0.6.1
     dev: false
 
-  /eslint-config-prettier@8.8.0(eslint@8.43.0):
-    resolution: {integrity: sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==}
-    hasBin: true
-    peerDependencies:
-      eslint: '>=7.0.0'
-    dependencies:
-      eslint: 8.43.0
-    dev: false
-
-  /eslint-scope@5.1.1:
-    resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
-    engines: {node: '>=8.0.0'}
-    dependencies:
-      esrecurse: 4.3.0
-      estraverse: 4.3.0
-    dev: false
-
-  /eslint-scope@7.2.0:
-    resolution: {integrity: sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==}
+  /eslint-scope@7.2.2:
+    resolution: {integrity: sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       esrecurse: 4.3.0
       estraverse: 5.3.0
     dev: false
 
-  /eslint-visitor-keys@3.4.1:
-    resolution: {integrity: sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==}
+  /eslint-visitor-keys@3.4.3:
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: false
 
-  /eslint@8.43.0:
-    resolution: {integrity: sha512-aaCpf2JqqKesMFGgmRPessmVKjcGXqdlAYLLC3THM8t5nBRZRQ+st5WM/hoJXkdioEXLLbXgclUpM0TXo5HX5Q==}
+  /eslint@8.47.0:
+    resolution: {integrity: sha512-spUQWrdPt+pRVP1TTJLmfRNJJHHZryFmptzcafwSvHsceV81djHOdnEeDmkdotZyLNjDhrOasNK8nikkoG1O8Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     hasBin: true
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@8.43.0)
-      '@eslint-community/regexpp': 4.5.1
-      '@eslint/eslintrc': 2.0.3
-      '@eslint/js': 8.43.0
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.47.0)
+      '@eslint-community/regexpp': 4.6.2
+      '@eslint/eslintrc': 2.1.2
+      '@eslint/js': 8.47.0
       '@humanwhocodes/config-array': 0.11.10
       '@humanwhocodes/module-importer': 1.0.1
       '@nodelib/fs.walk': 1.2.8
@@ -3862,19 +3896,18 @@ packages:
       debug: 4.3.4
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
-      eslint-scope: 7.2.0
-      eslint-visitor-keys: 3.4.1
-      espree: 9.5.2
+      eslint-scope: 7.2.2
+      eslint-visitor-keys: 3.4.3
+      espree: 9.6.1
       esquery: 1.5.0
       esutils: 2.0.3
       fast-deep-equal: 3.1.3
       file-entry-cache: 6.0.1
       find-up: 5.0.0
       glob-parent: 6.0.2
-      globals: 13.20.0
+      globals: 13.21.0
       graphemer: 1.4.0
       ignore: 5.2.4
-      import-fresh: 3.3.0
       imurmurhash: 0.1.4
       is-glob: 4.0.3
       is-path-inside: 3.0.3
@@ -3886,19 +3919,18 @@ packages:
       natural-compare: 1.4.0
       optionator: 0.9.3
       strip-ansi: 6.0.1
-      strip-json-comments: 3.1.1
       text-table: 0.2.0
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /espree@9.5.2:
-    resolution: {integrity: sha512-7OASN1Wma5fum5SrNhFMAMJxOUAbhyfQ8dQ//PJaJbNw0URTPWqIghHWt1MmAANKhHZIYOHruW4Kw4ruUWOdGw==}
+  /espree@9.6.1:
+    resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      acorn: 8.9.0
-      acorn-jsx: 5.3.2(acorn@8.9.0)
-      eslint-visitor-keys: 3.4.1
+      acorn: 8.10.0
+      acorn-jsx: 5.3.2(acorn@8.10.0)
+      eslint-visitor-keys: 3.4.3
     dev: false
 
   /esprima@4.0.1:
@@ -3921,11 +3953,6 @@ packages:
       estraverse: 5.3.0
     dev: false
 
-  /estraverse@4.3.0:
-    resolution: {integrity: sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==}
-    engines: {node: '>=4.0'}
-    dev: false
-
   /estraverse@5.3.0:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
@@ -3934,6 +3961,10 @@ packages:
   /esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+    dev: false
+
+  /eventemitter3@5.0.1:
+    resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
     dev: false
 
   /execa@5.1.1:
@@ -3949,6 +3980,21 @@ packages:
       onetime: 5.1.2
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
+    dev: false
+
+  /execa@7.2.0:
+    resolution: {integrity: sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==}
+    engines: {node: ^14.18.0 || ^16.14.0 || >=18.0.0}
+    dependencies:
+      cross-spawn: 7.0.3
+      get-stream: 6.0.1
+      human-signals: 4.3.1
+      is-stream: 3.0.0
+      merge-stream: 2.0.0
+      npm-run-path: 5.1.0
+      onetime: 6.0.0
+      signal-exit: 3.0.7
+      strip-final-newline: 3.0.0
     dev: false
 
   /exit@0.1.2:
@@ -3984,6 +4030,17 @@ packages:
 
   /fast-glob@3.2.12:
     resolution: {integrity: sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==}
+    engines: {node: '>=8.6.0'}
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.5
+    dev: false
+
+  /fast-glob@3.3.1:
+    resolution: {integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==}
     engines: {node: '>=8.6.0'}
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -4134,8 +4191,8 @@ packages:
     engines: {node: '>=4'}
     dev: false
 
-  /globals@13.20.0:
-    resolution: {integrity: sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==}
+  /globals@13.21.0:
+    resolution: {integrity: sha512-ybyme3s4yy/t/3s35bewwXKOf7cvzfreG2lH0lZl0JB7I4GxRP2ghxOK/Nb9EkRXdbBXZLfq/p/0W2JUONB/Gg==}
     engines: {node: '>=8'}
     dependencies:
       type-fest: 0.20.2
@@ -4147,7 +4204,7 @@ packages:
     dependencies:
       array-union: 2.1.0
       dir-glob: 3.0.1
-      fast-glob: 3.2.12
+      fast-glob: 3.3.1
       ignore: 5.2.4
       merge2: 1.4.1
       slash: 3.0.0
@@ -4155,10 +4212,6 @@ packages:
 
   /graceful-fs@4.2.10:
     resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==}
-    dev: false
-
-  /grapheme-splitter@1.0.4:
-    resolution: {integrity: sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==}
     dev: false
 
   /graphemer@1.4.0:
@@ -4225,6 +4278,11 @@ packages:
   /human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
+    dev: false
+
+  /human-signals@4.3.1:
+    resolution: {integrity: sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==}
+    engines: {node: '>=14.18.0'}
     dev: false
 
   /iconv-lite@0.6.3:
@@ -4298,6 +4356,11 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
+  /is-fullwidth-code-point@4.0.0:
+    resolution: {integrity: sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==}
+    engines: {node: '>=12'}
+    dev: false
+
   /is-generator-fn@2.1.0:
     resolution: {integrity: sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==}
     engines: {node: '>=6'}
@@ -4327,6 +4390,11 @@ packages:
   /is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
+    dev: false
+
+  /is-stream@3.0.0:
+    resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dev: false
 
   /isexe@2.0.0:
@@ -4395,7 +4463,7 @@ packages:
       '@jest/expect': 28.1.3
       '@jest/test-result': 28.1.3
       '@jest/types': 28.1.3
-      '@types/node': 20.3.2
+      '@types/node': 20.5.0
       chalk: 4.1.2
       co: 4.6.0
       dedent: 0.7.0
@@ -4414,7 +4482,7 @@ packages:
       - supports-color
     dev: false
 
-  /jest-cli@28.1.3(@types/node@18.16.18):
+  /jest-cli@28.1.3(@types/node@18.17.5):
     resolution: {integrity: sha512-roY3kvrv57Azn1yPgdTebPAXvdR2xfezaKKYzVxZ6It/5NCxzJym6tUI5P1zkdWhfUYkxEI9uZWcQdaFLo8mJQ==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     hasBin: true
@@ -4431,7 +4499,7 @@ packages:
       exit: 0.1.2
       graceful-fs: 4.2.10
       import-local: 3.1.0
-      jest-config: 28.1.3(@types/node@18.16.18)
+      jest-config: 28.1.3(@types/node@18.17.5)
       jest-util: 28.1.3
       jest-validate: 28.1.3
       prompts: 2.4.2
@@ -4442,7 +4510,7 @@ packages:
       - ts-node
     dev: false
 
-  /jest-config@28.1.3(@types/node@18.16.18):
+  /jest-config@28.1.3(@types/node@18.17.5):
     resolution: {integrity: sha512-MG3INjByJ0J4AsNBm7T3hsuxKQqFIiRo/AUqb1q9LRKI5UU6Aar9JHbr9Ivn1TVwfUD9KirRoM/T6u8XlcQPHQ==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     peerDependencies:
@@ -4457,7 +4525,7 @@ packages:
       '@babel/core': 7.20.5
       '@jest/test-sequencer': 28.1.3
       '@jest/types': 28.1.3
-      '@types/node': 18.16.18
+      '@types/node': 18.17.5
       babel-jest: 28.1.3(@babel/core@7.20.5)
       chalk: 4.1.2
       ci-info: 3.7.0
@@ -4481,7 +4549,7 @@ packages:
       - supports-color
     dev: false
 
-  /jest-config@28.1.3(@types/node@20.3.2):
+  /jest-config@28.1.3(@types/node@20.5.0):
     resolution: {integrity: sha512-MG3INjByJ0J4AsNBm7T3hsuxKQqFIiRo/AUqb1q9LRKI5UU6Aar9JHbr9Ivn1TVwfUD9KirRoM/T6u8XlcQPHQ==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     peerDependencies:
@@ -4496,7 +4564,7 @@ packages:
       '@babel/core': 7.20.5
       '@jest/test-sequencer': 28.1.3
       '@jest/types': 28.1.3
-      '@types/node': 20.3.2
+      '@types/node': 20.5.0
       babel-jest: 28.1.3(@babel/core@7.20.5)
       chalk: 4.1.2
       ci-info: 3.7.0
@@ -4566,7 +4634,7 @@ packages:
       '@jest/fake-timers': 28.1.3
       '@jest/types': 28.1.3
       '@types/jsdom': 16.2.15
-      '@types/node': 20.3.2
+      '@types/node': 20.5.0
       jest-mock: 28.1.3
       jest-util: 28.1.3
       jsdom: 19.0.0
@@ -4584,7 +4652,7 @@ packages:
       '@jest/environment': 28.1.3
       '@jest/fake-timers': 28.1.3
       '@jest/types': 28.1.3
-      '@types/node': 20.3.2
+      '@types/node': 20.5.0
       jest-mock: 28.1.3
       jest-util: 28.1.3
     dev: false
@@ -4605,7 +4673,7 @@ packages:
     dependencies:
       '@jest/types': 28.1.3
       '@types/graceful-fs': 4.1.5
-      '@types/node': 20.3.2
+      '@types/node': 20.5.0
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.10
@@ -4624,7 +4692,7 @@ packages:
     dependencies:
       '@jest/types': 29.3.1
       '@types/graceful-fs': 4.1.5
-      '@types/node': 20.3.2
+      '@types/node': 20.5.0
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.10
@@ -4700,7 +4768,7 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
       '@jest/types': 28.1.3
-      '@types/node': 20.3.2
+      '@types/node': 20.5.0
     dev: false
 
   /jest-mock@29.3.1:
@@ -4708,7 +4776,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.3.1
-      '@types/node': 20.3.2
+      '@types/node': 20.5.0
       jest-util: 29.3.1
     dev: false
 
@@ -4768,7 +4836,7 @@ packages:
       '@jest/test-result': 28.1.3
       '@jest/transform': 28.1.3
       '@jest/types': 28.1.3
-      '@types/node': 20.3.2
+      '@types/node': 20.5.0
       chalk: 4.1.2
       emittery: 0.10.2
       graceful-fs: 4.2.10
@@ -4886,7 +4954,7 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
       '@jest/types': 28.1.3
-      '@types/node': 20.3.2
+      '@types/node': 20.5.0
       chalk: 4.1.2
       ci-info: 3.7.0
       graceful-fs: 4.2.10
@@ -4898,7 +4966,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.3.1
-      '@types/node': 20.3.2
+      '@types/node': 20.5.0
       chalk: 4.1.2
       ci-info: 3.7.0
       graceful-fs: 4.2.10
@@ -4923,7 +4991,7 @@ packages:
     dependencies:
       '@jest/test-result': 28.1.3
       '@jest/types': 28.1.3
-      '@types/node': 20.3.2
+      '@types/node': 20.5.0
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.10.2
@@ -4935,7 +5003,7 @@ packages:
     resolution: {integrity: sha512-CqRA220YV/6jCo8VWvAt1KKx6eek1VIHMPeLEbpcfSfkEeWyBNppynM/o6q+Wmw+sOhos2ml34wZbSX3G13//g==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
-      '@types/node': 20.3.2
+      '@types/node': 20.5.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: false
@@ -4944,13 +5012,13 @@ packages:
     resolution: {integrity: sha512-lY4AnnmsEWeiXirAIA0c9SDPbuCBq8IYuDVL8PMm0MZ2PEs2yPvRA/J64QBXuZp7CYKrDM/rmNrc9/i3KJQncw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@types/node': 20.3.2
+      '@types/node': 20.5.0
       jest-util: 29.3.1
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: false
 
-  /jest@28.1.3(@types/node@18.16.18):
+  /jest@28.1.3(@types/node@18.17.5):
     resolution: {integrity: sha512-N4GT5on8UkZgH0O5LUavMRV1EDEhNTL0KEfRmDIeZHSV7p2XgLoY9t9VDUgL6o+yfdgYHVxuz81G8oB9VG5uyA==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     hasBin: true
@@ -4963,7 +5031,7 @@ packages:
       '@jest/core': 28.1.3
       '@jest/types': 28.1.3
       import-local: 3.1.0
-      jest-cli: 28.1.3(@types/node@18.16.18)
+      jest-cli: 28.1.3(@types/node@18.17.5)
     transitivePeerDependencies:
       - '@types/node'
       - supports-color
@@ -5089,14 +5157,56 @@ packages:
   /lichess-pgn-viewer@1.6.1:
     resolution: {integrity: sha512-rKGRbpqy7xgcQ8S5Wneu86UFuJnsTPyVw0TJYCUHxO/+x5eIN8GF8TCxf2Q/aZ6YR4kec2SLjIBTik4KejHeZw==}
     dependencies:
-      '@types/node': 18.16.18
-      chessground: 8.3.13
+      '@types/node': 18.17.5
+      chessground: 8.4.0
       chessops: 0.12.7
       snabbdom: 3.5.1
     dev: false
 
+  /lilconfig@2.1.0:
+    resolution: {integrity: sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==}
+    engines: {node: '>=10'}
+    dev: false
+
   /lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+    dev: false
+
+  /lint-staged@13.3.0:
+    resolution: {integrity: sha512-mPRtrYnipYYv1FEE134ufbWpeggNTo+O/UPzngoaKzbzHAthvR55am+8GfHTnqNRQVRRrYQLGW9ZyUoD7DsBHQ==}
+    engines: {node: ^16.14.0 || >=18.0.0}
+    hasBin: true
+    dependencies:
+      chalk: 5.3.0
+      commander: 11.0.0
+      debug: 4.3.4
+      execa: 7.2.0
+      lilconfig: 2.1.0
+      listr2: 6.6.1
+      micromatch: 4.0.5
+      pidtree: 0.6.0
+      string-argv: 0.3.2
+      yaml: 2.3.1
+    transitivePeerDependencies:
+      - enquirer
+      - supports-color
+    dev: false
+
+  /listr2@6.6.1:
+    resolution: {integrity: sha512-+rAXGHh0fkEWdXBmX+L6mmfmXmXvDGEKzkjxO+8mP3+nI/r/CWznVBvsibXdxda9Zz0OW2e2ikphN3OwCT/jSg==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      enquirer: '>= 2.3.0 < 3'
+    peerDependenciesMeta:
+      enquirer:
+        optional: true
+    dependencies:
+      cli-truncate: 3.1.0
+      colorette: 2.0.20
+      eventemitter3: 5.0.1
+      log-update: 5.0.1
+      rfdc: 1.3.0
+      wrap-ansi: 8.1.0
     dev: false
 
   /locate-path@5.0.0:
@@ -5125,6 +5235,17 @@ packages:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
     dev: false
 
+  /log-update@5.0.1:
+    resolution: {integrity: sha512-5UtUDQ/6edw4ofyljDNcOVJQ4c7OjDro4h3y8e1GQL5iYElYclVHJ3zeWchylvMaKnDbDilC8irOVyexnA/Slw==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      ansi-escapes: 5.0.0
+      cli-cursor: 4.0.0
+      slice-ansi: 5.0.0
+      strip-ansi: 7.1.0
+      wrap-ansi: 8.1.0
+    dev: false
+
   /loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
@@ -5143,7 +5264,7 @@ packages:
     resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
     engines: {node: '>=8'}
     dependencies:
-      semver: 6.3.0
+      semver: 6.3.1
     dev: false
 
   /make-error@1.3.6:
@@ -5194,6 +5315,11 @@ packages:
     engines: {node: '>=6'}
     dev: false
 
+  /mimic-fn@4.0.0:
+    resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
+    engines: {node: '>=12'}
+    dev: false
+
   /minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
     dependencies:
@@ -5202,10 +5328,6 @@ packages:
 
   /ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
-    dev: false
-
-  /natural-compare-lite@1.4.0:
-    resolution: {integrity: sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==}
     dev: false
 
   /natural-compare@1.4.0:
@@ -5232,6 +5354,13 @@ packages:
       path-key: 3.1.1
     dev: false
 
+  /npm-run-path@5.1.0:
+    resolution: {integrity: sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      path-key: 4.0.0
+    dev: false
+
   /numeral@2.0.6:
     resolution: {integrity: sha512-qaKRmtYPZ5qdw4jWJD6bxEf1FJEqllJrwxCLIm0sQU/A7v2/czigzOb+C2uSiFsa9lBUzeH7M1oK+Q+OLxL3kA==}
     dev: false
@@ -5256,6 +5385,13 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       mimic-fn: 2.1.0
+    dev: false
+
+  /onetime@6.0.0:
+    resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      mimic-fn: 4.0.0
     dev: false
 
   /optionator@0.8.3:
@@ -5355,6 +5491,11 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
+  /path-key@4.0.0:
+    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
+    engines: {node: '>=12'}
+    dev: false
+
   /path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
     dev: false
@@ -5371,6 +5512,12 @@ packages:
   /picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
+    dev: false
+
+  /pidtree@0.6.0:
+    resolution: {integrity: sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==}
+    engines: {node: '>=0.10'}
+    hasBin: true
     dev: false
 
   /pirates@4.0.5:
@@ -5395,9 +5542,9 @@ packages:
     engines: {node: '>= 0.8.0'}
     dev: false
 
-  /prettier@2.8.1:
-    resolution: {integrity: sha512-lqGoSJBQNJidqCHE80vqZJHWHRFoNYsSpP9AjFhlhi9ODCJA541svILes/+/1GM3VaL/abZi7cpFzOpdR9UPKg==}
-    engines: {node: '>=10.13.0'}
+  /prettier@3.0.1:
+    resolution: {integrity: sha512-fcOWSnnpCrovBsmFZIGIy9UqK2FaI7Hqax+DIO0A9UxeVoY4iweyaFjS5TavZN97Hfehph0nhsZnjlVKzEQSrQ==}
+    engines: {node: '>=14'}
     hasBin: true
     dev: false
 
@@ -5608,9 +5755,21 @@ packages:
       supports-preserve-symlinks-flag: 1.0.0
     dev: false
 
+  /restore-cursor@4.0.0:
+    resolution: {integrity: sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      onetime: 5.1.2
+      signal-exit: 3.0.7
+    dev: false
+
   /reusify@1.0.4:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+    dev: false
+
+  /rfdc@1.3.0:
+    resolution: {integrity: sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==}
     dev: false
 
   /rimraf@3.0.2:
@@ -5654,6 +5813,11 @@ packages:
     hasBin: true
     dev: false
 
+  /semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+    dev: false
+
   /semver@7.3.8:
     resolution: {integrity: sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==}
     engines: {node: '>=10'}
@@ -5664,6 +5828,14 @@ packages:
 
   /semver@7.5.3:
     resolution: {integrity: sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      lru-cache: 6.0.0
+    dev: false
+
+  /semver@7.5.4:
+    resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==}
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
@@ -5693,6 +5865,14 @@ packages:
   /slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
+    dev: false
+
+  /slice-ansi@5.0.0:
+    resolution: {integrity: sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      ansi-styles: 6.2.1
+      is-fullwidth-code-point: 4.0.0
     dev: false
 
   /snabbdom@3.5.1:
@@ -5739,6 +5919,11 @@ packages:
     resolution: {integrity: sha512-OTvOlz0ijCSmIb/YvOZ1Dn6vwZVS4Ge3N+RcV0d2b6LXUtCJ9UwmBHypRW3DZ+VXf8WNm7E3P+6jMTVvb3QaBg==}
     dev: false
 
+  /string-argv@0.3.2:
+    resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
+    engines: {node: '>=0.6.19'}
+    dev: false
+
   /string-length@4.0.2:
     resolution: {integrity: sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==}
     engines: {node: '>=10'}
@@ -5756,11 +5941,27 @@ packages:
       strip-ansi: 6.0.1
     dev: false
 
+  /string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.1.0
+    dev: false
+
   /strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
     dependencies:
       ansi-regex: 5.0.1
+    dev: false
+
+  /strip-ansi@7.1.0:
+    resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      ansi-regex: 6.0.1
     dev: false
 
   /strip-bom@4.0.0:
@@ -5771,6 +5972,11 @@ packages:
   /strip-final-newline@2.0.0:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
     engines: {node: '>=6'}
+    dev: false
+
+  /strip-final-newline@3.0.0:
+    resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
+    engines: {node: '>=12'}
     dev: false
 
   /strip-json-comments@3.1.1:
@@ -5928,7 +6134,16 @@ packages:
       punycode: 2.3.0
     dev: false
 
-  /ts-jest@28.0.8(@babel/core@7.20.5)(jest@28.1.3)(typescript@5.1.5):
+  /ts-api-utils@1.0.1(typescript@5.1.6):
+    resolution: {integrity: sha512-lC/RGlPmwdrIBFTX59wwNzqh7aR2otPNPR/5brHZm/XKFYKsfqxihXUe9pU3JI+3vGkl+vyCoNNnPhJn3aLK1A==}
+    engines: {node: '>=16.13.0'}
+    peerDependencies:
+      typescript: '>=4.2.0'
+    dependencies:
+      typescript: 5.1.6
+    dev: false
+
+  /ts-jest@28.0.8(@babel/core@7.20.5)(jest@28.1.3)(typescript@5.1.6):
     resolution: {integrity: sha512-5FaG0lXmRPzApix8oFG8RKjAz4ehtm8yMKOTy5HX3fY6W8kmvOrmcY0hKDElW52FJov+clhUbrKAqofnj4mXTg==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     hasBin: true
@@ -5952,28 +6167,14 @@ packages:
       '@babel/core': 7.20.5
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 28.1.3(@types/node@18.16.18)
+      jest: 28.1.3(@types/node@18.17.5)
       jest-util: 28.1.3
       json5: 2.2.2
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.3.8
-      typescript: 5.1.5
+      typescript: 5.1.6
       yargs-parser: 21.1.1
-    dev: false
-
-  /tslib@1.14.1:
-    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
-    dev: false
-
-  /tsutils@3.21.0(typescript@5.1.5):
-    resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
-    engines: {node: '>= 6'}
-    peerDependencies:
-      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
-    dependencies:
-      tslib: 1.14.1
-      typescript: 5.1.5
     dev: false
 
   /type-check@0.3.2:
@@ -6005,12 +6206,17 @@ packages:
     engines: {node: '>=10'}
     dev: false
 
+  /type-fest@1.4.0:
+    resolution: {integrity: sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==}
+    engines: {node: '>=10'}
+    dev: false
+
   /types-serviceworker@0.0.1:
     resolution: {integrity: sha512-EKO/SZ3AsHEZsqv+bsdlTCz5k955riOksnYGlG6JhVwNTVsPWj/TScTbiNVZ5+mmX8TcEXF0C8aSxUw0jTDpIw==}
     dev: false
 
-  /typescript@5.1.5:
-    resolution: {integrity: sha512-FOH+WN/DQjUvN6WgW+c4Ml3yi0PH+a/8q+kNIfRehv1wLhWONedw85iu+vQ39Wp49IzTJEsZ2lyLXpBF7mkF1g==}
+  /typescript@5.1.6:
+    resolution: {integrity: sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: false
@@ -6166,6 +6372,15 @@ packages:
       strip-ansi: 6.0.1
     dev: false
 
+  /wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      ansi-styles: 6.2.1
+      string-width: 5.1.2
+      strip-ansi: 7.1.0
+    dev: false
+
   /wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
     dev: false
@@ -6220,6 +6435,11 @@ packages:
 
   /yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+    dev: false
+
+  /yaml@2.3.1:
+    resolution: {integrity: sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==}
+    engines: {node: '>= 14'}
     dev: false
 
   /yargs-parser@21.1.1:

--- a/public/javascripts/confetti.js
+++ b/public/javascripts/confetti.js
@@ -195,12 +195,12 @@ var retina = window.devicePixelRatio,
       _g.beginPath();
       _g.moveTo(
         (this.pos.x + this.corners[0].x * this.size) * retina,
-        (this.pos.y + this.corners[0].y * this.size * this.cosA) * retina
+        (this.pos.y + this.corners[0].y * this.size * this.cosA) * retina,
       );
       for (var i = 1; i < 4; i++) {
         _g.lineTo(
           (this.pos.x + this.corners[i].x * this.size) * retina,
-          (this.pos.y + this.corners[i].y * this.size * this.cosA) * retina
+          (this.pos.y + this.corners[i].y * this.size * this.cosA) * retina,
         );
       }
       _g.closePath();
@@ -277,7 +277,7 @@ var retina = window.devicePixelRatio,
         this.particles[i] = new EulerMass(
           this.position.x,
           this.position.y - i * this.particleDist,
-          this.particleDrag
+          this.particleDrag,
         );
       }
     };
@@ -285,11 +285,11 @@ var retina = window.devicePixelRatio,
       for (var i = 0; i < this.particleCount - 1; i++) {
         var p0 = new Vector2(
           this.particles[i].position.x + this.xOff,
-          this.particles[i].position.y + this.yOff
+          this.particles[i].position.y + this.yOff,
         );
         var p1 = new Vector2(
           this.particles[i + 1].position.x + this.xOff,
-          this.particles[i + 1].position.y + this.yOff
+          this.particles[i + 1].position.y + this.yOff,
         );
         if (
           this.Side(
@@ -298,7 +298,7 @@ var retina = window.devicePixelRatio,
             this.particles[i + 1].position.x,
             this.particles[i + 1].position.y,
             p1.x,
-            p1.y
+            p1.y,
           ) < 0
         ) {
           _g.fillStyle = this.frontColor;
@@ -313,7 +313,7 @@ var retina = window.devicePixelRatio,
           _g.lineTo(this.particles[i + 1].position.x * retina, this.particles[i + 1].position.y * retina);
           _g.lineTo(
             (this.particles[i + 1].position.x + p1.x) * 0.5 * retina,
-            (this.particles[i + 1].position.y + p1.y) * 0.5 * retina
+            (this.particles[i + 1].position.y + p1.y) * 0.5 * retina,
           );
           _g.closePath();
           _g.stroke();
@@ -323,7 +323,7 @@ var retina = window.devicePixelRatio,
           _g.lineTo(p0.x * retina, p0.y * retina);
           _g.lineTo(
             (this.particles[i + 1].position.x + p1.x) * 0.5 * retina,
-            (this.particles[i + 1].position.y + p1.y) * 0.5 * retina
+            (this.particles[i + 1].position.y + p1.y) * 0.5 * retina,
           );
           _g.closePath();
           _g.stroke();
@@ -334,7 +334,7 @@ var retina = window.devicePixelRatio,
           _g.lineTo(this.particles[i + 1].position.x * retina, this.particles[i + 1].position.y * retina);
           _g.lineTo(
             (this.particles[i].position.x + p0.x) * 0.5 * retina,
-            (this.particles[i].position.y + p0.y) * 0.5 * retina
+            (this.particles[i].position.y + p0.y) * 0.5 * retina,
           );
           _g.closePath();
           _g.stroke();
@@ -344,7 +344,7 @@ var retina = window.devicePixelRatio,
           _g.lineTo(p0.x * retina, p0.y * retina);
           _g.lineTo(
             (this.particles[i].position.x + p0.x) * 0.5 * retina,
-            (this.particles[i].position.y + p0.y) * 0.5 * retina
+            (this.particles[i].position.y + p0.y) * 0.5 * retina,
           );
           _g.closePath();
           _g.stroke();
@@ -387,7 +387,7 @@ var retina = window.devicePixelRatio,
         ribbonPaperDist,
         ribbonPaperThick,
         45,
-        0.05
+        0.05,
       );
     }
     var confettiPapers = new Array();

--- a/public/javascripts/fipr.js
+++ b/public/javascripts/fipr.js
@@ -163,7 +163,7 @@ window.fipr = (function () {
                 } catch (t) {
                   return n.ERROR;
                 }
-              }
+              },
             ))
           : e.push(n.NOT_AVAILABLE),
         navigator.plugins && (e = e.concat(i(n))),
@@ -286,13 +286,13 @@ window.fipr = (function () {
         a = o.createShader(o.VERTEX_SHADER);
       o.shaderSource(
         a,
-        'attribute vec2 attrVertex;varying vec2 varyinTexCoordinate;uniform vec2 uniformOffset;void main(){varyinTexCoordinate=attrVertex+uniformOffset;gl_Position=vec4(attrVertex,0,1);}'
+        'attribute vec2 attrVertex;varying vec2 varyinTexCoordinate;uniform vec2 uniformOffset;void main(){varyinTexCoordinate=attrVertex+uniformOffset;gl_Position=vec4(attrVertex,0,1);}',
       ),
         o.compileShader(a);
       var i = o.createShader(o.FRAGMENT_SHADER);
       o.shaderSource(
         i,
-        'precision mediump float;varying vec2 varyinTexCoordinate;void main() {gl_FragColor=vec4(varyinTexCoordinate,0,1);}'
+        'precision mediump float;varying vec2 varyinTexCoordinate;void main() {gl_FragColor=vec4(varyinTexCoordinate,0,1);}',
       ),
         o.compileShader(i),
         o.attachShader(r, a),
@@ -328,10 +328,10 @@ window.fipr = (function () {
                 return 0 === n && (n = 2), n;
               }
               return null;
-            })(o)
+            })(o),
         ),
         c.push(
-          'webgl max combined texture image units:' + o.getParameter(o.MAX_COMBINED_TEXTURE_IMAGE_UNITS)
+          'webgl max combined texture image units:' + o.getParameter(o.MAX_COMBINED_TEXTURE_IMAGE_UNITS),
         ),
         c.push('webgl max cube map texture size:' + o.getParameter(o.MAX_CUBE_MAP_TEXTURE_SIZE)),
         c.push('webgl max fragment uniform vectors:' + o.getParameter(o.MAX_FRAGMENT_UNIFORM_VECTORS)),
@@ -588,7 +588,7 @@ window.fipr = (function () {
               navigator.userLanguage ||
               navigator.browserLanguage ||
               navigator.systemLanguage ||
-              t.NOT_AVAILABLE
+              t.NOT_AVAILABLE,
           );
         },
       },
@@ -903,7 +903,7 @@ window.fipr = (function () {
               o[e[0]] !== undefined &&
                 'function' == typeof o[e[0]].setValueAtTime &&
                 o[e[0]].setValueAtTime(e[1], a.currentTime);
-            }
+            },
           ),
             i.connect(o),
             o.connect(a.destination),
@@ -914,7 +914,7 @@ window.fipr = (function () {
               console.warn(
                 'Audio fingerprint timed out. Please report bug at https://github.com/Valve/fingerprintjs2 with your user agent: "' +
                   navigator.userAgent +
-                  '".'
+                  '".',
               ),
               (a.oncomplete = function () {}),
               (a = null),
@@ -1092,5 +1092,5 @@ lichess.load.then(() =>
       };
     if (storage.get()) send(storage.get());
     else fipr.get(c => send(fipr.x64hash128(c.map(x => x.value).join(''), 31)));
-  }, 1000)
+  }, 1000),
 );

--- a/public/javascripts/lag.js
+++ b/public/javascripts/lag.js
@@ -215,7 +215,7 @@ lichess.load.then(() => {
     }),
     function (c) {
       charts.server = c;
-    }
+    },
   );
   Highcharts.chart(
     document.querySelector('.network .meter'),
@@ -224,7 +224,7 @@ lichess.load.then(() => {
     }),
     function (c) {
       charts.network = c;
-    }
+    },
   );
   var values = {
     server: -1,

--- a/public/oops/diagnostics.html
+++ b/public/oops/diagnostics.html
@@ -72,8 +72,8 @@
             253,
             186,
             1,
-            11
-          )
+            11,
+          ),
         ),
         'i32x4.trunc_sat_f64x2_u_zero': WebAssembly.validate(
           Uint8Array.of(
@@ -114,8 +114,8 @@
             253,
             253,
             1,
-            11
-          )
+            11,
+          ),
         ),
       };
 

--- a/public/oops/disabled.html
+++ b/public/oops/disabled.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
@@ -8,7 +8,11 @@
     <style>
       html,
       body {
-        font: 16px Georgia, Times, 'Times New Roman', serif;
+        font:
+          16px Georgia,
+          Times,
+          'Times New Roman',
+          serif;
         font-style: italic;
         background: #000;
         color: #ebd488;

--- a/public/oops/scheduled-maintenance.html
+++ b/public/oops/scheduled-maintenance.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
@@ -7,7 +7,13 @@
     <style>
       body {
         text-align: center;
-        font: 18px 'Noto Sans', 'Lucida Grande', 'Lucida Sans Unicode', Geneva, Verdana, Sans-Serif;
+        font:
+          18px 'Noto Sans',
+          'Lucida Grande',
+          'Lucida Sans Unicode',
+          Geneva,
+          Verdana,
+          Sans-Serif;
         background-color: #181818;
         background-image: linear-gradient(to bottom, #2c2c2c, #181818 116px);
         background-repeat: no-repeat;

--- a/public/oops/servererror.html
+++ b/public/oops/servererror.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
@@ -7,7 +7,11 @@
     <style>
       html,
       body {
-        font: 16px Georgia, Times, 'Times New Roman', serif;
+        font:
+          16px Georgia,
+          Times,
+          'Times New Roman',
+          serif;
         font-style: italic;
         background: #000;
         color: #ebd488;

--- a/public/oops/timeout.html
+++ b/public/oops/timeout.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
@@ -7,7 +7,11 @@
     <style>
       html,
       body {
-        font: 16px Georgia, Times, 'Times New Roman', serif;
+        font:
+          16px Georgia,
+          Times,
+          'Times New Roman',
+          serif;
         font-style: italic;
         background: #000;
         color: #ebd488;
@@ -43,9 +47,12 @@
     <br />
     <img src="//lichess1.org/assets/images/maintenance.jpg" alt="Lichess timeout" />
     <script>
-      setTimeout(function () {
-        location.reload();
-      }, 2000 + Math.round(Math.random() * 10000));
+      setTimeout(
+        function () {
+          location.reload();
+        },
+        2000 + Math.round(Math.random() * 10000),
+      );
     </script>
   </body>
 </html>

--- a/public/oops/toomanyrequests.html
+++ b/public/oops/toomanyrequests.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />

--- a/public/sound/test.html
+++ b/public/sound/test.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
@@ -87,7 +87,7 @@
             .append(
               $('<button>')
                 .on('click', () => playSound(soundSet, name))
-                .text(name)
+                .text(name),
             )
             .appendTo(tr);
         });
@@ -104,7 +104,7 @@
           .append(
             $('<button>')
               .on('click', () => lichess.sound.play(sound))
-              .text(name)
+              .text(name),
           )
           .appendTo(tr);
       });

--- a/ui/@build/src/main.ts
+++ b/ui/@build/src/main.ts
@@ -174,8 +174,8 @@ class Env {
       console.log(
         `${prefix ? prefix + ' - ' : ''}${
           error ? esc(line, codes.error) : warn ? esc(line, codes.warn) : line
-        }`
-      )
+        }`,
+      ),
     );
   }
   done(code: number, ctx: 'sass' | 'tsc' | 'esbuild'): void {
@@ -188,7 +188,7 @@ class Env {
         (this.watch ? ` - ${colors.grey('Watching')}...` : ''),
       {
         ctx: ctx,
-      }
+      },
     );
 
     if (allDone) {

--- a/ui/@build/src/parse.ts
+++ b/ui/@build/src/parse.ts
@@ -47,7 +47,7 @@ async function parseModule(moduleDir: string): Promise<LichessModule> {
       if (moduleType !== 'esm' && moduleType !== 'iife') {
         env.log(
           c.warn('WARNING') +
-            ` - Unsupported module type '${c.cyan(moduleType)}' in '${c.cyan(mod.name + '/package.json')}'`
+            ` - Unsupported module type '${c.cyan(moduleType)}' in '${c.cyan(mod.name + '/package.json')}'`,
         );
         continue;
       }

--- a/ui/@build/src/sass.ts
+++ b/ui/@build/src/sass.ts
@@ -20,7 +20,7 @@ export async function sass(): Promise<void> {
 
   // filter to modules we're actually building
   builder.sources = new Set<string>(
-    allSources.filter(x => modNames.find(y => x.startsWith(`${y}${path.sep}`)))
+    allSources.filter(x => modNames.find(y => x.startsWith(`${y}${path.sep}`))),
   );
 
   for (const build of builder.sources) {
@@ -79,7 +79,7 @@ async function buildThemedScss() {
   env.log('Building themed scss', { ctx: 'sass' });
 
   const partials: string[] = (await globArray('./*/css/build/_*.scss', { abs: false })).filter(
-    (f: string) => !f.endsWith('.abstract.scss')
+    (f: string) => !f.endsWith('.abstract.scss'),
   );
   for (const file of partials) {
     const match = partialRe.exec(file);
@@ -124,10 +124,10 @@ function compile(sources: string[], tellTheWorld = true) {
         (src: string) =>
           `${src}:${path.join(
             env.cssDir,
-            path.basename(src).replace(/(.*)scss$/, env.prod ? '$1min.css' : '$1dev.css')
-          )}`
-      )
-    )
+            path.basename(src).replace(/(.*)scss$/, env.prod ? '$1min.css' : '$1dev.css'),
+          )}`,
+      ),
+    ),
   );
 
   proc.stdout?.on('data', (buf: Buffer) => {

--- a/ui/@build/src/tsc.ts
+++ b/ui/@build/src/tsc.ts
@@ -16,7 +16,7 @@ export async function tsc(): Promise<void> {
 
     const tsc = cps.spawn(
       'tsc',
-      ['-b', cfgPath].concat(env.watch ? ['-w', '--preserveWatchOutput'] : ['--force'])
+      ['-b', cfgPath].concat(env.watch ? ['-w', '--preserveWatchOutput'] : ['--force']),
     );
 
     env.log(`Checking typescript`, { ctx: 'tsc' });

--- a/ui/@types/cash/index.d.ts
+++ b/ui/@types/cash/index.d.ts
@@ -1,12 +1,8 @@
-interface Cash {
-  [index: number]: EleLoose | undefined;
-  length: number;
-  splice(start: number, deleteCount?: number): EleLoose[];
-  splice(start: number, deleteCount: number, ...items: Ele[]): EleLoose[];
-}
-interface CashStatic {
-  fn: Cash;
-}
+declare const cash: ((selector?: Selector, context?: Context | Cash) => Cash) & CashStatic;
+
+declare type MapCallback<T> = (this: T, index: number, ele: T) => Ele;
+declare type EachCallback<T> = (this: T, index: number, ele: T) => any;
+
 declare type falsy = undefined | null | false | 0 | '';
 declare type Ele = Window | Document | HTMLElement | Element | Node;
 declare type EleLoose = HTMLElement & Element & Node;
@@ -14,129 +10,74 @@ declare type EleLoose = HTMLElement & Element & Node;
 declare type Selector = falsy | string | HTMLCollection | NodeList | Ele | Ele[] | ArrayLike<Ele> | Cash;
 declare type Comparator = string | Ele | Cash | ((this: EleLoose, index: number, ele: EleLoose) => boolean);
 declare type Context = Document | HTMLElement | Element;
-declare type EventCallback = {
-  (event: any, data?: any): any;
-  guid?: number;
-};
-interface Cash {
-  init(selector?: Selector, context?: Context | Cash): Cash;
-}
-declare const cash: ((selector?: Selector, context?: Context | Cash) => Cash) & CashStatic;
-declare type MapCallback<T> = (this: T, index: number, ele: T) => Ele;
-interface Cash {
-  map(callback: MapCallback<EleLoose>): Cash;
-}
-interface Cash {
-  slice(start?: number, end?: number): Cash;
-}
-declare type EachCallback<T> = (this: T, index: number, ele: T) => any;
+declare type EventCallback = { (event: any, data?: any): any; guid?: number };
+
 interface CashStatic {
+  fn: Cash;
+  unique<T>(arr: ArrayLike<T>): ArrayLike<T>;
   each<T>(arr: ArrayLike<T>, callback: EachCallback<T>): void;
-}
-interface Cash {
-  each(callback: EachCallback<EleLoose>): this;
-}
-interface Cash {
-  removeProp(prop: string): this;
-}
-interface CashStatic {
   guid: number;
-}
-interface CashStatic {
   isWindow(x: any): x is Window;
   // eslint-disable-next-line @typescript-eslint/ban-types
   isFunction(x: any): x is Function;
   isNumeric(x: any): boolean;
   isArray(x: any): x is Array<any>;
+  parseHTML(html: string): EleLoose[];
 }
-interface Cash {
+
+declare class Cash {
+  length: number;
+  constructor(selector?: Selector, context?: Context | Cash);
+  init(selector?: Selector, context?: Context | Cash): Cash;
+  [index: number]: EleLoose | undefined;
+  splice(start: number, deleteCount?: number): EleLoose[];
+  splice(start: number, deleteCount: number, ...items: Ele[]): EleLoose[];
+  slice(start?: number, end?: number): Cash;
+  map(callback: MapCallback<EleLoose>): Cash;
+  each(callback: EachCallback<EleLoose>): this;
+  removeProp(prop: string): this;
   prop(prop: string): any;
   prop(prop: string, value: any): this;
   prop(props: Record<string, any>): this;
-}
-interface Cash {
   get(): EleLoose[];
   get(index: number): EleLoose | undefined;
-}
-interface Cash {
   eq(index: number): Cash;
-}
-interface Cash {
   first(): Cash;
-}
-interface Cash {
   last(): Cash;
-}
-interface Cash {
   filter(comparator?: Comparator): Cash;
-}
-interface Cash {
   hasClass(cls: string): boolean;
-}
-interface Cash {
   removeAttr(attrs: string): this;
-}
-interface Cash {
   attr(): undefined;
   attr(attrs: string): string | null;
   attr(attrs: string, value: string): this;
   attr(attrs: Record<string, string>): this;
-}
-interface Cash {
   toggleClass(classes: string, force?: boolean): this;
-}
-interface Cash {
   addClass(classes: string): this;
-}
-interface Cash {
   removeClass(classes?: string): this;
-}
-interface CashStatic {
-  unique<T>(arr: ArrayLike<T>): ArrayLike<T>;
-}
-interface Cash {
   add(selector: Selector, context?: Context): Cash;
-}
-interface Cash {
   css(prop: string): string | undefined;
   css(prop: string, value: number | string): this;
   css(props: Record<string, number | string>): this;
-}
-interface Cash {
   data(): Record<string, any> | undefined;
   data(name: string): any;
   data(name: string, value: any): this;
   data(datas: Record<string, any>): this;
-}
-interface Cash {
   innerWidth(): number | undefined;
   innerHeight(): number | undefined;
   outerWidth(includeMargins?: boolean): number;
   outerHeight(includeMargins?: boolean): number;
-}
-interface Cash {
   width(): number;
   width(value: number | string): this;
   height(): number;
   height(value: number | string): this;
-}
-interface Cash {
   toggle(force?: boolean): this;
-}
-interface Cash {
   hide(): this;
-}
-interface Cash {
   show(): this;
-}
-interface Cash {
   off(): this;
   off(events: string): this;
   off(events: Record<string, EventCallback>): this;
   off(events: string, callback: EventCallback): this;
   off(events: string, selector: string, callback: EventCallback): this;
-}
-interface Cash {
   on(events: Record<string, EventCallback>): this;
   on(events: Record<string, EventCallback>, selector: string): this;
   on(events: Record<string, EventCallback>, data: any): this;
@@ -151,8 +92,6 @@ interface Cash {
     callback: EventCallback,
     _one?: boolean,
   ): this;
-}
-interface Cash {
   one(events: Record<string, EventCallback>): this;
   one(events: Record<string, EventCallback>, selector: string): this;
   one(events: Record<string, EventCallback>, data: any): this;
@@ -161,154 +100,53 @@ interface Cash {
   one(events: string, selector: string, callback: EventCallback): this;
   one(events: string, data: any, callback: EventCallback): this;
   one(events: string, selector: string | null | undefined, data: any, callback: EventCallback): this;
-}
-interface Cash {
   // eslint-disable-next-line @typescript-eslint/ban-types
   ready(callback: Function): this;
-}
-interface Cash {
   trigger(event: Event | string, data?: any): this;
-}
-interface Cash {
   val(): string | string[];
   val(value: string | string[]): this;
-}
-interface Cash {
   clone(): this;
-}
-interface Cash {
   detach(comparator?: Comparator): this;
-}
-interface CashStatic {
-  parseHTML(html: string): EleLoose[];
-}
-interface Cash {
   empty(): this;
-}
-interface Cash {
   html(): string;
   html(html: string): this;
-}
-interface Cash {
   remove(comparator?: Comparator): this;
-}
-interface Cash {
   text(): string;
   text(text: string): this;
-}
-interface Cash {
   unwrap(): this;
-}
-interface Cash {
-  offset():
-    | undefined
-    | {
-        top: number;
-        left: number;
-      };
-}
-interface Cash {
+  offset(): undefined | { top: number; left: number };
   offsetParent(): Cash;
-}
-interface Cash {
-  position():
-    | undefined
-    | {
-        top: number;
-        left: number;
-      };
-}
-interface Cash {
+  position(): undefined | { top: number; left: number };
   children(comparator?: Comparator): Cash;
-}
-interface Cash {
   contents(): Cash;
-}
-interface Cash {
   find(selector: string): Cash;
-}
-interface Cash {
   after(...selectors: Selector[]): this;
-}
-interface Cash {
   append(...selectors: Selector[]): this;
-}
-interface Cash {
   appendTo(selector: Selector): this;
-}
-interface Cash {
   before(...selectors: Selector[]): this;
-}
-interface Cash {
   insertAfter(selector: Selector): this;
-}
-interface Cash {
   insertBefore(selector: Selector): this;
-}
-interface Cash {
   prepend(...selectors: Selector[]): this;
-}
-interface Cash {
   prependTo(selector: Selector): this;
-}
-interface Cash {
   replaceWith(selector: Selector): this;
-}
-interface Cash {
   replaceAll(selector: Selector): this;
-}
-interface Cash {
   wrapAll(selector?: Selector): this;
-}
-interface Cash {
   wrap(selector?: Selector): this;
-}
-interface Cash {
   wrapInner(selector?: Selector): this;
-}
-interface Cash {
   has(selector: string | Node): Cash;
-}
-interface Cash {
   is(comparator?: Comparator): boolean;
-}
-interface Cash {
   next(comparator?: Comparator, _all?: boolean, _until?: Comparator): Cash;
-}
-interface Cash {
   nextAll(comparator?: Comparator): Cash;
-}
-interface Cash {
   nextUntil(until?: Comparator, comparator?: Comparator): Cash;
-}
-interface Cash {
   not(comparator?: Comparator): Cash;
-}
-interface Cash {
   parent(comparator?: Comparator): Cash;
-}
-interface Cash {
   index(selector?: Selector): number;
-}
-interface Cash {
   closest(comparator?: Comparator): Cash;
-}
-interface Cash {
   parents(comparator?: Comparator, _until?: Comparator): Cash;
-}
-interface Cash {
   parentsUntil(until?: Comparator, comparator?: Comparator): Cash;
-}
-interface Cash {
   prev(comparator?: Comparator, _all?: boolean, _until?: Comparator): Cash;
-}
-interface Cash {
   prevAll(comparator?: Comparator): Cash;
-}
-interface Cash {
   prevUntil(until?: Comparator, comparator?: Comparator): Cash;
-}
-interface Cash {
   siblings(comparator?: Comparator): Cash;
 }
 /* hacks */

--- a/ui/@types/cash/index.d.ts
+++ b/ui/@types/cash/index.d.ts
@@ -18,8 +18,7 @@ declare type EventCallback = {
   (event: any, data?: any): any;
   guid?: number;
 };
-declare class Cash {
-  constructor(selector?: Selector, context?: Context | Cash);
+interface Cash {
   init(selector?: Selector, context?: Context | Cash): Cash;
 }
 declare const cash: ((selector?: Selector, context?: Context | Cash) => Cash) & CashStatic;

--- a/ui/@types/cash/index.d.ts
+++ b/ui/@types/cash/index.d.ts
@@ -150,7 +150,7 @@ interface Cash {
     selector: string | null | undefined,
     data: any,
     callback: EventCallback,
-    _one?: boolean
+    _one?: boolean,
   ): this;
 }
 interface Cash {

--- a/ui/@types/lichess/index.d.ts
+++ b/ui/@types/lichess/index.d.ts
@@ -78,7 +78,7 @@ interface LichessMousetrap {
   bind(
     keys: string | string[],
     callback: (e: KeyboardEvent) => void,
-    action?: 'keypress' | 'keydown' | 'keyup'
+    action?: 'keypress' | 'keydown' | 'keyup',
   ): LichessMousetrap;
 }
 
@@ -230,7 +230,7 @@ declare namespace Voice {
         partial?: boolean; // = false
         listener?: Listener; // = undefined
         listenerId?: string; // = recId (specify for multiple listeners on same recId)
-      }
+      },
     ): void;
     setRecognizer(recId: string): void;
 
@@ -239,7 +239,7 @@ declare namespace Voice {
       also?: {
         recId?: string; // = 'default'
         listenerId?: string; // = recId
-      }
+      },
     ): void;
     removeListener(listenerId: string): void;
     setController(listener: Listener): void; // for status display, indicators, etc

--- a/ui/analyse/src/autoShape.ts
+++ b/ui/analyse/src/autoShape.ts
@@ -20,7 +20,7 @@ export function makeShapesFromUci(
   color: Color,
   uci: Uci,
   brush: string,
-  modifiers?: DrawModifiers
+  modifiers?: DrawModifiers,
 ): DrawShape[] {
   if (uci === 'Current Position') return [];
   const move = parseUci(uci)!;
@@ -100,7 +100,7 @@ export function compute(ctrl: AnalyseCtrl): DrawShape[] {
             shapes = shapes.concat(
               makeShapesFromUci(color, pv.moves[0], 'paleGrey', {
                 lineWidth: Math.round(12 - shift * 50), // 12 to 2
-              })
+              }),
             );
           }
         });
@@ -118,7 +118,7 @@ export function compute(ctrl: AnalyseCtrl): DrawShape[] {
         shapes = shapes.concat(
           makeShapesFromUci(rcolor, pv.moves[0], 'paleRed', {
             lineWidth: Math.round(11 - shift * 45), // 11 to 2
-          })
+          }),
         );
       }
     });

--- a/ui/analyse/src/crazy/crazyCtrl.ts
+++ b/ui/analyse/src/crazy/crazyCtrl.ts
@@ -20,7 +20,7 @@ export function valid(
   chessground: ChessgroundApi,
   possibleDrops: string | undefined | null,
   piece: cg.Piece,
-  pos: Key
+  pos: Key,
 ): boolean {
   if (piece.color !== chessground.state.movable.color) return false;
 

--- a/ui/analyse/src/crazy/crazyView.ts
+++ b/ui/analyse/src/crazy/crazyView.ts
@@ -43,9 +43,9 @@ export default function (ctrl: AnalyseCtrl, color: Color, position: Position) {
               'data-color': color,
               'data-nb': nb,
             },
-          })
-        )
+          }),
+        ),
       );
-    })
+    }),
   );
 }

--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -122,7 +122,11 @@ export default class AnalyseCtrl {
   nvui?: NvuiPlugin;
   pvUciQueue: Uci[] = [];
 
-  constructor(readonly opts: AnalyseOpts, readonly redraw: Redraw, makeStudy?: typeof makeStudyCtrl) {
+  constructor(
+    readonly opts: AnalyseOpts,
+    readonly redraw: Redraw,
+    makeStudy?: typeof makeStudyCtrl,
+  ) {
     this.data = opts.data;
     this.element = opts.element;
     this.trans = opts.trans;
@@ -130,7 +134,7 @@ export default class AnalyseCtrl {
     this.promotion = new PromotionCtrl(
       this.withCg,
       () => this.withCg(g => g.set(this.cgConfig)),
-      this.redraw
+      this.redraw,
     );
 
     if (this.data.forecast) this.forecast = new ForecastCtrl(this.data.forecast, this.data, redraw);
@@ -183,7 +187,7 @@ export default class AnalyseCtrl {
     });
 
     lichess.pubsub.on('ply.trigger', () =>
-      lichess.pubsub.emit('ply', this.node.ply, this.tree.lastMainlineNode(this.path).ply === this.node.ply)
+      lichess.pubsub.emit('ply', this.node.ply, this.tree.lastMainlineNode(this.path).ply === this.node.ply),
     );
     lichess.pubsub.on('analysis.chart.click', index => {
       this.jumpToIndex(index);
@@ -582,7 +586,7 @@ export default class AnalyseCtrl {
         'Delete ' +
           plural('move', count.nodes) +
           (count.comments ? ' and ' + plural('comment', count.comments) : '') +
-          '?'
+          '?',
       )
     )
       return;
@@ -687,7 +691,7 @@ export default class AnalyseCtrl {
   outcome(node?: Tree.Node): Outcome | undefined {
     return this.position(node || this.node).unwrap(
       pos => pos.outcome(),
-      _ => undefined
+      _ => undefined,
     );
   }
 
@@ -830,7 +834,7 @@ export default class AnalyseCtrl {
     if (data.analysis)
       data.analysis.partial = !!treeOps.findInMainline(
         data.tree,
-        n => !n.eval && !!n.children.length && n.ply <= 300
+        n => !n.eval && !!n.children.length && n.ply <= 300,
       );
     if (data.division) this.data.game.division = data.division;
     if (this.retro) this.retro.onMergeAnalysisData();
@@ -850,7 +854,7 @@ export default class AnalyseCtrl {
         makeSquare(move.from),
         to,
         capture && piece && capture.color !== piece.color ? capture : undefined,
-        move.promotion
+        move.promotion,
       );
     } else
       this.chessground.newPiece(
@@ -858,7 +862,7 @@ export default class AnalyseCtrl {
           color: this.chessground.state.movable.color as Color,
           role: move.role,
         },
-        to
+        to,
       );
   }
 

--- a/ui/analyse/src/explorer/explorerConfig.ts
+++ b/ui/analyse/src/explorer/explorerConfig.ts
@@ -52,11 +52,11 @@ export class ExplorerConfigCtrl {
     readonly root: AnalyseCtrl,
     readonly variant: VariantKey,
     readonly onClose: () => void,
-    previous?: ExplorerConfigCtrl
+    previous?: ExplorerConfigCtrl,
   ) {
     this.myName = document.body.dataset['user'];
     this.participants = [root.data.player.user?.username, root.data.opponent.user?.username].filter(
-      name => name && name != this.myName
+      name => name && name != this.myName,
     );
     if (variant === 'standard') this.allDbs.unshift('masters');
     const byDbData = {} as ByDbSettings;
@@ -73,7 +73,7 @@ export class ExplorerConfigCtrl {
         'explorer.db2.' + variant,
         this.allDbs[0],
         str => str as ExplorerDb,
-        v => v
+        v => v,
       ),
       rating: storedJsonProp('analyse.explorer.rating', () => allRatings.slice(1)),
       speed: storedJsonProp<ExplorerSpeed[]>('explorer.speed', () => allSpeeds.slice(1)),
@@ -144,8 +144,8 @@ export function view(ctrl: ExplorerConfigCtrl): VNode[] {
           attrs: dataIcon(licon.Checkmark),
           hook: bind('click', ctrl.toggleOpen),
         },
-        ctrl.root.trans.noarg('allSet')
-      )
+        ctrl.root.trans.noarg('allSet'),
+      ),
     ),
   ];
 }
@@ -167,8 +167,8 @@ const playerDb = (ctrl: ExplorerConfigCtrl) => {
               hook: bind('click', () => ctrl.data.playerName.open(true), ctrl.root.redraw),
               attrs: name ? { title: selectText } : undefined,
             },
-            name || selectText
-          )
+            name || selectText,
+          ),
         ),
         h(
           'button.button-link.text.color',
@@ -176,7 +176,7 @@ const playerDb = (ctrl: ExplorerConfigCtrl) => {
             attrs: dataIcon(licon.ChasingArrows),
             hook: bind('click', ctrl.toggleColor, ctrl.root.redraw),
           },
-          ' ' + ctrl.root.trans(ctrl.data.color() == 'white' ? 'asWhite' : 'asBlack')
+          ' ' + ctrl.root.trans(ctrl.data.color() == 'white' ? 'asWhite' : 'asBlack'),
         ),
       ]),
     ]),
@@ -209,7 +209,7 @@ const radioButton =
         attrs: { 'aria-pressed': `${storage().includes(v)}`, title: render ? ucfirst('' + v) : '' },
         hook: bind('click', _ => ctrl.toggleMany(storage)(v), ctrl.root.redraw),
       },
-      render ? render(v) : ctrl.root.trans.noarg('' + v)
+      render ? render(v) : ctrl.root.trans.noarg('' + v),
     );
 
 const lichessDb = (ctrl: ExplorerConfigCtrl) =>
@@ -338,7 +338,7 @@ const playerModal = (ctrl: ExplorerConfigCtrl) => {
                 tag: 'span',
                 onSelect: v => onSelect(v.name),
               })
-              .then(() => input.focus())
+              .then(() => input.focus()),
           ),
         }),
       ]),
@@ -351,9 +351,9 @@ const playerModal = (ctrl: ExplorerConfigCtrl) => {
               {
                 hook: bind('click', () => onSelect(name)),
               },
-              name
-            )
-        )
+              name,
+            ),
+        ),
       ),
     ],
   });

--- a/ui/analyse/src/explorer/explorerCtrl.ts
+++ b/ui/analyse/src/explorer/explorerCtrl.ts
@@ -60,7 +60,11 @@ export default class ExplorerCtrl {
   private abortController: AbortController | undefined;
   private cache: Dictionary<ExplorerData> = {};
 
-  constructor(readonly root: AnalyseCtrl, readonly opts: ExplorerOpts, previous?: ExplorerCtrl) {
+  constructor(
+    readonly root: AnalyseCtrl,
+    readonly opts: ExplorerOpts,
+    previous?: ExplorerCtrl,
+  ) {
     this.allowed = prop(previous ? previous.allowed() : true);
     this.enabled = storedBooleanProp('analyse.explorer.enabled', false);
     this.withGames = root.synthetic || gameUtil.replayable(root.data) || !!root.data.opponent.ai;
@@ -134,16 +138,16 @@ export default class ExplorerCtrl {
                 withGames: this.withGames,
               },
               processData,
-              this.abortController.signal
+              this.abortController.signal,
             )
             .catch(onError)
-            .then(_ => true)
+            .then(_ => true),
         );
         this.lastStream.promise.then(() => this.root.redraw());
       }
     },
     250,
-    true
+    true,
   );
 
   private empty: OpeningData = {
@@ -213,7 +217,7 @@ export default class ExplorerCtrl {
         play: [],
         fen,
       },
-      deferred.resolve
+      deferred.resolve,
     );
     return await deferred.promise;
   };

--- a/ui/analyse/src/explorer/explorerUtil.ts
+++ b/ui/analyse/src/explorer/explorerUtil.ts
@@ -28,7 +28,7 @@ export const moveArrowAttributes = (ctrl: AnalyseCtrl, opts: MoveArrowOpts) => (
           $(el).attr('data-fen')!,
           $(e.target as HTMLElement)
             .parents('tr')
-            .attr('data-uci')
+            .attr('data-uci'),
         );
       });
       el.addEventListener('mouseout', _ => {

--- a/ui/analyse/src/explorer/explorerView.ts
+++ b/ui/analyse/src/explorer/explorerView.ts
@@ -27,7 +27,7 @@ function resultBar(move: OpeningMoveStats): VNode {
       {
         attrs: { style: 'width: ' + Math.round((move[key] * 1000) / sum) / 10 + '%' },
       },
-      percent > 12 ? Math.round(percent) + (percent > 20 ? '%' : '') : ''
+      percent > 12 ? Math.round(percent) + (percent > 20 ? '%' : '') : '',
     );
   };
   return h('div.bar', ['white', 'draws', 'black'].map(section));
@@ -77,9 +77,9 @@ function showMoveTable(ctrl: AnalyseCtrl, data: OpeningData): VNode | null {
             h('td', ((total / sumTotal) * 100).toFixed(0) + '%'),
             h('td', numberFormat(total)),
             h('td', { attrs: { title: moveTooltip(ctrl, move) } }, resultBar(move)),
-          ]
+          ],
         );
-      })
+      }),
     ),
   ]);
 }
@@ -141,12 +141,12 @@ function showGameTable(ctrl: AnalyseCtrl, fen: Fen, title: string, games: Openin
                 ctrl.explorer.opts.showRatings
                   ? h(
                       'td',
-                      [game.white, game.black].map(p => h('span', '' + p.rating))
+                      [game.white, game.black].map(p => h('span', '' + p.rating)),
                     )
                   : null,
                 h(
                   'td',
-                  [game.white, game.black].map(p => h('span', p.name))
+                  [game.white, game.black].map(p => h('span', p.name)),
                 ),
                 h('td', showResult(game.winner)),
                 h('td', game.month || game.year),
@@ -160,11 +160,11 @@ function showGameTable(ctrl: AnalyseCtrl, fen: Fen, title: string, games: Openin
                             title: ucfirst(game.speed),
                             ...dataIcon(perf.icons[game.speed]),
                           },
-                        })
+                        }),
                     ),
-              ]
+              ],
             );
-      })
+      }),
     ),
   ]);
 }
@@ -197,7 +197,7 @@ function gameActions(ctrl: AnalyseCtrl, game: OpeningGame): VNode {
         [
           h(
             'div.game_title',
-            `${game.white.name} - ${game.black.name}, ${showResult(game.winner).text}, ${game.year}`
+            `${game.white.name} - ${game.black.name}, ${showResult(game.winner).text}, ${game.year}`,
           ),
           h('div.menu', [
             h(
@@ -206,7 +206,7 @@ function gameActions(ctrl: AnalyseCtrl, game: OpeningGame): VNode {
                 attrs: dataIcon(licon.Eye),
                 hook: bind('click', _ => openGame(ctrl, game.id)),
               },
-              'View'
+              'View',
             ),
             ...(ctrl.study
               ? [
@@ -216,7 +216,7 @@ function gameActions(ctrl: AnalyseCtrl, game: OpeningGame): VNode {
                       attrs: dataIcon(licon.BubbleSpeech),
                       hook: bind('click', _ => send(false), ctrl.redraw),
                     },
-                    'Cite'
+                    'Cite',
                   ),
                   h(
                     'a.text',
@@ -224,7 +224,7 @@ function gameActions(ctrl: AnalyseCtrl, game: OpeningGame): VNode {
                       attrs: dataIcon(licon.PlusButton),
                       hook: bind('click', _ => send(true), ctrl.redraw),
                     },
-                    'Insert'
+                    'Insert',
                   ),
                 ]
               : []),
@@ -234,12 +234,12 @@ function gameActions(ctrl: AnalyseCtrl, game: OpeningGame): VNode {
                 attrs: dataIcon(licon.X),
                 hook: bind('click', _ => ctrl.explorer.gameMenu(null), ctrl.redraw),
               },
-              'Close'
+              'Close',
             ),
           ]),
-        ]
+        ],
       ),
-    ]
+    ],
   );
 }
 
@@ -250,7 +250,7 @@ const closeButton = (ctrl: AnalyseCtrl): VNode =>
       attrs: dataIcon(licon.X),
       hook: bind('click', ctrl.toggleExplorer, ctrl.redraw),
     },
-    ctrl.trans.noarg('close')
+    ctrl.trans.noarg('close'),
   );
 
 const showEmpty = (ctrl: AnalyseCtrl, data?: OpeningData): VNode =>
@@ -260,7 +260,7 @@ const showEmpty = (ctrl: AnalyseCtrl, data?: OpeningData): VNode =>
     h('div.message', [
       h(
         'strong',
-        ctrl.trans.noarg(ctrl.explorer.root.node.ply >= MAX_DEPTH ? 'maxDepthReached' : 'noGameFound')
+        ctrl.trans.noarg(ctrl.explorer.root.node.ply >= MAX_DEPTH ? 'maxDepthReached' : 'noGameFound'),
       ),
       data?.queuePosition
         ? h('p.explanation', `Indexing ${data.queuePosition} other players first ...`)
@@ -298,10 +298,10 @@ const openingTitle = (ctrl: AnalyseCtrl, data?: OpeningData) => {
                 target: '_blank',
               },
             },
-            title
+            title,
           ),
         ]
-      : [showTitle(ctrl, ctrl.data.game.variant)]
+      : [showTitle(ctrl, ctrl.data.game.variant)],
   );
 };
 
@@ -333,7 +333,7 @@ function show(ctrl: AnalyseCtrl): MaybeVNode {
         data.fen,
         trans(title),
         tooltip && trans(tooltip),
-        data.moves.filter(m => m.category == category)
+        data.moves.filter(m => m.category == category),
       );
     if (data.moves.length)
       lastShow = h('div.data', [
@@ -364,7 +364,7 @@ const explorerTitle = (explorer: ExplorerCtrl) => {
         attrs: { title },
         hook: bind('click', () => explorer.config.data.db(name.toLowerCase() as ExplorerDb), explorer.reload),
       },
-      name
+      name,
     );
   const playerLink = () =>
     h(
@@ -380,10 +380,10 @@ const explorerTitle = (explorer: ExplorerCtrl) => {
               explorer.config.data.open(true);
             }
           },
-          explorer.reload
+          explorer.reload,
         ),
       },
-      explorer.root.trans('player')
+      explorer.root.trans('player'),
     );
   const active = (nodes: MaybeVNodes, title: string) =>
     h(
@@ -392,7 +392,7 @@ const explorerTitle = (explorer: ExplorerCtrl) => {
         attrs: { title, ...dataIcon(licon.Book) },
         hook: db == 'player' ? bind('click', explorer.config.toggleColor, explorer.reload) : undefined,
       },
-      nodes
+      nodes,
     );
   const playerName = explorer.config.data.playerName.value();
   const masterDbExplanation = explorer.root.trans('masterDbExplanation', 2200, '1952', '2022-10'),
@@ -424,7 +424,7 @@ const explorerTitle = (explorer: ExplorerCtrl) => {
                   })
                 : undefined,
             ],
-            explorer.root.trans('switchSides')
+            explorer.root.trans('switchSides'),
           )
         : active([h('strong', 'Player'), ' database'], '')
       : playerLink(),
@@ -488,6 +488,6 @@ export default function (ctrl: AnalyseCtrl): VNode | undefined {
         },
         hook: bind('click', () => ctrl.explorer.config.toggleOpen(), ctrl.redraw),
       }),
-    ]
+    ],
   );
 }

--- a/ui/analyse/src/explorer/explorerXhr.ts
+++ b/ui/analyse/src/explorer/explorerXhr.ts
@@ -17,7 +17,7 @@ interface OpeningXhrOpts {
 export async function opening(
   opts: OpeningXhrOpts,
   processData: (data: OpeningData) => void,
-  signal?: AbortSignal
+  signal?: AbortSignal,
 ): Promise<void> {
   const conf = opts.config;
   const confByDb = conf.byDb();
@@ -68,7 +68,7 @@ export async function tablebase(
   endpoint: string,
   variant: VariantKey,
   fen: Fen,
-  signal?: AbortSignal
+  signal?: AbortSignal,
 ): Promise<TablebaseData> {
   const effectiveVariant = variant === 'fromPosition' || variant === 'chess960' ? 'standard' : variant;
   const data = await xhr.json(xhr.url(`${endpoint}/${effectiveVariant}`, { fen }), {

--- a/ui/analyse/src/explorer/tablebaseView.ts
+++ b/ui/analyse/src/explorer/tablebaseView.ts
@@ -8,7 +8,7 @@ export function showTablebase(
   fen: Fen,
   title: string,
   tooltip: string | undefined,
-  moves: TablebaseMoveStats[]
+  moves: TablebaseMoveStats[],
 ): VNode[] {
   if (!moves.length) return [];
   return [
@@ -24,9 +24,9 @@ export function showTablebase(
               key: move.uci,
               attrs: { 'data-uci': move.uci },
             },
-            [h('td', move.san), h('td', [showDtz(ctrl, fen, move), showDtm(ctrl, fen, move)])]
-          )
-        )
+            [h('td', move.san), h('td', [showDtz(ctrl, fen, move), showDtm(ctrl, fen, move)])],
+          ),
+        ),
       ),
     ]),
   ];
@@ -41,7 +41,7 @@ function showDtm(ctrl: AnalyseCtrl, fen: Fen, move: TablebaseMoveStats) {
           title: ctrl.trans.pluralSame('mateInXHalfMoves', Math.abs(move.dtm)) + ' (Depth To Mate)',
         },
       },
-      'DTM ' + Math.abs(move.dtm)
+      'DTM ' + Math.abs(move.dtm),
     );
   return undefined;
 }
@@ -66,6 +66,6 @@ function showDtz(ctrl: AnalyseCtrl, fen: Fen, move: TablebaseMoveStats): VNode |
         title: trans('dtzWithRounding') + ' (Distance To Zeroing)',
       },
     },
-    'DTZ ' + Math.abs(move.dtz)
+    'DTZ ' + Math.abs(move.dtz),
   );
 }

--- a/ui/analyse/src/forecast/forecastCtrl.ts
+++ b/ui/analyse/src/forecast/forecastCtrl.ts
@@ -10,7 +10,11 @@ export default class ForecastCtrl {
   forecasts: Prop<ForecastList> = prop<ForecastList>([]);
   loading = prop(false);
 
-  constructor(readonly cfg: ForecastData, readonly data: AnalyseData, readonly redraw: () => void) {
+  constructor(
+    readonly cfg: ForecastData,
+    readonly data: AnalyseData,
+    readonly redraw: () => void,
+  ) {
     this.forecasts(cfg.steps || []);
     this.fixAll();
   }
@@ -47,11 +51,11 @@ export default class ForecastCtrl {
   fixAll = () => {
     // remove contained forecasts
     this.update(fcs =>
-      fcs.filter((fc, i) => fcs.filter((f, j) => i !== j && this.contains(f, fc)).length === 0)
+      fcs.filter((fc, i) => fcs.filter((f, j) => i !== j && this.contains(f, fc)).length === 0),
     );
     // remove colliding forecasts
     this.update(fcs =>
-      fcs.filter((fc, i) => fcs.filter((f, j) => i < j && this.collides(f, fc)).length === 0)
+      fcs.filter((fc, i) => fcs.filter((f, j) => i < j && this.collides(f, fc)).length === 0),
     );
   };
 
@@ -98,7 +102,7 @@ export default class ForecastCtrl {
         body: JSON.stringify(
           this.findStartingWithNode(node)
             .filter(notEmpty)
-            .map(fc => fc.slice(1))
+            .map(fc => fc.slice(1)),
         ),
         headers: { 'Content-Type': 'application/json' },
       })
@@ -127,7 +131,7 @@ export default class ForecastCtrl {
           id: moveId,
           children: [],
         },
-        path // the path before this is its parent
+        path, // the path before this is its parent
       );
       path += moveId;
     });

--- a/ui/analyse/src/forecast/forecastView.ts
+++ b/ui/analyse/src/forecast/forecastView.ts
@@ -30,7 +30,7 @@ function onMyTurn(ctrl: AnalyseCtrl, fctrl: ForecastCtrl, cNodes: ForecastStep[]
           ? h('span', ctrl.trans.pluralSame('andSaveNbPremoveLines', lines.length))
           : h('span', ctrl.trans.noarg('noConditionalPremoves')),
       ]),
-    ]
+    ],
   );
 }
 
@@ -43,7 +43,7 @@ function makeCnodes(ctrl: AnalyseCtrl, fctrl: ForecastCtrl): ForecastStep[] {
       uci: node.uci!,
       san: node.san!,
       check: node.check,
-    }))
+    })),
   );
 }
 
@@ -72,7 +72,7 @@ export default function (ctrl: AnalyseCtrl, fctrl: ForecastCtrl): VNode {
                     const path = fctrl.showForecast(findCurrentPath(ctrl) || '', ctrl.tree, nodes);
                     ctrl.userJump(path);
                   },
-                  ctrl.redraw
+                  ctrl.redraw,
                 ),
               },
               [
@@ -81,9 +81,9 @@ export default function (ctrl: AnalyseCtrl, fctrl: ForecastCtrl): VNode {
                   attrs: { 'data-icon': licon.X, type: 'button' },
                 }),
                 h('sans', renderNodesHtml(nodes)),
-              ]
-            )
-          )
+              ],
+            ),
+          ),
         ),
         h(
           'button.add.text',
@@ -99,10 +99,10 @@ export default function (ctrl: AnalyseCtrl, fctrl: ForecastCtrl): VNode {
                   h('sans', renderNodesHtml(cNodes)),
                 ])
               : h('span', ctrl.trans.noarg('playVariationToCreateConditionalPremoves')),
-          ]
+          ],
         ),
       ]),
       fctrl.onMyTurn() ? onMyTurn(ctrl, fctrl, cNodes) : null,
-    ]
+    ],
   );
 }

--- a/ui/analyse/src/fork.ts
+++ b/ui/analyse/src/fork.ts
@@ -79,7 +79,7 @@ export function make(root: AnalyseCtrl): ForkCtrl {
 const eventToIndex = (e: MouseEvent): number | undefined => {
   const target = e.target as HTMLElement;
   return parseInt(
-    (target.parentNode as HTMLElement).getAttribute('data-it') || target.getAttribute('data-it') || ''
+    (target.parentNode as HTMLElement).getAttribute('data-it') || target.getAttribute('data-it') || '',
   );
 };
 
@@ -115,10 +115,10 @@ export function view(root: AnalyseCtrl, concealOf?: ConcealOf) {
               showEval: root.showComputer(),
               showGlyphs: root.showComputer(),
             },
-            node
-          )!
+            node,
+          )!,
         );
       return undefined;
-    })
+    }),
   );
 }

--- a/ui/analyse/src/ground.ts
+++ b/ui/analyse/src/ground.ts
@@ -34,7 +34,7 @@ export function promote(ground: CgApi, key: Key, role: cg.Role) {
             promoted: true,
           },
         ],
-      ])
+      ]),
     );
   }
 }

--- a/ui/analyse/src/keyboard.ts
+++ b/ui/analyse/src/keyboard.ts
@@ -78,14 +78,14 @@ export const bind = (ctrl: AnalyseCtrl) => {
     kbd.bind(key, () =>
       $(selector).each(function (this: HTMLElement) {
         this.dispatchEvent(new MouseEvent(eventName));
-      })
+      }),
     );
 
   //'Request computer analysis' & 'Learn From Your Mistakes' (mutually exclusive)
   keyToMouseEvent(
     'r',
     'click',
-    '.analyse__underboard__panels .computer-analysis button, .analyse__round-training .advice-summary a.button'
+    '.analyse__underboard__panels .computer-analysis button, .analyse__round-training .advice-summary a.button',
   );
   //'Next' button ("in Learn From Your Mistake")
   keyToMouseEvent('enter', 'click', '.analyse__tools .training-box a.continue');

--- a/ui/analyse/src/nodeFinder.ts
+++ b/ui/analyse/src/nodeFinder.ts
@@ -7,7 +7,7 @@ export function nextGlyphSymbol(
   color: Color,
   symbol: string,
   mainline: Tree.Node[],
-  fromPly: number
+  fromPly: number,
 ): Tree.Node | undefined {
   const len = mainline.length;
   if (!len) return;

--- a/ui/analyse/src/pgnImport.ts
+++ b/ui/analyse/src/pgnImport.ts
@@ -12,7 +12,7 @@ const readNode = (
   node: ChildNode<PgnNodeData>,
   pos: Position,
   ply: number,
-  withChildren = true
+  withChildren = true,
 ): Tree.Node => {
   const move = parseSan(pos, node.data.san);
   if (!move) throw `Can't replay move ${node.data.san} at ply ${ply}`;

--- a/ui/analyse/src/plugins/nvui.ts
+++ b/ui/analyse/src/plugins/nvui.ts
@@ -82,7 +82,7 @@ export function initModule(ctrl: AnalyseController) {
           h('h1', 'Textual representation'),
           h('h2', 'Game info'),
           ...['white', 'black'].map((color: Color) =>
-            h('p', [color + ' player: ', renderPlayer(ctrl, playerByColor(d, color))])
+            h('p', [color + ' player: ', renderPlayer(ctrl, playerByColor(d, color))]),
           ),
           h('p', `${d.game.rated ? 'Rated' : 'Casual'} ${d.game.perf}`),
           d.clock ? h('p', `Clock: ${d.clock.initial / 60} + ${d.clock.increment}`) : null,
@@ -95,7 +95,7 @@ export function initModule(ctrl: AnalyseController) {
                 'aria-live': 'off',
               },
             },
-            renderCurrentLine(ctrl, style)
+            renderCurrentLine(ctrl, style),
           ),
           ...(!ctrl.studyPractice
             ? [
@@ -107,7 +107,7 @@ export function initModule(ctrl: AnalyseController) {
                     },
                     hook: bind('click', _ => ctrl.explorer.toggle(), ctrl.redraw),
                   },
-                  ctrl.trans.noarg('openingExplorerAndTablebase')
+                  ctrl.trans.noarg('openingExplorerAndTablebase'),
                 ),
                 explorerView(ctrl),
               ]
@@ -124,7 +124,7 @@ export function initModule(ctrl: AnalyseController) {
               },
             },
             // make sure consecutive positions are different so that they get re-read
-            renderCurrentNode(ctrl, style) + (ctrl.node.ply % 2 === 0 ? '' : ' ')
+            renderCurrentNode(ctrl, style) + (ctrl.node.ply % 2 === 0 ? '' : ' '),
           ),
           h('h2', 'Move form'),
           h(
@@ -151,7 +151,7 @@ export function initModule(ctrl: AnalyseController) {
                   },
                 }),
               ]),
-            ]
+            ],
           ),
           notify.render(),
           // h('h2', 'Actions'),
@@ -176,7 +176,7 @@ export function initModule(ctrl: AnalyseController) {
                   $buttons.on('keydown', arrowKeyHandler(ctrl.data.player.color, borderSound));
                   $buttons.on(
                     'keypress',
-                    lastCapturedCommandHandler(fenSteps, pieceStyle.get(), prefixStyle.get())
+                    lastCapturedCommandHandler(fenSteps, pieceStyle.get(), prefixStyle.get()),
                   );
                   $buttons.on('keypress', positionJumpHandler());
                   $buttons.on('keypress', pieceJumpingHandler(selectSound, errorSound));
@@ -189,8 +189,8 @@ export function initModule(ctrl: AnalyseController) {
               pieceStyle.get(),
               prefixStyle.get(),
               positionStyle.get(),
-              boardStyle.get()
-            )
+              boardStyle.get(),
+            ),
           ),
           h(
             'div.boardstatus',
@@ -200,7 +200,7 @@ export function initModule(ctrl: AnalyseController) {
                 'aria-atomic': 'true',
               },
             },
-            ''
+            '',
           ),
           h('div.content', {
             hook: {
@@ -374,7 +374,7 @@ function onSubmit(ctrl: AnalyseController, notify: (txt: string) => void, style:
           uci.slice(0, 2) as Key,
           uci.slice(2, 4) as Key,
           undefined,
-          namePiece[uci.slice(4)] as Role | undefined
+          namePiece[uci.slice(4)] as Role | undefined,
         );
       else notify('Invalid command');
     }
@@ -410,7 +410,7 @@ function onCommand(ctrl: AnalyseController, notify: (txt: string) => void, c: st
     notify(
       commands.piece.apply(c, pieces, style) ||
         commands.scan.apply(c, pieces, style) ||
-        `Invalid command: ${c}`
+        `Invalid command: ${c}`,
     );
   }
 }
@@ -421,7 +421,7 @@ function renderAcpl(ctrl: AnalyseController, style: Style): MaybeVNodes | undefi
   const anal = ctrl.data.analysis;
   if (!anal) return undefined;
   const analysisNodes = ctrl.mainline.filter(n =>
-    (n.glyphs || []).find(g => analysisGlyphs.includes(g.symbol))
+    (n.glyphs || []).find(g => analysisGlyphs.includes(g.symbol)),
   );
   const res: Array<VNode> = [];
   ['white', 'black'].forEach((color: Color) => {
@@ -434,7 +434,7 @@ function renderAcpl(ctrl: AnalyseController, style: Style): MaybeVNodes | undefi
           hook: bind(
             'change',
             e => ctrl.jumpToMain(parseInt((e.target as HTMLSelectElement).value)),
-            ctrl.redraw
+            ctrl.redraw,
           ),
         },
         analysisNodes
@@ -449,11 +449,11 @@ function renderAcpl(ctrl: AnalyseController, style: Style): MaybeVNodes | undefi
                 },
               },
               [plyToTurn(node.ply), renderSan(node.san!, node.uci, style), renderComments(node, style)].join(
-                ' '
-              )
-            )
-          )
-      )
+                ' ',
+              ),
+            ),
+          ),
+      ),
     );
   });
   return res;
@@ -462,7 +462,7 @@ function renderAcpl(ctrl: AnalyseController, style: Style): MaybeVNodes | undefi
 function requestAnalysisButton(
   ctrl: AnalyseController,
   inProgress: Prop<boolean>,
-  notify: (msg: string) => void
+  notify: (msg: string) => void,
 ) {
   if (inProgress()) return h('p', 'Server-side analysis in progress');
   if (ctrl.ongoing || ctrl.synthetic) return undefined;
@@ -479,11 +479,11 @@ function requestAnalysisButton(
               inProgress(true);
               notify('Server-side analysis in progress');
             },
-            _ => notify('Cannot run server-side analysis')
-          )
+            _ => notify('Cannot run server-side analysis'),
+          ),
       ),
     },
-    'Request a computer analysis'
+    'Request a computer analysis',
   );
 }
 
@@ -532,7 +532,7 @@ function userHtml(ctrl: AnalyseController, player: Player) {
           {
             attrs: { href: '/@/' + user.username },
           },
-          user.title ? `${user.title} ${user.username}` : user.username
+          user.title ? `${user.title} ${user.username}` : user.username,
         ),
         rating ? ` ${rating}` : ``,
         ' ' + ratingDiff,

--- a/ui/analyse/src/plugins/studyTopicForm.ts
+++ b/ui/analyse/src/plugins/studyTopicForm.ts
@@ -10,7 +10,7 @@ lichess.load.then(() => {
   });
   const doFetch: (term: string) => Promise<string[]> = debounce(
     (term: string) => xhr.json(xhr.url('/study/topic/autocomplete', { term })),
-    300
+    300,
   );
   let clickDebounce: Timeout | undefined; // https://yaireo.github.io/tagify/#section-advance-options
   tagify

--- a/ui/analyse/src/practice/practiceCtrl.ts
+++ b/ui/analyse/src/practice/practiceCtrl.ts
@@ -124,7 +124,7 @@ export function make(root: AnalyseCtrl, playableDepth: () => number): PracticeCt
             uci: best,
             san: root.position(prev).unwrap(
               pos => makeSan(pos, parseUci(best!)!),
-              _ => '--'
+              _ => '--',
             ),
           }
         : undefined,
@@ -183,7 +183,7 @@ export function make(root: AnalyseCtrl, playableDepth: () => number): PracticeCt
         () => {
           if (!defined(root.node.tbhit)) root.node.tbhit = null;
           checkCeval();
-        }
+        },
       );
     else checkCeval();
   }

--- a/ui/analyse/src/practice/practiceView.ts
+++ b/ui/analyse/src/practice/practiceView.ts
@@ -22,8 +22,8 @@ function commentBest(c: Comment, root: AnalyseCtrl, ctrl: PracticeCtrl): MaybeVN
               destroy: () => ctrl.commentShape(false),
             },
           },
-          c.best.san
-        )
+          c.best.san,
+        ),
       )
     : [];
 }
@@ -67,7 +67,7 @@ function renderEvalProgress(node: Tree.Node, maxDepth: number): VNode {
           node.ceval ? (100 * Math.max(0, node.ceval.depth - minDepth)) / (maxDepth - minDepth) + '%' : 0
         }`,
       },
-    })
+    }),
   );
 }
 
@@ -91,11 +91,13 @@ function renderRunning(root: AnalyseCtrl, ctrl: PracticeCtrl): VNode {
                 {
                   hook: bind('click', () => root.practice!.hint(), ctrl.redraw),
                 },
-                root.trans.noarg(hint ? (hint.mode === 'piece' ? 'seeBestMove' : 'hideBestMove') : 'getAHint')
+                root.trans.noarg(
+                  hint ? (hint.mode === 'piece' ? 'seeBestMove' : 'hideBestMove') : 'getAHint',
+                ),
               )
             : '',
-        ])
-      )
+        ]),
+      ),
     ),
   ]);
 }
@@ -111,7 +113,7 @@ export default function (root: AnalyseCtrl): VNode | undefined {
     h('div.title', root.trans.noarg('practiceWithComputer')),
     h(
       'div.feedback',
-      !running ? renderOffTrack(root, ctrl) : end ? renderEnd(root, end) : renderRunning(root, ctrl)
+      !running ? renderOffTrack(root, ctrl) : end ? renderEnd(root, end) : renderRunning(root, ctrl),
     ),
     running
       ? h(
@@ -119,9 +121,9 @@ export default function (root: AnalyseCtrl): VNode | undefined {
           (end && !root.study?.practice ? renderNextChapter(root) : null) ||
             (comment
               ? ([h('span.verdict', root.trans.noarg(comment.verdict)), ' '] as MaybeVNodes).concat(
-                  commentBest(comment, root, ctrl)
+                  commentBest(comment, root, ctrl),
                 )
-              : [ctrl.isMyTurn() || end ? '' : h('span.wait', root.trans.noarg('evaluatingYourMove'))])
+              : [ctrl.isMyTurn() || end ? '' : h('span.wait', root.trans.noarg('evaluatingYourMove'))]),
         )
       : null,
   ]);

--- a/ui/analyse/src/retrospect/retroCtrl.ts
+++ b/ui/analyse/src/retrospect/retroCtrl.ts
@@ -63,7 +63,7 @@ export function make(root: AnalyseCtrl, color: Color): RetroCtrl {
     const colorModulo = color == 'white' ? 1 : 0;
     candidateNodes = evalSwings(
       root.mainline,
-      n => n.ply % 2 === colorModulo && !explorerCancelPlies.includes(n.ply)
+      n => n.ply % 2 === colorModulo && !explorerCancelPlies.includes(n.ply),
     );
     return candidateNodes.find(n => !isPlySolved(n.ply));
   }

--- a/ui/analyse/src/retrospect/retroView.ts
+++ b/ui/analyse/src/retrospect/retroView.ts
@@ -13,14 +13,14 @@ function skipOrViewSolution(ctrl: RetroCtrl) {
       {
         hook: bind('click', ctrl.viewSolution, ctrl.redraw),
       },
-      ctrl.noarg('viewTheSolution')
+      ctrl.noarg('viewTheSolution'),
     ),
     h(
       'a',
       {
         hook: bind('click', ctrl.skip),
       },
-      ctrl.noarg('skipThisMove')
+      ctrl.noarg('skipThisMove'),
     ),
   ]);
 }
@@ -31,7 +31,7 @@ function jumpToNext(ctrl: RetroCtrl) {
     {
       hook: bind('click', ctrl.jumpToNext),
     },
-    [h('i', { attrs: dataIcon(licon.PlayTriangle) }), ctrl.noarg('next')]
+    [h('i', { attrs: dataIcon(licon.PlayTriangle) }), ctrl.noarg('next')],
   );
 }
 
@@ -47,7 +47,7 @@ function renderEvalProgress(node: Tree.Node): VNode {
           node.ceval ? (100 * Math.max(0, node.ceval.depth - minDepth)) / (maxDepth - minDepth) + '%' : 0
         }`,
       },
-    })
+    }),
   );
 }
 
@@ -69,10 +69,10 @@ const feedback = {
                     showGlyphs: true,
                     showEval: false,
                   },
-                  ctrl.current()!.fault.node
-                )!
-              )
-            )
+                  ctrl.current()!.fault.node,
+                )!,
+              ),
+            ),
           ),
           h('em', ctrl.noarg(ctrl.color === 'white' ? 'findBetterMoveForWhite' : 'findBetterMoveForBlack')),
           skipOrViewSolution(ctrl),
@@ -93,7 +93,7 @@ const feedback = {
               {
                 hook: bind('click', ctrl.jumpToNext),
               },
-              ctrl.noarg('resumeLearning')
+              ctrl.noarg('resumeLearning'),
             ),
           ]),
         ]),
@@ -116,7 +116,7 @@ const feedback = {
     return [
       h(
         'div.half.top',
-        h('div.player', [h('div.icon', '✓'), h('div.instruction', h('strong', ctrl.noarg('goodMove')))])
+        h('div.player', [h('div.icon', '✓'), h('div.instruction', h('strong', ctrl.noarg('goodMove')))]),
       ),
       jumpToNext(ctrl),
     ];
@@ -140,13 +140,13 @@ const feedback = {
                       withDots: true,
                       showEval: false,
                     },
-                    ctrl.current()!.solution.node
-                  )!
-                )
-              )
+                    ctrl.current()!.solution.node,
+                  )!,
+                ),
+              ),
             ),
           ]),
-        ])
+        ]),
       ),
       jumpToNext(ctrl),
     ];
@@ -160,7 +160,7 @@ const feedback = {
             h('strong', ctrl.noarg('evaluatingYourMove')),
             renderEvalProgress(ctrl.node()),
           ]),
-        ])
+        ]),
       ),
     ];
   },
@@ -169,7 +169,7 @@ const feedback = {
       return [
         h(
           'div.half.top',
-          h('div.player', [h('div.icon', spinner()), h('div.instruction', ctrl.noarg('waitingForAnalysis'))])
+          h('div.player', [h('div.icon', spinner()), h('div.instruction', ctrl.noarg('waitingForAnalysis'))]),
         ),
       ];
     const nothing = !ctrl.completion()[1];
@@ -182,8 +182,8 @@ const feedback = {
             nothing
               ? ctrl.noarg(ctrl.color === 'white' ? 'noMistakesFoundForWhite' : 'noMistakesFoundForBlack')
               : ctrl.noarg(
-                  ctrl.color === 'white' ? 'doneReviewingWhiteMistakes' : 'doneReviewingBlackMistakes'
-                )
+                  ctrl.color === 'white' ? 'doneReviewingWhiteMistakes' : 'doneReviewingBlackMistakes',
+                ),
           ),
           h('div.choices.end', [
             nothing
@@ -193,14 +193,14 @@ const feedback = {
                   {
                     hook: bind('click', ctrl.reset),
                   },
-                  ctrl.noarg('doItAgain')
+                  ctrl.noarg('doItAgain'),
                 ),
             h(
               'a',
               {
                 hook: bind('click', ctrl.flip),
               },
-              ctrl.noarg(ctrl.color === 'white' ? 'reviewBlackMistakes' : 'reviewWhiteMistakes')
+              ctrl.noarg(ctrl.color === 'white' ? 'reviewBlackMistakes' : 'reviewWhiteMistakes'),
             ),
           ]),
         ]),

--- a/ui/analyse/src/serverSideUnderboard.ts
+++ b/ui/analyse/src/serverSideUnderboard.ts
@@ -152,7 +152,7 @@ export default function (element: HTMLElement, ctrl: AnalyseCtrl) {
           '</pre><br />' +
           iframe +
           '<br /><br />' +
-          `<a class="text" data-icon="${licon.InfoCircle}" href="/developers#embed-game">Read more about embedding games</a></div>`
+          `<a class="text" data-icon="${licon.InfoCircle}" href="/developers#embed-game">Read more about embedding games</a></div>`,
       ),
     });
   });

--- a/ui/analyse/src/start.ts
+++ b/ui/analyse/src/start.ts
@@ -7,7 +7,7 @@ import type * as studyDeps from './study/studyDeps';
 
 export default function (
   patch: (oldVnode: VNode | Element | DocumentFragment, vnode: VNode) => VNode,
-  deps?: typeof studyDeps
+  deps?: typeof studyDeps,
 ) {
   return function (opts: AnalyseOpts): AnalyseApi {
     opts.element = document.querySelector('main.analyse') as HTMLElement;

--- a/ui/analyse/src/study/chapterEditForm.ts
+++ b/ui/analyse/src/study/chapterEditForm.ts
@@ -32,7 +32,7 @@ export function ctrl(
   send: StudySocketSend,
   chapterConfig: (id: string) => Promise<StudyChapterConfig>,
   trans: Trans,
-  redraw: Redraw
+  redraw: Redraw,
 ): StudyChapterEditFormCtrl {
   const current = prop<StudyChapterMeta | StudyChapterConfig | null>(null);
 
@@ -115,7 +115,7 @@ export function view(ctrl: StudyChapterEditFormCtrl): VNode | undefined {
                   {
                     attrs: { for: 'chapter-name' },
                   },
-                  noarg('name')
+                  noarg('name'),
                 ),
                 h('input#chapter-name.form-control', {
                   attrs: {
@@ -132,7 +132,7 @@ export function view(ctrl: StudyChapterEditFormCtrl): VNode | undefined {
                 }),
               ]),
               ...(isLoaded(data) ? viewLoaded(ctrl, data) : [spinner()]),
-            ]
+            ],
           ),
         ],
       })
@@ -159,13 +159,13 @@ function viewLoaded(ctrl: StudyChapterEditFormCtrl, data: StudyChapterConfig): V
           {
             attrs: { for: 'chapter-orientation' },
           },
-          noarg('orientation')
+          noarg('orientation'),
         ),
         h(
           'select#chapter-orientation.form-control',
           ['white', 'black'].map(function (color) {
             return option(color, data.orientation, noarg(color));
-          })
+          }),
         ),
       ]),
       h('div.form-group.form-half', [
@@ -174,13 +174,13 @@ function viewLoaded(ctrl: StudyChapterEditFormCtrl, data: StudyChapterConfig): V
           {
             attrs: { for: 'chapter-mode' },
           },
-          noarg('analysisMode')
+          noarg('analysisMode'),
         ),
         h(
           'select#chapter-mode.form-control',
           chapterForm.modeChoices.map(c => {
             return option(c[0], mode, noarg(c[1]));
-          })
+          }),
         ),
       ]),
     ]),
@@ -190,14 +190,14 @@ function viewLoaded(ctrl: StudyChapterEditFormCtrl, data: StudyChapterConfig): V
         {
           attrs: { for: 'chapter-description' },
         },
-        noarg('pinnedChapterComment')
+        noarg('pinnedChapterComment'),
       ),
       h(
         'select#chapter-description.form-control',
         [
           ['', noarg('noPinnedComment')],
           ['1', noarg('rightUnderTheBoard')],
-        ].map(v => option(v[0], data.description ? '1' : '', v[1]))
+        ].map(v => option(v[0], data.description ? '1' : '', v[1])),
       ),
     ]),
     h('div.form-actions-secondary.destructive', [
@@ -209,11 +209,11 @@ function viewLoaded(ctrl: StudyChapterEditFormCtrl, data: StudyChapterConfig): V
             _ => {
               if (confirm(noarg('clearAllCommentsInThisChapter'))) ctrl.clearAnnotations(data.id);
             },
-            ctrl.redraw
+            ctrl.redraw,
           ),
           attrs: { type: 'button', title: noarg('clearAllCommentsInThisChapter') },
         },
-        noarg('clearAnnotations')
+        noarg('clearAnnotations'),
       ),
       h(
         emptyRedButton,
@@ -223,11 +223,11 @@ function viewLoaded(ctrl: StudyChapterEditFormCtrl, data: StudyChapterConfig): V
             _ => {
               if (confirm(noarg('clearVariations'))) ctrl.clearVariations(data.id);
             },
-            ctrl.redraw
+            ctrl.redraw,
           ),
           attrs: { type: 'button' },
         },
-        noarg('clearVariations')
+        noarg('clearVariations'),
       ),
     ]),
     h('div.form-actions', [
@@ -239,18 +239,18 @@ function viewLoaded(ctrl: StudyChapterEditFormCtrl, data: StudyChapterConfig): V
             _ => {
               if (confirm(noarg('deleteThisChapter'))) ctrl.delete(data.id);
             },
-            ctrl.redraw
+            ctrl.redraw,
           ),
           attrs: { type: 'button', title: noarg('deleteThisChapter') },
         },
-        noarg('deleteChapter')
+        noarg('deleteChapter'),
       ),
       h(
         'button.button',
         {
           attrs: { type: 'submit' },
         },
-        noarg('saveChapter')
+        noarg('saveChapter'),
       ),
     ]),
   ];

--- a/ui/analyse/src/study/chapterNewForm.ts
+++ b/ui/analyse/src/study/chapterNewForm.ts
@@ -51,7 +51,7 @@ export function ctrl(
   send: StudySocketSend,
   chapters: Prop<StudyChapterMeta[]>,
   setTab: () => void,
-  root: AnalyseCtrl
+  root: AnalyseCtrl,
 ): StudyChapterNewFormCtrl {
   const multiPgnMax = 32;
 
@@ -133,7 +133,7 @@ export function view(ctrl: StudyChapterNewFormCtrl): VNode {
         attrs: { role: 'tab', title },
         hook: bind('click', () => ctrl.vm.tab(key), ctrl.root.redraw),
       },
-      name
+      name,
     );
   };
   const gameOrPgn = activeTab === 'game' || activeTab === 'pgn';
@@ -187,7 +187,7 @@ export function view(ctrl: StudyChapterNewFormCtrl): VNode {
               {
                 attrs: { for: 'chapter-name' },
               },
-              noarg('name')
+              noarg('name'),
             ),
             h('input#chapter-name.form-control', {
               attrs: {
@@ -237,7 +237,7 @@ export function view(ctrl: StudyChapterNewFormCtrl): VNode {
                     },
                   },
                 },
-                [spinner()]
+                [spinner()],
               )
             : null,
           activeTab === 'game'
@@ -247,7 +247,7 @@ export function view(ctrl: StudyChapterNewFormCtrl): VNode {
                   {
                     attrs: { for: 'chapter-game' },
                   },
-                  trans('loadAGameFromXOrY', 'lichess.org', 'chessgames.com')
+                  trans('loadAGameFromXOrY', 'lichess.org', 'chessgames.com'),
                 ),
                 h('textarea#chapter-game.form-control', {
                   attrs: {
@@ -264,9 +264,9 @@ export function view(ctrl: StudyChapterNewFormCtrl): VNode {
                             .trim()
                             .match(
                               new RegExp(
-                                `^((.*${location.host}/\\w{8,12}.*)|\\w{8}|\\w{12}|(.*chessgames\\.com/.*[?&]gid=\\d+.*)|)$`
-                              )
-                            )
+                                `^((.*${location.host}/\\w{8,12}.*)|\\w{8}|\\w{12}|(.*chessgames\\.com/.*[?&]gid=\\d+.*)|)$`,
+                              ),
+                            ),
                         );
                       el.setCustomValidity(ok ? '' : 'Invalid game ID(s) or URL(s)');
                     });
@@ -284,7 +284,7 @@ export function view(ctrl: StudyChapterNewFormCtrl): VNode {
                   hook: onInsert((el: HTMLInputElement) => {
                     el.addEventListener('change', () => el.reportValidity());
                     el.addEventListener('input', _ =>
-                      el.setCustomValidity(parseFen(el.value.trim()).isOk ? '' : 'Invalid FEN')
+                      el.setCustomValidity(parseFen(el.value.trim()).isOk ? '' : 'Invalid FEN'),
                     );
                   }),
                 }),
@@ -306,7 +306,7 @@ export function view(ctrl: StudyChapterNewFormCtrl): VNode {
                         .then(pgnData => $('#chapter-pgn').val(pgnData));
                     }),
                   },
-                  trans('importFromChapterX', study.currentChapter().name)
+                  trans('importFromChapterX', study.currentChapter().name),
                 ),
                 window.FileReader
                   ? h('input#chapter-pgn-file.form-control', {
@@ -335,7 +335,7 @@ export function view(ctrl: StudyChapterNewFormCtrl): VNode {
                 {
                   attrs: { for: 'chapter-variant' },
                 },
-                noarg('Variant')
+                noarg('Variant'),
               ),
               h(
                 'select#chapter-variant.form-control',
@@ -349,10 +349,10 @@ export function view(ctrl: StudyChapterNewFormCtrl): VNode {
                         {
                           attrs: { value: 'standard' },
                         },
-                        noarg('automatic')
+                        noarg('automatic'),
                       ),
                     ]
-                  : ctrl.vm.variants.map(v => option(v.key, currentChapter.setup.variant.key, v.name))
+                  : ctrl.vm.variants.map(v => option(v.key, currentChapter.setup.variant.key, v.name)),
               ),
             ]),
             h('div.form-group.form-half', [
@@ -361,7 +361,7 @@ export function view(ctrl: StudyChapterNewFormCtrl): VNode {
                 {
                   attrs: { for: 'chapter-orientation' },
                 },
-                noarg('orientation')
+                noarg('orientation'),
               ),
               h(
                 'select#chapter-orientation.form-control',
@@ -372,8 +372,8 @@ export function view(ctrl: StudyChapterNewFormCtrl): VNode {
                   }),
                 },
                 [...(activeTab === 'pgn' ? ['automatic'] : []), 'white', 'black'].map(c =>
-                  option(c, currentChapter.setup.orientation, noarg(c))
-                )
+                  option(c, currentChapter.setup.orientation, noarg(c)),
+                ),
               ),
             ]),
           ]),
@@ -383,11 +383,11 @@ export function view(ctrl: StudyChapterNewFormCtrl): VNode {
               {
                 attrs: { for: 'chapter-mode' },
               },
-              noarg('analysisMode')
+              noarg('analysisMode'),
             ),
             h(
               'select#chapter-mode.form-control',
-              modeChoices.map(c => option(c[0], mode, noarg(c[1])))
+              modeChoices.map(c => option(c[0], mode, noarg(c[1]))),
             ),
           ]),
           h(
@@ -397,10 +397,10 @@ export function view(ctrl: StudyChapterNewFormCtrl): VNode {
               {
                 attrs: { type: 'submit' },
               },
-              noarg('createChapter')
-            )
+              noarg('createChapter'),
+            ),
           ),
-        ]
+        ],
       ),
     ],
   });

--- a/ui/analyse/src/study/commentForm.ts
+++ b/ui/analyse/src/study/commentForm.ts
@@ -126,6 +126,6 @@ export function view(root: AnalyseCtrl): VNode {
         }),
       ]),
       h('div.analyse__wiki.study__wiki.force-ltr'),
-    ]
+    ],
   );
 }

--- a/ui/analyse/src/study/description.ts
+++ b/ui/analyse/src/study/description.ts
@@ -9,7 +9,11 @@ export type Save = (t: string) => void;
 export class DescriptionCtrl {
   edit = false;
 
-  constructor(public text: string | undefined, readonly doSave: Save, readonly redraw: () => void) {}
+  constructor(
+    public text: string | undefined,
+    readonly doSave: Save,
+    readonly redraw: () => void,
+  ) {}
 
   save(t: string) {
     this.text = t;
@@ -46,7 +50,7 @@ export function view(study: StudyCtrl, chapter: boolean): VNode | undefined {
                   _ => {
                     desc.edit = true;
                   },
-                  desc.redraw
+                  desc.redraw,
                 ),
               }),
           h('a', {
@@ -69,10 +73,10 @@ export function view(study: StudyCtrl, chapter: boolean): VNode | undefined {
               _ => {
                 desc.edit = true;
               },
-              desc.redraw
+              desc.redraw,
             ),
           },
-          descTitle(chapter)
+          descTitle(chapter),
         )
       : h('div.text', { hook: richHTML(desc.text) }),
   ]);
@@ -92,7 +96,7 @@ const edit = (ctrl: DescriptionCtrl, id: string, chapter: boolean): VNode =>
           () => {
             ctrl.edit = false;
           },
-          ctrl.redraw
+          ctrl.redraw,
         ),
       }),
     ]),

--- a/ui/analyse/src/study/gamebook/gamebookButtons.ts
+++ b/ui/analyse/src/study/gamebook/gamebookButtons.ts
@@ -22,7 +22,7 @@ export function playButtons(root: AnalyseCtrl): VNode | undefined {
             },
             hook: bind('click', () => root.userJump(''), ctrl.redraw),
           },
-          root.trans.noarg('back')
+          root.trans.noarg('back'),
         )
       : null,
     myTurn
@@ -35,7 +35,7 @@ export function playButtons(root: AnalyseCtrl): VNode | undefined {
             },
             hook: bind('click', ctrl.solution, ctrl.redraw),
           },
-          root.trans.noarg('viewTheSolution')
+          root.trans.noarg('viewTheSolution'),
         )
       : undefined,
     overrideButton(study),
@@ -59,10 +59,10 @@ export function overrideButton(study: StudyCtrl): VNode | undefined {
             () => {
               study.setGamebookOverride(o === 'play' ? undefined : 'play');
             },
-            study.redraw
+            study.redraw,
           ),
         },
-        'Preview'
+        'Preview',
       );
     else {
       const isAnalyse = o === 'analyse',
@@ -78,10 +78,10 @@ export function overrideButton(study: StudyCtrl): VNode | undefined {
               () => {
                 study.setGamebookOverride(isAnalyse ? undefined : 'analyse');
               },
-              study.redraw
+              study.redraw,
             ),
           },
-          study.trans.noarg('analysis')
+          study.trans.noarg('analysis'),
         );
     }
   }

--- a/ui/analyse/src/study/gamebook/gamebookEdit.ts
+++ b/ui/analyse/src/study/gamebook/gamebookEdit.ts
@@ -32,10 +32,10 @@ export function render(ctrl: AnalyseCtrl): VNode {
           $('#comment-text').each(function (this: HTMLTextAreaElement) {
             this.focus();
           }),
-        500
+        500,
       );
     },
-    ctrl.redraw
+    ctrl.redraw,
   );
 
   if (!ctrl.path) {
@@ -47,7 +47,7 @@ export function render(ctrl: AnalyseCtrl): VNode {
             hook: commentHook,
             class: { done: isCommented },
           },
-          [iconTag(licon.BubbleSpeech), h('p', 'Help the player find the initial move, with a comment.')]
+          [iconTag(licon.BubbleSpeech), h('p', 'Help the player find the initial move, with a comment.')],
         ),
         renderHint(ctrl),
       ];
@@ -58,7 +58,7 @@ export function render(ctrl: AnalyseCtrl): VNode {
           {
             hook: commentHook,
           },
-          [iconTag(licon.BubbleSpeech), h('p', 'Introduce the gamebook with a comment')]
+          [iconTag(licon.BubbleSpeech), h('p', 'Introduce the gamebook with a comment')],
         ),
         h('div.legend.todo', { class: { done: !!ctrl.node.children[0] } }, [
           iconTag(licon.PlayTriangle),
@@ -77,7 +77,7 @@ export function render(ctrl: AnalyseCtrl): VNode {
           [
             iconTag(licon.BubbleSpeech),
             h('p', 'Explain the opponent move, and help the player find the next move, with a comment.'),
-          ]
+          ],
         ),
         renderHint(ctrl),
       ];
@@ -92,9 +92,9 @@ export function render(ctrl: AnalyseCtrl): VNode {
             iconTag(licon.BubbleSpeech),
             h(
               'p',
-              "You may reflect on the player's correct move, with a comment; or leave empty to jump immediately to the next move."
+              "You may reflect on the player's correct move, with a comment; or leave empty to jump immediately to the next move.",
             ),
-          ]
+          ],
         ),
         hasVariation
           ? null
@@ -106,7 +106,7 @@ export function render(ctrl: AnalyseCtrl): VNode {
               [
                 iconTag(licon.PlayTriangle),
                 h('p', 'Add variation moves to explain why specific other moves are wrong.'),
-              ]
+              ],
             ),
         renderDeviation(ctrl),
       ];
@@ -118,7 +118,7 @@ export function render(ctrl: AnalyseCtrl): VNode {
           hook: commentHook,
           class: { done: isCommented },
         },
-        [iconTag(licon.BubbleSpeech), h('p', 'Explain why this move is wrong in a comment')]
+        [iconTag(licon.BubbleSpeech), h('p', 'Explain why this move is wrong in a comment')],
       ),
       h('div.legend', [h('p', 'Or promote it as the mainline if it is the right move.')]),
     ];
@@ -128,7 +128,7 @@ export function render(ctrl: AnalyseCtrl): VNode {
     {
       hook: { insert: _ => lichess.loadCssPath('analyse.gamebook.edit') },
     },
-    content
+    content,
   );
 }
 

--- a/ui/analyse/src/study/gamebook/gamebookPlayCtrl.ts
+++ b/ui/analyse/src/study/gamebook/gamebookPlayCtrl.ts
@@ -19,7 +19,7 @@ export default class GamebookPlayCtrl {
     readonly root: AnalyseCtrl,
     readonly chapterId: string,
     readonly trans: Trans,
-    readonly redraw: () => void
+    readonly redraw: () => void,
   ) {
     // ensure all original nodes have a gamebook entry,
     // so we can differentiate original nodes from user-made ones
@@ -108,7 +108,7 @@ export default class GamebookPlayCtrl {
 
   solution = () => {
     this.root.chessground.setShapes(
-      makeShapesFromUci(this.root.turnColor(), this.root.node.children[0].uci!, 'green')
+      makeShapesFromUci(this.root.turnColor(), this.root.node.children[0].uci!, 'green'),
     );
   };
 

--- a/ui/analyse/src/study/gamebook/gamebookPlayView.ts
+++ b/ui/analyse/src/study/gamebook/gamebookPlayView.ts
@@ -29,10 +29,10 @@ export function render(ctrl: GamebookPlayCtrl): VNode {
                       ? ctrl.trans('whatWouldYouPlay')
                       : state.feedback == 'end'
                       ? ctrl.trans('youCompletedThisLesson')
-                      : undefined
+                      : undefined,
                   ),
               hintZone(ctrl),
-            ]
+            ],
           )
         : undefined,
       h('div.floor', [
@@ -45,7 +45,7 @@ export function render(ctrl: GamebookPlayCtrl): VNode {
           },
         }),
       ]),
-    ]
+    ],
   );
 }
 
@@ -70,7 +70,7 @@ function renderFeedback(ctrl: GamebookPlayCtrl, state: State) {
         attrs: { type: 'button' },
         hook: bind('click', ctrl.retry),
       },
-      [iconTag(licon.Reload), h('span', ctrl.trans.noarg('retry'))]
+      [iconTag(licon.Reload), h('span', ctrl.trans.noarg('retry'))],
     );
   if (fb === 'good' && state.comment)
     return h(
@@ -79,7 +79,10 @@ function renderFeedback(ctrl: GamebookPlayCtrl, state: State) {
         attrs: { type: 'button' },
         hook: bind('click', ctrl.next),
       },
-      [h('span.text', { attrs: dataIcon(licon.PlayTriangle) }, ctrl.trans.noarg('next')), h('kbd', '<space>')]
+      [
+        h('span.text', { attrs: dataIcon(licon.PlayTriangle) }, ctrl.trans.noarg('next')),
+        h('kbd', '<space>'),
+      ],
     );
   if (fb === 'end') return renderEnd(ctrl);
   return h(
@@ -93,12 +96,12 @@ function renderFeedback(ctrl: GamebookPlayCtrl, state: State) {
               h('strong', ctrl.trans.noarg('yourTurn')),
               h(
                 'em',
-                ctrl.trans.noarg(color === 'white' ? 'findTheBestMoveForWhite' : 'findTheBestMoveForBlack')
+                ctrl.trans.noarg(color === 'white' ? 'findTheBestMoveForWhite' : 'findTheBestMoveForBlack'),
               ),
             ]),
           ]
-        : ctrl.trans.noarg('goodMove')
-    )
+        : ctrl.trans.noarg('goodMove'),
+    ),
   );
 }
 
@@ -115,7 +118,7 @@ function renderEnd(ctrl: GamebookPlayCtrl) {
             },
             hook: bind('click', study.goToNextChapter),
           },
-          study.trans.noarg('nextChapter')
+          study.trans.noarg('nextChapter'),
         )
       : undefined,
     h(
@@ -127,7 +130,7 @@ function renderEnd(ctrl: GamebookPlayCtrl) {
         },
         hook: bind('click', () => ctrl.root.userJump(''), ctrl.redraw),
       },
-      study.trans.noarg('playAgain')
+      study.trans.noarg('playAgain'),
     ),
     h(
       'button.analyse',
@@ -138,7 +141,7 @@ function renderEnd(ctrl: GamebookPlayCtrl) {
         },
         hook: bind('click', () => study.setGamebookOverride('analyse'), ctrl.redraw),
       },
-      study.trans.noarg('analysis')
+      study.trans.noarg('analysis'),
     ),
   ]);
 }

--- a/ui/analyse/src/study/inviteForm.ts
+++ b/ui/analyse/src/study/inviteForm.ts
@@ -24,7 +24,7 @@ export function makeCtrl(
   members: Prop<StudyMemberMap>,
   setTab: () => void,
   redraw: () => void,
-  trans: Trans
+  trans: Trans,
 ): StudyInviteFormCtrl {
   const open = prop(false),
     spectators = prop<string[]>([]);
@@ -70,7 +70,7 @@ export function view(ctrl: ReturnType<typeof makeCtrl>): VNode {
       h(
         'p.info',
         { attrs: { 'data-icon': licon.InfoCircle } },
-        ctrl.trans.noarg('pleaseOnlyInvitePeopleYouKnow')
+        ctrl.trans.noarg('pleaseOnlyInvitePeopleYouKnow'),
       ),
       h('div.input-wrapper', [
         // because typeahead messes up with snabbdom
@@ -90,7 +90,7 @@ export function view(ctrl: ReturnType<typeof makeCtrl>): VNode {
                   ctrl.redraw();
                 },
               })
-              .then(() => input.focus())
+              .then(() => input.focus()),
           ),
         }),
       ]),
@@ -106,9 +106,9 @@ export function view(ctrl: ReturnType<typeof makeCtrl>): VNode {
                     ctrl.invite(username);
                   }),
                 },
-                username
+                username,
               );
-            })
+            }),
           )
         : undefined,
     ],

--- a/ui/analyse/src/study/multiBoard.ts
+++ b/ui/analyse/src/study/multiBoard.ts
@@ -15,7 +15,11 @@ export class MultiBoardCtrl {
   pager?: Paginator<ChapterPreview>;
   playing = false;
 
-  constructor(readonly studyId: string, readonly redraw: () => void, readonly trans: Trans) {}
+  constructor(
+    readonly studyId: string,
+    readonly redraw: () => void,
+    readonly trans: Trans,
+  ) {}
 
   addNode = (pos: Position, node: Tree.Node) => {
     const cp = this.pager && this.pager.currentPageResults.find(cp => cp.id == pos.chapterId);
@@ -100,7 +104,7 @@ export function view(ctrl: MultiBoardCtrl, study: StudyCtrl): VNode | undefined 
         },
       },
     },
-    ctrl.pager ? renderPager(ctrl.pager, study) : [spinner()]
+    ctrl.pager ? renderPager(ctrl.pager, study) : [spinner()],
   );
 }
 
@@ -149,7 +153,7 @@ function pagerButton(
   icon: string,
   click: () => void,
   enable: boolean,
-  ctrl: MultiBoardCtrl
+  ctrl: MultiBoardCtrl,
 ): VNode {
   return h('button.fbt', {
     attrs: {
@@ -184,7 +188,7 @@ const makePreview = (study: StudyCtrl) => (preview: ChapterPreview) =>
             if (preview.outcome) {
               lichess.miniGame.finish(
                 vnode.elm as HTMLElement,
-                preview.outcome === '1-0' ? 'white' : preview.outcome === '0-1' ? 'black' : undefined
+                preview.outcome === '1-0' ? 'white' : preview.outcome === '0-1' ? 'black' : undefined,
               );
             } else {
               lichess.miniGame.update(vnode.elm as HTMLElement, {
@@ -203,7 +207,7 @@ const makePreview = (study: StudyCtrl) => (preview: ChapterPreview) =>
       boardPlayer(preview, CgOpposite(preview.orientation)),
       h('span.cg-wrap'),
       boardPlayer(preview, preview.orientation),
-    ]
+    ],
   );
 
 const userName = (u: ChapterPreviewPlayer) =>

--- a/ui/analyse/src/study/nextChapter.ts
+++ b/ui/analyse/src/study/nextChapter.ts
@@ -18,6 +18,6 @@ export const renderNextChapter = (ctrl: AnalyseCtrl) =>
             highlighted: !!ctrl.outcome() || ctrl.node == treeOps.last(ctrl.mainline),
           },
         },
-        ctrl.trans.noarg('nextChapter')
+        ctrl.trans.noarg('nextChapter'),
       )
     : null;

--- a/ui/analyse/src/study/playerBars.ts
+++ b/ui/analyse/src/study/playerBars.ts
@@ -32,8 +32,8 @@ export default function (ctrl: AnalyseCtrl): VNode[] | undefined {
       color,
       ticking === color,
       ctrl.bottomColor() !== color,
-      study.data.hideRatings && looksLikeLichessGame(tags)
-    )
+      study.data.hideRatings && looksLikeLichessGame(tags),
+    ),
   );
 }
 
@@ -45,7 +45,7 @@ function renderPlayer(
   color: Color,
   ticking: boolean,
   top: boolean,
-  hideRatings?: boolean
+  hideRatings?: boolean,
 ): VNode {
   const title = findTag(tags, `${color}title`),
     elo = hideRatings ? undefined : findTag(tags, `${color}elo`),
@@ -66,6 +66,6 @@ function renderPlayer(
       ]),
       materialDiffs[top ? 0 : 1],
       clocks?.[color === 'white' ? 0 : 1],
-    ]
+    ],
   );
 }

--- a/ui/analyse/src/study/practice/studyPracticeCtrl.ts
+++ b/ui/analyse/src/study/practice/studyPracticeCtrl.ts
@@ -10,7 +10,7 @@ import AnalyseCtrl from '../../ctrl';
 export default function (
   root: AnalyseCtrl,
   studyData: StudyData,
-  data: StudyPracticeData
+  data: StudyPracticeData,
 ): StudyPracticeCtrl {
   const goal = prop<Goal>(root.data.practiceGoal!),
     nbMoves = prop(0),

--- a/ui/analyse/src/study/practice/studyPracticeView.ts
+++ b/ui/analyse/src/study/practice/studyPracticeView.ts
@@ -23,7 +23,7 @@ function selector(data: StudyPracticeData) {
         {
           attrs: { disabled: true, selected: true },
         },
-        'Practice list'
+        'Practice list',
       ),
       ...data.structure.map(section =>
         h(
@@ -31,10 +31,12 @@ function selector(data: StudyPracticeData) {
           {
             attrs: { label: section.name },
           },
-          section.studies.map(study => option(section.id + '/' + study.slug + '/' + study.id, '', study.name))
-        )
+          section.studies.map(study =>
+            option(section.id + '/' + study.slug + '/' + study.id, '', study.name),
+          ),
+        ),
       ),
-    ]
+    ],
   );
 }
 
@@ -78,7 +80,7 @@ export function underboard(ctrl: StudyCtrl): MaybeVNodes {
             : {
                 attrs: { href: '/practice' },
               },
-          [h('span', 'Success!'), ctrl.nextChapter() ? 'Go to next exercise' : 'Back to practice menu']
+          [h('span', 'Success!'), ctrl.nextChapter() ? 'Go to next exercise' : 'Back to practice menu'],
         ),
       ];
     case false:
@@ -88,7 +90,7 @@ export function underboard(ctrl: StudyCtrl): MaybeVNodes {
           {
             hook: bind('click', p.reset, ctrl.redraw),
           },
-          [h('span', [renderGoal(p, p.goal().moves!)]), h('strong', 'Click to retry')]
+          [h('span', [renderGoal(p, p.goal().moves!)]), h('strong', 'Click to retry')],
         ),
       ];
     default:
@@ -105,7 +107,7 @@ export function underboard(ctrl: StudyCtrl): MaybeVNodes {
             change: p.autoNext,
           },
           ctrl.trans,
-          ctrl.redraw
+          ctrl.redraw,
         ),
       ];
   }
@@ -156,11 +158,11 @@ export function side(ctrl: StudyCtrl): VNode {
                   },
                 }),
                 h('h3', chapter.name),
-              ]
+              ],
             ),
           ];
         })
-        .reduce((a, b) => a.concat(b), [])
+        .reduce((a, b) => a.concat(b), []),
     ),
     h('div.finally', [
       h('a.back', {

--- a/ui/analyse/src/study/relay/relayCtrl.ts
+++ b/ui/analyse/src/study/relay/relayCtrl.ts
@@ -18,7 +18,7 @@ export default class RelayCtrl {
     readonly send: AnalyseSocketSend,
     readonly redraw: () => void,
     readonly members: StudyMemberCtrl,
-    chapter: StudyChapter
+    chapter: StudyChapter,
   ) {
     this.applyChapterRelay(chapter, chapter.relay);
     this.tourShow = {

--- a/ui/analyse/src/study/relay/relayManagerView.ts
+++ b/ui/analyse/src/study/relay/relayManagerView.ts
@@ -25,7 +25,7 @@ export default function (ctrl: RelayCtrl): VNode | undefined {
             ? (ctrl.data.sync.ongoing ? stateOn : stateOff)(ctrl)
             : null,
           renderLog(ctrl),
-        ]
+        ],
       )
     : undefined;
 }
@@ -55,7 +55,7 @@ function renderLog(ctrl: RelayCtrl) {
                 },
               }
             : {},
-          e.error
+          e.error,
         );
       return h(
         'div' + (err ? '.err' : ''),
@@ -63,7 +63,7 @@ function renderLog(ctrl: RelayCtrl) {
           key: e.at,
           attrs: dataIcon(err ? licon.CautionCircle : licon.Checkmark),
         },
-        [h('div', [...(err ? [err] : logSuccess(e)), h('time', dateFormatter(new Date(e.at)))])]
+        [h('div', [...(err ? [err] : logSuccess(e)), h('time', dateFormatter(new Date(e.at)))])],
       );
     });
   if (ctrl.loading()) logLines.unshift(h('div.load', [h('i.ddloader'), 'Polling source...']));
@@ -91,9 +91,9 @@ function stateOn(ctrl: RelayCtrl) {
             ]
           : ids
           ? ['Connected to', h('br'), ids.length, ' game(s)']
-          : []
+          : [],
       ),
-    ]
+    ],
   );
 }
 
@@ -104,7 +104,7 @@ const stateOff = (ctrl: RelayCtrl) =>
       hook: bind('click', _ => ctrl.setSync(true)),
       attrs: dataIcon(licon.PlayTriangle),
     },
-    [h('div.fat', 'Click to connect')]
+    [h('div.fat', 'Click to connect')],
   );
 
 let cachedDateFormatter: (date: Date) => string;

--- a/ui/analyse/src/study/relay/relayTourView.ts
+++ b/ui/analyse/src/study/relay/relayTourView.ts
@@ -22,7 +22,7 @@ export default function (ctrl: AnalyseCtrl): VNode | undefined {
         attrs: { role: 'tab' },
         hook: bind('mousedown', () => relay.tab(key), relay.redraw),
       },
-      name
+      name,
     );
 
   const tabs = h('div.tabs-horiz', { attrs: { role: 'tablist' } }, [
@@ -55,7 +55,7 @@ const leaderboard = (relay: RelayCtrl): VNode[] => {
               withRating ? h('th', 'Elo') : undefined,
               h('th', 'Score'),
               h('th', 'Games'),
-            ])
+            ]),
           ),
           h(
             'tbody',
@@ -65,8 +65,8 @@ const leaderboard = (relay: RelayCtrl): VNode[] => {
                 withRating ? h('td', player.rating) : undefined,
                 h('td', player.score),
                 h('td', player.played),
-              ])
-            )
+              ]),
+            ),
           ),
         ]),
       ]),
@@ -97,10 +97,10 @@ const overview = (relay: RelayCtrl, study: StudyCtrl) => {
                 {
                   hook: onInsert(el => el.setAttribute('datetime', '' + round.startsAt)),
                 },
-                lichess.timeago(round.startsAt)
+                lichess.timeago(round.startsAt),
               )
             : null,
-        ]
+        ],
       ),
       relay.data.tour.markup
         ? h('div', {
@@ -130,17 +130,17 @@ const schedule = (relay: RelayCtrl): VNode[] => [
                   {
                     attrs: { href: relay.roundPath(round) },
                   },
-                  round.name
-                )
+                  round.name,
+                ),
               ),
               h('td', round.startsAt ? lichess.dateFormat()(new Date(round.startsAt)) : undefined),
               h(
                 'td',
-                roundStateIcon(round) || (round.startsAt ? lichess.timeago(round.startsAt) : undefined)
+                roundStateIcon(round) || (round.startsAt ? lichess.timeago(round.startsAt) : undefined),
               ),
-            ])
-          )
-        )
+            ]),
+          ),
+        ),
       ),
     ]),
   ]),
@@ -175,7 +175,7 @@ export function rounds(ctrl: StudyCtrl): VNode {
               {
                 attrs: { href: relay.roundPath(round) },
               },
-              round.name
+              round.name,
             ),
             roundStateIcon(round),
             canContribute
@@ -186,8 +186,8 @@ export function rounds(ctrl: StudyCtrl): VNode {
                   },
                 })
               : null,
-          ]
-        )
+          ],
+        ),
       )
       .concat(
         canContribute
@@ -202,11 +202,11 @@ export function rounds(ctrl: StudyCtrl): VNode {
                       'data-icon': licon.PlusButton,
                     },
                   },
-                  ctrl.trans.noarg('addRound')
-                )
+                  ctrl.trans.noarg('addRound'),
+                ),
               ),
             ]
-          : []
-      )
+          : [],
+      ),
   );
 }

--- a/ui/analyse/src/study/serverEval.ts
+++ b/ui/analyse/src/study/serverEval.ts
@@ -9,7 +9,10 @@ export default class ServerEval {
   requested = false;
   chart?: AcplChart;
 
-  constructor(readonly root: AnalyseCtrl, readonly chapterId: () => string) {}
+  constructor(
+    readonly root: AnalyseCtrl,
+    readonly chapterId: () => string,
+  ) {}
 
   reset = () => {
     this.requested = false;
@@ -38,12 +41,12 @@ export function view(ctrl: ServerEval): VNode {
             el,
             ctrl.root.data,
             ctrl.root.mainline,
-            ctrl.root.trans
+            ctrl.root.trans,
           );
         }, 800);
       }),
     },
-    [h('div.study__message', spinnerVdom())]
+    [h('div.study__message', spinnerVdom())],
   );
 }
 
@@ -71,8 +74,8 @@ function requestButton(ctrl: ServerEval) {
               },
               hook: bind('click', ctrl.request, root.redraw),
             },
-            noarg('requestAComputerAnalysis')
+            noarg('requestAComputerAnalysis'),
           ),
-        ]
+        ],
   );
 }

--- a/ui/analyse/src/study/studyChapters.ts
+++ b/ui/analyse/src/study/studyChapters.ts
@@ -26,7 +26,7 @@ export default class StudyChaptersCtrl {
     readonly send: StudySocketSend,
     setTab: () => void,
     chapterConfig: (id: string) => Promise<StudyChapterConfig>,
-    root: AnalyseCtrl
+    root: AnalyseCtrl,
   ) {
     this.list = prop(initChapters);
     this.newForm = chapterNewForm(send, this.list, setTab, root);
@@ -150,7 +150,7 @@ export function view(ctrl: StudyCtrl): VNode {
               : null,
             !chapter.ongoing && chapter.res ? h('res', chapter.res) : null,
             canContribute ? h('i.act', { attrs: dataIcon(licon.Gear) }) : null,
-          ]
+          ],
         );
       })
       .concat(
@@ -161,10 +161,10 @@ export function view(ctrl: StudyCtrl): VNode {
                 {
                   hook: bind('click', ctrl.chapters.toggleNewForm, ctrl.redraw),
                 },
-                [h('span', iconTag(licon.PlusButton)), h('h3', ctrl.trans.noarg('addNewChapter'))]
+                [h('span', iconTag(licon.PlusButton)), h('h3', ctrl.trans.noarg('addNewChapter'))],
               ),
             ]
-          : []
-      )
+          : [],
+      ),
   );
 }

--- a/ui/analyse/src/study/studyComments.ts
+++ b/ui/analyse/src/study/studyComments.ts
@@ -20,7 +20,7 @@ function authorDom(author: Author): string | VNode {
     {
       attrs: { 'data-href': '/@/' + author.id },
     },
-    author.name
+    author.name,
   );
 }
 
@@ -55,7 +55,7 @@ export function currentComments(ctrl: AnalyseCtrl, includingMine: boolean): VNod
                   if (confirm('Delete ' + authorText(by) + "'s comment?"))
                     study.commentForm.delete(chapter.id, ctrl.path, comment.id);
                 },
-                ctrl.redraw
+                ctrl.redraw,
               ),
             })
           : null,
@@ -64,6 +64,6 @@ export function currentComments(ctrl: AnalyseCtrl, includingMine: boolean): VNod
         ': ',
         h('div.text', { hook: richHTML(comment.text) }),
       ]);
-    })
+    }),
   );
 }

--- a/ui/analyse/src/study/studyCtrl.ts
+++ b/ui/analyse/src/study/studyCtrl.ts
@@ -50,7 +50,7 @@ import { SearchCtrl } from './studySearch';
 interface Handlers {
   path(d: WithWhoAndPos): void;
   addNode(
-    d: WithWhoAndPos & { d: string; n: Tree.Node; o: Opening; s: boolean; relay?: StudyChapterRelay }
+    d: WithWhoAndPos & { d: string; n: Tree.Node; o: Opening; s: boolean; relay?: StudyChapterRelay },
   ): void;
   deleteNode(d: WithWhoAndPos): void;
   promote(d: WithWhoAndPos & { toMainline: boolean }): void;
@@ -83,7 +83,7 @@ export default function (
   ctrl: AnalyseCtrl,
   tagTypes: TagTypes,
   practiceData?: StudyPracticeData,
-  relayData?: RelayData
+  relayData?: RelayData,
 ): StudyCtrl {
   const send = ctrl.socket.send;
   const redraw = ctrl.redraw;
@@ -144,7 +144,7 @@ export default function (
     send,
     () => setTab('chapters'),
     chapterId => xhr.chapterConfig(data.id, chapterId),
-    ctrl
+    ctrl,
   );
 
   const currentChapter = (): StudyChapterMeta => chapters.get(vm.chapterId)!;
@@ -172,7 +172,7 @@ export default function (
     () => data,
     ctrl.trans,
     redraw,
-    relay
+    relay,
   );
 
   const isWriting = (): boolean => vm.mode.write && !isGamebookPlay();
@@ -194,7 +194,7 @@ export default function (
       data.description = t;
       send('descStudy', t);
     }, 500),
-    redraw
+    redraw,
   );
   const chapterDesc = new DescriptionCtrl(
     data.chapter.description,
@@ -202,7 +202,7 @@ export default function (
       data.chapter.description = t;
       send('descChapter', { id: vm.chapterId, desc: t });
     }, 500),
-    redraw
+    redraw,
   );
 
   const serverEval = new ServerEval(ctrl, () => vm.chapterId);
@@ -213,7 +213,7 @@ export default function (
     topics => send('setTopics', topics),
     () => data.topics || [],
     ctrl.trans,
-    redraw
+    redraw,
   );
 
   function addChapterId<T>(req: T): T & { ch: string } {
@@ -317,7 +317,7 @@ export default function (
       return xhr
         .reload(practice ? 'practice/load' : 'study', data.id, vm.mode.sticky ? undefined : vm.chapterId)
         .then(onReload, lichess.reload);
-    }
+    },
   );
 
   const onSetPath = throttle(300, (path: Tree.Path) => {
@@ -326,7 +326,7 @@ export default function (
         'setPath',
         addChapterId({
           path,
-        })
+        }),
       );
   });
 
@@ -346,7 +346,7 @@ export default function (
     bottomColor,
     relay,
     redraw,
-    ctrl.trans
+    ctrl.trans,
   );
 
   const practice: StudyPracticeCtrl | undefined = practiceData && practiceCtrl(ctrl, data, practiceData);
@@ -371,7 +371,7 @@ export default function (
           addChapterId({
             path: ctrl.path,
             shapes,
-          })
+          }),
         );
       }
       gamebookPlay && gamebookPlay.onShapeChange(shapes);
@@ -688,7 +688,7 @@ export default function (
         addChapterId({
           path,
           jumpTo: ctrl.path,
-        })
+        }),
       );
     },
     promote(path, toMainline) {
@@ -697,7 +697,7 @@ export default function (
         addChapterId({
           toMainline,
           path,
-        })
+        }),
       );
     },
     forceVariation(path, force) {
@@ -706,7 +706,7 @@ export default function (
         addChapterId({
           force,
           path,
-        })
+        }),
       );
     },
     setChapter,

--- a/ui/analyse/src/study/studyForm.ts
+++ b/ui/analyse/src/study/studyForm.ts
@@ -46,7 +46,7 @@ const select = (s: Select): VNode =>
       {
         attrs: { for: 'study-' + s.key },
       },
-      s.name
+      s.name,
     ),
     h(
       `select#study-${s.key}.form-control`,
@@ -59,9 +59,9 @@ const select = (s: Select): VNode =>
               selected: s.selected === o[0],
             },
           },
-          o[1]
+          o[1],
         );
-      })
+      }),
     ),
   ]);
 
@@ -70,7 +70,7 @@ export function ctrl(
   getData: () => StudyData,
   trans: Trans,
   redraw: Redraw,
-  relay?: RelayCtrl
+  relay?: RelayCtrl,
 ): StudyFormCtrl {
   const initAt = Date.now();
 
@@ -145,7 +145,7 @@ export function view(ctrl: StudyFormCtrl): VNode {
                 sticky: getVal('sticky') as 'true' | 'false',
                 description: getVal('description') as 'true' | 'false',
               },
-              isNew
+              isNew,
             );
           }, ctrl.redraw),
         },
@@ -239,14 +239,14 @@ export function view(ctrl: StudyFormCtrl): VNode {
                       href: `/broadcast/${ctrl.relay.data.tour.id}/edit`,
                     },
                   },
-                  'Tournament settings'
+                  'Tournament settings',
                 ),
                 h(
                   'a.text',
                   {
                     attrs: { 'data-icon': licon.RadioTower, href: `/broadcast/round/${data.id}/edit` },
                   },
-                  'Round settings'
+                  'Round settings',
                 ),
               ])
             : null,
@@ -263,10 +263,10 @@ export function view(ctrl: StudyFormCtrl): VNode {
                     'submit',
                     _ =>
                       isNew ||
-                      prompt(ctrl.trans('confirmDeleteStudy', data.name))?.trim() === data.name.trim()
+                      prompt(ctrl.trans('confirmDeleteStudy', data.name))?.trim() === data.name.trim(),
                   ),
                 },
-                [h(emptyRedButton, ctrl.trans.noarg(isNew ? 'cancel' : 'deleteStudy'))]
+                [h(emptyRedButton, ctrl.trans.noarg(isNew ? 'cancel' : 'deleteStudy'))],
               ),
               isNew
                 ? null
@@ -278,10 +278,10 @@ export function view(ctrl: StudyFormCtrl): VNode {
                         method: 'post',
                       },
                       hook: bindNonPassive('submit', _ =>
-                        confirm(ctrl.trans.noarg('deleteTheStudyChatHistory'))
+                        confirm(ctrl.trans.noarg('deleteTheStudyChatHistory')),
                       ),
                     },
-                    [h(emptyRedButton, ctrl.trans.noarg('clearChat'))]
+                    [h(emptyRedButton, ctrl.trans.noarg('clearChat'))],
                   ),
             ]),
             h(
@@ -289,10 +289,10 @@ export function view(ctrl: StudyFormCtrl): VNode {
               {
                 attrs: { type: 'submit' },
               },
-              ctrl.trans.noarg(isNew ? 'start' : 'save')
+              ctrl.trans.noarg(isNew ? 'start' : 'save'),
             ),
           ]),
-        ]
+        ],
       ),
     ],
   });

--- a/ui/analyse/src/study/studyGlyph.ts
+++ b/ui/analyse/src/study/studyGlyph.ts
@@ -30,7 +30,7 @@ function renderGlyph(ctrl: GlyphCtrl, node: Tree.Node) {
           active: !!node.glyphs && !!node.glyphs.find(g => g.id === glyph.id),
         },
       },
-      [glyph.name]
+      [glyph.name],
     );
 }
 
@@ -50,7 +50,7 @@ export function ctrl(root: AnalyseCtrl): GlyphCtrl {
       'toggleGlyph',
       root.study!.withPosition({
         id,
-      })
+      }),
     );
     root.redraw();
   });
@@ -77,6 +77,6 @@ export function view(ctrl: GlyphCtrl): VNode {
           h('div.position', all.position.map(renderGlyph(ctrl, node))),
           h('div.observation', all.observation.map(renderGlyph(ctrl, node))),
         ]
-      : [h('div.study__message', spinner())]
+      : [h('div.study__message', spinner())],
   );
 }

--- a/ui/analyse/src/study/studyMembers.ts
+++ b/ui/analyse/src/study/studyMembers.ts
@@ -179,7 +179,7 @@ export function view(ctrl: StudyCtrl): VNode {
       {
         attrs: { 'data-href': '/@/' + u.name },
       },
-      (u.title ? u.title + ' ' : '') + u.name
+      (u.title ? u.title + ' ' : '') + u.name,
     );
   }
 
@@ -195,7 +195,7 @@ export function view(ctrl: StudyCtrl): VNode {
         },
         attrs: { title: ctrl.trans.noarg(contrib ? 'contributor' : 'spectator') },
       },
-      [iconTag(contrib ? licon.User : licon.Eye)]
+      [iconTag(contrib ? licon.User : licon.Eye)],
     );
   }
 
@@ -206,7 +206,7 @@ export function view(ctrl: StudyCtrl): VNode {
         hook: bind(
           'click',
           _ => members.confing(members.confing() == member.user.id ? null : member.user.id),
-          ctrl.redraw
+          ctrl.redraw,
         ),
       });
     if (!isOwner && member.user.id === members.myId)
@@ -242,7 +242,7 @@ export function view(ctrl: StudyCtrl): VNode {
                 e => {
                   members.setRole(member.user.id, (e.target as HTMLInputElement).checked ? 'w' : 'r');
                 },
-                ctrl.redraw
+                ctrl.redraw,
               ),
             }),
             h('label', { attrs: { for: roleId } }),
@@ -257,10 +257,10 @@ export function view(ctrl: StudyCtrl): VNode {
               attrs: dataIcon(licon.X),
               hook: bind('click', _ => members.kick(member.user.id), ctrl.redraw),
             },
-            ctrl.trans.noarg('kick')
-          )
+            ctrl.trans.noarg('kick'),
+          ),
         ),
-      ]
+      ],
     );
   }
 
@@ -282,7 +282,7 @@ export function view(ctrl: StudyCtrl): VNode {
                 key: member.user.id,
                 class: { editing: !!confing },
               },
-              [h('div.left', [statusIcon(member), username(member)]), configButton(ctrl, member)]
+              [h('div.left', [statusIcon(member), username(member)]), configButton(ctrl, member)],
             ),
             confing ? memberConfig(member) : null,
           ];
@@ -300,7 +300,7 @@ export function view(ctrl: StudyCtrl): VNode {
                 h('span.status', iconTag(licon.PlusButton)),
                 h('div.user-link', ctrl.trans.noarg('addMembers')),
               ]),
-            ]
+            ],
           )
         : null,
       !members.canContribute() && ctrl.data.admin
@@ -313,9 +313,9 @@ export function view(ctrl: StudyCtrl): VNode {
                 return false;
               }),
             },
-            [h('button.button.button-red.button-thin', 'Enter as admin')]
+            [h('button.button.button-red.button-thin', 'Enter as admin')],
           )
         : null,
-    ]
+    ],
   );
 }

--- a/ui/analyse/src/study/studySearch.ts
+++ b/ui/analyse/src/study/studySearch.ts
@@ -14,7 +14,7 @@ export class SearchCtrl {
     readonly studyName: string,
     readonly chapters: Prop<StudyChapterMeta[]>,
     readonly rootSetChapter: (id: string) => void,
-    readonly redraw: Redraw
+    readonly redraw: Redraw,
   ) {
     this.open = propWithEffect(false, () => this.query(''));
     lichess.pubsub.on('study.search.open', () => this.open(true));
@@ -59,7 +59,7 @@ export function view(ctrl: SearchCtrl) {
         attrs: { autofocus: 1, placeholder: `Search in ${ctrl.studyName}`, value: ctrl.query() },
         hook: onInsert((el: HTMLInputElement) => {
           el.addEventListener('input', (e: KeyboardEvent) =>
-            ctrl.query((e.target as HTMLInputElement).value.trim())
+            ctrl.query((e.target as HTMLInputElement).value.trim()),
           );
           el.addEventListener('keydown', (e: KeyboardEvent) => e.key == 'Enter' && ctrl.setFirstChapter());
         }),
@@ -86,13 +86,13 @@ export function view(ctrl: SearchCtrl) {
                       }
                     : {},
                 },
-                c.name
+                c.name,
               ),
               c.ongoing ? h('ongoing', { attrs: { ...dataIcon(licon.DiscBig), title: 'Ongoing' } }) : null,
               !c.ongoing && c.res ? h('res', c.res) : null,
-            ]
-          )
-        )
+            ],
+          ),
+        ),
       ),
     ],
   });

--- a/ui/analyse/src/study/studyShare.ts
+++ b/ui/analyse/src/study/studyShare.ts
@@ -30,7 +30,7 @@ function fromPly(ctrl: StudyShareCtrl): VNode {
       withDots: true,
       showEval: false,
     },
-    ctrl.currentNode()
+    ctrl.currentNode(),
   );
   return h(
     'div.ply-wrap',
@@ -44,7 +44,7 @@ function fromPly(ctrl: StudyShareCtrl): VNode {
             ? ctrl.trans.vdom('startAtX', h('strong', renderedMove))
             : [ctrl.trans.noarg('startAtInitialPosition')]),
         ])
-      : null
+      : null,
   );
 }
 
@@ -56,7 +56,7 @@ export function ctrl(
   bottomColor: () => Color,
   relay: RelayCtrl | undefined,
   redraw: () => void,
-  trans: Trans
+  trans: Trans,
 ): StudyShareCtrl {
   const withPly = prop(false);
   return {
@@ -101,7 +101,7 @@ export function view(ctrl: StudyShareCtrl): VNode {
     h(
       'p.form-help.text',
       { attrs: { 'data-icon': licon.InfoCircle } },
-      ctrl.trans.noarg('youCanPasteThisInTheForumToEmbed')
+      ctrl.trans.noarg('youCanPasteThisInTheForumToEmbed'),
     );
   return h(
     'div.study__share',
@@ -117,7 +117,7 @@ export function view(ctrl: StudyShareCtrl): VNode {
                       href: `/study/${studyId}/clone`,
                     },
                   },
-                  ctrl.trans.noarg('cloneStudy')
+                  ctrl.trans.noarg('cloneStudy'),
                 )
               : null,
             ctrl.relay &&
@@ -130,7 +130,7 @@ export function view(ctrl: StudyShareCtrl): VNode {
                     download: true,
                   },
                 },
-                ctrl.trans.noarg('downloadAllRounds')
+                ctrl.trans.noarg('downloadAllRounds'),
               ),
             h(
               'a.button.text',
@@ -141,7 +141,7 @@ export function view(ctrl: StudyShareCtrl): VNode {
                   download: true,
                 },
               },
-              ctrl.trans.noarg(ctrl.relay ? 'downloadAllGames' : 'studyPgn')
+              ctrl.trans.noarg(ctrl.relay ? 'downloadAllGames' : 'studyPgn'),
             ),
             h(
               'a.button.text',
@@ -152,7 +152,7 @@ export function view(ctrl: StudyShareCtrl): VNode {
                   download: true,
                 },
               },
-              ctrl.trans.noarg(ctrl.relay ? 'downloadGame' : 'chapterPgn')
+              ctrl.trans.noarg(ctrl.relay ? 'downloadGame' : 'chapterPgn'),
             ),
             h(
               'a.button.text',
@@ -166,11 +166,11 @@ export function view(ctrl: StudyShareCtrl): VNode {
                   const iconFeedback = (success: boolean) => {
                     (event.target as HTMLElement).setAttribute(
                       'data-icon',
-                      success ? licon.Checkmark : licon.X
+                      success ? licon.Checkmark : licon.X,
                     );
                     setTimeout(
                       () => (event.target as HTMLElement).setAttribute('data-icon', licon.Clipboard),
-                      1000
+                      1000,
                     );
                   };
                   writePgnClipboard(`/study/${studyId}/${ctrl.chapter().id}.pgn`).then(
@@ -178,11 +178,11 @@ export function view(ctrl: StudyShareCtrl): VNode {
                     err => {
                       console.log(err);
                       iconFeedback(false);
-                    }
+                    },
                   );
                 }),
               },
-              ctrl.trans.noarg('copyChapterPgn')
+              ctrl.trans.noarg('copyChapterPgn'),
             ),
             h(
               'a.button.text',
@@ -200,7 +200,7 @@ export function view(ctrl: StudyShareCtrl): VNode {
                   download: true,
                 },
               },
-              'Board'
+              'Board',
             ),
             h(
               'a.button.text',
@@ -214,7 +214,7 @@ export function view(ctrl: StudyShareCtrl): VNode {
                   download: true,
                 },
               },
-              'GIF'
+              'GIF',
             ),
           ]),
           h('form.form3', [
@@ -246,7 +246,7 @@ export function view(ctrl: StudyShareCtrl): VNode {
                   }),
                 ]),
                 ...(pastable ? [fromPly(ctrl), !isPrivate ? youCanPasteThis() : null] : []),
-              ])
+              ]),
             ),
             h(
               'div.form-group',
@@ -258,7 +258,7 @@ export function view(ctrl: StudyShareCtrl): VNode {
                     disabled: isPrivate,
                     value: !isPrivate
                       ? `<iframe width=600 height=371 src="${baseUrl()}${addPly(
-                          `/study/embed/${studyId}/${chapter.id}`
+                          `/study/embed/${studyId}/${chapter.id}`,
                         )}" frameborder=0></iframe>`
                       : ctrl.trans.noarg('onlyPublicStudiesCanBeEmbedded'),
                   },
@@ -277,11 +277,11 @@ export function view(ctrl: StudyShareCtrl): VNode {
                             'data-icon': licon.InfoCircle,
                           },
                         },
-                        ctrl.trans.noarg('readMoreAboutEmbedding')
+                        ctrl.trans.noarg('readMoreAboutEmbedding'),
                       ),
                     ]
-                  : []
-              )
+                  : [],
+              ),
             ),
             h('div.form-group', [
               h('label.form-label', 'FEN'),
@@ -294,6 +294,6 @@ export function view(ctrl: StudyShareCtrl): VNode {
             ]),
           ]),
         ]
-      : h('div', 'Sharing and exporting were disabled by the study owner.')
+      : h('div', 'Sharing and exporting were disabled by the study owner.'),
   );
 }

--- a/ui/analyse/src/study/studyTags.ts
+++ b/ui/analyse/src/study/studyTags.ts
@@ -41,7 +41,7 @@ function renderPgnTags(
   submit: ((type: string) => (tag: string) => void) | false,
   types: string[],
   trans: Trans,
-  hideRatings?: boolean
+  hideRatings?: boolean,
 ): VNode {
   let rows: TagRow[] = [];
   if (chapter.setup.variant.key !== 'standard') rows.push(['Variant', fixed(chapter.setup.variant.name)]);
@@ -49,9 +49,9 @@ function renderPgnTags(
     chapter.tags
       .filter(
         tag =>
-          !hideRatings || !['WhiteElo', 'BlackElo'].includes(tag[0]) || !looksLikeLichessGame(chapter.tags)
+          !hideRatings || !['WhiteElo', 'BlackElo'].includes(tag[0]) || !looksLikeLichessGame(chapter.tags),
       )
-      .map(tag => [tag[0], submit ? editable(tag[1], submit(tag[0])) : fixed(tag[1])])
+      .map(tag => [tag[0], submit ? editable(tag[1], submit(tag[0])) : fixed(tag[1])]),
   );
   if (submit) {
     const existingTypes = chapter.tags.map(t => t[0]);
@@ -84,7 +84,7 @@ function renderPgnTags(
             if (!existingTypes.includes(t)) return option(t, '', t);
             return undefined;
           }),
-        ]
+        ],
       ),
       editable('', (value, el) => {
         if (selectedType) {
@@ -105,10 +105,10 @@ function renderPgnTags(
           {
             key: '' + r[0],
           },
-          [h('th', [r[0]]), h('td', [r[1]])]
+          [h('th', [r[0]]), h('td', [r[1]])],
         );
-      })
-    )
+      }),
+    ),
   );
 }
 
@@ -137,8 +137,8 @@ function doRender(root: StudyCtrl): VNode {
       root.vm.mode.write && root.tags.submit,
       root.tags.types,
       root.trans,
-      root.data.hideRatings
-    )
+      root.data.hideRatings,
+    ),
   );
 }
 

--- a/ui/analyse/src/study/studyView.ts
+++ b/ui/analyse/src/study/studyView.ts
@@ -45,10 +45,10 @@ function toolButton(opts: ToolButtonOpts): VNode {
           if (opts.onClick) opts.onClick();
           opts.ctrl.vm.toolTab(opts.tab);
         },
-        opts.ctrl.redraw
+        opts.ctrl.redraw,
       ),
     },
-    [opts.count ? h('count.data-count', { attrs: { 'data-count': opts.count } }) : null, opts.icon]
+    [opts.count ? h('count.data-count', { attrs: { 'data-count': opts.count } }) : null, opts.icon],
   );
 }
 
@@ -68,7 +68,7 @@ function buttons(root: AnalyseCtrl): VNode {
               class: { on: ctrl.vm.mode.sticky },
               hook: bind('click', ctrl.toggleSticky),
             },
-            [ctrl.vm.behind ? h('span.behind', '' + ctrl.vm.behind) : h('i.is'), 'SYNC']
+            [ctrl.vm.behind ? h('span.behind', '' + ctrl.vm.behind) : h('i.is'), 'SYNC'],
           )
         : null,
       ctrl.members.canContribute()
@@ -79,7 +79,7 @@ function buttons(root: AnalyseCtrl): VNode {
               class: { on: ctrl.vm.mode.write },
               hook: bind('click', ctrl.toggleWrite),
             },
-            [h('i.is'), 'REC']
+            [h('i.is'), 'REC'],
           )
         : null,
       toolButton({
@@ -157,7 +157,7 @@ function metadata(ctrl: StudyCtrl): VNode {
           },
           hook: bind('click', ctrl.toggleLike),
         },
-        '' + d.likes
+        '' + d.likes,
       ),
     ]),
     topicsView(ctrl),
@@ -177,7 +177,7 @@ export function side(ctrl: StudyCtrl): VNode {
         attrs: { role: 'tab' },
         hook: bind('mousedown', () => ctrl.setTab(key)),
       },
-      name
+      name,
     );
 
   const tourTab =
@@ -191,14 +191,14 @@ export function side(ctrl: StudyCtrl): VNode {
           () => {
             tourShow.active = true;
           },
-          ctrl.redraw
+          ctrl.redraw,
         ),
         attrs: {
           'data-icon': licon.RadioTower,
           role: 'tab',
         },
       },
-      'Broadcast'
+      'Broadcast',
     );
 
   const chaptersTab =
@@ -206,7 +206,7 @@ export function side(ctrl: StudyCtrl): VNode {
       ? null
       : makeTab(
           'chapters',
-          ctrl.trans.pluralSame(ctrl.relay ? 'nbGames' : 'nbChapters', ctrl.chapters.list().length)
+          ctrl.trans.pluralSame(ctrl.relay ? 'nbGames' : 'nbChapters', ctrl.chapters.list().length),
         );
 
   const tabs = h('div.tabs-horiz', { attrs: { role: 'tablist' } }, [
@@ -249,7 +249,7 @@ export function contextMenu(ctrl: StudyCtrl, path: Tree.Path, node: Tree.Node): 
               ctrl.commentForm.start(ctrl.currentChapter()!.id, path, node);
             }),
           },
-          ctrl.trans.noarg('commentThisMove')
+          ctrl.trans.noarg('commentThisMove'),
         ),
         h(
           'a.glyph-icon',
@@ -259,7 +259,7 @@ export function contextMenu(ctrl: StudyCtrl, path: Tree.Path, node: Tree.Node): 
               ctrl.userJump(path);
             }),
           },
-          ctrl.trans.noarg('annotateWithGlyphs')
+          ctrl.trans.noarg('annotateWithGlyphs'),
         ),
       ]
     : [];
@@ -298,7 +298,7 @@ export function underboard(ctrl: AnalyseCtrl): MaybeVNodes {
             ctrl,
             study.members.canContribute()
               ? 'Press REC to comment moves'
-              : 'Only the study members can comment on moves'
+              : 'Only the study members can comment on moves',
           );
       break;
     case 'glyphs':

--- a/ui/analyse/src/study/topics.ts
+++ b/ui/analyse/src/study/topics.ts
@@ -14,7 +14,7 @@ export default class TopicsCtrl {
     readonly save: (data: string[]) => void,
     readonly getTopics: () => Topic[],
     readonly trans: Trans,
-    readonly redraw: Redraw
+    readonly redraw: Redraw,
   ) {}
 }
 
@@ -26,8 +26,8 @@ export const view = (ctrl: StudyCtrl): VNode =>
         {
           attrs: { href: `/study/topic/${encodeURIComponent(topic)}/hot` },
         },
-        topic
-      )
+        topic,
+      ),
     ),
     ctrl.members.canContribute()
       ? h(
@@ -35,7 +35,7 @@ export const view = (ctrl: StudyCtrl): VNode =>
           {
             hook: bind('click', () => ctrl.topics.open(true), ctrl.redraw),
           },
-          ctrl.trans.noarg('manageTopics')
+          ctrl.trans.noarg('manageTopics'),
         )
       : null,
   ]);
@@ -68,16 +68,16 @@ export const formView = (ctrl: TopicsCtrl, userId?: string): VNode =>
             {
               hook: onInsert(elm => setupTagify(elm as HTMLTextAreaElement, userId)),
             },
-            ctrl.getTopics().join(', ').replace(/[<>]/g, '')
+            ctrl.getTopics().join(', ').replace(/[<>]/g, ''),
           ),
           h(
             'button.button',
             {
               type: 'submit',
             },
-            ctrl.trans.noarg('save')
+            ctrl.trans.noarg('save'),
           ),
-        ]
+        ],
       ),
     ],
   });

--- a/ui/analyse/src/treeView/columnView.ts
+++ b/ui/analyse/src/treeView/columnView.ts
@@ -34,7 +34,7 @@ function emptyMove(conceal?: Conceal): VNode {
     {
       class: c,
     },
-    '...'
+    '...',
   );
 }
 
@@ -49,7 +49,7 @@ function renderChildrenOf(ctx: Ctx, node: Tree.Node, opts: Opts): MaybeVNodes | 
   if (opts.isMainline) {
     const isWhite = main.ply % 2 === 1,
       commentTags = renderMainlineCommentsOf(ctx, main, conceal, true, opts.parentPath + main.id).filter(
-        nonEmpty
+        nonEmpty,
       );
     if (!cs[1] && isEmpty(commentTags) && !main.forceVariation)
       return ((isWhite ? [moveView.renderIndex(main.ply, false)] : []) as MaybeVNodes).concat(
@@ -57,7 +57,7 @@ function renderChildrenOf(ctx: Ctx, node: Tree.Node, opts: Opts): MaybeVNodes | 
           parentPath: opts.parentPath,
           isMainline: true,
           conceal,
-        }) || []
+        }) || [],
       );
     const mainChildren = main.forceVariation
       ? undefined
@@ -75,7 +75,7 @@ function renderChildrenOf(ctx: Ctx, node: Tree.Node, opts: Opts): MaybeVNodes | 
       .concat(
         main.forceVariation
           ? []
-          : [renderMoveOf(ctx, main, passOpts), isWhite ? emptyMove(passOpts.conceal) : null]
+          : [renderMoveOf(ctx, main, passOpts), isWhite ? emptyMove(passOpts.conceal) : null],
       )
       .concat([
         h(
@@ -86,12 +86,12 @@ function renderChildrenOf(ctx: Ctx, node: Tree.Node, opts: Opts): MaybeVNodes | 
               isMainline: passOpts.isMainline,
               conceal,
               noConceal: !conceal,
-            })
-          )
+            }),
+          ),
         ),
       ] as MaybeVNodes)
       .concat(
-        isWhite && mainChildren ? [moveView.renderIndex(main.ply, false), emptyMove(passOpts.conceal)] : []
+        isWhite && mainChildren ? [moveView.renderIndex(main.ply, false), emptyMove(passOpts.conceal)] : [],
       )
       .concat(mainChildren || []);
   }
@@ -129,10 +129,10 @@ function renderLines(ctx: Ctx, nodes: Tree.Node[], opts: Opts): VNode {
             withIndex: true,
             noConceal: opts.noConceal,
             truncate: n.comp && !treePath.contains(ctx.ctrl.path, opts.parentPath + n.id) ? 3 : undefined,
-          })
+          }),
         )
       );
-    })
+    }),
   );
 }
 
@@ -150,7 +150,7 @@ function renderMainlineMoveOf(ctx: Ctx, node: Tree.Node, opts: Opts): VNode {
       attrs: { p: path },
       class: classes,
     },
-    moveView.renderMove(ctx, node)
+    moveView.renderMove(ctx, node),
   );
 }
 
@@ -167,7 +167,7 @@ function renderVariationMoveOf(ctx: Ctx, node: Tree.Node, opts: Opts): VNode {
       attrs: { p: path },
       class: classes,
     },
-    content
+    content,
   );
 }
 
@@ -180,7 +180,7 @@ function renderMoveAndChildrenOf(ctx: Ctx, node: Tree.Node, opts: Opts): MaybeVN
         {
           attrs: { p: path },
         },
-        [h('index', '[...]')]
+        [h('index', '[...]')],
       ),
     ];
   return [
@@ -205,7 +205,7 @@ function renderInline(ctx: Ctx, node: Tree.Node, opts: Opts): VNode {
       isMainline: false,
       noConceal: opts.noConceal,
       truncate: opts.truncate,
-    })
+    }),
   );
 }
 
@@ -214,7 +214,7 @@ function renderMainlineCommentsOf(
   node: Tree.Node,
   conceal: Conceal,
   withColor: boolean,
-  path: string
+  path: string,
 ): MaybeVNodes {
   if (!ctx.ctrl.showComments || isEmpty(node.comments)) return [];
 
@@ -264,7 +264,7 @@ export default function (ctrl: AnalyseCtrl, concealOf?: ConcealOf): VNode {
       renderChildrenOf(ctx, root, {
         parentPath: '',
         isMainline: true,
-      }) || []
-    )
+      }) || [],
+    ),
   );
 }

--- a/ui/analyse/src/treeView/common.ts
+++ b/ui/analyse/src/treeView/common.ts
@@ -129,7 +129,7 @@ export const renderComment = (
   sel: string,
   ctx: Ctx,
   path: string,
-  maxLength: number
+  maxLength: number,
 ) => {
   if (comment.by === 'lichess' && !ctx.showComputer) return;
   const by = !others[1] ? '' : `<span class="by">${commentAuthorText(comment.by)}</span>`,

--- a/ui/analyse/src/treeView/contextMenu.ts
+++ b/ui/analyse/src/treeView/contextMenu.ts
@@ -62,7 +62,7 @@ function action(icon: string, text: string, handler: () => void): VNode {
       attrs: { 'data-icon': icon },
       hook: bind('click', handler),
     },
-    text
+    text,
   );
 }
 
@@ -95,7 +95,7 @@ function view(opts: Opts, coords: Coords): VNode {
         onMainline
           ? action(licon.InternalArrow, trans('forceVariation'), () => ctrl.forceVariation(opts.path, true))
           : null,
-      ])
+      ]),
   );
 }
 

--- a/ui/analyse/src/treeView/inlineView.ts
+++ b/ui/analyse/src/treeView/inlineView.ts
@@ -42,7 +42,7 @@ function renderChildrenOf(ctx: Ctx, node: Tree.Node, opts: Opts): MaybeVNodes | 
           renderLines(ctx, main.forceVariation ? cs : cs.slice(1), {
             parentPath: opts.parentPath,
             isMainline: true,
-          })
+          }),
         ),
         ...(main.forceVariation
           ? []
@@ -83,10 +83,10 @@ function renderLines(ctx: Ctx, nodes: Tree.Node[], opts: Opts): VNode {
             isMainline: false,
             withIndex: true,
             truncate: n.comp && !treePath.contains(ctx.ctrl.path, opts.parentPath + n.id) ? 3 : undefined,
-          })
+          }),
         )
       );
-    })
+    }),
   );
 }
 
@@ -103,7 +103,7 @@ function renderMoveAndChildrenOf(ctx: Ctx, node: Tree.Node, opts: Opts): MaybeVN
         isMainline: opts.isMainline,
         truncate: opts.truncate ? opts.truncate - 1 : undefined,
         withIndex: !!comments[0],
-      }) || []
+      }) || [],
     );
 }
 
@@ -116,7 +116,7 @@ function renderInline(ctx: Ctx, node: Tree.Node, opts: Opts): VNode {
       withIndex: true,
       parentPath: opts.parentPath,
       isMainline: false,
-    })
+    }),
   );
 }
 
@@ -133,7 +133,7 @@ function renderMoveOf(ctx: Ctx, node: Tree.Node, opts: Opts): VNode {
       attrs: { p: path },
       class: nodeClasses(ctx, node, path),
     },
-    content
+    content,
   );
 }
 
@@ -157,6 +157,6 @@ export default function (ctrl: AnalyseCtrl): VNode {
         parentPath: '',
         isMainline: true,
       }) || []),
-    ]
+    ],
   );
 }

--- a/ui/analyse/src/treeView/treeView.ts
+++ b/ui/analyse/src/treeView/treeView.ts
@@ -20,7 +20,7 @@ export function ctrl(initialValue: TreeViewKey = 'column'): TreeView {
     'treeView',
     initialValue,
     str => str as TreeViewKey,
-    v => v
+    v => v,
   );
   function inline() {
     return value() === 'inline';

--- a/ui/analyse/src/view/actionMenu.ts
+++ b/ui/analyse/src/view/actionMenu.ts
@@ -58,9 +58,9 @@ function autoplayButtons(ctrl: AnalyseCtrl): VNode {
           },
           hook: bind('click', () => ctrl.togglePlay(speed.delay), ctrl.redraw),
         },
-        ctrl.trans.noarg(speed.name)
+        ctrl.trans.noarg(speed.name),
       );
-    })
+    }),
   );
 }
 
@@ -80,7 +80,7 @@ export function studyButton(ctrl: AnalyseCtrl) {
           'data-icon': licon.StudyBoard,
         },
       },
-      ctrl.trans.noarg('openStudy')
+      ctrl.trans.noarg('openStudy'),
     );
   if (ctrl.study || ctrl.ongoing) return;
   return h(
@@ -111,9 +111,9 @@ export function studyButton(ctrl: AnalyseCtrl) {
             'data-icon': licon.StudyBoard,
           },
         },
-        ctrl.trans.noarg('toStudy')
+        ctrl.trans.noarg('toStudy'),
       ),
-    ]
+    ],
   );
 }
 
@@ -135,7 +135,7 @@ export function view(ctrl: AnalyseCtrl): VNode {
             title: 'Hotkey: f',
           },
         },
-        noarg('flipBoard')
+        noarg('flipBoard'),
       ),
       ctrl.ongoing
         ? null
@@ -155,7 +155,7 @@ export function view(ctrl: AnalyseCtrl): VNode {
                 rel: 'nofollow',
               },
             },
-            noarg('boardEditor')
+            noarg('boardEditor'),
           ),
       canContinue
         ? h(
@@ -164,11 +164,11 @@ export function view(ctrl: AnalyseCtrl): VNode {
               hook: bind('click', _ =>
                 modal({
                   content: $('.continue-with.g_' + d.game.id),
-                })
+                }),
               ),
               attrs: dataIcon(licon.Swords),
             },
-            noarg('continueFromHere')
+            noarg('continueFromHere'),
           )
         : null,
       studyButton(ctrl),
@@ -191,7 +191,7 @@ export function view(ctrl: AnalyseCtrl): VNode {
               disabled: mandatoryCeval,
               change: ctrl.toggleComputer,
             },
-            ctrl
+            ctrl,
           ),
           ...(ctrl.showComputer()
             ? [
@@ -203,7 +203,7 @@ export function view(ctrl: AnalyseCtrl): VNode {
                     checked: ctrl.showAutoShapes(),
                     change: ctrl.toggleAutoShapes,
                   },
-                  ctrl
+                  ctrl,
                 ),
                 ctrlToggle(
                   {
@@ -212,7 +212,7 @@ export function view(ctrl: AnalyseCtrl): VNode {
                     checked: ctrl.showGauge(),
                     change: ctrl.toggleGauge,
                   },
-                  ctrl
+                  ctrl,
                 ),
                 ctrlToggle(
                   {
@@ -222,7 +222,7 @@ export function view(ctrl: AnalyseCtrl): VNode {
                     checked: ceval.infinite(),
                     change: ctrl.cevalSetInfinite,
                   },
-                  ctrl
+                  ctrl,
                 ),
                 ceval.technology != 'external'
                   ? ctrlToggle(
@@ -236,7 +236,7 @@ export function view(ctrl: AnalyseCtrl): VNode {
                         change: ceval.enableNnue,
                         disabled: !ceval.platform.supportsNnue,
                       },
-                      ctrl
+                      ctrl,
                     )
                   : null,
                 (id => {
@@ -271,7 +271,7 @@ export function view(ctrl: AnalyseCtrl): VNode {
                     }),
                     h(
                       'div.range_value',
-                      `${ceval.threads ? ceval.threads() : 1} / ${ceval.platform.maxThreads}`
+                      `${ceval.threads ? ceval.threads() : 1} / ${ceval.platform.maxThreads}`,
                     ),
                   ]);
                 })('analyse-threads'),
@@ -289,7 +289,7 @@ export function view(ctrl: AnalyseCtrl): VNode {
                       },
                       hook: rangeConfig(
                         () => Math.floor(Math.log2(ceval.hashSize())),
-                        v => ctrl.cevalSetHashSize(Math.pow(2, v))
+                        v => ctrl.cevalSetHashSize(Math.pow(2, v)),
                       ),
                     }),
                     h('div.range_value', formatHashSize(ceval.hashSize())),
@@ -311,7 +311,7 @@ export function view(ctrl: AnalyseCtrl): VNode {
           ctrl.actionMenu.toggle();
         },
       },
-      ctrl
+      ctrl,
     ),
     ctrlToggle(
       {
@@ -321,7 +321,7 @@ export function view(ctrl: AnalyseCtrl): VNode {
         checked: ctrl.showMoveAnnotation(),
         change: ctrl.toggleMoveAnnotation,
       },
-      ctrl
+      ctrl,
     ),
   ];
 
@@ -343,7 +343,7 @@ export function view(ctrl: AnalyseCtrl): VNode {
                 rel: 'nofollow',
               },
             },
-            noarg('playWithTheMachine')
+            noarg('playWithTheMachine'),
           ),
           h(
             'a.button',
@@ -355,7 +355,7 @@ export function view(ctrl: AnalyseCtrl): VNode {
                 rel: 'nofollow',
               },
             },
-            noarg('playWithAFriend')
+            noarg('playWithAFriend'),
           ),
         ])
       : null,

--- a/ui/analyse/src/view/clocks.ts
+++ b/ui/analyse/src/view/clocks.ts
@@ -39,7 +39,7 @@ const renderClock = (centis: number | undefined, active: boolean, cls: string, s
     {
       class: { active },
     },
-    clockContent(centis, showTenths)
+    clockContent(centis, showTenths),
   );
 
 function clockContent(centis: number | undefined, showTenths: boolean): Array<string | VNode> {

--- a/ui/analyse/src/view/externalEngine.ts
+++ b/ui/analyse/src/view/externalEngine.ts
@@ -23,10 +23,10 @@ export function config(ctrl: AnalyseCtrl) {
                 selected: ctrl.getCeval().externalEngine?.id == engine.id,
               },
             },
-            engine.name
-          )
+            engine.name,
+          ),
         ),
-      ]
+      ],
     ),
   ];
 }

--- a/ui/analyse/src/view/moveView.ts
+++ b/ui/analyse/src/view/moveView.ts
@@ -16,7 +16,7 @@ export const renderGlyph = (glyph: Tree.Glyph): VNode =>
     {
       attrs: { title: glyph.name },
     },
-    glyph.symbol
+    glyph.symbol,
   );
 
 const renderEval = (e: string): VNode => h('eval', e.replace('-', '−'));

--- a/ui/analyse/src/view/roundTraining.ts
+++ b/ui/analyse/src/view/roundTraining.ts
@@ -30,14 +30,14 @@ const renderPlayer = (ctrl: AnalyseCtrl, color: Color): VNode => {
       {
         attrs: { href: '/@/' + p.user.username },
       },
-      [p.user.username, ' ', renderRatingDiff(p.ratingDiff)]
+      [p.user.username, ' ', renderRatingDiff(p.ratingDiff)],
     );
   return h(
     'span',
     p.name ||
       (p.ai && 'Stockfish level ' + p.ai) ||
       (ctrl.study && findTag(ctrl.study.data.chapter.tags, color)) ||
-      'Anonymous'
+      'Anonymous',
   );
 };
 
@@ -79,7 +79,7 @@ const error = (ctrl: AnalyseCtrl, nb: number, color: Color, advice: Advice) =>
   h(
     'div.advice-summary__error' + (nb ? `.symbol.${advice.kind}` : ''),
     { attrs: nb ? { 'data-color': color, 'data-symbol': advice.symbol } : {} },
-    ctrl.trans.vdomPlural(advice.i18n, nb, h('strong', nb))
+    ctrl.trans.vdomPlural(advice.i18n, nb, h('strong', nb)),
   );
 
 const markerColorPrefix = (el: Element): string => {
@@ -130,10 +130,10 @@ const doRender = (ctrl: AnalyseCtrl): VNode => {
               attrs: dataIcon(licon.PlayTriangle),
               hook: bind('click', ctrl.toggleRetro, ctrl.redraw),
             },
-            ctrl.trans.noarg('learnFromYourMistakes')
+            ctrl.trans.noarg('learnFromYourMistakes'),
           ),
       playerTable(ctrl, 'black'),
-    ]
+    ],
   );
 };
 
@@ -151,8 +151,8 @@ export function puzzleLink(ctrl: AnalyseCtrl): VNode | undefined {
             href: `/training/${puzzle.key}/${ctrl.bottomColor()}`,
           },
         },
-        ['Recommended puzzle training', h('br'), puzzle.name]
-      )
+        ['Recommended puzzle training', h('br'), puzzle.name],
+      ),
     )
   );
 }

--- a/ui/analyse/src/view/util.ts
+++ b/ui/analyse/src/view/util.ts
@@ -29,5 +29,5 @@ export const option = (value: string, current: string | undefined, name: string)
         selected: value === current,
       },
     },
-    name
+    name,
   );

--- a/ui/analyse/src/view/view.ts
+++ b/ui/analyse/src/view/view.ts
@@ -148,7 +148,7 @@ function inputs(ctrl: AnalyseCtrl): VNode | undefined {
                   if (pgn !== pgnExport.renderFullTxt(ctrl)) ctrl.changePgn(pgn, true);
                 }),
               },
-              ctrl.trans.noarg('importPgn')
+              ctrl.trans.noarg('importPgn'),
             ),
       ]),
     ]),
@@ -178,7 +178,7 @@ function controls(ctrl: AnalyseCtrl) {
             ctrl.persistence?.autoOpen(false);
             ctrl.togglePersistence();
           }
-        }, ctrl.redraw)
+        }, ctrl.redraw),
       ),
     },
     [
@@ -232,7 +232,7 @@ function controls(ctrl: AnalyseCtrl) {
                     },
                   })
                 : null,
-            ]
+            ],
       ),
       h('div.jumps', [
         jumpButton(licon.JumpFirst, 'first', canJumpPrev),
@@ -250,7 +250,7 @@ function controls(ctrl: AnalyseCtrl) {
               'data-icon': licon.Hamburger,
             },
           }),
-    ]
+    ],
   );
 }
 
@@ -277,7 +277,7 @@ const analysisDisabled = (ctrl: AnalyseCtrl): MaybeVNode =>
             hook: bind('click', ctrl.toggleComputer, ctrl.redraw),
             attrs: { type: 'button' },
           },
-          ctrl.trans.noarg('enable')
+          ctrl.trans.noarg('enable'),
         ),
       ])
     : undefined;
@@ -292,7 +292,7 @@ export const renderMaterialDiffs = (ctrl: AnalyseCtrl): [VNode, VNode] =>
     ctrl.node.fen,
     !!(ctrl.data.player.checks || ctrl.data.opponent.checks), // showChecks
     ctrl.nodeList,
-    ctrl.node.ply
+    ctrl.node.ply,
   );
 
 function renderPlayerStrips(ctrl: AnalyseCtrl): [VNode, VNode] | undefined {
@@ -423,7 +423,7 @@ export default function (deps?: typeof studyDeps) {
                         if (e.deltaY > 0 && scroll) control.next(ctrl);
                         else if (e.deltaY < 0 && scroll) control.prev(ctrl);
                         ctrl.redraw();
-                      })
+                      }),
                     ),
             },
             [
@@ -432,7 +432,7 @@ export default function (deps?: typeof studyDeps) {
               chessground.render(ctrl),
               playerBars ? playerBars[ctrl.bottomIsWhite() ? 0 : 1] : null,
               ctrl.promotion.view(ctrl.data.game.variant.key === 'antichess'),
-            ]
+            ],
           ),
         gaugeOn && !tour ? cevalView.renderGauge(ctrl) : null,
         menuIsOpen || tour ? null : crazyView(ctrl, ctrl.topColor(), 'top'),
@@ -462,7 +462,7 @@ export default function (deps?: typeof studyDeps) {
                     ? undefined
                     : onInsert(elm => serverSideUnderboard(elm, ctrl)),
               },
-              study ? deps?.studyView.underboard(ctrl) : [inputs(ctrl)]
+              study ? deps?.studyView.underboard(ctrl) : [inputs(ctrl)],
             ),
         tour ? null : trainingView(ctrl),
         ctrl.studyPractice
@@ -492,17 +492,17 @@ export default function (deps?: typeof studyDeps) {
                                 'data-icon': licon.Back,
                               },
                             },
-                            ctrl.trans.noarg('backToGame')
-                          )
+                            ctrl.trans.noarg('backToGame'),
+                          ),
                         )
                       : null,
-                  ]
+                  ],
             ),
         study && study.relay && deps?.relayManager(study.relay),
         h('div.chat__members.none', {
           hook: onInsert(lichess.watchers),
         }),
-      ]
+      ],
     );
   };
 }
@@ -529,7 +529,7 @@ function renderPersistence(ctrl: AnalyseCtrl): VNode | undefined {
           },
           hook: bind('click', ctrl.persistence.clear),
         },
-        noarg('clearSavedMoves')
+        noarg('clearSavedMoves'),
       ),
     ]),
   ]);

--- a/ui/analyse/src/wiki.ts
+++ b/ui/analyse/src/wiki.ts
@@ -22,7 +22,7 @@ export default function wikiTheory(): WikiTheory {
   const removeTableExpl = (html: string) =>
     html.replace(
       /For explanation of theory tables see theory table and for notation see algebraic notation.?/,
-      ''
+      '',
     );
   const removeContributing = (html: string) =>
     html.replace('When contributing to this Wikibook, please follow the Conventions for organization.', '');
@@ -68,7 +68,7 @@ export default function wikiTheory(): WikiTheory {
       }
     },
     500,
-    true
+    true,
   );
 }
 

--- a/ui/board/src/menu.ts
+++ b/ui/board/src/menu.ts
@@ -20,7 +20,7 @@ export const menu = (
   trans: Trans,
   redraw: Redraw,
   toggle: Toggle,
-  content: (menu: BoardMenu) => MaybeVNodes
+  content: (menu: BoardMenu) => MaybeVNodes,
 ): MaybeVNode =>
   toggle()
     ? h(
@@ -28,12 +28,15 @@ export const menu = (
         {
           hook: onInsert(onClickAway(() => toggle(false))),
         },
-        content(new BoardMenu(trans, redraw))
+        content(new BoardMenu(trans, redraw)),
       )
     : undefined;
 
 export class BoardMenu {
-  constructor(readonly trans: Trans, readonly redraw: Redraw) {}
+  constructor(
+    readonly trans: Trans,
+    readonly redraw: Redraw,
+  ) {}
 
   flip = (name: string, active: boolean, onChange: () => void) =>
     h(
@@ -46,7 +49,7 @@ export class BoardMenu {
         },
         hook: onInsert(bindMobileMousedown(onChange)),
       },
-      name
+      name,
     );
 
   zenMode = (enabled = true) =>

--- a/ui/ceval/src/ctrl.ts
+++ b/ui/ceval/src/ctrl.ts
@@ -72,7 +72,7 @@ export default class CevalCtrl {
     this.externalEngine = this.opts.externalEngines?.find(
       e =>
         e.id == this.selectedEngine() &&
-        (this.officialStockfish || e.variants.map(lichessRules).includes(this.rules))
+        (this.officialStockfish || e.variants.map(lichessRules).includes(this.rules)),
     );
     this.platform = detectPlatform(this.officialStockfish, this.enableNnue(), this.externalEngine);
     this.technology = this.platform.technology;
@@ -88,7 +88,7 @@ export default class CevalCtrl {
     const stored = lichess.storage.get(this.storageKey('ceval.threads'));
     return Math.min(
       this.platform.maxThreads,
-      stored ? parseInt(stored, 10) : Math.ceil((navigator.hardwareConcurrency || 1) / 4)
+      stored ? parseInt(stored, 10) : Math.ceil((navigator.hardwareConcurrency || 1) / 4),
     );
   };
 
@@ -187,7 +187,7 @@ export default class CevalCtrl {
             wasmMemory: sharedWasmMemory(2048, this.platform.maxWasmPages(2048)),
             cache: window.indexedDB && new Cache('ceval-wasm-cache'),
           },
-          this.opts.redraw
+          this.opts.redraw,
         );
       else if (this.technology == 'hce')
         this.worker = new ThreadedWasmWorker(
@@ -197,7 +197,7 @@ export default class CevalCtrl {
             version: 'a022fa',
             wasmMemory: sharedWasmMemory(1024, this.platform.maxWasmPages(1088)),
           },
-          this.opts.redraw
+          this.opts.redraw,
         );
       else
         this.worker = new WebWorker(
@@ -207,7 +207,7 @@ export default class CevalCtrl {
                 ? 'vendor/stockfish.js/stockfish.wasm.js'
                 : 'vendor/stockfish.js/stockfish.js',
           },
-          this.opts.redraw
+          this.opts.redraw,
         );
     }
 

--- a/ui/ceval/src/platform.ts
+++ b/ui/ceval/src/platform.ts
@@ -17,7 +17,7 @@ export interface CevalPlatform {
 export function detectPlatform(
   officialStockfish: boolean,
   enableNnue: boolean,
-  externalEngine?: ExternalEngine
+  externalEngine?: ExternalEngine,
 ): CevalPlatform {
   let technology: CevalTechnology = 'asmjs',
     growableSharedMem = false,
@@ -51,7 +51,7 @@ export function detectPlatform(
     : technology == 'nnue' || technology == 'hce'
     ? Math.min(
         Math.max((navigator.hardwareConcurrency || 1) - 1, 1),
-        growableSharedMem ? 32 : officialStockfish ? 2 : 1
+        growableSharedMem ? 32 : officialStockfish ? 2 : 1,
       )
     : 1;
 

--- a/ui/ceval/src/protocol.ts
+++ b/ui/ceval/src/protocol.ts
@@ -182,7 +182,7 @@ export class Protocol {
         'UCI_Variant',
         this.work.variant === 'antichess'
           ? 'giveaway' // for old asmjs fallback
-          : lichessRules(this.work.variant)
+          : lichessRules(this.work.variant),
       );
       this.setOption('Threads', this.work.threads);
       this.setOption('Hash', this.work.hashSize || 16);
@@ -192,7 +192,7 @@ export class Protocol {
       this.send(
         this.work.maxDepth >= 99
           ? `go depth ${maxStockfishPlies}` // 'go infinite' would not finish even if entire tree search completed
-          : 'go movetime 90000'
+          : 'go movetime 90000',
       );
     }
   }

--- a/ui/ceval/src/view.ts
+++ b/ui/ceval/src/view.ts
@@ -18,7 +18,7 @@ import CevalCtrl from './ctrl';
 
 let gaugeLast = 0;
 const gaugeTicks: VNode[] = [...Array(8).keys()].map(i =>
-  h(i === 3 ? 'tick.zero' : 'tick', { attrs: { style: `height: ${(i + 1) * 12.5}%` } })
+  h(i === 3 ? 'tick.zero' : 'tick', { attrs: { style: `height: ${(i + 1) * 12.5}%` } }),
 );
 
 function localEvalInfo(ctrl: ParentCtrl, evs: NodeEvals): Array<VNode | string> {
@@ -49,7 +49,7 @@ function localEvalInfo(ctrl: ParentCtrl, evs: NodeEvals): Array<VNode | string> 
           'data-icon': licon.PlusButton,
         },
         hook: bind('click', ceval.goDeeper),
-      })
+      }),
     );
   else if (!evs.client.cloud && evs.client.knps) t.push(', ' + Math.round(evs.client.knps) + 'k nodes/s');
   return t;
@@ -88,7 +88,7 @@ function engineName(ctrl: CevalCtrl): VNode[] {
               title: 'Engine running outside of the browser',
             },
           },
-          'EXTERNAL'
+          'EXTERNAL',
         )
       : ctrl.technology == 'nnue'
       ? h(
@@ -99,20 +99,20 @@ function engineName(ctrl: CevalCtrl): VNode[] {
                 'Multi-threaded WebAssembly with SIMD (efficiently updatable neural network, using 4x smaller net by Sopel97)',
             },
           },
-          'NNUE'
+          'NNUE',
         )
       : ctrl.technology == 'hce'
       ? h(
           'span.technology.good',
           { attrs: { title: 'Multi-threaded WebAssembly (classical hand crafted evaluation)' } },
-          'HCE'
+          'HCE',
         )
       : ctrl.technology == 'wasm'
       ? h('span.technology', { attrs: { title: 'Single-threaded WebAssembly fallback (slow)' } }, 'WASM')
       : h(
           'span.technology',
           { attrs: { title: 'Single-threaded JavaScript fallback (very slow)' } },
-          'ASMJS'
+          'ASMJS',
         ),
   ];
 }
@@ -153,7 +153,7 @@ export function renderGauge(ctrl: ParentCtrl): VNode | undefined {
         reverse: ctrl.getOrientation() === 'black',
       },
     },
-    [h('div.black', { attrs: { style: `height: ${100 - (ev + 1) * 50}%` } }), ...gaugeTicks]
+    [h('div.black', { attrs: { style: `height: ${100 - (ev + 1) * 50}%` } }), ...gaugeTicks],
   );
 }
 
@@ -208,7 +208,7 @@ export function renderCeval(ctrl: ParentCtrl): VNode | undefined {
               vnode.data!.threatMode = threatMode;
             },
           },
-        })
+        }),
       )
     : null;
 
@@ -225,7 +225,7 @@ export function renderCeval(ctrl: ParentCtrl): VNode | undefined {
               ? [trans.noarg('threefoldRepetition')]
               : threatMode
               ? [threatInfo(ctrl, threat)]
-              : localEvalInfo(ctrl, evs)
+              : localEvalInfo(ctrl, evs),
           ),
         ]),
       ]
@@ -256,7 +256,7 @@ export function renderCeval(ctrl: ParentCtrl): VNode | undefined {
               hook: bind('change', ctrl.toggleCeval),
             }),
             h('label', { attrs: { for: 'analyse-toggle-ceval' } }),
-          ]
+          ],
         );
 
   return h(
@@ -266,7 +266,7 @@ export function renderCeval(ctrl: ParentCtrl): VNode | undefined {
         computing: percent < 100 && instance.getState() === CevalState.Computing,
       },
     },
-    [progressBar, ...body, threatButton(ctrl), switchButton]
+    [progressBar, ...body, threatButton(ctrl), switchButton],
   );
 }
 
@@ -305,7 +305,7 @@ function getElPvMoves(e: TouchEvent | MouseEvent): (string | null)[] {
 function checkHover(el: HTMLElement, instance: CevalCtrl): void {
   lichess.requestIdleCallback(
     () => instance.setHovering(getElFen(el), $(el).find('div.pv:hover').attr('data-uci') || undefined),
-    500
+    500,
   );
 }
 
@@ -361,7 +361,7 @@ export function renderPvs(ctrl: ParentCtrl): VNode | undefined {
                   ctrl.getCeval().setPvBoard({ fen, uci });
                 }
               }
-            })
+            }),
           );
           el.addEventListener('mouseout', () => ctrl.getCeval().setHovering(getElFen(el)));
           for (const event of ['touchstart', 'mousedown']) {
@@ -384,10 +384,10 @@ export function renderPvs(ctrl: ParentCtrl): VNode | undefined {
     },
     [
       ...[...Array(multiPv).keys()].map(i =>
-        renderPv(threat, multiPv, pvs[i], pos.isOk ? pos.value : undefined)
+        renderPv(threat, multiPv, pvs[i], pos.isOk ? pos.value : undefined),
       ),
       renderPvBoard(ctrl),
-    ]
+    ],
   );
 }
 
@@ -457,8 +457,8 @@ function renderPvMoves(pos: Position, pv: Uci[]): VNode[] {
             'data-board': `${fen}|${uci}`,
           },
         },
-        san
-      )
+        san,
+      ),
     );
   }
   return vnodes;

--- a/ui/ceval/src/worker.ts
+++ b/ui/ceval/src/worker.ts
@@ -29,7 +29,10 @@ export class WebWorker implements CevalWorker {
   private protocol = new Protocol();
   private worker: Worker | undefined;
 
-  constructor(private opts: WebWorkerOpts, private redraw: Redraw) {}
+  constructor(
+    private opts: WebWorkerOpts,
+    private redraw: Redraw,
+  ) {}
 
   getState() {
     return !this.worker
@@ -56,7 +59,7 @@ export class WebWorker implements CevalWorker {
           this.failed = true;
           this.redraw();
         },
-        true
+        true,
       );
       this.protocol.connected(cmd => this.worker?.postMessage(cmd));
     }
@@ -112,7 +115,10 @@ export class ThreadedWasmWorker implements CevalWorker {
   private static protocols = { Stockfish: new Protocol(), StockfishMv: new Protocol() };
   private static sf: { Stockfish?: Promise<void>; StockfishMv?: Promise<void> } = {};
 
-  constructor(private opts: ThreadedWasmWorkerOpts, private redraw: Redraw) {}
+  constructor(
+    private opts: ThreadedWasmWorkerOpts,
+    private redraw: Redraw,
+  ) {}
 
   getState() {
     return !ThreadedWasmWorker.sf[this.opts.module]
@@ -190,7 +196,7 @@ export class ThreadedWasmWorker implements CevalWorker {
           console.error(err);
           ThreadedWasmWorker.failed[this.opts.module] = true;
           this.redraw();
-        }
+        },
       );
     }
   }
@@ -240,7 +246,10 @@ export class ExternalWorker implements CevalWorker {
   private sessionId = randomToken();
   private req: AbortController | undefined;
 
-  constructor(private opts: ExternalEngine, private redraw: Redraw) {}
+  constructor(
+    private opts: ExternalEngine,
+    private redraw: Redraw,
+  ) {}
 
   getState() {
     return this.state;

--- a/ui/challenge/src/view.ts
+++ b/ui/challenge/src/view.ts
@@ -30,7 +30,7 @@ function allChallenges(ctrl: Ctrl, d: ChallengeData, nb: number): VNode {
         postpatch: userPowertips,
       },
     },
-    d.in.map(challenge(ctrl, 'in')).concat(d.out.map(challenge(ctrl, 'out')))
+    d.in.map(challenge(ctrl, 'in')).concat(d.out.map(challenge(ctrl, 'out'))),
   );
 }
 
@@ -54,7 +54,7 @@ function challenge(ctrl: Ctrl, dir: ChallengeDirection) {
               h('span.is.color-icon.' + myColor),
               ' • ',
               [ctrl.trans()(c.rated ? 'rated' : 'casual'), timeControl(c.timeControl), c.variant.name].join(
-                ' • '
+                ' • ',
               ),
             ]),
           ]),
@@ -73,7 +73,7 @@ function challenge(ctrl: Ctrl, dir: ChallengeDirection) {
             })
           : null,
         h('div.buttons', (dir === 'in' ? inButtons : outButtons)(ctrl, c)),
-      ]
+      ],
     );
   };
 }
@@ -99,7 +99,7 @@ function inButtons(ctrl: Ctrl, c: Challenge): VNode[] {
           },
           hook: onClick(ctrl.onRedirect),
         }),
-      ]
+      ],
     ),
     h('button.button.decline', {
       attrs: {
@@ -120,8 +120,8 @@ function inButtons(ctrl: Ctrl, c: Challenge): VNode[] {
         },
       },
       Object.entries(ctrl.reasons()).map(([key, name]) =>
-        h('option', { attrs: { value: key } }, key == 'generic' ? '' : name)
-      )
+        h('option', { attrs: { value: key } }, key == 'generic' ? '' : name),
+      ),
     ),
   ];
 }
@@ -182,10 +182,10 @@ function renderUser(u: ChallengeUser | undefined, showRatings: boolean): VNode {
           : [1, 2, 3, 4].map(i =>
               h('i', {
                 class: { off: u.lag! < i },
-              })
-            )
+              }),
+            ),
       ),
-    ]
+    ],
   );
 }
 
@@ -197,7 +197,7 @@ const empty = (): VNode =>
         'data-icon': licon.InfoCircle,
       },
     },
-    'No challenges.'
+    'No challenges.',
   );
 
 const onClick = (f: (e: Event) => void) => ({

--- a/ui/chart/src/ratingDistribution.ts
+++ b/ui/chart/src/ratingDistribution.ts
@@ -100,7 +100,7 @@ export async function initModule(data: any) {
         gridZIndex: -1,
         tickInterval: 100,
         plotLines: buildRatingLine(data.myRating, colors[2], 13, trans.noarg('yourRating')).concat(
-          buildRatingLine(data.otherRating, colors[6], 50, data.otherPlayer)
+          buildRatingLine(data.otherRating, colors[6], 50, data.otherPlayer),
         ),
       },
       yAxis: [

--- a/ui/chart/src/ratingHistory.ts
+++ b/ui/chart/src/ratingHistory.ts
@@ -101,7 +101,7 @@ export async function initModule({ data, singlePerfName, perfIndex }: Opts) {
         .filter((v: any) => !singlePerfName || v.name === singlePerfName)
         .map((serie: any, i: number) => {
           const originalDatesAndRatings = serie.points.map((r: any) =>
-            singlePerfName && serie.name !== singlePerfName ? [] : [Date.UTC(r[0], r[1], r[2]), r[3]]
+            singlePerfName && serie.name !== singlePerfName ? [] : [Date.UTC(r[0], r[1], r[2]), r[3]],
           );
           return {
             name: serie.name,

--- a/ui/chat/css/_discussion.scss
+++ b/ui/chat/css/_discussion.scss
@@ -95,7 +95,10 @@
 
     li:hover i {
       display: block;
-      text-shadow: 0 0 2px $c-bg-box, 0 0 5px $c-bg-box, 0 0 10px $c-bg-box;
+      text-shadow:
+        0 0 2px $c-bg-box,
+        0 0 5px $c-bg-box,
+        0 0 10px $c-bg-box;
     }
 
     li.me i {

--- a/ui/chat/src/discussion.ts
+++ b/ui/chat/src/discussion.ts
@@ -37,19 +37,21 @@ export default function (ctrl: Ctrl): Array<VNode | undefined> {
               lichess.pubsub.emit('jump', (e.target as HTMLElement).getAttribute('data-ply'));
             });
             if (hasMod)
-              $el.on('click', '.mod', (e: Event) =>
-                ctrl.moderation()?.open((e.target as HTMLElement).parentNode as HTMLElement)
+              $el.on(
+                'click',
+                '.mod',
+                (e: Event) => ctrl.moderation()?.open((e.target as HTMLElement).parentNode as HTMLElement),
               );
             else
               $el.on('click', '.flag', (e: Event) =>
-                report(ctrl, (e.target as HTMLElement).parentNode as HTMLElement)
+                report(ctrl, (e.target as HTMLElement).parentNode as HTMLElement),
               );
             scrollCb(vnode);
           },
           postpatch: (_, vnode) => scrollCb(vnode),
         },
       },
-      selectLines(ctrl).map(line => renderLine(ctrl, line))
+      selectLines(ctrl).map(line => renderLine(ctrl, line)),
     ),
     renderInput(ctrl),
   ];
@@ -130,7 +132,7 @@ const setupHooks = (ctrl: Ctrl, chatEl: HTMLInputElement) => {
       el.removeAttribute('placeholder');
       if (!ctrl.opts.public) el.classList.toggle('whisper', !!txt.match(whisperRegex));
       storage.set(txt);
-    })
+    }),
   );
 
   lichess.mousetrap.bind('c', () => chatEl.focus());
@@ -149,7 +151,7 @@ const setupHooks = (ctrl: Ctrl, chatEl: HTMLInputElement) => {
 
   chatEl.onfocus = () =>
     mouchEvents.forEach(event =>
-      document.body.addEventListener(event, mouchListener, { passive: true, capture: true })
+      document.body.addEventListener(event, mouchListener, { passive: true, capture: true }),
     );
 
   chatEl.onblur = () =>
@@ -179,7 +181,7 @@ function updateText(parseMoves: boolean) {
     if ((vnode.data as VNodeData).lichessChat !== (oldVnode.data as VNodeData).lichessChat) {
       (vnode.elm as HTMLElement).innerHTML = enhance.enhance(
         (vnode.data as VNodeData).lichessChat,
-        parseMoves
+        parseMoves,
       );
     }
   };
@@ -239,6 +241,6 @@ function renderLine(ctrl: Ctrl, line: Line): VNode {
           userNode,
           ' ',
           textNode,
-        ]
+        ],
   );
 }

--- a/ui/chat/src/moderation.ts
+++ b/ui/chat/src/moderation.ts
@@ -92,7 +92,7 @@ export function moderationView(ctrl?: ModerationCtrl): VNode[] | undefined {
                   href: '/@/' + data.username + '?mod',
                 },
               },
-              'profile'
+              'profile',
             ),
           ])
           .concat(
@@ -105,11 +105,11 @@ export function moderationView(ctrl?: ModerationCtrl): VNode[] | undefined {
                         href: '/mod/' + data.username + '/communication',
                       },
                     },
-                    'coms'
+                    'coms',
                   ),
                 ]
-              : []
-          )
+              : [],
+          ),
       )
     : undefined;
 
@@ -124,8 +124,8 @@ export function moderationView(ctrl?: ModerationCtrl): VNode[] | undefined {
                 attrs: { 'data-icon': licon.Clock },
                 hook: bind('click', () => ctrl.timeout(r, data.text)),
               },
-              r.name
-            )
+              r.name,
+            ),
           ),
         ])
       : h('div.timeout.block', [
@@ -137,7 +137,7 @@ export function moderationView(ctrl?: ModerationCtrl): VNode[] | undefined {
                 attrs: { 'data-icon': licon.Clock },
                 hook: bind('click', () => ctrl.timeout(ctrl.opts.reasons[0], data.text)),
               },
-              'Timeout 15 minutes'
+              'Timeout 15 minutes',
             ),
             h(
               'a.text',
@@ -148,7 +148,7 @@ export function moderationView(ctrl?: ModerationCtrl): VNode[] | undefined {
                   ctrl.timeout(ctrl.opts.reasons[0], data.text);
                 }),
               },
-              'Timeout and report to Lichess'
+              'Timeout and report to Lichess',
             ),
           ],
         ]);
@@ -175,11 +175,11 @@ export function moderationView(ctrl?: ModerationCtrl): VNode[] | undefined {
                   'td',
                   h('time.timeago', {
                     attrs: { datetime: e.date },
-                  })
+                  }),
                 ),
               ]);
-            })
-          )
+            }),
+          ),
         ),
       ])
     : undefined;
@@ -191,7 +191,7 @@ export function moderationView(ctrl?: ModerationCtrl): VNode[] | undefined {
         {
           attrs: { 'data-icon': licon.Agent },
         },
-        [userLink(data.username)]
+        [userLink(data.username)],
       ),
       h('a', {
         attrs: { 'data-icon': licon.X },

--- a/ui/chat/src/preset.ts
+++ b/ui/chat/src/preset.ts
@@ -83,9 +83,9 @@ export function presetView(ctrl: PresetCtrl): VNode | undefined {
                 !disabled && ctrl.post(p);
               }),
             },
-            p.key
+            p.key,
           );
-        })
+        }),
       )
     : undefined;
 }

--- a/ui/chat/src/spam.ts
+++ b/ui/chat/src/spam.ts
@@ -41,7 +41,7 @@ const spamRegex = new RegExp(
     'trasderk.blogspot.com',
   ]
     .map(url => url.replace(/\./g, '\\.').replace(/\//g, '\\/'))
-    .join('|')
+    .join('|'),
 );
 
 const suspLink = (txt: string) => !!txt.match(spamRegex);

--- a/ui/chat/src/view.ts
+++ b/ui/chat/src/view.ts
@@ -21,7 +21,7 @@ export default function (ctrl: Ctrl): VNode {
         destroy: ctrl.destroy,
       },
     },
-    moderationView(mod) || normalView(ctrl)
+    moderationView(mod) || normalView(ctrl),
   );
 }
 
@@ -66,7 +66,7 @@ function normalView(ctrl: Ctrl) {
         ? [noteView(ctrl.note, ctrl.vm.autofocus)]
         : ctrl.plugin && active === ctrl.plugin.tab.key
         ? [ctrl.plugin.view()]
-        : discussionView(ctrl)
+        : discussionView(ctrl),
     ),
   ];
 }
@@ -79,7 +79,7 @@ const renderTab = (ctrl: Ctrl, tab: Tab, active: Tab) =>
       class: { 'mchat__tab-active': tab === active },
       hook: bind('click', () => ctrl.setTab(tab)),
     },
-    tabName(ctrl, tab)
+    tabName(ctrl, tab),
   );
 
 function tabName(ctrl: Ctrl, tab: Tab) {

--- a/ui/chat/src/xhr.ts
+++ b/ui/chat/src/xhr.ts
@@ -24,7 +24,7 @@ export const timeout = (
     userId: string;
     reason: string;
     text: string;
-  }
+  },
 ) => {
   const [chan, roomId] = resourceId.split('/');
   return text(`/mod/public-chat/timeout`, {

--- a/ui/chess/css/_variant-style.scss
+++ b/ui/chess/css/_variant-style.scss
@@ -1,6 +1,8 @@
 .variant-racingKings .cg-wrap {
   &.cg-wrap cg-container::before {
-    box-shadow: 0 14px 28px rgba(0, 0, 0, 0.25), 0 10px 10px rgba(0, 0, 0, 0.22);
+    box-shadow:
+      0 14px 28px rgba(0, 0, 0, 0.25),
+      0 10px 10px rgba(0, 0, 0, 0.22);
     background: hsla(0, 0%, 90%, 0.2);
     width: 100%;
     height: 12.5%;

--- a/ui/chess/src/main.ts
+++ b/ui/chess/src/main.ts
@@ -29,7 +29,7 @@ export function readDests(lines?: string): Dests | null {
         line
           .slice(1)
           .split('')
-          .map(c => uciChar[c])
+          .map(c => uciChar[c]),
       );
     }
   return dests;
@@ -52,10 +52,10 @@ export const src = (uci: Uci) => uci.slice(0, 2) as Key;
 export const dest = (uci: Uci) => uci.slice(2, 4) as Key;
 
 export const Roles = ['king', 'queen', 'rook', 'bishop', 'knight', 'pawn'] as const;
-export type Role = typeof Roles[number];
+export type Role = (typeof Roles)[number];
 
 export const RoleChars = ['K', 'Q', 'R', 'B', 'N', 'P'] as const;
-export type RoleChar = typeof RoleChars[number];
+export type RoleChar = (typeof RoleChars)[number];
 
 export const roleChar = (role: string) =>
   ({
@@ -65,7 +65,7 @@ export const roleChar = (role: string) =>
     bishop: 'B',
     knight: 'N',
     pawn: 'P',
-  }[role] as RoleChar);
+  })[role] as RoleChar;
 export const charRole = (char: string) =>
   ({
     P: 'pawn',
@@ -74,5 +74,5 @@ export const charRole = (char: string) =>
     R: 'rook',
     Q: 'queen',
     K: 'king',
-  }[char] as Role);
+  })[char] as Role;
 export const promo = (uci: Uci) => charRole(uci.slice(4, 5).toUpperCase() as RoleChar);

--- a/ui/chess/src/promotion.ts
+++ b/ui/chess/src/promotion.ts
@@ -33,7 +33,7 @@ export function promote(g: CgApi, key: Key, role: cg.Role): void {
             promoted: true,
           },
         ],
-      ])
+      ]),
     );
   }
 }
@@ -46,7 +46,7 @@ export class PromotionCtrl {
     private withGround: <A>(f: (cg: CgApi) => A) => A | false | undefined,
     private onCancel: () => void,
     private redraw: () => void,
-    private autoQueenPref: Prefs.AutoQueen = Prefs.AutoQueen.Never
+    private autoQueenPref: Prefs.AutoQueen = Prefs.AutoQueen.Never,
   ) {}
 
   start = (orig: Key, dest: Key, hooks: Hooks, meta?: cg.MoveMetadata, forceAutoQueen = false): boolean =>
@@ -108,8 +108,8 @@ export class PromotionCtrl {
           promoting.dest,
           antichess ? PROMOTABLE_ROLES.concat('king') : PROMOTABLE_ROLES,
           cgUtil.opposite(g.state.turnColor),
-          g.state.orientation
-        )
+          g.state.orientation,
+        ),
       ) || null
     );
   };
@@ -143,7 +143,7 @@ export class PromotionCtrl {
           },
           brush: '',
         } as DrawShape,
-      ])
+      ]),
     );
   }
 
@@ -174,9 +174,9 @@ export class PromotionCtrl {
               this.finish(serverRole);
             }),
           },
-          [h('piece.' + serverRole + '.' + color)]
+          [h('piece.' + serverRole + '.' + color)],
         );
-      })
+      }),
     );
   }
 }

--- a/ui/cli/src/main.ts
+++ b/ui/cli/src/main.ts
@@ -67,7 +67,7 @@ function help() {
         commandHelp('/', '', 'Type a command') +
         commandHelp('c', '', 'Focus the chat input') +
         commandHelp('esc', '', 'Close modals like this one') +
-        '</div>'
+        '</div>',
     ),
     class: 'clinput-help',
   });

--- a/ui/common/css/abstract/_extends.scss
+++ b/ui/common/css/abstract/_extends.scss
@@ -112,7 +112,9 @@
   @if $theme == 'transp' {
     @include back-blur();
   }
-  box-shadow: 0 14px 28px rgba(0, 0, 0, 0.25), 0 10px 10px rgba(0, 0, 0, 0.22);
+  box-shadow:
+    0 14px 28px rgba(0, 0, 0, 0.25),
+    0 10px 10px rgba(0, 0, 0, 0.22);
 }
 
 %button-shadow {

--- a/ui/common/css/base/_fonts.scss
+++ b/ui/common/css/base/_fonts.scss
@@ -7,13 +7,17 @@
 @font-face {
   font-family: 'lichess';
   font-display: block;
-  src: local-font('lichess.woff2') format('woff2'), local-font('lichess.woff') format('woff');
+  src:
+    local-font('lichess.woff2') format('woff2'),
+    local-font('lichess.woff') format('woff');
 }
 
 @font-face {
   font-family: 'Noto Chess';
   font-display: block;
-  src: local-font('lichess.chess.woff2') format('woff2'), local-font('lichess.chess.woff') format('woff');
+  src:
+    local-font('lichess.chess.woff2') format('woff2'),
+    local-font('lichess.chess.woff') format('woff');
 }
 
 /* Noto Sans (v7) */
@@ -21,21 +25,30 @@
 /* cyrillic-ext */
 @font-face {
   font-family: 'Noto Sans';
-  src: local('Noto Sans'), local('NotoSans'), local-font('noto-sans-cyrillic-ext.woff2') format('woff2');
+  src:
+    local('Noto Sans'),
+    local('NotoSans'),
+    local-font('noto-sans-cyrillic-ext.woff2') format('woff2');
   unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
 }
 
 /* cyrillic */
 @font-face {
   font-family: 'Noto Sans';
-  src: local('Noto Sans'), local('NotoSans'), local-font('noto-sans-cyrillic.woff2') format('woff2');
+  src:
+    local('Noto Sans'),
+    local('NotoSans'),
+    local-font('noto-sans-cyrillic.woff2') format('woff2');
   unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
 
 /* devanagari */
 @font-face {
   font-family: 'Noto Sans';
-  src: local('Noto Sans'), local('NotoSans'), local-font('noto-sans-devanagari.woff2') format('woff2');
+  src:
+    local('Noto Sans'),
+    local('NotoSans'),
+    local-font('noto-sans-devanagari.woff2') format('woff2');
   unicode-range: U+0900-097F, U+1CD0-1CF6, U+1CF8-1CF9, U+200C-200D, U+20A8, U+20B9, U+25CC, U+A830-A839,
     U+A8E0-A8FB;
 }
@@ -43,28 +56,39 @@
 /* greek-ext */
 @font-face {
   font-family: 'Noto Sans';
-  src: local('Noto Sans'), local('NotoSans'), local-font('noto-sans-greek-ext.woff2') format('woff2');
+  src:
+    local('Noto Sans'),
+    local('NotoSans'),
+    local-font('noto-sans-greek-ext.woff2') format('woff2');
   unicode-range: U+1F00-1FFF;
 }
 
 /* greek */
 @font-face {
   font-family: 'Noto Sans';
-  src: local('Noto Sans'), local('NotoSans'), local-font('noto-sans-greek.woff2') format('woff2');
+  src:
+    local('Noto Sans'),
+    local('NotoSans'),
+    local-font('noto-sans-greek.woff2') format('woff2');
   unicode-range: U+0370-03FF;
 }
 
 /* vietnamese */
 @font-face {
   font-family: 'Noto Sans';
-  src: local('Noto Sans'), local('NotoSans'), local-font('noto-sans-vietnamese.woff2') format('woff2');
+  src:
+    local('Noto Sans'),
+    local('NotoSans'),
+    local-font('noto-sans-vietnamese.woff2') format('woff2');
   unicode-range: U+0102-0103, U+0110-0111, U+1EA0-1EF9, U+20AB;
 }
 
 /* latin-ext */
 @font-face {
   font-family: 'Noto Sans';
-  src: local('Noto Sans'), local('NotoSans'),
+  src:
+    local('Noto Sans'),
+    local('NotoSans'),
     local-font('noto-sans-v14-latin-ext-regular.woff2') format('woff2');
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F,
     U+A720-A7FF;
@@ -73,7 +97,10 @@
 /* latin */
 @font-face {
   font-family: 'Noto Sans';
-  src: local('Noto Sans'), local('NotoSans'), local-font('noto-sans-v14-latin-regular.woff2') format('woff2');
+  src:
+    local('Noto Sans'),
+    local('NotoSans'),
+    local-font('noto-sans-v14-latin-regular.woff2') format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074,
     U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
@@ -84,7 +111,9 @@
 @font-face {
   font-family: 'Noto Sans';
   font-weight: 700;
-  src: local('Noto Sans Bold'), local('NotoSans-Bold'),
+  src:
+    local('Noto Sans Bold'),
+    local('NotoSans-Bold'),
     local-font('noto-sans-bold-cyrillic-ext.woff2') format('woff2');
   unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
 }
@@ -93,7 +122,9 @@
 @font-face {
   font-family: 'Noto Sans';
   font-weight: 700;
-  src: local('Noto Sans Bold'), local('NotoSans-Bold'),
+  src:
+    local('Noto Sans Bold'),
+    local('NotoSans-Bold'),
     local-font('noto-sans-bold-cyrillic.woff2') format('woff2');
   unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
@@ -102,7 +133,9 @@
 @font-face {
   font-family: 'Noto Sans';
   font-weight: 700;
-  src: local('Noto Sans Bold'), local('NotoSans-Bold'),
+  src:
+    local('Noto Sans Bold'),
+    local('NotoSans-Bold'),
     local-font('noto-sans-bold-devanagari.woff2') format('woff2');
   unicode-range: U+0900-097F, U+1CD0-1CF6, U+1CF8-1CF9, U+200C-200D, U+20A8, U+20B9, U+25CC, U+A830-A839,
     U+A8E0-A8FB;
@@ -112,7 +145,9 @@
 @font-face {
   font-family: 'Noto Sans';
   font-weight: 700;
-  src: local('Noto Sans Bold'), local('NotoSans-Bold'),
+  src:
+    local('Noto Sans Bold'),
+    local('NotoSans-Bold'),
     local-font('noto-sans-bold-greek-ext.woff2') format('woff2');
   unicode-range: U+1F00-1FFF;
 }
@@ -121,7 +156,9 @@
 @font-face {
   font-family: 'Noto Sans';
   font-weight: 700;
-  src: local('Noto Sans Bold'), local('NotoSans-Bold'),
+  src:
+    local('Noto Sans Bold'),
+    local('NotoSans-Bold'),
     local-font('noto-sans-bold-greek.woff2') format('woff2');
   unicode-range: U+0370-03FF;
 }
@@ -130,7 +167,9 @@
 @font-face {
   font-family: 'Noto Sans';
   font-weight: 700;
-  src: local('Noto Sans Bold'), local('NotoSans-Bold'),
+  src:
+    local('Noto Sans Bold'),
+    local('NotoSans-Bold'),
     local-font('noto-sans-bold-vietnamese.woff2') format('woff2');
   unicode-range: U+0102-0103, U+0110-0111, U+1EA0-1EF9, U+20AB;
 }
@@ -139,7 +178,9 @@
 @font-face {
   font-family: 'Noto Sans';
   font-weight: 700;
-  src: local('Noto Sans Bold'), local('NotoSans-Bold'),
+  src:
+    local('Noto Sans Bold'),
+    local('NotoSans-Bold'),
     local-font('noto-sans-v14-latin-ext-700.woff2') format('woff2');
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F,
     U+A720-A7FF;
@@ -149,7 +190,9 @@
 @font-face {
   font-family: 'Noto Sans';
   font-weight: 700;
-  src: local('Noto Sans Bold'), local('NotoSans-Bold'),
+  src:
+    local('Noto Sans Bold'),
+    local('NotoSans-Bold'),
     local-font('noto-sans-v14-latin-700.woff2') format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074,
     U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
@@ -161,7 +204,9 @@
 @font-face {
   font-family: 'Roboto';
   font-weight: 300;
-  src: local('Roboto Light'), local('Roboto-Light'),
+  src:
+    local('Roboto Light'),
+    local('Roboto-Light'),
     local-font('roboto-light-cyrillic-ext.woff2') format('woff2');
   unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
 }
@@ -170,7 +215,10 @@
 @font-face {
   font-family: 'Roboto';
   font-weight: 300;
-  src: local('Roboto Light'), local('Roboto-Light'), local-font('roboto-light-cyrillic.woff2') format('woff2');
+  src:
+    local('Roboto Light'),
+    local('Roboto-Light'),
+    local-font('roboto-light-cyrillic.woff2') format('woff2');
   unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
 
@@ -178,7 +226,9 @@
 @font-face {
   font-family: 'Roboto';
   font-weight: 300;
-  src: local('Roboto Light'), local('Roboto-Light'),
+  src:
+    local('Roboto Light'),
+    local('Roboto-Light'),
     local-font('roboto-light-greek-ext.woff2') format('woff2');
   unicode-range: U+1F00-1FFF;
 }
@@ -187,7 +237,10 @@
 @font-face {
   font-family: 'Roboto';
   font-weight: 300;
-  src: local('Roboto Light'), local('Roboto-Light'), local-font('roboto-light-greek.woff2') format('woff2');
+  src:
+    local('Roboto Light'),
+    local('Roboto-Light'),
+    local-font('roboto-light-greek.woff2') format('woff2');
   unicode-range: U+0370-03FF;
 }
 
@@ -195,7 +248,9 @@
 @font-face {
   font-family: 'Roboto';
   font-weight: 300;
-  src: local('Roboto Light'), local('Roboto-Light'),
+  src:
+    local('Roboto Light'),
+    local('Roboto-Light'),
     local-font('roboto-light-vietnamese.woff2') format('woff2');
   unicode-range: U+0102-0103, U+0110-0111, U+1EA0-1EF9, U+20AB;
 }
@@ -204,7 +259,9 @@
 @font-face {
   font-family: 'Roboto';
   font-weight: 300;
-  src: local('Roboto Light'), local('Roboto-Light'),
+  src:
+    local('Roboto Light'),
+    local('Roboto-Light'),
     local-font('roboto-light-latin-ext.woff2') format('woff2');
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F,
     U+A720-A7FF;
@@ -214,7 +271,10 @@
 @font-face {
   font-family: 'Roboto';
   font-weight: 300;
-  src: local('Roboto Light'), local('Roboto-Light'), local-font('roboto-light-latin.woff2') format('woff2');
+  src:
+    local('Roboto Light'),
+    local('Roboto-Light'),
+    local-font('roboto-light-latin.woff2') format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074,
     U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }

--- a/ui/common/css/component/_fire-trophy.scss
+++ b/ui/common/css/component/_fire-trophy.scss
@@ -1,19 +1,34 @@
 %fire-trophy-shadow {
-  text-shadow: 0 0.008em 0.127em #fefcc9, 0.055em -0.066em 0.2em #feec85, -0.111em -0.127em 0.272em #ffae34,
-    0.111em -0.272em 0.411em #ec760c, -0.111em -0.456em 0.416em #cd4606, 0 -0.533em 0.577em #973716,
+  text-shadow:
+    0 0.008em 0.127em #fefcc9,
+    0.055em -0.066em 0.2em #feec85,
+    -0.111em -0.127em 0.272em #ffae34,
+    0.111em -0.272em 0.411em #ec760c,
+    -0.111em -0.456em 0.416em #cd4606,
+    0 -0.533em 0.577em #973716,
     0.055em -0.55em 0.533em #451b0e;
 }
 
 @keyframes fire-trophy {
   0% {
-    text-shadow: 0 0.008em 0.127em #fefcc9, 0.055em -0.066em 0.2em #feec85, -0.111em -0.127em 0.272em #ffae34,
-      0.111em -0.272em 0.411em #ec760c, -0.111em -0.456em 0.416em #cd4606, 0 -0.533em 0.577em #973716,
+    text-shadow:
+      0 0.008em 0.127em #fefcc9,
+      0.055em -0.066em 0.2em #feec85,
+      -0.111em -0.127em 0.272em #ffae34,
+      0.111em -0.272em 0.411em #ec760c,
+      -0.111em -0.456em 0.416em #cd4606,
+      0 -0.533em 0.577em #973716,
       0.055em -0.55em 0.533em #451b0e;
   }
 
   100% {
-    text-shadow: 0 0 0.111em #fefcc9, 0.055em -0.055em 0.166em #fefcc9, -0.111em -0.111em 0.222em #feec85,
-      0.122em -0.233em 0.333em #ffae34, -0.122em -0.322em 0.277em #ec760c, 0 -0.456em 0.444em #cd4606,
+    text-shadow:
+      0 0 0.111em #fefcc9,
+      0.055em -0.055em 0.166em #fefcc9,
+      -0.111em -0.111em 0.222em #feec85,
+      0.122em -0.233em 0.333em #ffae34,
+      -0.122em -0.322em 0.277em #ec760c,
+      0 -0.456em 0.444em #cd4606,
       0.055em -0.5em 0.444em #973716;
   }
 }

--- a/ui/common/css/component/_tabs-horiz.scss
+++ b/ui/common/css/component/_tabs-horiz.scss
@@ -21,7 +21,9 @@ $c-tabs-active: $c-accent !default;
     position: relative;
     border-bottom: 2px solid transparent;
 
-    transition: color 0.25s, border-color 0.25s;
+    transition:
+      color 0.25s,
+      border-color 0.25s;
 
     min-width: 15%;
     letter-spacing: -0.5px;

--- a/ui/common/css/component/_tagify.scss
+++ b/ui/common/css/component/_tagify.scss
@@ -246,7 +246,9 @@
         max-width: $tag-max-width;
         min-width: var(--tag--min-width, $tag-min-width);
         max-width: var(--tag--max-width, $tag-max-width);
-        transition: 0.8s ease, 0.1s color;
+        transition:
+          0.8s ease,
+          0.1s color;
         unicode-bidi: plaintext;
 
         &[contenteditable] {

--- a/ui/common/css/form/_cmn-toggle.scss
+++ b/ui/common/css/form/_cmn-toggle.scss
@@ -77,7 +77,9 @@
     @include transition(background);
 
     &::before {
-      transition: margin $transition-duration, color $transition-duration;
+      transition:
+        margin $transition-duration,
+        color $transition-duration;
     }
 
     &::after {

--- a/ui/common/css/header/_topnav-hidden.scss
+++ b/ui/common/css/header/_topnav-hidden.scss
@@ -54,7 +54,9 @@
           top: -9px;
         }
 
-        transition: top 0.1s 0.25s ease-in, opacity 0.1s ease-in;
+        transition:
+          top 0.1s 0.25s ease-in,
+          opacity 0.1s ease-in;
       }
 
       &::after {
@@ -64,7 +66,9 @@
           bottom: -10px;
         }
 
-        transition: bottom 0.1s 0.25s ease-in, transform 0.22s cubic-bezier(0.55, 0.055, 0.675, 0.19);
+        transition:
+          bottom 0.1s 0.25s ease-in,
+          transform 0.22s cubic-bezier(0.55, 0.055, 0.675, 0.19);
       }
     }
 
@@ -80,13 +84,17 @@
         &::before {
           top: 0;
           opacity: 0;
-          transition: top 0.1s ease-out, opacity 0.1s 0.12s ease-out;
+          transition:
+            top 0.1s ease-out,
+            opacity 0.1s 0.12s ease-out;
         }
 
         &::after {
           bottom: 0;
           transform: rotate(-90deg);
-          transition: bottom 0.1s ease-out, transform 0.22s 0.12s cubic-bezier(0.215, 0.61, 0.355, 1);
+          transition:
+            bottom 0.1s ease-out,
+            transform 0.22s 0.12s cubic-bezier(0.215, 0.61, 0.355, 1);
         }
       }
     }

--- a/ui/common/css/theme/_default.scss
+++ b/ui/common/css/theme/_default.scss
@@ -139,7 +139,9 @@ $border: $border-width $border-style $c-border;
 
 /* Shadows */
 
-$box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 3px 1px -2px rgba(0, 0, 0, 0.2),
+$box-shadow:
+  0 2px 2px 0 rgba(0, 0, 0, 0.14),
+  0 3px 1px -2px rgba(0, 0, 0, 0.2),
   0 1px 5px 0 rgba(0, 0, 0, 0.12);
 
 // $box-shadow: 0 2px 2px 0 rgba(0,0,0,.157);

--- a/ui/common/css/vendor/_flatpickr.scss
+++ b/ui/common/css/vendor/_flatpickr.scss
@@ -19,9 +19,17 @@
   -ms-touch-action: manipulation;
   touch-action: manipulation;
   background: #3f4458;
-  -webkit-box-shadow: 1px 0 0 #20222c, -1px 0 0 #20222c, 0 1px 0 #20222c, 0 -1px 0 #20222c,
+  -webkit-box-shadow:
+    1px 0 0 #20222c,
+    -1px 0 0 #20222c,
+    0 1px 0 #20222c,
+    0 -1px 0 #20222c,
     0 3px 13px rgba(0, 0, 0, 0.08);
-  box-shadow: 1px 0 0 #20222c, -1px 0 0 #20222c, 0 1px 0 #20222c, 0 -1px 0 #20222c,
+  box-shadow:
+    1px 0 0 #20222c,
+    -1px 0 0 #20222c,
+    0 1px 0 #20222c,
+    0 -1px 0 #20222c,
     0 3px 13px rgba(0, 0, 0, 0.08);
 }
 .flatpickr-calendar.open,
@@ -62,8 +70,12 @@
   .flatpickr-days
   .dayContainer:nth-child(n + 2)
   .flatpickr-day.inRange:nth-child(7n + 1) {
-  -webkit-box-shadow: -2px 0 0 #e6e6e6, 5px 0 0 #e6e6e6;
-  box-shadow: -2px 0 0 #e6e6e6, 5px 0 0 #e6e6e6;
+  -webkit-box-shadow:
+    -2px 0 0 #e6e6e6,
+    5px 0 0 #e6e6e6;
+  box-shadow:
+    -2px 0 0 #e6e6e6,
+    5px 0 0 #e6e6e6;
 }
 .flatpickr-calendar .hasWeeks .dayContainer,
 .flatpickr-calendar .hasTime .dayContainer {
@@ -599,8 +611,12 @@ span.flatpickr-weekday {
 }
 .flatpickr-day.inRange {
   border-radius: 0;
-  -webkit-box-shadow: -5px 0 0 #646c8c, 5px 0 0 #646c8c;
-  box-shadow: -5px 0 0 #646c8c, 5px 0 0 #646c8c;
+  -webkit-box-shadow:
+    -5px 0 0 #646c8c,
+    5px 0 0 #646c8c;
+  box-shadow:
+    -5px 0 0 #646c8c,
+    5px 0 0 #646c8c;
 }
 .flatpickr-day.flatpickr-disabled,
 .flatpickr-day.flatpickr-disabled:hover,
@@ -621,8 +637,12 @@ span.flatpickr-weekday {
 }
 .flatpickr-day.week.selected {
   border-radius: 0;
-  -webkit-box-shadow: -5px 0 0 #80cbc4, 5px 0 0 #80cbc4;
-  box-shadow: -5px 0 0 #80cbc4, 5px 0 0 #80cbc4;
+  -webkit-box-shadow:
+    -5px 0 0 #80cbc4,
+    5px 0 0 #80cbc4;
+  box-shadow:
+    -5px 0 0 #80cbc4,
+    5px 0 0 #80cbc4;
 }
 .flatpickr-day.hidden {
   visibility: hidden;

--- a/ui/common/src/complete.ts
+++ b/ui/common/src/complete.ts
@@ -110,7 +110,7 @@ export default function <Result>(opts: Opts<Result>) {
             if (opts.onSelect) opts.onSelect(result);
             return true;
           })
-          .appendTo($container)
+          .appendTo($container),
       );
     else $container.html(empty());
     renderedResults = results;

--- a/ui/common/src/controls.ts
+++ b/ui/common/src/controls.ts
@@ -35,7 +35,7 @@ export function toggle(t: ToggleSettings, trans: Trans, redraw: () => void) {
         h('label', { attrs: { for: fullId } }),
       ]),
       h('label', { attrs: { for: fullId } }, trans.noarg(t.name)),
-    ]
+    ],
   );
 }
 

--- a/ui/common/src/debounce.ts
+++ b/ui/common/src/debounce.ts
@@ -1,7 +1,7 @@
 export default function debounce<T extends (...args: any) => void>(
   f: T,
   wait: number,
-  immediate = false
+  immediate = false,
 ): (...args: Parameters<T>) => void {
   let timeout: Timeout | undefined;
   let lastBounce = 0;

--- a/ui/common/src/gridHacks.ts
+++ b/ui/common/src/gridHacks.ts
@@ -7,7 +7,7 @@ export const runner = (hacks: () => void, throttleMs = 100): void => {
     requestAnimationFrame(() => {
       hacks();
       schedule();
-    })
+    }),
   );
 
   function schedule() {

--- a/ui/common/src/linkPopup.ts
+++ b/ui/common/src/linkPopup.ts
@@ -24,12 +24,12 @@ export const onClick = (a: HTMLLinkElement, trans: Trans): boolean => {
             ${trans('proceedToX', url.host)}
           </a>
         </div>
-      </div>`
+      </div>`,
       ),
       onInsert($wrap) {
         $wrap.find('.cancel').on('click', modal.close);
       },
-    })
+    }),
   );
   return false;
 };

--- a/ui/common/src/mini-board.ts
+++ b/ui/common/src/mini-board.ts
@@ -22,7 +22,7 @@ export const initWith = (node: HTMLElement, fen: string, orientation: Color, lm?
           enabled: false,
           visible: false,
         },
-      })
+      }),
     );
   }
 };

--- a/ui/common/src/mobile.ts
+++ b/ui/common/src/mobile.ts
@@ -31,7 +31,7 @@ export const bindMobileMousedown =
           e.preventDefault();
           if (redraw) redraw();
         },
-        { passive: false }
+        { passive: false },
       );
     }
   };

--- a/ui/common/src/modal.ts
+++ b/ui/common/src/modal.ts
@@ -23,7 +23,7 @@ const overlayId = 'modal-overlay';
 export default function modal(opts: Modal) {
   modal.close();
   const $wrap = $(
-    `<div id="modal-wrap"><span class="close" role="button" aria-label="Close" data-icon="${licon.X}" tabindex="0"></span></div>`
+    `<div id="modal-wrap"><span class="close" role="button" aria-label="Close" data-icon="${licon.X}" tabindex="0"></span></div>`,
   );
   const $overlay = $(`<div id="${overlayId}" class="${opts.class}">`);
   if (!opts.noClickAway) $overlay.on('click', modal.close);
@@ -83,9 +83,9 @@ export function snabModal(opts: SnabModal): VNode {
             hook: onInsert(el => bindClose(el, close)),
           }),
           h('div', opts.content),
-        ]
+        ],
       ),
-    ]
+    ],
   );
 }
 

--- a/ui/common/src/prefs.ts
+++ b/ui/common/src/prefs.ts
@@ -6,39 +6,39 @@ export const Coords = {
   Inside: 1,
   Outside: 2,
 };
-export type Coords = typeof Coords[keyof typeof Coords];
+export type Coords = (typeof Coords)[keyof typeof Coords];
 
 export const AutoQueen = {
   Never: 1,
   OnPremove: 2,
   Always: 3,
 };
-export type AutoQueen = typeof AutoQueen[keyof typeof AutoQueen];
+export type AutoQueen = (typeof AutoQueen)[keyof typeof AutoQueen];
 
 export const ShowClockTenths = {
   Never: 0,
   Below10Secs: 1,
   Always: 2,
 };
-export type ShowClockTenths = typeof ShowClockTenths[keyof typeof ShowClockTenths];
+export type ShowClockTenths = (typeof ShowClockTenths)[keyof typeof ShowClockTenths];
 
 export const ShowResizeHandle = {
   Never: 0,
   OnlyAtStart: 1,
   Always: 2,
 };
-export type ShowResizeHandle = typeof ShowResizeHandle[keyof typeof ShowResizeHandle];
+export type ShowResizeHandle = (typeof ShowResizeHandle)[keyof typeof ShowResizeHandle];
 
 export const MoveEvent = {
   Click: 0,
   Drag: 1,
   ClickOrDrag: 2,
 };
-export type MoveEvent = typeof MoveEvent[keyof typeof MoveEvent];
+export type MoveEvent = (typeof MoveEvent)[keyof typeof MoveEvent];
 
 export const Replay = {
   Never: 0,
   OnlySlowGames: 1,
   Always: 2,
 };
-export type Replay = typeof Replay[keyof typeof Replay];
+export type Replay = (typeof Replay)[keyof typeof Replay];

--- a/ui/common/src/resize.ts
+++ b/ui/common/src/resize.ts
@@ -11,7 +11,7 @@ export default function resizeHandle(
   els: cg.Elements,
   pref: Prefs.ShowResizeHandle,
   ply: number,
-  visible?: Visible
+  visible?: Visible,
 ) {
   if (pref === Prefs.ShowResizeHandle.Never) return;
 
@@ -51,7 +51,7 @@ export default function resizeHandle(
         document.removeEventListener(mousemoveEvent, resize);
         document.body.classList.remove('resizing');
       },
-      { once: true }
+      { once: true },
     );
   };
 

--- a/ui/common/src/richText.ts
+++ b/ui/common/src/richText.ts
@@ -15,7 +15,7 @@ export function toLink(url: string): string {
   if (!url.match(/^[A-Za-z]+:\/\//)) url = 'https://' + url;
   return `<a target="_blank" rel="nofollow noopener noreferrer" href="${url}">${url.replace(
     /https?:\/\//,
-    ''
+    '',
   )}</a>`;
 }
 
@@ -83,7 +83,7 @@ export function enhance(text: string, parseMoves: boolean): string {
 function toYouTubeEmbedUrl(url: string) {
   if (!url) return;
   const m = url.match(
-    /(?:https?:\/\/)?(?:www\.)?(?:youtube\.com|youtu\.be)\/(?:watch)?(?:\?v=)?([^"&?\/ ]{11})(?:\?|&|)(\S*)/i
+    /(?:https?:\/\/)?(?:www\.)?(?:youtube\.com|youtu\.be)\/(?:watch)?(?:\?v=)?([^"&?\/ ]{11})(?:\?|&|)(\S*)/i,
   );
   if (!m) return;
   let start = 0;

--- a/ui/common/src/snabbdom.ts
+++ b/ui/common/src/snabbdom.ts
@@ -20,8 +20,8 @@ export function bind(eventName: string, f: (e: Event) => any, redraw?: () => voi
         redraw?.();
         return res;
       },
-      { passive }
-    )
+      { passive },
+    ),
   );
 }
 

--- a/ui/common/src/spinner.ts
+++ b/ui/common/src/spinner.ts
@@ -34,8 +34,8 @@ export const spinnerVdom = (box = '-2 -2 54 54'): VNode =>
               fill: 'none',
             },
           },
-          pathAttrs.map(attrs => h('path', { attrs }))
+          pathAttrs.map(attrs => h('path', { attrs })),
         ),
       ]),
-    ]
+    ],
   );

--- a/ui/common/src/storage.ts
+++ b/ui/common/src/storage.ts
@@ -8,7 +8,7 @@ export function storedProp<V>(
   key: string,
   defaultValue: V,
   fromStr: (str: string) => V,
-  toStr: (v: V) => string
+  toStr: (v: V) => string,
 ): StoredProp<V> {
   const compatKey = 'analyse.' + key;
   let cached: V;
@@ -34,7 +34,7 @@ export const storedStringProp = (k: string, defaultValue: string): StoredProp<st
     k,
     defaultValue,
     str => str,
-    v => v
+    v => v,
   );
 
 export const storedBooleanProp = (k: string, defaultValue: boolean): StoredProp<boolean> =>
@@ -42,19 +42,19 @@ export const storedBooleanProp = (k: string, defaultValue: boolean): StoredProp<
     k,
     defaultValue,
     str => str === 'true',
-    v => v.toString()
+    v => v.toString(),
   );
 
 export const storedStringPropWithEffect = (
   k: string,
   defaultValue: string,
-  effect: (v: string) => void
+  effect: (v: string) => void,
 ): Prop<string> => withEffect(storedStringProp(k, defaultValue), effect);
 
 export const storedBooleanPropWithEffect = (
   k: string,
   defaultValue: boolean,
-  effect: (v: boolean) => void
+  effect: (v: boolean) => void,
 ): Prop<boolean> => withEffect(storedBooleanProp(k, defaultValue), effect);
 
 export const storedIntProp = (k: string, defaultValue: number): StoredProp<number> =>
@@ -62,13 +62,13 @@ export const storedIntProp = (k: string, defaultValue: number): StoredProp<numbe
     k,
     defaultValue,
     str => parseInt(str),
-    v => v + ''
+    v => v + '',
   );
 
 export const storedIntPropWithEffect = (
   k: string,
   defaultValue: number,
-  effect: (v: number) => void
+  effect: (v: number) => void,
 ): Prop<number> => withEffect(storedIntProp(k, defaultValue), effect);
 
 export type StoredJsonProp<V> = Prop<V>;

--- a/ui/common/src/tablesort-number.ts
+++ b/ui/common/src/tablesort-number.ts
@@ -5,7 +5,7 @@ export default function extendTablesortNumber() {
   tablesort.extend(
     'number',
     (item: string) => item.match(/^[-+]?(\d)*-?([,\.]){0,1}-?(\d)+([E,e][\-+][\d]+)?%?$/),
-    (a: string, b: string) => compareNumber(cleanNumber(b), cleanNumber(a))
+    (a: string, b: string) => compareNumber(cleanNumber(b), cleanNumber(a)),
   );
 }
 

--- a/ui/common/src/throttle.ts
+++ b/ui/common/src/throttle.ts
@@ -4,7 +4,7 @@
  * the previous call to complete.
  */
 export function throttlePromise<T extends (...args: any) => Promise<any>>(
-  wrapped: T
+  wrapped: T,
 ): (...args: Parameters<T>) => void {
   let current: Promise<void> | undefined;
   let afterCurrent: (() => void) | undefined;
@@ -32,7 +32,7 @@ export function throttlePromise<T extends (...args: any) => Promise<any>>(
  */
 export function finallyDelay<T extends (...args: any) => Promise<any>>(
   delay: (...args: Parameters<T>) => number,
-  wrapped: T
+  wrapped: T,
 ): (...args: Parameters<T>) => Promise<void> {
   return function (this: any, ...args: Parameters<T>): Promise<void> {
     const self = this;
@@ -48,7 +48,7 @@ export function finallyDelay<T extends (...args: any) => Promise<any>>(
  */
 export function throttlePromiseDelay<T extends (...args: any) => Promise<any>>(
   delay: (...args: Parameters<T>) => number,
-  wrapped: T
+  wrapped: T,
 ): (...args: Parameters<T>) => void {
   return throttlePromise(finallyDelay(delay, wrapped));
 }
@@ -59,7 +59,7 @@ export function throttlePromiseDelay<T extends (...args: any) => Promise<any>>(
  */
 export default function throttle<T extends (...args: any) => void>(
   delay: number,
-  wrapped: T
+  wrapped: T,
 ): (...args: Parameters<T>) => void {
   return throttlePromise(function (this: any, ...args: Parameters<T>) {
     wrapped.apply(this, args);

--- a/ui/common/src/userLink.ts
+++ b/ui/common/src/userLink.ts
@@ -20,6 +20,6 @@ export default function userLink(u: string, title?: string, patron?: boolean): V
         href: '/@/' + u,
       },
     },
-    title && title != 'BOT' ? [line, h('span.utitle', title), u] : [line, u]
+    title && title != 'BOT' ? [line, h('span.utitle', title), u] : [line, u],
   );
 }

--- a/ui/coordinateTrainer/css/_svgAnimation.scss
+++ b/ui/coordinateTrainer/css/_svgAnimation.scss
@@ -33,7 +33,9 @@ svg.coords-svg {
     }
 
     // for animating the removal of this element
-    transition: opacity $timing, transform $timing;
+    transition:
+      opacity $timing,
+      transform $timing;
   }
 
   g.next {

--- a/ui/coordinateTrainer/src/ctrl.ts
+++ b/ui/coordinateTrainer/src/ctrl.ts
@@ -76,14 +76,17 @@ export default class CoordinateTrainerCtrl {
   wrongTimeout: number;
   zen: boolean;
 
-  constructor(readonly config: CoordinateTrainerConfig, readonly redraw: Redraw) {
+  constructor(
+    readonly config: CoordinateTrainerConfig,
+    readonly redraw: Redraw,
+  ) {
     const setZen = throttlePromiseDelay(
       () => 1000,
       zen =>
         xhr.text('/pref/zen', {
           method: 'post',
           body: xhr.form({ zen: zen ? 1 : 0 }),
-        })
+        }),
     );
 
     lichess.pubsub.on('zen', () => {
@@ -111,9 +114,9 @@ export default class CoordinateTrainerCtrl {
       'coordinateTrainer.colorChoice',
       'random',
       str => str as ColorChoice,
-      v => v
+      v => v,
     ),
-    () => this.setOrientationFromColorChoice()
+    () => this.setOrientationFromColorChoice(),
   );
 
   orientation = orientationFromColorChoice(this.colorChoice());
@@ -129,9 +132,9 @@ export default class CoordinateTrainerCtrl {
       'coordinateTrainer.mode',
       window.location.hash === '#name' ? 'nameSquare' : 'findSquare',
       str => str as Mode,
-      v => v
+      v => v,
     ),
-    () => this.onModeChange()
+    () => this.onModeChange(),
   );
 
   onModeChange = () => {
@@ -142,7 +145,7 @@ export default class CoordinateTrainerCtrl {
 
   selectionEnabled = withEffect<boolean>(
     storedBooleanProp('coordinateTrainer.selectionEnabled', false),
-    this.redraw
+    this.redraw,
   );
 
   selectedFiles = new Set<Files>();
@@ -163,16 +166,16 @@ export default class CoordinateTrainerCtrl {
       'coordinateTrainer.timeControl',
       document.body.classList.contains('kid') ? 'untimed' : 'thirtySeconds',
       str => str as TimeControl,
-      v => v
+      v => v,
     ),
-    this.redraw
+    this.redraw,
   );
 
   timeDisabled = () => this.timeControl() === 'untimed';
 
   showCoordinates = withEffect<boolean>(
     storedBooleanProp('coordinateTrainer.showCoordinates', document.body.classList.contains('kid')),
-    (show: boolean) => this.onShowCoordinatesChange(show)
+    (show: boolean) => this.onShowCoordinatesChange(show),
   );
 
   onShowCoordinatesChange = (show: boolean) => {
@@ -181,7 +184,7 @@ export default class CoordinateTrainerCtrl {
   };
 
   showPieces = withEffect<boolean>(storedBooleanProp('coordinateTrainer.showPieces', true), () =>
-    this.onShowPiecesChange()
+    this.onShowPiecesChange(),
   );
 
   onShowPiecesChange = () => {
@@ -196,9 +199,9 @@ export default class CoordinateTrainerCtrl {
       'coordinateTrainer.coordinateInputMethod',
       window.innerWidth >= 980 ? 'text' : 'buttons',
       str => str as InputMethod,
-      v => v
+      v => v,
     ),
-    this.redraw
+    this.redraw,
   );
 
   toggleInputMethod = () =>

--- a/ui/coordinateTrainer/src/side.ts
+++ b/ui/coordinateTrainer/src/side.ts
@@ -47,10 +47,10 @@ const filesAndRanksSelection = (ctrl: CoordinateTrainerCtrl): VNodes =>
                       title: fileLetter,
                     },
                   },
-                  fileLetter
+                  fileLetter,
                 ),
-              ])
-            )
+              ]),
+            ),
           ),
         ]),
         h('form.ranks.buttons', [
@@ -82,10 +82,10 @@ const filesAndRanksSelection = (ctrl: CoordinateTrainerCtrl): VNodes =>
                       title: rank,
                     },
                   },
-                  rank
+                  rank,
                 ),
-              ])
-            )
+              ]),
+            ),
           ),
         ]),
       ]
@@ -124,14 +124,14 @@ const configurationButtons = (ctrl: CoordinateTrainerCtrl): VNodes => [
               attrs: {
                 for: `coord_mode_${mode}`,
                 title: ctrl.trans(
-                  mode === 'findSquare' ? 'aCoordinateAppears' : 'aSquareIsHighlightedExplanation'
+                  mode === 'findSquare' ? 'aCoordinateAppears' : 'aSquareIsHighlightedExplanation',
                 ),
               },
             },
-            ctrl.trans(mode)
+            ctrl.trans(mode),
           ),
-        ])
-      )
+        ]),
+      ),
     ),
   ]),
   h('form.timeControl.buttons', [
@@ -161,14 +161,14 @@ const configurationButtons = (ctrl: CoordinateTrainerCtrl): VNodes => [
               attrs: {
                 for: `coord_timeControl_${timeControl}`,
                 title: ctrl.trans(
-                  timeControl === 'thirtySeconds' ? 'youHaveThirtySeconds' : 'goAsLongAsYouWant'
+                  timeControl === 'thirtySeconds' ? 'youHaveThirtySeconds' : 'goAsLongAsYouWant',
                 ),
               },
             },
-            timeControlLabel
+            timeControlLabel,
           ),
-        ])
-      )
+        ]),
+      ),
     ),
   ]),
   h('form.color.buttons', [
@@ -200,10 +200,10 @@ const configurationButtons = (ctrl: CoordinateTrainerCtrl): VNodes => [
                 title: ctrl.trans.noarg(i18n),
               },
             },
-            h('i')
+            h('i'),
           ),
-        ])
-      )
+        ]),
+      ),
     ),
   ]),
 ];
@@ -232,9 +232,9 @@ const scoreCharts = (ctrl: CoordinateTrainerCtrl): VNode =>
                 },
               }),
             ])
-          : null
-      )
-    )
+          : null,
+      ),
+    ),
   );
 
 const scoreBox = (ctrl: CoordinateTrainerCtrl): VNode =>
@@ -254,8 +254,8 @@ const backButton = (ctrl: CoordinateTrainerCtrl): VNode =>
       {
         hook: bind('click', ctrl.stop),
       },
-      `« ${ctrl.trans('back')}`
-    )
+      `« ${ctrl.trans('back')}`,
+    ),
   );
 
 const settings = (ctrl: CoordinateTrainerCtrl): VNode => {
@@ -270,19 +270,19 @@ const settings = (ctrl: CoordinateTrainerCtrl): VNode => {
             change: ctrl.selectionEnabled,
           },
           trans,
-          redraw
+          redraw,
         )
       : null,
     ...filesAndRanksSelection(ctrl),
     toggle(
       { name: 'showCoordinates', id: 'showCoordinates', checked: showCoordinates(), change: showCoordinates },
       trans,
-      redraw
+      redraw,
     ),
     toggle(
       { name: 'showPieces', id: 'showPieces', checked: showPieces(), change: showPieces },
       trans,
-      redraw
+      redraw,
     ),
   ]);
 };
@@ -292,7 +292,7 @@ const playingAs = (ctrl: CoordinateTrainerCtrl): VNode => {
     h(`label.color_${ctrl.orientation}`, h('i')),
     h(
       'em',
-      ctrl.trans.noarg(ctrl.orientation === 'white' ? 'youPlayTheWhitePieces' : 'youPlayTheBlackPieces')
+      ctrl.trans.noarg(ctrl.orientation === 'white' ? 'youPlayTheWhitePieces' : 'youPlayTheBlackPieces'),
     ),
   ]);
 };

--- a/ui/coordinateTrainer/src/view.ts
+++ b/ui/coordinateTrainer/src/view.ts
@@ -26,9 +26,9 @@ const textOverlay = (ctrl: CoordinateTrainerCtrl): VNode | null => {
                     } as unknown as VNodeStyle)
                   : undefined,
             },
-            h('text', modifier === 'current' ? ctrl.currentKey : ctrl.nextKey)
-          )
-        )
+            h('text', modifier === 'current' ? ctrl.currentKey : ctrl.nextKey),
+          ),
+        ),
       )
     : null;
 };
@@ -58,7 +58,7 @@ const table = (ctrl: CoordinateTrainerCtrl): VNode => {
           {
             hook: bind('click', ctrl.start),
           },
-          ctrl.trans('startTraining')
+          ctrl.trans('startTraining'),
         ),
   ]);
 };
@@ -68,7 +68,7 @@ const progress = (ctrl: CoordinateTrainerCtrl): VNode => {
     'div.progress',
     ctrl.hasPlayed
       ? h('div.progress__bar', { style: { width: `${100 * (1 - ctrl.timeLeft / DURATION)}%` } })
-      : null
+      : null,
   );
 };
 
@@ -90,9 +90,9 @@ const coordinateInput = (ctrl: CoordinateTrainerCtrl): MaybeVNode => {
                   },
                 },
               },
-              fileOrRank
-            )
-          )
+              fileOrRank,
+            ),
+          ),
         )
       : null,
     h('div.voice-container', renderVoiceBar(ctrl.voice, ctrl.redraw, 'coords')),
@@ -111,7 +111,7 @@ const coordinateInput = (ctrl: CoordinateTrainerCtrl): MaybeVNode => {
       h(
         'a',
         { on: { click: () => ctrl.toggleInputMethod() } },
-        ctrl.coordinateInputMethod() === 'text' ? 'Show buttons' : 'Hide buttons'
+        ctrl.coordinateInputMethod() === 'text' ? 'Show buttons' : 'Hide buttons',
       ),
     ]),
   ];
@@ -133,7 +133,7 @@ const view = (ctrl: CoordinateTrainerCtrl): VNode =>
       table(ctrl),
       progress(ctrl),
       coordinateInput(ctrl),
-    ]
+    ],
   );
 
 export default view;

--- a/ui/dasher/src/background.ts
+++ b/ui/dasher/src/background.ts
@@ -66,7 +66,7 @@ export function ctrl(data: BackgroundData, trans: Trans, redraw: Redraw, close: 
             method: 'post',
           })
           .then(reloadAllTheThings, announceFail);
-      }
+      },
     ),
     getImage: () => data.image,
     setImage(i: string) {
@@ -100,9 +100,9 @@ export function view(ctrl: BackgroundCtrl): VNode {
             attrs: { 'data-icon': licon.Checkmark, title: bg.title || '', type: 'button' },
             hook: bind('click', () => ctrl.set(bg.key)),
           },
-          bg.name
+          bg.name,
         );
-      })
+      }),
     ),
     cur !== 'transp' ? null : ctrl.data.gallery ? galleryInput(ctrl) : imageInput(ctrl),
   ]);
@@ -130,7 +130,7 @@ function imageInput(ctrl: BackgroundCtrl) {
                 url.length <= 400
               )
                 ctrl.setImage(url);
-            }, 300)
+            }, 300),
           );
         },
       },
@@ -174,7 +174,7 @@ function applyBackground(data: BackgroundData, list: Background[]) {
     bgData
       ? (bgData.innerHTML = 'body.transp::before{background-image:url(' + data.image + ');}')
       : $('head').append(
-          '<style id="bg-data">body.transp::before{background-image:url(' + data.image + ');}</style>'
+          '<style id="bg-data">body.transp::before{background-image:url(' + data.image + ');}</style>',
         );
   }
 }
@@ -216,8 +216,8 @@ function galleryInput(ctrl: BackgroundCtrl) {
           return h(`div#${urlId(assetUrl)}${divClass}`, {
             hook: bind('click', () => setImg(assetUrl)),
           });
-        })
-      )
+        }),
+      ),
     ),
     h('span#url', [
       h('label', 'URL'),
@@ -226,8 +226,8 @@ function galleryInput(ctrl: BackgroundCtrl) {
         hook: onInsert((el: HTMLInputElement) =>
           $(el).on(
             'change keyup paste',
-            debounce(() => setImg(el.value.trim()), 300)
-          )
+            debounce(() => setImg(el.value.trim()), 300),
+          ),
         ),
       }),
     ]),

--- a/ui/dasher/src/board.ts
+++ b/ui/dasher/src/board.ts
@@ -27,7 +27,7 @@ export function ctrl(data: BoardData, trans: Trans, redraw: Redraw, close: Close
       xhr
         .text('/pref/zoom?v=' + readZoom(), { method: 'post' })
         .catch(() => lichess.announce({ msg: 'Failed to save zoom' })),
-    1000
+    1000,
   );
 
   return {
@@ -67,7 +67,7 @@ export function view(ctrl: BoardCtrl): VNode {
           attrs: { 'data-icon': licon.Checkmark, type: 'button' },
           hook: bind('click', () => ctrl.setIs3d(false)),
         },
-        '2D'
+        '2D',
       ),
       h(
         'button.text',
@@ -76,7 +76,7 @@ export function view(ctrl: BoardCtrl): VNode {
           attrs: { 'data-icon': licon.Checkmark, type: 'button' },
           hook: bind('click', () => ctrl.setIs3d(true)),
         },
-        '3D'
+        '3D',
       ),
     ]),
     h(
@@ -100,7 +100,7 @@ export function view(ctrl: BoardCtrl): VNode {
                 },
               },
             }),
-          ]
+          ],
     ),
   ]);
 }

--- a/ui/dasher/src/langs.ts
+++ b/ui/dasher/src/langs.ts
@@ -42,7 +42,7 @@ export function view(ctrl: LangsCtrl): VNode {
       {
         attrs: { method: 'post', action: '/translation/select' },
       },
-      ctrl.list().map(langView(ctrl.current, ctrl.accepted))
+      ctrl.list().map(langView(ctrl.current, ctrl.accepted)),
     ),
     h(
       'a.help.text',
@@ -52,7 +52,7 @@ export function view(ctrl: LangsCtrl): VNode {
           'data-icon': licon.Heart,
         },
       },
-      'Help translate Lichess'
+      'Help translate Lichess',
     ),
   ]);
 }
@@ -70,5 +70,5 @@ const langView =
           title: code,
         },
       },
-      name
+      name,
     );

--- a/ui/dasher/src/links.ts
+++ b/ui/dasher/src/links.ts
@@ -15,7 +15,7 @@ export default function (ctrl: DasherCtrl): VNode {
           h(
             'a.user-link.online.text.is-green',
             linkCfg(`/@/${d.user.name}`, d.user.patron ? licon.Wings : licon.Disc),
-            noarg('profile')
+            noarg('profile'),
           ),
 
           h('a.text', linkCfg('/inbox', licon.Envelope), noarg('inbox')),
@@ -25,9 +25,9 @@ export default function (ctrl: DasherCtrl): VNode {
             linkCfg(
               '/account/preferences/display',
               licon.Gear,
-              ctrl.opts.playing ? { target: '_blank', rel: 'noopener' } : undefined
+              ctrl.opts.playing ? { target: '_blank', rel: 'noopener' } : undefined,
             ),
-            noarg('preferences')
+            noarg('preferences'),
           ),
 
           !d.coach ? null : h('a.text', linkCfg('/coach/edit', licon.GraduateCap), noarg('coachManager')),
@@ -48,9 +48,9 @@ export default function (ctrl: DasherCtrl): VNode {
                     'data-icon': licon.Power,
                   },
                 },
-                noarg('logOut')
+                noarg('logOut'),
               ),
-            ]
+            ],
           ),
         ])
       : null;
@@ -80,7 +80,7 @@ export default function (ctrl: DasherCtrl): VNode {
             },
             hook: bind('click', () => lichess.pubsub.emit('zen')),
           },
-          noarg('zenMode')
+          noarg('zenMode'),
         ),
       ])
     : null;

--- a/ui/dasher/src/main.ts
+++ b/ui/dasher/src/main.ts
@@ -32,7 +32,7 @@ export async function initModule() {
     toggle,
     {
       attributes: true,
-    }
+    },
   );
 
   return ctrl;

--- a/ui/dasher/src/piece.ts
+++ b/ui/dasher/src/piece.ts
@@ -28,7 +28,7 @@ export function ctrl(
   trans: Trans,
   dimension: () => keyof PieceData,
   redraw: Redraw,
-  close: Close
+  close: Close,
 ): PieceCtrl {
   function dimensionData() {
     return data[dimension()];
@@ -84,7 +84,7 @@ function pieceView(current: Piece, set: (t: Piece) => void, is3d: boolean) {
         h('piece', {
           attrs: { style: `background-image:url(${lichess.assetUrl(pieceImage(t, is3d))})` },
         }),
-      ]
+      ],
     );
 }
 

--- a/ui/dasher/src/ping.ts
+++ b/ui/dasher/src/ping.ts
@@ -6,7 +6,10 @@ export class PingCtrl {
   ping: number | undefined;
   server: number | undefined;
 
-  constructor(readonly trans: Trans, readonly redraw: Redraw) {
+  constructor(
+    readonly trans: Trans,
+    readonly redraw: Redraw,
+  ) {
     lichess.pubsub.on('dasher.toggle', v => (v ? this.connect() : this.disconnect()));
   }
 
@@ -58,14 +61,14 @@ export const view = (ctrl: PingCtrl): VNode =>
         {
           attrs: { title: 'PING: ' + ctrl.trans.noarg('networkLagBetweenYouAndLichess') },
         },
-        showMillis('PING', ctrl.ping)
+        showMillis('PING', ctrl.ping),
       ),
       h(
         'span.server',
         {
           attrs: { title: 'SERVER: ' + ctrl.trans.noarg('timeToProcessAMoveOnLichessServer') },
         },
-        showMillis('SERVER', ctrl.server)
+        showMillis('SERVER', ctrl.server),
       ),
-    ]
+    ],
   );

--- a/ui/dasher/src/sound.ts
+++ b/ui/dasher/src/sound.ts
@@ -36,7 +36,7 @@ export function ctrl(raw: string[], trans: Trans, redraw: Redraw, close: Close):
           body: xhr.form({ set }),
           method: 'post',
         })
-        .catch(() => lichess.announce({ msg: 'Failed to save sound preference' }))
+        .catch(() => lichess.announce({ msg: 'Failed to save sound preference' })),
   );
 
   return {
@@ -104,7 +104,7 @@ export function view(ctrl: SoundCtrl): VNode {
         }),
         h('div.selector', ctrl.makeList().map(soundView(ctrl, current))),
       ]),
-    ]
+    ],
   );
 }
 
@@ -116,5 +116,5 @@ const soundView = (ctrl: SoundCtrl, current: Key) => (s: Sound) =>
       class: { active: current === s[0] },
       attrs: { 'data-icon': licon.Checkmark, type: 'button' },
     },
-    s[1]
+    s[1],
   );

--- a/ui/dasher/src/theme.ts
+++ b/ui/dasher/src/theme.ts
@@ -28,7 +28,7 @@ export function ctrl(
   trans: Trans,
   dimension: () => keyof ThemeData,
   redraw: Redraw,
-  close: Close
+  close: Close,
 ): ThemeCtrl {
   function dimensionData() {
     return data[dimension()];
@@ -72,7 +72,7 @@ function themeView(current: Theme, set: (t: Theme) => void) {
         attrs: { title: t, type: 'button' },
         class: { active: current === t },
       },
-      [h('span.' + t)]
+      [h('span.' + t)],
     );
 }
 

--- a/ui/dasher/src/util.ts
+++ b/ui/dasher/src/util.ts
@@ -43,6 +43,6 @@ export function header(name: string, close: Close) {
       attrs: { 'data-icon': licon.LessThan, type: 'button' },
       hook: bind('click', close),
     },
-    name
+    name,
   );
 }

--- a/ui/dgt/src/config.ts
+++ b/ui/dgt/src/config.ts
@@ -58,7 +58,7 @@ export default function () {
       [true, false].forEach(v => {
         const input = document.getElementById(`${k}_${v}`) as HTMLInputElement;
         input.checked = localStorage.getItem(k) == '' + v;
-      })
+      }),
     );
     ['san', 'uci'].forEach(v => {
       const k = 'dgt-speech-announce-move-format';

--- a/ui/dgt/src/play.ts
+++ b/ui/dgt/src/play.ts
@@ -111,7 +111,7 @@ export default function (token: string) {
   function rewireLoggingToElement(
     eleLocator: HTMLPreElement,
     eleOverflowLocator: HTMLDivElement,
-    autoScroll: boolean
+    autoScroll: boolean,
   ) {
     //Clear the console
     eleLocator.innerHTML = '';
@@ -444,7 +444,7 @@ export default function (token: string) {
       console.warn('No connection to event stream. Attempting re-connection. Attempt: ' + attempts);
     }
     console.error(
-      'No connection to event stream after maximum number of attempts 20. Reload page to start again.'
+      'No connection to event stream after maximum number of attempts 20. Reload page to start again.',
     );
   }
 
@@ -468,13 +468,13 @@ export default function (token: string) {
     */
     if (playableGames.length == 0) {
       console.log(
-        'No started playable games, challenges or games are disconnected. Please start a new game or fix connection.'
+        'No started playable games, challenges or games are disconnected. Please start a new game or fix connection.',
       );
       //TODO What happens if the games reconnect and this move is not sent?
     } else {
       if (playableGames.length > 1) {
         console.warn(
-          'Multiple active games detected. Current game will be selected based on board position.'
+          'Multiple active games detected. Current game will be selected based on board position.',
         );
         console.table(playableGames);
       }
@@ -506,7 +506,7 @@ export default function (token: string) {
           if (verbose)
             console.log(
               'chooseCurrentGame - Board will remain attached to current game. currentGameId: ' +
-                currentGameId
+                currentGameId,
             );
         } else {
           //No match and No valid current game but there are active games
@@ -520,7 +520,7 @@ export default function (token: string) {
           //This is the happy path, board matches and game needs to be updated
           if (verbose)
             console.log(
-              'chooseCurrentGame - Position matched to gameId: ' + playableGames[Number(index)].gameId
+              'chooseCurrentGame - Position matched to gameId: ' + playableGames[Number(index)].gameId,
             );
           currentGameId = playableGames[Number(index)].gameId;
           attachCurrentGameIdToDGTBoard(); //Let the board know which color the player is actually playing and setup the position
@@ -530,7 +530,7 @@ export default function (token: string) {
           if (verbose)
             console.log(
               'chooseCurrentGame - Board will remain attached to current game. currentGameId: ' +
-                currentGameId
+                currentGameId,
             );
         }
       }
@@ -736,21 +736,21 @@ export default function (token: string) {
           announceWinner(
             keywords[gameState.winner],
             'flag',
-            keywords[gameState.winner] + ' ' + keywords['wins by'] + ' ' + keywords['timeout']
+            keywords[gameState.winner] + ' ' + keywords['wins by'] + ' ' + keywords['timeout'],
           );
           break;
         case 'resign':
           announceWinner(
             keywords[gameState.winner],
             'resign',
-            keywords[gameState.winner] + ' ' + keywords['wins by'] + ' ' + keywords['resignation']
+            keywords[gameState.winner] + ' ' + keywords['wins by'] + ' ' + keywords['resignation'],
           );
           break;
         case 'mate':
           announceWinner(
             keywords[lastMove.player],
             'mate',
-            keywords[lastMove.player] + ' ' + keywords['wins by'] + ' ' + keywords['#']
+            keywords[lastMove.player] + ' ' + keywords['wins by'] + ' ' + keywords['#'],
           );
           break;
         case 'draw':
@@ -778,7 +778,7 @@ export default function (token: string) {
         const moves = gameState.moves.split(' ');
         if (verbose)
           console.log(
-            `getLastUCIMove - ${moves.length} moves detected. Last one: ${moves[moves.length - 1]}`
+            `getLastUCIMove - ${moves.length} moves detected. Last one: ${moves[moves.length - 1]}`,
           );
         if (moves.length % 2 == 0)
           return { player: 'black', move: moves[moves.length - 1], by: gameInfo.black.id };
@@ -928,7 +928,7 @@ export default function (token: string) {
           if (movesToProcess > 1) {
             if (verbose)
               console.warn(
-                'onmessage - Multiple moves received on single message - movesToProcess: ' + movesToProcess
+                'onmessage - Multiple moves received on single message - movesToProcess: ' + movesToProcess,
               );
             if (localBoard.turn == currentGameColor) {
               //If more than one move is received when it's the DGT board player's turn this may be a invalid move
@@ -939,7 +939,7 @@ export default function (token: string) {
               if (JSON.stringify(lastLegalParam.san) != JSON.stringify(quarantinedlastLegalParam.san)) {
                 //lastLegalParam was altered, this mean a new move was received from LiveChess during quarantine
                 console.warn(
-                  'onmessage - Invalid moved quarantined and not sent to lichess. Newer move interpretation received.'
+                  'onmessage - Invalid moved quarantined and not sent to lichess. Newer move interpretation received.',
                 );
                 return;
               }
@@ -951,7 +951,7 @@ export default function (token: string) {
                 //It looks like a duplicate, so just ignore it
                 if (verbose)
                   console.info(
-                    'onmessage - Duplicate position and san move received after quarantine and will be ignored'
+                    'onmessage - Duplicate position and san move received after quarantine and will be ignored',
                   );
                 return;
               }
@@ -1013,7 +1013,7 @@ export default function (token: string) {
                 if (verbose)
                   console.error(
                     'onmessage - invalidMove - Position Mismatch between DGT Board and internal in-memory Board. SAN: ' +
-                      SANMove
+                      SANMove,
                   );
                 announceInvalidMove();
                 console.info(board(localBoard.board));
@@ -1047,13 +1047,13 @@ export default function (token: string) {
         //Websocket is fine but still no board detected
         console.warn(
           'Connection to DGT Live Chess is Fine but no board is detected. Attempting re-connection. Attempt: ' +
-            attempts
+            attempts,
         );
         liveChessConnection.send('{"id":1,"call":"eboards"}');
       }
     }
     console.error(
-      'No connection to DGT Live Chess after maximum number of attempts (20). Reload page to start again.'
+      'No connection to DGT Live Chess after maximum number of attempts (20). Reload page to start again.',
     );
   }
 
@@ -1088,7 +1088,7 @@ export default function (token: string) {
     } else {
       console.error('WebSocket is not open or is not ready to receive setup - cannot send setup command.');
       console.error(
-        `isLiveChessConnected: ${isLiveChessConnected} - DGTgameId: ${DGTgameId} - currentSerialnr: ${currentSerialnr} - currentGameId: ${currentGameId}`
+        `isLiveChessConnected: ${isLiveChessConnected} - DGTgameId: ${DGTgameId} - currentSerialnr: ${currentSerialnr} - currentGameId: ${currentGameId}`,
       );
     }
   }
@@ -1111,7 +1111,7 @@ export default function (token: string) {
     ) {
       //Wait a few seconds to see if the games reconnects or starts and give some space to other code to run
       console.warn(
-        'validateAndSendBoardMove - Cannot send move while disconnected. Re-Trying in 2 seconds...'
+        'validateAndSendBoardMove - Cannot send move while disconnected. Re-Trying in 2 seconds...',
       );
       await sleep(2000);
       //Now attempt to select for which game is this command intended
@@ -1176,7 +1176,7 @@ export default function (token: string) {
       try {
         extendedSanMove = extendedSanMove.replace(
           keywordsBase[i],
-          ' ' + keywords[keywordsBase[i]].toLowerCase() + ' '
+          ' ' + keywords[keywordsBase[i]].toLowerCase() + ' ',
         );
       } catch (error) {
         console.error(`raplaceKeywords - Error replacing keyword. ${keywordsBase[i]} . ${error}`);

--- a/ui/editor/src/ctrl.ts
+++ b/ui/editor/src/ctrl.ts
@@ -91,7 +91,7 @@ export default class EditorCtrl {
     const boardFen = this.chessground?.getFen() || this.initialFen;
     const board = parseFen(boardFen).unwrap(
       setup => setup.board,
-      _ => Board.empty()
+      _ => Board.empty(),
     );
     return {
       board,
@@ -112,14 +112,14 @@ export default class EditorCtrl {
   private getLegalFen(): string | undefined {
     return setupPosition(this.rules, this.getSetup()).unwrap(
       pos => makeFen(pos.toSetup()),
-      _ => undefined
+      _ => undefined,
     );
   }
 
   private isPlayable(): boolean {
     return setupPosition(this.rules, this.getSetup()).unwrap(
       pos => !pos.isEnd(),
-      _ => false
+      _ => false,
     );
   }
 
@@ -191,7 +191,7 @@ export default class EditorCtrl {
         this.onChange();
         return true;
       },
-      _ => false
+      _ => false,
     );
   }
 

--- a/ui/editor/src/view.ts
+++ b/ui/editor/src/view.ts
@@ -60,9 +60,9 @@ function studyButton(ctrl: EditorCtrl, state: EditorState): VNode {
             disabled: !state.legalFen,
           },
         },
-        ctrl.trans.noarg('toStudy')
+        ctrl.trans.noarg('toStudy'),
       ),
-    ]
+    ],
   );
 }
 
@@ -75,7 +75,7 @@ function variant2option(key: Rules, name: string, ctrl: EditorCtrl): VNode {
         selected: key == ctrl.rules,
       },
     },
-    `${ctrl.trans.noarg('variant')} | ${name}`
+    `${ctrl.trans.noarg('variant')} | ${name}`,
   );
 }
 
@@ -100,7 +100,7 @@ function controls(ctrl: EditorCtrl, state: EditorState): VNode {
           'data-fen': pos.fen,
         },
       },
-      pos.name
+      pos.name,
     );
   };
 
@@ -111,7 +111,7 @@ function controls(ctrl: EditorCtrl, state: EditorState): VNode {
         on: { click: ctrl.startPosition },
         attrs: icon ? dataIcon(icon) : {},
       },
-      ctrl.trans.noarg('startPosition')
+      ctrl.trans.noarg('startPosition'),
     );
   const buttonClear = (icon?: string) =>
     h(
@@ -120,7 +120,7 @@ function controls(ctrl: EditorCtrl, state: EditorState): VNode {
         on: { click: ctrl.clearBoard },
         attrs: icon ? dataIcon(icon) : {},
       },
-      ctrl.trans.noarg('clearBoard')
+      ctrl.trans.noarg('clearBoard'),
     );
 
   return h('div.board-editor__tools', [
@@ -148,10 +148,10 @@ function controls(ctrl: EditorCtrl, state: EditorState): VNode {
                   selected: key[0] === ctrl.turn[0],
                 },
               },
-              ctrl.trans(key)
+              ctrl.trans(key),
             );
-          })
-        )
+          }),
+        ),
       ),
       h('div.castling', [
         h('strong', ctrl.trans.noarg('castling')),
@@ -178,7 +178,7 @@ function controls(ctrl: EditorCtrl, state: EditorState): VNode {
                     'data-fen': pos.fen,
                   },
                 },
-                pos.eco ? `${pos.eco} ${pos.name}` : pos.name
+                pos.eco ? `${pos.eco} ${pos.name}` : pos.name,
               );
             const epd = state.fen.split(' ').slice(0, 4).join(' ');
             const value =
@@ -206,9 +206,9 @@ function controls(ctrl: EditorCtrl, state: EditorState): VNode {
                 optgroup(ctrl.trans.noarg('popularOpenings'), ctrl.cfg.positions.map(positionOption)),
                 optgroup(
                   ctrl.trans.noarg('endgamePositions'),
-                  ctrl.cfg.endgamePositions.map(endgamePosition2option)
+                  ctrl.cfg.endgamePositions.map(endgamePosition2option),
                 ),
-              ]
+              ],
             );
           })(),
         ]),
@@ -226,7 +226,7 @@ function controls(ctrl: EditorCtrl, state: EditorState): VNode {
                   },
                 },
               },
-              allVariants.map(x => variant2option(x[0], x[1], ctrl))
+              allVariants.map(x => variant2option(x[0], x[1], ctrl)),
             ),
           ]),
           h('div.actions', [
@@ -243,7 +243,7 @@ function controls(ctrl: EditorCtrl, state: EditorState): VNode {
                   },
                 },
               },
-              ctrl.trans.noarg('flipBoard')
+              ctrl.trans.noarg('flipBoard'),
             ),
             h(
               'a',
@@ -262,7 +262,7 @@ function controls(ctrl: EditorCtrl, state: EditorState): VNode {
                   disabled: !state.legalFen,
                 },
               },
-              ctrl.trans.noarg('analysis')
+              ctrl.trans.noarg('analysis'),
             ),
             h(
               'button',
@@ -281,7 +281,13 @@ function controls(ctrl: EditorCtrl, state: EditorState): VNode {
                   },
                 },
               },
-              [h('span.text', { attrs: { 'data-icon': licon.Swords } }, ctrl.trans.noarg('continueFromHere'))]
+              [
+                h(
+                  'span.text',
+                  { attrs: { 'data-icon': licon.Swords } },
+                  ctrl.trans.noarg('continueFromHere'),
+                ),
+              ],
             ),
             studyButton(ctrl, state),
           ]),
@@ -294,7 +300,7 @@ function controls(ctrl: EditorCtrl, state: EditorState): VNode {
                   rel: 'nofollow',
                 },
               },
-              ctrl.trans.noarg('playWithTheMachine')
+              ctrl.trans.noarg('playWithTheMachine'),
             ),
             h(
               'a.button',
@@ -304,7 +310,7 @@ function controls(ctrl: EditorCtrl, state: EditorState): VNode {
                   rel: 'nofollow',
                 },
               },
-              ctrl.trans.noarg('playWithAFriend')
+              ctrl.trans.noarg('playWithAFriend'),
             ),
           ]),
         ]),
@@ -416,9 +422,9 @@ function sparePieces(ctrl: EditorCtrl, color: Color, _orientation: Color, positi
             },
           },
         },
-        [h('div', [h('piece', { attrs })])]
+        [h('div', [h('piece', { attrs })])],
       );
-    })
+    }),
   );
 }
 
@@ -438,7 +444,7 @@ function onSelectSparePiece(ctrl: EditorCtrl, s: Selected, upEvent: string): (e:
           role: s[1],
         },
         e,
-        true
+        true,
       );
 
       document.addEventListener(
@@ -449,7 +455,7 @@ function onSelectSparePiece(ctrl: EditorCtrl, s: Selected, upEvent: string): (e:
           else ctrl.selected(s);
           ctrl.redraw();
         },
-        { once: true }
+        { once: true },
       );
     }
   };
@@ -481,6 +487,6 @@ export default function (ctrl: EditorCtrl): VNode {
       sparePieces(ctrl, color, color, 'bottom'),
       controls(ctrl, state),
       inputs(ctrl, state.fen),
-    ]
+    ],
   );
 }

--- a/ui/game/src/view/material.ts
+++ b/ui/game/src/view/material.ts
@@ -8,7 +8,7 @@ function renderMaterialDiff(
   material: MaterialDiffSide,
   score: number,
   position: 'top' | 'bottom',
-  checks?: number
+  checks?: number,
 ): VNode {
   const children: VNode[] = [];
   let role: cg.Role;
@@ -30,7 +30,7 @@ export function renderMaterialDiffs(
   fen: Fen,
   showChecks: boolean,
   checkStates: CheckState[],
-  ply: Ply
+  ply: Ply,
 ): [VNode, VNode] {
   const material = getMaterialDiff(showCaptured ? fen : '');
   const score = getScore(material) * (bottomColor === 'white' ? 1 : -1);

--- a/ui/game/src/view/status.ts
+++ b/ui/game/src/view/status.ts
@@ -56,7 +56,7 @@ export default function status(ctrl: Ctrl): string {
           return noarg('whiteLeftTheGame') + winnerSuffix;
         default:
           return `${d.game.turns % 2 === 0 ? noarg('whiteLeftTheGame') : noarg('blackLeftTheGame')} • ${noarg(
-            'draw'
+            'draw',
           )}`;
       }
     case 'draw': {

--- a/ui/insight/src/axis.ts
+++ b/ui/insight/src/axis.ts
@@ -35,7 +35,7 @@ const option = (ctrl: Ctrl, item: Metric | Dimension, axis: 'metric' | 'dimensio
         // disabled: !ctrl.validCombination(item, ctrl.vm.metric),
       },
     },
-    item.name
+    item.name,
   );
 
 export default function (ctrl: Ctrl, attrs: any = null) {
@@ -44,20 +44,20 @@ export default function (ctrl: Ctrl, attrs: any = null) {
       'select.ms.metric',
       selectData(
         v => ctrl.setMetric(v.value),
-        () => ctrl.vm.metric.key
+        () => ctrl.vm.metric.key,
       ),
-      ctrl.ui.metricCategs.map(optgroup(y => option(ctrl, y, 'metric')))
+      ctrl.ui.metricCategs.map(optgroup(y => option(ctrl, y, 'metric'))),
     ),
     h('span.by', 'by'),
     h(
       'select.ms.dimension',
       selectData(
         v => ctrl.setDimension(v.value),
-        () => ctrl.vm.dimension.key
+        () => ctrl.vm.dimension.key,
       ),
       ctrl.ui.dimensionCategs.map(
-        optgroup(x => (x.key !== 'period' ? option(ctrl, x, 'dimension') : undefined))
-      )
+        optgroup(x => (x.key !== 'period' ? option(ctrl, x, 'dimension') : undefined)),
+      ),
     ),
   ]);
 }

--- a/ui/insight/src/boards.ts
+++ b/ui/insight/src/boards.ts
@@ -37,7 +37,7 @@ const miniGame = (game: Game) =>
           game.user2.title ? ' ' + game.user2.title : '',
         ]),
       ]),
-    ]
+    ],
   );
 
 export default function (ctrl: Ctrl, attrs: any = null) {

--- a/ui/insight/src/ctrl.ts
+++ b/ui/insight/src/ctrl.ts
@@ -27,11 +27,11 @@ export default class {
 
     this.dimensions = Array.prototype.concat.apply(
       [],
-      env.ui.dimensionCategs.map(c => c.items)
+      env.ui.dimensionCategs.map(c => c.items),
     );
     this.metrics = Array.prototype.concat.apply(
       [],
-      env.ui.metricCategs.map(c => c.items)
+      env.ui.metricCategs.map(c => c.items),
     );
 
     this.vm = {
@@ -100,13 +100,13 @@ export default class {
                   this.vm.loading = false;
                   this.vm.broken = true;
                   this.redraw();
-                }
+                },
               )
               .finally(resolve),
-          1
+          1,
         );
       });
-    }
+    },
   );
 
   makeUrl(dKey: string, mKey: string, filters: Filters) {

--- a/ui/insight/src/filters.ts
+++ b/ui/insight/src/filters.ts
@@ -21,7 +21,7 @@ const select = (ctrl: Ctrl) => (dimension: Dimension) => {
             onClick: view =>
               ctrl.setFilter(
                 dimension.key,
-                single ? [view.value] : $(vnode.elm).multipleSelect('getSelects')
+                single ? [view.value] : $(vnode.elm).multipleSelect('getSelects'),
               ),
           }),
         postpatch: (_oldVnode, vnode) => {
@@ -38,9 +38,9 @@ const select = (ctrl: Ctrl) => (dimension: Dimension) => {
             selected: ctrl.vm.filters[dimension.key]?.includes(value.key),
           },
         },
-        value.name
-      )
-    )
+        value.name,
+      ),
+    ),
   );
 };
 
@@ -50,8 +50,8 @@ export default function (ctrl: Ctrl) {
     h(
       'div.items',
       ctrl.ui.dimensionCategs.map(categ =>
-        h('div.categ.box', [h('div.top', categ.name), ...categ.items.map(select(ctrl))])
-      )
-    )
+        h('div.categ.box', [h('div.top', categ.name), ...categ.items.map(select(ctrl))]),
+      ),
+    ),
   );
 }

--- a/ui/insight/src/global.d.ts
+++ b/ui/insight/src/global.d.ts
@@ -26,7 +26,7 @@ interface MultipleSelect {
       | 'focus'
       | 'blur'
       | 'refresh'
-      | 'close'
+      | 'close',
   ): void;
   (option: MultiSelectOpts): void;
 }

--- a/ui/insight/src/help.ts
+++ b/ui/insight/src/help.ts
@@ -9,7 +9,7 @@ export default function (ctrl: Ctrl) {
       ['metric', 'dimension'].map(type => {
         const data = ctrl.vm[type as 'metric' | 'dimension'];
         return h('section.' + type, [h('h3', data.name), h('p', data.description)]);
-      })
+      }),
     ),
   ]);
 }

--- a/ui/insight/src/info.ts
+++ b/ui/insight/src/info.ts
@@ -25,9 +25,9 @@ export default function (ctrl: Ctrl) {
                   rel: 'noopener',
                 },
               },
-              shareText
+              shareText,
             )
-          : shareText
+          : shareText,
       ),
     ]),
     h(
@@ -51,12 +51,12 @@ export default function (ctrl: Ctrl) {
                   {
                     hook: onInsert(el => el.insertAdjacentHTML('afterbegin', lichess.spinnerHtml)),
                   },
-                  [h('br'), h('p', h('strong', 'Now crunching data just for you!'))]
+                  [h('br'), h('p', h('strong', 'Now crunching data just for you!'))],
                 ),
-              ]
+              ],
             ),
           ])
-        : null
+        : null,
     ),
   ]);
 }

--- a/ui/insight/src/multiple-select.ts
+++ b/ui/insight/src/multiple-select.ts
@@ -45,7 +45,7 @@ export const registerMultipleSelect = () => {
           `<span class="placeholder">${this.options.placeholder}</span>`,
           '<div></div>',
           '</button>',
-        ].join('')
+        ].join(''),
       );
       this.$drop = $(`<div class="ms-drop ${this.options.position}"/>`);
       this.$el.after(this.$parent);
@@ -87,7 +87,7 @@ export const registerMultipleSelect = () => {
             '<div class="ms-search">',
             '<input type="text" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false">',
             '</div>',
-          ].join('')
+          ].join(''),
         );
       }
       if (this.options.selectAll && !this.options.single) {
@@ -101,7 +101,7 @@ export const registerMultipleSelect = () => {
             this.options.selectAllDelimiter?.[1] || '',
             '</label>',
             '</li>',
-          ].join('')
+          ].join(''),
         );
       }
       $.each(this.$el.children(), function (i, elm) {
@@ -149,7 +149,7 @@ export const registerMultipleSelect = () => {
             text,
             '</label>',
             '</li>',
-          ].join('')
+          ].join(''),
         );
         return $el;
       }
@@ -168,7 +168,7 @@ export const registerMultipleSelect = () => {
             label,
             '</label>',
             '</li>',
-          ].join('')
+          ].join(''),
         );
         $.each($elm.children(), function (i, elm) {
           $group.append(that.optionToHtml(i, elm!, group, disabled));
@@ -346,7 +346,7 @@ export const registerMultipleSelect = () => {
           .html(
             this.options.countSelected
               .replace('#', selects.length + '')
-              .replace('%', this.$selectItems.length + this.$disableItems.length + '')
+              .replace('%', this.$selectItems.length + this.$disableItems.length + ''),
           );
       } else {
         $span.removeClass('placeholder').text(selects.join(this.options.delimiter));
@@ -427,7 +427,7 @@ export const registerMultipleSelect = () => {
       });
       this.$selectAll.prop(
         'checked',
-        this.$selectItems.length === this.$selectItems.filter(':checked').length
+        this.$selectItems.length === this.$selectItems.filter(':checked').length,
       );
       $.each(that.$selectGroups!, function (_i, val) {
         const group = $(val).parent().attr('data-group'),

--- a/ui/insight/src/presets.ts
+++ b/ui/insight/src/presets.ts
@@ -15,9 +15,9 @@ export default function (ctrl: Ctrl) {
           attrs: { 'data-icon': licon.Target },
           hook: bind('click', () => ctrl.setQuestion(p)),
         },
-        p.name
-      )
-    )
+        p.name,
+      ),
+    ),
   );
 }
 

--- a/ui/insight/src/table.ts
+++ b/ui/insight/src/table.ts
@@ -28,7 +28,7 @@ export function vert(ctrl: Ctrl, attrs: any = null) {
           h('th', answer.xAxis.name),
           ...answer.series.map(serie => h('th', serie.name)),
           h('th', answer.sizeYaxis.name),
-        ])
+        ]),
       ),
       h(
         'tbody',
@@ -38,8 +38,8 @@ export function vert(ctrl: Ctrl, attrs: any = null) {
             ...answer.series.map(serie => h('td.data', formatNumber(serie.dataType, serie.data[i]))),
             h('td.size', formatNumber(answer.sizeSerie.dataType, answer.sizeSerie.data[i])),
           ]);
-        })
+        }),
       ),
-    ])
+    ]),
   );
 }

--- a/ui/insight/src/view.ts
+++ b/ui/insight/src/view.ts
@@ -124,7 +124,7 @@ function portraitView(ctrl: Ctrl) {
             info(ctrl),
             ctrl.vm.view === 'filters' ? clearBtn(ctrl) : null,
             ctrl.vm.view === 'presets' ? presets(ctrl) : filters(ctrl),
-          ])
+          ]),
     ),
   ]);
 }
@@ -137,7 +137,7 @@ function clearBtn(ctrl: Ctrl) {
         attrs: { title: 'Clear all filters', 'data-icon': licon.X },
         hook: bind('click', ctrl.clearFilters.bind(ctrl)),
       },
-      isLandscapeLayout() ? 'CLEAR' : 'CLEAR FILTERS'
+      isLandscapeLayout() ? 'CLEAR' : 'CLEAR FILTERS',
     );
   return isLandscapeLayout() ? btn() : h('div.center-clear', btn());
 }

--- a/ui/keyboardMove/src/main.ts
+++ b/ui/keyboardMove/src/main.ts
@@ -157,7 +157,7 @@ export function render(ctrl: KeyboardMove) {
         autocomplete: 'off',
       },
       hook: onInsert((input: HTMLInputElement) =>
-        loadKeyboardMove({ input, ctrl }).then((m: KeyboardMoveHandler) => ctrl.registerHandler(m))
+        loadKeyboardMove({ input, ctrl }).then((m: KeyboardMoveHandler) => ctrl.registerHandler(m)),
       ),
     }),
     ctrl.isFocused()

--- a/ui/keyboardMove/src/plugins/keyboardMove.test.ts
+++ b/ui/keyboardMove/src/plugins/keyboardMove.test.ts
@@ -140,7 +140,7 @@ describe('keyboardMove', () => {
       input,
       ctrl: {
         ...defaultCtrl,
-        clock: () => ({ millisOf: mockMillisOf } as any),
+        clock: () => ({ millisOf: mockMillisOf }) as any,
       },
     }) as any;
 

--- a/ui/learn/@types/chessground/index.d.ts
+++ b/ui/learn/@types/chessground/index.d.ts
@@ -50,7 +50,7 @@ declare namespace chessground {
           viewOnly: boolean;
           minimalDom: boolean;
         }
-      >
+      >,
     ): void;
     /** change the view angle */
     toggleOrientation(): void;

--- a/ui/learn/css/_board.scss
+++ b/ui/learn/css/_board.scss
@@ -37,7 +37,9 @@
 
   .apple {
     background-image: url(../images/learn/star.png);
-    animation: 0.6s ease-in-out 0s 1 forwards apple-appear, 1.7s ease-in-out 0.7s infinite none soft-grow,
+    animation:
+      0.6s ease-in-out 0s 1 forwards apple-appear,
+      1.7s ease-in-out 0.7s infinite none soft-grow,
       0.7s ease-in-out 0.7s infinite none soft-hue;
   }
 
@@ -129,7 +131,9 @@
     top: 14px;
     #{$end-direction}: 4px;
     color: #fff;
-    text-shadow: 0 0 9px rgba(0, 0, 0, 1), 0 0 4px rgba(0, 0, 0, 1);
+    text-shadow:
+      0 0 9px rgba(0, 0, 0, 1),
+      0 0 4px rgba(0, 0, 0, 1);
     font-size: 30px;
     font-weight: bold;
   }

--- a/ui/learn/css/_map.scss
+++ b/ui/learn/css/_map.scss
@@ -34,7 +34,9 @@
     height: 90px;
     color: #fff;
     margin-top: 13px;
-    box-shadow: 0 3px 5px 0 rgba(0, 0, 0, 0.3), 0 1px 1px 0 rgba(0, 0, 0, 0.2);
+    box-shadow:
+      0 3px 5px 0 rgba(0, 0, 0, 0.3),
+      0 1px 1px 0 rgba(0, 0, 0, 0.2);
     font-size: 1.2em;
 
     img {

--- a/ui/learn/css/_side-home.scss
+++ b/ui/learn/css/_side-home.scss
@@ -72,7 +72,9 @@
     border-radius: 0 5px 5px 0;
     background-image: img-url('grain.png');
     transform: translateX(-100px);
-    animation: animatedBackground 50s linear infinite, animatedBar 1s forwards;
+    animation:
+      animatedBackground 50s linear infinite,
+      animatedBar 1s forwards;
   }
 
   .progress .text {

--- a/ui/learn/src/chess.ts
+++ b/ui/learn/src/chess.ts
@@ -37,7 +37,7 @@ export default function (fen: string, appleKeys: Key[]): ChessCtrl {
           type: 'p',
           color: color,
         },
-        key
+        key,
       );
     });
   }

--- a/ui/learn/src/ground.ts
+++ b/ui/learn/src/ground.ts
@@ -122,7 +122,7 @@ export function check(chess: ChessCtrl) {
     cg.setShapes(
       checks.map(function (move) {
         return arrow(move.orig + move.dest, 'yellow');
-      })
+      }),
     );
 }
 

--- a/ui/learn/src/level.ts
+++ b/ui/learn/src/level.ts
@@ -67,7 +67,7 @@ export default function (blueprint: Level, opts: LevelOpts): LevelCtrl {
         m.redraw();
         if (!blueprint.nextButton) timeouts.setTimeout(opts.onComplete, 1200);
       },
-      ground.data().stats.dragged ? 1 : 250
+      ground.data().stats.dragged ? 1 : 250,
     );
   };
 

--- a/ui/learn/src/map/mapSide.ts
+++ b/ui/learn/src/map/mapSide.ts
@@ -29,7 +29,7 @@ function renderInStage(ctrl: SideCtrl) {
             src: util.assetUrl + 'images/learn/brutal-helm.svg',
           }),
           ctrl.trans.noarg('menu'),
-        ]
+        ],
       ),
       ...stages.categs.map(function (categ, categId) {
         return m(
@@ -45,7 +45,7 @@ function renderInStage(ctrl: SideCtrl) {
                   ctrl.categId(categId);
                 },
               },
-              ctrl.trans.noarg(categ.name)
+              ctrl.trans.noarg(categ.name),
             ),
             m(
               'div.categ_stages',
@@ -64,11 +64,11 @@ function renderInStage(ctrl: SideCtrl) {
                       src: s.image,
                     }),
                     m('span', ctrl.trans.noarg(s.title)),
-                  ]
+                  ],
                 );
-              })
+              }),
             ),
-          ]
+          ],
         );
       }),
     ]),
@@ -98,7 +98,7 @@ function renderHome(ctrl: SideCtrl) {
                 if (confirm(ctrl.trans.noarg('youWillLoseAllYourProgress'))) ctrl.reset();
               },
             },
-            ctrl.trans.noarg('resetMyProgress')
+            ctrl.trans.noarg('resetMyProgress'),
           )
         : null,
     ]),

--- a/ui/learn/src/map/mapView.ts
+++ b/ui/learn/src/map/mapView.ts
@@ -12,7 +12,7 @@ function makeStars(nb: number) {
     stars.push(
       m('i', {
         'data-icon': licon.Star,
-      })
+      }),
     );
   return stars;
 }
@@ -32,8 +32,8 @@ function ribbon(ctrl: MapCtrl, s: stages.Stage, status: string, res: StageProgre
       {
         class: status,
       },
-      content
-    )
+      content,
+    ),
   );
 }
 
@@ -52,7 +52,7 @@ function whatNext(ctrl: MapCtrl) {
           src: util.assetUrl + 'images/learn/' + img + '.svg',
         }),
         m('div.text', [m('h3', transTitle), m('p.subtitle', ctrl.trans.noarg(subtitle))]),
-      ]
+      ],
     );
   };
   const userId = ctrl.data._id;
@@ -106,9 +106,9 @@ export default function (ctrl: MapCtrl) {
                     src: s.image,
                   }),
                   m('div.text', [m('h3', title), m('p.subtitle', ctrl.trans.noarg(s.subtitle))]),
-                ]
+                ],
               );
-            })
+            }),
           ),
         ]);
       }),

--- a/ui/learn/src/mithrilFix.ts
+++ b/ui/learn/src/mithrilFix.ts
@@ -18,12 +18,12 @@ interface MithrilFixed extends _mithril.MithrilStatic {
   <T extends _mithril.MithrilController>(
     selector: string,
     attributes: Record<string, unknown>,
-    children?: Children<T>
+    children?: Children<T>,
   ): _mithril.MithrilVirtualElement<T>;
 
   <T extends _mithril.MithrilController>(
     selector: string,
-    children?: Children<T>
+    children?: Children<T>,
   ): _mithril.MithrilVirtualElement<T>;
 }
 

--- a/ui/learn/src/progress.ts
+++ b/ui/learn/src/progress.ts
@@ -43,8 +43,8 @@ export function view(ctrl: Progress) {
           config: m.route,
           class: status,
         },
-        label
+        label,
       );
-    })
+    }),
   );
 }

--- a/ui/learn/src/promotion.ts
+++ b/ui/learn/src/promotion.ts
@@ -50,7 +50,7 @@ function renderPromotion(
   pieces: PromotionRole[],
   color: Color,
   orientation: Color,
-  explain: boolean
+  explain: boolean,
 ) {
   if (!promoting) return;
 
@@ -70,7 +70,7 @@ function renderPromotion(
             finish(serverRole);
           },
         },
-        m('piece.' + serverRole + '.' + color)
+        m('piece.' + serverRole + '.' + color),
       );
     }),
     explain ? renderExplanation(ctrl) : null,
@@ -96,7 +96,7 @@ export function view(ctrl: Ctrl, stage: LevelCtrl) {
     pieces,
     opposite(ground.data().turnColor),
     ground.data().orientation,
-    !!stage.blueprint.explainPromotion
+    !!stage.blueprint.explainPromotion,
   );
 }
 

--- a/ui/learn/src/run/runView.ts
+++ b/ui/learn/src/run/runView.ts
@@ -16,7 +16,7 @@ function renderFailed(ctrl: Ctrl) {
     {
       onclick: ctrl.restart,
     },
-    [m('h2', ctrl.trans.noarg('puzzleFailed')), m('button', ctrl.trans.noarg('retry'))]
+    [m('h2', ctrl.trans.noarg('puzzleFailed')), m('button', ctrl.trans.noarg('retry'))],
   );
 }
 
@@ -32,7 +32,7 @@ function renderCompleted(ctrl: Ctrl, level: LevelCtrl) {
       level.blueprint.nextButton
         ? m('button', ctrl.trans.noarg('next'))
         : makeStars(level.blueprint, level.vm.score),
-    ]
+    ],
   );
 }
 
@@ -80,6 +80,6 @@ export default function (ctrl: Ctrl) {
           renderProgress(ctrl.progress),
         ]),
       ]),
-    ]
+    ],
   );
 }

--- a/ui/learn/src/run/stageComplete.ts
+++ b/ui/learn/src/run/stageComplete.ts
@@ -38,9 +38,9 @@ export default function (ctrl: Ctrl) {
                   }, 300);
               },
             },
-            '0'
-          )
-        )
+            '0',
+          ),
+        ),
       ),
       m('p', util.withLinebreaks(ctrl.trans.noarg(stage.complete))),
       m('div.buttons', [
@@ -51,7 +51,7 @@ export default function (ctrl: Ctrl) {
                 href: '/' + next.id,
                 config: m.route,
               },
-              [ctrl.trans('nextX', ctrl.trans.noarg(next.title)) + ' ', m('i[data-icon=]')]
+              [ctrl.trans('nextX', ctrl.trans.noarg(next.title)) + ' ', m('i[data-icon=]')],
             )
           : null,
         m(
@@ -60,9 +60,9 @@ export default function (ctrl: Ctrl) {
             href: '/',
             config: m.route,
           },
-          ctrl.trans.noarg('backToMenu')
+          ctrl.trans.noarg('backToMenu'),
         ),
       ]),
-    ])
+    ]),
   );
 }

--- a/ui/learn/src/run/stageStarting.ts
+++ b/ui/learn/src/run/stageStarting.ts
@@ -19,9 +19,9 @@ export default function (ctrl: Ctrl) {
           {
             onclick: ctrl.hideStartingPane,
           },
-          ctrl.trans.noarg('letsGo')
-        )
+          ctrl.trans.noarg('letsGo'),
+        ),
       ),
-    ])
+    ]),
   );
 }

--- a/ui/learn/src/util.ts
+++ b/ui/learn/src/util.ts
@@ -64,7 +64,7 @@ export function roundSvg(url: string) {
     'div.round-svg',
     m('img', {
       src: url,
-    })
+    }),
   );
 }
 

--- a/ui/lobby/src/boot.ts
+++ b/ui/lobby/src/boot.ts
@@ -29,7 +29,7 @@ export function initModule(opts: LobbyOpts) {
         lobbyCtrl.spreadPlayersNumber && lobbyCtrl.spreadPlayersNumber(msg.d);
         setTimeout(
           () => lobbyCtrl.spreadGamesNumber && lobbyCtrl.spreadGamesNumber(msg.r),
-          lichess.socket.pingInterval() / 2
+          lichess.socket.pingInterval() / 2,
         );
       },
       reload_timeline() {
@@ -61,7 +61,7 @@ export function initModule(opts: LobbyOpts) {
       xhr.url(`/setup/hook/${lichess.sri}/like/${gameId}`, { deltaMin: ratingMin, deltaMax: ratingMax }),
       {
         method: 'post',
-      }
+      },
     );
     lobbyCtrl.setTab('real_time');
     lobbyCtrl.redraw();
@@ -83,6 +83,8 @@ function suggestBgSwitch() {
   $('.bg-switch')
     .addClass('active')
     .on('click', () =>
-      loadDasher().then(m => m.subs.background.set(document.body.dataset.theme === 'dark' ? 'light' : 'dark'))
+      loadDasher().then(m =>
+        m.subs.background.set(document.body.dataset.theme === 'dark' ? 'light' : 'dark'),
+      ),
     );
 }

--- a/ui/lobby/src/ctrl.ts
+++ b/ui/lobby/src/ctrl.ts
@@ -45,7 +45,10 @@ export default class LobbyController {
   private flushHooksTimeout?: number;
   private alreadyWatching: string[] = [];
 
-  constructor(readonly opts: LobbyOpts, readonly redraw: () => void) {
+  constructor(
+    readonly opts: LobbyOpts,
+    readonly redraw: () => void,
+  ) {
     this.data = opts.data;
     this.data.hooks = [];
     this.me = opts.data.me;

--- a/ui/lobby/src/filter.ts
+++ b/ui/lobby/src/filter.ts
@@ -17,7 +17,10 @@ export default class Filter {
   data: FilterData | null;
   open = false;
 
-  constructor(storage: LichessStorage, readonly root: LobbyController) {
+  constructor(
+    storage: LichessStorage,
+    readonly root: LobbyController,
+  ) {
     this.store = makeStore(storage);
     this.set(this.store.get());
   }

--- a/ui/lobby/src/options.ts
+++ b/ui/lobby/src/options.ts
@@ -26,7 +26,7 @@ export const variantsBlindMode: Variant[] = variants.filter(({ key }: Variant) =
     'atomic',
     'racingKings',
     'horde',
-  ].includes(key)
+  ].includes(key),
 );
 
 export const variantsForGameType = (baseVariants: Variant[], gameType: GameType): Variant[] =>
@@ -148,7 +148,7 @@ export const daysVToDays = (v: InputValue): RealValue => {
 export const sliderInitVal = (
   v: RealValue,
   f: (x: InputValue) => RealValue,
-  max: InputValue
+  max: InputValue,
 ): InputValue | undefined => {
   for (let i = 0; i < max; i++) {
     if (f(i) === v) return i;

--- a/ui/lobby/src/setupCtrl.ts
+++ b/ui/lobby/src/setupCtrl.ts
@@ -211,7 +211,7 @@ export default class SetupController {
         xhr.url('/setup/validate-fen', {
           fen,
           strict: this.gameType === 'ai' ? 1 : undefined,
-        })
+        }),
       )
       .then(
         () => {
@@ -222,7 +222,7 @@ export default class SetupController {
         () => {
           this.fenError = true;
           this.root.redraw();
-        }
+        },
       );
   }, 300);
 
@@ -326,7 +326,7 @@ export default class SetupController {
           ? Object.keys(errs)
               .map(k => `${k}: ${errs[k]}`)
               .join('\n')
-          : 'Invalid setup'
+          : 'Invalid setup',
       );
       if (response.status == 403) {
         // 403 FORBIDDEN closes this modal because challenges to the recipient

--- a/ui/lobby/src/socket.ts
+++ b/ui/lobby/src/socket.ts
@@ -10,7 +10,10 @@ interface Handlers {
 export default class LobbySocket {
   handlers: Handlers;
 
-  constructor(readonly send: SocketSend, ctrl: LobbyController) {
+  constructor(
+    readonly send: SocketSend,
+    ctrl: LobbyController,
+  ) {
     this.handlers = {
       had(hook: Hook) {
         hookRepo.add(ctrl, hook);
@@ -43,7 +46,7 @@ export default class LobbySocket {
       () => {
         send('idle', false);
         ctrl.awake();
-      }
+      },
     );
   }
 

--- a/ui/lobby/src/view/correspondence.ts
+++ b/ui/lobby/src/view/correspondence.ts
@@ -28,7 +28,7 @@ function renderSeek(ctrl: LobbyController, seek: Seek): VNode {
             {
               attrs: { 'data-href': '/@/' + seek.username },
             },
-            seek.username
+            seek.username,
           )
         : 'Anonymous',
       seek.rating && !ctrl.opts.hideRatings ? seek.rating + (seek.provisional ? '?' : '') : '',
@@ -39,7 +39,7 @@ function renderSeek(ctrl: LobbyController, seek: Seek): VNode {
         }),
         noarg(seek.mode === 1 ? 'rated' : 'casual'),
       ]),
-    ])
+    ]),
   );
 }
 
@@ -52,10 +52,10 @@ function createSeek(ctrl: LobbyController): VNode | undefined {
           hook: bind(
             'click',
             () => ctrl.setupCtrl.openModal('hook', { variant: 'standard', timeMode: 'correspondence' }),
-            ctrl.redraw
+            ctrl.redraw,
           ),
         },
-        ctrl.trans('createAGame')
+        ctrl.trans('createAGame'),
       ),
     ]);
   return;
@@ -67,7 +67,7 @@ export default function (ctrl: LobbyController): MaybeVNodes {
       h('thead', [
         h(
           'tr',
-          ['', 'player', 'rating', 'time', 'mode'].map(header => h('th', ctrl.trans(header)))
+          ['', 'player', 'rating', 'time', 'mode'].map(header => h('th', ctrl.trans(header))),
         ),
       ]),
       h(
@@ -87,7 +87,7 @@ export default function (ctrl: LobbyController): MaybeVNodes {
             } while (el.nodeName !== 'TABLE');
           }),
         },
-        ctrl.data.seeks.map(s => renderSeek(ctrl, s))
+        ctrl.data.seeks.map(s => renderSeek(ctrl, s)),
       ),
     ]),
     createSeek(ctrl),

--- a/ui/lobby/src/view/playing.ts
+++ b/ui/lobby/src/view/playing.ts
@@ -13,7 +13,7 @@ function timer(pov: NowPlaying) {
         },
       },
     },
-    lichess.timeago(date)
+    lichess.timeago(date),
   );
 }
 
@@ -48,11 +48,11 @@ export default function (ctrl: LobbyController) {
                 ? pov.secondsLeft && pov.hasMoved
                   ? timer(pov)
                   : [ctrl.trans.noarg('yourTurn')]
-                : h('span', '\xa0')
+                : h('span', '\xa0'),
             ), // &nbsp;
           ]),
-        ]
-      )
-    )
+        ],
+      ),
+    ),
   );
 }

--- a/ui/lobby/src/view/pools.ts
+++ b/ui/lobby/src/view/pools.ts
@@ -13,7 +13,7 @@ export function hooks(ctrl: LobbyController): Hooks {
       if (id === 'custom') ctrl.setupCtrl.openModal('hook');
       else if (id) ctrl.clickPool(id);
     },
-    ctrl.redraw
+    ctrl.redraw,
   );
 }
 
@@ -38,7 +38,7 @@ export function render(ctrl: LobbyController) {
             ? h('div.range', member.range.replace('-', '–'))
             : h('div.perf', pool.perf),
           active ? spinner() : null,
-        ]
+        ],
       );
     })
     .concat(
@@ -48,7 +48,7 @@ export function render(ctrl: LobbyController) {
           class: { transp: !!member },
           attrs: { 'data-id': 'custom' },
         },
-        ctrl.trans.noarg('custom')
-      )
+        ctrl.trans.noarg('custom'),
+      ),
     );
 }

--- a/ui/lobby/src/view/realTime/chart.ts
+++ b/ui/lobby/src/view/realTime/chart.ts
@@ -100,13 +100,13 @@ function renderXAxis() {
         {
           attrs: { style: 'left:' + percents(l - 1.5) },
         },
-        '' + v
-      )
+        '' + v,
+      ),
     );
     tags.push(
       h('div.grid.vert', {
         attrs: { style: 'width:' + percents(l) },
-      })
+      }),
     );
   });
   return tags;
@@ -124,13 +124,13 @@ function renderYAxis() {
         {
           attrs: { style: 'bottom:' + percents(b + 1) },
         },
-        '' + v
-      )
+        '' + v,
+      ),
     );
     tags.push(
       h('div.grid.horiz', {
         attrs: { style: 'height:' + percents(b + 0.8) },
-      })
+      }),
     );
   });
   return tags;
@@ -155,10 +155,10 @@ export function render(ctrl: LobbyController, hooks: Hook[]) {
             if ((e.target as HTMLElement).classList.contains('plot'))
               ctrl.clickHook((e.target as HTMLElement).id);
           },
-          ctrl.redraw
+          ctrl.redraw,
         ),
       },
-      hooks.map(hook => renderPlot(ctrl, hook))
+      hooks.map(hook => renderPlot(ctrl, hook)),
     ),
     ...renderYAxis(),
     ...renderXAxis(),

--- a/ui/lobby/src/view/realTime/list.ts
+++ b/ui/lobby/src/view/realTime/list.ts
@@ -31,7 +31,7 @@ function renderHook(ctrl: LobbyController, hook: Hook) {
             {
               attrs: { 'data-href': '/@/' + hook.u },
             },
-            hook.u
+            hook.u,
           )
         : noarg('anonymous'),
       hook.rating && !ctrl.opts.hideRatings ? hook.rating + (hook.prov ? '?' : '') : '',
@@ -41,9 +41,9 @@ function renderHook(ctrl: LobbyController, hook: Hook) {
         {
           attrs: { 'data-icon': perfIcons[hook.perf] },
         },
-        noarg(hook.ra ? 'rated' : 'casual')
+        noarg(hook.ra ? 'rated' : 'casual'),
       ),
-    ])
+    ]),
   );
 }
 
@@ -86,9 +86,9 @@ export const render = (ctrl: LobbyController, allHooks: Hook[]) => {
               {
                 attrs: { colspan: 5 },
               },
-              '— ' + ctrl.trans('variant') + ' —'
+              '— ' + ctrl.trans('variant') + ' —',
             ),
-          ]
+          ],
         )
       : null,
     ...variants.map(render),
@@ -109,7 +109,7 @@ export const render = (ctrl: LobbyController, allHooks: Hook[]) => {
             },
             hook: bind('click', _ => ctrl.setSort('rating'), ctrl.redraw),
           },
-          [h('i.is'), ctrl.trans('rating')]
+          [h('i.is'), ctrl.trans('rating')],
         ),
         h(
           'th',
@@ -120,10 +120,10 @@ export const render = (ctrl: LobbyController, allHooks: Hook[]) => {
             },
             hook: bind('click', _ => ctrl.setSort('time'), ctrl.redraw),
           },
-          [h('i.is'), ctrl.trans('time')]
+          [h('i.is'), ctrl.trans('time')],
         ),
         h('th', ctrl.trans('mode')),
-      ])
+      ]),
     ),
     h(
       'tbody',
@@ -138,10 +138,10 @@ export const render = (ctrl: LobbyController, allHooks: Hook[]) => {
               if (el.nodeName === 'TR') return ctrl.clickHook(el.getAttribute('data-id')!);
             } while (el.nodeName !== 'TABLE');
           },
-          ctrl.redraw
+          ctrl.redraw,
         ),
       },
-      renderedHooks
+      renderedHooks,
     ),
   ]);
 };

--- a/ui/lobby/src/view/setup/components/colorButtons.ts
+++ b/ui/lobby/src/view/setup/components/colorButtons.ts
@@ -17,13 +17,13 @@ const renderBlindModeColorPicker = (ctrl: LobbyController) => [
                 ctrl.setupCtrl.blindModeColor((e.target as HTMLSelectElement).value as Color | 'random'),
             },
           },
-          colors(ctrl.trans).map(color => option(color, ctrl.setupCtrl.blindModeColor()))
+          colors(ctrl.trans).map(color => option(color, ctrl.setupCtrl.blindModeColor())),
         ),
       ]),
   h(
     'button',
     { on: { click: () => ctrl.setupCtrl.submit(ctrl.setupCtrl.blindModeColor()) } },
-    'Create the game'
+    'Create the game',
   ),
 ];
 
@@ -54,8 +54,8 @@ export const colorButtons = (ctrl: LobbyController) => {
               attrs: { disabled: !enabledColors.includes(key), title: name, value: key },
               on: { click: () => ctrl.setupCtrl.submit(key) },
             },
-            h('i')
-          )
-        )
+            h('i'),
+          ),
+        ),
   );
 };

--- a/ui/lobby/src/view/setup/components/fenInput.ts
+++ b/ui/lobby/src/view/setup/components/fenInput.ts
@@ -40,8 +40,8 @@ export const fenInput = (ctrl: LobbyController) => {
                 insert: vnode => lichess.miniBoard.init(vnode.elm as HTMLElement),
                 update: vnode => lichess.miniBoard.init(vnode.elm as HTMLElement),
               },
-            })
-          )
+            }),
+          ),
     ),
   ]);
 };

--- a/ui/lobby/src/view/setup/components/gameModeButtons.ts
+++ b/ui/lobby/src/view/setup/components/gameModeButtons.ts
@@ -29,7 +29,7 @@ export const gameModeButtons = (ctrl: LobbyController): MaybeVNode => {
           }),
           h('label', { class: { disabled }, attrs: { for: `sf_mode_${key}` } }, name),
         ]);
-      })
-    )
+      }),
+    ),
   );
 };

--- a/ui/lobby/src/view/setup/components/levelButtons.ts
+++ b/ui/lobby/src/view/setup/components/levelButtons.ts
@@ -12,7 +12,7 @@ export const levelButtons = (ctrl: LobbyController) => {
           {
             on: { change: (e: Event) => setupCtrl.aiLevel(parseInt((e.target as HTMLSelectElement).value)) },
           },
-          '12345678'.split('').map(key => option({ key, name: key }, setupCtrl.aiLevel().toString()))
+          '12345678'.split('').map(key => option({ key, name: key }, setupCtrl.aiLevel().toString())),
         ),
       ]
     : [
@@ -37,16 +37,16 @@ export const levelButtons = (ctrl: LobbyController) => {
                     },
                   }),
                   h('label', { attrs: { for: `sf_level_${level}` } }, level),
-                ])
-              )
-            )
+                ]),
+              ),
+            ),
           ),
           h(
             'div.ai_info',
             h(
               `div.sf_level_${setupCtrl.aiLevel()}`,
-              trans('aiNameLevelAiLevel', 'Fairy-Stockfish 14', setupCtrl.aiLevel())
-            )
+              trans('aiNameLevelAiLevel', 'Fairy-Stockfish 14', setupCtrl.aiLevel()),
+            ),
           ),
         ]),
       ];

--- a/ui/lobby/src/view/setup/components/ratingDifferenceSliders.ts
+++ b/ui/lobby/src/view/setup/components/ratingDifferenceSliders.ts
@@ -63,6 +63,6 @@ export const ratingDifferenceSliders = (ctrl: LobbyController) => {
           },
         }),
       ]),
-    ]
+    ],
   );
 };

--- a/ui/lobby/src/view/setup/components/ratingView.ts
+++ b/ui/lobby/src/view/setup/components/ratingView.ts
@@ -24,11 +24,11 @@ export const ratingView = (ctrl: LobbyController): MaybeVNode => {
               h(
                 'strong',
                 perfIconAttrs,
-                data.ratingMap[selectedPerf].rating + (data.ratingMap[selectedPerf].prov ? '?' : '')
-              )
+                data.ratingMap[selectedPerf].rating + (data.ratingMap[selectedPerf].prov ? '?' : ''),
+              ),
             ),
             perfOrSpeed.name,
-          ]
+          ],
     );
   }
   return undefined;

--- a/ui/lobby/src/view/setup/components/timePickerAndSliders.ts
+++ b/ui/lobby/src/view/setup/components/timePickerAndSliders.ts
@@ -27,8 +27,8 @@ const renderBlindModeTimePickers = (ctrl: LobbyController, allowAnonymous: boole
               },
             },
             sliderTimes.map((sliderTime, timeV) =>
-              option({ key: timeV.toString(), name: showTime(sliderTime) }, setupCtrl.timeV().toString())
-            )
+              option({ key: timeV.toString(), name: showTime(sliderTime) }, setupCtrl.timeV().toString()),
+            ),
           ),
         ])
       : null,
@@ -46,9 +46,9 @@ const renderBlindModeTimePickers = (ctrl: LobbyController, allowAnonymous: boole
             Array.from(Array(31).keys()).map(incrementV =>
               option(
                 { key: incrementV.toString(), name: incrementVToIncrement(incrementV).toString() },
-                setupCtrl.incrementV().toString()
-              )
-            )
+                setupCtrl.incrementV().toString(),
+              ),
+            ),
           ),
         ])
       : null,
@@ -66,9 +66,9 @@ const renderBlindModeTimePickers = (ctrl: LobbyController, allowAnonymous: boole
             Array.from(Array(7).keys()).map(daysV =>
               option(
                 { key: (daysV + 1).toString(), name: daysVToDays(daysV + 1).toString() },
-                setupCtrl.daysV().toString()
-              )
-            )
+                setupCtrl.daysV().toString(),
+              ),
+            ),
           ),
         ])
       : null,
@@ -87,7 +87,7 @@ const renderTimeModePicker = (ctrl: LobbyController, allowAnonymous = false) => 
               change: (e: Event) => setupCtrl.timeMode((e.target as HTMLSelectElement).value as TimeMode),
             },
           },
-          timeModes(trans).map(timeMode => option(timeMode, setupCtrl.timeMode()))
+          timeModes(trans).map(timeMode => option(timeMode, setupCtrl.timeMode())),
         ),
       ])
     : null;
@@ -132,9 +132,9 @@ export const timePickerAndSliders = (ctrl: LobbyController, allowAnonymous = fal
                   `${trans('daysPerTurn')}: `,
                   h('span', setupCtrl.days()),
                   inputRange(1, 7, setupCtrl.daysV),
-                ])
+                ]),
               )
             : null,
-        ]
+        ],
   );
 };

--- a/ui/lobby/src/view/setup/components/variantPicker.ts
+++ b/ui/lobby/src/view/setup/components/variantPicker.ts
@@ -18,8 +18,8 @@ export const variantPicker = (ctrl: LobbyController) => {
         hook: onInsert<HTMLSelectElement>(element => element.focus()),
       },
       variantsForGameType(baseVariants, setupCtrl.gameType!).map(variant =>
-        option(variant, setupCtrl.variant())
-      )
+        option(variant, setupCtrl.variant()),
+      ),
     ),
   ]);
 };

--- a/ui/lobby/src/view/table.ts
+++ b/ui/lobby/src/view/table.ts
@@ -34,13 +34,13 @@ export default function table(ctrl: LobbyController) {
                 : bind(
                     lichess.blindMode ? 'click' : 'mousedown',
                     () => ctrl.setupCtrl.openModal(gameType),
-                    ctrl.redraw
+                    ctrl.redraw,
                   ),
             },
-            trans(transKey)
-          )
-        )
-      )
+            trans(transKey),
+          ),
+        ),
+      ),
     ),
     renderSetupModal(ctrl),
     // Use a thunk here so that snabbdom does not rerender; we will do so manually after insert
@@ -63,9 +63,9 @@ export default function table(ctrl: LobbyController) {
                     ctrl.spreadPlayersNumber = ctrl.initNumberSpreader(elm, 10, members);
                   }),
                 },
-                numberFormat(members)
-              )
-            )
+                numberFormat(members),
+              ),
+            ),
           ),
           h(
             'a',
@@ -81,12 +81,12 @@ export default function table(ctrl: LobbyController) {
                     ctrl.spreadGamesNumber = ctrl.initNumberSpreader(elm, 8, rounds);
                   }),
                 },
-                numberFormat(rounds)
-              )
-            )
+                numberFormat(rounds),
+              ),
+            ),
           ),
         ]),
-      []
+      [],
     ),
   ]);
 }

--- a/ui/lobby/src/view/tabs.ts
+++ b/ui/lobby/src/view/tabs.ts
@@ -14,7 +14,7 @@ function tab(ctrl: LobbyController, key: Tab, active: Tab, content: MaybeVNodes)
       },
       hook: bind('mousedown', _ => ctrl.setTab(key), ctrl.redraw),
     },
-    content
+    content,
   );
 }
 
@@ -32,7 +32,7 @@ export default function (ctrl: LobbyController) {
           ...ctrl.trans.vdomPlural(
             'nbGamesInPlay',
             nbPlaying,
-            nbPlaying >= 100 ? '100+' : nbPlaying.toString()
+            nbPlaying >= 100 ? '100+' : nbPlaying.toString(),
           ),
           myTurnPovsNb > 0 ? h('i.unread', myTurnPovsNb >= 9 ? '9+' : myTurnPovsNb) : null,
         ])

--- a/ui/mod/src/activity.ts
+++ b/ui/mod/src/activity.ts
@@ -59,8 +59,8 @@ function activity(data: any) {
         ...conf('Closed reports', data.common.xaxis),
         series: data.reports.series,
       },
-      extend
-    )
+      extend,
+    ),
   ).render();
 
   new ApexCharts(
@@ -70,8 +70,8 @@ function activity(data: any) {
         ...conf('Mod actions', data.common.xaxis),
         series: data.actions.series,
       },
-      extend
-    )
+      extend,
+    ),
   ).render();
 }
 
@@ -92,7 +92,7 @@ function queues(data: any) {
           stacked: true,
         },
         colors: ['#03A9F4', '#4CAF50', '#F9CE1D', '#FF9800'],
-      }
+      },
     );
     new ApexCharts($('<div>').appendTo($grid)[0], cfg).render();
   });

--- a/ui/mod/src/checkBoxes.ts
+++ b/ui/mod/src/checkBoxes.ts
@@ -37,7 +37,7 @@ export const checkBoxAll = (table: HTMLTableElement) =>
     .on('change', (e: MouseEvent) =>
       $(table)
         .find('tbody input:not(:disabled)')
-        .prop('checked', (e.target as HTMLInputElement).checked)
+        .prop('checked', (e.target as HTMLInputElement).checked),
     );
 
 export const selector =

--- a/ui/mod/src/games.ts
+++ b/ui/mod/src/games.ts
@@ -39,7 +39,7 @@ const setupActionForm = () => {
         const reload = confirm('Analysis completed. Reload the page?');
         if (reload) lichess.reload();
       }),
-    1000
+    1000,
   );
   $(form).on('click', 'button', (e: Event) => {
     const button = e.target as HTMLButtonElement;

--- a/ui/mod/src/inquiry.ts
+++ b/ui/mod/src/inquiry.ts
@@ -29,7 +29,7 @@ lichess.load.then(() => {
             .then(html => $notes.replaceWith(html))
             .then(noteStore.remove)
             .then(() => loadNotes())
-            .catch(() => alert('Invalid note, is it too short or too long?'))
+            .catch(() => alert('Invalid note, is it too short or too long?')),
         );
       return false;
     });
@@ -71,7 +71,7 @@ lichess.load.then(() => {
   });
 
   lichess.mousetrap.bind('d', () =>
-    $('#inquiry .actions.close form.process button[type="submit"]').trigger('click')
+    $('#inquiry .actions.close form.process button[type="submit"]').trigger('click'),
   );
 
   $('#inquiry .atom p').each(function (this: HTMLParagraphElement) {
@@ -81,9 +81,9 @@ lichess.load.then(() => {
           .html()
           .replace(
             /(?:https:\/\/)?lichess\.org\/((?:[\w\/:(&;)=@-]|[?.]\w)+)/gi,
-            '<a href="/$1">lichess.org/$1</a>'
-          )
-      )
+            '<a href="/$1">lichess.org/$1</a>',
+          ),
+      ),
     );
   });
 

--- a/ui/mod/src/search.ts
+++ b/ui/mod/src/search.ts
@@ -23,13 +23,13 @@ lichess.load.then(() => {
     if (select)
       selector(
         table,
-        select as HTMLSelectElement
+        select as HTMLSelectElement,
       )(async action => {
         if (action == 'alt') {
           const usernames = Array.from(
             $(table)
               .find('td:last-child input:checked')
-              .map((_, input) => $(input).parents('tr').find('td:first-child').data('sort'))
+              .map((_, input) => $(input).parents('tr').find('td:first-child').data('sort')),
           );
           if (usernames.length > 0 && confirm(`Close ${usernames.length} alt accounts?`)) {
             console.log(usernames);

--- a/ui/mod/src/teamAdmin.ts
+++ b/ui/mod/src/teamAdmin.ts
@@ -26,7 +26,7 @@ function initTagify(input: HTMLInputElement, maxTags: number) {
   });
   const doFetch: (term: string) => Promise<string[]> = debounce(
     (term: string) => xhr.json(xhr.url('/api/player/autocomplete', { term, names: 1, team })),
-    300
+    300,
   );
   tagify.on('input', e => {
     const term = e.detail.value.trim();

--- a/ui/mod/src/user.ts
+++ b/ui/mod/src/user.ts
@@ -103,7 +103,7 @@ lichess.load.then(() => {
     makeReady('form.gdpr-erasure', confirmButton);
 
     makeReady('form.fide-title select', el =>
-      $(el).on('change', () => ($(el).parent('form')[0] as HTMLFormElement).submit())
+      $(el).on('change', () => ($(el).parent('form')[0] as HTMLFormElement).submit()),
     );
 
     makeReady('form.pm-preset select', (el: HTMLSelectElement) =>
@@ -111,7 +111,7 @@ lichess.load.then(() => {
         const form = $(el).parent('form')[0] as HTMLFormElement;
         xhr.text(form.getAttribute('action') + encodeURIComponent(el.value), { method: 'post' });
         $(form).html('Sent!');
-      })
+      }),
     );
 
     makeReady('.mz-section--others', el => {
@@ -125,13 +125,13 @@ lichess.load.then(() => {
         if (select)
           selector(
             table,
-            select as HTMLSelectElement
+            select as HTMLSelectElement,
           )(async action => {
             if (action == 'alt') {
               const usernames = Array.from(
                 $(table)
                   .find('td:last-child input:checked')
-                  .map((_, input) => $(input).parents('tr').find('td:first-child').data('sort'))
+                  .map((_, input) => $(input).parents('tr').find('td:first-child').data('sort')),
               );
               if (usernames.length > 0 && confirm(`Close ${usernames.length} alt accounts?`)) {
                 await xhr.text('/mod/alt-many', { method: 'post', body: usernames.join(' ') });
@@ -176,7 +176,7 @@ lichess.load.then(() => {
       el => {
         tablesort(el, { descending: true });
       },
-      'ready-sort'
+      'ready-sort',
     );
     makeReady('.mz-section--others .more-others', el => {
       $(el)

--- a/ui/msg/src/ctrl.ts
+++ b/ui/msg/src/ctrl.ts
@@ -27,7 +27,11 @@ export default class MsgCtrl {
   typing?: Typing;
   textStore?: LichessStorage;
 
-  constructor(data: MsgData, readonly trans: Trans, readonly redraw: Redraw) {
+  constructor(
+    data: MsgData,
+    readonly trans: Trans,
+    readonly redraw: Redraw,
+  ) {
     this.data = data;
     this.pane = data.convo ? 'convo' : 'side';
     this.connected = network.websocketHandler(this);
@@ -111,7 +115,7 @@ export default class MsgCtrl {
               this.data.contacts = data.contacts;
               this.redraw();
             }),
-          1000
+          1000,
         );
       scroller.enable(true);
       this.redraw();

--- a/ui/msg/src/network.ts
+++ b/ui/msg/src/network.ts
@@ -20,7 +20,7 @@ export function search(q: string): Promise<SearchResult> {
       ({
         ...res,
         contacts: res.contacts.map(upgradeContact),
-      } as SearchResult)
+      }) as SearchResult,
   );
 }
 

--- a/ui/msg/src/view/actions.ts
+++ b/ui/msg/src/view/actions.ts
@@ -16,7 +16,7 @@ export default function renderActions(ctrl: MsgCtrl, convo: Convo): VNode[] {
         href: `/?user=${convo.user.name}#friend`,
         title: ctrl.trans.noarg('challengeToPlay'),
       },
-    })
+    }),
   );
   nodes.push(h('div.msg-app__convo__action__sep', '|'));
   if (convo.relations.out === false)
@@ -30,7 +30,7 @@ export default function renderActions(ctrl: MsgCtrl, convo: Convo): VNode[] {
           'data-hover-text': ctrl.trans.noarg('unblock'),
         },
         hook: bind('click', ctrl.unblock),
-      })
+      }),
     );
   else
     nodes.push(
@@ -42,7 +42,7 @@ export default function renderActions(ctrl: MsgCtrl, convo: Convo): VNode[] {
           title: ctrl.trans.noarg('block'),
         },
         hook: bind('click', withConfirm(ctrl.block)),
-      })
+      }),
     );
   nodes.push(
     h(`button.${cls}.bad`, {
@@ -53,7 +53,7 @@ export default function renderActions(ctrl: MsgCtrl, convo: Convo): VNode[] {
         title: ctrl.trans.noarg('delete'),
       },
       hook: bind('click', withConfirm(ctrl.delete)),
-    })
+    }),
   );
   if (ctrl.reportableMsg())
     nodes.push(
@@ -65,7 +65,7 @@ export default function renderActions(ctrl: MsgCtrl, convo: Convo): VNode[] {
           title: ctrl.trans('reportXToModerators', convo.user.name),
         },
         hook: bind('click', withConfirm(ctrl.report)),
-      })
+      }),
     );
   return nodes;
 }

--- a/ui/msg/src/view/contact.ts
+++ b/ui/msg/src/view/contact.ts
@@ -29,7 +29,7 @@ export default function renderContact(ctrl: MsgCtrl, contact: Contact, active?: 
             {
               class: { 'msg-app__side__contact__msg--new': isNew },
             },
-            msg.text
+            msg.text,
           ),
           isNew
             ? h('i.msg-app__side__contact__new', {
@@ -38,7 +38,7 @@ export default function renderContact(ctrl: MsgCtrl, contact: Contact, active?: 
             : null,
         ]),
       ]),
-    ]
+    ],
   );
 }
 
@@ -52,6 +52,6 @@ function renderDate(msg: LastMsg): VNode {
         datetime: msg.date.getTime(),
       },
     },
-    lichess.timeago(msg.date)
+    lichess.timeago(msg.date),
   );
 }

--- a/ui/msg/src/view/convo.ts
+++ b/ui/msg/src/view/convo.ts
@@ -34,7 +34,7 @@ export default function renderConvo(ctrl: MsgCtrl, convo: Convo): VNode {
             [
               h('i.line' + (user.id == 'lichess' ? '.moderator' : user.patron ? '.patron' : '')),
               h('span', userName(user)),
-            ]
+            ],
           ),
         ]),
         h('div.msg-app__convo__head__actions', renderActions(ctrl, convo)),
@@ -49,7 +49,7 @@ export default function renderConvo(ctrl: MsgCtrl, convo: Convo): VNode {
           ? renderInteract(ctrl, user)
           : blocked(`${user.name} doesn't accept new messages.`),
       ]),
-    ]
+    ],
   );
 }
 
@@ -59,5 +59,5 @@ const blocked = (msg: string) =>
     {
       attrs: { 'data-icon': licon.NotAllowed },
     },
-    msg
+    msg,
   );

--- a/ui/msg/src/view/enhance.ts
+++ b/ui/msg/src/view/enhance.ts
@@ -37,7 +37,7 @@ const expandUrls = (html: string) =>
 const expandGameIds = (html: string) =>
   html.replace(
     /\s#([\w]{8})($|[^\w-])/g,
-    (_: string, id: string, suffix: string) => ' ' + linkReplace('/' + id, '#' + id, 'text') + suffix
+    (_: string, id: string, suffix: string) => ' ' + linkReplace('/' + id, '#' + id, 'text') + suffix,
   );
 
 const expandTeamMessage = (html: string) =>
@@ -45,14 +45,14 @@ const expandTeamMessage = (html: string) =>
     teamMessageRegex,
     (_: string, url: string) =>
       `${expandLink(
-        url
-      )} <form action="${url}/subscribe" class="unsub" method="post"><button type="submit" class="button button-empty button-thin button-red">Unsubscribe from these messages</button></form>`
+        url,
+      )} <form action="${url}/subscribe" class="unsub" method="post"><button type="submit" class="button button-empty button-thin button-red">Unsubscribe from these messages</button></form>`,
   );
 
 export const enhance = (str: string) =>
   expandTeamMessage(expandGameIds(expandMentions(expandUrls(lichess.escapeHtml(str))))).replace(
     newLineRegex,
-    '<br>'
+    '<br>',
   );
 
 interface Expandable {
@@ -68,7 +68,7 @@ type LinkType = 'game';
 
 const domain = window.location.host;
 const gameRegex = new RegExp(
-  `(?:https?://)${domain}/(?:embed/)?(?:game/)?(\\w{8})(?:(?:/(white|black))|\\w{4}|)(?:(?:#)(\\d+))?$`
+  `(?:https?://)${domain}/(?:embed/)?(?:game/)?(\\w{8})(?:(?:/(white|black))|\\w{4}|)(?:(?:#)(\\d+))?$`,
 );
 const notGames = [
   'training',

--- a/ui/msg/src/view/interact.ts
+++ b/ui/msg/src/view/interact.ts
@@ -28,7 +28,7 @@ export default function renderInteract(ctrl: MsgCtrl, user: User): VNode {
           disabled: !connected,
         },
       }),
-    ]
+    ],
   );
 }
 
@@ -76,7 +76,7 @@ function setupTextarea(area: HTMLTextAreaElement, contact: string, ctrl: MsgCtrl
       // and save content
       storage.set(text);
       ctrl.sendTyping(contact);
-    })
+    }),
   );
 
   // restore previously saved content

--- a/ui/msg/src/view/main.ts
+++ b/ui/msg/src/view/main.ts
@@ -21,7 +21,7 @@ export default function (ctrl: MsgCtrl): VNode {
           ? search.renderResults(ctrl, ctrl.search.result)
           : h(
               'div.msg-app__contacts.msg-app__side__content',
-              ctrl.data.contacts.map(t => renderContact(ctrl, t, activeId))
+              ctrl.data.contacts.map(t => renderContact(ctrl, t, activeId)),
             ),
       ]),
       ctrl.data.convo
@@ -29,6 +29,6 @@ export default function (ctrl: MsgCtrl): VNode {
         : ctrl.loading
         ? h('div.msg-app__convo', { key: ':' }, [h('div.msg-app__convo__head'), spinner()])
         : '',
-    ]
+    ],
   );
 }

--- a/ui/msg/src/view/msgs.ts
+++ b/ui/msg/src/view/msgs.ts
@@ -32,13 +32,13 @@ export default function renderMsgs(ctrl: MsgCtrl, convo: Convo): VNode {
                   ctrl.getMore();
                 }),
               },
-              'Load more'
+              'Load more',
             )
           : null,
         ...contentMsgs(ctrl, convo.msgs),
         h('div.msg-app__convo__msgs__typing', ctrl.typing ? `${convo.user.name} is typing...` : null),
       ]),
-    ]
+    ],
   );
 }
 
@@ -55,8 +55,8 @@ function renderDaily(ctrl: MsgCtrl, daily: Daily): VNode[] {
     ...daily.msgs.map(group =>
       h(
         'group',
-        group.map(msg => renderMsg(ctrl, msg))
-      )
+        group.map(msg => renderMsg(ctrl, msg)),
+      ),
     ),
   ];
 }
@@ -121,7 +121,7 @@ const renderText = (msg: Msg) =>
             const el = vnode.elm as HTMLElement;
             el.innerHTML = enhance.enhance(msg.text);
             el.querySelectorAll('img').forEach(c =>
-              c.addEventListener('load', scroller.auto, { once: true })
+              c.addEventListener('load', scroller.auto, { once: true }),
             );
             $('form.unsub', el).on('submit', function (this: HTMLFormElement) {
               teamUnsub(this);

--- a/ui/msg/src/view/scroller.ts
+++ b/ui/msg/src/view/scroller.ts
@@ -14,7 +14,7 @@ class Scroller {
         const el = this.element;
         this.enable(!!el && el.offsetHeight + el.scrollTop > el.scrollHeight - 20);
       }),
-      { passive: true }
+      { passive: true },
     );
   };
   auto = () => {

--- a/ui/msg/src/view/search.ts
+++ b/ui/msg/src/view/search.ts
@@ -18,13 +18,13 @@ export function renderInput(ctrl: MsgCtrl): VNode {
           const input = vnode.elm as HTMLInputElement;
           input.addEventListener(
             'input',
-            throttle(500, () => ctrl.searchInput(input.value.trim()))
+            throttle(500, () => ctrl.searchInput(input.value.trim())),
           );
           input.addEventListener('blur', () =>
             setTimeout(() => {
               input.value = '';
               ctrl.searchInput('');
-            }, 500)
+            }, 500),
           );
         },
       },
@@ -39,7 +39,7 @@ export function renderResults(ctrl: MsgCtrl, res: SearchResult): VNode {
         h('h2', ctrl.trans.noarg('discussions')),
         h(
           'div.msg-app__search__contacts',
-          res.contacts.map(t => renderContacts(ctrl, t))
+          res.contacts.map(t => renderContacts(ctrl, t)),
         ),
       ]),
     res.friends[0] &&
@@ -47,7 +47,7 @@ export function renderResults(ctrl: MsgCtrl, res: SearchResult): VNode {
         h('h2', ctrl.trans.noarg('friends')),
         h(
           'div.msg-app__search__users',
-          res.friends.map(u => renderUser(ctrl, u))
+          res.friends.map(u => renderUser(ctrl, u)),
         ),
       ]),
     res.users[0] &&
@@ -55,7 +55,7 @@ export function renderResults(ctrl: MsgCtrl, res: SearchResult): VNode {
         h('h2', ctrl.trans.noarg('players')),
         h(
           'div.msg-app__search__users',
-          res.users.map(u => renderUser(ctrl, u))
+          res.users.map(u => renderUser(ctrl, u)),
         ),
       ]),
   ]);
@@ -73,6 +73,6 @@ function renderUser(ctrl: MsgCtrl, user: User): VNode {
       h('div.msg-app__side__contact__user', [
         h('div.msg-app__side__contact__head', [h('div.msg-app__side__contact__name', userName(user))]),
       ]),
-    ]
+    ],
   );
 }

--- a/ui/msg/src/view/util.ts
+++ b/ui/msg/src/view/util.ts
@@ -10,7 +10,7 @@ export function userIcon(user: User, cls: string): VNode {
         offline: !user.online,
       },
     },
-    [h('i.line' + (user.patron ? '.patron' : ''))]
+    [h('i.line' + (user.patron ? '.patron' : ''))],
   );
 }
 

--- a/ui/notify/src/ctrl.ts
+++ b/ui/notify/src/ctrl.ts
@@ -37,7 +37,7 @@ export default function makeCtrl(opts: NotifyOpts, redraw: Redraw): Ctrl {
   const loadPage = (page: number) =>
     xhr.json(xhr.url('/notify', { page: page || 1 })).then(
       d => update(d),
-      _ => lichess.announce({ msg: 'Failed to load notifications' })
+      _ => lichess.announce({ msg: 'Failed to load notifications' }),
     );
 
   function nextPage() {
@@ -93,7 +93,7 @@ export default function makeCtrl(opts: NotifyOpts, redraw: Redraw): Ctrl {
   function clear() {
     xhr.text('/notify/clear', { method: 'post' }).then(
       _ => update(emptyNotifyData),
-      _ => lichess.announce({ msg: 'Failed to clear notifications' })
+      _ => lichess.announce({ msg: 'Failed to clear notifications' }),
     );
   }
 

--- a/ui/notify/src/renderers.ts
+++ b/ui/notify/src/renderers.ts
@@ -161,7 +161,7 @@ function generic(n: Notification, url: string | undefined, icon: string, content
         attrs: { 'data-icon': icon },
       }),
       h('span.content', content),
-    ]
+    ],
   );
 }
 
@@ -175,7 +175,7 @@ function drawTime(n: Notification) {
         datetime: n.date,
       },
     },
-    lichess.timeago(date)
+    lichess.timeago(date),
   );
 }
 

--- a/ui/notify/src/view.ts
+++ b/ui/notify/src/view.ts
@@ -8,7 +8,7 @@ export default function view(ctrl: Ctrl): VNode {
   const d = ctrl.data();
   return h(
     'div#notify-app.links.dropdown',
-    d && !ctrl.initiating() ? renderContent(ctrl, d) : [h('div.initiating', spinner())]
+    d && !ctrl.initiating() ? renderContent(ctrl, d) : [h('div.initiating', spinner())],
   );
 }
 
@@ -22,7 +22,7 @@ function renderContent(ctrl: Ctrl, d: NotifyData): VNode[] {
     h(`div.pager.prev${pager.previousPage ? '' : '.disabled'}`, {
       attrs: { 'data-icon': licon.UpTriangle },
       hook: clickHook(ctrl.previousPage),
-    })
+    }),
   );
 
   if (nb > 0)
@@ -33,7 +33,7 @@ function renderContent(ctrl: Ctrl, d: NotifyData): VNode[] {
           title: 'Clear',
         },
         hook: clickHook(ctrl.clear),
-      })
+      }),
     );
 
   nodes.push(nb ? recentNotifications(d, ctrl.scrolling()) : empty());
@@ -43,7 +43,7 @@ function renderContent(ctrl: Ctrl, d: NotifyData): VNode[] {
       h('div.pager.next', {
         attrs: { 'data-icon': licon.DownTriangle },
         hook: clickHook(ctrl.nextPage),
-      })
+      }),
     );
 
   if (!('Notification' in window))
@@ -68,7 +68,7 @@ function notificationDenied(): VNode {
         rel: 'noopener',
       },
     },
-    'Notification popups disabled by browser setting'
+    'Notification popups disabled by browser setting',
   );
 }
 
@@ -101,7 +101,7 @@ function recentNotifications(d: NotifyData, scrolling: boolean): VNode {
         postpatch: contentLoaded,
       },
     },
-    d.pager.currentPageResults.map(n => asHtml(n, trans)) as VNode[]
+    d.pager.currentPageResults.map(n => asHtml(n, trans)) as VNode[],
   );
 }
 

--- a/ui/nvui/src/chess.ts
+++ b/ui/nvui/src/chess.ts
@@ -123,7 +123,7 @@ export function symbolToFile(char: string) {
 
 export function supportedVariant(key: string) {
   return ['standard', 'chess960', 'kingOfTheHill', 'threeCheck', 'fromPosition', 'atomic', 'horde'].includes(
-    key
+    key,
   );
 }
 
@@ -214,7 +214,7 @@ const renderPrefixStyle = (color: Color, prefixStyle: PrefixStyle) => {
 export function lastCaptured(
   movesGenerator: () => string[],
   pieceStyle: PieceStyle,
-  prefixStyle: PrefixStyle
+  prefixStyle: PrefixStyle,
 ): string {
   const moves = movesGenerator();
   const oldFen = moves[moves.length - 2];
@@ -284,11 +284,11 @@ export function renderPieces(pieces: Pieces, style: Style): VNode {
               `${l[0]}: ${l
                 .slice(1)
                 .map((k: string) => renderKey(k, style))
-                .join(', ')}`
+                .join(', ')}`,
           )
           .join(', '),
       ]);
-    })
+    }),
   );
 }
 
@@ -318,7 +318,7 @@ export function renderBoard(
   pieceStyle: PieceStyle,
   prefixStyle: PrefixStyle,
   positionStyle: PositionStyle,
-  boardStyle: BoardStyle
+  boardStyle: BoardStyle,
 ): VNode {
   const doRankHeader = (rank: Rank): VNode => {
     return h('th', { attrs: { scope: 'row' } }, rank);
@@ -343,14 +343,14 @@ export function renderBoard(
     file: File,
     letter: string,
     color: Color | 'none',
-    text: string
+    text: string,
   ): VNode => {
     return h(
       'button',
       {
         attrs: { rank: rank, file: file, piece: letter.toLowerCase(), color: color },
       },
-      text
+      text,
     );
   };
   const doPiece = (rank: Rank, file: File): VNode => {
@@ -422,7 +422,7 @@ export function positionJumpHandler() {
       return true;
     }
     const newBtn = document.querySelector(
-      '.board-wrapper button[rank="' + $newRank + '"][file="' + $newFile + '"]'
+      '.board-wrapper button[rank="' + $newRank + '"][file="' + $newFile + '"]',
     ) as HTMLElement;
     if (newBtn) {
       newBtn.focus();
@@ -496,7 +496,7 @@ export function arrowKeyHandler(pov: Color, borderSound: () => void) {
       return true;
     }
     const $newSq = document.querySelector(
-      '.board-wrapper [file="' + $file + '"][rank="' + $rank + '"]'
+      '.board-wrapper [file="' + $file + '"][rank="' + $rank + '"]',
     ) as HTMLElement;
     if ($newSq) {
       $newSq.focus();
@@ -580,7 +580,7 @@ export function boardCommandsHandler() {
 export function lastCapturedCommandHandler(
   steps: () => string[],
   pieceStyle: PieceStyle,
-  prefixStyle: PrefixStyle
+  prefixStyle: PrefixStyle,
 ) {
   return (ev: KeyboardEvent) => {
     const $boardLive = $('.boardstatus');
@@ -600,7 +600,7 @@ export function possibleMovesHandler(
   piecesFunc: () => Pieces,
   variant: string,
   moveable: () => Map<string, Array<string>> | undefined,
-  steps: () => RoundStep[]
+  steps: () => RoundStep[],
 ) {
   return (ev: KeyboardEvent) => {
     if (ev.key !== 'm' && ev.key !== 'M') return true;
@@ -717,8 +717,8 @@ export function renderMainline(nodes: Tree.Node[], currentPath: Tree.Path, style
           attrs: { p: path },
           class: { active: path === currentPath },
         },
-        content
-      )
+        content,
+      ),
     );
     res.push(renderComments(node, style));
     res.push(', ');
@@ -738,7 +738,7 @@ function renderComment(comment: Tree.Comment, style: Style): string {
   return comment.by === 'lichess'
     ? comment.text.replace(
         /Best move was (.+)\./,
-        (_, san) => 'Best move was ' + renderSan(san, undefined, style)
+        (_, san) => 'Best move was ' + renderSan(san, undefined, style),
       )
     : comment.text;
 }

--- a/ui/nvui/src/notify.ts
+++ b/ui/nvui/src/notify.ts
@@ -32,6 +32,6 @@ export class Notify {
           'aria-atomic': 'true',
         },
       },
-      this.currentText()
+      this.currentText(),
     );
 }

--- a/ui/nvui/src/setting.ts
+++ b/ui/nvui/src/setting.ts
@@ -50,9 +50,9 @@ export function renderSetting<A>(setting: Setting<A>, redraw: () => void): VNode
             selected: key === v,
           },
         },
-        name
+        name,
       );
-    })
+    }),
   );
 }
 

--- a/ui/opening/src/chart.ts
+++ b/ui/opening/src/chart.ts
@@ -12,7 +12,7 @@ chart.Chart.register(
   chart.Tooltip,
   chart.Filler,
   chart.Title,
-  chart.TimeScale
+  chart.TimeScale,
 );
 
 const firstDate = new Date('2017-01-01');

--- a/ui/opening/src/wiki.ts
+++ b/ui/opening/src/wiki.ts
@@ -18,7 +18,7 @@ async function fetchAndRender(data: OpeningPage, render: (html: string) => void)
   const removeTableExpl = (html: string) =>
     html.replace(
       /For explanation of theory tables see theory table and for notation see algebraic notation.?/,
-      ''
+      '',
     );
   const removeContributing = (html: string) =>
     html.replace('When contributing to this Wikibook, please follow the Conventions for organization.', '');

--- a/ui/palantir/src/main.ts
+++ b/ui/palantir/src/main.ts
@@ -48,7 +48,7 @@ export function initModule(opts: PalantirOpts): Palantir | undefined {
             },
             function (err) {
               log(`Failed to get local stream: ${err}`);
-            }
+            },
           )
           .catch(err => log(err));
       })
@@ -232,9 +232,9 @@ export function initModule(opts: PalantirOpts): Palantir | undefined {
                         (vnode.elm as HTMLAudioElement).srcObject = c.remoteStream;
                       },
                     },
-                  })
+                  }),
                 )
-              : []
+              : [],
           )
         : null;
     },

--- a/ui/puz/css/_combo.scss
+++ b/ui/puz/css/_combo.scss
@@ -74,13 +74,17 @@
       .puz-mod-malus-slow & {
         transition-property: width;
         background: $c-bad;
-        box-shadow: 0 0 10px $c-bad, 0 0 20px $c-bad;
+        box-shadow:
+          0 0 10px $c-bad,
+          0 0 20px $c-bad;
       }
     }
 
     &__in-full {
       background: $c-primary;
-      box-shadow: 0 0 10px $c-primary, 0 0 20px $c-primary;
+      box-shadow:
+        0 0 10px $c-primary,
+        0 0 20px $c-primary;
       width: 100%;
       display: none;
       opacity: 0;
@@ -132,7 +136,9 @@
     @keyframes level-fade-in {
       from {
         background: white;
-        box-shadow: 0 0 15px white, 0 0 25px white;
+        box-shadow:
+          0 0 15px white,
+          0 0 25px white;
       }
 
       to {

--- a/ui/puz/css/_font.scss
+++ b/ui/puz/css/_font.scss
@@ -3,5 +3,7 @@
   font-style: normal;
   font-weight: 400;
 
-  src: url('#{$font-path}/Segment7.woff2') format('woff2'), url('#{$font-path}/Segment7.woff') format('woff');
+  src:
+    url('#{$font-path}/Segment7.woff2') format('woff2'),
+    url('#{$font-path}/Segment7.woff') format('woff');
 }

--- a/ui/puz/src/clock.ts
+++ b/ui/puz/src/clock.ts
@@ -5,7 +5,10 @@ export class Clock {
   startAt: number | undefined;
   initialMillis: number;
 
-  public constructor(readonly config: Config, startedMillisAgo: number | undefined = 0) {
+  public constructor(
+    readonly config: Config,
+    startedMillisAgo: number | undefined = 0,
+  ) {
     this.initialMillis = config.clock.initial * 1000 - (startedMillisAgo || 0);
   }
 

--- a/ui/puz/src/combo.ts
+++ b/ui/puz/src/combo.ts
@@ -19,7 +19,7 @@ export class Combo {
   level = () =>
     this.config.combo.levels.reduce(
       (lvl, [threshold, _], index) => (threshold <= this.current ? index : lvl),
-      0
+      0,
     );
 
   percent = () => {

--- a/ui/puz/src/current.ts
+++ b/ui/puz/src/current.ts
@@ -9,7 +9,10 @@ export default class CurrentPuzzle {
   moveIndex = -1;
   pov: Color;
 
-  constructor(readonly index: number, readonly puzzle: Puzzle) {
+  constructor(
+    readonly index: number,
+    readonly puzzle: Puzzle,
+  ) {
     this.line = puzzle.line.split(' ');
     this.pov = opposite(parseFen(puzzle.fen).unwrap().turn);
     this.startAt = getNow();

--- a/ui/puz/src/view/history.ts
+++ b/ui/puz/src/view/history.ts
@@ -24,7 +24,7 @@ const toggleButton = (prop: Toggle, title: string): VNode =>
       },
       hook: onInsert(e => e.addEventListener('click', prop.toggle)),
     },
-    title
+    title,
   );
 
 export default (ctrl: PuzCtrl): VNode => {
@@ -45,7 +45,7 @@ export default (ctrl: PuzCtrl): VNode => {
           r =>
             (!r.win || !filters.fail()) &&
             (!slowIds || slowIds.has(r.puzzle.id)) &&
-            (!filters.skip || !filters.skip() || r.puzzle.id === ctrl.run.skipId)
+            (!filters.skip || !filters.skip() || r.puzzle.id === ctrl.run.skipId),
         )
         .map(round =>
           h(
@@ -74,9 +74,9 @@ export default (ctrl: PuzCtrl): VNode => {
                 ]),
                 h('span.puz-history__round__id', '#' + round.puzzle.id),
               ]),
-            ]
-          )
-        )
+            ],
+          ),
+        ),
     ),
   ]);
 };

--- a/ui/puz/src/view/util.ts
+++ b/ui/puz/src/view/util.ts
@@ -40,9 +40,9 @@ export const renderCombo =
                   active: l < level,
                 },
               },
-              h('span', renderBonus(config.combo.levels[l + 1][1]))
-            )
-          )
+              h('span', renderBonus(config.combo.levels[l + 1][1])),
+            ),
+          ),
         ),
       ]),
     ]);

--- a/ui/puzzle/css/_dashboard.scss
+++ b/ui/puzzle/css/_dashboard.scss
@@ -99,7 +99,8 @@
       $c-fix: mix($c-good, $c-darken, 50%);
       $c-fail: mix($c-bad, $c-darken, 80%);
 
-      background: #{$glow-gradient},
+      background:
+        #{$glow-gradient},
         linear-gradient(
           to $end-direction,
           $c-first 0%,

--- a/ui/puzzle/src/autoShape.ts
+++ b/ui/puzzle/src/autoShape.ts
@@ -17,7 +17,7 @@ function makeAutoShapesFromUci(
   color: Color,
   uci: Uci,
   brush: string,
-  modifiers?: DrawModifiers
+  modifiers?: DrawModifiers,
 ): DrawShape[] {
   const move = parseUci(uci)! as NormalMove; // no crazyhouse
   const to = makeSquare(move.to);
@@ -56,7 +56,7 @@ export default function (opts: Opts): DrawShape[] {
           shapes = shapes.concat(
             makeAutoShapesFromUci(color, pv.moves[0], 'paleGrey', {
               lineWidth: Math.round(12 - shift * 50), // 12 to 2
-            })
+            }),
           );
         });
       }
@@ -71,7 +71,7 @@ export default function (opts: Opts): DrawShape[] {
         shapes = shapes.concat(
           makeAutoShapesFromUci(opposite(color), pv.moves[0], 'paleRed', {
             lineWidth: Math.round(11 - shift * 45), // 11 to 2
-          })
+          }),
         );
       });
     } else shapes = shapes.concat(makeAutoShapesFromUci(opposite(color), n.threat.pvs[0].moves[0], 'red'));

--- a/ui/puzzle/src/ctrl.ts
+++ b/ui/puzzle/src/ctrl.ts
@@ -133,7 +133,7 @@ export default function (opts: PuzzleOpts, redraw: Redraw): Controller {
         jump(initialPath);
         redraw();
       },
-      opts.pref.animation.duration > 0 ? 500 : 0
+      opts.pref.animation.duration > 0 ? 500 : 0,
     );
 
     // just to delay button display
@@ -250,7 +250,7 @@ export default function (opts: PuzzleOpts, redraw: Redraw): Controller {
         check: defined(check) ? makeSquare(check) : undefined,
         children: [],
       },
-      path
+      path,
     );
   }
 
@@ -316,10 +316,13 @@ export default function (opts: PuzzleOpts, redraw: Redraw): Controller {
       }
     } else if (progress) {
       vm.lastFeedback = 'good';
-      setTimeout(() => {
-        const pos = Chess.fromSetup(parseFen(progress.fen).unwrap()).unwrap();
-        sendMoveAt(progress.path, pos, progress.move);
-      }, opts.pref.animation.duration * (autoNext() ? 1 : 1.5));
+      setTimeout(
+        () => {
+          const pos = Chess.fromSetup(parseFen(progress.fen).unwrap()).unwrap();
+          sendMoveAt(progress.path, pos, progress.move);
+        },
+        opts.pref.animation.duration * (autoNext() ? 1 : 1.5),
+      );
     }
   }
 
@@ -341,7 +344,7 @@ export default function (opts: PuzzleOpts, redraw: Redraw): Controller {
       rated,
       data.replay,
       streak,
-      opts.settings.color
+      opts.settings.color,
     );
     const next = res.next;
     if (next?.user && data.user) {
@@ -407,7 +410,8 @@ export default function (opts: PuzzleOpts, redraw: Redraw): Controller {
             const threat = ev as Tree.LocalEval;
             if (!node.threat || node.threat.depth <= threat.depth || node.threat.maxDepth < threat.maxDepth)
               node.threat = threat;
-          } else if (!node.ceval || node.ceval.depth <= ev.depth || (node.ceval.maxDepth ?? 0) < ev.maxDepth) node.ceval = ev;
+          } else if (!node.ceval || node.ceval.depth <= ev.depth || (node.ceval.maxDepth ?? 0) < ev.maxDepth)
+            node.ceval = ev;
           if (work.path === vm.path) {
             setAutoShapes();
             redraw();
@@ -427,7 +431,7 @@ export default function (opts: PuzzleOpts, redraw: Redraw): Controller {
           ground: g,
           threatMode: threatMode(),
           nextNodeBest: nextNodeBest(),
-        })
+        }),
       );
     });
   }

--- a/ui/puzzle/src/plugins/nvui.ts
+++ b/ui/puzzle/src/plugins/nvui.ts
@@ -70,7 +70,7 @@ export function initModule() {
                 'aria-live': 'off',
               },
             },
-            renderMainline(ctrl.vm.mainline, ctrl.vm.path, moveStyle.get())
+            renderMainline(ctrl.vm.mainline, ctrl.vm.path, moveStyle.get()),
           ),
           h('h2', 'Pieces'),
           h('div.pieces', renderPieces(ground.state.pieces, moveStyle.get())),
@@ -84,7 +84,7 @@ export function initModule() {
                 'aria-atomic': 'true',
               },
             },
-            renderStatus(ctrl)
+            renderStatus(ctrl),
           ),
           h('div.replay', renderReplay(ctrl)),
           ...(ctrl.streak ? renderStreak(ctrl) : []),
@@ -97,7 +97,7 @@ export function initModule() {
                 'aria-atomic': 'true',
               },
             },
-            lastMove(ctrl, moveStyle.get())
+            lastMove(ctrl, moveStyle.get()),
           ),
           h('h2', 'Move form'),
           h(
@@ -122,7 +122,7 @@ export function initModule() {
                   },
                 }),
               ]),
-            ]
+            ],
           ),
           notify.render(),
           h('h2', 'Actions'),
@@ -140,13 +140,13 @@ export function initModule() {
                 const opponentColor = ctrl.vm.pov === 'white' ? 'black' : 'white';
                 $board.on(
                   'click',
-                  selectionHandler(() => opponentColor, selectSound)
+                  selectionHandler(() => opponentColor, selectSound),
                 );
                 $board.on('keydown', arrowKeyHandler(ctrl.vm.pov, borderSound));
                 $board.on('keypress', boardCommandsHandler());
                 $buttons.on(
                   'keypress',
-                  lastCapturedCommandHandler(fenSteps, pieceStyle.get(), prefixStyle.get())
+                  lastCapturedCommandHandler(fenSteps, pieceStyle.get(), prefixStyle.get()),
                 );
                 $buttons.on(
                   'keypress',
@@ -157,8 +157,8 @@ export function initModule() {
                     () => ground.state.pieces,
                     'standard',
                     () => ground.state.movable.dests,
-                    uciSteps
-                  )
+                    uciSteps,
+                  ),
                 );
                 $buttons.on('keypress', positionJumpHandler());
                 $buttons.on('keypress', pieceJumpingHandler(selectSound, errorSound));
@@ -170,8 +170,8 @@ export function initModule() {
               pieceStyle.get(),
               prefixStyle.get(),
               positionStyle.get(),
-              boardStyle.get()
-            )
+              boardStyle.get(),
+            ),
           ),
           h(
             'div.boardstatus',
@@ -181,7 +181,7 @@ export function initModule() {
                 'aria-atomic': 'true',
               },
             },
-            ''
+            '',
           ),
           h('h2', 'Settings'),
           h('label', ['Move notation', renderSetting(moveStyle, ctrl.redraw)]),
@@ -243,7 +243,7 @@ export function initModule() {
             h('br'),
             'Omission results in promotion to queen',
           ]),
-        ])
+        ]),
       );
     },
   };
@@ -280,7 +280,7 @@ function onSubmit(
   notify: (txt: string) => void,
   style: () => Style,
   $input: Cash,
-  ground: Api
+  ground: Api,
 ): () => false {
   return () => {
     let input = castlingFlavours(($input.val() as string).trim());
@@ -333,7 +333,7 @@ function onCommand(ctrl: Controller, notify: (txt: string) => void, c: string, s
     notify(
       commands.piece.apply(c, pieces, style) ||
         commands.scan.apply(c, pieces, style) ||
-        `Invalid command: ${c}`
+        `Invalid command: ${c}`,
     );
 }
 
@@ -389,7 +389,7 @@ function playActions(ctrl: Controller): VNode {
       ctrl.trans.noarg('skip'),
       ctrl.skip,
       ctrl.trans.noarg('streakSkipExplanation'),
-      !ctrl.streak.data.skip
+      !ctrl.streak.data.skip,
     );
   else return h('div.actions_play', button('View the solution', ctrl.viewSolution));
 }
@@ -400,7 +400,7 @@ function afterActions(ctrl: Controller): VNode {
     'div.actions_after',
     ctrl.streak && !win
       ? anchor(ctrl.trans.noarg('newStreak'), '/streak')
-      : [...renderVote(ctrl), button('Continue training', ctrl.nextPuzzle)]
+      : [...renderVote(ctrl), button('Continue training', ctrl.nextPuzzle)],
   );
 }
 
@@ -424,7 +424,7 @@ function anchor(text: string, href: string): VNode {
     {
       attrs: { href },
     },
-    text
+    text,
   );
 }
 
@@ -438,6 +438,6 @@ function button(text: string, action: (e: Event) => void, title?: string, disabl
         disabled: !!disabled,
       },
     },
-    text
+    text,
   );
 }

--- a/ui/puzzle/src/session.ts
+++ b/ui/puzzle/src/session.ts
@@ -17,7 +17,11 @@ export default class PuzzleSession {
   maxSize = 100;
   maxAge = 1000 * 3600;
 
-  constructor(readonly theme: ThemeKey, readonly userId: string | undefined, readonly streak: boolean) {}
+  constructor(
+    readonly theme: ThemeKey,
+    readonly userId: string | undefined,
+    readonly streak: boolean,
+  ) {}
 
   default = () => ({
     theme: this.theme,

--- a/ui/puzzle/src/view/after.ts
+++ b/ui/puzzle/src/view/after.ts
@@ -30,9 +30,9 @@ const renderVote = (ctrl: Controller): VNode =>
               h('div.vote.vote-down', {
                 hook: bind('click', () => ctrl.vote(false)),
               }),
-            ]
+            ],
           ),
-        ]
+        ],
   );
 
 const renderContinue = (ctrl: Controller) =>
@@ -41,7 +41,7 @@ const renderContinue = (ctrl: Controller) =>
     {
       hook: bind('click', ctrl.nextPuzzle),
     },
-    [h('i', { attrs: dataIcon(licon.PlayTriangle) }), ctrl.trans.noarg('continueTraining')]
+    [h('i', { attrs: dataIcon(licon.PlayTriangle) }), ctrl.trans.noarg('continueTraining')],
   );
 
 const renderStreak = (ctrl: Controller): MaybeVNodes => [
@@ -54,7 +54,7 @@ const renderStreak = (ctrl: Controller): MaybeVNodes => [
     {
       attrs: { href: router.withLang('/streak') },
     },
-    [h('i', { attrs: dataIcon(licon.PlayTriangle) }), ctrl.trans('newStreak')]
+    [h('i', { attrs: dataIcon(licon.PlayTriangle) }), ctrl.trans('newStreak')],
   ),
 ];
 
@@ -84,10 +84,10 @@ export default function (ctrl: Controller): VNode {
                   {
                     hook: bind('click', ctrl.nextPuzzle),
                   },
-                  ctrl.trans.noarg(ctrl.streak ? 'continueTheStreak' : 'continueTraining')
+                  ctrl.trans.noarg(ctrl.streak ? 'continueTheStreak' : 'continueTraining'),
                 )
               : undefined,
           ]),
-        ]
+        ],
   );
 }

--- a/ui/puzzle/src/view/boardMenu.ts
+++ b/ui/puzzle/src/view/boardMenu.ts
@@ -15,7 +15,7 @@ export default function (ctrl: Controller) {
       h(
         'a',
         { attrs: { target: '_blank', href: '/account/preferences/display' } },
-        'Game display preferences'
+        'Game display preferences',
       ),
     ]),
   ]);

--- a/ui/puzzle/src/view/feedback.ts
+++ b/ui/puzzle/src/view/feedback.ts
@@ -19,9 +19,9 @@ const viewSolution = (ctrl: Controller): VNode =>
                 title: ctrl.trans.noarg('streakSkipExplanation'),
               },
             },
-            ctrl.trans.noarg('skip')
+            ctrl.trans.noarg('skip'),
           ),
-        ]
+        ],
       )
     : h(
         'div.view_solution',
@@ -34,9 +34,9 @@ const viewSolution = (ctrl: Controller): VNode =>
             {
               hook: bind('click', ctrl.viewSolution),
             },
-            ctrl.trans.noarg('viewTheSolution')
+            ctrl.trans.noarg('viewTheSolution'),
           ),
-        ]
+        ],
       );
 
 const initial = (ctrl: Controller): VNode =>
@@ -47,7 +47,7 @@ const initial = (ctrl: Controller): VNode =>
         h('strong', ctrl.trans.noarg('yourTurn')),
         h(
           'em',
-          ctrl.trans.noarg(ctrl.vm.pov === 'white' ? 'findTheBestMoveForWhite' : 'findTheBestMoveForBlack')
+          ctrl.trans.noarg(ctrl.vm.pov === 'white' ? 'findTheBestMoveForWhite' : 'findTheBestMoveForBlack'),
         ),
       ]),
     ]),

--- a/ui/puzzle/src/view/main.ts
+++ b/ui/puzzle/src/view/main.ts
@@ -51,7 +51,7 @@ function controls(ctrl: Controller): VNode {
             else if (action === 'next') control.next(ctrl);
             else if (action === 'first') control.first(ctrl);
             else if (action === 'last') control.last(ctrl);
-          }, ctrl.redraw)
+          }, ctrl.redraw),
         ),
       },
       [
@@ -60,7 +60,7 @@ function controls(ctrl: Controller): VNode {
         jumpButton(licon.JumpNext, 'next', !nextNode),
         jumpButton(licon.JumpLast, 'last', !nextNode, notOnLastMove),
         boardMenuToggleButton(ctrl.menu, ctrl.trans.noarg('menu')),
-      ]
+      ],
     ),
     boardMenu(ctrl),
   ]);
@@ -120,10 +120,10 @@ export default function (ctrl: Controller): VNode {
                     if (e.deltaY > 0 && scroll) control.next(ctrl);
                     else if (e.deltaY < 0 && scroll) control.prev(ctrl);
                     ctrl.redraw();
-                  })
+                  }),
                 ),
         },
-        [chessground(ctrl), ctrl.promotion.view()]
+        [chessground(ctrl), ctrl.promotion.view()],
       ),
       cevalView.renderGauge(ctrl),
       h('div.puzzle__tools', [
@@ -135,7 +135,7 @@ export default function (ctrl: Controller): VNode {
           {
             class: { none: !showCeval },
           },
-          showCeval ? [cevalView.renderCeval(ctrl), cevalView.renderPvs(ctrl)] : []
+          showCeval ? [cevalView.renderCeval(ctrl), cevalView.renderPvs(ctrl)] : [],
         ),
         renderAnalyse(ctrl),
         feedbackView(ctrl),
@@ -144,7 +144,7 @@ export default function (ctrl: Controller): VNode {
       ctrl.keyboardMove ? renderKeyboardMove(ctrl.keyboardMove) : null,
       session(ctrl),
       ctrl.keyboardHelp() ? keyboard.view(ctrl) : null,
-    ]
+    ],
   );
 }
 
@@ -171,7 +171,7 @@ function session(ctrl: Controller) {
             ...(ctrl.streak ? { target: '_blank', rel: 'noopener' } : {}),
           },
         },
-        rd
+        rd,
       );
     }),
     rounds.find(r => r.id == current)
@@ -193,7 +193,7 @@ function session(ctrl: Controller) {
                   href: `/training/${ctrl.session.theme}/${current}`,
                 },
           },
-          ctrl.streak?.data.index
+          ctrl.streak?.data.index,
         ),
   ]);
 }

--- a/ui/puzzle/src/view/side.ts
+++ b/ui/puzzle/src/view/side.ts
@@ -37,9 +37,9 @@ const puzzleInfos = (ctrl: Controller, puzzle: Puzzle): VNode =>
                       ...(ctrl.streak ? { target: '_blank', rel: 'noopener' } : {}),
                     },
                   },
-                  '#' + puzzle.id
-                )
-              )
+                  '#' + puzzle.id,
+                ),
+              ),
             ),
         ctrl.showRatings
           ? h(
@@ -48,13 +48,13 @@ const puzzleInfos = (ctrl: Controller, puzzle: Puzzle): VNode =>
                 'ratingX',
                 !ctrl.streak && ctrl.vm.mode === 'play'
                   ? h('span.hidden', ctrl.trans.noarg('hidden'))
-                  : h('strong', puzzle.rating)
-              )
+                  : h('strong', puzzle.rating),
+              ),
             )
           : null,
         h('p', ctrl.trans.vdomPlural('playedXTimes', puzzle.plays, h('strong', numberFormat(puzzle.plays)))),
       ]),
-    ]
+    ],
   );
 
 function gameInfos(ctrl: Controller, game: PuzzleGame, puzzle: Puzzle): VNode {
@@ -72,9 +72,9 @@ function gameInfos(ctrl: Controller, game: PuzzleGame, puzzle: Puzzle): VNode {
                 {
                   attrs: { href: `/${game.id}/${ctrl.vm.pov}#${puzzle.initialPly}` },
                 },
-                gameName
-              )
-        )
+                gameName,
+              ),
+        ),
       ),
       h(
         'div.players',
@@ -88,11 +88,11 @@ function gameInfos(ctrl: Controller, game: PuzzleGame, puzzle: Puzzle): VNode {
                   {
                     attrs: { href: '/@/' + p.userId },
                   },
-                  p.title && p.title != 'BOT' ? [h('span.utitle', p.title), ' ' + name] : name
+                  p.title && p.title != 'BOT' ? [h('span.utitle', p.title), ' ' + name] : name,
                 )
-              : name
+              : name,
           );
-        })
+        }),
       ),
     ]),
   ]);
@@ -108,7 +108,7 @@ const renderStreak = (streak: PuzzleStreak, noarg: TransNoArg) =>
             {
               attrs: dataIcon(licon.ArrowThruApple),
             },
-            'Puzzle Streak'
+            'Puzzle Streak',
           ),
           h('p', noarg('streakDescription')),
         ])
@@ -117,8 +117,8 @@ const renderStreak = (streak: PuzzleStreak, noarg: TransNoArg) =>
           {
             attrs: dataIcon(licon.ArrowThruApple),
           },
-          streak.data.index
-        )
+          streak.data.index,
+        ),
   );
 
 export const userBox = (ctrl: Controller): VNode => {
@@ -160,7 +160,7 @@ export const userBox = (ctrl: Controller): VNode => {
               ...(diff && diff < 0 ? [' ', h('bad.rp', '−' + -diff)] : []),
             ])
           : null
-        : h('p.puzzle__side__user__rating__casual', noarg('yourPuzzleRatingWillNotChange'))
+        : h('p.puzzle__side__user__rating__casual', noarg('yourPuzzleRatingWillNotChange')),
     ),
   ]);
 };
@@ -193,7 +193,7 @@ export function replay(ctrl: Controller): MaybeVNode {
           href: `/training/dashboard/${replay.days}`,
         },
       },
-      ['« ', `Replaying ${ctrl.trans.noarg(ctrl.getData().angle.key)} puzzles`]
+      ['« ', `Replaying ${ctrl.trans.noarg(ctrl.getData().angle.key)} puzzles`],
     ),
     h('div.puzzle__side__replay__bar', {
       attrs: {
@@ -249,14 +249,14 @@ export const renderDifficultyForm = (ctrl: Controller): VNode =>
         {
           attrs: { for: 'puzzle-difficulty' },
         },
-        ctrl.trans.noarg('difficultyLevel')
+        ctrl.trans.noarg('difficultyLevel'),
       ),
       h(
         'select#puzzle-difficulty.puzzle__difficulty__selector',
         {
           attrs: { name: 'difficulty' },
           hook: onInsert(elm =>
-            elm.addEventListener('change', () => (elm.parentNode as HTMLFormElement).submit())
+            elm.addEventListener('change', () => (elm.parentNode as HTMLFormElement).submit()),
           ),
         },
         difficulties.map(([key, delta]) =>
@@ -270,15 +270,15 @@ export const renderDifficultyForm = (ctrl: Controller): VNode =>
                   !!delta &&
                   ctrl.trans.pluralSame(
                     delta < 0 ? 'nbPointsBelowYourPuzzleRating' : 'nbPointsAboveYourPuzzleRating',
-                    Math.abs(delta)
+                    Math.abs(delta),
                   ),
               },
             },
-            [ctrl.trans.noarg(key), delta ? ` (${delta > 0 ? '+' : ''}${delta})` : '']
-          )
-        )
+            [ctrl.trans.noarg(key), delta ? ` (${delta > 0 ? '+' : ''}${delta})` : ''],
+          ),
+        ),
       ),
-    ]
+    ],
   );
 
 export const renderColorForm = (ctrl: Controller): VNode =>
@@ -296,9 +296,9 @@ export const renderColorForm = (ctrl: Controller): VNode =>
                 title: ctrl.trans.noarg(i18n),
               },
             },
-            h('i')
+            h('i'),
           ),
-        ])
-      )
-    )
+        ]),
+      ),
+    ),
   );

--- a/ui/puzzle/src/view/theme.ts
+++ b/ui/puzzle/src/view/theme.ts
@@ -19,7 +19,7 @@ export default function theme(ctrl: Controller): MaybeVNode {
     : ctrl.vm.isDaily
     ? h(
         'div.puzzle__side__theme.puzzle__side__theme--daily',
-        puzzleMenu(h('h2', ctrl.trans.noarg('dailyPuzzle')))
+        puzzleMenu(h('h2', ctrl.trans.noarg('dailyPuzzle'))),
       )
     : h('div.puzzle__side__theme', [
         puzzleMenu(
@@ -30,8 +30,8 @@ export default function theme(ctrl: Controller): MaybeVNode {
                 long: angle.name.length > 20,
               },
             },
-            ['« ', angle.name]
-          )
+            ['« ', angle.name],
+          ),
         ),
         angle.opening
           ? h('a', { attrs: { href: `/opening/${angle.opening.key}` } }, [
@@ -50,7 +50,7 @@ export default function theme(ctrl: Controller): MaybeVNode {
                       rel: 'noopener',
                     },
                   },
-                  [' ', ctrl.trans.noarg('example')]
+                  [' ', ctrl.trans.noarg('example')],
                 ),
             ]),
         showEditor
@@ -101,7 +101,7 @@ const editor = (ctrl: Controller): VNode[] => {
                   title: trans(`${key}Description`),
                 },
               },
-              trans(key)
+              trans(key),
             ),
             !allThemes
               ? null
@@ -113,7 +113,7 @@ const editor = (ctrl: Controller): VNode[] => {
                           'div.puzzle__themes__lock',
                           h('i', {
                             attrs: dataIcon(licon.Padlock),
-                          })
+                          }),
                         ),
                       ]
                     : [
@@ -125,11 +125,11 @@ const editor = (ctrl: Controller): VNode[] => {
                           class: { active: votedThemes[key] === false },
                           attrs: { 'data-theme': key },
                         }),
-                      ]
+                      ],
                 ),
-          ]
-        )
-      )
+          ],
+        ),
+      ),
     ),
     ...(availableThemes
       ? [
@@ -152,7 +152,7 @@ const editor = (ctrl: Controller): VNode[] => {
                 {
                   attrs: { value: '', selected: true },
                 },
-                trans('addAnotherTheme')
+                trans('addAnotherTheme'),
               ),
               ...availableThemes.map(theme =>
                 h(
@@ -163,10 +163,10 @@ const editor = (ctrl: Controller): VNode[] => {
                       title: trans(`${theme}Description`),
                     },
                   },
-                  trans(theme)
-                )
+                  trans(theme),
+                ),
               ),
-            ]
+            ],
           ),
           h(
             'a.puzzle__themes__study.text',
@@ -178,7 +178,7 @@ const editor = (ctrl: Controller): VNode[] => {
                 rel: 'noopener',
               },
             },
-            'About puzzle themes'
+            'About puzzle themes',
           ),
         ]
       : []),

--- a/ui/puzzle/src/view/tree.ts
+++ b/ui/puzzle/src/view/tree.ts
@@ -74,7 +74,7 @@ function renderChildrenOf(ctx: Ctx, node: Tree.Node, opts: RenderOpts): MaybeVNo
         renderLines(ctx, cs.slice(1), {
           parentPath: opts.parentPath,
           isMainline: true,
-        })
+        }),
       ),
       ...(isWhite && mainChildren ? [renderIndex(main.ply, false), emptyMove()] : []),
       ...mainChildren,
@@ -96,9 +96,9 @@ function renderLines(ctx: Ctx, nodes: Tree.Node[], opts: RenderOpts): VNode {
           parentPath: opts.parentPath,
           isMainline: false,
           withIndex: true,
-        })
+        }),
       );
-    })
+    }),
   );
 }
 
@@ -120,7 +120,7 @@ function renderMainlineMoveOf(ctx: Ctx, node: Tree.Node, opts: RenderOpts): VNod
       attrs: { p: path },
       class: classes,
     },
-    renderMove(ctx, node)
+    renderMove(ctx, node),
   );
 }
 
@@ -130,7 +130,7 @@ function renderGlyph(glyph: Glyph): VNode {
     {
       attrs: { title: glyph.name },
     },
-    glyph.symbol
+    glyph.symbol,
   );
 }
 
@@ -186,7 +186,7 @@ function renderVariationMoveOf(ctx: Ctx, node: Tree.Node, opts: RenderOpts): VNo
       attrs: { p: path },
       class: classes,
     },
-    [withIndex ? renderIndex(node.ply, true) : null, node.san, puzzleGlyph(ctx, node)]
+    [withIndex ? renderIndex(node.ply, true) : null, node.san, puzzleGlyph(ctx, node)],
   );
 }
 
@@ -251,6 +251,6 @@ export function render(ctrl: Controller): VNode {
         parentPath: '',
         isMainline: true,
       }),
-    ]
+    ],
   );
 }

--- a/ui/puzzle/src/xhr.ts
+++ b/ui/puzzle/src/xhr.ts
@@ -12,7 +12,7 @@ export const complete = (
   rated: StoredProp<boolean>,
   replay?: PuzzleReplay,
   streak?: PuzzleStreak,
-  color?: Color
+  color?: Color,
 ): Promise<PuzzleResult> =>
   xhr.json(`/training/complete/${theme}/${puzzleId}`, {
     method: 'POST',
@@ -43,5 +43,5 @@ export const setZen = throttlePromiseDelay(
     xhr.text('/pref/zen', {
       method: 'post',
       body: xhr.form({ zen: zen ? 1 : 0 }),
-    })
+    }),
 );

--- a/ui/racer/css/_countdown.scss
+++ b/ui/racer/css/_countdown.scss
@@ -33,19 +33,25 @@
         &.red {
           background: $c-red;
           &.active {
-            box-shadow: 0 0 2em $c-red, 0 0 4em $c-red;
+            box-shadow:
+              0 0 2em $c-red,
+              0 0 4em $c-red;
           }
         }
         &.orange {
           background: $c-brag;
           &.active {
-            box-shadow: 0 0 2em $c-brag, 0 0 4em $c-brag;
+            box-shadow:
+              0 0 2em $c-brag,
+              0 0 4em $c-brag;
           }
         }
         &.green {
           background: $c-good;
           &.active {
-            box-shadow: 0 0 2em $c-good, 0 0 4em $c-good;
+            box-shadow:
+              0 0 2em $c-good,
+              0 0 4em $c-good;
           }
         }
       }

--- a/ui/racer/src/countdown.ts
+++ b/ui/racer/src/countdown.ts
@@ -3,7 +3,11 @@ import { Clock } from 'puz/clock';
 export class Countdown {
   played = new Set<number>();
 
-  public constructor(readonly clock: Clock, readonly onStart: () => void, readonly redraw: () => void) {
+  public constructor(
+    readonly clock: Clock,
+    readonly onStart: () => void,
+    readonly redraw: () => void,
+  ) {
     for (let i = 10; i >= 0; i--) lichess.sound.load(`countDown${i}`);
   }
 

--- a/ui/racer/src/ctrl.ts
+++ b/ui/racer/src/ctrl.ts
@@ -46,7 +46,10 @@ export default class RacerCtrl implements PuzCtrl {
   flipped = false;
   redrawInterval: Timeout;
 
-  constructor(opts: RacerOpts, readonly redraw: () => void) {
+  constructor(
+    opts: RacerOpts,
+    readonly redraw: () => void,
+  ) {
     this.data = opts.data;
     this.race = this.data.race;
     this.pref = opts.pref;
@@ -74,7 +77,7 @@ export default class RacerCtrl implements PuzCtrl {
         this.run.current.moveIndex = 0;
         this.setGround();
       },
-      () => setTimeout(this.redraw)
+      () => setTimeout(this.redraw),
     );
     this.promotion = new PromotionCtrl(this.withGround, this.setGround, this.redraw);
     this.serverUpdate(opts.data);
@@ -267,7 +270,7 @@ export default class RacerCtrl implements PuzCtrl {
       xhr.text('/pref/zen', {
         method: 'post',
         body: xhr.form({ zen: zen ? 1 : 0 }),
-      })
+      }),
   );
 
   private toggleZen = () => lichess.pubsub.emit('zen');

--- a/ui/racer/src/view/board.ts
+++ b/ui/racer/src/view/board.ts
@@ -30,9 +30,9 @@ const renderGround = (ctrl: RacerCtrl): VNode =>
                     movable: { color: ctrl.run.pov },
                   },
               ctrl.pref,
-              ctrl.userMove
-            )
-          )
+              ctrl.userMove,
+            ),
+          ),
         ),
     },
   });

--- a/ui/racer/src/view/main.ts
+++ b/ui/racer/src/view/main.ts
@@ -24,7 +24,7 @@ export default function (ctrl: RacerCtrl): VNode {
       h('div.puz-side', selectScreen(ctrl)),
       renderRace(ctrl),
       ctrl.status() === 'post' && ctrl.run.history.length > 0 ? renderHistory(ctrl) : null,
-    ]
+    ],
   );
 }
 
@@ -42,7 +42,7 @@ const selectScreen = (ctrl: RacerCtrl): MaybeVNodes => {
                   'p',
                   ctrl.knowsSkip()
                     ? noarg(ctrl.vm.startsAt ? 'getReady' : 'waitingForMorePlayers')
-                    : skipHelp(noarg)
+                    : skipHelp(noarg),
                 ),
                 povMsg,
               ]),
@@ -100,7 +100,7 @@ const renderSkip = (ctrl: RacerCtrl) =>
       },
       hook: bind('click', ctrl.skip),
     },
-    ctrl.trans.noarg('skip')
+    ctrl.trans.noarg('skip'),
   );
 
 const skipHelp = (noarg: TransNoArg) => h('p', noarg('skipHelp'));
@@ -110,13 +110,13 @@ const puzzleRacer = () => h('strong', 'Puzzle Racer');
 const waitingToStart = (noarg: TransNoArg) =>
   h(
     'div.puz-side__top.puz-side__start',
-    h('div.puz-side__start__text', [puzzleRacer(), h('span', noarg('waitingToStart'))])
+    h('div.puz-side__start__text', [puzzleRacer(), h('span', noarg('waitingToStart'))]),
   );
 
 const spectating = (noarg: TransNoArg) =>
   h(
     'div.puz-side__top.puz-side__start',
-    h('div.puz-side__start__text', [puzzleRacer(), h('span', noarg('spectating'))])
+    h('div.puz-side__start__text', [puzzleRacer(), h('span', noarg('spectating'))]),
   );
 
 const renderBonus = (bonus: number) => `+${bonus}`;
@@ -134,7 +134,7 @@ const renderControls = (ctrl: RacerCtrl): VNode =>
         title: ctrl.trans.noarg('flipBoard') + ' (Keyboard: f)',
       },
       hook: bind('click', ctrl.flip),
-    })
+    }),
   );
 
 const comboZone = (ctrl: RacerCtrl) =>
@@ -179,8 +179,8 @@ const renderStart = (ctrl: RacerCtrl) =>
               disabled: ctrl.players().length < 2,
             },
           },
-          ctrl.trans.noarg('startTheRace')
-        )
+          ctrl.trans.noarg('startTheRace'),
+        ),
       )
     : null;
 
@@ -192,8 +192,8 @@ const renderJoin = (ctrl: RacerCtrl) =>
       {
         hook: bind('click', ctrl.join),
       },
-      ctrl.trans.noarg('joinTheRace')
-    )
+      ctrl.trans.noarg('joinTheRace'),
+    ),
   );
 
 const yourRank = (ctrl: RacerCtrl) => {
@@ -210,7 +210,7 @@ const waitForRematch = (noarg: TransNoArg) =>
     {
       attrs: { disabled: true },
     },
-    noarg('waitForRematch')
+    noarg('waitForRematch'),
   );
 
 const lobbyNext = (ctrl: RacerCtrl) =>
@@ -225,9 +225,9 @@ const lobbyNext = (ctrl: RacerCtrl) =>
     [
       h(
         `button.racer__new-race.button.button-navaway${ctrl.race.lobby ? '.button-fat' : '.button-empty'}`,
-        ctrl.trans.noarg('nextRace')
+        ctrl.trans.noarg('nextRace'),
       ),
-    ]
+    ],
   );
 
 const friendNext = (ctrl: RacerCtrl) =>
@@ -237,7 +237,7 @@ const friendNext = (ctrl: RacerCtrl) =>
       {
         attrs: { href: `/racer/${ctrl.race.id}/rematch` },
       },
-      ctrl.trans.noarg('joinRematch')
+      ctrl.trans.noarg('joinRematch'),
     ),
     h(
       'form.racer__post__next__new',
@@ -254,7 +254,7 @@ const friendNext = (ctrl: RacerCtrl) =>
             type: 'submit',
           },
         },
-        ctrl.trans.noarg('createNewGame')
-      )
+        ctrl.trans.noarg('createNewGame'),
+      ),
     ),
   ]);

--- a/ui/racer/src/view/race.ts
+++ b/ui/racer/src/view/race.ts
@@ -30,7 +30,7 @@ export const renderRace = (ctrl: RacerCtrl) => {
         style: `height:${players.length * trackHeight + 14}px`,
       },
     },
-    h('div.racer__race__tracks', tracks)
+    h('div.racer__race__tracks', tracks),
   );
 };
 
@@ -40,7 +40,7 @@ const renderTrack = (
   bestScore: number,
   boost: Boost,
   player: PlayerWithScore,
-  index: number
+  index: number,
 ) => {
   return h(
     'div.racer__race__track',
@@ -64,10 +64,10 @@ const renderTrack = (
         [
           h(`div.racer__race__player__car.car-${index}`, [0]),
           h('span.racer__race__player__name', playerLink(player, isMe)),
-        ]
+        ],
       ),
       h('div.racer__race__score', player.score),
-    ]
+    ],
   );
 };
 
@@ -78,7 +78,7 @@ export const playerLink = (player: PlayerWithScore, isMe: boolean) =>
         {
           attrs: { href: '/@/' + player.name },
         },
-        player.title ? [h('span.utitle', player.title), player.name] : [player.name]
+        player.title ? [h('span.utitle', player.title), player.name] : [player.name],
       )
     : h(
         'anonymous',
@@ -87,5 +87,5 @@ export const playerLink = (player: PlayerWithScore, isMe: boolean) =>
             title: 'Anonymous player',
           },
         },
-        [player.name, isMe ? ' (you)' : undefined]
+        [player.name, isMe ? ' (you)' : undefined],
       );

--- a/ui/round/css/_zh.scss
+++ b/ui/round/css/_zh.scss
@@ -73,7 +73,9 @@
 @each $color, $c in ('white': w, 'black': b) {
   @each $role, $r in (pawn: P, knight: N, bishop: B, rook: R, queen: Q) {
     body.cursor-#{$color}-#{$role} * {
-      cursor: url(../piece/cburnett/#{$c}#{$r}.svg) 22 22, auto !important;
+      cursor:
+        url(../piece/cburnett/#{$c}#{$r}.svg) 22 22,
+        auto !important;
     }
   }
 }

--- a/ui/round/src/boot.ts
+++ b/ui/round/src/boot.ts
@@ -30,7 +30,7 @@ export default async function (opts: RoundOpts, roundMain: (opts: RoundOpts, nvu
               ? [o.player.title, o.player.name, data.pref.ratings ? o.player.rating : '']
                   .filter(x => x)
                   .join('&nbsp')
-              : 'Anonymous'
+              : 'Anonymous',
           );
       },
       endData() {
@@ -72,7 +72,7 @@ export default async function (opts: RoundOpts, roundMain: (opts: RoundOpts, nvu
 
   const round: RoundApi = roundMain(
     opts,
-    lichess.blindMode ? await lichess.loadEsm<NvuiPlugin>('round.nvui') : undefined
+    lichess.blindMode ? await lichess.loadEsm<NvuiPlugin>('round.nvui') : undefined,
   );
   const chatOpts = opts.chat;
   if (chatOpts) {

--- a/ui/round/src/clock/clockCtrl.ts
+++ b/ui/round/src/clock/clockCtrl.ts
@@ -76,7 +76,10 @@ export class ClockController {
 
   private tickCallback?: number;
 
-  constructor(d: RoundData, readonly opts: ClockOpts) {
+  constructor(
+    d: RoundData,
+    readonly opts: ClockOpts,
+  ) {
     const cdata = d.clock!;
 
     if (cdata.showTenths === Prefs.ShowClockTenths.Never) this.showTenths = () => false;
@@ -132,7 +135,7 @@ export class ClockController {
       this.tick,
       // changing the value of active node confuses the chromevox screen reader
       // so update the clock less often
-      this.opts.nvui ? 1000 : (time % (this.showTenths(time) ? 100 : 500)) + 1 + extraDelay
+      this.opts.nvui ? 1000 : (time % (this.showTenths(time) ? 100 : 500)) + 1 + extraDelay,
     );
   };
 

--- a/ui/round/src/clock/clockView.ts
+++ b/ui/round/src/clock/clockView.ts
@@ -53,7 +53,7 @@ export function renderClock(ctrl: RoundController, player: game.Player, position
           renderBerserk(ctrl, player.color, position),
           isPlayer ? goBerserk(ctrl) : button.moretime(ctrl),
           tourRank(ctrl, player.color, position),
-        ]
+        ],
   );
 }
 
@@ -158,7 +158,7 @@ const tourRank = (ctrl: RoundController, color: Color, position: Position) => {
         {
           attrs: { title: 'Current tournament rank' },
         },
-        '#' + ranks[color]
+        '#' + ranks[color],
       )
     : null;
 };

--- a/ui/round/src/corresClock/corresClockCtrl.ts
+++ b/ui/round/src/corresClock/corresClockCtrl.ts
@@ -27,7 +27,7 @@ interface Times {
 export function ctrl(
   root: RoundController,
   data: CorresClockData,
-  onFlag: () => void
+  onFlag: () => void,
 ): CorresClockController {
   const timePercentDivisor = 0.1 / data.increment;
 

--- a/ui/round/src/corresClock/corresClockView.ts
+++ b/ui/round/src/corresClock/corresClockView.ts
@@ -37,7 +37,7 @@ export default function (
   trans: Trans,
   color: Color,
   position: Position,
-  runningColor: Color
+  runningColor: Color,
 ) {
   const millis = ctrl.millisOf(color),
     update = (el: HTMLElement) => {
@@ -69,6 +69,6 @@ export default function (
         },
       }),
       isPlayer ? null : moretime(ctrl.root),
-    ]
+    ],
   );
 }

--- a/ui/round/src/crazy/crazyCtrl.ts
+++ b/ui/round/src/crazy/crazyCtrl.ts
@@ -108,7 +108,7 @@ export function init(ctrl: RoundController) {
           }
         }
       },
-      'keyup'
+      'keyup',
     );
   }
 
@@ -127,7 +127,7 @@ export function init(ctrl: RoundController) {
     e => {
       if (e.target && (e.target as HTMLElement).localName === 'input') resetKeys();
     },
-    { capture: true }
+    { capture: true },
   );
 
   if (lichess.storage.get('crazyKeyHist') !== '0') preloadMouseIcons(ctrl.data);

--- a/ui/round/src/crazy/crazyView.ts
+++ b/ui/round/src/crazy/crazyView.ts
@@ -27,8 +27,8 @@ export default function pocket(ctrl: RoundController, color: Color, position: Po
         eventNames.forEach(name =>
           el.addEventListener(name, (e: cg.MouchEvent) => {
             if (position === (ctrl.flip ? 'top' : 'bottom') && crazyKeys.length == 0) drag(ctrl, e);
-          })
-        )
+          }),
+        ),
       ),
     },
     pieceRoles.map(role => {
@@ -48,9 +48,9 @@ export default function pocket(ctrl: RoundController, color: Color, position: Po
               'data-color': color,
               'data-nb': nb,
             },
-          })
-        )
+          }),
+        ),
       );
-    })
+    }),
   );
 }

--- a/ui/round/src/ctrl.ts
+++ b/ui/round/src/ctrl.ts
@@ -92,7 +92,11 @@ export default class RoundController {
   sign: string = Math.random().toString(36);
   keyboardHelp: boolean = location.hash === '#keyboard';
 
-  constructor(readonly opts: RoundOpts, readonly redraw: Redraw, readonly nvui?: NvuiPlugin) {
+  constructor(
+    readonly opts: RoundOpts,
+    readonly redraw: Redraw,
+    readonly nvui?: NvuiPlugin,
+  ) {
     round.massage(opts.data);
 
     const d = (this.data = opts.data);
@@ -126,7 +130,7 @@ export default class RoundController {
         xhr.reload(this).then(this.reload, lichess.reload);
       },
       this.redraw,
-      d.pref.autoQueen
+      d.pref.autoQueen,
     );
 
     this.setQuietMode();
@@ -199,7 +203,7 @@ export default class RoundController {
         show: this.voiceMove?.promotionHook(),
       },
       meta,
-      this.keyboardMove?.justSelected()
+      this.keyboardMove?.justSelected(),
     );
 
   private onPremove = (orig: cg.Key, dest: cg.Key, meta: cg.MoveMetadata) =>
@@ -424,7 +428,7 @@ export default class RoundController {
             role: o.role,
             color: playedColor,
           },
-          o.uci.slice(2, 4) as cg.Key
+          o.uci.slice(2, 4) as cg.Key,
         );
       else {
         // This block needs to be idempotent, even for castling moves in
@@ -636,7 +640,7 @@ export default class RoundController {
       lichess.quietMode = is;
       $('body').toggleClass(
         'no-select',
-        is && this.clock && this.clock.millisOf(this.data.player.color) <= 3e5
+        is && this.clock && this.clock.millisOf(this.data.player.color) <= 3e5,
       );
     }
   };
@@ -679,7 +683,7 @@ export default class RoundController {
 
   opponentRequest(req: string, i18nKey: string) {
     this.voiceMove?.listenForResponse(req, (v: boolean) =>
-      this.socket.sendLoading(`${req}-${v ? 'yes' : 'no'}`)
+      this.socket.sendLoading(`${req}-${v ? 'yes' : 'no'}`),
     );
     notify(this.noarg(i18nKey));
   }

--- a/ui/round/src/moveOn.ts
+++ b/ui/round/src/moveOn.ts
@@ -5,7 +5,10 @@ import RoundController from './ctrl';
 export default class MoveOn {
   private storage = lichess.storage.boolean(this.key);
 
-  constructor(private ctrl: RoundController, private key: string) {}
+  constructor(
+    private ctrl: RoundController,
+    private key: string,
+  ) {}
 
   toggle = () => {
     this.storage.toggle();

--- a/ui/round/src/plugins/nvui.ts
+++ b/ui/round/src/plugins/nvui.ts
@@ -78,7 +78,7 @@ export function initModule(): NvuiPlugin {
             animation: { enabled: false },
             drawable: { enabled: false },
             coordinates: false,
-          })
+          }),
         );
         if (variantNope) setTimeout(() => notify.set(variantNope), 3000);
       }
@@ -91,7 +91,7 @@ export function initModule(): NvuiPlugin {
           h('h1', gameText(ctrl)),
           h('h2', 'Game info'),
           ...['white', 'black'].map((color: Color) =>
-            h('p', [color + ' player: ', playerHtml(ctrl, ctrl.playerByColor(color))])
+            h('p', [color + ' player: ', playerHtml(ctrl, ctrl.playerByColor(color))]),
           ),
           h('p', `${d.game.rated ? 'Rated' : 'Casual'} ${d.game.perf}`),
           d.clock ? h('p', `Clock: ${d.clock.initial / 60} + ${d.clock.increment}`) : null,
@@ -104,7 +104,7 @@ export function initModule(): NvuiPlugin {
                 'aria-live': 'off',
               },
             },
-            renderMoves(d.steps.slice(1), style)
+            renderMoves(d.steps.slice(1), style),
           ),
           h('h2', 'Pieces'),
           h('div.pieces', renderPieces(ctrl.chessground.state.pieces, style)),
@@ -118,7 +118,7 @@ export function initModule(): NvuiPlugin {
                 'aria-atomic': 'true',
               },
             },
-            [ctrl.data.game.status.name === 'started' ? 'Playing' : renderResult(ctrl)]
+            [ctrl.data.game.status.name === 'started' ? 'Playing' : renderResult(ctrl)],
           ),
           h('h2', 'Last move'),
           h(
@@ -130,7 +130,7 @@ export function initModule(): NvuiPlugin {
               },
             },
             // make sure consecutive moves are different so that they get re-read
-            renderSan(step.san, step.uci, style) + (ctrl.ply % 2 === 0 ? '' : ' ')
+            renderSan(step.san, step.uci, style) + (ctrl.ply % 2 === 0 ? '' : ' '),
           ),
           ...(ctrl.isPlaying()
             ? [
@@ -160,7 +160,7 @@ export function initModule(): NvuiPlugin {
                         },
                       }),
                     ]),
-                  ]
+                  ],
                 ),
               ]
             : []),
@@ -186,7 +186,7 @@ export function initModule(): NvuiPlugin {
                 const $buttons = $board.find('button');
                 $buttons.on(
                   'click',
-                  selectionHandler(() => ctrl.data.opponent.color, selectSound)
+                  selectionHandler(() => ctrl.data.opponent.color, selectSound),
                 );
                 $buttons.on('keydown', arrowKeyHandler(ctrl.data.player.color, borderSound));
                 $buttons.on('keypress', boardCommandsHandler());
@@ -195,8 +195,8 @@ export function initModule(): NvuiPlugin {
                   lastCapturedCommandHandler(
                     () => ctrl.data.steps.map(step => step.fen),
                     pieceStyle.get(),
-                    prefixStyle.get()
-                  )
+                    prefixStyle.get(),
+                  ),
                 );
                 $buttons.on(
                   'keypress',
@@ -207,8 +207,8 @@ export function initModule(): NvuiPlugin {
                     () => ctrl.chessground.state.pieces,
                     ctrl.data.game.variant.key,
                     () => ctrl.chessground.state.movable.dests,
-                    () => ctrl.data.steps
-                  )
+                    () => ctrl.data.steps,
+                  ),
                 );
                 $buttons.on('keypress', positionJumpHandler());
                 $buttons.on('keypress', pieceJumpingHandler(selectSound, errorSound));
@@ -220,8 +220,8 @@ export function initModule(): NvuiPlugin {
               pieceStyle.get(),
               prefixStyle.get(),
               positionStyle.get(),
-              boardStyle.get()
-            )
+              boardStyle.get(),
+            ),
           ),
           h(
             'div.boardstatus',
@@ -231,7 +231,7 @@ export function initModule(): NvuiPlugin {
                 'aria-atomic': 'true',
               },
             },
-            ''
+            '',
           ),
           // h('p', takes(ctrl.data.steps.map(data => data.fen))),
           h('h2', 'Settings'),
@@ -295,7 +295,7 @@ export function initModule(): NvuiPlugin {
             h('br'),
             'Omission results in promotion to queen',
           ]),
-        ]
+        ],
       );
     },
   };
@@ -305,7 +305,7 @@ function createSubmitHandler(
   ctrl: RoundController,
   notify: (txt: string) => void,
   style: () => Style,
-  $input: Cash
+  $input: Cash,
 ) {
   return (submitStoredPremove = false) => {
     const nvui = ctrl.nvui!;
@@ -375,7 +375,7 @@ function onCommand(ctrl: RoundController, notify: (txt: string) => void, c: stri
     notify(
       commands.piece.apply(c, pieces, style) ||
         commands.scan.apply(c, pieces, style) ||
-        `Invalid command: ${c}`
+        `Invalid command: ${c}`,
     );
   }
 }
@@ -422,7 +422,7 @@ function playerHtml(ctrl: RoundController, player: game.Player) {
           {
             attrs: { href: '/@/' + user.username },
           },
-          user.title ? `${user.title} ${user.username}` : user.username
+          user.title ? `${user.title} ${user.username}` : user.username,
         ),
         rating ? ` ${rating}` : ``,
         ' ' + ratingDiff,

--- a/ui/round/src/socket.ts
+++ b/ui/round/src/socket.ts
@@ -149,7 +149,7 @@ export function make(send: SocketSend, ctrl: RoundController): RoundSocket {
       lichess.loadCssPath('modal');
       modal({
         content: $(
-          `<div><p>Simul complete!</p><br /><br /><a class="button" href="/simul/${simul.id}">Back to ${simul.name} simul</a></div>`
+          `<div><p>Simul complete!</p><br /><br /><a class="button" href="/simul/${simul.id}">Back to ${simul.name} simul</a></div>`,
         ),
       });
     },

--- a/ui/round/src/title.ts
+++ b/ui/round/src/title.ts
@@ -12,7 +12,7 @@ const F = ['/assets/logo/lichess-favicon-32.png', '/assets/logo/lichess-favicon-
       (document.getElementById('favicon') as HTMLAnchorElement).href = path;
       curFaviconIdx = i;
     }
-  }
+  },
 );
 
 let tickerTimer: Timeout | undefined;

--- a/ui/round/src/tourStanding.ts
+++ b/ui/round/src/tourStanding.ts
@@ -11,7 +11,7 @@ export interface TourStandingCtrl extends ChatPlugin {
 export const tourStandingCtrl = (
   players: TourPlayer[],
   team: Team | undefined,
-  name: string
+  name: string,
 ): TourStandingCtrl => ({
   set(d: TourPlayer[]) {
     players = d;
@@ -33,7 +33,7 @@ export const tourStandingCtrl = (
               {
                 attrs: { 'data-icon': licon.Group },
               },
-              team.name
+              team.name,
             )
           : null,
         h('table.slist', [
@@ -48,7 +48,7 @@ export const tourStandingCtrl = (
                     {
                       attrs: { href: `/@/${p.n}` },
                     },
-                    (p.t ? p.t + ' ' : '') + p.n
+                    (p.t ? p.t + ' ' : '') + p.n,
                   ),
                 ]),
                 h(
@@ -59,13 +59,13 @@ export const tourStandingCtrl = (
                         attrs: { 'data-icon': licon.Fire },
                       }
                     : {},
-                  '' + p.s
+                  '' + p.s,
                 ),
               ]);
-            })
+            }),
           ),
         ]),
-      ]
+      ],
     );
   },
 });

--- a/ui/round/src/view/boardMenu.ts
+++ b/ui/round/src/view/boardMenu.ts
@@ -26,12 +26,12 @@ export default function (ctrl: RoundController) {
         h(
           'a',
           { attrs: { target: '_blank', href: '/account/preferences/display' } },
-          'Game display preferences'
+          'Game display preferences',
         ),
         h(
           'a',
           { attrs: { target: '_blank', href: '/account/preferences/game-behavior ' } },
-          'Game behavior preferences'
+          'Game behavior preferences',
         ),
       ]),
     ];

--- a/ui/round/src/view/button.ts
+++ b/ui/round/src/view/button.ts
@@ -36,7 +36,7 @@ function analysisButton(ctrl: RoundController): VNode | null {
             if (location.pathname === url.split('#')[0]) location.reload();
           }),
         },
-        ctrl.noarg('analysis')
+        ctrl.noarg('analysis'),
       )
     : null;
 }
@@ -59,7 +59,7 @@ function rematchButtons(ctrl: RoundController): MaybeVNodes {
             },
             hook: util.bind('click', () => ctrl.socket.send('rematch-no')),
           },
-          ctrl.nvui ? noarg('decline') : ''
+          ctrl.nvui ? noarg('decline') : '',
         )
       : null,
     h(
@@ -87,10 +87,10 @@ function rematchButtons(ctrl: RoundController): MaybeVNodes {
               if (!disabled && !d.opponent.onGame) ctrl.challengeRematch();
             }
           },
-          ctrl.redraw
+          ctrl.redraw,
         ),
       },
-      [me ? spinner() : h('span', noarg('rematch'))]
+      [me ? spinner() : h('span', noarg('rematch'))],
     ),
   ];
 }
@@ -101,7 +101,7 @@ export function standard(
   icon: string,
   hint: string,
   socketMsg: string,
-  onclick?: () => void
+  onclick?: () => void,
 ): VNode {
   // disabled if condition callback is provided and is falsy
   const enabled = () => !condition || condition(ctrl.data).enabled;
@@ -117,7 +117,7 @@ export function standard(
         if (enabled()) onclick ? onclick() : ctrl.socket.sendLoading(socketMsg);
       }),
     },
-    [h('span', ctrl.nvui ? [ctrl.noarg(hintFn())] : util.justIcon(icon))]
+    [h('span', ctrl.nvui ? [ctrl.noarg(hintFn())] : util.justIcon(icon))],
   );
 }
 
@@ -132,14 +132,14 @@ export function opponentGone(ctrl: RoundController) {
           {
             hook: util.bind('click', () => ctrl.socket.sendLoading('resign-force')),
           },
-          ctrl.noarg('forceResignation')
+          ctrl.noarg('forceResignation'),
         ),
         h(
           'button.button',
           {
             hook: util.bind('click', () => ctrl.socket.sendLoading('draw-force')),
           },
-          ctrl.noarg('forceDraw')
+          ctrl.noarg('forceDraw'),
         ),
       ])
     : gone
@@ -178,7 +178,7 @@ export const claimThreefold = (ctrl: RoundController, condition: (d: RoundData) 
     'button.button.draw-yes',
     {
       hook: util.bind('click', () =>
-        condition(ctrl.data).enabled ? ctrl.socket.sendLoading('draw-claim') : undefined
+        condition(ctrl.data).enabled ? ctrl.socket.sendLoading('draw-claim') : undefined,
       ),
       attrs: {
         title: ctrl.noarg(condition(ctrl.data)?.overrideHint || 'claimADraw'),
@@ -188,7 +188,7 @@ export const claimThreefold = (ctrl: RoundController, condition: (d: RoundData) 
         disabled: !condition(ctrl.data).enabled,
       },
     },
-    h('span', '½')
+    h('span', '½'),
   );
 
 export function threefoldSuggestion(ctrl: RoundController) {
@@ -199,7 +199,7 @@ export function threefoldSuggestion(ctrl: RoundController) {
           {
             hook: onSuggestionHook,
           },
-          ctrl.noarg('threefoldRepetition')
+          ctrl.noarg('threefoldRepetition'),
         ),
       ])
     : null;
@@ -233,7 +233,7 @@ export function backToTournament(ctrl: RoundController): VNode | undefined {
             },
             hook: util.bind('click', ctrl.setRedirecting),
           },
-          ctrl.noarg('backToTournament')
+          ctrl.noarg('backToTournament'),
         ),
         h(
           'form',
@@ -243,7 +243,7 @@ export function backToTournament(ctrl: RoundController): VNode | undefined {
               action: '/tournament/' + d.tournament.id + '/withdraw',
             },
           },
-          [h('button.text.fbt.weak', util.justIcon(licon.Pause), 'Pause')]
+          [h('button.text.fbt.weak', util.justIcon(licon.Pause), 'Pause')],
         ),
         analysisButton(ctrl),
       ])
@@ -263,7 +263,7 @@ export function backToSwiss(ctrl: RoundController): VNode | undefined {
             },
             hook: util.bind('click', ctrl.setRedirecting),
           },
-          ctrl.noarg('backToTournament')
+          ctrl.noarg('backToTournament'),
         ),
         analysisButton(ctrl),
       ])
@@ -305,7 +305,7 @@ export function followUp(ctrl: RoundController): VNode {
           {
             attrs: { href: '/tournament/' + d.tournament.id },
           },
-          ctrl.noarg('viewTournament')
+          ctrl.noarg('viewTournament'),
         )
       : null,
     d.swiss
@@ -314,7 +314,7 @@ export function followUp(ctrl: RoundController): VNode {
           {
             attrs: { href: '/swiss/' + d.swiss.id },
           },
-          ctrl.noarg('viewTournament')
+          ctrl.noarg('viewTournament'),
         )
       : null,
     newable
@@ -326,7 +326,7 @@ export function followUp(ctrl: RoundController): VNode {
                 d.game.source === 'pool' ? poolUrl(d.clock!, d.opponent.user) : '/?hook_like=' + d.game.id,
             },
           },
-          ctrl.noarg('newOpponent')
+          ctrl.noarg('newOpponent'),
         )
       : null,
     analysisButton(ctrl),
@@ -344,7 +344,7 @@ export function watcherFollowUp(ctrl: RoundController): VNode | null {
                 href: `/${d.game.rematch}/${d.opponent.color}`,
               },
             },
-            ctrl.noarg('viewRematch')
+            ctrl.noarg('viewRematch'),
           )
         : null,
       d.tournament
@@ -353,7 +353,7 @@ export function watcherFollowUp(ctrl: RoundController): VNode | null {
             {
               attrs: { href: '/tournament/' + d.tournament.id },
             },
-            ctrl.noarg('viewTournament')
+            ctrl.noarg('viewTournament'),
           )
         : null,
       d.swiss
@@ -362,7 +362,7 @@ export function watcherFollowUp(ctrl: RoundController): VNode | null {
             {
               attrs: { href: '/swiss/' + d.swiss.id },
             },
-            ctrl.noarg('viewTournament')
+            ctrl.noarg('viewTournament'),
           )
         : null,
       analysisButton(ctrl),

--- a/ui/round/src/view/expiration.ts
+++ b/ui/round/src/view/expiration.ts
@@ -25,6 +25,6 @@ export default function (ctrl: RoundController): MaybeVNode {
         'bar-glider': myTurn,
       },
     },
-    ctrl.trans.vdomPlural('nbSecondsToPlayTheFirstMove', secondsLeft, h('strong', '' + secondsLeft))
+    ctrl.trans.vdomPlural('nbSecondsToPlayTheFirstMove', secondsLeft, h('strong', '' + secondsLeft)),
   );
 }

--- a/ui/round/src/view/main.ts
+++ b/ui/round/src/view/main.ts
@@ -20,7 +20,7 @@ export function main(ctrl: RoundController): VNode {
       ctrl.stepAt(ctrl.ply).fen,
       !!(ctrl.data.player.checks || ctrl.data.opponent.checks), // showChecks
       ctrl.data.steps,
-      ctrl.ply
+      ctrl.ply,
     );
 
   return ctrl.nvui
@@ -43,10 +43,10 @@ export function main(ctrl: RoundController): VNode {
                       }
                     }),
                     undefined,
-                    false
+                    false,
                   ),
           },
-          [renderGround(ctrl), ctrl.promotion.view(ctrl.data.game.variant.key === 'antichess')]
+          [renderGround(ctrl), ctrl.promotion.view(ctrl.data.game.variant.key === 'antichess')],
         ),
         ctrl.voiceMove ? renderVoiceBar(ctrl.voiceMove.ui, ctrl.redraw) : null,
         ctrl.keyboardHelp ? keyboard.view(ctrl) : null,

--- a/ui/round/src/view/replay.ts
+++ b/ui/round/src/view/replay.ts
@@ -39,7 +39,7 @@ const autoScroll = throttle(100, (movesEl: HTMLElement, ctrl: RoundController) =
       else if (isCol1()) movesEl.scrollLeft = st;
       else movesEl.scrollTop = st;
     }
-  })
+  }),
 );
 
 const renderDrawOffer = () =>
@@ -50,7 +50,7 @@ const renderDrawOffer = () =>
         title: 'Draw offer',
       },
     },
-    '½?'
+    '½?',
   );
 
 const renderMove = (step: Step, curPly: number, orEmpty: boolean, drawOffers: Set<number>) =>
@@ -65,7 +65,7 @@ const renderMove = (step: Step, curPly: number, orEmpty: boolean, drawOffers: Se
         [
           step.san[0] === 'P' ? step.san.slice(1) : step.san,
           drawOffers.has(step.ply) ? renderDrawOffer() : undefined,
-        ]
+        ],
       )
     : orEmpty
     ? h(moveTag, '…')
@@ -95,7 +95,7 @@ export function renderResult(ctrl: RoundController): VNode | undefined {
             else setTimeout(() => ctrl.autoScroll(), 200);
           }),
         },
-        viewStatus(ctrl)
+        viewStatus(ctrl),
       ),
     ]);
   }
@@ -146,7 +146,7 @@ export function analysisButton(ctrl: RoundController): VNode | undefined {
             'data-icon': licon.Microscope,
           },
         },
-        forecastCount ? ['' + forecastCount] : []
+        forecastCount ? ['' + forecastCount] : [],
       )
     : undefined;
 }
@@ -166,7 +166,7 @@ function renderButtons(ctrl: RoundController) {
           const ply = parseInt(target.getAttribute('data-ply') || '');
           if (!isNaN(ply)) ctrl.userJump(ply);
         },
-        ctrl.redraw
+        ctrl.redraw,
       ),
     },
     [
@@ -188,7 +188,7 @@ function renderButtons(ctrl: RoundController) {
         });
       }),
       boardMenuToggleButton(ctrl.menu, ctrl.noarg('menu')),
-    ]
+    ],
   );
 }
 
@@ -246,7 +246,7 @@ export function render(ctrl: RoundController): VNode | undefined {
             ctrl.autoScroll();
           }),
         },
-        renderMoves(ctrl)
+        renderMoves(ctrl),
       );
   const renderMovesOrResult = moves ? moves : renderResult(ctrl);
   return ctrl.nvui

--- a/ui/round/src/view/table.ts
+++ b/ui/round/src/view/table.ts
@@ -62,7 +62,7 @@ export const renderTablePlay = (ctrl: RoundController) => {
                   licon.Back,
                   'proposeATakeback',
                   'takeback-yes',
-                  ctrl.takebackYes
+                  ctrl.takebackYes,
                 ),
             ctrl.drawConfirm
               ? button.drawConfirm(ctrl)
@@ -83,7 +83,7 @@ export const renderTablePlay = (ctrl: RoundController) => {
                   licon.OneHalf,
                   'offerDraw',
                   'draw-yes',
-                  () => ctrl.offerDraw(true)
+                  () => ctrl.offerDraw(true),
                 ),
             ctrl.resignConfirm
               ? button.resignConfirm(ctrl)
@@ -93,7 +93,7 @@ export const renderTablePlay = (ctrl: RoundController) => {
                   licon.FlagOutline,
                   'resign',
                   'resign',
-                  () => ctrl.resign(true)
+                  () => ctrl.resign(true),
                 ),
             replay.analysisButton(ctrl),
             boardMenuToggleButton(ctrl.menu, ctrl.noarg('menu')),
@@ -109,7 +109,7 @@ export const renderTablePlay = (ctrl: RoundController) => {
         {
           class: { confirm: !!(ctrl.drawConfirm || ctrl.resignConfirm) },
         },
-        icons
+        icons,
       ),
       ...buttons,
     ]),
@@ -125,7 +125,7 @@ function whosTurn(ctrl: RoundController, color: Color, position: Position) {
           'div.rclock-turn__text',
           d.player.spectator
             ? ctrl.trans(d.game.player + 'Plays')
-            : ctrl.trans(d.game.player === d.player.color ? 'yourTurn' : 'waitingForOpponent')
+            : ctrl.trans(d.game.player === d.player.color ? 'yourTurn' : 'waitingForOpponent'),
         )
       : null,
   ]);

--- a/ui/round/src/view/user.ts
+++ b/ui/round/src/view/user.ts
@@ -59,7 +59,7 @@ export function userHtml(ctrl: RoundController, player: Player, position: Positi
                 ' ',
                 user.username,
               ]
-            : [user.username]
+            : [user.username],
         ),
         rating ? h('rating', rating + (player.provisional ? '?' : '')) : null,
         rating ? ratingDiff : null,
@@ -71,7 +71,7 @@ export function userHtml(ctrl: RoundController, player: Player, position: Positi
               },
             })
           : null,
-      ]
+      ],
     );
   }
   const connecting = !player.onGame && ctrl.firstSeconds;
@@ -91,7 +91,7 @@ export function userHtml(ctrl: RoundController, player: Player, position: Positi
         },
       }),
       h('name', player.name || ctrl.noarg('anonymous')),
-    ]
+    ],
   );
 }
 

--- a/ui/round/src/xhr.ts
+++ b/ui/round/src/xhr.ts
@@ -27,5 +27,5 @@ export const setZen = throttlePromiseDelay(
     xhr.text('/pref/zen', {
       method: 'post',
       body: xhr.form({ zen: zen ? 1 : 0 }),
-    })
+    }),
 );

--- a/ui/serviceWorker/src/main.ts
+++ b/ui/serviceWorker/src/main.ts
@@ -17,7 +17,7 @@ self.addEventListener('push', event => {
       tag: data.tag,
       data: data.payload,
       requireInteraction: true,
-    })
+    }),
   );
 });
 

--- a/ui/simul/src/ctrl.ts
+++ b/ui/simul/src/ctrl.ts
@@ -7,7 +7,10 @@ export default class SimulCtrl {
   trans: Trans;
   socket: SimulSocket;
 
-  constructor(readonly opts: SimulOpts, readonly redraw: () => void) {
+  constructor(
+    readonly opts: SimulOpts,
+    readonly redraw: () => void,
+  ) {
     this.data = opts.data;
     this.trans = lichess.trans(opts.i18n);
     this.socket = makeSocket(opts.socketSend, this);
@@ -24,7 +27,7 @@ export default class SimulCtrl {
       },
       () => {
         hostIsAround = true;
-      }
+      },
     );
     setInterval(() => {
       if (this.data.isCreated && hostIsAround) xhr.ping(this.data.id);

--- a/ui/simul/src/view/created.ts
+++ b/ui/simul/src/view/created.ts
@@ -38,7 +38,7 @@ export default function (showText: (ctrl: SimulCtrl) => MaybeVNode) {
                   {
                     hook: bind('click', () => xhr.withdraw(ctrl.data.id)),
                   },
-                  ctrl.trans('withdraw')
+                  ctrl.trans('withdraw'),
                 )
               : h(
                   'a.button.text' + (canJoin ? '' : '.disabled'),
@@ -65,7 +65,7 @@ export default function (showText: (ctrl: SimulCtrl) => MaybeVNode) {
                         })
                       : {},
                   },
-                  ctrl.trans('join')
+                  ctrl.trans('join'),
                 )
             : h(
                 'a.button.text',
@@ -75,8 +75,8 @@ export default function (showText: (ctrl: SimulCtrl) => MaybeVNode) {
                     href: '/login?referrer=' + window.location.pathname,
                   },
                 },
-                ctrl.trans('signIn')
-              )
+                ctrl.trans('signIn'),
+              ),
         ),
       ]),
       showText(ctrl),
@@ -108,9 +108,9 @@ export default function (showText: (ctrl: SimulCtrl) => MaybeVNode) {
                     {
                       attrs: { colspan: 3 },
                     },
-                    [h('strong', candidates.length), ' candidate players']
-                  )
-                )
+                    [h('strong', candidates.length), ' candidate players'],
+                  ),
+                ),
               ),
               h(
                 'tbody',
@@ -138,13 +138,13 @@ export default function (showText: (ctrl: SimulCtrl) => MaybeVNode) {
                                 hook: bind('click', () => xhr.accept(applicant.player.id)(ctrl.data.id)),
                               }),
                             ]
-                          : []
+                          : [],
                       ),
-                    ]
+                    ],
                   );
-                })
-              )
-            )
+                }),
+              ),
+            ),
           ),
           h('div.half.accepted', [
             h(
@@ -157,8 +157,8 @@ export default function (showText: (ctrl: SimulCtrl) => MaybeVNode) {
                     {
                       attrs: { colspan: 3 },
                     },
-                    [h('strong', accepted.length), ' accepted players']
-                  )
+                    [h('strong', accepted.length), ' accepted players'],
+                  ),
                 ),
                 isHost && candidates.length && !accepted.length
                   ? [h('tr.help', h('th', 'Now you get to accept some players, then start the simul'))]
@@ -189,15 +189,15 @@ export default function (showText: (ctrl: SimulCtrl) => MaybeVNode) {
                                 hook: bind('click', () => xhr.reject(applicant.player.id)(ctrl.data.id)),
                               }),
                             ]
-                          : []
+                          : [],
                       ),
-                    ]
+                    ],
                   );
-                })
-              )
+                }),
+              ),
             ),
           ]),
-        ]
+        ],
       ),
       ctrl.data.quote
         ? h('blockquote.pull-quote', [h('p', ctrl.data.quote.text), h('footer', ctrl.data.quote.author)])
@@ -212,9 +212,9 @@ export default function (showText: (ctrl: SimulCtrl) => MaybeVNode) {
                 'data-variant': variant.key,
               },
             },
-            variant.name
-          )
-        )
+            variant.name,
+          ),
+        ),
       ),
     ];
   };
@@ -236,7 +236,7 @@ const randomButton = (ctrl: SimulCtrl) =>
             xhr.accept(randomCandidate.player.id)(ctrl.data.id);
           }),
         },
-        'Accept random candidate'
+        'Accept random candidate',
       )
     : null;
 
@@ -250,7 +250,7 @@ const startOrCancel = (ctrl: SimulCtrl, accepted: Applicant[]) =>
           },
           hook: bind('click', () => xhr.start(ctrl.data.id)),
         },
-        `Start (${accepted.length})`
+        `Start (${accepted.length})`,
       )
     : h(
         'a.button.button-red.text',
@@ -262,5 +262,5 @@ const startOrCancel = (ctrl: SimulCtrl, accepted: Applicant[]) =>
             if (confirm('Delete this simul?')) xhr.abort(ctrl.data.id);
           }),
         },
-        ctrl.trans('cancel')
+        ctrl.trans('cancel'),
       );

--- a/ui/simul/src/view/main.ts
+++ b/ui/simul/src/view/main.ts
@@ -36,12 +36,12 @@ export default function (ctrl: SimulCtrl) {
             },
           },
         },
-        handler(ctrl)
+        handler(ctrl),
       ),
       h('div.chat__members.none', {
         hook: onInsert(lichess.watchers),
       }),
-    ]
+    ],
   );
 }
 

--- a/ui/simul/src/view/pairings.ts
+++ b/ui/simul/src/view/pairings.ts
@@ -36,7 +36,7 @@ const miniPairing = (ctrl: SimulCtrl) => (pairing: Pairing) => {
           [
             h('span.name', player.title ? [h('span.utitle', player.title), ' ', player.name] : [player.name]),
             ...(ctrl.opts.showRatings ? [' ', h('span.rating', player.rating)] : []),
-          ]
+          ],
         ),
         game.clock
           ? renderClock(opposite(game.orient), game.clock[opposite(game.orient)])
@@ -53,6 +53,6 @@ const miniPairing = (ctrl: SimulCtrl) => (pairing: Pairing) => {
           ? renderClock(game.orient, game.clock[game.orient])
           : h('span.mini-game__result', game.winner ? (game.winner == game.orient ? 1 : 0) : '½'),
       ]),
-    ]
+    ],
   );
 };

--- a/ui/simul/src/view/results.ts
+++ b/ui/simul/src/view/results.ts
@@ -8,19 +8,19 @@ export default function (ctrl: SimulCtrl) {
   return h('div.results', [
     h(
       'div',
-      trans(ctrl, 'nbPlaying', p => p.game.status < status.ids.aborted)
+      trans(ctrl, 'nbPlaying', p => p.game.status < status.ids.aborted),
     ),
     h(
       'div',
-      trans(ctrl, 'nbWins', p => p.game.winner === p.hostColor)
+      trans(ctrl, 'nbWins', p => p.game.winner === p.hostColor),
     ),
     h(
       'div',
-      trans(ctrl, 'nbDraws', p => p.game.status >= status.ids.mate && !p.game.winner)
+      trans(ctrl, 'nbDraws', p => p.game.status >= status.ids.mate && !p.game.winner),
     ),
     h(
       'div',
-      trans(ctrl, 'nbLosses', p => p.game.winner === opposite(p.hostColor))
+      trans(ctrl, 'nbLosses', p => p.game.winner === opposite(p.hostColor)),
     ),
   ]);
 }

--- a/ui/simul/src/view/util.ts
+++ b/ui/simul/src/view/util.ts
@@ -18,7 +18,7 @@ export function player(p: Player, ctrl: SimulCtrl) {
       h(`i.line${p.patron ? '.patron' : ''}`),
       h('span.name', userName(p)),
       ctrl.opts.showRatings ? h('em', ` ${p.rating}${p.provisional ? '?' : ''}`) : null,
-    ]
+    ],
   );
 }
 

--- a/ui/simul/src/xhr.ts
+++ b/ui/simul/src/xhr.ts
@@ -13,7 +13,7 @@ export default {
   abort: post('abort'),
   join: throttlePromiseDelay(
     () => 4000,
-    (id: string, variant: VariantKey) => post(`join/${variant}`)(id)
+    (id: string, variant: VariantKey) => post(`join/${variant}`)(id),
   ),
   withdraw: post('withdraw'),
   accept: (user: string) => post(`accept/${user}`),

--- a/ui/site/css/_blog.scss
+++ b/ui/site/css/_blog.scss
@@ -233,7 +233,9 @@
     position: relative;
 
     &:hover {
-      box-shadow: 0 0 5px $c-link, 0 0 20px $c-link;
+      box-shadow:
+        0 0 5px $c-link,
+        0 0 20px $c-link;
     }
 
     time {

--- a/ui/site/css/forum/_completion.scss
+++ b/ui/site/css/forum/_completion.scss
@@ -1,6 +1,8 @@
 .forum .textcomplete-dropdown {
   border: 1px solid #ccc;
-  box-shadow: 0 0.5px 5px rgba(0, 0, 0, 0.25), 0 0.5px 8px rgba(0, 0, 0, 0.15);
+  box-shadow:
+    0 0.5px 5px rgba(0, 0, 0, 0.25),
+    0 0.5px 8px rgba(0, 0, 0, 0.15);
   background: #fff;
 
   li {

--- a/ui/site/css/practice/_side.scss
+++ b/ui/site/css/practice/_side.scss
@@ -70,7 +70,9 @@
     background: mix($c-font-clearer, $c-primary, 25%);
     background-image: img-url('grain.png');
     transform: translateX(-100px);
-    animation: animatedBackground 50s linear infinite, animatedBar 1s forwards;
+    animation:
+      animatedBackground 50s linear infinite,
+      animatedBar 1s forwards;
   }
 
   .progress .text {

--- a/ui/site/css/ublog/_card.scss
+++ b/ui/site/css/ublog/_card.scss
@@ -16,7 +16,9 @@
     text-align: left;
 
     &--link:hover {
-      box-shadow: 0 0 5px $c-link, 0 0 20px $c-link;
+      box-shadow:
+        0 0 5px $c-link,
+        0 0 20px $c-link;
     }
 
     &__over-image {

--- a/ui/site/css/user/_trophy.scss
+++ b/ui/site/css/user/_trophy.scss
@@ -94,7 +94,10 @@
   }
 
   &.marathonTopFifty {
-    text-shadow: 0 0 5px #ffae34, 0 0 6.25px #ec760c, 0 0 7.5px #cd4606;
+    text-shadow:
+      0 0 5px #ffae34,
+      0 0 6.25px #ec760c,
+      0 0 7.5px #cd4606;
   }
 
   &.marathonTopHundred {

--- a/ui/site/src/account.ts
+++ b/ui/site/src/account.ts
@@ -38,8 +38,8 @@ lichess.load.then(() => {
   localPrefs.forEach(([categ, name, storeKey, def]) =>
     $(`#ir${categ}_${name}_${lichess.storage.boolean(storeKey).getOrDefault(def) ? 1 : 0}`).prop(
       'checked',
-      true
-    )
+      true,
+    ),
   );
 
   $('form[action="/account/oauth/token/create"]').each(function (this: HTMLFormElement) {

--- a/ui/site/src/captcha.ts
+++ b/ui/site/src/captcha.ts
@@ -47,7 +47,7 @@ function init() {
                       promoted: true,
                     },
                   ],
-                ])
+                ]),
               );
             }
             $captcha.removeClass('success failure');
@@ -70,7 +70,7 @@ function init() {
                 turnColor: cg.state.orientation,
                 movable: { dests },
               }),
-            300
+            300,
           );
       });
     };

--- a/ui/site/src/checkout.ts
+++ b/ui/site/src/checkout.ts
@@ -109,7 +109,7 @@ export default (window as any).checkoutStart = function (stripePublicKey: string
       $('<input type="hidden">')
         .attr('name', name)
         .val($(`input[name=${name}]:checked`).val())
-        .appendTo($currencyForm)
+        .appendTo($currencyForm),
     );
     ($currencyForm[0] as HTMLFormElement).submit();
   });
@@ -199,7 +199,7 @@ function stripeStart(
   $checkout: Cash,
   publicKey: string,
   pricing: Pricing,
-  getAmount: () => number | undefined
+  getAmount: () => number | undefined,
 ) {
   const stripe = window.Stripe(publicKey);
   $checkout.find('.service .stripe').on('click', function () {

--- a/ui/site/src/clas.ts
+++ b/ui/site/src/clas.ts
@@ -45,14 +45,14 @@ lichess.load.then(() => {
                     object: 1,
                     teacher: 1,
                     term,
-                  })
+                  }),
                 )
                 .then(
                   (res: UserCompleteResult) => {
                     const current = currentUserIds();
                     callback(res.result.filter(t => !current.includes(t.id)));
                   },
-                  _ => callback([])
+                  _ => callback([]),
                 );
           },
           template: (o: LightUserOnline) =>

--- a/ui/site/src/coachForm.ts
+++ b/ui/site/src/coachForm.ts
@@ -74,7 +74,7 @@ lichess.load.then(() => {
         .getAttribute('data-value')
         ?.split(',')
         .map(code => whitelist?.find(l => l.code == code))
-        .filter(notNull) as Tagify.TagData[]
+        .filter(notNull) as Tagify.TagData[],
     );
   }
 

--- a/ui/site/src/component/announce.ts
+++ b/ui/site/src/component/announce.ts
@@ -17,7 +17,7 @@ const announce = (d: LichessAnnouncement) => {
           escapeHtml(d.msg) +
           (d.date ? '<time class="timeago" datetime="' + d.date + '"></time>' : '') +
           '<div class="actions"><a class="close">×</a></div>' +
-          '</div>'
+          '</div>',
       )
       .find('#announce .close')
       .on('click', kill);

--- a/ui/site/src/component/assets.ts
+++ b/ui/site/src/component/assets.ts
@@ -19,7 +19,7 @@ export const loadCss = (url: string, media?: 'dark' | 'light'): Promise<void> =>
       url,
       new Promise<void>(resolve => {
         el.onload = () => resolve();
-      })
+      }),
     );
     document.head.append(el);
   }
@@ -31,7 +31,7 @@ export const loadCssPath = async (key: string): Promise<void> => {
   const load = (theme: string, media?: 'dark' | 'light') =>
     loadCss(
       `css/${key}.${document.dir || 'ltr'}.${theme}.${$('body').data('dev') ? 'dev' : 'min'}.css`,
-      media
+      media,
     );
   if (theme === 'system') {
     if (supportsSystemTheme()) {
@@ -54,7 +54,7 @@ export const loadIife = (url: string, opts: AssetUrlOpts = {}): Promise<void> =>
 
 export async function loadEsm<T, ModuleOpts = any>(
   name: string,
-  opts?: { init?: ModuleOpts; url?: AssetUrlOpts }
+  opts?: { init?: ModuleOpts; url?: AssetUrlOpts },
 ): Promise<T> {
   const module = await import(assetUrl(jsModule(name), opts?.url));
   return module.initModule ? module.initModule(opts?.init) : module.default(opts?.init);

--- a/ui/site/src/component/clock-widget.ts
+++ b/ui/site/src/component/clock-widget.ts
@@ -14,7 +14,10 @@ export default function (el: HTMLElement, opts: Opts) {
 class ClockWidget {
   target: number;
   interval: number;
-  constructor(readonly el: HTMLElement, private opts: Opts) {
+  constructor(
+    readonly el: HTMLElement,
+    private opts: Opts,
+  ) {
     this.target = opts.time * 1000 + Date.now();
     if (!opts.pause) this.interval = setInterval(this.render, 1000);
     this.render();

--- a/ui/site/src/component/friends.ts
+++ b/ui/site/src/component/friends.ts
@@ -30,7 +30,7 @@ export default class OnlineFriends {
     this.users = new Map();
     pubsub.on('socket.in.following_onlines', this.receive);
     (['enters', 'leaves', 'playing', 'stopped_playing'] as const).forEach(k =>
-      pubsub.on('socket.in.following_' + k, this[k])
+      pubsub.on('socket.in.following_' + k, this[k]),
     );
   }
   receive = (friends: TitleName[], msg: { playing: string[]; patrons: string[] }) => {
@@ -53,7 +53,7 @@ export default class OnlineFriends {
         this.titleEl.innerHTML = siteTrans.pluralSame(
           'nbFriendsOnline',
           ids.length,
-          this.loaded ? `<strong>${ids.length}</strong>` : '-'
+          this.loaded ? `<strong>${ids.length}</strong>` : '-',
         );
         this.el.querySelector('.nobody')?.classList.toggle('none', !!ids[0]);
         this.el.querySelector('.list')!.innerHTML = ids

--- a/ui/site/src/component/mic.ts
+++ b/ui/site/src/component/mic.ts
@@ -106,7 +106,7 @@ export const mic = new (class implements Voice.Microphone {
       partial?: boolean;
       listener?: Voice.Listener;
       listenerId?: string;
-    } = {}
+    } = {},
   ) {
     if (words.length === 0) {
       this.recs.delete(also.recId);
@@ -268,7 +268,7 @@ export const mic = new (class implements Voice.Microphone {
         this.broadcast(
           e.total <= 0
             ? 'Downloading...'
-            : `Downloaded ${Math.round((100 * e.loaded) / e.total)}% of ${Math.round(e.total / 1000000)}MB`
+            : `Downloaded ${Math.round((100 * e.loaded) / e.total)}% of ${Math.round(e.total / 1000000)}MB`,
         );
       };
 

--- a/ui/site/src/component/mini-game.ts
+++ b/ui/site/src/component/mini-game.ts
@@ -29,7 +29,7 @@ export const init = (node: HTMLElement) => {
           time: parseInt(this.getAttribute('data-time')!),
           pause: color != turnColor || !clockIsRunning(fen, color),
         });
-      })
+      }),
     );
   }
   return node.getAttribute('data-live');

--- a/ui/site/src/component/mousetrap.ts
+++ b/ui/site/src/component/mousetrap.ts
@@ -213,7 +213,7 @@ export default class Mousetrap {
         // Chrome will not fire a keypress if meta or control is down,
         // Safari will fire a keypress if meta or meta+shift is down,
         // Firefox will fire a keypress if meta or control is down
-        ((action == 'keypress' && !e.metaKey && !e.ctrlKey) || modifiersMatch(modifiers, binding.modifiers))
+        ((action == 'keypress' && !e.metaKey && !e.ctrlKey) || modifiersMatch(modifiers, binding.modifiers)),
     );
   };
 }

--- a/ui/site/src/component/powertip.ts
+++ b/ui/site/src/component/powertip.ts
@@ -32,7 +32,7 @@ const userPowertip = (el: HTMLElement, pos?: PowerTip.Placement) =>
             uptA('/@/' + u + '/tv', licon.AnalogTv) +
             uptA('/inbox/new?user=' + u, licon.BubbleSpeech) +
             uptA('/?user=' + u + '#friend', licon.Swords) +
-            '<a class="btn-rack__btn relation-button" disabled></a></div>'
+            '<a class="btn-rack__btn relation-button" disabled></a></div>',
         );
       }),
       placement:
@@ -58,7 +58,7 @@ function powerTipWith(el: HTMLElement, ev: Event, f: (el: HTMLElement) => void) 
 function onIdleForAll(par: HTMLElement, sel: string, f: (el: HTMLElement) => void) {
   requestIdleCallback(
     () => Array.prototype.forEach.call(par.querySelectorAll(sel), (el: HTMLElement) => f(el)), // do not codegolf to `f`
-    800
+    800,
   );
 }
 
@@ -248,7 +248,11 @@ class DisplayController {
   hoverTimer?: number;
   el: WithTooltip;
 
-  constructor(readonly element: Cash, readonly options: Options, readonly tipController: TooltipController) {
+  constructor(
+    readonly element: Cash,
+    readonly options: Options,
+    readonly tipController: TooltipController,
+  ) {
     this.el = un$(element);
     this.scoped = session.scoped[options.popupId!];
     // expose the methods
@@ -326,7 +330,7 @@ function placementCalculator() {
       placement: PowerTip.Placement,
       tipWidth: number,
       tipHeight: number,
-      offset: number
+      offset: number,
     ) {
       const placementBase = placement.split('-')[0], // ignore 'alt' for corners
         coords = cssCoordinates(),
@@ -541,7 +545,7 @@ class TooltipController {
         const collisions = getViewportCollisions(
           this.placeTooltip(element, pos),
           this.tipElement.outerWidth() || this.options.defaultSize[0],
-          this.tipElement.outerHeight() || this.options.defaultSize[1]
+          this.tipElement.outerHeight() || this.options.defaultSize[1],
         );
 
         // break if there were no collisions
@@ -580,7 +584,7 @@ class TooltipController {
         placement,
         tipWidth,
         tipHeight,
-        this.options.offset!
+        this.options.offset!,
       );
 
       // place the tooltip
@@ -657,7 +661,7 @@ function initTracking() {
         session.windowWidth = $window.width();
         session.windowHeight = $window.height();
       },
-      { passive: true }
+      { passive: true },
     );
 
     window.addEventListener(
@@ -674,7 +678,7 @@ function initTracking() {
           session.scrollTop = y;
         }
       },
-      { passive: true }
+      { passive: true },
     );
   }
 }

--- a/ui/site/src/component/serviceWorker.ts
+++ b/ui/site/src/component/serviceWorker.ts
@@ -7,7 +7,7 @@ export default async function () {
     assetUrl(jsModule('serviceWorker'), {
       sameDomain: true,
     }),
-    self.location.href // eslint-disable-line no-restricted-globals
+    self.location.href, // eslint-disable-line no-restricted-globals
   );
   workerUrl.searchParams.set('asset-url', document.body.getAttribute('data-asset-url')!);
   if (document.body.getAttribute('data-dev')) workerUrl.searchParams.set('dev', '1');

--- a/ui/site/src/component/socket.ts
+++ b/ui/site/src/component/socket.ts
@@ -83,7 +83,11 @@ export default class StrongSocket {
     StrongSocket.resolveFirstConnect = r;
   });
 
-  constructor(readonly url: string, version: number | false, settings: Partial<Settings> = {}) {
+  constructor(
+    readonly url: string,
+    version: number | false,
+    settings: Partial<Settings> = {},
+  ) {
     this.settings = {
       receive: settings.receive,
       events: settings.events || {},
@@ -309,7 +313,7 @@ export default class StrongSocket {
           this.options.idle = false;
           if (this.ws) clearTimeout(disconnectTimeout);
           else location.reload();
-        }
+        },
       );
     }
   };

--- a/ui/site/src/component/sound.ts
+++ b/ui/site/src/component/sound.ts
@@ -231,7 +231,10 @@ class Sound {
   node: GainNode;
   ctx: AudioContext;
 
-  constructor(ctx: AudioContext, readonly buffer: AudioBuffer) {
+  constructor(
+    ctx: AudioContext,
+    readonly buffer: AudioBuffer,
+  ) {
     this.rewire(ctx);
   }
 

--- a/ui/site/src/component/storage.ts
+++ b/ui/site/src/component/storage.ts
@@ -11,7 +11,7 @@ const builder = (storage: Storage): LichessStorageHelper => {
           sri,
           nonce: Math.random(), // ensure item changes
           value: v,
-        })
+        }),
       ),
     remove: (k: string) => storage.removeItem(k),
     make: (k: string) => ({

--- a/ui/site/src/component/top-bar.ts
+++ b/ui/site/src/component/top-bar.ts
@@ -16,7 +16,7 @@ export default function () {
     $('#topnav > section > a').removeAttr('href');
 
   $('#topnav-toggle').on('change', e =>
-    document.body.classList.toggle('masked', (e.target as HTMLInputElement).checked)
+    document.body.classList.toggle('masked', (e.target as HTMLInputElement).checked),
   );
 
   $('#top').on('click', '.toggle', function (this: HTMLElement) {

--- a/ui/site/src/component/watchers.ts
+++ b/ui/site/src/component/watchers.ts
@@ -19,7 +19,7 @@ export default function watchers(element: HTMLElement) {
   $element.data('watched', 1);
   const $innerElement = $('<div class="chat__members__inner">').appendTo($element);
   const $numberEl = $(
-    `<div class="chat__members__number" data-icon="${licon.User}" title="Spectators"></div>`
+    `<div class="chat__members__number" data-icon="${licon.User}" title="Spectators"></div>`,
   ).appendTo($innerElement);
   const $listEl = $('<div>').appendTo($innerElement);
 
@@ -40,7 +40,7 @@ export default function watchers(element: HTMLElement) {
       if ($listEl.data('prevUsers') !== prevUsers) {
         $listEl.data('prevUsers', prevUsers);
         const tags = data.users.map(u =>
-          u ? `<a class="user-link ulpt" href="/@/${name(u)}">${u}</a>` : 'Anonymous'
+          u ? `<a class="user-link ulpt" href="/@/${name(u)}">${u}</a>` : 'Anonymous',
         );
         if (data.anons === 1) tags.push('Anonymous');
         else if (data.anons) tags.push(`Anonymous (${data.anons})`);

--- a/ui/site/src/expandText.ts
+++ b/ui/site/src/expandText.ts
@@ -16,7 +16,7 @@ interface Candidate {
 
 function toYouTubeEmbedUrl(url: string) {
   const m = url?.match(
-    /(?:https?:\/\/)?(?:www\.)?(?:youtube\.com|youtu\.be)\/(?:watch)?(?:\?v=)?([^"&?/ ]{11})(?:\?|&|)(\S*)/i
+    /(?:https?:\/\/)?(?:www\.)?(?:youtube\.com|youtu\.be)\/(?:watch)?(?:\?v=)?([^"&?/ ]{11})(?:\?|&|)(\S*)/i,
   );
   if (!m) return;
   let start = 0;
@@ -77,8 +77,8 @@ lichess.load.then(() => {
       $(
         `<blockquote class="twitter-tweet" data-dnt="true" data-theme="${currentTheme()}"><a href="${
           a.src
-        }">${a.src}</a></blockquote>`
-      )
+        }">${a.src}</a></blockquote>`,
+      ),
     );
     if (!twitterLoaded) {
       twitterLoaded = true;

--- a/ui/site/src/forum.ts
+++ b/ui/site/src/forum.ts
@@ -137,7 +137,7 @@ lichess.load.then(() => {
           {
             placement: 'top',
             appendTo: '#lichess_forum',
-          }
+          },
         );
       });
   });
@@ -155,7 +155,7 @@ lichess.load.then(() => {
         },
         _ => {
           lichess.announce({ msg: 'Failed to send forum post reaction' });
-        }
+        },
       );
     }
   });

--- a/ui/site/src/gameSearch.ts
+++ b/ui/site/src/gameSearch.ts
@@ -21,7 +21,7 @@ lichess.load.then(() => {
       row: HTMLTableRowElement,
       rowClassName: string,
       user: string,
-      dataKey: string
+      dataKey: string,
     ): boolean => {
       const player: string = $form.data(dataKey);
       return row.classList.contains(rowClassName) && !!player.length && user == player;
@@ -40,7 +40,7 @@ lichess.load.then(() => {
               ? { selected: '' }
               : {}),
           })
-          .text(user)
+          .text(user),
       );
     }
     row.classList.toggle('none', !usernames.length);

--- a/ui/site/src/infiniteScroll.ts
+++ b/ui/site/src/infiniteScroll.ts
@@ -23,7 +23,7 @@ function register(el: HTMLElement, selector: string, backoff = 500) {
               res();
             }
           },
-          { passive: true }
+          { passive: true },
         );
     })
       .then(() => {
@@ -41,7 +41,7 @@ function register(el: HTMLElement, selector: string, backoff = 500) {
         e => {
           console.log(e);
           nav.remove();
-        }
+        },
       );
 }
 

--- a/ui/site/src/lpv.embed.ts
+++ b/ui/site/src/lpv.embed.ts
@@ -38,7 +38,7 @@ interface OptsWithI18n extends Opts {
     const text = lpv.game.initial.comments[0] || 'Start';
     lpv.div?.insertAdjacentHTML(
       'beforeend',
-      `<a href="${opts.gamebook.url}" target="_blank" rel="noopener" class="button button-no-upper lpv__gamebook">${text}</a>`
+      `<a href="${opts.gamebook.url}" target="_blank" rel="noopener" class="button button-no-upper lpv__gamebook">${text}</a>`,
     );
   }
 };

--- a/ui/site/src/publicChats.ts
+++ b/ui/site/src/publicChats.ts
@@ -20,7 +20,7 @@ lichess.load.then(() => {
       $('<a class="auto-refresh button">Auto refresh</a>').on('click', () => {
         autoRefreshEnabled = !autoRefreshEnabled;
         renderButton();
-      })
+      }),
     );
     renderButton();
 

--- a/ui/site/src/site.ts
+++ b/ui/site/src/site.ts
@@ -165,10 +165,12 @@ lichess.load.then(() => {
       lichess.redirect(d);
     });
     pubsub.on('socket.in.fen', e =>
-      document.querySelectorAll('.mini-game-' + e.id).forEach((el: HTMLElement) => miniGame.update(el, e))
+      document.querySelectorAll('.mini-game-' + e.id).forEach((el: HTMLElement) => miniGame.update(el, e)),
     );
     pubsub.on('socket.in.finish', e =>
-      document.querySelectorAll('.mini-game-' + e.id).forEach((el: HTMLElement) => miniGame.finish(el, e.win))
+      document
+        .querySelectorAll('.mini-game-' + e.id)
+        .forEach((el: HTMLElement) => miniGame.finish(el, e.win)),
     );
     pubsub.on('socket.in.announce', announce);
     pubsub.on('socket.in.tournamentReminder', (data: { id: string; name: string }) => {
@@ -187,14 +189,14 @@ lichess.load.then(() => {
                     xhr.text(this.href, { method: 'post' });
                     $('#announce').remove();
                     return false;
-                  })
+                  }),
               )
               .append(
                 $(`<a class="text" data-icon="${licon.PlayTriangle}">`)
                   .attr('href', url)
-                  .text(siteTrans('resume'))
-              )
-          )
+                  .text(siteTrans('resume')),
+              ),
+          ),
       );
     });
   }, 800);

--- a/ui/site/src/soundMove.ts
+++ b/ui/site/src/soundMove.ts
@@ -28,7 +28,7 @@ export async function initModule(): Promise<SoundMove> {
   const load = async (instrument: string, index: number, filename: string) =>
     lichess.sound.load(
       `orchestra.${instrument}.${index}`,
-      `${lichess.sound.baseUrl}/instrument/${instrument}/${filename}`
+      `${lichess.sound.baseUrl}/instrument/${instrument}/${filename}`,
     );
 
   const isPawn = (san: string) => san[0] === san[0].toLowerCase();

--- a/ui/site/src/streamer.ts
+++ b/ui/site/src/streamer.ts
@@ -10,7 +10,7 @@ lichess.load.then(() => {
           $(this)
             .data('action')
             .replace(/set=[^&]+/, `set=${target.checked}`),
-          { method: 'post' }
+          { method: 'post' },
         );
       });
   });

--- a/ui/site/src/teamBattleForm.ts
+++ b/ui/site/src/teamBattleForm.ts
@@ -32,7 +32,7 @@ lichess.load.then(() => {
                 .slice(0, -1);
               callback(res.filter(t => !current.includes(t.id)));
             },
-            _ => callback([])
+            _ => callback([]),
           );
         },
         template: (team: Team) => team.name + ', by ' + team.owner + ', with ' + team.members + ' members',

--- a/ui/site/src/tvEmbed.ts
+++ b/ui/site/src/tvEmbed.ts
@@ -26,7 +26,7 @@ window.onload = () => {
           miniGame.update(findGame(), msg.d);
         }
       },
-      false
+      false,
     );
   resize();
   window.addEventListener('resize', resize);

--- a/ui/site/src/ublog.ts
+++ b/ui/site/src/ublog.ts
@@ -22,8 +22,8 @@ lichess.load.then(() => {
             $('.ublog-post__like').toggleClass(likeClass, liked).attr('title', newText);
             $('.ublog-post__like__nb').text(likes);
           });
-      }
-    )
+      },
+    ),
   );
   $('.ublog-post__follow button').on(
     'click',
@@ -37,8 +37,8 @@ lichess.load.then(() => {
             method: 'post',
           })
           .then(() => button.parent().toggleClass(followClass));
-      }
-    )
+      },
+    ),
   );
   $('#form3-tier').on('change', function (this: HTMLSelectElement) {
     (this.parentNode as HTMLFormElement).submit();

--- a/ui/site/src/ublogForm.ts
+++ b/ui/site/src/ublogForm.ts
@@ -38,7 +38,7 @@ const setupImage = (form: HTMLFormElement) => {
         replace(html);
         showText();
       },
-      err => replace(wrap(`<bad>${err}</bad>`))
+      err => replace(wrap(`<bad>${err}</bad>`)),
     );
     replace(wrap(lichess.spinnerHtml));
     return false;

--- a/ui/site/src/user.ts
+++ b/ui/site/src/user.ts
@@ -22,7 +22,7 @@ export function initModule(opts: { i18n: I18nDict }): void {
             .formToXhr(form, this)
             .then(html => $zone.replaceWith(html))
             .then(() => loadNoteZone())
-            .catch(() => alert('Invalid note, is it too short or too long?'))
+            .catch(() => alert('Invalid note, is it too short or too long?')),
         );
       return false;
     });

--- a/ui/site/src/userComplete.ts
+++ b/ui/site/src/userComplete.ts
@@ -29,10 +29,10 @@ export function initModule(opts: Opts): void {
             tour: opts.tour,
             swiss: opts.swiss,
             object: 1,
-          })
+          }),
         )
         .then((r: Result) => ({ term, ...r })),
-    150
+    150,
   );
 
   complete<LightUserOnline>({

--- a/ui/storm/src/view/end.ts
+++ b/ui/storm/src/view/end.ts
@@ -30,7 +30,7 @@ const renderSummary = (ctrl: StormCtrl): VNode[] => {
                 h('strong', noarg(newHighI18n[high.key])),
                 high.prev ? h('span', ctrl.trans('previousHighscoreWasX', high.prev)) : null,
               ]),
-            ])
+            ]),
           ),
         ]
       : []),
@@ -40,7 +40,7 @@ const renderSummary = (ctrl: StormCtrl): VNode[] => {
         {
           hook: onInsert(el => numberSpread(el, scoreSteps, Math.round(scoreSteps * 50), 0)(run.score)),
         },
-        '0'
+        '0',
       ),
       h('p', noarg('puzzlesSolved')),
     ]),
@@ -64,7 +64,7 @@ const renderSummary = (ctrl: StormCtrl): VNode[] => {
       {
         attrs: ctrl.run.endAt! < getNow() - 900 ? { href: '/storm' } : {},
       },
-      noarg('playAgain')
+      noarg('playAgain'),
     ),
   ];
 };

--- a/ui/storm/src/view/main.ts
+++ b/ui/storm/src/view/main.ts
@@ -20,7 +20,7 @@ export default function (ctrl: StormCtrl): VNode {
       {
         class: playModifiers(ctrl.run),
       },
-      renderPlay(ctrl)
+      renderPlay(ctrl),
     );
   return h('main.storm.storm--end', renderEnd(ctrl));
 }
@@ -32,8 +32,8 @@ const chessground = (ctrl: StormCtrl): VNode =>
         ctrl.ground(
           Chessground(
             vnode.elm as HTMLElement,
-            makeCgConfig(makeCgOpts(ctrl.run, !ctrl.run.endAt, ctrl.flipped), ctrl.pref, ctrl.userMove)
-          )
+            makeCgConfig(makeCgOpts(ctrl.run, !ctrl.run.endAt, ctrl.flipped), ctrl.pref, ctrl.userMove),
+          ),
         ),
     },
   });
@@ -106,6 +106,6 @@ const renderReload = (ctrl: StormCtrl, msgKey: string) =>
       {
         attrs: { href: '/storm' },
       },
-      ctrl.trans.noarg('clickToReload')
+      ctrl.trans.noarg('clickToReload'),
     ),
   ]);

--- a/ui/storm/src/xhr.ts
+++ b/ui/storm/src/xhr.ts
@@ -20,5 +20,5 @@ export const setZen = throttlePromiseDelay(
     xhr.text('/pref/zen', {
       method: 'post',
       body: xhr.form({ zen: zen ? 1 : 0 }),
-    })
+    }),
 );

--- a/ui/swiss/src/ctrl.ts
+++ b/ui/swiss/src/ctrl.ts
@@ -19,7 +19,10 @@ export default class SwissCtrl {
 
   private lastStorage = lichess.storage.make('last-redirect');
 
-  constructor(readonly opts: SwissOpts, readonly redraw: () => void) {
+  constructor(
+    readonly opts: SwissOpts,
+    readonly redraw: () => void,
+  ) {
     this.data = this.readData(opts.data);
     this.trans = lichess.trans(opts.i18n);
     this.socket = makeSocket(opts.socketSend, this);
@@ -145,7 +148,7 @@ export default class SwissCtrl {
     if (!this.reloadSoonThrottle)
       this.reloadSoonThrottle = throttlePromiseDelay(
         () => Math.max(2000, Math.min(5000, this.data.nbPlayers * 20)),
-        () => xhr.reloadNow(this)
+        () => xhr.reloadNow(this),
       );
     this.reloadSoonThrottle();
   };
@@ -154,7 +157,7 @@ export default class SwissCtrl {
 
   private redrawNbRounds = () =>
     $('.swiss__meta__round').text(
-      this.trans.plural('nbRounds', this.data.nbRounds, `${this.data.round}/${this.data.nbRounds}`)
+      this.trans.plural('nbRounds', this.data.nbRounds, `${this.data.round}/${this.data.nbRounds}`),
     );
 
   private readData = (data: SwissData) => ({

--- a/ui/swiss/src/search.ts
+++ b/ui/swiss/src/search.ts
@@ -45,6 +45,6 @@ export function input(ctrl: TournamentController): VNode {
           }
         });
       }),
-    })
+    }),
   );
 }

--- a/ui/swiss/src/view/boards.ts
+++ b/ui/swiss/src/view/boards.ts
@@ -37,7 +37,7 @@ const renderBoard =
           },
         }),
         boardPlayer(board, board.orientation, opts),
-      ]
+      ],
     );
 
 function boardPlayer(board: Board, color: Color, opts: SwissOpts) {

--- a/ui/swiss/src/view/header.ts
+++ b/ui/swiss/src/view/header.ts
@@ -28,7 +28,7 @@ function clock(ctrl: SwissCtrl): VNode | undefined {
   return h(`div.clock.clock-created.time-cache-${next.at}`, [
     h(
       'span.shy',
-      ctrl.data.status == 'created' ? ctrl.trans.noarg('startingIn') : ctrl.trans.noarg('nextRound')
+      ctrl.data.status == 'created' ? ctrl.trans.noarg('startingIn') : ctrl.trans.noarg('nextRound'),
     ),
     h('span.time.text', {
       hook: startClock(next.in + 1),
@@ -60,11 +60,11 @@ export default function (ctrl: SwissCtrl): VNode {
                   rel: 'noopener',
                 },
               },
-              greatPlayer.name
+              greatPlayer.name,
             ),
             ' Tournament',
           ]
-        : [ctrl.data.name]
+        : [ctrl.data.name],
     ),
     ctrl.data.status == 'finished' ? undefined : clock(ctrl) || ongoing(ctrl),
   ]);

--- a/ui/swiss/src/view/main.ts
+++ b/ui/swiss/src/view/main.ts
@@ -45,7 +45,7 @@ export default function (ctrl: SwissCtrl) {
             hook: onInsert(lichess.watchers),
           })
         : null,
-    ]
+    ],
   );
 }
 
@@ -125,10 +125,10 @@ function nextRound(ctrl: SwissCtrl): VNode | undefined {
             onClose() {
               (el.parentNode as HTMLFormElement).submit();
             },
-          })
+          }),
         ),
       }),
-    ]
+    ],
   );
 }
 
@@ -143,7 +143,7 @@ function joinButton(ctrl: SwissCtrl): VNode | undefined {
           'data-icon': licon.PlayTriangle,
         },
       },
-      ctrl.trans('signIn')
+      ctrl.trans('signIn'),
     );
 
   if (d.joinTeam)
@@ -155,7 +155,7 @@ function joinButton(ctrl: SwissCtrl): VNode | undefined {
           'data-icon': licon.Group,
         },
       },
-      ctrl.trans.noarg('joinTeam')
+      ctrl.trans.noarg('joinTeam'),
     );
 
   if (d.canJoin)
@@ -173,10 +173,10 @@ function joinButton(ctrl: SwissCtrl): VNode | undefined {
                   if (p !== null) ctrl.join(p);
                 } else ctrl.join();
               },
-              ctrl.redraw
+              ctrl.redraw,
             ),
           },
-          ctrl.trans.noarg('join')
+          ctrl.trans.noarg('join'),
         );
 
   if (d.me && d.status != 'finished')
@@ -189,7 +189,7 @@ function joinButton(ctrl: SwissCtrl): VNode | undefined {
               attrs: dataIcon(licon.PlayTriangle),
               hook: bind('click', _ => ctrl.join(), ctrl.redraw),
             },
-            ctrl.trans.noarg('join')
+            ctrl.trans.noarg('join'),
           )
       : ctrl.joinSpinner
       ? spinner()
@@ -199,7 +199,7 @@ function joinButton(ctrl: SwissCtrl): VNode | undefined {
             attrs: dataIcon(licon.FlagOutline),
             hook: bind('click', ctrl.withdraw, ctrl.redraw),
           },
-          ctrl.trans.noarg('withdraw')
+          ctrl.trans.noarg('withdraw'),
         );
 
   return;
@@ -213,7 +213,7 @@ function joinTheGame(ctrl: SwissCtrl) {
         {
           attrs: { href: '/' + gameId },
         },
-        [ctrl.trans('youArePlaying'), h('br'), ctrl.trans('joinTheGame')]
+        [ctrl.trans('youArePlaying'), h('br'), ctrl.trans('joinTheGame')],
       )
     : undefined;
 }
@@ -252,7 +252,7 @@ function stats(ctrl: SwissCtrl): VNode | undefined {
                 href: `/swiss/${ctrl.data.id}/round/1`,
               },
             },
-            ctrl.trans('viewAllXRounds', ctrl.data.round)
+            ctrl.trans('viewAllXRounds', ctrl.data.round),
           ),
           h('br'),
           h(
@@ -264,7 +264,7 @@ function stats(ctrl: SwissCtrl): VNode | undefined {
                 download: true,
               },
             },
-            'Download TRF file'
+            'Download TRF file',
           ),
           h(
             'a.text',
@@ -275,7 +275,7 @@ function stats(ctrl: SwissCtrl): VNode | undefined {
                 download: true,
               },
             },
-            'Download all games'
+            'Download all games',
           ),
           h(
             'a.text',
@@ -286,7 +286,7 @@ function stats(ctrl: SwissCtrl): VNode | undefined {
                 download: true,
               },
             },
-            'Download results as NDJSON'
+            'Download results as NDJSON',
           ),
           h(
             'a.text',
@@ -297,7 +297,7 @@ function stats(ctrl: SwissCtrl): VNode | undefined {
                 download: true,
               },
             },
-            'Download results as CSV'
+            'Download results as CSV',
           ),
           h('br'),
           h(
@@ -308,7 +308,7 @@ function stats(ctrl: SwissCtrl): VNode | undefined {
                 href: 'https://lichess.org/api#tag/Swiss-tournaments',
               },
             },
-            'Swiss API documentation'
+            'Swiss API documentation',
           ),
         ]),
       ])

--- a/ui/swiss/src/view/playerInfo.ts
+++ b/ui/swiss/src/view/playerInfo.ts
@@ -71,7 +71,7 @@ export default function (ctrl: SwissCtrl): VNode | undefined {
                   h('th', '' + round),
                   h('td.outcome', { attrs: { colspan: 3 } }, p),
                   h('td', p == 'absent' ? '-' : p == 'bye' ? '1' : '½'),
-                ]
+                ],
               );
             const res = result(p);
             return h(
@@ -89,12 +89,12 @@ export default function (ctrl: SwissCtrl): VNode | undefined {
                 ctrl.opts.showRatings ? h('td', '' + p.rating) : null,
                 h('td.is.color-icon.' + (p.c ? 'white' : 'black')),
                 h('td', res),
-              ]
+              ],
             );
-          })
+          }),
         ),
       ]),
-    ]
+    ],
   );
 }
 

--- a/ui/swiss/src/view/podium.ts
+++ b/ui/swiss/src/view/podium.ts
@@ -28,10 +28,10 @@ function podiumPosition(p: PodiumPlayer, pos: string, ctrl: SwissCtrl): VNode | 
             {
               attrs: { href: '/@/' + p.user.name },
             },
-            userName(p.user)
+            userName(p.user),
           ),
           podiumStats(p, ctrl),
-        ]
+        ],
       )
     : undefined;
 }

--- a/ui/swiss/src/view/standing.ts
+++ b/ui/swiss/src/view/standing.ts
@@ -27,7 +27,7 @@ function playerTr(ctrl: SwissCtrl, player: Player) {
                 title: 'Absent',
               },
             })
-          : [player.rank]
+          : [player.rank],
       ),
       h('td.player', renderPlayer(player, false, ctrl.opts.showRatings)),
       h(
@@ -51,15 +51,15 @@ function playerTr(ctrl: SwissCtrl, player: Player) {
                       },
                       hook: onInsert(lichess.powertip.manualGame),
                     },
-                    p.o ? '*' : p.w === true ? '1' : p.w === false ? '0' : '½'
-                  )
+                    p.o ? '*' : p.w === true ? '1' : p.w === false ? '0' : '½',
+                  ),
             )
-            .concat([...Array(Math.max(0, ctrl.data.nbRounds - player.sheet.length))].map(_ => h('r')))
-        )
+            .concat([...Array(Math.max(0, ctrl.data.nbRounds - player.sheet.length))].map(_ => h('r'))),
+        ),
       ),
       h('td.points', title('Points'), '' + player.points),
       h('td.tieBreak', title('Tie Break'), '' + player.tieBreak),
-    ]
+    ],
   );
 }
 
@@ -94,8 +94,8 @@ export default function standing(ctrl: SwissCtrl, pag: Pager, klass?: string): V
             },
           },
         },
-        tableBody
+        tableBody,
       ),
-    ]
+    ],
   );
 }

--- a/ui/swiss/src/view/util.ts
+++ b/ui/swiss/src/view/util.ts
@@ -16,7 +16,7 @@ export function player(p: BasePlayer, asLink: boolean, withRating: boolean) {
     [
       h('span.name', userName(p.user)),
       withRating ? h('span.rating', ' ' + p.rating + (p.provisional ? '?' : '')) : null,
-    ]
+    ],
   );
 }
 
@@ -33,7 +33,7 @@ export function numberRow(name: string, value: any, typ?: string) {
         ? value[1] > 0
           ? ratio2percent(value[0] / value[1])
           : 0
-        : numberFormat(value)
+        : numberFormat(value),
     ),
   ]);
 }

--- a/ui/swiss/src/xhr.ts
+++ b/ui/swiss/src/xhr.ts
@@ -29,7 +29,7 @@ const loadPageOf = (ctrl: SwissCtrl, userId: string): Promise<any> =>
 
 const reload = (ctrl: SwissCtrl) =>
   json(
-    `/swiss/${ctrl.data.id}?page=${ctrl.focusOnMe ? '' : ctrl.page}&playerInfo=${ctrl.playerInfoId || ''}`
+    `/swiss/${ctrl.data.id}?page=${ctrl.focusOnMe ? '' : ctrl.page}&playerInfo=${ctrl.playerInfoId || ''}`,
   ).then(data => {
     ctrl.reload(data);
     ctrl.redraw();
@@ -50,7 +50,7 @@ const readSheetMin = (str: string) =>
               g: s.slice(0, 8),
               o: s[8] == 'o',
               w: s[8] == 'w' ? true : s[8] == 'l' ? false : undefined,
-            }
+            },
       )
     : [];
 

--- a/ui/tournament/src/main.ts
+++ b/ui/tournament/src/main.ts
@@ -15,7 +15,7 @@ export function initModule(opts: TournamentOpts) {
     opts.data.socketVersion,
     {
       receive: (t: string, d: any) => ctrl.socket.receive(t, d),
-    }
+    },
   );
   opts.socketSend = lichess.socket.send;
   opts.element = document.querySelector('main.tour') as HTMLElement;

--- a/ui/tournament/src/pagination.ts
+++ b/ui/tournament/src/pagination.ts
@@ -12,7 +12,7 @@ function button(
   icon: string,
   click: () => void,
   enable: boolean,
-  ctrl: TournamentController
+  ctrl: TournamentController,
 ): VNode {
   return h('button.fbt.is', {
     attrs: {

--- a/ui/tournament/src/search.ts
+++ b/ui/tournament/src/search.ts
@@ -46,6 +46,6 @@ export function input(ctrl: TournamentController): VNode {
           }
         });
       }),
-    })
+    }),
   );
 }

--- a/ui/tournament/src/sound.ts
+++ b/ui/tournament/src/sound.ts
@@ -17,7 +17,7 @@ function doCountDown(targetTime: number) {
       const nextTick = Math.min(10, bestTick - 1);
       countDownTimeout = setTimeout(
         curCounter,
-        1000 * Math.min(1.1, Math.max(0.8, secondsToStart - nextTick))
+        1000 * Math.min(1.1, Math.max(0.8, secondsToStart - nextTick)),
       );
     }
 
@@ -50,7 +50,7 @@ export function countDown(data: TournamentData) {
 
   countDownTimeout = setTimeout(
     doCountDown(window.performance.now() + 1000 * data.secondsToStart - 100),
-    900
+    900,
   ); // wait 900ms before starting countdown.
 
   // Preload countdown sounds.

--- a/ui/tournament/src/view/arena.ts
+++ b/ui/tournament/src/view/arena.ts
@@ -53,7 +53,7 @@ function playerTr(ctrl: TournamentController, player: StandingPlayer) {
                 title: ctrl.trans.noarg('pause'),
               },
             })
-          : player.rank
+          : player.rank,
       ),
       h('td.player', [
         renderPlayer(player, false, ctrl.opts.showRatings, userId === ctrl.data.defender),
@@ -65,7 +65,7 @@ function playerTr(ctrl: TournamentController, player: StandingPlayer) {
           ? h('strong.is-gold', { attrs: dataIcon(licon.Fire) }, player.score)
           : h('strong', player.score),
       ]),
-    ]
+    ],
   );
 }
 
@@ -75,7 +75,7 @@ function podiumUsername(p: PodiumPlayer) {
     {
       attrs: { href: '/@/' + p.name },
     },
-    playerName(p)
+    playerName(p),
   );
 }
 
@@ -102,7 +102,7 @@ function podiumPosition(
   p: PodiumPlayer,
   pos: string,
   berserkable: boolean,
-  ctrl: TournamentController
+  ctrl: TournamentController,
 ): VNode | undefined {
   if (p) return h('div.' + pos, [h('div.trophy'), podiumUsername(p), podiumStats(p, berserkable, ctrl)]);
   return undefined;
@@ -147,8 +147,8 @@ export function standing(ctrl: TournamentController, pag: Pagination, klass?: st
             },
           },
         },
-        tableBody
+        tableBody,
       ),
-    ]
+    ],
   );
 }

--- a/ui/tournament/src/view/battle.ts
+++ b/ui/tournament/src/view/battle.ts
@@ -35,8 +35,8 @@ export function joinWithTeamSelector(ctrl: TournamentController) {
                       'data-id': id,
                     },
                   },
-                  tb.teams[id]
-                )
+                  tb.teams[id],
+                ),
               ),
             ]
           : [
@@ -51,10 +51,10 @@ export function joinWithTeamSelector(ctrl: TournamentController) {
                       {
                         attrs: { href: '/team/' + t },
                       },
-                      tb.teams[t]
-                    )
-                  )
-                )
+                      tb.teams[t],
+                    ),
+                  ),
+                ),
               ),
             ]),
       ]),
@@ -91,9 +91,9 @@ function extraTeams(ctrl: TournamentController): VNode {
             href: `/tournament/${ctrl.data.id}/teams`,
           },
         },
-        ctrl.trans('viewAllXTeams', Object.keys(ctrl.data.teamBattle!.teams).length)
-      )
-    )
+        ctrl.trans('viewAllXTeams', Object.keys(ctrl.data.teamBattle!.teams).length),
+      ),
+    ),
   );
 }
 
@@ -105,7 +105,7 @@ function myTeam(ctrl: TournamentController, battle: TeamBattle): MaybeVNode {
 export function teamName(battle: TeamBattle, teamId: string): VNode {
   return h(
     battle.hasMoreThanTenTeams ? 'team' : 'team.ttc-' + Object.keys(battle.teams).indexOf(teamId),
-    battle.teams[teamId]
+    battle.teams[teamId],
   );
 }
 
@@ -126,8 +126,8 @@ function teamTr(ctrl: TournamentController, battle: TeamBattle, team: RankedTeam
             destroy: vnode => $.powerTip.destroy(vnode.elm as HTMLElement),
           },
         },
-        [...(i === 0 ? [h('username', playerName(p.user)), ' '] : []), '' + p.score]
-      )
+        [...(i === 0 ? [h('username', playerName(p.user)), ' '] : []), '' + p.score],
+      ),
     );
   });
   return h(
@@ -153,10 +153,10 @@ function teamTr(ctrl: TournamentController, battle: TeamBattle, team: RankedTeam
             }
           }),
         },
-        players
+        players,
       ),
       h('td.total', [h('strong', '' + team.score)]),
-    ]
+    ],
   );
 }
 

--- a/ui/tournament/src/view/button.ts
+++ b/ui/tournament/src/view/button.ts
@@ -17,7 +17,7 @@ export function withdraw(ctrl: TournamentController): VNode {
         attrs: dataIcon(pause ? licon.Pause : licon.FlagOutline),
         hook: bind('click', ctrl.withdraw, ctrl.redraw),
       },
-      ctrl.trans.noarg(pause ? 'pause' : 'withdraw')
+      ctrl.trans.noarg(pause ? 'pause' : 'withdraw'),
     );
   });
 }
@@ -35,7 +35,7 @@ export function join(ctrl: TournamentController): VNode {
         },
         hook: bind('click', _ => ctrl.join(), ctrl.redraw),
       },
-      ctrl.trans.noarg('join')
+      ctrl.trans.noarg('join'),
     );
     return delay
       ? h(
@@ -60,9 +60,9 @@ export function join(ctrl: TournamentController): VNode {
                   },
                 },
               },
-              [button]
+              [button],
             ),
-          ]
+          ],
         )
       : button;
   });
@@ -78,7 +78,7 @@ export function joinWithdraw(ctrl: TournamentController): VNode | undefined {
           'data-icon': licon.PlayTriangle,
         },
       },
-      ctrl.trans('signIn')
+      ctrl.trans('signIn'),
     );
   if (!ctrl.data.isFinished) return ctrl.isIn() ? withdraw(ctrl) : join(ctrl);
   return undefined;

--- a/ui/tournament/src/view/finished.ts
+++ b/ui/tournament/src/view/finished.ts
@@ -52,7 +52,7 @@ function stats(ctrl: TournamentController): VNode | undefined {
                   href: `/tournament/${data.id}/teams`,
                 },
               },
-              trans('viewAllXTeams', Object.keys(data.teamBattle.teams).length)
+              trans('viewAllXTeams', Object.keys(data.teamBattle.teams).length),
             ),
             h('br'),
           ]
@@ -66,7 +66,7 @@ function stats(ctrl: TournamentController): VNode | undefined {
             download: true,
           },
         },
-        'Download all games'
+        'Download all games',
       ),
       data.me &&
         h(
@@ -78,7 +78,7 @@ function stats(ctrl: TournamentController): VNode | undefined {
               download: true,
             },
           },
-          'Download my games'
+          'Download my games',
         ),
       h(
         'a.text',
@@ -89,7 +89,7 @@ function stats(ctrl: TournamentController): VNode | undefined {
             download: true,
           },
         },
-        'Download results as NDJSON'
+        'Download results as NDJSON',
       ),
       h(
         'a.text',
@@ -100,7 +100,7 @@ function stats(ctrl: TournamentController): VNode | undefined {
             download: true,
           },
         },
-        'Download results as CSV'
+        'Download results as CSV',
       ),
       h('br'),
       h(
@@ -111,7 +111,7 @@ function stats(ctrl: TournamentController): VNode | undefined {
             href: 'https://lichess.org/api#tag/Arena-tournaments',
           },
         },
-        'Arena API documentation'
+        'Arena API documentation',
       ),
     ]),
   ]);

--- a/ui/tournament/src/view/header.ts
+++ b/ui/tournament/src/view/header.ts
@@ -33,7 +33,7 @@ function clock(d: TournamentData): VNode | undefined {
             insert(vnode) {
               (vnode.elm as HTMLElement).setAttribute(
                 'datetime',
-                '' + (Date.now() + d.secondsToStart! * 1000)
+                '' + (Date.now() + d.secondsToStart! * 1000),
               );
             },
           },
@@ -72,7 +72,7 @@ function title(ctrl: TournamentController) {
         {
           attrs: { href: '/tournament/shields' },
         },
-        perfIcons[d.perf.key]
+        perfIcons[d.perf.key],
       ),
       d.fullName,
     ]);
@@ -89,12 +89,12 @@ function title(ctrl: TournamentController) {
                 rel: 'noopener',
               },
             },
-            d.greatPlayer.name
+            d.greatPlayer.name,
           ),
           ' Arena',
         ]
       : [d.fullName]
-    ).concat(d.private ? [' ', h('span', { attrs: dataIcon(licon.Padlock) })] : [])
+    ).concat(d.private ? [' ', h('span', { attrs: dataIcon(licon.Padlock) })] : []),
   );
 }
 

--- a/ui/tournament/src/view/main.ts
+++ b/ui/tournament/src/view/main.ts
@@ -36,8 +36,8 @@ export default function (ctrl: TournamentController) {
         {
           class: { 'tour__main-finished': ctrl.data.isFinished },
         },
-        handler.main(ctrl)
-      )
+        handler.main(ctrl),
+      ),
     ),
     ctrl.opts.chat
       ? h('div.chat__members.none', {

--- a/ui/tournament/src/view/playerInfo.ts
+++ b/ui/tournament/src/view/playerInfo.ts
@@ -63,7 +63,7 @@ export default function (ctrl: TournamentController): VNode {
               {
                 hook: bind('click', () => ctrl.showTeamInfo(data.player.team!), ctrl.redraw),
               },
-              [teamName(ctrl.data.teamBattle!, data.player.team)]
+              [teamName(ctrl.data.teamBattle!, data.player.team)],
             )
           : null,
         h('table', [
@@ -106,11 +106,11 @@ export default function (ctrl: TournamentController): VNode {
                 ctrl.opts.showRatings ? h('td', p.op.rating) : null,
                 h('td.is.color-icon.' + p.color),
                 h('td', res),
-              ]
+              ],
             );
-          })
+          }),
         ),
       ]),
-    ]
+    ],
   );
 }

--- a/ui/tournament/src/view/started.ts
+++ b/ui/tournament/src/view/started.ts
@@ -15,7 +15,7 @@ function joinTheGame(ctrl: TournamentController, gameId: string) {
     {
       attrs: { href: '/' + gameId },
     },
-    [ctrl.trans('youArePlaying'), h('br'), ctrl.trans('joinTheGame')]
+    [ctrl.trans('youArePlaying'), h('br'), ctrl.trans('joinTheGame')],
   );
 }
 

--- a/ui/tournament/src/view/table.ts
+++ b/ui/tournament/src/view/table.ts
@@ -51,7 +51,7 @@ function featured(game: FeaturedGame, opts: TournamentOpts): VNode {
         },
       }),
       featuredPlayer(game, game.orientation, opts),
-    ]
+    ],
   );
 }
 
@@ -75,12 +75,12 @@ function renderDuel(ctrl: TournamentController) {
         battle && duelTeams
           ? h(
               'line.t',
-              [0, 1].map(i => teamName(battle, duelTeams[d.p[i].n.toLowerCase()]))
+              [0, 1].map(i => teamName(battle, duelTeams[d.p[i].n.toLowerCase()])),
             )
           : undefined,
         h('line.a', [h('strong', d.p[0].n), h('span', duelPlayerMeta(d.p[1], ctrl).reverse())]),
         h('line.b', [h('span', duelPlayerMeta(d.p[0], ctrl)), h('strong', d.p[1].n)]),
-      ]
+      ],
     );
 }
 
@@ -103,9 +103,9 @@ export default function (ctrl: TournamentController): VNode {
             {
               hook: bind('click', _ => !ctrl.disableClicks),
             },
-            [h('h2', 'Top games')].concat(ctrl.data.duels.map(renderDuel(ctrl)))
+            [h('h2', 'Top games')].concat(ctrl.data.duels.map(renderDuel(ctrl))),
           )
         : null,
-    ]
+    ],
   );
 }

--- a/ui/tournament/src/view/teamInfo.ts
+++ b/ui/tournament/src/view/teamInfo.ts
@@ -59,9 +59,9 @@ export default function (ctrl: TournamentController): VNode | undefined {
                 {
                   attrs: { href: '/team/' + data.id },
                 },
-                noarg('teamPage')
-              )
-            )
+                noarg('teamPage'),
+              ),
+            ),
           ),
         ]),
       ]),
@@ -83,11 +83,11 @@ export default function (ctrl: TournamentController): VNode | undefined {
                     ? h('strong.is-gold', { attrs: dataIcon(licon.Fire) }, '' + p.score)
                     : h('strong', '' + p.score),
                 ]),
-              ]
-            )
-          )
+              ],
+            ),
+          ),
         ),
       ]),
-    ]
+    ],
   );
 }

--- a/ui/tournament/src/view/util.ts
+++ b/ui/tournament/src/view/util.ts
@@ -14,7 +14,7 @@ export const player = (
   asLink: boolean,
   withRating: boolean,
   defender = false,
-  leader = false
+  leader = false,
 ) =>
   h(
     'a.ulpt.user-link' + (((p.title || '') + p.name).length > 15 ? '.long' : ''),
@@ -28,10 +28,10 @@ export const player = (
       h(
         'span.name' + (defender ? '.defender' : leader ? '.leader' : ''),
         defender ? { attrs: dataIcon(licon.Shield) } : leader ? { attrs: dataIcon(licon.Crown) } : {},
-        playerName(p)
+        playerName(p),
       ),
       withRating ? h('span.rating', ' ' + p.rating + (p.provisional ? '?' : '')) : null,
-    ]
+    ],
   );
 
 export function numberRow(name: string, value: number): VNode;
@@ -48,7 +48,7 @@ export function numberRow(name: string, value: any, typ?: string) {
         ? value[1] > 0
           ? ratio2percent(value[0] / value[1])
           : 0
-        : numberFormat(value)
+        : numberFormat(value),
     ),
   ]);
 }

--- a/ui/tournament/src/xhr.ts
+++ b/ui/tournament/src/xhr.ts
@@ -27,7 +27,7 @@ export const join = throttlePromiseDelay(
             if (t.error) alert(t.error);
             else lichess.reload();
           });
-      }, onFail)
+      }, onFail),
 );
 
 export const withdraw = throttlePromiseDelay(
@@ -37,7 +37,7 @@ export const withdraw = throttlePromiseDelay(
       .text('/tournament/' + ctrl.data.id + '/withdraw', {
         method: 'POST',
       })
-      .then(() => {}, onFail)
+      .then(() => {}, onFail),
 );
 
 export const loadPage = throttlePromiseDelay(
@@ -47,7 +47,7 @@ export const loadPage = throttlePromiseDelay(
       ctrl.loadPage(data);
       callback?.();
       ctrl.redraw();
-    }, onFail)
+    }, onFail),
 );
 
 export const loadPageOf = (ctrl: TournamentController, userId: string) =>
@@ -71,7 +71,7 @@ export const reloadNow: (ctrl: TournamentController) => Promise<void> = finallyD
       {
         ...xhr.defaultInit,
         headers: xhr.jsonHeader,
-      }
+      },
     )
       .then(res => xhr.ensureOk(res).json())
       .then(
@@ -84,8 +84,8 @@ export const reloadNow: (ctrl: TournamentController) => Promise<void> = finallyD
             ctrl.data.reloadEndpoint = reloadEndpointFallback(ctrl);
             return reloadNow(ctrl);
           } else return onFail();
-        }
-      )
+        },
+      ),
 );
 
 export const reloadSoon = throttlePromiseDelay(() => 4000 + Math.floor(Math.random() * 1000), reloadNow);

--- a/ui/tournamentCalendar/src/view.ts
+++ b/ui/tournamentCalendar/src/view.ts
@@ -49,17 +49,17 @@ function renderTournament(tour: Tournament, day: Date) {
                 'data-icon': iconOf(tour),
               },
             }
-          : {}
+          : {},
       ),
       h('span.body', [tour.fullName]),
-    ]
+    ],
   );
 }
 
 function renderLane(tours: Tournament[], day: Date) {
   return h(
     'lane',
-    tours.map(t => renderTournament(t, day))
+    tours.map(t => renderTournament(t, day)),
   );
 }
 
@@ -91,11 +91,11 @@ function renderDay(ctrl: Ctrl) {
             title: format(day, 'EEEE, dd/MM/yyyy'),
           },
         },
-        [format(day, 'dd/MM')]
+        [format(day, 'dd/MM')],
       ),
       h(
         'lanes',
-        makeLanes(tours).map(l => renderLane(l, day))
+        makeLanes(tours).map(l => renderLane(l, day)),
       ),
     ]);
   };
@@ -118,9 +118,9 @@ function renderTimeline() {
         {
           attrs: { style: startDirection() + ': ' + (hour / 24) * 100 + '%' },
         },
-        timeString(hour)
-      )
-    )
+        timeString(hour),
+      ),
+    ),
   );
 }
 

--- a/ui/tournamentSchedule/src/view.ts
+++ b/ui/tournamentSchedule/src/view.ts
@@ -142,8 +142,8 @@ function renderTournament(ctrl: Ctrl, tour: Tournament) {
           0,
           Math.min(
             width - 250, // max padding, reserved text space
-            leftPos(now) - left - 380
-          )
+            leftPos(now) - left - 380,
+          ),
         ); // distance from Now
   // cut right overflow to fit viewport and not widen it, for marathons
   width = Math.min(width, leftPos(stopTime) - left);
@@ -178,7 +178,7 @@ function renderTournament(ctrl: Ctrl, tour: Tournament) {
                 title: tour.perf.name,
               },
             }
-          : {}
+          : {},
       ),
       h('span.body', [
         h('span.name', i18nName(tour)),
@@ -195,12 +195,12 @@ function renderTournament(ctrl: Ctrl, tour: Tournament) {
                 {
                   attrs: { 'data-icon': licon.User },
                 },
-                tour.nbPlayers
+                tour.nbPlayers,
               )
             : null,
         ]),
       ]),
-    ]
+    ],
   );
 }
 
@@ -220,15 +220,15 @@ function renderTimeline() {
           class: { hour: !time.getMinutes() },
           attrs: { style: startDirection() + ': ' + leftPos(time.getTime()) + 'px' },
         },
-        timeString(time)
-      )
+        timeString(time),
+      ),
     );
     time.setUTCMinutes(time.getUTCMinutes() + minutesBetween);
   }
   timeHeaders.push(
     h('div.timeheader.now', {
       attrs: { style: startDirection() + ': ' + leftPos(now) + 'px' },
-    })
+    }),
   );
 
   return h('div.timeline', timeHeaders);
@@ -264,7 +264,7 @@ export default function (ctrl: Ctrl) {
 
   // group system tournaments into dedicated lanes for PerfType
   const tourLanes = splitOverlaping(group(systemTours, laneGrouper).concat([userTours])).filter(
-    lane => lane.length > 0
+    lane => lane.length > 0,
   );
 
   return h('div.tour-chart', [
@@ -301,10 +301,10 @@ export default function (ctrl: Ctrl) {
         ...tourLanes.map(lane => {
           return h(
             'div.tournamentline',
-            lane.map(tour => renderTournament(ctrl, tour))
+            lane.map(tour => renderTournament(ctrl, tour)),
           );
         }),
-      ]
+      ],
     ),
   ]);
 }

--- a/ui/tree/src/ops.ts
+++ b/ui/tree/src/ops.ts
@@ -5,7 +5,7 @@ export function withMainlineChild<T>(node: Tree.Node, f: (node: Tree.Node) => T)
 
 export function findInMainline(
   fromNode: Tree.Node,
-  predicate: (node: Tree.Node) => boolean
+  predicate: (node: Tree.Node) => boolean,
 ): Tree.Node | undefined {
   const findFrom = function (node: Tree.Node): Tree.Node | undefined {
     if (predicate(node)) return node;

--- a/ui/voice/@build/src/makeGrammar.ts
+++ b/ui/voice/@build/src/makeGrammar.ts
@@ -15,7 +15,7 @@ const buildMode: SubRestriction = { del: true, sub: 2 }; // allow dels and/or sp
 function buildCostMap(
   subMap: Map<string, SubInfo>, // the map of all valid substitutions within --max-ops distance
   freqThreshold: number, // minimum frequency of a substitution to be considered
-  countThreshold: number // minimum count for a substitution to be considered
+  countThreshold: number, // minimum count for a substitution to be considered
 ) {
   const costMax = 0.9;
   const subCostMin = 0.4;
@@ -78,7 +78,7 @@ function parseTransforms(xss: Transform[][], entry: LexEntry, subMap: Map<string
         cost.count++;
         cost.conf += x.at < entry.c.length ? entry.c[x.at] : 0;
         subMap.set(`${x.from} ${x.to}`, cost);
-      })
+      }),
     );
 }
 
@@ -90,7 +90,7 @@ function findTransforms(
   pos = 0, // for recursion
   line: Transform[] = [],
   lines: Transform[][] = [],
-  crumbs = new Map<string, number>()
+  crumbs = new Map<string, number>(),
 ): Transform[][] {
   if (h === x) return [line];
   if (pos >= x.length && !mode.del) return [];
@@ -105,8 +105,8 @@ function findTransforms(
       pos + (op === 'skip' ? 1 : op.to.length),
       op === 'skip' ? line : [...line, op],
       lines,
-      crumbs
-    )
+      crumbs,
+    ),
   );
 }
 
@@ -157,7 +157,7 @@ function ppCost(key: string, e: SubInfo) {
         prettyPair('freq', e.freq.toFixed(3)),
         prettyPair('cost', e.cost?.toFixed(2) ?? '1'),
       ].join(grey(', ')) +
-      ` }${grey(',')}`
+      ` }${grey(',')}`,
   );
 }
 
@@ -307,7 +307,7 @@ class Builder {
   }
   addOccurrence(phrase: string) {
     [...this.encode(phrase)].forEach(token =>
-      this.occurrences.set(token, (this.occurrences.get(token) ?? 0) + 1)
+      this.occurrences.set(token, (this.occurrences.get(token) ?? 0) + 1),
     );
   }
   addSub(token: string, sub: Sub) {
@@ -360,7 +360,7 @@ class Builder {
                     return `{ to: '${s.to}', cost: ${c} }`;
                   })
                   .join(',\n      ')}${e.subs.length > 1 ? ',\n    ],' : '],'}`
-              : '')
+              : ''),
         )
         .join('\n  },\n  {\n    ') +
       '\n  },\n]'

--- a/ui/voice/src/move/arrows.ts
+++ b/ui/voice/src/move/arrows.ts
@@ -21,7 +21,7 @@ const LABEL_SIZE = 40; // size of arrow labels in svg user units, 100 is the wid
 export function numberedArrows(
   choices: [string, Uci][],
   timer: number | undefined,
-  asWhite: boolean
+  asWhite: boolean,
 ): DrawShape[] {
   if (!choices) return [];
   const shapes: DrawShape[] = [];
@@ -43,8 +43,8 @@ export function numberedArrows(
         choices.length > 1 ? labelOffset(choices[0][1], dests, asWhite) : [0, 0],
         timer,
         choices.length > 1 ? 'grey' : 'white',
-        0.6
-      )
+        0.6,
+      ),
     );
   }
   if (choices.length > 1)
@@ -105,7 +105,7 @@ function labelShape(
   uci: Uci,
   dests: Map<Key, number | Set<number>>,
   label: string,
-  asWhite: boolean
+  asWhite: boolean,
 ): DrawShape {
   const fontSize = Math.round(LABEL_SIZE * 0.82);
   const r = LABEL_SIZE / 2;

--- a/ui/voice/src/move/moveCtrl.ts
+++ b/ui/voice/src/move/moveCtrl.ts
@@ -129,7 +129,7 @@ export function initModule(opts: { root: RootCtrl; ui: VoiceCtrl; initialFen: st
   function initTimerRec() {
     if (timer() === 0) return;
     const words = [...partials.commands, ...(colorsPref() ? partials.colors : partials.numbers)].map(w =>
-      valWord(w)
+      valWord(w),
     );
     lichess.mic.initRecognizer(words, { recId: 'timer', partial: true, listener: listenTimer });
   }
@@ -198,7 +198,7 @@ export function initModule(opts: { root: RootCtrl; ui: VoiceCtrl; initialFen: st
 
     const chosen = matchOne(
       heard,
-      [...choices].map(([w, uci]) => [wordVal(w), [uci]])
+      [...choices].map(([w, uci]) => [wordVal(w), [uci]]),
     );
     if (!chosen) {
       clearMoveProgress();
@@ -250,7 +250,7 @@ export function initModule(opts: { root: RootCtrl; ui: VoiceCtrl; initialFen: st
   function matchOneTags(heard: string, tags: string[], vals: string[] = []): string | false {
     return matchOne(heard, [...vals.map(v => [v, [v]]), ...byTags(tags).map(e => [e.val!, [e.val!]])] as [
       string,
-      string[]
+      string[],
     ][]);
   }
 
@@ -301,7 +301,7 @@ export function initModule(opts: { root: RootCtrl; ui: VoiceCtrl; initialFen: st
     options = options
       .filter(
         ([uci, _], keepIfFirst) =>
-          options.findIndex(first => first[0].slice(0, 4) === uci.slice(0, 4)) === keepIfFirst
+          options.findIndex(first => first[0].slice(0, 4) === uci.slice(0, 4)) === keepIfFirst,
       )
       .slice(0, maxArrows());
 
@@ -332,11 +332,14 @@ export function initModule(opts: { root: RootCtrl; ui: VoiceCtrl; initialFen: st
     console.info('ambiguate', choices);
     choiceTimeout = 0;
     if (preferred && timer()) {
-      choiceTimeout = setTimeout(() => {
-        submit(options[0][0]);
-        choiceTimeout = undefined;
-        lichess.mic.setRecognizer('default');
-      }, timer() * 1000 + 100);
+      choiceTimeout = setTimeout(
+        () => {
+          submit(options[0][0]);
+          choiceTimeout = undefined;
+          lichess.mic.setRecognizer('default');
+        },
+        timer() * 1000 + 100,
+      );
       lichess.mic.setRecognizer('timer');
     }
     makeArrows();
@@ -354,7 +357,7 @@ export function initModule(opts: { root: RootCtrl; ui: VoiceCtrl; initialFen: st
     cg.setShapes(
       colorsPref()
         ? coloredArrows([...choices], arrowTime)
-        : numberedArrows([...choices], arrowTime, cg.state.orientation === 'white')
+        : numberedArrows([...choices], arrowTime, cg.state.orientation === 'white'),
     );
   }
 
@@ -409,7 +412,7 @@ export function initModule(opts: { root: RootCtrl; ui: VoiceCtrl; initialFen: st
               if (val && roles.includes(cs.charRole(val))) ctrl.finish(cs.charRole(val));
               else if (val === 'no') ctrl.cancel();
             },
-            { listenerId: 'promotion' }
+            { listenerId: 'promotion' },
           )
         : lichess.mic.removeListener('promotion');
   }

--- a/ui/voice/src/move/view.ts
+++ b/ui/voice/src/move/view.ts
@@ -7,7 +7,7 @@ export function settingNodes(
   colors: Prop<boolean>,
   clarity: Prop<number>,
   timer: Prop<number>,
-  redraw: () => void
+  redraw: () => void,
 ) {
   return [colorsSetting(colors, redraw), claritySetting(clarity, redraw), timerSetting(timer, redraw)];
 }
@@ -24,9 +24,9 @@ export function colorsSetting(colors: Prop<boolean>, redraw: () => void) {
             class: { active: colors() === (pref === 'Colors') },
             hook: bind('click', () => colors(pref === 'Colors'), redraw),
           },
-          pref
-        )
-      )
+          pref,
+        ),
+      ),
     ),
   ]);
 }

--- a/ui/voice/src/util.ts
+++ b/ui/voice/src/util.ts
@@ -10,7 +10,7 @@ export function findTransforms(
   pos = 0, // for recursion
   line: Transform[] = [], // for recursion
   lines: Transform[][] = [], // for recursion
-  crumbs = new Map<string, number>() // for (finite) recursion
+  crumbs = new Map<string, number>(), // for (finite) recursion
 ): Transform[][] {
   if (h === x) return [line];
   if (pos >= x.length && !mode.del) return [];
@@ -24,8 +24,8 @@ export function findTransforms(
       pos + (op === 'skip' ? 1 : op.to.length),
       op === 'skip' ? line : [...line, op],
       lines,
-      crumbs
-    )
+      crumbs,
+    ),
   );
 }
 
@@ -87,7 +87,7 @@ export function movesTo(s: number, role: string, board: cs.Board): number[] {
     return deltas([6, 10, 15, 17], s).filter(o => o >= 0 && o < 64 && cs.squareDist(s, o) <= 2);
   const dests: number[] = [];
   for (const delta of deltas(
-    role === 'Q' ? [1, 7, 8, 9] : role === 'R' ? [1, 8] : role === 'B' ? [7, 9] : []
+    role === 'Q' ? [1, 7, 8, 9] : role === 'R' ? [1, 8] : role === 'B' ? [7, 9] : [],
   )) {
     for (
       let square = s + delta;

--- a/ui/voice/src/view.ts
+++ b/ui/voice/src/view.ts
@@ -88,10 +88,10 @@ function langSetting(ctrl: VoiceCtrl) {
                 {
                   attrs: l[0] === ctrl.lang() ? { value: l[0], selected: '' } : { value: l[0] },
                 },
-                l[1]
-              )
+                l[1],
+              ),
             ),
-          ]
+          ],
         ),
       ]);
 }
@@ -121,9 +121,9 @@ function deviceSelector(ctrl: VoiceCtrl, redraw: () => void) {
               selected: d.deviceId === ctrl.micId(),
             },
           },
-          d.label
-        )
-      )
+          d.label,
+        ),
+      ),
     ),
   ]);
 }
@@ -140,10 +140,10 @@ function voiceDisable() {
           hook: bind('click', () =>
             xhr
               .text('/pref/voice', { method: 'post', body: xhr.form({ voice: '0' }) })
-              .then(() => window.location.reload())
+              .then(() => window.location.reload()),
           ),
         },
-        'Disable voice recognition'
+        'Disable voice recognition',
       );
 }
 
@@ -188,7 +188,7 @@ function renderHelpModal(ctrl: VoiceCtrl) {
       el.find('.scrollable').html(html);
       const valToWord = (val: string, phonetic: boolean) =>
         grammar.entries.find(
-          (e: Entry) => (e.val ?? e.tok) === val && (!phonetic || e.tags?.includes('phonetic'))
+          (e: Entry) => (e.val ?? e.tok) === val && (!phonetic || e.tags?.includes('phonetic')),
         )?.in;
       $('.val-to-word', el).each(function (this: HTMLElement) {
         const tryPhonetic = (val: string) =>

--- a/ui/voice/src/vosk.ts
+++ b/ui/voice/src/vosk.ts
@@ -53,7 +53,7 @@ export function initModule(): VoskModule {
         `Created ${opts.audioCtx.sampleRate.toFixed()}Hz recognizer '${
           opts.recId
         }' with buffer size ${bufSize}`,
-        opts.words
+        opts.words,
       );
 
     recs.set(opts.recId, new KaldiRec(kaldi, node, opts.partial));


### PR DESCRIPTION
Totally optional, install these with `pnpm add-hooks` and remove with `pnpm remove-hooks`

If installed:
- any files committed to lila will be formatted first (if they are assigned to prettier)
- git push will run es-lint on client sources.

You can disable one or the other behavior by removing one of `pre-commit` or `pre-push` in `bin/git-hooks`

Also, update to prettier 3.0.x with more aggressive trailing commas and better compound property formatting in scss