### PR TITLE
Fix YouTube iframe for the Racing Kings variant page

### DIFF
--- a/modules/blog/src/main/Youtube.scala
+++ b/modules/blog/src/main/Youtube.scala
@@ -5,9 +5,9 @@ object Youtube:
   def augmentEmbeds(html: Html): Html =
     addCredentialless(fixStartTimes(html))
 
-  private val IframeRegex = """allowfullscreen></iframe>""".r
+  private val IframeRegex = """(<iframe[^>]*)>""".r
   private def addCredentialless(html: Html) = Html:
-    IframeRegex.replaceAllIn(html.value, """credentialless="credentialless" allowfullscreen></iframe>""")
+    IframeRegex.replaceAllIn(html.value, """$1 credentialless>""")
 
   private val TimeMarkerRegex = """youtube\.com/watch\?v=[\w-]++\#t=([^"]++)[^?]++\?feature=oembed""".r
   private val HourMinSecRegex = """(\d++)h(\d++)m(\d++)s""".r

--- a/modules/blog/src/test/Fixtures.scala
+++ b/modules/blog/src/test/Fixtures.scala
@@ -250,7 +250,7 @@ object Fixtures:
 
 <h4>Modified Chigorin/Trompowsky </h4>
 
-<div data-oembed="https://www.youtube.com/watch?v=uz-dZ2W4Bf0#t=1m01s" data-oembed-type="video" data-oembed-provider="youtube"><iframe width="480" height="270" src="https://www.youtube.com/embed/uz-dZ2W4Bf0?feature=oembed" frameborder="0" allowfullscreen></iframe></div>
+<div data-oembed="https://www.youtube.com/watch?v=uz-dZ2W4Bf0#t=1m01s" data-oembed-type="video" data-oembed-provider="youtube"><iframe width="480" height="270" src="https://www.youtube.com/embed/uz-dZ2W4Bf0?feature=oembed" frameborder="0" allowfullscreen title="Crazyhouse opening repertoire"></iframe></div>
 
 <p><em>Basic setup:</em> 1. d4 ... 2. Nc3 ... 3. Bg5 ... 4. Nf3 ... 5. e3 (or e4, if allowed) ... 6. Be2/d3 ... 7. 0-0</p>
 

--- a/modules/blog/src/test/YoutubeTest.scala
+++ b/modules/blog/src/test/YoutubeTest.scala
@@ -9,12 +9,22 @@ class YoutubeTest extends munit.FunSuite:
     val fixed = Youtube.augmentEmbeds(Fixtures.withYoutube).value
     assert(
       !fixed.contains(
-        """<div data-oembed="https://www.youtube.com/watch?v=uz-dZ2W4Bf0#t=4m14s" data-oembed-type="video" data-oembed-provider="youtube"><iframe width="480" height="270" src="https://www.youtube.com/embed/uz-dZ2W4Bf0?feature=oembed" frameborder="0" credentialless="credentialless" allowfullscreen></iframe></div>"""
+        """<div data-oembed="https://www.youtube.com/watch?v=uz-dZ2W4Bf0#t=4m14s" data-oembed-type="video" data-oembed-provider="youtube"><iframe width="480" height="270" src="https://www.youtube.com/embed/uz-dZ2W4Bf0?feature=oembed" frameborder="0" allowfullscreen credentialless></iframe></div>"""
       )
     )
     assert(
       fixed.contains(
-        """<div data-oembed="https://www.youtube.com/watch?v=uz-dZ2W4Bf0#t=4m14s" data-oembed-type="video" data-oembed-provider="youtube"><iframe width="480" height="270" src="https://www.youtube.com/embed/uz-dZ2W4Bf0?feature=oembed&start=254" frameborder="0" credentialless="credentialless" allowfullscreen></iframe></div>"""
+        """<div data-oembed="https://www.youtube.com/watch?v=uz-dZ2W4Bf0#t=4m14s" data-oembed-type="video" data-oembed-provider="youtube"><iframe width="480" height="270" src="https://www.youtube.com/embed/uz-dZ2W4Bf0?feature=oembed&start=254" frameborder="0" allowfullscreen credentialless></iframe></div>"""
+      )
+    )
+    assert(
+      !fixed.contains(
+        """<div data-oembed="https://www.youtube.com/watch?v=uz-dZ2W4Bf0#t=1m01s" data-oembed-type="video" data-oembed-provider="youtube"><iframe width="480" height="270" src="https://www.youtube.com/embed/uz-dZ2W4Bf0?feature=oembed" frameborder="0" allowfullscreen title="Crazyhouse opening repertoire" credentialless></iframe></div>"""
+      )
+    )
+    assert(
+      fixed.contains(
+        """<div data-oembed="https://www.youtube.com/watch?v=uz-dZ2W4Bf0#t=1m01s" data-oembed-type="video" data-oembed-provider="youtube"><iframe width="480" height="270" src="https://www.youtube.com/embed/uz-dZ2W4Bf0?feature=oembed&start=61" frameborder="0" allowfullscreen title="Crazyhouse opening repertoire" credentialless></iframe></div>"""
       )
     )
   }


### PR DESCRIPTION
The fix makes the iframe replacement regex more robust.

The problem lies on [the Racing Kings variant page](https://lichess.org/variant/racingKings): the embedded YouTube player doesn't work.

This happens because the Racing Kings iframe ends in `allowfullscreen="" title="Racing Kings variant - Blitz Chess w/ commentary"></iframe>`, which means that it is not picked up by the regex in https://github.com/lichess-org/lila/commit/ddc248d0ab14b345c97c008520ec04db7e14388d, which is supposed to detect the `iframe` tag and add the `credentialless` attribute. As a result, that attribute was not added to the YouTube `iframe` tag for the Racing Kings page.

Tests have been added for this extra case as well.