### PR TITLE
Fix Gift Patron wings for monthly patrons

### DIFF
--- a/app/views/relation/actions.scala
+++ b/app/views/relation/actions.scala
@@ -34,7 +34,7 @@ object actions:
             ),
             (!blocked && !user.isPatron) option a(
               titleOrText(trans.patron.giftPatronWingsShort.txt()),
-              href     := s"${routes.Plan.index}?dest=gift&giftUsername=${user.name}",
+              href     := s"${routes.Plan.list}?dest=gift&giftUsername=${user.name}",
               cls      := "btn-rack__btn",
               dataIcon := licon.Wings
             ),


### PR DESCRIPTION
Fix #13496
The `list` works for both patrons and non-patrons