### PR TITLE
preventing moves list items from flickering and or dissapearing in ex…

### DIFF
--- a/ui/analyse/css/explorer/_explorer.scss
+++ b/ui/analyse/css/explorer/_explorer.scss
@@ -107,6 +107,7 @@
   }
 
   .moves {
+    will-change: transform, opacity; /* Prevents flicker in Safari */
     th {
       @extend %roboto;
       font-size: 0.8rem;


### PR DESCRIPTION
preventing moves list items from flickering and or dissapearing in explorer.

I was able to reproduce on my M1 macbook and this PR seems to solve this issue for safari 17

<img width="286" alt="Screenshot 2023-11-04 at 16 45 50" src="https://github.com/lichess-org/lila/assets/232150/4beaa3e3-28d0-403b-b34a-646836f3e861">
