### PR TITLE
Do not use `xhr.json` on study endpoints returning no content

### DIFF
--- a/ui/analyse/src/study/studyXhr.ts
+++ b/ui/analyse/src/study/studyXhr.ts
@@ -16,12 +16,12 @@ export const chapterConfig = (studyId: string, chapterId: string): Promise<Study
   xhr.json(`/study/${studyId}/${chapterId}/meta`);
 
 export const practiceComplete = (chapterId: string, nbMoves: number) =>
-  xhr.json(`/practice/complete/${chapterId}/${nbMoves}`, {
+  xhr.text(`/practice/complete/${chapterId}/${nbMoves}`, {
     method: 'POST',
   });
 
 export const importPgn = (studyId: string, data: any) =>
-  xhr.json(`/study/${studyId}/import-pgn?sri=${lichess.sri}`, {
+  xhr.text(`/study/${studyId}/import-pgn?sri=${lichess.sri}`, {
     method: 'POST',
     body: xhr.form(data),
   });


### PR DESCRIPTION
tested locally for both endpoints. fix https://github.com/lichess-org/lila/issues/13919