### PR TITLE
Cancel promotion after game ends

### DIFF
--- a/ui/round/src/ctrl.ts
+++ b/ui/round/src/ctrl.ts
@@ -549,6 +549,7 @@ export default class RoundController {
     ) {
       this.reload(d);
     }
+    this.promotion.cancel();
     this.chessground.stop();
     if (o.ratingDiff) {
       d.player.ratingDiff = o.ratingDiff[d.player.color];


### PR DESCRIPTION
As titled. There's some weird behaviour if the promotion dialog is open while the game ends. We should cancel any promotions when `endWithData` triggers. `promotion.cancel()` already checks if one is ongoing and no-ops otherwise so it should be safe to call in all cases.


See below for the before/after behaviour comparison. Screen recording wasn't working so I had to improvise.

**Before**

Weird post-game promotion:

https://github.com/lichess-org/lila/assets/30640147/144e0279-6621-44d6-ae83-a3aca4d94c1b

Promotion flips to other color during timeout:

https://github.com/lichess-org/lila/assets/30640147/0eba8891-d772-48d0-be1e-3d839056bc7e

**After**


https://github.com/lichess-org/lila/assets/30640147/dda1dc4e-b1bc-41cc-99d2-1a3e9fd02dfd

