### PR TITLE
Fix highchart navigator series used on profile

### DIFF
--- a/modules/history/src/main/RatingChartApi.scala
+++ b/modules/history/src/main/RatingChartApi.scala
@@ -48,7 +48,7 @@ final class RatingChartApi(
 
 object RatingChartApi:
 
-  def bestPerfIndex(user: User.WithPerfs): Int = user.perfs.bestRatedPerf.so(perfTypes indexOf _)
+  def bestPerfIndex(user: User.WithPerfs): Int = user.perfs.bestRatedPerf.so(perfTypes indexOf _.perfType)
 
   import lila.rating.PerfType.*
   private val perfTypes = List(


### PR DESCRIPTION
The highchart navigator on a users profile is not displaying the correct data series. It's being defaulted to "Bullet" as that's the first series in the chart (according to highchart docs). For those who do not play bullet, the navigator data is empty. This is a regression introduced in [this commit](https://github.com/lichess-org/lila/commit/12da21d30925ff7325963d19a4b4fb88e9aaabf9).

The navigator on a users profile should be showing the best rated perf data.

**Issue**
![image](https://github.com/lichess-org/lila/assets/3620552/3ad7cfa5-6f8f-4da6-8f0a-e4d17b4a5580)

**After testing**
![image](https://github.com/lichess-org/lila/assets/3620552/1b1f1f85-9a21-4fd7-92ac-65ed5a3ebf7d)
