### PR TITLE
Revert "Ratinghistory tooltip symbols"

### DIFF
--- a/ui/chart/src/ratingHistory.ts
+++ b/ui/chart/src/ratingHistory.ts
@@ -86,30 +86,6 @@ export async function initModule({ data, singlePerfName, perfIndex }: Opts) {
       },
       tooltip: {
         valueDecimals: 0,
-        useHTML: true,
-        formatter: function (this: any) {
-          const tooltipSymbolMapping = {
-            circle: '&#9679',
-            diamond: '&#9670',
-            square: '&#9632',
-            triangle: '&#9652',
-            'triangle-down': '&#9662',
-          };
-          let tooltipHTML = '<b>' + window.Highcharts.dateFormat('%A, %b %e, %Y', this.x) + '</b>';
-          this.points.forEach((point: any) => {
-            tooltipHTML +=
-              '<br/><span style="color: ' +
-              point.series.color +
-              '; margin-right: 5px;"> ' +
-              (tooltipSymbolMapping[point.series.symbol as keyof typeof tooltipSymbolMapping] ||
-                tooltipSymbolMapping['circle']) +
-              '</span>' +
-              point.series.name +
-              ': ' +
-              point.y;
-          });
-          return tooltipHTML;
-        },
       },
       xAxis: {
         title: noText,


### PR DESCRIPTION
This reverts commit 1c07e6b9f8a6be207e890ef59e3b4ed079faf66c.

I don't think it looks better, since the root issue is that unicode symbols do not have the same size, and it also introduce problems with alignment and rounding.

before the revert
<img width="988" alt="image" src="https://github.com/lichess-org/lila/assets/56031107/5ed3497b-021f-478f-b02e-22a15d71a0da">


fix https://github.com/lichess-org/lila/issues/13715