### PR TITLE
fix wiki api failure if extract is empty but still present

### DIFF
--- a/ui/analyse/src/wiki.ts
+++ b/ui/analyse/src/wiki.ts
@@ -49,7 +49,6 @@ export default function wikiTheory(): WikiTheory {
         const title = `Chess_Opening_Theory/${path}`;
         try {
           const res = await fetch(`${wikiBooksUrl}/w/api.php?titles=${title}&${apiArgs}`);
-          console.log(`${wikiBooksUrl}/w/api.php?titles=${title}&${apiArgs}`);
           const saveAndShow = (html: string) => {
             cache.set(path, html);
             show(html);
@@ -57,7 +56,6 @@ export default function wikiTheory(): WikiTheory {
           if (res.ok) {
             const json = await res.json();
             const page = json.query.pages[0];
-            console.log(page);
             if (page.missing) saveAndShow('');
             else if (page.extract === '') saveAndShow('');
             else if (page.invalid) show('invalid request: ' + page.invalidreason);

--- a/ui/analyse/src/wiki.ts
+++ b/ui/analyse/src/wiki.ts
@@ -49,6 +49,7 @@ export default function wikiTheory(): WikiTheory {
         const title = `Chess_Opening_Theory/${path}`;
         try {
           const res = await fetch(`${wikiBooksUrl}/w/api.php?titles=${title}&${apiArgs}`);
+          console.log(`${wikiBooksUrl}/w/api.php?titles=${title}&${apiArgs}`);
           const saveAndShow = (html: string) => {
             cache.set(path, html);
             show(html);
@@ -56,7 +57,9 @@ export default function wikiTheory(): WikiTheory {
           if (res.ok) {
             const json = await res.json();
             const page = json.query.pages[0];
+            console.log(page);
             if (page.missing) saveAndShow('');
+            else if (page.extract === '') saveAndShow('');
             else if (page.invalid) show('invalid request: ' + page.invalidreason);
             else if (!page.extract)
               show('error: unexpected API response:<br><pre>' + JSON.stringify(page) + '</pre>');


### PR DESCRIPTION
closes #13877

If the extract given by Wikibooks is an empty string, but is still there, it currently throws that api error due to
https://github.com/lichess-org/lila/blob/a2f76a964261d1df724354ffceb023969bc973f6/ui/analyse/src/wiki.ts#L61-L62

Need to check that it is not empty first, so that it doesn't show an api error in this case

I chose to just show nothing as if the opening doesn't exist (because it doesn't in Wikibooks)