### PR TITLE
Incorrect mouse hit area on promotion

### DIFF
--- a/ui/chess/css/_promotion.scss
+++ b/ui/chess/css/_promotion.scss
@@ -12,14 +12,13 @@
     border-radius: 50%;
     background-color: #b0b0b0;
     box-shadow: inset 0 0 25px 3px #808080;
-
+    pointer-events: all;
     @include transition;
   }
 
   piece {
-    pointer-events: auto;
+    pointer-events: none;
     opacity: 1;
-
     /* cancels blindfold */
   }
 


### PR DESCRIPTION
This change fixes #13545, which specifically affects 3d pieces, although the proposed change will affect 2d pieces as well. 

## Before the fix:

**3D**
https://github.com/lichess-org/lila/assets/59802340/d78cab5c-5202-47db-ae11-9331f7b7aca2
**2D**
https://github.com/lichess-org/lila/assets/59802340/c0a32237-0736-4b99-aa7b-6f4c9330908b

## After the fix: 
**3D**
https://github.com/lichess-org/lila/assets/59802340/03ea8be7-4773-4627-a17e-be9288369863
**2D**
https://github.com/lichess-org/lila/assets/59802340/4bdd1a10-9273-41e8-908a-20206f1a9445


Tested on the following platforms:
Platform | Chrome 116.0.5845.187 | Safari 18615.3.12.11.2 | Firefox 117.0.1
--- | --- | --- | --- 
Verified | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark:

Should be a pretty simple fix, let me know if more testing is required. This is my first issue so I could be missing something. 