### PR TITLE
Update board menu to have consistent board flip

### DIFF
--- a/ui/round/src/view/boardMenu.ts
+++ b/ui/round/src/view/boardMenu.ts
@@ -1,6 +1,5 @@
 import { h } from 'snabbdom';
 import RoundController from '../ctrl';
-import { game as gameRoute } from 'game/router';
 import { menu as menuDropdown } from 'board/menu';
 import { boolPrefXhrToggle } from 'common/controls';
 
@@ -9,13 +8,7 @@ export default function (ctrl: RoundController) {
     const d = ctrl.data,
       spectator = d.player.spectator;
     return [
-      h('section', [
-        menu.flip(ctrl.noarg('flipBoard'), ctrl.flip, () => {
-          if (d.tv) location.href = '/tv/' + d.tv.channel + (d.tv.flip ? '' : '?flip=1');
-          else if (spectator) location.href = gameRoute(d, d.opponent.color);
-          else ctrl.flipNow();
-        }),
-      ]),
+      h('section', [menu.flip(ctrl.noarg('flipBoard'), ctrl.flip, ctrl.flipNow)]),
       h('section', [
         menu.zenMode(ctrl.zenable),
         menu.voiceInput(boolPrefXhrToggle('voice', !!ctrl.voiceMove), !spectator),


### PR DESCRIPTION
Update to avoid seemingly unnecessary page refresh when flipping the board via the board menu when spectating a TV game (user or lichess TV). This also fixes the issue where if watching a users TV channel and the "flip board" button is pressed, it brings me to the game URL on flip instead of keeping me on the users TV URL.