### PR TITLE
Internationalization "onlyInviteLeadersTrust"

### DIFF
--- a/app/views/team/admin.scala
+++ b/app/views/team/admin.scala
@@ -22,9 +22,7 @@ object admin:
         bits.menu(none),
         div(cls := "page-menu__content box box-pad")(
           adminTop(t, teamLeaders),
-          p(
-            "Only invite leaders that you fully trust. Team leaders can kick members and other leaders out of the team."
-          ),
+          p(onlyInviteLeadersTrust()),
           postForm(cls := "leaders", action := routes.Team.leaders(t.id))(
             form3.group(form("leaders"), frag(usersWhoCanManageThisTeam()))(teamMembersAutoComplete(t)),
             form3.actions(

--- a/modules/i18n/src/main/I18nKeys.scala
+++ b/modules/i18n/src/main/I18nKeys.scala
@@ -1758,6 +1758,7 @@ object I18nKeys:
     val `messageAllMembersLongDescription` = I18nKey("team:messageAllMembersLongDescription")
     val `teamsIlead` = I18nKey("team:teamsIlead")
     val `youWayWantToLinkOneOfTheseTournaments` = I18nKey("team:youWayWantToLinkOneOfTheseTournaments")
+    val `onlyInviteLeadersTrust` = I18nKey("team:onlyInviteLeadersTrust")
     val `usersWhoCanManageThisTeam` = I18nKey("team:usersWhoCanManageThisTeam")
     val `leadersChat` = I18nKey("team:leadersChat")
     val `closeTeam` = I18nKey("team:closeTeam")

--- a/translation/source/team.xml
+++ b/translation/source/team.xml
@@ -43,6 +43,7 @@ You can use this to call players to join a tournament or a team battle.
 Players who don't like receiving your messages might leave the team.</string>
   <string name="teamsIlead">Teams I lead</string>
   <string name="youWayWantToLinkOneOfTheseTournaments">You may want to link one of these upcoming tournaments?</string>
+  <string name="onlyInviteLeadersTrust">Only invite leaders that you fully trust. Team leaders can kick members and other leaders out of the team.</string>
   <string name="usersWhoCanManageThisTeam">Users who can manage this team</string>
   <string name="leadersChat">Leaders chat</string>
   <string name="closeTeam">Close team</string>


### PR DESCRIPTION
I'm trying to internationalize the phrase
"Only invite leaders that you fully trust. Team leaders can kick members and other leaders out of the team."

note:
I committed via gitpod
and when trying to test it only shows "team:onlyInviteLeadersTrust"
I may have done something wrong