### PR TITLE
Allow different asset url for requests from Dasher

### DIFF
--- a/app/controllers/Dasher.scala
+++ b/app/controllers/Dasher.scala
@@ -55,7 +55,7 @@ final class Dasher(env: Env)(using ws: StandaloneWSClient) extends LilaControlle
   private lazy val galleryJson = env.memo.cacheApi.unit[Option[JsValue]]:
     _.refreshAfterWrite(1.minute)
       .buildAsyncFuture: _ =>
-        ws.url(s"${env.net.assetBaseUrl}/assets/lifat/background/gallery.json")
+        ws.url(s"${env.net.assetBaseUrlInternal}/assets/lifat/background/gallery.json")
           .get()
           .map:
             case res if res.status == 200 => res.body[JsValue].some

--- a/conf/base.conf
+++ b/conf/base.conf
@@ -16,6 +16,7 @@ net {
   socket.domains = [ "localhost:9664" ]
   asset.domain = ${net.domain}
   asset.base_url = "http://"${net.asset.domain}
+  asset.base_url_internal = ${net.asset.base_url}
   asset.minified = false
   base_url = "http://"${net.domain}
   email = ""

--- a/modules/common/src/main/config.scala
+++ b/modules/common/src/main/config.scala
@@ -40,6 +40,9 @@ object config:
   opaque type AssetBaseUrl = String
   object AssetBaseUrl extends OpaqueString[AssetBaseUrl]
 
+  opaque type AssetBaseUrlInternal = String
+  object AssetBaseUrlInternal extends OpaqueString[AssetBaseUrlInternal]
+
   opaque type RateLimit = Boolean
   object RateLimit extends YesNo[RateLimit]
 
@@ -52,6 +55,7 @@ object config:
       @ConfigName("base_url") baseUrl: BaseUrl,
       @ConfigName("asset.domain") assetDomain: AssetDomain,
       @ConfigName("asset.base_url") assetBaseUrl: AssetBaseUrl,
+      @ConfigName("asset.base_url_internal") assetBaseUrlInternal: AssetBaseUrlInternal,
       @ConfigName("asset.minified") minifiedAssets: Boolean,
       @ConfigName("stage.banner") stageBanner: Boolean,
       @ConfigName("site.name") siteName: String,

--- a/modules/common/src/main/config.scala
+++ b/modules/common/src/main/config.scala
@@ -40,9 +40,6 @@ object config:
   opaque type AssetBaseUrl = String
   object AssetBaseUrl extends OpaqueString[AssetBaseUrl]
 
-  opaque type AssetBaseUrlInternal = String
-  object AssetBaseUrlInternal extends OpaqueString[AssetBaseUrlInternal]
-
   opaque type RateLimit = Boolean
   object RateLimit extends YesNo[RateLimit]
 
@@ -55,7 +52,7 @@ object config:
       @ConfigName("base_url") baseUrl: BaseUrl,
       @ConfigName("asset.domain") assetDomain: AssetDomain,
       @ConfigName("asset.base_url") assetBaseUrl: AssetBaseUrl,
-      @ConfigName("asset.base_url_internal") assetBaseUrlInternal: AssetBaseUrlInternal,
+      @ConfigName("asset.base_url_internal") assetBaseUrlInternal: String,
       @ConfigName("asset.minified") minifiedAssets: Boolean,
       @ConfigName("stage.banner") stageBanner: Boolean,
       @ConfigName("site.name") siteName: String,


### PR DESCRIPTION
Would it be possible to add a separate config value to fix an issue in gitpod/docker-compose environments? Ref lichess-org/lila-docker#15

In this case of the Dasher controller, the request to gallery.json is coming from the lila backend, and I need to customize the hostname to get the networking to work.