### PR TITLE
bugfix for Learn:Board setup 6 to not get stuck 

### DIFF
--- a/ui/learn/src/assert.ts
+++ b/ui/learn/src/assert.ts
@@ -84,6 +84,10 @@ export function noCheckIn(nbMoves: number) {
   };
 }
 
+export function kingCaptured(level: AssertData) {
+  return level.chess.instance.in_checkmate();
+}
+
 type Assert = (level: AssertData) => boolean;
 
 export function not(assert: Assert) {

--- a/ui/learn/src/chess.ts
+++ b/ui/learn/src/chess.ts
@@ -154,6 +154,7 @@ export default function (fen: string, appleKeys: Key[]): ChessCtrl {
           };
         });
       setColor(color);
+      if (checks.length === 0) return null;
       return checks;
     },
     playRandomMove: function () {

--- a/ui/learn/src/stage/castling.ts
+++ b/ui/learn/src/stage/castling.ts
@@ -1,4 +1,4 @@
-import { and, lastMoveSan, not, or, pieceNotOn } from '../assert';
+import { and, lastMoveSan, not, or, pieceNotOn, mate } from '../assert';
 import { arrow, assetUrl, circle, roundSvg, toLevel } from '../util';
 import { LevelPartial } from './list';
 
@@ -6,8 +6,14 @@ const imgUrl = assetUrl + 'images/learn/castle.svg';
 
 const castledKingSide = lastMoveSan('O-O');
 const castledQueenSide = lastMoveSan('O-O-O');
-const cantCastleKingSide = and(not(castledKingSide), or(pieceNotOn('K', 'e1'), pieceNotOn('R', 'h1')));
-const cantCastleQueenSide = and(not(castledQueenSide), or(pieceNotOn('K', 'e1'), pieceNotOn('R', 'a1')));
+const cantCastleKingSide = and(
+  not(castledKingSide),
+  or(pieceNotOn('K', 'e1'), pieceNotOn('R', 'h1'), mate, pieceNotOn('k', 'e8')),
+);
+const cantCastleQueenSide = and(
+  not(castledQueenSide),
+  or(pieceNotOn('K', 'e1'), pieceNotOn('R', 'a1'), mate, pieceNotOn('k', 'e8')),
+);
 
 export default {
   key: 'castling',


### PR DESCRIPTION
bugfix for Learn:Board setup 6 to not get stuck  and minor improvemens to castling lessons.

This attempts to solve: https://github.com/lichess-org/lila/issues/13581

I believe fully solving the stuck issues with the castling excersises will require patching chess.js
https://github.com/jhlywa/chess.js/releases/tag/v0.10.2

Probably worth looking into upgrading to a more recent release first as v0.13.4 seems to be latest.
https://github.com/jhlywa/chess.js/releases/tag/v0.13.4

If no one is attempting this I could look into it.
