### PR TITLE
lobby: do not redirect to current games when no games being played

### DIFF
--- a/ui/lobby/src/ctrl.ts
+++ b/ui/lobby/src/ctrl.ts
@@ -63,6 +63,9 @@ export default class LobbyController {
     this.socket = new LobbySocket(opts.socketSend, this);
 
     this.stores = makeStores(this.me?.username.toLowerCase());
+    if (!this.me?.isBot && this.stores.tab.get() == 'now_playing' && this.data.nbNowPlaying == 0) {
+      this.stores.tab.set('pools');
+    }
     this.tab = this.me?.isBot ? 'now_playing' : this.stores.tab.get();
     this.mode = this.stores.mode.get();
     this.sort = this.stores.sort.get();


### PR DESCRIPTION
The current behavior after coming back on the homepage when last tab selected was `now_playing`

<img width="707" alt="Screenshot 2023-11-01 at 23 21 46" src="https://github.com/lichess-org/lila/assets/56031107/a3bd7f23-a7b0-4c5a-b09f-26a677c15943">

Now fallback to pools