### PR TITLE
Show pending simuls for a player

### DIFF
--- a/modules/simul/src/main/SimulRepo.scala
+++ b/modules/simul/src/main/SimulRepo.scala
@@ -61,8 +61,16 @@ final private[simul] class SimulRepo(val coll: Coll)(using Executor):
   def findCreated(id: SimulId): Fu[Option[Simul]] =
     find(id) map (_ filter (_.isCreated))
 
-  def findPending(hostId: UserId): Fu[List[Simul]] =
-    coll.list[Simul](createdSelect ++ $doc("hostId" -> hostId))
+  def findPending(userId: UserId): Fu[List[Simul]] =
+    coll.list[Simul](
+      createdSelect ++
+        $or(
+          $doc("hostId" -> userId),
+          $doc(
+            "applicants" -> $doc("$elemMatch" -> $doc("player.user" -> userId))
+          )
+        )
+    )
 
   def byTeamLeaders(teamId: TeamId, hostIds: Seq[UserId]): Fu[List[Simul]] =
     coll


### PR DESCRIPTION
Once a player joins a simul and until it starts, there's not an easy way to get back to it without the direct link.

This PR changes it so once you're in the `applicants` list, it will show in the "Your Pending Simuls" list, previously meant for just hosts.

fixes #13529