### PR TITLE
Update FIDE handbook url & related faq entries

### DIFF
--- a/app/views/site/faq.scala
+++ b/app/views/site/faq.scala
@@ -10,7 +10,7 @@ object faq:
 
   import trans.faq.*
 
-  val fideHandbookUrl = "https://handbook.fide.com/chapter/E012018"
+  val fideHandbookUrl = "https://handbook.fide.com/chapter/E012023"
 
   private def question(id: String, title: String, answer: Frag*) =
     div(

--- a/translation/source/faq.xml
+++ b/translation/source/faq.xml
@@ -57,7 +57,7 @@ Note that it can be possible to mate with a single knight or bishop if the oppon
   <string name="discoveringEnPassant">Why can a pawn capture another pawn when it is already passed? (en passant)</string>
   <string name="explainingEnPassant">This is a legal move known as "en passant". The Wikipedia article gives a %1$s.
 
-It is described in section 3.7 (d) of the %2$s:
+It is described in sections 3.7.3.1 and 3.7.3.2 of the %2$s:
 
 "A pawn occupying a square on the same rank as and on an adjacent file to an opponent’s pawn which has just advanced two squares in one move from its original square may capture this opponent’s pawn as though the latter had been moved only one square. This capture is only legal on the move following this advance and is called an ‘en passant’ capture."
 
@@ -66,7 +66,7 @@ See the %3$s on this move for some practice with it.</string>
   <string name="lichessTraining">Lichess training</string>
   <string name="watchIMRosenCheckmate">Watch International Master Eric Rosen checkmate %s.</string>
   <string name="threefoldRepetition">Threefold repetition</string>
-  <string name="threefoldRepetitionExplanation">If a position occurs three times, players can claim a draw by %1$s. Lichess implements the official FIDE rules, as described in Article 9.2 (d) of the %2$s.</string>
+  <string name="threefoldRepetitionExplanation">If a position occurs three times, players can claim a draw by %1$s. Lichess implements the official FIDE rules, as described in Article 9.2 of the %2$s.</string>
   <string name="threefoldRepetitionLowerCase">threefold repetition</string>
   <string name="notRepeatedMoves">We did not repeat moves. Why was the game still drawn by repetition?</string>
   <string name="repeatedPositionsThatMatters">Threefold repetition is about repeated %1$s, not moves. Repetition does not have to occur consecutively.</string>


### PR DESCRIPTION
This
- changes the "fideHandbookUrl" link to the [current version](https://handbook.fide.com/chapter/E012023) which is in effect since 1 January 2023,
- replaces **_section 3.7 (d)_** in the "explainingEnPassant" string with **_sections 3.7.3.1 and 3.7.3.2_** as the former doesn't exist and is split into two sections,
- replaces **_Article 9.2 (d)_** in the "threefoldRepetitionExplanation" string with **_Article 9.2_** as the former doesn't exist.

And I wasn't sure if the corresponding translation keys should be renamed for this, so I left it out.