### PR TITLE
Added text to dropdown when no microphone access given

### DIFF
--- a/ui/voice/src/view.ts
+++ b/ui/voice/src/view.ts
@@ -111,18 +111,29 @@ function deviceSelector(ctrl: VoiceCtrl, redraw: () => void) {
             });
         }),
       },
-      (devices || []).map(d =>
-        h(
-          'option',
-          {
-            attrs: {
-              value: d.deviceId,
-              selected: d.deviceId === ctrl.micId(),
+      devices
+        ? devices.map(d =>
+            h(
+              'option',
+              {
+                attrs: {
+                  value: d.deviceId,
+                  selected: d.deviceId === ctrl.micId(),
+                },
+              },
+              d.label,
+            ),
+          )
+        : h(
+            'option',
+            {
+              attrs: {
+                value: 'none',
+                selected: true,
+              },
             },
-          },
-          d.label,
-        ),
-      ),
+            'Please grant access to your microphone',
+          ),
     ),
   ]);
 }


### PR DESCRIPTION
Relating to issue #13776 
If user has not yet granted access to their microphone, then the drop-down should reflect it