### PR TITLE
Fix draw label for threefold games with insufficient material

### DIFF
--- a/ui/game/src/view/status.ts
+++ b/ui/game/src/view/status.ts
@@ -60,11 +60,11 @@ export default function status(ctrl: Ctrl): string {
           )}`;
       }
     case 'draw': {
-      if (insufficientMaterial(d.game.variant.key, d.game.fen))
-        return `${noarg('insufficientMaterial')} • ${noarg('draw')}`;
       if (d.game.fen.split(' ')[4] === '100')
         return `${noarg('fiftyMovesWithoutProgress')} • ${noarg('draw')}`;
       if (d.game.threefold) return `${noarg('threefoldRepetition')} • ${noarg('draw')}`;
+      if (insufficientMaterial(d.game.variant.key, d.game.fen))
+        return `${noarg('insufficientMaterial')} • ${noarg('draw')}`;
       if (d.game.drawOffers?.some(turn => turn >= d.game.turns)) return noarg('drawByMutualAgreement');
       return noarg('draw');
     }


### PR DESCRIPTION
The [scala code](https://github.com/lichess-org/lila/blob/8d769b28e1fd6e82ddffdf01eb06a739b58e358c/app/templating/GameHelper.scala#L215-L223) checks for threefold before checking for insufficient material. Updates the ts to do the same.

Fixes #13540