### PR TITLE
Correct the text direction when mixing LTR and RTL text.

### DIFF
--- a/app/views/puzzle/theme.scala
+++ b/app/views/puzzle/theme.scala
@@ -53,7 +53,7 @@ object theme:
             else routes.Puzzle.show(pt.theme.key.value)
           a(cls := "puzzle-themes__link", href := (pt.count > 0).option(langHref(url)))(
             span(
-              h3(cls := "puzzle-themes__name")(
+              h3(
                 pt.theme.name(),
                 em(cls := "puzzle-themes__count")(pt.count.localize)
               ),

--- a/ui/puzzle/css/_themes.scss
+++ b/ui/puzzle/css/_themes.scss
@@ -99,12 +99,8 @@
     }
   }
 
-  &__name {
-    unicode-bidi: isolate-override;
-  }
-
   &__count {
-    unicode-bidi: embed;
+    unicode-bidi: plaintext;
   }
 
   &__db {


### PR DESCRIPTION
Unfortunately, I'm not a native speaker of Arabic, so I missed this when double-checking my original fix.

As you can see, `f7` is spelled backwards.
Before:
![Puzzle Theme i18n - Arabic - Before](https://github.com/lichess-org/lila/assets/12627125/6aaac209-fe75-4625-8262-b10209b59cc2)

After:
![Puzzle Theme i18n - Arabic - After](https://github.com/lichess-org/lila/assets/12627125/9cbe7064-c9e6-494c-9edf-442041ebfe12)