### PR TITLE
Don't truncate the wikibook page

### DIFF
--- a/ui/analyse/src/wiki.ts
+++ b/ui/analyse/src/wiki.ts
@@ -13,7 +13,7 @@ export default function wikiTheory(): WikiTheory {
     `${Math.floor((node.ply + 1) / 2)}${node.ply % 2 === 1 ? '._' : '...'}`;
 
   const wikiBooksUrl = 'https://en.wikibooks.org';
-  const apiArgs = 'redirects&origin=*&action=query&prop=extracts&formatversion=2&format=json&exchars=1200';
+  const apiArgs = 'redirects&origin=*&action=query&prop=extracts&formatversion=2&format=json';
 
   const removeEmptyParagraph = (html: string) => html.replace(/<p>(<br \/>|\s)*<\/p>/g, '');
 

--- a/ui/opening/src/wiki.ts
+++ b/ui/opening/src/wiki.ts
@@ -9,7 +9,7 @@ export default async function wikiTheory(data: OpeningPage) {
 
 async function fetchAndRender(data: OpeningPage, render: (html: string) => void) {
   const wikiBooksUrl = 'https://en.wikibooks.org';
-  const apiArgs = 'redirects&origin=*&action=query&prop=extracts&formatversion=2&format=json&exchars=1200';
+  const apiArgs = 'redirects&origin=*&action=query&prop=extracts&formatversion=2&format=json';
 
   const removeH1 = (html: string) => html.replace(/<h1>.+<\/h1>/g, '');
   const removeEmptyParagraph = (html: string) => html.replace(/<p>(<br \/>|\s)*<\/p>/g, '');


### PR DESCRIPTION
Often the truncation of the wikibooks page is annoying. E.g.:

https://en.wikibooks.org/w/api.php?titles=Chess_Opening_Theory/1._e4/1...d5&redirects&origin=*&action=query&prop=extracts&formatversion=2&format=json

<img width="362" alt="image" src="https://github.com/lichess-org/lila/assets/381361/7cba2240-a81d-48ce-8dc8-9d7b286174fe">

vs.
https://en.wikibooks.org/w/api.php?titles=Chess_Opening_Theory/1._e4/1...d5&redirects&origin=*&action=query&prop=extracts&formatversion=2&format=json&exchars=1200

![Screen Shot 2023-10-23 at 19 10 07](https://github.com/lichess-org/lila/assets/381361/4bf663ab-a335-48f7-abf6-4bfac7dfff2c)
