### PR TITLE
Fix removing fields from teams

### DIFF
--- a/modules/team/src/main/TeamApi.scala
+++ b/modules/team/src/main/TeamApi.scala
@@ -81,7 +81,8 @@ final class TeamApi(
     )
     import reactivemongo.api.bson.*
     for
-      _        <- teamRepo.coll.update.one($id(team.id), $set(bsonWriteDoc(team)))
+      blocklist <- blocklist.get(old)
+      _        <- teamRepo.coll.update.one($id(team.id), bsonWriteDoc(team) ++ $doc("blocklist" -> blocklist))
       isLeader <- hasPerm(team.id, me, _.Settings)
     yield
       if !isLeader then modLog.teamEdit(team.createdBy, team.name)


### PR DESCRIPTION
`def $doc(elements: ElementProducer*): Bdoc = BSONDocument.strict(elements*)` used internally by `$set` did not produce fields when they were empty, so it was impossible to unset fields.

A cleaner version would have been to have a `updateOrUnsetFields(doc: Bdoc)` but there was no functions like that, so for one case it seemed a bit overkill.

fix https://github.com/lichess-org/lila/issues/13948

Another option was to make blocklist part of `Team` object. Generally it seems a bit funky that we both have a team blocklist AND set a declined join request.