### PR TITLE
make sure closed accounts do not re-appear on the leaderboard

### DIFF
--- a/modules/user/src/main/User.scala
+++ b/modules/user/src/main/User.scala
@@ -85,7 +85,7 @@ case class User(
   def isBot = title has Title.BOT
   def noBot = !isBot
 
-  def rankable = noBot && !marks.rankban
+  def rankable = enabled.yes && noBot && !marks.rankban
 
   def withPerf(perf: Perf): User.WithPerf = User.WithPerf(this, perf)
 


### PR DESCRIPTION
Sometimes closed accounts stay on the leaderboard, my guess they are added after their closure by a rating-refund.

This will ensure it does not happen anymore.

Lichess forum: https://lichess.org/forum/lichess-feedback/closed-account-in-leaderboard#9