### PR TITLE
Fix losses against Stockfish appearing under "Draws" tab in paginator

### DIFF
--- a/modules/game/src/main/Query.scala
+++ b/modules/game/src/main/Query.scala
@@ -26,7 +26,10 @@ object Query:
 
   val mate: Bdoc = status(Status.Mate)
 
-  def draw(u: UserId): Bdoc = user(u) ++ finished ++ F.winnerId.$exists(false)
+  def draw(u: UserId): Bdoc =
+    user(u) ++ finished ++ F.winnerId.$exists(false) ++ $doc(
+      F.status $in List(Status.Stalemate.id, Status.Draw.id)
+    )
 
   val finished: Bdoc = F.status $gte Status.Mate.id
 

--- a/modules/game/src/main/Query.scala
+++ b/modules/game/src/main/Query.scala
@@ -64,6 +64,11 @@ object Query:
     "p1.ai" $exists false
   )
 
+  val vsAi: Bdoc = $or(
+    "p0.ai" $exists true,
+    "p1.ai" $exists true
+  )
+
   def nowPlaying[U: UserIdOf](u: U) = $doc(F.playingUids -> u)
 
   def recentlyPlaying(u: UserId) =
@@ -84,9 +89,12 @@ object Query:
   def loss(u: UserId) =
     user(u) ++ $doc(
       F.status $in Status.finishedWithWinner.map(_.id),
-      F.winnerId -> $doc(
-        "$exists" -> true,
-        "$ne"     -> u
+      $or(
+        $doc(
+          F.winnerId $exists true,
+          F.winnerId $ne u
+        ),
+        vsAi
       )
     )
 


### PR DESCRIPTION
Fixes the issue where losses against Stockfish are incorrectly appearing in the "Draws" tab in the paginator (l.org/@/user/draws), and not in the "Losses" tab.

This is happening as the ai does not have a user id, and therefore does not populate the `wid` field in the database. The draw case is resolved by including the valid draw status ids, and losses by checking if the game was versus the ai if the `wid` field is empty.

**Screenshot of the issue:**
![stockfish-losses-under-draws](https://github.com/lichess-org/lila/assets/3620552/8bc3499c-fa34-46bf-8550-25eefa269e52)

**Screenshot showing Stockfish losses missing from Losses tab:**
![Screenshot_20230906_202952](https://github.com/lichess-org/lila/assets/3620552/88b0b00c-aeb3-48d8-9a80-d6d226f3dd03)


