### PR TITLE
Fix losses against Stockfish appearing under "Draws" tab

### DIFF
--- a/modules/game/src/main/Query.scala
+++ b/modules/game/src/main/Query.scala
@@ -26,7 +26,10 @@ object Query:
 
   val mate: Bdoc = status(Status.Mate)
 
-  def draw(u: UserId): Bdoc = user(u) ++ finished ++ F.winnerId.$exists(false)
+  def draw(u: UserId): Bdoc =
+    user(u) ++ finished ++ F.winnerId.$exists(false) ++ $doc(
+      F.status $in List(Status.Stalemate.id, Status.Draw.id)
+    )
 
   val finished: Bdoc = F.status $gte Status.Mate.id
 


### PR DESCRIPTION
Fixes the issue where losses against Stockfish are incorrectly appearing in the "Draws" tab (l.org/@/user/draws).

This incorporates just the draw query changes from #13553 as this change only adds matching the status id to those which are a draw. Similar logic is already used as part of the `loss` query [here](https://github.com/lichess-org/lila/blob/d5760fc76e21336fa4ea4b080688123d7abb06a8/modules/game/src/main/Query.scala#L83).

To allow losses against Stockfish to correctly appear under the "Losses" tab, we would also need to include [this commit](https://github.com/lichess-org/lila/pull/13553/commits/ad9aee1b0a71ba6fcada41667d84789ac60ad228), but I know there was some concern about `$or` queries being slow and having ill effects on the db servers.
