### PR TITLE
From position FEN input and miniboard fixes

### DIFF
--- a/ui/lobby/src/view/setup/components/fenInput.ts
+++ b/ui/lobby/src/view/setup/components/fenInput.ts
@@ -12,7 +12,7 @@ export const fenInput = (ctrl: LobbyController) => {
         attrs: { placeholder: trans('pasteTheFenStringHere'), value: fen },
         on: {
           input: (e: InputEvent) => {
-            setupCtrl.fen((e.target as HTMLInputElement).value);
+            setupCtrl.fen((e.target as HTMLInputElement).value.trim());
             setupCtrl.validateFen();
           },
         },

--- a/ui/lobby/src/view/setup/components/fenInput.ts
+++ b/ui/lobby/src/view/setup/components/fenInput.ts
@@ -29,7 +29,7 @@ export const fenInput = (ctrl: LobbyController) => {
     ]),
     h(
       'a.fen__board',
-      { attrs: { href: '/editor' } },
+      { attrs: { href: `/editor/${setupCtrl.lastValidFen.replace(' ', '_')}` } },
       !setupCtrl.lastValidFen || !setupCtrl.validFen()
         ? null
         : h(


### PR DESCRIPTION
Fixes:
1. From position miniboard href uses default `/editor` link instead of the displayed position
2. From position miniboard is empty if the FEN input has prepended spaces:
![image](https://github.com/lichess-org/lila/assets/3620552/0987a903-65ed-48f4-8a93-b6847a9acb42)
