### PR TITLE
add small chin to dropdown menus

### DIFF
--- a/ui/common/css/header/_topnav-visible.scss
+++ b/ui/common/css/header/_topnav-visible.scss
@@ -90,6 +90,7 @@
       div {
         visibility: visible;
         max-height: none;
+        padding-bottom: 8px;
       }
     }
   }


### PR DESCRIPTION
It takes unnecessary care to properly click the last menu item in a drop down due to over-aggressive closure around the lower pixels. Instigated by #13665 but not sure the issues are the same so I'm reluctant to close it.