### PR TITLE
updated ceval bar.

### DIFF
--- a/ui/ceval/css/_ctrl.scss
+++ b/ui/ceval/css/_ctrl.scss
@@ -99,6 +99,8 @@
   .bar span {
     display: block;
     height: 3px;
+    border-radius: 2px;
+    transform: translate3d(3px, -11px, 0);
     width: 0;
     background: $c-good;
     transition: width 1s;


### PR DESCRIPTION
![Screenshot 2023-10-11 at 14 50 24](https://github.com/lichess-org/lila/assets/89607421/d6879629-ba5e-4224-9345-a1c12bddfe88)
![Screenshot 2023-10-11 at 14 51 13](https://github.com/lichess-org/lila/assets/89607421/cd9a90ff-73ab-42e5-a126-7b0df1ed6a3b)
ceval bar was overriding text..
