### PR TITLE
use baseUrl, no static url

### DIFF
--- a/modules/study/src/main/PgnDump.scala
+++ b/modules/study/src/main/PgnDump.scala
@@ -58,7 +58,7 @@ final class PgnDump(
     s"${net.baseUrl}/study/$studyId/$chapterId"
 
   private def annotatorTag(study: Study) =
-    Tag(_.Annotator, s"https://lichess.org/@/${ownerName(study)}")
+    Tag(_.Annotator, s"${net.baseUrl}/@/${ownerName(study)}")
 
   private def makeTags(study: Study, chapter: Chapter)(using flags: WithFlags): Tags =
     Tags:


### PR DESCRIPTION
It was one of the points raised in #13760 (although it is closed)
the annotator link would always send to l.org instead of the mirror server