### PR TITLE
From position: Use default board editor path on invalid FEN input

### DIFF
--- a/ui/lobby/src/view/setup/components/fenInput.ts
+++ b/ui/lobby/src/view/setup/components/fenInput.ts
@@ -23,7 +23,7 @@ export const fenInput = (ctrl: LobbyController) => {
         attrs: {
           'data-icon': licon.Pencil,
           title: trans('boardEditor'),
-          href: '/editor' + (fen ? `/${fen.replace(' ', '_')}` : ''),
+          href: '/editor' + (fen && !setupCtrl.fenError ? `/${fen.replace(' ', '_')}` : ''),
         },
       }),
     ]),


### PR DESCRIPTION
Update to use the default board editor path if the FEN input is invalid.