### PR TITLE
setupCtrl modal and rated unlimited vs friend fixes

### DIFF
--- a/modules/setup/src/main/HookConfig.scala
+++ b/modules/setup/src/main/HookConfig.scala
@@ -77,8 +77,6 @@ case class HookConfig(
               ratingRange = ratingRange
             )
 
-  def noRatedUnlimited = mode.casual || hasClock || makeDaysPerTurn.isDefined
-
   def updateFrom(game: lila.game.Game) =
     copy(
       variant = game.variant,

--- a/modules/setup/src/main/HumanConfig.scala
+++ b/modules/setup/src/main/HumanConfig.scala
@@ -7,6 +7,8 @@ private[setup] trait HumanConfig extends Config:
   // casual or rated
   val mode: Mode
 
+  def noRatedUnlimited = mode.casual || hasClock || makeDaysPerTurn.isDefined
+
 private[setup] trait BaseHumanConfig extends BaseConfig:
 
   val modes = Mode.all map (_.id)

--- a/modules/setup/src/main/SetupForm.scala
+++ b/modules/setup/src/main/SetupForm.scala
@@ -52,6 +52,7 @@ object SetupForm:
     )(FriendConfig.from)(_.>>)
       .verifying("Invalid clock", _.validClock)
       .verifying("Invalid speed", _.validSpeed(me.exists(_.isBot)))
+      .verifying("Can't create rated unlimited game", _.noRatedUnlimited)
       .verifying("invalidFen", _.validFen)
 
   def hookFilled(timeModeString: Option[String])(using me: Option[Me]): Form[HookConfig] =
@@ -69,7 +70,7 @@ object SetupForm:
       "color"       -> color
     )(HookConfig.from)(_.>>)
       .verifying("Invalid clock", _.validClock)
-      .verifying("Can't create rated unlimited in lobby", _.noRatedUnlimited)
+      .verifying("Can't create rated unlimited game", _.noRatedUnlimited)
 
   private lazy val boardApiHookBase: Mapping[HookConfig] =
     mapping(

--- a/ui/lobby/src/setupCtrl.ts
+++ b/ui/lobby/src/setupCtrl.ts
@@ -100,9 +100,9 @@ export default class SetupController {
   private loadPropsFromStore = (forceOptions?: ForceSetupOptions) => {
     const storeProps = this.store[this.gameType!]();
     // Load props from the store, but override any store values with values found in forceOptions
-    this.variant = propWithEffect(forceOptions?.variant || storeProps.variant, this.onVariantChange);
+    this.variant = propWithEffect(forceOptions?.variant || storeProps.variant, this.onDropdownChange);
     this.fen = this.propWithApply(forceOptions?.fen || storeProps.fen);
-    this.timeMode = this.propWithApply(forceOptions?.timeMode || storeProps.timeMode);
+    this.timeMode = propWithEffect(forceOptions?.timeMode || storeProps.timeMode, this.onDropdownChange);
     this.timeV = this.propWithApply(sliderInitVal(storeProps.time, timeVToTime, 100)!);
     this.incrementV = this.propWithApply(sliderInitVal(storeProps.increment, incrementVToIncrement, 100)!);
     this.daysV = this.propWithApply(sliderInitVal(storeProps.days, daysVToDays, 20)!);
@@ -169,7 +169,7 @@ export default class SetupController {
     this.root.redraw();
   };
 
-  private onVariantChange = () => {
+  private onDropdownChange = () => {
     // Handle rating update here
     this.enforcePropRules();
     if (this.isProvisional()) {


### PR DESCRIPTION
This PR addresses two related issues surrounding the setupCtrl modal.

The first issue is that the "Rated" game mode can be set on unlimited time control games (if "Rated" was previously selected for a different time mode), even though casual is only allowed. The game creation in this case is stopped correctly.

The second issue is the same, but via "Play a friend". However in this case I can successfully set up a rated unlimited game.

**Issue 1**

https://github.com/lichess-org/lila/assets/3620552/0ff1f0ad-4587-45cb-adfa-424b9bd62c35

**Issue 2**

https://github.com/lichess-org/lila/assets/3620552/66d67ef4-6aef-4588-beb4-82c5bfb0c124




