### PR TITLE
dont flow text around blog image in teaser

### DIFF
--- a/app/views/blog/index.scala
+++ b/app/views/blog/index.scala
@@ -76,16 +76,16 @@ object index:
         div(cls := "body")(
           doc.getStructuredText("blog.body").map { body =>
             raw(lila.blog.BlogApi.extract(body))
-          },
-          p(cls := "more")(
-            a(
-              cls      := "button",
-              href     := routes.Blog.show(doc.id, doc.slug, ref = prismic.maybeRef),
-              dataIcon := licon.PlayTriangle
-            )(
-              " Continue reading this post"
-            )
-          )
+          }
+        )
+      ),
+      p(cls := "more")(
+        a(
+          cls      := "button",
+          href     := routes.Blog.show(doc.id, doc.slug, ref = prismic.maybeRef),
+          dataIcon := licon.PlayTriangle
+        )(
+          " Continue reading this post"
         )
       )
     )

--- a/ui/site/css/_blog.scss
+++ b/ui/site/css/_blog.scss
@@ -151,7 +151,7 @@
         text-align: center;
       }
 
-      margin-bottom: 2em;
+      margin-bottom: 1em;
     }
 
     .meta {
@@ -160,13 +160,18 @@
 
     .parts {
       @extend %box-padding-horiz;
+      @extend %flex-center-nowrap;
+      margin: 3em 0 1em;
+      gap: 3em;
 
-      margin-top: 3em;
+      @media (max-width: $mq-width-medium) {
+        flex-flow: column;
+      }
 
       .illustration {
-        float: left;
-        max-width: 40%;
-        margin: 0 3em 2em 0;
+        flex: 1 0 40%;
+        max-width: 80%;
+        margin: 0;
 
         img {
           margin: 0;
@@ -176,11 +181,11 @@
       .body {
         font-size: 1.15em;
         line-height: 1.7;
+        margin: 0;
       }
     }
-
     .more {
-      margin-top: 2em;
+      font-size: 1.3em;
       text-align: center;
     }
   }


### PR DESCRIPTION
resolve #14001

Weird text flow of intro paragraphs in trevlar's blog. This PR proposes a basic flex layout rather than text flow.

Before:
![image](https://github.com/lichess-org/lila/assets/101470903/23a8d3e2-a145-47c1-9169-ab5a15e8cd13)

After:
![image](https://github.com/lichess-org/lila/assets/101470903/69337e53-df56-48f2-9a90-76515713c37e)
![image](https://github.com/lichess-org/lila/assets/101470903/e82bbf80-4f3f-44ba-931c-1d1c1d91cf50)
