### PR TITLE
Fix key bind for analysis board in blind mode

### DIFF
--- a/ui/nvui/src/chess.ts
+++ b/ui/nvui/src/chess.ts
@@ -348,7 +348,7 @@ export function renderBoard(
     return h(
       'button',
       {
-        attrs: { rank: rank, file: file, piece: letter.toLowerCase(), color: color },
+        attrs: { rank: rank, file: file, piece: letter.toLowerCase(), color: color, 'trap-bypass': true },
       },
       text,
     );

--- a/ui/site/src/component/mousetrap.ts
+++ b/ui/site/src/component/mousetrap.ts
@@ -194,7 +194,11 @@ export default class Mousetrap {
     for (const binding of this.getMatches(e)) {
       if (
         binding.combination == 'esc' ||
-        (el.tagName != 'INPUT' && el.tagName != 'SELECT' && el.tagName != 'TEXTAREA' && !el.isContentEditable)
+        (el.tagName != 'INPUT' &&
+          el.tagName != 'SELECT' &&
+          el.tagName != 'TEXTAREA' &&
+          !el.isContentEditable &&
+          !el.hasAttribute('trap-bypass'))
       ) {
         binding.callback(e);
         e.preventDefault();


### PR DESCRIPTION
Fixes #13165
- The fix makes it possible to move pieces on the analysis board in blind mode, similar to how it is implemented on a round board
- The issue was coming from the `mousetrap.ts` stopping key event propagation. The fix adds a `trap_bypass` attribute to the board buttons. Events on elements with this attribute are exempt from being trapped by `mousetrap.ts`