### PR TITLE
Fix gift checkout buttons

### DIFF
--- a/ui/site/src/checkout.ts
+++ b/ui/site/src/checkout.ts
@@ -90,7 +90,6 @@ export default (window as any).checkoutStart = function (stripePublicKey: string
     $checkout.find('.service .paypal:not(.paypal--disabled)').toggleClass('none', !enabled);
   };
 
-  toggleCheckout();
   $userInput.on('change', toggleCheckout).on('input', toggleCheckout);
 
   const getAmountToCharge = () => {
@@ -123,6 +122,8 @@ export default (window as any).checkoutStart = function (stripePublicKey: string
     if (queryParams.has(name))
       $(`input[name=${name}]`).val(queryParams.get(name)!.replace(/[^a-z0-9_-]/gi, ''));
   }
+
+  toggleCheckout();
 
   payPalOrderStart($checkout, pricing, getAmountToCharge);
   payPalSubscriptionStart($checkout, pricing, getAmountToCharge);


### PR DESCRIPTION
After clicking the gift link on a non-patron profile, the username is automatically completed, but the form buttons are not enabled.

Moves `toggleCheckout()` (used to enable the stripe + paypal buttons) to after the input values are automatically set.

Fixes #13498

Followup to #13395