### PR TITLE
Fix: consistent zen mode for puzzle racer

### DIFF
--- a/ui/racer/css/_zen.scss
+++ b/ui/racer/css/_zen.scss
@@ -5,7 +5,9 @@
 }
 
 #friend_box,
+.puz-side__solved__text,
 .puz-side__table,
+.racer__race,
 .site-title-nav,
 .site-buttons {
   @extend %zen;


### PR DESCRIPTION
Fixes #13433

This pull request aims to enhance the Zen mode experience in Puzzle Racer by addressing distracting elements that are currently present in the mode. This highlights the need for a more focused and serene Zen mode that aligns with user expectations. Furthermore, these changes will bring Zen mode's consistency in line with the rest of the puzzle-solving experiences across the application.

Puzzle Racer Zen Mode:
![puzzle-racer](https://github.com/lichess-org/lila/assets/78294042/46dd2c42-2f0b-4a92-85cb-27e9f69c1c52)

Puzzle Storm Zen Mode:
![puzzle-storm](https://github.com/lichess-org/lila/assets/78294042/f2dcc283-2e51-4717-b4f0-8de366ec3c02)
