### PR TITLE
Player autocomplete, return bad request for usernames shorter than 3 characters

### DIFF
--- a/modules/common/src/main/base/LilaUserId.scala
+++ b/modules/common/src/main/base/LilaUserId.scala
@@ -39,7 +39,7 @@ trait LilaUserId:
   // "chess-" is a valid username prefix, but not a valid username
   opaque type UserSearch = String
   object UserSearch extends OpaqueString[UserSearch]:
-    private val regex = "(?i)[a-z0-9][a-z0-9_-]{0,28}".r
+    private val regex = "(?i)[a-z0-9][a-z0-9_-]{3,28}".r
     def read(str: String): Option[UserSearch] =
       val clean = str.trim.takeWhile(' ' !=)
       if regex.matches(clean) then Some(clean) else None


### PR DESCRIPTION
All client-code for Lichess already check that and lichobile does too: https://github.com/lichess-org/lichobile/blob/663e69fab10e4267a9b3369febe85d1363816ba2/src/ui/players/PlayersCtrl.ts#L51

prompted by https://github.com/lichess-org/berserk/pull/48.

Note that currently it does sometimes return a result (undocumented), hitting the `userIdsLikeCache` cache, so maybe this is intended.
