### PR TITLE
Fix click away triggering on old element

### DIFF
--- a/ui/common/src/common.ts
+++ b/ui/common/src/common.ts
@@ -79,7 +79,17 @@ export const scrollTo = (el: HTMLElement, target: HTMLElement | null) => {
 };
 
 export const onClickAway = (f: () => void) => (el: HTMLElement) => {
-  const listen: () => void = () => $(document).one('click', e => (el.contains(e.target) ? listen() : f()));
+  const listen: () => void = () =>
+    $(document).one('click', e => {
+      if (!document.contains(el)) {
+        return;
+      }
+      if (el.contains(e.target)) {
+        listen();
+      } else {
+        f();
+      }
+    });
   setTimeout(listen, 300);
 };
 


### PR DESCRIPTION
Currently, clicking on the board menu button to close it won't trigger the click away listener so when you then immediately open it again you will have two listeners and clicking on the toggles in the menu will immediately close the menu because the toggle isn't contained in the old menu element.