### PR TITLE
Remove duplicates between game participants and username search history

### DIFF
--- a/ui/analyse/src/explorer/explorerConfig.ts
+++ b/ui/analyse/src/explorer/explorerConfig.ts
@@ -317,6 +317,16 @@ const playerModal = (ctrl: ExplorerConfigCtrl) => {
     ctrl.selectPlayer(name);
     ctrl.root.redraw();
   };
+  const nameToOptionalColor = (name: string | undefined) => {
+    if (!name) {
+      return;
+    } else if (name === ctrl.myName) {
+      return '.button-green';
+    } else if (ctrl.data.playerName.previous().includes(name)) {
+      return '';
+    }
+    return '.button-metal';
+  };
   return snabModal({
     class: 'explorer__config__player__choice',
     onClose() {
@@ -344,15 +354,20 @@ const playerModal = (ctrl: ExplorerConfigCtrl) => {
       ]),
       h(
         'div.previous',
-        [...(ctrl.myName ? [ctrl.myName] : []), ...ctrl.participants, ...ctrl.data.playerName.previous()].map(
-          name =>
-            h(
-              `button.button${name == ctrl.myName ? '.button-green' : ''}`,
-              {
-                hook: bind('click', () => onSelect(name)),
-              },
-              name,
-            ),
+        [
+          ...new Set([
+            ...(ctrl.myName ? [ctrl.myName] : []),
+            ...ctrl.participants,
+            ...ctrl.data.playerName.previous(),
+          ]),
+        ].map(name =>
+          h(
+            `button.button${nameToOptionalColor(name)}`,
+            {
+              hook: bind('click', () => onSelect(name)),
+            },
+            name,
+          ),
         ),
       ),
     ],


### PR DESCRIPTION
In this example, we are opening up the Personal Opening Explorer player selection modal in the analysis board for Aleksandr vs. Jacob. Aleksandr is already in the search history, whereas Jacob is not.

Before:
![LiChess Names Before](https://github.com/lichess-org/lila/assets/12627125/245bd123-c54b-43b9-b35e-6a41f099c049)

After:
![LiChess Names After](https://github.com/lichess-org/lila/assets/12627125/7e2d1b7f-5b5b-4752-8f19-0b7bf41bb2a6)

Please let me know if you'd like me to swap the colours that I'm using for the game participants and the players in the search history.