### PR TITLE
show correct ratings in simul

### DIFF
--- a/modules/simul/src/main/JsonView.scala
+++ b/modules/simul/src/main/JsonView.scala
@@ -78,7 +78,8 @@ final class JsonView(
           .obj(
             "id"     -> host.id,
             "name"   -> host.name,
-            "rating" -> simul.hostRating
+            "rating" -> simul.hostRating,
+            "provisional" -> simul.hostProvisional
           )
           .add("gameId" -> simul.hostGameId.ifTrue(simul.isRunning))
           .add("title" -> host.title)

--- a/modules/simul/src/main/JsonView.scala
+++ b/modules/simul/src/main/JsonView.scala
@@ -76,11 +76,11 @@ final class JsonView(
       "host" -> lightHost.map { host =>
         Json
           .obj(
-            "id"          -> host.id,
-            "name"        -> host.name,
-            "rating"      -> simul.hostRating,
-            "provisional" -> simul.hostProvisional
+            "id"     -> host.id,
+            "name"   -> host.name,
+            "rating" -> simul.hostRating
           )
+          .add("provisional" -> simul.hostProvisional)
           .add("gameId" -> simul.hostGameId.ifTrue(simul.isRunning))
           .add("title" -> host.title)
           .add("patron" -> host.isPatron)

--- a/modules/simul/src/main/JsonView.scala
+++ b/modules/simul/src/main/JsonView.scala
@@ -76,9 +76,9 @@ final class JsonView(
       "host" -> lightHost.map { host =>
         Json
           .obj(
-            "id"     -> host.id,
-            "name"   -> host.name,
-            "rating" -> simul.hostRating,
+            "id"          -> host.id,
+            "name"        -> host.name,
+            "rating"      -> simul.hostRating,
             "provisional" -> simul.hostProvisional
           )
           .add("gameId" -> simul.hostGameId.ifTrue(simul.isRunning))

--- a/modules/simul/src/main/Simul.scala
+++ b/modules/simul/src/main/Simul.scala
@@ -153,26 +153,29 @@ object Simul:
       estimatedStartAt: Option[Instant],
       featurable: Option[Boolean],
       conditions: SimulCondition.All
-  ): Simul = Simul(
-    _id = SimulId(ThreadLocalRandom nextString 8),
-    name = name,
-    status = SimulStatus.Created,
-    clock = clock,
-    hostId = host.id,
-    hostRating = host.perfs.bestPerf(variants.map { PerfType(_, Speed(clock.config.some)) }).intRating,
-    hostProvisional = host.perfs.bestPerf(variants.map { PerfType(_, Speed(clock.config.some)) }).provisional.some,
-    hostGameId = none,
-    createdAt = nowInstant,
-    estimatedStartAt = estimatedStartAt,
-    variants = if position.isDefined then List(chess.variant.Standard) else variants,
-    position = position,
-    applicants = Nil,
-    pairings = Nil,
-    startedAt = none,
-    finishedAt = none,
-    hostSeenAt = nowInstant.some,
-    color = color.some,
-    text = text,
-    featurable = featurable,
-    conditions = conditions
-  )
+  ): Simul = {
+    val hostPerf = host.perfs.bestPerf(variants.map { PerfType(_, Speed(clock.config.some)) })
+    Simul(
+      _id = SimulId(ThreadLocalRandom nextString 8),
+      name = name,
+      status = SimulStatus.Created,
+      clock = clock,
+      hostId = host.id,
+      hostRating = hostPerf.intRating,
+      hostProvisional = hostPerf.provisional.some,
+      hostGameId = none,
+      createdAt = nowInstant,
+      estimatedStartAt = estimatedStartAt,
+      variants = if position.isDefined then List(chess.variant.Standard) else variants,
+      position = position,
+      applicants = Nil,
+      pairings = Nil,
+      startedAt = none,
+      finishedAt = none,
+      hostSeenAt = nowInstant.some,
+      color = color.some,
+      text = text,
+      featurable = featurable,
+      conditions = conditions
+    )
+  }

--- a/modules/simul/src/main/Simul.scala
+++ b/modules/simul/src/main/Simul.scala
@@ -22,6 +22,7 @@ case class Simul(
     estimatedStartAt: Option[Instant] = None,
     hostId: UserId,
     hostRating: IntRating,
+    hostProvisional: Option[RatingProvisional],
     hostGameId: Option[String], // game the host is focusing on
     startedAt: Option[Instant],
     finishedAt: Option[Instant],
@@ -158,11 +159,8 @@ object Simul:
     status = SimulStatus.Created,
     clock = clock,
     hostId = host.id,
-    hostRating = host.perfs.bestRatingIn:
-      variants.map {
-        PerfType(_, Speed(clock.config.some))
-      } ::: List(PerfType.Blitz, PerfType.Rapid, PerfType.Classical)
-    ,
+    hostRating = host.perfs.bestPerf(variants.map { PerfType(_, Speed(clock.config.some)) }).intRating,
+    hostProvisional = host.perfs.bestPerf(variants.map { PerfType(_, Speed(clock.config.some)) }).provisional.some,
     hostGameId = none,
     createdAt = nowInstant,
     estimatedStartAt = estimatedStartAt,

--- a/modules/simul/src/main/Simul.scala
+++ b/modules/simul/src/main/Simul.scala
@@ -153,7 +153,7 @@ object Simul:
       estimatedStartAt: Option[Instant],
       featurable: Option[Boolean],
       conditions: SimulCondition.All
-  ): Simul = {
+  ): Simul =
     val hostPerf = host.perfs.bestPerf(variants.map { PerfType(_, Speed(clock.config.some)) })
     Simul(
       _id = SimulId(ThreadLocalRandom nextString 8),
@@ -178,4 +178,3 @@ object Simul:
       featurable = featurable,
       conditions = conditions
     )
-  }

--- a/modules/simul/src/main/SimulApi.scala
+++ b/modules/simul/src/main/SimulApi.scala
@@ -97,7 +97,7 @@ final class SimulApi(
             .filter(simul.variants.contains)
             .ifTrue(simul.nbAccepted < Game.maxPlayingRealtime)
             .so: variant =>
-              val perfType = PerfType(variant, chess.Speed.Rapid)
+              val perfType = PerfType(variant, chess.Speed(simul.clock.config.some))
               perfsRepo
                 .withPerf(me.value, perfType)
                 .flatMap: user =>

--- a/modules/user/src/main/UserPerfs.scala
+++ b/modules/user/src/main/UserPerfs.scala
@@ -101,7 +101,7 @@ case class UserPerfs(
       .map(apply)
       .foldLeft(none[Perf]):
         case (ro, p) if ro.forall(_.intRating < p.intRating) => p.some
-        case (ro, _) => ro
+        case (ro, _)                                         => ro
       .getOrElse(Perf.default)
 
   def bestRatingInWithMinGames(types: List[PerfType], nbGames: Int): Option[IntRating] =

--- a/modules/user/src/main/UserPerfs.scala
+++ b/modules/user/src/main/UserPerfs.scala
@@ -96,6 +96,14 @@ case class UserPerfs(
       case (ro, _) => ro
     .getOrElse(Perf.default.intRating)
 
+  def bestPerf(types: List[PerfType]): Perf =
+    types
+      .map(apply)
+      .foldLeft(none[Perf]):
+        case (ro, p) if ro.forall(_.intRating < p.intRating) => p.some
+        case (ro, _) => ro
+      .getOrElse(Perf.default)
+
   def bestRatingInWithMinGames(types: List[PerfType], nbGames: Int): Option[IntRating] =
     types
       .map(apply)

--- a/ui/simul/src/interfaces.ts
+++ b/ui/simul/src/interfaces.ts
@@ -42,6 +42,7 @@ export interface Player extends LightUserOnline {
 
 export interface Host extends LightUserOnline {
   rating: number;
+  provisional?: boolean;
   gameId?: string;
 }
 


### PR DESCRIPTION
Currently, all simuls show players' rapid rating. (i.e. a blitz simul shows rapid ratings).

This fixes that so it shows the rating that corresponds to the simul's time control. (i.e. a blitz simul shows blitz ratings).

https://discord.com/channels/280713822073913354/352976626558042122/1169767913234894858