### PR TITLE
Player autocomplete, return bad request for usernames shorter than 3 characters

### DIFF
--- a/modules/analyse/src/main/AccuracyPercent.scala
+++ b/modules/analyse/src/main/AccuracyPercent.scala
@@ -99,16 +99,12 @@ for x in xs:
     // }
 
     def colorAccuracy(color: Color) = for
-      weighted <- Maths.weightedMean {
-        weightedAccuracies collect {
+      weighted <- Maths.weightedMean:
+        weightedAccuracies.collect:
           case (weightedAccuracy, c) if c == color => weightedAccuracy
-        }
-      }
-      harmonic <- Maths.harmonicMean {
-        weightedAccuracies collect {
+      harmonic <- Maths.harmonicMean:
+        weightedAccuracies.collect:
           case ((accuracy, _), c) if c == color => accuracy
-        }
-      }
     yield AccuracyPercent((weighted + harmonic) / 2)
 
     ByColor(colorAccuracy)

--- a/modules/analyse/src/main/Advice.scala
+++ b/modules/analyse/src/main/Advice.scala
@@ -18,12 +18,10 @@ sealed trait Advice:
       (this.match
         case MateAdvice(seq, _, _, _) => seq.desc
         case CpAdvice(judgment, _, _) => judgment.toString
-      )
-      + "." + {
-        withBestMove.so:
-          info.variation.headOption.so: move =>
-            s" $move was best."
-      }
+      ) + "." + withBestMove.so:
+        info.variation.headOption.so: move =>
+          s" $move was best."
+
   }
 
   def evalComment: Option[String] = {
@@ -96,6 +94,7 @@ private[analyse] case class MateAdvice(
     info: Info,
     prev: Info
 ) extends Advice
+
 private[analyse] object MateAdvice:
 
   def apply(prev: Info, info: Info): Option[MateAdvice] =

--- a/modules/common/src/main/base/LilaUserId.scala
+++ b/modules/common/src/main/base/LilaUserId.scala
@@ -39,7 +39,7 @@ trait LilaUserId:
   // "chess-" is a valid username prefix, but not a valid username
   opaque type UserSearch = String
   object UserSearch extends OpaqueString[UserSearch]:
-    private val regex = "(?i)[a-z0-9][a-z0-9_-]{0,28}".r
+    private val regex = "(?i)[a-z0-9][a-z0-9_-]{3,28}".r
     def read(str: String): Option[UserSearch] =
       val clean = str.trim.takeWhile(' ' !=)
       if regex.matches(clean) then Some(clean) else None

--- a/modules/common/src/main/base/LilaUserId.scala
+++ b/modules/common/src/main/base/LilaUserId.scala
@@ -39,7 +39,7 @@ trait LilaUserId:
   // "chess-" is a valid username prefix, but not a valid username
   opaque type UserSearch = String
   object UserSearch extends OpaqueString[UserSearch]:
-    private val regex = "(?i)[a-z0-9][a-z0-9_-]{3,28}".r
+    private val regex = "(?i)[a-z0-9][a-z0-9_-]{2,28}".r
     def read(str: String): Option[UserSearch] =
       val clean = str.trim.takeWhile(' ' !=)
       if regex.matches(clean) then Some(clean) else None


### PR DESCRIPTION
All client-code for Lichess already check that and lichobile does too: https://github.com/lichess-org/lichobile/blob/663e69fab10e4267a9b3369febe85d1363816ba2/src/ui/players/PlayersCtrl.ts#L51

prompted by https://github.com/lichess-org/berserk/pull/48.

Note that currently it does sometimes return a result (undocumented), hitting the `userIdsLikeCache` cache, so maybe this is intended.

new version of https://github.com/lichess-org/lila/pull/13803