### PR TITLE
Ublog: Increase max image height

### DIFF
--- a/ui/common/css/component/_markdown.scss
+++ b/ui/common/css/component/_markdown.scss
@@ -1,4 +1,4 @@
-@mixin rendered-markdown($element-margin: 1em) {
+@mixin rendered-markdown($element-margin: 1em, $img-max-height: 50vh) {
   @extend %break-word;
 
   strong {
@@ -75,7 +75,7 @@
   img {
     display: block;
     max-width: 100%;
-    max-height: 50vh;
+    max-height: $img-max-height;
     margin: auto;
   }
 

--- a/ui/site/css/ublog/_markup.scss
+++ b/ui/site/css/ublog/_markup.scss
@@ -1,5 +1,5 @@
 .ublog-post__markup {
-  @include rendered-markdown(2em);
+  @include rendered-markdown(2em, 450vh);
   @include rendered-markdown--code;
   @include rendered-markdown--quote;
 


### PR DESCRIPTION
As long as the width is kept to 100% it's still easy to read/see by scrolling. This notably will allow data-analysis figures to be more readable, as they're usually the pictures with high heights.

For example, after the change https://lichess.org/@/oortcloud_o/blog/tell-me-the-elo/JGcZSVhN is much easier to read (can be tested locally by overriding the value in browser). The `450hv` comes from this blog post.

The introduction of the new variable `$img-max-height` is to minimise disturbance as it is also used in team descriptions or class, where larger images may not be wanted.
