### PR TITLE
Fix zen mode toggling via the board menu

### DIFF
--- a/ui/round/src/ctrl.ts
+++ b/ui/round/src/ctrl.ts
@@ -90,6 +90,7 @@ export default class RoundController {
   preDrop?: cg.Role;
   sign: string = Math.random().toString(36);
   keyboardHelp: boolean = location.hash === '#keyboard';
+  zenable = false;
 
   constructor(
     readonly opts: RoundOpts,
@@ -142,6 +143,8 @@ export default class RoundController {
     this.trans = lichess.trans(opts.i18n);
     this.noarg = this.trans.noarg;
 
+    this.zenable = !d.player.spectator || !!d.tv;
+
     setTimeout(this.delayedInit, 200);
 
     setTimeout(this.showExpiration, 350);
@@ -155,10 +158,12 @@ export default class RoundController {
     });
 
     lichess.pubsub.on('zen', () => {
-      const zen = $('body').toggleClass('zen').hasClass('zen');
-      window.dispatchEvent(new Event('resize'));
-      if (!$('body').hasClass('zen-auto')) {
-        xhr.setZen(zen);
+      if (this.zenable) {
+        const zen = $('body').toggleClass('zen').hasClass('zen');
+        window.dispatchEvent(new Event('resize'));
+        if (!$('body').hasClass('zen-auto')) {
+          xhr.setZen(zen);
+        }
       }
     });
 

--- a/ui/round/src/view/boardMenu.ts
+++ b/ui/round/src/view/boardMenu.ts
@@ -17,7 +17,7 @@ export default function (ctrl: RoundController) {
         }),
       ]),
       h('section', [
-        menu.zenMode(!spectator),
+        menu.zenMode(ctrl.zenable),
         menu.voiceInput(boolPrefXhrToggle('voice', !!ctrl.voiceMove), !spectator),
         menu.keyboardInput(boolPrefXhrToggle('keyboardMove', !!ctrl.keyboardMove), !spectator),
         !spectator && d.pref.submitMove ? menu.confirmMove(ctrl.confirmMoveEnabled) : undefined,


### PR DESCRIPTION
Fixes zen mode toggling via the board menu. There's an issue where if you're spectating a TV game (l.org/tv/best), you _can_ toggle zen mode using the hotkey, but not via the board menu even though this page has a zen view. Additionally, if you are watching the TV channel _of a user_ (e.g. l.org/@/temp006/tv) the zen mode toggle should actually be disabled (which it is), but you can still use the 'z' hotkey and affect the zen toggle status (even though it won't do anything on this page as a zen view has not been implemented).

This change enables the zen toggle when necessary and blocks the 'z' hotkey from affecting the zen status when it's disabled.

**Screenshots showing the issue:**
![zen-disabled](https://github.com/lichess-org/lila/assets/3620552/332e60d7-a0e9-4cc5-8252-9ae49085b1aa)

Toggled via hotkey
![zen-disabled-but-enabled](https://github.com/lichess-org/lila/assets/3620552/53cae622-a777-4bc7-8178-961f99763ce1)
