### PR TITLE
Use internal asset base url to fetch flair list

### DIFF
--- a/app/Env.scala
+++ b/app/Env.scala
@@ -176,7 +176,7 @@ final class EnvBoot(
   given Scheduler = system.scheduler
   given Mode      = environment.mode
   val netConfig   = config.get[NetConfig]("net")
-  export netConfig.{ domain, baseUrl, assetBaseUrl }
+  export netConfig.{ domain, baseUrl, assetBaseUrlInternal }
 
   // eagerly load the Uptime object to fix a precise date
 

--- a/modules/common/src/main/config.scala
+++ b/modules/common/src/main/config.scala
@@ -40,6 +40,9 @@ object config:
   opaque type AssetBaseUrl = String
   object AssetBaseUrl extends OpaqueString[AssetBaseUrl]
 
+  opaque type AssetBaseUrlInternal = String
+  object AssetBaseUrlInternal extends OpaqueString[AssetBaseUrlInternal]
+
   opaque type RateLimit = Boolean
   object RateLimit extends YesNo[RateLimit]
 
@@ -52,7 +55,7 @@ object config:
       @ConfigName("base_url") baseUrl: BaseUrl,
       @ConfigName("asset.domain") assetDomain: AssetDomain,
       @ConfigName("asset.base_url") assetBaseUrl: AssetBaseUrl,
-      @ConfigName("asset.base_url_internal") assetBaseUrlInternal: String,
+      @ConfigName("asset.base_url_internal") assetBaseUrlInternal: AssetBaseUrlInternal,
       @ConfigName("asset.minified") minifiedAssets: Boolean,
       @ConfigName("stage.banner") stageBanner: Boolean,
       @ConfigName("site.name") siteName: String,

--- a/modules/user/src/main/Env.scala
+++ b/modules/user/src/main/Env.scala
@@ -27,7 +27,7 @@ final class Env(
     cacheApi: lila.memo.CacheApi,
     isOnline: lila.socket.IsOnline,
     onlineIds: lila.socket.OnlineIds,
-    assetBaseUrl: AssetBaseUrl
+    assetBaseUrlInternal: AssetBaseUrlInternal
 )(using Executor, Scheduler, StandaloneWSClient, akka.stream.Materializer, play.api.Mode):
 
   private val config = appConfig.get[UserConfig]("user")(AutoConfig.loader)


### PR DESCRIPTION
Similar request to #13937 - gitpod/docker environments use an `assetBaseUrl` that is not resolvable from lila's container, only the host.

Error was only visible in the logs after adding:

```scala
.recover { case e =>
  logger.error(s"Cannot fetch $listUrl", e)
}
```

I had to add the opaque type back in and unsure if this is the right way to do it, but it works.