### PR TITLE
add flags of Netherlands Antilles, Canary Islands

### DIFF
--- a/modules/user/src/main/Flags.scala
+++ b/modules/user/src/main/Flags.scala
@@ -125,7 +125,7 @@ object Flags:
     C("HR", "Croatia"),
     C("HT", "Haiti"),
     C("HU", "Hungary"),
-    C("IC", "Canary Islands")
+    C("IC", "Canary Islands"),
     C("ID", "Indonesia"),
     C("IE", "Ireland"),
     C("IL", "Israel"),

--- a/modules/user/src/main/Flags.scala
+++ b/modules/user/src/main/Flags.scala
@@ -22,6 +22,7 @@ object Flags:
     C("AL", "Albania"),
     C("AM", "Armenia"),
     C("AM-RA", "Artsakh"),
+    C("AN", "Netherlands Antilles"),
     C("AO", "Angola"),
     C("AQ", "Antarctica"),
     C("AR", "Argentina"),
@@ -124,6 +125,7 @@ object Flags:
     C("HR", "Croatia"),
     C("HT", "Haiti"),
     C("HU", "Hungary"),
+    C("IC", "Canary Islands")
     C("ID", "Indonesia"),
     C("IE", "Ireland"),
     C("IL", "Israel"),


### PR DESCRIPTION
A crossmatch between `public/images/flags/` and `modules/user/src/main/Flags.scala` showed that two flags are present in the repository, but haven't been added as user options.