### PR TITLE
Fix /patron/list donation buttons not working on some browsers

### DIFF
--- a/app/http/HttpFilter.scala
+++ b/app/http/HttpFilter.scala
@@ -55,7 +55,8 @@ final class HttpFilter(env: Env)(using val mat: Materializer)(using Executor)
     else result
 
   private def addCrendentialless(req: RequestHeader)(result: Result): Result =
-    if HTTPRequest.actionName(req) != "Plan.index" &&
+    val actionName = HTTPRequest actionName req
+    if actionName != "Plan.index" && actionName != "Plan.list" &&
       HTTPRequest.uaMatches(req, env.credentiallessUaRegex.get())
     then result.withHeaders(credentiallessHeaders*)
     else result

--- a/modules/mailer/src/main/AutomaticEmail.scala
+++ b/modules/mailer/src/main/AutomaticEmail.scala
@@ -163,9 +163,9 @@ To make a new donation, head to $baseUrl/patron"""
           if lifetime then "lifetime Patron wings"
           else "Patron wings for one month"
         alsoSendAsPrivateMessage(from): _ =>
-          s"""You gift @${to.username} the $wings. Thank you so much!"""
+          s"""You gifted @${to.username} $wings. Thank you so much!"""
         alsoSendAsPrivateMessage(to): _ =>
-          s"""@${from.username} gifts you the $wings!"""
+          s"""@${from.username} gifted you $wings!"""
 
     }
 


### PR DESCRIPTION
Well this one took me forever to track down...

See a video of the _issue_ in detail here: https://github.com/lichess-org/lila/assets/3620552/cc7a9702-8995-4f37-ac8e-01c0e2ea5d04. I recorded the video on lichess.dev, but I assure you this same issue happens on prod. This issue is oddly dependent on browser, as I can only get this to replicate using Chrome (and not everyone can even replicate it using Chrome).

This issue isn't specific to _gifting_, but instead specific to the `/patron/list` page as it was adding credentialless headers and `/patron` is not.

Tested in my local development instance as I was able to get stripe set up. Video of fix in local development instance: 
https://github.com/lichess-org/lila/assets/3620552/d78d6d49-b8f9-44fc-aaca-7ed545f756ca

Also touched up the wording of the patron gift private messages.

Resolves #13681