### PR TITLE
Show puzzle ID in streak after puzzle is completed

### DIFF
--- a/ui/puzzle/src/view/side.ts
+++ b/ui/puzzle/src/view/side.ts
@@ -34,7 +34,7 @@ const puzzleInfos = (ctrl: Controller, puzzle: Puzzle): VNode =>
         'p',
         ctrl.trans.vdom(
           'puzzleId',
-          ctrl.vm.mode === 'play'
+          ctrl.streak && ctrl.vm.mode === 'play'
             ? h('span.hidden', ctrl.trans.noarg('hidden'))
             : h(
                 'a',

--- a/ui/puzzle/src/view/side.ts
+++ b/ui/puzzle/src/view/side.ts
@@ -30,24 +30,24 @@ const puzzleInfos = (ctrl: Controller, puzzle: Puzzle): VNode =>
       },
     }),
     h('div', [
-      ctrl.streak
-        ? null
-        : h(
-            'p',
-            ctrl.trans.vdom(
-              'puzzleId',
-              h(
-                'a',
-                {
-                  attrs: {
-                    href: router.withLang(`/training/${puzzle.id}`),
-                    ...(ctrl.streak ? { target: '_blank', rel: 'noopener' } : {}),
-                  },
-                },
-                '#' + puzzle.id,
-              ),
-            ),
+      h(
+        'p',
+        ctrl.trans.vdom(
+          'puzzleId',
+          ctrl.vm.mode === 'play'
+          ? h('span.hidden', ctrl.trans.noarg('hidden'))
+          : h(
+            'a',
+            {
+              attrs: {
+                href: router.withLang(`/training/${puzzle.id}`),
+                ...(ctrl.streak ? { target: '_blank', rel: 'noopener' } : {}),
+              },
+            },
+            '#' + puzzle.id,
           ),
+        ),
+      ),
       ctrl.showRatings
         ? h(
             'p',

--- a/ui/puzzle/src/view/side.ts
+++ b/ui/puzzle/src/view/side.ts
@@ -35,17 +35,17 @@ const puzzleInfos = (ctrl: Controller, puzzle: Puzzle): VNode =>
         ctrl.trans.vdom(
           'puzzleId',
           ctrl.vm.mode === 'play'
-          ? h('span.hidden', ctrl.trans.noarg('hidden'))
-          : h(
-            'a',
-            {
-              attrs: {
-                href: router.withLang(`/training/${puzzle.id}`),
-                ...(ctrl.streak ? { target: '_blank', rel: 'noopener' } : {}),
-              },
-            },
-            '#' + puzzle.id,
-          ),
+            ? h('span.hidden', ctrl.trans.noarg('hidden'))
+            : h(
+                'a',
+                {
+                  attrs: {
+                    href: router.withLang(`/training/${puzzle.id}`),
+                    ...(ctrl.streak ? { target: '_blank', rel: 'noopener' } : {}),
+                  },
+                },
+                '#' + puzzle.id,
+              ),
         ),
       ),
       ctrl.showRatings


### PR DESCRIPTION
Shows the ID of the puzzle in the top left

Hidden when puzzle is not yet completed
<img width="1493" alt="image" src="https://github.com/lichess-org/lila/assets/1687121/e4f35e85-6a97-4751-851b-8e51c887249a">

Shown when it is completed
<img width="1497" alt="image" src="https://github.com/lichess-org/lila/assets/1687121/2486e6a0-b841-4758-abe2-8cc22300379b">

Chose to hide it when not complete so it can't be played out in normal puzzles first to get the correct answer.