### PR TITLE
Only load stripe and paypal scripts when logged in

### DIFF
--- a/app/views/plan/index.scala
+++ b/app/views/plan/index.scala
@@ -29,28 +29,26 @@ object index:
     views.html.base.layout(
       title = becomePatron.txt(),
       moreCss = cssTag("plan"),
-      moreJs =
-        if ctx.isAuth then
+      moreJs = ctx.isAuth option
+        frag(
+          stripeScript,
           frag(
-            stripeScript,
-            frag(
-              // gotta load the paypal SDK twice, for onetime and subscription :facepalm:
-              // https://stackoverflow.com/questions/69024268/how-can-i-show-a-paypal-smart-subscription-button-and-a-paypal-smart-capture-but/69024269
-              script(
-                src := s"https://www.paypal.com/sdk/js?client-id=${payPalPublicKey}&currency=${pricing.currency}$localeParam",
-                namespaceAttr := "paypalOrder"
-              ),
-              script(
-                src := s"https://www.paypal.com/sdk/js?client-id=${payPalPublicKey}&vault=true&intent=subscription&currency=${pricing.currency}$localeParam",
-                namespaceAttr := "paypalSubscription"
-              )
+            // gotta load the paypal SDK twice, for onetime and subscription :facepalm:
+            // https://stackoverflow.com/questions/69024268/how-can-i-show-a-paypal-smart-subscription-button-and-a-paypal-smart-capture-but/69024269
+            script(
+              src := s"https://www.paypal.com/sdk/js?client-id=${payPalPublicKey}&currency=${pricing.currency}$localeParam",
+              namespaceAttr := "paypalOrder"
             ),
-            jsModule("checkout"),
-            embedJsUnsafeLoadThen(s"""checkoutStart("$stripePublicKey", ${safeJsonValue(
-                lila.plan.PlanPricingApi.pricingWrites.writes(pricing)
-              )})""")
-          )
-        else emptyFrag,
+            script(
+              src := s"https://www.paypal.com/sdk/js?client-id=${payPalPublicKey}&vault=true&intent=subscription&currency=${pricing.currency}$localeParam",
+              namespaceAttr := "paypalSubscription"
+            )
+          ),
+          jsModule("checkout"),
+          embedJsUnsafeLoadThen(s"""checkoutStart("$stripePublicKey", ${safeJsonValue(
+              lila.plan.PlanPricingApi.pricingWrites.writes(pricing)
+            )})""")
+        ),
       openGraph = lila.app.ui
         .OpenGraph(
           title = becomePatron.txt(),

--- a/app/views/plan/index.scala
+++ b/app/views/plan/index.scala
@@ -29,25 +29,28 @@ object index:
     views.html.base.layout(
       title = becomePatron.txt(),
       moreCss = cssTag("plan"),
-      moreJs = frag(
-        stripeScript,
-        frag(
-          // gotta load the paypal SDK twice, for onetime and subscription :facepalm:
-          // https://stackoverflow.com/questions/69024268/how-can-i-show-a-paypal-smart-subscription-button-and-a-paypal-smart-capture-but/69024269
-          script(
-            src := s"https://www.paypal.com/sdk/js?client-id=${payPalPublicKey}&currency=${pricing.currency}$localeParam",
-            namespaceAttr := "paypalOrder"
-          ),
-          script(
-            src := s"https://www.paypal.com/sdk/js?client-id=${payPalPublicKey}&vault=true&intent=subscription&currency=${pricing.currency}$localeParam",
-            namespaceAttr := "paypalSubscription"
+      moreJs =
+        if ctx.isAuth then
+          frag(
+            stripeScript,
+            frag(
+              // gotta load the paypal SDK twice, for onetime and subscription :facepalm:
+              // https://stackoverflow.com/questions/69024268/how-can-i-show-a-paypal-smart-subscription-button-and-a-paypal-smart-capture-but/69024269
+              script(
+                src := s"https://www.paypal.com/sdk/js?client-id=${payPalPublicKey}&currency=${pricing.currency}$localeParam",
+                namespaceAttr := "paypalOrder"
+              ),
+              script(
+                src := s"https://www.paypal.com/sdk/js?client-id=${payPalPublicKey}&vault=true&intent=subscription&currency=${pricing.currency}$localeParam",
+                namespaceAttr := "paypalSubscription"
+              )
+            ),
+            jsModule("checkout"),
+            embedJsUnsafeLoadThen(s"""checkoutStart("$stripePublicKey", ${safeJsonValue(
+                lila.plan.PlanPricingApi.pricingWrites.writes(pricing)
+              )})""")
           )
-        ),
-        jsModule("checkout"),
-        embedJsUnsafeLoadThen(s"""checkoutStart("$stripePublicKey", ${safeJsonValue(
-            lila.plan.PlanPricingApi.pricingWrites.writes(pricing)
-          )})""")
-      ),
+        else emptyFrag,
       openGraph = lila.app.ui
         .OpenGraph(
           title = becomePatron.txt(),

--- a/modules/game/src/main/Namer.scala
+++ b/modules/game/src/main/Namer.scala
@@ -10,20 +10,18 @@ object Namer:
     playerTextUser(player, player.userId flatMap lightUser, withRating)
 
   def playerText(player: Player, withRating: Boolean = false)(using lightUser: LightUser.Getter): Fu[String] =
-    player.userId.so(lightUser) dmap {
+    player.userId.so(lightUser) dmap:
       playerTextUser(player, _, withRating)
-    }
 
   private def playerTextUser(player: Player, user: Option[LightUser], withRating: Boolean = false): String =
-    player.aiLevel.fold(
-      user.fold(player.name | "Anon.") { u =>
-        ratingString(player).ifTrue(withRating).fold(u.titleName) { rating =>
-          s"${u.titleName} ($rating)"
-        }
-      }
-    ) { level =>
-      s"Stockfish level $level"
-    }
+    player.aiLevel match
+      case Some(level) => s"Stockfish level $level"
+      case None =>
+        user.fold(player.name | "Anon."): u =>
+          ratingString(player)
+            .ifTrue(withRating)
+            .fold(u.titleName): rating =>
+              s"${u.titleName} ($rating)"
 
   def gameVsTextBlocking(game: Game, withRatings: Boolean = false)(using
       lightUser: LightUser.GetterSync
@@ -37,6 +35,5 @@ object Namer:
       }
 
   def ratingString(p: Player): Option[String] =
-    p.rating.map { rating =>
+    p.rating.map: rating =>
       s"$rating${p.provisional.yes so "?"}"
-    }


### PR DESCRIPTION
Multiple browser console errors can be seen when navigating to `/patron` while not logged in. This is because the stripe and paypal scripts are started regardless if the div elements `paypal--order` and `paypal--subscription` are displayed ([code](https://github.com/lichess-org/lila/blob/master/app/views/plan/index.scala#L210-L222)).

![Screenshot_20231023_171443](https://github.com/lichess-org/lila/assets/3620552/3f0b113c-9b8f-47f0-aa90-c0472e507ff2)
![Screenshot_20231023_171454](https://github.com/lichess-org/lila/assets/3620552/e0ef7274-62cc-4e5b-b0a8-84b5ce90e40f)

This PR updates to only provide `moreJs` the frag to load the stripe and paypal scripts only when logged in, otherwise provide `emptyFrag`.
