### PR TITLE
ratingHistory - Fix access of undefined index

### DIFF
--- a/ui/chart/src/ratingHistory.ts
+++ b/ui/chart/src/ratingHistory.ts
@@ -25,7 +25,7 @@ export async function initModule({ data, singlePerfName, perfIndex }: Opts) {
   }
   const $el = $('div.rating-history');
   const singlePerfIndex = data.findIndex((x: any) => x.name === singlePerfName);
-  if (singlePerfName && data[singlePerfIndex].points.length === 0) {
+  if (singlePerfName && !data[singlePerfIndex]?.points.length) {
     $el.hide();
     return;
   }


### PR DESCRIPTION
Fixes the access of an undefined index that can occur in `ratingHistory.ts: initModule`:

From prod:
![Screenshot_20230924_134452](https://github.com/lichess-org/lila/assets/3620552/ba156b27-483f-4a1b-9f6d-ac4583962f1b)

Unminified:
![Screenshot_20230924_134553](https://github.com/lichess-org/lila/assets/3620552/8ca028f4-af99-4845-854f-5f16ce18ede9)

The above console error occurs when accessing the `/perf/standard` page of a player. Not high priority as this page generally won't be accessed as there aren't any links to it, but considering this is shared code with the other perfs, I figured it be best to ensure the index is available.