### PR TITLE
distinguished link instead of embed for private studies

### DIFF
--- a/app/controllers/Analyse.scala
+++ b/app/controllers/Analyse.scala
@@ -6,8 +6,7 @@ import play.api.mvc.*
 import views.*
 
 import lila.app.{ given, * }
-import lila.api.LpvEmbed
-import lila.common.HTTPRequest
+import lila.common.{ HTTPRequest, LpvEmbed }
 import lila.game.{ PgnDump, Pov }
 import lila.round.JsonView.WithFlags
 import lila.oauth.AccessToken

--- a/app/controllers/Analyse.scala
+++ b/app/controllers/Analyse.scala
@@ -6,6 +6,7 @@ import play.api.mvc.*
 import views.*
 
 import lila.app.{ given, * }
+import lila.api.LpvEmbed
 import lila.common.HTTPRequest
 import lila.game.{ PgnDump, Pov }
 import lila.round.JsonView.WithFlags
@@ -100,7 +101,7 @@ final class Analyse(
   def embedReplayGame(gameId: GameId, color: String) = Anon:
     InEmbedContext:
       env.api.textLpvExpand.getPgn(gameId) map {
-        case Some(pgn) =>
+        case Some(LpvEmbed.PublicPgn(pgn)) =>
           render:
             case AcceptsPgn() => Ok(pgn)
             case _            => Ok(html.analyse.embed.lpv(pgn, chess.Color.fromName(color), getPgn = true))

--- a/app/controllers/Study.scala
+++ b/app/controllers/Study.scala
@@ -5,10 +5,9 @@ import play.api.mvc.*
 import scala.util.chaining.*
 
 import lila.app.{ given, * }
-import lila.api.LpvEmbed
 import lila.analyse.Analysis
 import lila.common.paginator.{ Paginator, PaginatorJson }
-import lila.common.{ Bus, HTTPRequest, IpAddress }
+import lila.common.{ Bus, HTTPRequest, IpAddress, LpvEmbed }
 import lila.socket.Socket
 import lila.study.actorApi.{ BecomeStudyAdmin, Who }
 import lila.study.JsonView.JsData

--- a/app/controllers/Study.scala
+++ b/app/controllers/Study.scala
@@ -5,16 +5,17 @@ import play.api.mvc.*
 import scala.util.chaining.*
 
 import lila.app.{ given, * }
+import lila.api.LpvEmbed
+import lila.analyse.Analysis
 import lila.common.paginator.{ Paginator, PaginatorJson }
 import lila.common.{ Bus, HTTPRequest, IpAddress }
+import lila.socket.Socket
 import lila.study.actorApi.{ BecomeStudyAdmin, Who }
 import lila.study.JsonView.JsData
 import lila.study.Study.WithChapter
-import lila.study.{ Order, StudyForm, Study as StudyModel, Chapter, Settings }
+import lila.study.{ Chapter, Order, Settings, StudyForm, Study as StudyModel }
 import lila.tree.Node.partitionTreeJsonWriter
 import views.*
-import lila.analyse.Analysis
-import lila.socket.Socket
 
 final class Study(
     env: Env,
@@ -358,14 +359,13 @@ final class Study(
         else env.study.api.byIdWithChapterOrFallback(studyId, chapterId)
       def notFound = NotFound(html.study.embed.notFound)
       studyFu
-        .map(_.filterNot(_.study.isPrivate))
         .flatMap:
           _.fold(notFound.toFuccess): sc =>
             env.api.textLpvExpand
               .getChapterPgn(sc.chapter.id)
               .map:
-                _.fold(notFound): pgn =>
-                  Ok(html.study.embed(sc.study, sc.chapter, pgn))
+                case Some(LpvEmbed.PublicPgn(pgn)) => Ok(html.study.embed(sc.study, sc.chapter, pgn))
+                case _                             => notFound
 
   def cloneStudy(id: StudyId) = Auth { ctx ?=> _ ?=>
     Found(env.study.api.byId(id)): study =>

--- a/modules/api/src/main/TextLpvExpand.scala
+++ b/modules/api/src/main/TextLpvExpand.scala
@@ -6,6 +6,7 @@ import lila.analyse.{ Analysis, AnalysisRepo }
 import lila.game.GameRepo
 import lila.memo.CacheApi
 import chess.format.pgn.{ Pgn, PgnStr }
+import lila.common.LpvEmbed
 import lila.common.config.NetDomain
 
 final class TextLpvExpand(
@@ -50,7 +51,7 @@ final class TextLpvExpand(
 
   // used by blogs & ublogs to build game|chapter id -> pgn maps
   // the substitution happens later in blog/BlogApi or common/MarkdownRender
-  def allPgnsFromText(text: String): Fu[Map[String, PgnStr]] =
+  def allPgnsFromText(text: String): Fu[Map[String, LpvEmbed]] =
     regex.blogPgnCandidatesRe
       .findAllMatchIn(text)
       .map(_.group(1))
@@ -62,7 +63,7 @@ final class TextLpvExpand(
       .parallel
       .map:
         _.collect:
-          case (id, Some(LpvEmbed.PublicPgn(embed))) => id -> embed
+          case (id, Some(embed)) => id -> embed
         .toMap
 
   private val regex = LpvGameRegex(net.domain)
@@ -128,7 +129,3 @@ final class LpvGameRegex(domain: NetDomain):
   val gamePgnRe    = raw"^(/(\w{8})(?:\w{4}|/(?:white|black))?$params)$$".r
   val chapterPgnRe = raw"^(/study/(?:embed/)?(?:\w{8})/(\w{8})$params)$$".r
   val studyPgnRe   = raw"^(/study/(?:embed/)?(\w{8})$params)$$".r
-
-enum LpvEmbed:
-  case PublicPgn(pgn: PgnStr)
-  case PrivateStudy

--- a/modules/blog/src/main/BlogApi.scala
+++ b/modules/blog/src/main/BlogApi.scala
@@ -6,7 +6,7 @@ import play.api.mvc.RequestHeader
 import play.api.libs.ws.StandaloneWSClient
 import java.util.regex.{ Pattern, Matcher }
 
-import lila.common.Bus
+import lila.common.{ Bus, LpvEmbed }
 import lila.common.config.{ BaseUrl, MaxPerPage }
 import lila.common.paginator.*
 import lila.hub.actorApi.lpv.AllPgnsFromText
@@ -106,26 +106,28 @@ final class BlogApi(
   private def expandGames(html: String) = expandGameRegex.replaceAllIn(
     html,
     m =>
-      pgnCache
-        .getIfPresent(m.group(1))
-        .fold(m.matched): pgn =>
+      pgnCache.getIfPresent(m.group(1)) match {
+        case Some(LpvEmbed.PublicPgn(pgn)) =>
           val esc = Matcher.quoteReplacement:
             lila.common.base.StringUtils.escapeHtmlRaw(pgn.value)
           val color = Option(m.group(2)).getOrElse("white")
           val ply   = Option(m.group(3)).getOrElse("last")
           s"""<div class="lpv--autostart" data-pgn="$esc" data-orientation="$color" data-ply="$ply"></div>"""
+        case _ => m.matched
+      }
   )
 
   private def expandChapters(html: String) = expandChapterRegex.replaceAllIn(
     html,
     m =>
-      pgnCache
-        .getIfPresent(m.group(1))
-        .fold(m.matched): pgn =>
+      pgnCache.getIfPresent(m.group(1)) match {
+        case Some(LpvEmbed.PublicPgn(pgn)) =>
           val esc = Matcher.quoteReplacement:
             lila.common.base.StringUtils.escapeHtmlRaw(pgn.value)
           val ply = Option(m.group(2)).getOrElse("last")
           s"""<div class="lpv--autostart" data-pgn="$esc" data-ply="$ply"></div>"""
+        case _ => m.matched
+      }
   )
 
   // match the entire <a.../> tag with scheme & domain.  href value should be identical to inner text
@@ -138,7 +140,7 @@ final class BlogApi(
     val chapterUrlRegex = quotedBaseUrl + """/study/(?:embed/)?(?:\w{8})/(\w{8})(?:#(last|\d+))?"""
     ("<a href=\"" + chapterUrlRegex + "\">" + chapterUrlRegex + "</a>").r
 
-  private val pgnCache = cacheApi.notLoadingSync[String, PgnStr](256, "prisblog.markup.pgn"):
+  private val pgnCache = cacheApi.notLoadingSync[String, LpvEmbed](256, "prisblog.markup.pgn"):
     _.expireAfterWrite(10.seconds).build()
 
   private def resolveRef(api: Api)(ref: Option[String]) =

--- a/modules/blog/src/main/BlogApi.scala
+++ b/modules/blog/src/main/BlogApi.scala
@@ -106,7 +106,7 @@ final class BlogApi(
   private def expandGames(html: String) = expandGameRegex.replaceAllIn(
     html,
     m =>
-      pgnCache.getIfPresent(m.group(1)) match {
+      pgnCache.getIfPresent(m.group(1)) match
         case Some(LpvEmbed.PublicPgn(pgn)) =>
           val esc = Matcher.quoteReplacement:
             lila.common.base.StringUtils.escapeHtmlRaw(pgn.value)
@@ -114,20 +114,18 @@ final class BlogApi(
           val ply   = Option(m.group(3)).getOrElse("last")
           s"""<div class="lpv--autostart" data-pgn="$esc" data-orientation="$color" data-ply="$ply"></div>"""
         case _ => m.matched
-      }
   )
 
   private def expandChapters(html: String) = expandChapterRegex.replaceAllIn(
     html,
     m =>
-      pgnCache.getIfPresent(m.group(1)) match {
+      pgnCache.getIfPresent(m.group(1)) match
         case Some(LpvEmbed.PublicPgn(pgn)) =>
           val esc = Matcher.quoteReplacement:
             lila.common.base.StringUtils.escapeHtmlRaw(pgn.value)
           val ply = Option(m.group(2)).getOrElse("last")
           s"""<div class="lpv--autostart" data-pgn="$esc" data-ply="$ply"></div>"""
         case _ => m.matched
-      }
   )
 
   // match the entire <a.../> tag with scheme & domain.  href value should be identical to inner text

--- a/modules/common/src/main/MarkdownRender.scala
+++ b/modules/common/src/main/MarkdownRender.scala
@@ -244,7 +244,7 @@ object MarkdownRender:
         color: Option[String],
         ply: Option[String]
     ) =
-      embed match {
+      embed match
         case LpvEmbed.PublicPgn(pgn) =>
           html
             .attr("data-pgn", pgn.value)
@@ -276,7 +276,6 @@ object MarkdownRender:
           context.renderChildren(node)
           html
             .tag("/a")
-      }
 
   private object LilaLinkExtension extends HtmlRenderer.HtmlRendererExtension:
     override def rendererOptions(options: MutableDataHolder) = ()

--- a/modules/common/src/main/MarkdownRender.scala
+++ b/modules/common/src/main/MarkdownRender.scala
@@ -107,7 +107,7 @@ object MarkdownRender:
   type Key         = String
   type PgnSourceId = String
 
-  case class PgnSourceExpand(domain: config.NetDomain, getPgn: PgnSourceId => Option[PgnStr])
+  case class PgnSourceExpand(domain: config.NetDomain, getPgn: PgnSourceId => Option[LpvEmbed])
 
   private val rel = "nofollow noopener noreferrer"
 
@@ -215,11 +215,11 @@ object MarkdownRender:
           case pgnRegexes.game(id, color, ply) =>
             expander
               .getPgn(id)
-              .fold(justAsLink())(renderPgnViewer(node, html, link, _, Option(color), Option(ply)))
+              .fold(justAsLink())(renderLpvEmbed(node, context, html, link, _, Option(color), Option(ply)))
           case pgnRegexes.chapter(id, ply) =>
             expander
               .getPgn(id)
-              .fold(justAsLink())(renderPgnViewer(node, html, link, _, none, Option(ply)))
+              .fold(justAsLink())(renderLpvEmbed(node, context, html, link, _, none, Option(ply)))
           case _ => justAsLink()
 
     private def renderLinkWithBase(
@@ -235,27 +235,48 @@ object MarkdownRender:
       context.renderChildren(node)
       html.tag("/a")
 
-    private def renderPgnViewer(
+    private def renderLpvEmbed(
         node: LinkNode,
+        context: NodeRendererContext,
         html: HtmlWriter,
         link: ResolvedLink,
-        pgn: PgnStr,
+        embed: LpvEmbed,
         color: Option[String],
         ply: Option[String]
     ) =
-      html
-        .attr("data-pgn", pgn.value)
-        .attr("class", "lpv--autostart is2d")
-      color.foreach:
-        html.attr("data-orientation", _)
-      ply.foreach:
-        html.attr("data-ply", _)
-      html
-        .srcPos(node.getChars())
-        .withAttr(link)
-        .tag("div")
-        .text(link.getUrl)
-        .tag("/div")
+      embed match {
+        case LpvEmbed.PublicPgn(pgn) =>
+          html
+            .attr("data-pgn", pgn.value)
+            .attr("class", "lpv--autostart is2d")
+          color.foreach:
+            html.attr("data-orientation", _)
+          ply.foreach:
+            html.attr("data-ply", _)
+          html
+            .srcPos(node.getChars())
+            .withAttr(link)
+            .tag("div")
+            .text(link.getUrl)
+            .tag("/div")
+        case LpvEmbed.PrivateStudy =>
+          html
+            .attr("href", link.getUrl)
+            .attr(link.getNonNullAttributes())
+            .srcPos(node.getChars())
+            .withAttr(link)
+            .tag("a")
+            .withAttr()
+            .attr("data-icon", licon.Padlock.toString)
+            .attr("class", "private-study")
+            .attr("title", "Private")
+            .attr("aria-label", "Private")
+            .tag("i")
+            .tag("/i")
+          context.renderChildren(node)
+          html
+            .tag("/a")
+      }
 
   private object LilaLinkExtension extends HtmlRenderer.HtmlRendererExtension:
     override def rendererOptions(options: MutableDataHolder) = ()

--- a/modules/common/src/main/model.scala
+++ b/modules/common/src/main/model.scala
@@ -1,5 +1,6 @@
 package lila.common
 
+import chess.format.pgn.PgnStr
 import io.mola.galimatias.IPv4Address.parseIPv4Address
 import io.mola.galimatias.IPv6Address.parseIPv6Address
 import play.api.mvc.Call
@@ -89,3 +90,7 @@ case class Preload[A](value: Option[A]) extends AnyVal:
 object Preload:
   def apply[A](value: A): Preload[A] = Preload(value.some)
   def none[A]                        = Preload[A](None)
+
+enum LpvEmbed:
+  case PublicPgn(pgn: PgnStr)
+  case PrivateStudy

--- a/modules/common/src/test/MarkdownTest.scala
+++ b/modules/common/src/test/MarkdownTest.scala
@@ -1,6 +1,7 @@
 package lila.common
 
 import chess.format.pgn.PgnStr
+import lila.common.LpvEmbed
 import lila.common.config.AssetDomain
 
 class MarkdownTest extends munit.FunSuite:
@@ -33,9 +34,10 @@ class MarkdownTest extends munit.FunSuite:
   val gameUrl    = s"http://l.org/$gameId"
   val chapterPgn = PgnStr("Nf3 Nf6 d4")
   val chapterUrl = s"http://l.org/study/$studyId/$chapterId"
-  val pgns       = Map(gameId.value -> gamePgn, chapterId.value -> chapterPgn)
-  val expander   = MarkdownRender.PgnSourceExpand(domain, pgns.get)
-  val mdRender   = MarkdownRender(pgnExpand = expander.some)("test") _
+  val pgns =
+    Map(gameId.value -> LpvEmbed.PublicPgn(gamePgn), chapterId.value -> LpvEmbed.PublicPgn(chapterPgn))
+  val expander = MarkdownRender.PgnSourceExpand(domain, pgns.get)
+  val mdRender = MarkdownRender(pgnExpand = expander.some)("test") _
 
   test("markdown game embeds full link") {
     val md = Markdown(s"foo [game]($gameUrl) bar")

--- a/modules/hub/src/main/actorApi.scala
+++ b/modules/hub/src/main/actorApi.scala
@@ -1,6 +1,7 @@
 package lila.hub
 package actorApi
 
+import lila.common.LpvEmbed
 import chess.format.{ Uci, Fen }
 import java.time.Duration
 import play.api.libs.json.*
@@ -98,7 +99,7 @@ package captcha:
   case class ValidCaptcha(id: GameId, solution: String)
 
 package lpv:
-  case class AllPgnsFromText(text: String, promise: Promise[Map[String, chess.format.pgn.PgnStr]])
+  case class AllPgnsFromText(text: String, promise: Promise[Map[String, LpvEmbed]])
   case class LpvLinkRenderFromText(text: String, promise: Promise[lila.base.RawHtml.LinkRender])
 
 package simul:

--- a/modules/ublog/src/main/UblogMarkup.scala
+++ b/modules/ublog/src/main/UblogMarkup.scala
@@ -4,7 +4,7 @@ import java.util.regex.Matcher
 import play.api.Mode
 
 import lila.common.config
-import lila.common.{ Bus, Markdown, MarkdownRender }
+import lila.common.{ Bus, LpvEmbed, Markdown, MarkdownRender }
 import lila.hub.actorApi.lpv.AllPgnsFromText
 import lila.memo.CacheApi
 
@@ -21,7 +21,7 @@ final class UblogMarkup(
   type PgnSourceId = String
 
   private val pgnCache =
-    cacheApi.notLoadingSync[PgnSourceId, chess.format.pgn.PgnStr](256, "ublogMarkup.pgn"):
+    cacheApi.notLoadingSync[PgnSourceId, LpvEmbed](256, "ublogMarkup.pgn"):
       _.expireAfterWrite(1 second).build()
 
   private val renderer = MarkdownRender(

--- a/ui/site/css/ublog/_markup.scss
+++ b/ui/site/css/ublog/_markup.scss
@@ -28,4 +28,9 @@
     color-scheme: normal;
     margin: auto;
   }
+
+  .private-study {
+    color: $c-brag;
+    font-size: 1.2em;
+  }
 }


### PR DESCRIPTION
Fixes lichess-org/pgn-viewer#29 (by not embedding the private study at all).

Hopefully the padlock is enough to explain why the particular embed is not working.

![image](https://github.com/lichess-org/lila/assets/402777/cce56cf8-eee0-4dd2-9f36-117ca9cd39ae)

Matches the icon at:

![image](https://github.com/lichess-org/lila/assets/402777/6f078fd5-62a5-4dad-ae47-b9b5f48583da)
