### PR TITLE
Fix being in zen out of a game with in-game option

### DIFF
--- a/app/views/round/player.scala
+++ b/app/views/round/player.scala
@@ -61,7 +61,7 @@ object player:
         )
       ),
       openGraph = povOpenGraph(pov).some,
-      playing = true,
+      playing = pov.game.playable,
       zenable = true
     ):
       main(cls := "round")(


### PR DESCRIPTION
Fixes #13904

This would have the side-effect of removing the css "fixed-scroll" from the body (only outside active/potentially-active games), but it was commented that it is for "dragging a piece out"; meaning gameplay shouldn't be affected. I also couldn't find any effective side-effect.