### PR TITLE
layout issue when ratings are hidden

### DIFF
--- a/ui/lobby/css/_layout.scss
+++ b/ui/lobby/css/_layout.scss
@@ -99,7 +99,7 @@ $mq-not-col3: $mq-not-small;
       'side   app     app     table'
       'tv     blog    blog    puzzle'
       'tv     support support puzzle'
-      'leader tours   tours   winner'
+      'leader winner  tours   tours'
       'about  about   about   about';
     &__side {
       margin-top: 2em;


### PR DESCRIPTION
In current master, wide desktop layout with hide ratings will show:

![image](https://github.com/lichess-org/lila/assets/101470903/8dabeeb7-140d-4e10-b980-bce731597199)

Here's what I had in the lobby-tweaks branch, noone noticed the symmetry breaking. Doesn't bother me either, ymmv