### PR TITLE
fix safari autoplay text

### DIFF
--- a/app/views/site/faq.scala
+++ b/app/views/site/faq.scala
@@ -404,8 +404,8 @@ object faq:
           ul(
             li("Go to lichess.org"),
             li("Click Safari in the menu bar"),
-            li("Click Settings for This Website"),
-            li("Allow Auto-Play")
+            li("Click Settings for lichess.org..."),
+            li("Allow All Auto-Play")
           ),
           h3("Microsoft Edge (desktop):"),
           ul(


### PR DESCRIPTION
Updates the autoplay page for Safari to display what will actually be shown for Safari users
<img width="231" alt="image" src="https://github.com/lichess-org/lila/assets/1687121/02739ee4-1f07-4f84-8bef-a5a5ef8ab65d">
<img width="370" alt="image" src="https://github.com/lichess-org/lila/assets/1687121/8372990f-8a1d-4302-8d5d-b4d748e94022">
