### PR TITLE
SetupController "From Position" fixes

### DIFF
--- a/app/views/lobby/home.scala
+++ b/app/views/lobby/home.scala
@@ -197,5 +197,6 @@ object home:
     trans.side,
     trans.white,
     trans.randomColor,
-    trans.black
+    trans.black,
+    trans.boardEditor
   )

--- a/ui/lobby/src/setupCtrl.ts
+++ b/ui/lobby/src/setupCtrl.ts
@@ -280,7 +280,7 @@ export default class SetupController {
       color,
     });
 
-  validFen = (): boolean => this.variant() !== 'fromPosition' || !this.fenError;
+  validFen = (): boolean => this.variant() !== 'fromPosition' || (!this.fenError && !!this.fen());
   validTime = (): boolean => this.timeMode() !== 'realTime' || this.time() > 0 || this.increment() > 0;
   validAiTime = (): boolean =>
     this.gameType !== 'ai' ||

--- a/ui/lobby/src/view/setup/components/fenInput.ts
+++ b/ui/lobby/src/view/setup/components/fenInput.ts
@@ -30,7 +30,7 @@ export const fenInput = (ctrl: LobbyController) => {
     h(
       'a.fen__board',
       { attrs: { href: '/editor' } },
-      setupCtrl.fenError || !setupCtrl.lastValidFen
+      !setupCtrl.lastValidFen || !setupCtrl.validFen()
         ? null
         : h(
             'span.preview',


### PR DESCRIPTION
Fixes related to the SetupController when "From Position" is selected (Play a Friend / Play with the Computer):

1) Currently, you can attempt to start a "From Position" game with the FEN input field empty. This causes a dialog to pop up and leaves the modal in an odd state where the spinner is still displayed instead of the color buttons. This PR disables the color buttons if the FEN is empty.

2) Currently, if you enter a valid FEN in the input a miniboard is displayed showing the position. If you delete the FEN, the miniboard is still displayed. This PR removes the miniboard when the FEN is deleted.

3) The board editor pencil icon next to the FEN input has a tooltip that reads "boardEditor". This PR adds the missing `boardEditor` translation to the i18nKeys list so the tooltip displays properly.

