### PR TITLE
tweak entry requirement display of completed tournaments

### DIFF
--- a/app/views/tournament/side.scala
+++ b/app/views/tournament/side.scala
@@ -60,7 +60,7 @@ object side:
             markdownLinksOrRichText(d)
           ),
         tour.looksLikePrize option bits.userPrizeDisclaimer(tour.createdBy),
-        views.html.gathering.verdicts(verdicts, tour.perfType),
+        !tour.isFinished option views.html.gathering.verdicts(verdicts, tour.perfType),
         tour.noBerserk option div(cls := "text", dataIcon := licon.Berserk)(trans.arena.noBerserkAllowed()),
         tour.noStreak option div(cls := "text", dataIcon := licon.Fire)(trans.arena.noArenaStreaks()),
         !tour.isScheduled option frag(small(trans.by(userIdLink(tour.createdBy.some))), br),


### PR DESCRIPTION
I have changed the code so that the entry requirements are not displayed when the tournament is over. Note that I haven't been able to fully test this: debugging tournament related issues in the developer environment proves to be a bit of a hassle as they have a minimum duration of 20 minutes as well as a countdown before starting. Not only that, but tournaments are automatically deleted if there are no players or if no games were played.
I would greatly appreciate it if someone were to offer me some pointers in order to test this more efficiently, despite this being quite a trivial addition.