### PR TITLE
Fix forum autocomplete getting stuck on error response

### DIFF
--- a/ui/site/src/forum.ts
+++ b/ui/site/src/forum.ts
@@ -130,7 +130,11 @@ lichess.load.then(() => {
                     // and there are no matches in the forum thread participants
                     xhr
                       .json(xhr.url('/api/player/autocomplete', { term }), { cache: 'default' })
-                      .then(candidateUsers => callback(searchCandidates(term, candidateUsers)));
+                      .then(candidateUsers => callback(searchCandidates(term, candidateUsers)))
+                      .catch(error => {
+                        console.error('Autocomplete request failed:', error);
+                        callback([]);
+                      });
                   } else {
                     callback([]);
                   }


### PR DESCRIPTION
If the incomplete mention ends with a dash or underscore it causes a 400 Bad Request bc that's an invalid username which currently causes the autocomplete to get stuck. Now, it at least won't get stuck anymore.

I guess ideally, such requests would also be allowed but that seems a bit annoying to implement since most of the search methods currently require a valid `UserId`.