### PR TITLE
word-break image credit text to fix layout issue

### DIFF
--- a/ui/site/css/ublog/_post.scss
+++ b/ui/site/css/ublog/_post.scss
@@ -95,6 +95,7 @@
       font-size: 0.9em;
       color: $c-font-dim;
       text-align: right;
+      word-break: break-word;
     }
   }
   &__intro {


### PR DESCRIPTION
Fixes #13921 
Image credit after fix:
![image](https://github.com/lichess-org/lila/assets/204700/a4fb0bd7-de50-4603-a441-e12a503594f9)
