### PR TITLE
Fix duplicate broadcast created via api

### DIFF
--- a/app/controllers/RelayTour.scala
+++ b/app/controllers/RelayTour.scala
@@ -62,10 +62,7 @@ final class RelayTour(env: Env, apiC: => Api, prismicC: => Prismic) extends Lila
               env.relay.api.tourCreate(setup) flatMap { tour =>
                 negotiate(
                   Redirect(routes.RelayRound.form(tour.id)).flashSuccess,
-                  JsonOk:
-                    env.relay.api.tourCreate(setup) map { tour =>
-                      env.relay.jsonView(tour.withRounds(Nil), withUrls = true)
-                    }
+                  JsonOk(env.relay.jsonView(tour.withRounds(Nil), withUrls = true))
                 )
               }
         )


### PR DESCRIPTION
Fixes duplicate broadcasts being created via api by removing the second call to `env.relay.api.tourCreate`.
Fixes #13481 