### PR TITLE
Fix accidentally solving retro mistake when browsed away

### DIFF
--- a/ui/analyse/src/retrospect/retroCtrl.ts
+++ b/ui/analyse/src/retrospect/retroCtrl.ts
@@ -44,7 +44,7 @@ interface Retrospection {
   openingUcis: Uci[];
 }
 
-type Feedback = 'find' | 'eval' | 'win' | 'fail' | 'view';
+type Feedback = 'find' | 'eval' | 'win' | 'fail' | 'view' | 'offTrack';
 
 export function make(root: AnalyseCtrl, color: Color): RetroCtrl {
   const game = root.data.game;
@@ -125,7 +125,10 @@ export function make(root: AnalyseCtrl, color: Color): RetroCtrl {
       fb = feedback(),
       cur = current();
     if (!cur) return;
-    if (fb === 'eval' && cur.fault.node.ply !== node.ply) {
+    if (
+      (fb === 'eval' && cur.fault.node.ply !== node.ply) ||
+      (fb === 'offTrack' && cur.prev.path === root.path)
+    ) {
       feedback('find');
       root.setAutoShapes();
       return;
@@ -140,6 +143,8 @@ export function make(root: AnalyseCtrl, color: Color): RetroCtrl {
         if (!root.ceval.enabled()) root.toggleCeval();
         checkCeval();
       }
+    } else if (isSolving() && cur.prev.path !== root.path) {
+      feedback('offTrack');
     }
     root.setAutoShapes();
   }


### PR DESCRIPTION
Frequently, when I use "Learn from your mistakes" I browse away from the main mistake node to look at a different variation and end up "solving" one of my mistakes. This is because it's checking the ply of the fault node against the current ply (even if browsed away).

This fix allows browsing away, and only allows solving when at the fault node.

**Video showing problem:**
https://github.com/lichess-org/lila/assets/3620552/f780c2b5-d09e-4103-96d9-0f4c0d4afcf7

**Video of fix:**
https://github.com/lichess-org/lila/assets/3620552/4399d8da-2277-470f-a6f9-6c03cbaff23c



