### PR TITLE
Keyboard shortcut "who" to read from controller instead of DOM

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -307,6 +307,9 @@ importers:
       common:
         specifier: workspace:*
         version: link:../common
+      game:
+        specifier: workspace:*
+        version: link:../game
       snabbdom:
         specifier: ^3.5.1
         version: 3.5.1

--- a/ui/keyboardMove/package.json
+++ b/ui/keyboardMove/package.json
@@ -17,6 +17,7 @@
     "@jest/globals": "^29.3.1",
     "chess": "workspace:*",
     "common": "workspace:*",
+    "game": "workspace:*",
     "snabbdom": "^3.5.1"
   },
   "scripts": {

--- a/ui/keyboardMove/src/main.ts
+++ b/ui/keyboardMove/src/main.ts
@@ -5,6 +5,7 @@ import { onInsert } from 'common/snabbdom';
 import { promote } from 'chess/promotion';
 import { snabDialog } from 'common/dialog';
 import { propWithEffect, Prop } from 'common';
+import { Player } from 'game';
 import { load as loadKeyboardMove } from './plugins/keyboardMove';
 import KeyboardChecker from './plugins/keyboardChecker';
 
@@ -33,6 +34,7 @@ export interface KeyboardMove {
   resign(v: boolean, immediately?: boolean): void;
   helpModalOpen: Prop<boolean>;
   checker?: KeyboardChecker;
+  opponent?: string;
 }
 
 const sanToRole: { [key: string]: cg.Role } = {
@@ -51,6 +53,7 @@ export interface RootData {
   crazyhouse?: { pockets: [CrazyPocket, CrazyPocket] };
   game: { variant: { key: VariantKey } };
   player: { color: Color };
+  opponent?: Player;
 }
 export interface RootController {
   chessground: CgApi;
@@ -144,6 +147,7 @@ export function ctrl(root: RootController, step: Step): KeyboardMove {
     helpModalOpen,
     isFocused,
     checker: root.clock ? new KeyboardChecker() : undefined,
+    opponent: root.data.opponent?.user?.username,
   };
 }
 

--- a/ui/keyboardMove/src/plugins/keyboardMove.ts
+++ b/ui/keyboardMove/src/plugins/keyboardMove.ts
@@ -92,8 +92,8 @@ export function initModule(opts: Opts) {
         clear();
       }
     } else if (v.length > 0 && 'who'.startsWith(v.toLowerCase())) {
-      if ('who' === v.toLowerCase()) {
-        readOpponentName();
+      if ('who' === v.toLowerCase() && opts.ctrl.opponent) {
+        lichess.sound.say(opts.ctrl.opponent, false, true);
         clear();
       }
     } else if (v.length > 0 && 'draw'.startsWith(v.toLowerCase())) {
@@ -228,11 +228,6 @@ function readClocks(clockCtrl: any | undefined) {
     return `${color} ${msg}`;
   });
   lichess.sound.say(msgs.join('. '));
-}
-
-function readOpponentName(): void {
-  const opponentName = document.querySelector('.ruser-top') as HTMLInputElement;
-  lichess.sound.say(opponentName.innerText.split('\n')[0]);
 }
 
 function simplePlural(nb: number, word: string) {


### PR DESCRIPTION
Resolving review feedback from #11252.

1. Uses opponent name from controller data instead of DOM. Would work with flipped boards now.
1. Typing "who" will always speak now, even if speech synthesis is not selected as the sound

![image](https://github.com/lichess-org/lila/assets/271432/70b00088-1389-45a2-a3f0-db1a6d3e17dd)