### PR TITLE
Add script to backfill user playTime

### DIFF
--- a/bin/mongodb/user-playtime.js
+++ b/bin/mongodb/user-playtime.js
@@ -18,6 +18,7 @@ db.user4
         {
           $match: {
             us: user._id,
+            c: { $exists: true },
           },
         },
         {

--- a/bin/mongodb/user-playtime.js
+++ b/bin/mongodb/user-playtime.js
@@ -38,7 +38,7 @@ db.user4
       ])
       .toArray();
 
-    let duration = Math.floor(result[0].totalDuration / 1000);
+    let duration = NumberInt(Math.floor(result[0].totalDuration / 1000));
 
     db.user4.updateOne(
       { _id: user._id },

--- a/bin/mongodb/user-playtime.js
+++ b/bin/mongodb/user-playtime.js
@@ -29,6 +29,12 @@ db.user4
           },
         },
         {
+          $match: {
+            // ignore games over 4 hours (either correspondence or bad data)
+            duration: { $lte: NumberLong(4 * 60 * 60 * 1000) },
+          },
+        },
+        {
           $group: {
             _id: null,
             totalDuration: {
@@ -38,6 +44,11 @@ db.user4
         },
       ])
       .toArray();
+
+    if (result.length === 0) {
+      print(currentRecord++, user._id, 'skipping');
+      return;
+    }
 
     let duration = NumberInt(Math.floor(result[0].totalDuration / 1000));
 

--- a/bin/mongodb/user-playtime.js
+++ b/bin/mongodb/user-playtime.js
@@ -1,0 +1,58 @@
+print('Backfilling user playTime, for https://github.com/lichess-org/lila/issues/6995');
+
+let currentRecord = 1;
+
+db.user4
+  .find(
+    {
+      // recently active users without a `time` field
+      time: { $exists: false },
+      'count.game': { $gte: 1 },
+      seenAt: { $gte: ISODate('2023-10-01T00:00:00Z') },
+    },
+    { _id: 1 },
+  )
+  .forEach(user => {
+    let result = db.game5
+      .aggregate([
+        {
+          $match: {
+            us: user._id,
+          },
+        },
+        {
+          $project: {
+            duration: {
+              $subtract: ['$ua', '$ca'],
+            },
+          },
+        },
+        {
+          $group: {
+            _id: null,
+            totalDuration: {
+              $sum: '$duration',
+            },
+          },
+        },
+      ])
+      .toArray();
+
+    let duration = Math.floor(result[0].totalDuration / 1000);
+
+    db.user4.updateOne(
+      { _id: user._id },
+      {
+        $set: {
+          time: {
+            total: duration,
+            tv: 0,
+          },
+        },
+      },
+    );
+
+    print(currentRecord++, user._id, duration);
+  });
+
+print('Done');


### PR DESCRIPTION
Calculates an approximate `time.total` value for users missing it by using the createdAt and updatedAt ISODate values from their game records.

To run:
```bash
mongo lichess user-playtime.js
```

To remove a local user's `time` value (for testing):
```js
mongo lichess
db.user4.updateOne({ _id: 'bobby' }, { $unset: { time: 1 } });
```

Tested on mongodb 4.4.25 and 5.0.22
Fixes #6995