### PR TITLE
fix games page overflow

### DIFF
--- a/ui/site/css/tv/_games.scss
+++ b/ui/site/css/tv/_games.scss
@@ -6,7 +6,7 @@
   .page-menu__menu {
     max-width: 100vw;
   }
-  
+
   .page-menu__content {
     @extend %box-radius-force;
 

--- a/ui/site/css/tv/_games.scss
+++ b/ui/site/css/tv/_games.scss
@@ -3,10 +3,15 @@
 @include body-fixed-scroll;
 
 .tv-games {
+  .page-menu__menu {
+    max-width: 100vw;
+  }
+  
   .page-menu__content {
     @extend %box-radius-force;
 
     grid-template-columns: repeat(auto-fill, minmax(15em, 1fr));
     align-content: start;
+    max-width: 100vw;
   }
 }


### PR DESCRIPTION
Go to https://lichess.org/games on a phone, and you will see the problem with overflow resorting to horizontal scrolling. Hard to screenshot.

This fixes that, while maintaining desktop view as the same.
<img width="829" alt="image" src="https://github.com/lichess-org/lila/assets/1687121/b289a4ad-9829-44d6-a850-9df363063402">
