### PR TITLE
remove players in wrong variant on simul update

### DIFF
--- a/modules/simul/src/main/SimulApi.scala
+++ b/modules/simul/src/main/SimulApi.scala
@@ -73,6 +73,7 @@ final class SimulApi(
       name = setup.name,
       clock = setup.clock,
       variants = setup.actualVariants,
+      applicants = prev.applicants.filter(setup.actualVariants contains _.player.variant),
       position = setup.realPosition,
       color = setup.color.some,
       text = setup.text,


### PR DESCRIPTION
Currently, if a simul host has two variants selected and then updates the simul to remove one of the variants, the players who joined with the removed variant remain there.

This fixes that by removing players of the wrong variant when the simul host updates the simul.