### PR TITLE
Use CSS to fix how dates are displayed in RTL languages

### DIFF
--- a/app/templating/DateHelper.scala
+++ b/app/templating/DateHelper.scala
@@ -50,12 +50,10 @@ trait DateHelper:
   def showEnglishInstant(instant: Instant): String = englishDateTimeFormatter print instant
 
   def semanticDate(instant: Instant)(using lang: Lang): Tag =
-    timeTag(datetimeAttr := isoDateTime(instant), style := "unicode-bidi:plaintext")(showDate(instant))
+    timeTag(datetimeAttr := isoDateTime(instant))(showDate(instant))
 
   def semanticDate(date: LocalDate)(using lang: Lang): Tag =
-    timeTag(datetimeAttr := isoDateTime(date.atStartOfDay.instant), style := "unicode-bidi:plaintext")(
-      showDate(date)
-    )
+    timeTag(datetimeAttr := isoDateTime(date.atStartOfDay.instant))(showDate(date))
 
   def showMinutes(minutes: Int)(using Lang): String =
     showDuration(Duration.ofMinutes(minutes))

--- a/app/templating/DateHelper.scala
+++ b/app/templating/DateHelper.scala
@@ -6,7 +6,7 @@ import play.api.i18n.Lang
 import java.time.format.{ FormatStyle, DateTimeFormatter }
 import java.time.{ Duration, LocalDate }
 
-import lila.app.ui.ScalatagsTemplate.{*, given}
+import lila.app.ui.ScalatagsTemplate.*
 import lila.i18n.PeriodLocales
 
 trait DateHelper:
@@ -50,16 +50,12 @@ trait DateHelper:
   def showEnglishInstant(instant: Instant): String = englishDateTimeFormatter print instant
 
   def semanticDate(instant: Instant)(using lang: Lang): Tag =
-    timeTag(
-      datetimeAttr := isoDateTime(instant),
-      dir := isRTL.option("rtl")
-    )(showDate(instant))
+    timeTag(datetimeAttr := isoDateTime(instant), style := "unicode-bidi:plaintext")(showDate(instant))
 
   def semanticDate(date: LocalDate)(using lang: Lang): Tag =
-    timeTag(
-      datetimeAttr := isoDateTime(date.atStartOfDay.instant),
-      dir := isRTL.option("rtl")
-    )(showDate(date))
+    timeTag(datetimeAttr := isoDateTime(date.atStartOfDay.instant), style := "unicode-bidi:plaintext")(
+      showDate(date)
+    )
 
   def showMinutes(minutes: Int)(using Lang): String =
     showDuration(Duration.ofMinutes(minutes))

--- a/ui/common/css/base/_elements.scss
+++ b/ui/common/css/base/_elements.scss
@@ -61,6 +61,7 @@ time {
   opacity: 0.9;
 
   /* don't use c-color-dim, it overrides too hard */
+  unicode-bidi: plaintext;
 }
 
 hr {

--- a/ui/site/css/ublog/_post.scss
+++ b/ui/site/css/ublog/_post.scss
@@ -29,6 +29,9 @@
       margin-#{$start-direction}: -0.5rem;
       vertical-align: top;
     }
+    &__date {
+      unicode-bidi: embed;
+    }
   }
   &__topics {
     @extend %flex-wrap;


### PR DESCRIPTION
In response to https://github.com/lichess-org/lila/pull/13461#pullrequestreview-1596825476, I have updated the fix to use CSS only.

Moreover, I have updated the fix so that the username appears beside the donor badge. I also validated the order of the date components with Google Translate: it should be `<year> <month> <day>` in RTL languages (e.g. Arabic, Farsi, Urdu).

Before:
![LiChess i18n Before](https://github.com/lichess-org/lila/assets/12627125/b7b7e898-6090-4799-8c65-c2c1e6042950)

After:
![LiChess i18n After](https://github.com/lichess-org/lila/assets/12627125/dbc8063a-0dcd-460e-8fe2-6bfb27583abd)
