### PR TITLE
Unselect player in personal opening search history upon deletion.

### DIFF
--- a/ui/analyse/src/explorer/explorerConfig.ts
+++ b/ui/analyse/src/explorer/explorerConfig.ts
@@ -108,6 +108,9 @@ export class ExplorerConfigCtrl {
     if (!name) return;
     const previous = this.data.playerName.previous().filter(n => n !== name);
     this.data.playerName.previous(previous);
+    if (this.data.playerName.value() === name) {
+      this.data.playerName.value('');
+    }
   };
 
   toggleMany =

--- a/ui/analyse/src/explorer/explorerConfig.ts
+++ b/ui/analyse/src/explorer/explorerConfig.ts
@@ -108,6 +108,7 @@ export class ExplorerConfigCtrl {
     if (!name) return;
     const previous = this.data.playerName.previous().filter(n => n !== name);
     this.data.playerName.previous(previous);
+
     if (this.data.playerName.value() === name) {
       this.data.playerName.value('');
     }


### PR DESCRIPTION
Deleting a player from the personal opening search history should unselect it.

Currently, the deleted player remains selected.

# Screenshots (post-fix)
Before deleting "Boris" from the personal search history:
<img src="https://github.com/lichess-org/lila/assets/12627125/1fa95274-d915-4470-9a38-e8f01c3d4831" alt="Lichess personal opening search history with user 'Boris'." width="350px" />

After:
<img src="https://github.com/lichess-org/lila/assets/12627125/26e17b75-1859-4e9f-8835-c0f6dc0711f4" alt="Lichess personal opening search history with empty search history." width="350px" />
