### PR TITLE
Use gregorian calender and western numerics for arabic users

### DIFF
--- a/ui/site/src/component/timeago.ts
+++ b/ui/site/src/component/timeago.ts
@@ -31,18 +31,22 @@ const formatDiff = (seconds: number): string => {
 
 let formatterInst: (date: Date) => string;
 
+const newFormatter = () => {
+  const options: Intl.DateTimeFormatOptions = {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: 'numeric',
+  };
+  // for many users, using the islamic calendar is not practical on the internet
+  // due to international context, so we make sure it's displayed using the gregorian calender
+  const lang = document.documentElement.lang.startsWith('ar-') ? 'ar-ma' : document.documentElement.lang;
+  return new Intl.DateTimeFormat(lang, options).format;
+};
+
 export const formatter = () =>
-  (formatterInst =
-    formatterInst ||
-    (window.Intl && Intl.DateTimeFormat
-      ? new Intl.DateTimeFormat(document.documentElement.lang, {
-          year: 'numeric',
-          month: 'short',
-          day: 'numeric',
-          hour: 'numeric',
-          minute: 'numeric',
-        }).format
-      : d => d.toLocaleString()));
+  (formatterInst = formatterInst || (window.Intl ? newFormatter() : d => d.toLocaleString()));
 
 export const format = (date: DateLike) => formatDiff((Date.now() - toDate(date).getTime()) / 1000);
 

--- a/ui/site/src/component/timeago.ts
+++ b/ui/site/src/component/timeago.ts
@@ -41,7 +41,7 @@ const newFormatter = () => {
   };
   // for many users, using the islamic calendar is not practical on the internet
   // due to international context, so we make sure it's displayed using the gregorian calender
-  const lang = document.documentElement.lang.startsWith('ar-') ? 'ar-ma' : document.documentElement.lang;
+  const lang = document.documentElement.lang.startsWith('ar-') ? 'ar-ly' : document.documentElement.lang;
   return new Intl.DateTimeFormat(lang, options).format;
 };
 


### PR DESCRIPTION
For many users, using the islamic calendar is not practical on the internet, due to international context, so we make sure it's displayed using the gregorian calender.

This was reported by and confirmed by native speakers. ~~`ar-ma`~~ `ar-ly` is a locale which displays the date in arabic while still using gregorian calender and latin numbers.

now renders like this:
<img width="165" alt="image" src="https://github.com/lichess-org/lila/assets/56031107/56a83c49-37d2-48e3-b8c8-439fceff5fc3">

close https://github.com/lichess-org/lila/issues/11893