### PR TITLE
Add dynamicImport as an engine require

### DIFF
--- a/ui/ceval/src/engines/engines.ts
+++ b/ui/ceval/src/engines/engines.ts
@@ -38,7 +38,7 @@ export class Engines {
             name: 'Stockfish 16 NNUE · 7MB',
             short: 'SF 16 · 7MB',
             tech: 'NNUE',
-            requires: ['simd', 'dynamicImport'],
+            requires: ['simd', 'webWorkerDynamicImport'],
             minMem: 1536,
             assets: {
               version: 'sfw002',
@@ -54,7 +54,7 @@ export class Engines {
             name: 'Stockfish 16 NNUE · 40MB',
             short: 'SF 16 · 40MB',
             tech: 'NNUE',
-            requires: ['simd', 'dynamicImport'],
+            requires: ['simd', 'webWorkerDynamicImport'],
             minMem: 2048,
             assets: {
               version: 'sfw002',
@@ -87,7 +87,7 @@ export class Engines {
             name: 'Fairy Stockfish 14+',
             short: 'FSF 14+',
             tech: 'HCE',
-            requires: ['simd'],
+            requires: ['simd', 'webWorkerDynamicImport'],
             variants: [
               'crazyhouse',
               'atomic',

--- a/ui/ceval/src/engines/engines.ts
+++ b/ui/ceval/src/engines/engines.ts
@@ -38,7 +38,7 @@ export class Engines {
             name: 'Stockfish 16 NNUE · 7MB',
             short: 'SF 16 · 7MB',
             tech: 'NNUE',
-            requires: 'simd',
+            requires: ['simd', 'dynamicImport'],
             minMem: 1536,
             assets: {
               version: 'sfw002',
@@ -54,7 +54,7 @@ export class Engines {
             name: 'Stockfish 16 NNUE · 40MB',
             short: 'SF 16 · 40MB',
             tech: 'NNUE',
-            requires: 'simd',
+            requires: ['simd', 'dynamicImport'],
             minMem: 2048,
             assets: {
               version: 'sfw002',
@@ -70,7 +70,7 @@ export class Engines {
             name: 'Stockfish 14 NNUE',
             short: 'SF 14',
             tech: 'NNUE',
-            requires: 'simd',
+            requires: ['simd'],
             minMem: 2048,
             assets: {
               version: 'b6939d',
@@ -87,7 +87,7 @@ export class Engines {
             name: 'Fairy Stockfish 14+',
             short: 'FSF 14+',
             tech: 'HCE',
-            requires: 'simd',
+            requires: ['simd'],
             variants: [
               'crazyhouse',
               'atomic',
@@ -112,7 +112,7 @@ export class Engines {
             name: 'Stockfish 11 Multi-Variant',
             short: 'SF 11 MV',
             tech: 'HCE',
-            requires: 'sharedMem',
+            requires: ['sharedMem'],
             variants: [
               'crazyhouse',
               'atomic',
@@ -140,7 +140,7 @@ export class Engines {
             name: 'Stockfish 11 HCE',
             short: 'SF 11',
             tech: 'HCE',
-            requires: 'sharedMem',
+            requires: ['sharedMem'],
             assets: {
               version: 'a022fa',
               root: 'npm/stockfish.wasm',
@@ -157,7 +157,7 @@ export class Engines {
             short: 'Stockfish',
             tech: 'HCE',
             maxThreads: 1,
-            requires: 'wasm',
+            requires: ['wasm'],
             obsoletedBy: 'sharedMem',
             assets: {
               version: 'a022fa',
@@ -184,7 +184,11 @@ export class Engines {
           make: (e: BrowserEngineInfo) => new SimpleEngine(e, progress),
         },
       ]
-        .filter(e => hasFeature(e.info.requires) && !(e.info.obsoletedBy && hasFeature(e.info.obsoletedBy)))
+        .filter(
+          e =>
+            e.info.requires?.map(req => hasFeature(req)).every(x => !!x) &&
+            !(e.info.obsoletedBy && hasFeature(e.info.obsoletedBy)),
+        )
         .map(e => [e.info.id, { info: withDefaults(e.info as BrowserEngineInfo), make: e.make }]),
     );
   }

--- a/ui/ceval/src/types.ts
+++ b/ui/ceval/src/types.ts
@@ -33,7 +33,7 @@ export interface EngineInfo {
   variants?: VariantKey[];
   maxThreads?: number;
   maxHash?: number;
-  requires?: Feature;
+  requires?: Feature[];
 }
 
 export interface ExternalEngineInfo extends EngineInfo {

--- a/ui/ceval/src/view/main.ts
+++ b/ui/ceval/src/view/main.ts
@@ -109,7 +109,7 @@ function engineName(ctrl: CevalCtrl): VNode[] {
               },
               engineTech,
             )
-          : engine.requires === 'simd'
+          : engine.requires?.includes('simd')
           ? h(
               'span.technology.good',
               {
@@ -119,9 +119,9 @@ function engineName(ctrl: CevalCtrl): VNode[] {
               },
               engineTech,
             )
-          : engine.requires === 'sharedMem'
+          : engine.requires?.includes('sharedMem')
           ? h('span.technology.good', { attrs: { title: 'Multi-threaded WebAssembly' } }, engineTech)
-          : engine.requires === 'wasm'
+          : engine.requires?.includes('wasm')
           ? h('span.technology', { attrs: { title: 'Single-threaded WebAssembly' } }, engineTech)
           : h('span.technology', { attrs: { title: 'Single-threaded JavaScript' } }, engineTech),
       ]

--- a/ui/common/src/device.ts
+++ b/ui/common/src/device.ts
@@ -54,6 +54,17 @@ export const isIOS = (constraint?: { below?: number; atLeast?: number }) => {
 
 export const isChrome = (): boolean => /Chrome\//.test(navigator.userAgent);
 
+export const isFirefox = (): boolean => /Firefox/.test(navigator.userAgent);
+
+export const getFirefoxMajorVersion = (): number => {
+  if (!isFirefox()) {
+    return 0;
+  }
+  const match = /Firefox\/(\d*)/.exec(navigator.userAgent);
+  if (!match || match.length < 2) return 0;
+  return parseInt(match[1]);
+};
+
 export const isIOSChrome = (): boolean => /CriOS/.test(navigator.userAgent);
 
 export const isTouchDevice = () => !hasMouse();
@@ -61,7 +72,7 @@ export const isTouchDevice = () => !hasMouse();
 export const isIPad = (): boolean =>
   navigator?.maxTouchPoints > 2 && /iPad|Macintosh/.test(navigator.userAgent);
 
-export type Feature = 'wasm' | 'sharedMem' | 'simd';
+export type Feature = 'wasm' | 'sharedMem' | 'simd' | 'dynamicImport';
 
 export const hasFeature = (feat?: string) => !feat || features().includes(feat as Feature);
 
@@ -79,6 +90,9 @@ export const features = memoize<readonly Feature[]>(() => {
       const sourceWithSimd = Uint8Array.from([0, 97, 115, 109, 1, 0, 0, 0, 1, 12, 2, 96, 2, 123, 123, 1, 123, 96, 1, 123, 1, 123, 3, 3, 2, 0, 1, 7, 9, 2, 1, 97, 0, 0, 1, 98, 0, 1, 10, 19, 2, 9, 0, 32, 0, 32, 1, 253, 186, 1, 11, 7, 0, 32, 0, 253, 253, 1, 11]); // prettier-ignore
       if (WebAssembly.validate(sourceWithSimd)) features.push('simd');
     }
+  }
+  if (!getFirefoxMajorVersion() || getFirefoxMajorVersion() >= 114) {
+    features.push('dynamicImport');
   }
   return Object.freeze(features);
 });

--- a/ui/common/src/device.ts
+++ b/ui/common/src/device.ts
@@ -72,7 +72,7 @@ export const isTouchDevice = () => !hasMouse();
 export const isIPad = (): boolean =>
   navigator?.maxTouchPoints > 2 && /iPad|Macintosh/.test(navigator.userAgent);
 
-export type Feature = 'wasm' | 'sharedMem' | 'simd' | 'dynamicImport';
+export type Feature = 'wasm' | 'sharedMem' | 'simd' | 'webWorkerDynamicImport';
 
 export const hasFeature = (feat?: string) => !feat || features().includes(feat as Feature);
 
@@ -92,7 +92,7 @@ export const features = memoize<readonly Feature[]>(() => {
     }
   }
   if (!getFirefoxMajorVersion() || getFirefoxMajorVersion() >= 114) {
-    features.push('dynamicImport');
+    features.push('webWorkerDynamicImport');
   }
   return Object.freeze(features);
 });


### PR DESCRIPTION
* Make the engine requires an array to support this change.
* Removes dynamicImport as a feature for any user on firefox < 114.
* Adds dynamicImport as a require for SF16 engines.

Fixes https://github.com/lichess-org/lila/issues/14029