### PR TITLE
Don't consider mods as local team mods in swiss

### DIFF
--- a/app/controllers/Swiss.scala
+++ b/app/controllers/Swiss.scala
@@ -56,7 +56,7 @@ final class Swiss(
                   env.user.lightUserApi.preloadMany(c.chat.userIds) inject
                     c.copy(locked = !env.api.chatFreshness.of(swiss)).some
             streamers  <- streamerCache get swiss.id
-            isLocalMod <- ctx.me.so { env.team.api.isGranted(swiss.teamId, _, _.Comm) }
+            isLocalMod <- ctx.me.so { env.team.api.hasPerm(swiss.teamId, _, _.Comm) }
             page       <- renderPage(html.swiss.show(swiss, verdicts, json, chat, streamers, isLocalMod))
           yield Ok(page),
         json = swissOption.fold[Fu[Result]](notFoundJson("No such swiss tournament")): swiss =>

--- a/app/controllers/Team.scala
+++ b/app/controllers/Team.scala
@@ -403,7 +403,7 @@ final class Team(
       api
         .withLeaders(team)
         .flatMap: t =>
-          val admins = t.leaders.filter(_.isGranted(_.Admin))
+          val admins = t.leaders.filter(_.hasPerm(_.Admin))
           if admins.nonEmpty && admins.forall(_ is me)
           then
             val msg = lila.i18n.I18nKeys.team.onlyLeaderLeavesTeam.txt()

--- a/app/controllers/Tournament.scala
+++ b/app/controllers/Tournament.scala
@@ -207,7 +207,7 @@ final class Tournament(env: Env, apiC: => Api)(using akka.stream.Materializer) e
   def teamBattleForm(teamId: TeamId) = Auth { ctx ?=> me ?=>
     NoBot:
       env.team.api.lightsByTourLeader(me) flatMap { teams =>
-        env.team.api.isGranted(teamId, _.Tour) elseNotFound
+        env.team.api.isGranted(teamId, me, _.Tour) elseNotFound
           Ok.page(html.tournament.form.create(forms.create(teams, teamId.some), Nil))
       }
   }

--- a/app/mashup/TeamInfo.scala
+++ b/app/mashup/TeamInfo.scala
@@ -23,9 +23,9 @@ case class TeamInfo(
 
   export withLeaders.{ team, leaders, publicLeaders }
 
-  def mine                                              = member.isDefined
-  def ledByMe                                           = member.exists(_.perms.nonEmpty)
-  def amGranted(perm: TeamSecurity.Permission.Selector) = member.exists(_.isGranted(perm))
+  def mine                                             = member.isDefined
+  def ledByMe                                          = member.exists(_.perms.nonEmpty)
+  def havePerm(perm: TeamSecurity.Permission.Selector) = member.exists(_.hasPerm(perm))
 
   def hasRequests = requests.nonEmpty
 
@@ -76,7 +76,7 @@ final class TeamInfoApi(
       withForum: Option[TeamMember] => Boolean
   ): Fu[TeamInfo] = for
     member     <- me.so(api.memberOf(team.id, _))
-    requests   <- (team.enabled && member.exists(_.isGranted(_.Request))) so api.requestsWithUsers(team.team)
+    requests   <- (team.enabled && member.exists(_.hasPerm(_.Request))) so api.requestsWithUsers(team.team)
     myRequest  <- member.isEmpty so me.so(m => requestRepo.find(team.id, m.id))
     subscribed <- member.so(api.isSubscribed(team.team, _))
     forumPosts <- withForum(member) soFu forumRecent(team.id)

--- a/app/views/team/form.scala
+++ b/app/views/team/form.scala
@@ -53,7 +53,7 @@ object form:
             )
           ),
           hr,
-          (t.enabled && (member.isGranted(_.Admin) || isGranted(_.ManageTeam))) option
+          (t.enabled && (member.hasPerm(_.Admin) || isGranted(_.ManageTeam))) option
             postForm(cls := "inline", action := routes.Team.disable(t.id))(
               explainInput,
               submitButton(

--- a/app/views/team/show.scala
+++ b/app/views/team/show.scala
@@ -48,7 +48,7 @@ object show:
               timeout = chat.timeout,
               public = true,
               resourceId = lila.chat.Chat.ResourceId(s"team/${chat.chat.id}"),
-              localMod = info.amGranted(_.Comm)
+              localMod = info.havePerm(_.Comm)
             ))
       )
     ):
@@ -110,11 +110,11 @@ object show:
                     label(`for` := "team-subscribe")(subToTeamMessages.txt())
                   )
                 ),
-              (info.mine && !info.amGranted(_.Admin)) option
+              (info.mine && !info.havePerm(_.Admin)) option
                 postForm(cls := "quit", action := routes.Team.quit(t.id))(
                   submitButton(cls := "button button-empty button-red confirm")(quitTeam.txt())
                 ),
-              t.enabled && info.amGranted(_.Tour) option frag(
+              t.enabled && info.havePerm(_.Tour) option frag(
                 a(
                   href     := routes.Tournament.teamBattleForm(t.id),
                   cls      := "button button-empty text",
@@ -145,7 +145,7 @@ object show:
                     em(swissTournamentOverview())
                   )
               ),
-              t.enabled && info.amGranted(_.PmAll) option frag(
+              t.enabled && info.havePerm(_.PmAll) option frag(
                 a(
                   href     := routes.Team.pmAll(t.id),
                   cls      := "button button-empty text",
@@ -156,23 +156,23 @@ object show:
                     em(messageAllMembersOverview())
                   )
               ),
-              ((t.enabled && info.amGranted(_.Settings)) || asMod) option
+              ((t.enabled && info.havePerm(_.Settings)) || asMod) option
                 a(href := routes.Team.edit(t.id), cls := "button button-empty text", dataIcon := licon.Gear)(
                   trans.settings.settings()
                 ),
-              ((t.enabled && info.amGranted(_.Admin)) || asMod) option
+              ((t.enabled && info.havePerm(_.Admin)) || asMod) option
                 a(
                   cls      := "button button-empty text",
                   href     := routes.Team.leaders(t.id),
                   dataIcon := licon.Group
                 )(teamLeaders()),
-              ((t.enabled && info.amGranted(_.Kick)) || asMod) option
+              ((t.enabled && info.havePerm(_.Kick)) || asMod) option
                 a(
                   cls      := "button button-empty text",
                   href     := routes.Team.kick(t.id),
                   dataIcon := licon.InternalArrow
                 )(kickSomeone()),
-              ((t.enabled && info.amGranted(_.Request)) || asMod) option
+              ((t.enabled && info.havePerm(_.Request)) || asMod) option
                 a(
                   cls      := "button button-empty text",
                   href     := routes.Team.declinedRequests(t.id),
@@ -200,7 +200,7 @@ object show:
           ),
           div(cls := "team-show__content__col2")(
             standardFlash,
-            t.intro.isEmpty && info.amGranted(_.Settings) option div(cls := "flash flash-warning")(
+            t.intro.isEmpty && info.havePerm(_.Settings) option div(cls := "flash flash-warning")(
               div(cls := "flash__content"):
                 a(href := routes.Team.edit(t.id))("Give your team a short introduction text!")
             ),

--- a/modules/api/src/main/ForumAccess.scala
+++ b/modules/api/src/main/ForumAccess.scala
@@ -42,6 +42,6 @@ final class ForumAccess(teamApi: lila.team.TeamApi, teamCached: lila.team.Cached
       (me.count.game > 0 && me.createdSinceDays(2)) || me.hasTitle || me.isVerified || me.isPatron
     }
 
-  def isGrantedMod(categId: ForumCategId)(using me: Option[Me]): Fu[Boolean] = me.soUse: _ ?=>
+  def isGrantedMod(categId: ForumCategId)(using meOpt: Option[Me]): Fu[Boolean] = meOpt.so: me =>
     if Granter.opt(_.ModerateForum) then fuTrue
-    else ForumCateg.toTeamId(categId).so(teamApi.isGranted(_, _.Comm))
+    else ForumCateg.toTeamId(categId).so(teamApi.hasPerm(_, me, _.Comm))

--- a/modules/team/src/main/Team.scala
+++ b/modules/team/src/main/Team.scala
@@ -48,8 +48,8 @@ object Team:
 
   case class WithLeaders(team: Team, leaders: List[TeamMember]):
     export team.*
-    def hasAdminCreator = leaders.exists(l => l.is(team.createdBy) && l.isGranted(_.Admin))
-    def publicLeaders   = leaders.filter(_.isGranted(_.Public))
+    def hasAdminCreator = leaders.exists(l => l.is(team.createdBy) && l.hasPerm(_.Admin))
+    def publicLeaders   = leaders.filter(_.hasPerm(_.Public))
 
   case class IdAndLeaderIds(id: TeamId, leaderIds: Set[UserId])
 

--- a/modules/team/src/main/TeamMember.scala
+++ b/modules/team/src/main/TeamMember.scala
@@ -12,7 +12,7 @@ case class TeamMember(
 ):
   inline def id = _id
 
-  def isGranted(perm: TeamSecurity.Permission.Selector): Boolean =
+  def hasPerm(perm: TeamSecurity.Permission.Selector): Boolean =
     perms(perm(TeamSecurity.Permission))
 
 object TeamMember:


### PR DESCRIPTION
Main change is in controllers/Swiss, to only consider actual team members with the Comm perm to be local mods so that real mods still get the full timeout view.

But to reduce confusion, I also removed the isGranted overload that only considered team perms (while the remaining one considers both mods and team perms) and renamed all other team-related isGranted methods that in reality only checked perms. Now, isGranted always checks both and hasPerm is used to only check the team perm.

I also noticed that the removed TeamApi.isGranted didn't check for team membership while hasPerm does. Not too sure about this but presumably, it's superfluous in hasPerm as well, since non-team members won't be in the members repo?