### PR TITLE
Fix "Create a game" and "Play with a friend" control discrepancies

### DIFF
--- a/ui/lobby/src/setupCtrl.ts
+++ b/ui/lobby/src/setupCtrl.ts
@@ -230,7 +230,7 @@ export default class SetupController {
     // anonymous games cannot be rated
     !this.root.me ||
     // unlimited games cannot be rated
-    (this.gameType === 'hook' && this.timeMode() === 'unlimited') ||
+    this.timeMode() === 'unlimited' ||
     // variants with very low time cannot be rated
     (this.variant() !== 'standard' &&
       (this.timeMode() !== 'realTime' ||


### PR DESCRIPTION
There's an issue in the "Play with a friend" control where standard games with an unlimited time control can be played rated, but variants cannot. This differs from the "Create a game" control where _all_  game types with an unlimited time control cannot play rated.

In the PR I went with the comment the line above the changes that states unlimited games cannot be rated, and applied that as the fix. If friends should be able to play all game types rated with unlimited time control let me know and I'll get the PR updated with the proper fix.

**Video showing the problem:**

https://github.com/lichess-org/lila/assets/3620552/4a45bcc7-b7e3-430f-9fef-410b02fafd60


