### PR TITLE
Fix how puzzle theme text is rendered in RTL languages

### DIFF
--- a/app/views/puzzle/theme.scala
+++ b/app/views/puzzle/theme.scala
@@ -53,9 +53,9 @@ object theme:
             else routes.Puzzle.show(pt.theme.key.value)
           a(cls := "puzzle-themes__link", href := (pt.count > 0).option(langHref(url)))(
             span(
-              h3(
+              h3(cls := "puzzle-themes__name")(
                 pt.theme.name(),
-                em(pt.count.localize)
+                em(cls := "puzzle-themes__count")(pt.count.localize)
               ),
               span(pt.theme.description())
             )

--- a/ui/puzzle/css/_themes.scss
+++ b/ui/puzzle/css/_themes.scss
@@ -99,6 +99,14 @@
     }
   }
 
+  &__name {
+    unicode-bidi: isolate-override;
+  }
+
+  &__count {
+    unicode-bidi: embed;
+  }
+
   &__db {
     @extend %box-padding;
 


### PR DESCRIPTION
Fixes #13357.

Before: 
![Puzzle Theme i18n - Arabic - Before](https://github.com/lichess-org/lila/assets/12627125/897ef145-bc29-4dcd-a5fb-8d981730b187)

After:
![Puzzle Theme i18n - Arabic - After](https://github.com/lichess-org/lila/assets/12627125/9add5e77-1aa9-4952-a854-eba1da8b081d)