### PR TITLE
Fix simul join dialog when multiple variants available

### DIFF
--- a/ui/simul/src/view/created.ts
+++ b/ui/simul/src/view/created.ts
@@ -53,9 +53,13 @@ export default function (showText: (ctrl: SimulCtrl) => MaybeVNode) {
                             xhr.join(ctrl.data.id, ctrl.data.variants[0].key);
                           else
                             domDialog({
-                              show: 'modal',
                               cash: $('.simul .continue-with'),
-                              onClose: dlg => xhr.join(ctrl.data.id, dlg.view.dataset.variant as VariantKey),
+                            }).then(dlg => {
+                              $('button.button', dlg.view).on('click', function (this: HTMLButtonElement) {
+                                xhr.join(ctrl.data.id, this.dataset.variant as VariantKey);
+                                dlg.close();
+                              });
+                              dlg.showModal();
                             });
                         })
                       : {},


### PR DESCRIPTION
When a host creates a simul with multiple variants, the participants can select which variant they want for their game. They're presented a modal dialog after clicking Join.

This PR fixes a current bug where none of the buttons have any action when clicked.

Copied `domDialog()` behavior from [publicChats.ts](https://github.com/lichess-org/lila/blob/27f1db88d269c17a04ccdbdfa67ed9cda6bd4514/ui/site/src/publicChats.ts#L43-L62)