### PR TITLE
Remove study tour button from underboard on interactive chapters

### DIFF
--- a/ui/analyse/src/study/studyView.ts
+++ b/ui/analyse/src/study/studyView.ts
@@ -125,7 +125,7 @@ function buttons(root: AnalyseCtrl): VNode {
         hint: noarg('shareAndExport'),
         icon: iconTag(licon.NodeBranching),
       }),
-      !ctrl.relay
+      !ctrl.relay && !ctrl.data.chapter.gamebook
         ? h('span.help', {
             attrs: { title: 'Need help? Get the tour!', ...dataIcon(licon.InfoCircle) },
             hook: bind('click', ctrl.startTour),


### PR DESCRIPTION
In the underboard of a study, the "tour button" (![image](https://github.com/lichess-org/lila/assets/3620552/7b0d2f18-e513-4a03-bae3-7ad135542054)) only works if the study is not an interactive (gamebook) chapter. This is correct [per design](https://github.com/lichess-org/lila/blob/master/ui/analyse/src/study/studyTour.ts#L5), but it's odd to click the button and not receive any sort of feedback. This PR removes the tour button if the chapter is interactive.

[Video showing issue](https://github.com/lichess-org/lila/assets/3620552/1a025a7c-fe0b-436a-a0a3-245d93e7f1da)
[Video of fix](https://github.com/lichess-org/lila/assets/3620552/1e25928e-0ffd-441e-974d-55ccc679c551)

