### PR TITLE
Fix unsubscribe link in correspondence notification emails

### DIFF
--- a/app/views/account/notification.scala
+++ b/app/views/account/notification.scala
@@ -38,9 +38,13 @@ object notification:
                 ).map(makeRow(form))
               )
             ),
-            setting(
-              correspondenceEmailNotification(),
-              radios(form("correspondenceEmail"), translatedBooleanChoices)
+            div(
+              id := "correspondence-email-notif"
+            )( // id is set to allow direct unsubcribe link in correspondence emails
+              setting(
+                correspondenceEmailNotification(),
+                radios(form("correspondenceEmail"), translatedBooleanChoices)
+              )
             ),
             setting(
               bellNotificationSound(),

--- a/modules/mailer/src/main/AutomaticEmail.scala
+++ b/modules/mailer/src/main/AutomaticEmail.scala
@@ -183,7 +183,7 @@ To make a new donation, head to $baseUrl/patron"""
               "Hello and thank you for playing correspondence chess on Lichess!"
             val disableSettingNotice =
               "You are receiving this email because you have correspondence email notification turned on. You can turn it off in your settings:"
-            val disableLink = s"$baseUrl/account/preferences/game-behavior#correspondence-email-notif"
+            val disableLink = s"$baseUrl/account/preferences/notification#correspondence-email-notif"
             mailer send Mailer.Message(
               to = email,
               subject = "Daily correspondence notice",


### PR DESCRIPTION
was broken since d9cb18bdcd12ac2b40ba950559c62e348f763712

For now the `id` link is a bit overkill, but I think it's a nice thing to have, and future proof in case the notification page grows longer