### PR TITLE
fix(classes): Make it possible to fully remove invited accounts

### DIFF
--- a/app/controllers/Clas.scala
+++ b/app/controllers/Clas.scala
@@ -467,6 +467,9 @@ final class Clas(env: Env, authC: Auth) extends LilaController(env):
         if s.student.managed then
           env.clas.api.student.closeAccount(s) >>
             env.api.accountClosure.close(s.user) inject redirectTo(clas).flashSuccess
+        else if !s.student.managed && !s.student.isActive then
+          env.clas.api.student.closeAccount(s) >>
+            redirectTo(clas).flashSuccess
         else redirectTo(clas)
   }
 

--- a/app/controllers/Clas.scala
+++ b/app/controllers/Clas.scala
@@ -467,7 +467,7 @@ final class Clas(env: Env, authC: Auth) extends LilaController(env):
         if s.student.managed then
           env.clas.api.student.closeAccount(s) >>
             env.api.accountClosure.close(s.user) inject redirectTo(clas).flashSuccess
-        else if !s.student.isActive then
+        else if s.student.isArchived then
           env.clas.api.student.closeAccount(s) >>
             redirectTo(clas).flashSuccess
         else redirectTo(clas)

--- a/app/controllers/Clas.scala
+++ b/app/controllers/Clas.scala
@@ -467,7 +467,7 @@ final class Clas(env: Env, authC: Auth) extends LilaController(env):
         if s.student.managed then
           env.clas.api.student.closeAccount(s) >>
             env.api.accountClosure.close(s.user) inject redirectTo(clas).flashSuccess
-        else if !s.student.managed && !s.student.isActive then
+        else if !s.student.isActive then
           env.clas.api.student.closeAccount(s) >>
             redirectTo(clas).flashSuccess
         else redirectTo(clas)

--- a/app/views/clas/student.scala
+++ b/app/views/clas/student.scala
@@ -306,7 +306,15 @@ object student:
             href  := clasRoutes.studentClose(clas.id.value, s.user.username),
             cls   := "button button-empty button-red",
             title := trans.clas.closeDesc1.txt()
-          )(trans.clas.closeStudent())
+          )(trans.clas.closeStudent()),
+          !s.student.isActive && !s.student.managed option
+            postForm(
+              action := clasRoutes.studentClosePost(clas.id.value, s.user.username)
+            )(
+              form3.submit(trans.clas.closeStudent(), icon = none)(
+                cls := "confirm button-red button-empty"
+              )
+            )
         )
       )
     )

--- a/app/views/clas/student.scala
+++ b/app/views/clas/student.scala
@@ -34,8 +34,15 @@ object student:
         s.student.archived map { archived =>
           div(cls := "student-show__archived archived")(
             bits.showArchived(archived),
-            postForm(action := clasRoutes.studentArchive(clas.id.value, s.user.username, v = false))(
-              form3.submit(trans.clas.inviteTheStudentBack(), icon = none)(cls := "confirm button-empty")
+            div(cls := "student-show__archived__actions")(
+              postForm(action := clasRoutes.studentArchive(clas.id.value, s.user.username, v = false)):
+                form3.submit(trans.clas.inviteTheStudentBack(), icon = none)(cls := "confirm button-empty")
+              ,
+              postForm(action := clasRoutes.studentClosePost(clas.id.value, s.user.username)):
+                form3.submit(trans.clas.removeStudent(), icon = none)(
+                  cls   := "confirm button-red button-empty",
+                  title := "Fully erase the student from the class archives."
+                )
             )
           )
         },
@@ -306,15 +313,7 @@ object student:
             href  := clasRoutes.studentClose(clas.id.value, s.user.username),
             cls   := "button button-empty button-red",
             title := trans.clas.closeDesc1.txt()
-          )(trans.clas.closeStudent()),
-          !s.student.isActive && !s.student.managed option
-            postForm(
-              action := clasRoutes.studentClosePost(clas.id.value, s.user.username)
-            )(
-              form3.submit(trans.clas.closeStudent(), icon = none)(
-                cls := "confirm button-red button-empty"
-              )
-            )
+          )(trans.clas.closeStudent())
         )
       )
     )

--- a/modules/clas/src/main/ClasApi.scala
+++ b/modules/clas/src/main/ClasApi.scala
@@ -316,9 +316,8 @@ ${clas.desc}""",
           .void
           .flatMap: _ =>
             sendInviteMessage(teacher, user, clas, invite)
-          .recover {
+          .recover:
             lila.db.recoverDuplicateKey(_ => Found)
-          }
       }
 
     def get(id: ClasInvite.Id) = colls.invite.one[ClasInvite]($id(id))


### PR DESCRIPTION
This seemed pretty simple, but it's my first time touching any scala so feedback is welcome.

Fixes https://github.com/lichess-org/lila/issues/10736

Existing accounts that were invited to a class could be placed in 'Removed' status but then could only be re-invited or left in that state. This change lets them be taken out entirely.