### PR TITLE
Do not allow empty passwords on /password/reset/confirm/{token} form

### DIFF
--- a/modules/security/src/main/SecurityForm.scala
+++ b/modules/security/src/main/SecurityForm.scala
@@ -22,7 +22,7 @@ final class SecurityForm(
   import SecurityForm.*
 
   private val newPasswordField =
-    text(minLength = 4, maxLength = 999).verifying(PasswordCheck.newConstraint)
+    nonEmptyText(minLength = 4, maxLength = 999).verifying(PasswordCheck.newConstraint)
   private def newPasswordFieldForMe(using me: Me) =
     newPasswordField.verifying(PasswordCheck.sameConstraint(me.username into UserStr))
 


### PR DESCRIPTION
The password reset form at `/password/reset/confirm/{token}` (sent via email) does not check if the new password is empty. Therefore, you can successfully set your password to all spaces. However, after the first auto login you cannot login again as the login form checks for an empty password.