### PR TITLE
Add CSS class for the selected pocket piece

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@typescript-eslint/eslint-plugin": "^6.4.0",
     "@typescript-eslint/parser": "^6.4.0",
     "ab": "github:lichess-org/ab-stub",
-    "chessground": "^9.0.4",
+    "chessground": "link:/chessground",
     "eslint": "^8.47.0",
     "lint-staged": "^14.0.0",
     "prettier": "^3.0.2",

--- a/ui/chess/css/_zh-pocket.scss
+++ b/ui/chess/css/_zh-pocket.scss
@@ -64,6 +64,10 @@
         background-color: #aaa;
       }
 
+      &.selected-to-drop {
+        background-color: rgba(20, 85, 30, 0.5);
+      }
+
       &:first-child:hover {
         @extend %box-radius-left;
       }


### PR DESCRIPTION
fixes #12866 
This change depends on this PR to lichess-org/chessground:


This is the styling I propose for the selected piece:
![image](https://github.com/lichess-org/lila/assets/7948305/18ec51f6-6327-4777-a619-bda5a60be012)

I'm definitely open to other ideas on how we should style the selected piece.
I copied that color from the selected piece background in chessground.
A similar style we use on the pocket is what we do for the pre-dropped piece where we highlight the background a shade of gray.