### PR TITLE
Center disabled paypal button text

### DIFF
--- a/app/views/plan/index.scala
+++ b/app/views/plan/index.scala
@@ -213,7 +213,7 @@ object index:
                           button(cls := "stripe button")(withCreditCard()),
                           div(cls := "paypal paypal--order"),
                           div(cls := "paypal paypal--subscription"),
-                          button(cls := "paypal button disabled paypal--disabled")("PAYPAL")
+                          button(cls := "button disabled paypal--disabled")("PAYPAL")
                         )
                       else
                         a(


### PR DESCRIPTION
Centers the disabled paypal button text seen if gifting without a username entered. Changes do not affect the enabled paypal button.

**Before:**
![image](https://github.com/lichess-org/lila/assets/3620552/c1bac579-bf6a-422f-8425-c5896fb62d3f)

**After:**
![image](https://github.com/lichess-org/lila/assets/3620552/4de2c043-0e94-43c5-8985-0dfd68d42609)