### PR TITLE
show engine error dialog always and forever

### DIFF
--- a/ui/ceval/css/_ctrl.scss
+++ b/ui/ceval/css/_ctrl.scss
@@ -182,3 +182,39 @@
     animation: bar-anim 1000s linear infinite;
   }
 }
+
+.engine-error {
+  @extend %flex-column;
+  align-items: center;
+  row-gap: 1em;
+  padding: 3em;
+  text-align: left;
+  max-width: 60vw;
+
+  @media (max-width: $mq-width-medium) {
+    max-width: 80vw;
+  }
+  @media (max-width: $mq-width-xx-small) {
+    max-width: unset;
+    width: 96vw;
+  }
+
+  h2 {
+    font-family: 'Noto Sans';
+    font-size: 1.3em;
+  }
+  li {
+    margin: 0 2em;
+    line-height: 1.5em;
+    list-style: disc;
+  }
+  pre {
+    width: 100%;
+    border: 1px solid #888;
+    box-shadow: inset 0 0 2px $c-font-dim;
+    padding: 1em;
+    margin-bottom: 1em;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+  }
+}

--- a/ui/ceval/src/ctrl.ts
+++ b/ui/ceval/src/ctrl.ts
@@ -1,7 +1,7 @@
 import throttle from 'common/throttle';
 import { Engines } from './engines/engines';
 import { CevalOpts, CevalState, CevalEngine, Work, Step, Hovering, PvBoard, Started } from './types';
-import { sanIrreversible } from './util';
+import { sanIrreversible, showEngineError } from './util';
 import { defaultPosition, setupPosition } from 'chessops/variant';
 import { parseFen } from 'chessops/fen';
 import { lichessRules } from 'chessops/compat';
@@ -11,7 +11,6 @@ import { hasFeature } from 'common/device';
 import { Result } from '@badrap/result';
 import { storedIntProp } from 'common/storage';
 import { Rules } from 'chessops';
-import { type Dialog, domDialog } from 'common/dialog';
 
 const cevalDisabledSentinel = '1';
 
@@ -238,24 +237,7 @@ export default class CevalCtrl {
   };
 
   engineFailed(msg: string) {
-    domDialog({
-      class: 'engine-error',
-      htmlText:
-        `<h2>${lichess.escapeHtml(this.engines.active?.name ?? 'Engine')} <bad>error</bad></h2>` +
-        `<pre tabindex="0" class="err">${lichess.escapeHtml(msg)}</pre><h2>Things to try</h2><ul>` +
-        '<li>Decrease memory slider in engine settings</li><li>Clear site settings for lichess.org</li>' +
-        '<li>Select another engine</li><li>Update your browser</li></ul>',
-    }).then((dlg: Dialog) => {
-      const select = () =>
-        setTimeout(() => {
-          const range = document.createRange();
-          range.selectNodeContents(dlg.view.querySelector('.err')!);
-          window.getSelection()?.removeAllRanges();
-          window.getSelection()?.addRange(range);
-        }, 0);
-      dlg.view.querySelector('.err')?.addEventListener('focus', select);
-      dlg.showModal();
-    });
+    showEngineError(this.engines.active?.name ?? 'Engine', msg);
   }
 
   cacheable() {

--- a/ui/ceval/src/ctrl.ts
+++ b/ui/ceval/src/ctrl.ts
@@ -11,7 +11,7 @@ import { hasFeature } from 'common/device';
 import { Result } from '@badrap/result';
 import { storedIntProp } from 'common/storage';
 import { Rules } from 'chessops';
-import { domDialog } from 'common/dialog';
+import { type Dialog, domDialog } from 'common/dialog';
 
 const cevalDisabledSentinel = '1';
 
@@ -239,11 +239,22 @@ export default class CevalCtrl {
 
   engineFailed(msg: string) {
     domDialog({
-      show: 'modal',
+      class: 'engine-error',
       htmlText:
-        `<div><p>${this.engines.active?.name ?? 'Engine'} failed:</p><hr><code>${msg}</code><hr>` +
-        '<p>Things you can try:</p><p>Decrease memory slider in engine settings. Update your browser. ' +
-        'Clear site settings for lichess.org. Or select another engine</p></div>',
+        `<h2>${lichess.escapeHtml(this.engines.active?.name ?? 'Engine')} <bad>error</bad></h2>` +
+        `<pre tabindex="0" class="err">${lichess.escapeHtml(msg)}</pre><h2>Things to try</h2><ul>` +
+        '<li>Decrease memory slider in engine settings</li><li>Clear site settings for lichess.org</li>' +
+        '<li>Select another engine</li><li>Update your browser</li></ul>',
+    }).then((dlg: Dialog) => {
+      const select = () =>
+        setTimeout(() => {
+          const range = document.createRange();
+          range.selectNodeContents(dlg.view.querySelector('.err')!);
+          window.getSelection()?.removeAllRanges();
+          window.getSelection()?.addRange(range);
+        }, 0);
+      dlg.view.querySelector('.err')?.addEventListener('focus', select);
+      dlg.showModal();
     });
   }
 

--- a/ui/ceval/src/engines/engines.ts
+++ b/ui/ceval/src/engines/engines.ts
@@ -24,13 +24,13 @@ export class Engines {
     this.selectProp = storedStringProp('ceval.engine', this.localEngines[0].id);
   }
 
-  makeEngineMap() {
-    const progress = (download?: { bytes: number; total: number }, error?: string) => {
-      if (this.ctrl.enabled()) this.ctrl.download = download;
-      if (error) this.ctrl.engineFailed(error);
-      this.ctrl.opts.redraw();
-    };
+  status = (status: { download?: { bytes: number; total: number }; error?: string } = {}) => {
+    if (this.ctrl.enabled()) this.ctrl.download = status.download;
+    if (status.error) this.ctrl.engineFailed(status.error);
+    this.ctrl.opts.redraw();
+  };
 
+  makeEngineMap() {
     return new Map<string, WithMake>(
       [
         {
@@ -47,7 +47,7 @@ export class Engines {
               js: 'linrock-nnue-7.js',
             },
           },
-          make: (e: BrowserEngineInfo) => new StockfishWebEngine(e, progress),
+          make: (e: BrowserEngineInfo) => new StockfishWebEngine(e, this.status),
         },
         {
           info: {
@@ -63,7 +63,7 @@ export class Engines {
               js: 'sf-nnue-40.js',
             },
           },
-          make: (e: BrowserEngineInfo) => new StockfishWebEngine(e, progress),
+          make: (e: BrowserEngineInfo) => new StockfishWebEngine(e, this.status),
         },
         {
           info: {
@@ -80,7 +80,7 @@ export class Engines {
               wasm: 'stockfish.wasm',
             },
           },
-          make: (e: BrowserEngineInfo) => new ThreadedEngine(e, progress),
+          make: (e: BrowserEngineInfo) => new ThreadedEngine(e, this.status),
         },
         {
           info: {
@@ -105,7 +105,7 @@ export class Engines {
             },
           },
           make: (e: BrowserEngineInfo) =>
-            new StockfishWebEngine(e, progress, v => (v === 'threeCheck' ? '3check' : v.toLowerCase())),
+            new StockfishWebEngine(e, this.status, v => (v === 'threeCheck' ? '3check' : v.toLowerCase())),
         },
         {
           info: {
@@ -131,7 +131,7 @@ export class Engines {
             },
           },
           make: (e: BrowserEngineInfo) =>
-            new ThreadedEngine(e, progress, (v: VariantKey) =>
+            new ThreadedEngine(e, this.status, (v: VariantKey) =>
               v === 'antichess' ? 'giveaway' : lichessRules(v),
             ),
         },
@@ -149,7 +149,7 @@ export class Engines {
               wasm: 'stockfish.wasm',
             },
           },
-          make: (e: BrowserEngineInfo) => new ThreadedEngine(e, progress),
+          make: (e: BrowserEngineInfo) => new ThreadedEngine(e, this.status),
         },
         {
           info: {
@@ -166,7 +166,7 @@ export class Engines {
               js: 'stockfish.wasm.js',
             },
           },
-          make: (e: BrowserEngineInfo) => new SimpleEngine(e, progress),
+          make: (e: BrowserEngineInfo) => new SimpleEngine(e, this.status),
         },
         {
           info: {
@@ -182,7 +182,7 @@ export class Engines {
               js: 'stockfish.js',
             },
           },
-          make: (e: BrowserEngineInfo) => new SimpleEngine(e, progress),
+          make: (e: BrowserEngineInfo) => new SimpleEngine(e, this.status),
         },
       ]
         .filter(
@@ -249,7 +249,7 @@ export class Engines {
 
     return e.tech !== 'EXTERNAL'
       ? this.localEngineMap.get(e.id)!.make(e as BrowserEngineInfo)
-      : new ExternalEngine(e as ExternalEngineInfo, this.ctrl.opts.redraw);
+      : new ExternalEngine(e as ExternalEngineInfo, this.status);
   }
 }
 

--- a/ui/ceval/src/engines/externalEngine.ts
+++ b/ui/ceval/src/engines/externalEngine.ts
@@ -1,4 +1,4 @@
-import { Work, ExternalEngineInfo, CevalEngine, CevalState } from '../types';
+import { Work, ExternalEngineInfo, CevalEngine, CevalState, EngineNotifier } from '../types';
 import { randomToken } from 'common/random';
 import { readNdJson } from 'common/ndjson';
 import throttle from 'common/throttle';
@@ -22,7 +22,7 @@ export class ExternalEngine implements CevalEngine {
 
   constructor(
     private opts: ExternalEngineInfo,
-    private progress?: (download?: { bytes: number; total: number }) => void,
+    private status?: EngineNotifier,
   ) {}
 
   getState() {
@@ -84,16 +84,16 @@ export class ExternalEngine implements CevalEngine {
       });
 
       this.state = CevalState.Initial;
+      this.status?.();
     } catch (err: unknown) {
       if ((err as Error).name !== 'AbortError') {
         console.error(err);
         this.state = CevalState.Failed;
+        this.status?.({ error: String(err) });
       } else {
         this.state = CevalState.Initial;
       }
     }
-
-    this.progress?.();
   }
 
   stop() {

--- a/ui/ceval/src/engines/simpleEngine.ts
+++ b/ui/ceval/src/engines/simpleEngine.ts
@@ -1,15 +1,15 @@
 import { Protocol } from '../protocol';
-import { Work, CevalState, CevalEngine, BrowserEngineInfo } from '../types';
+import { Work, CevalState, CevalEngine, BrowserEngineInfo, EngineNotifier } from '../types';
 
 export class SimpleEngine implements CevalEngine {
-  private failed = false;
+  private failed: Error;
   private protocol = new Protocol();
   private worker: Worker | undefined;
   url: string;
 
   constructor(
     readonly info: BrowserEngineInfo,
-    readonly progress?: (download?: { bytes: number; total: number }) => void,
+    readonly status?: EngineNotifier,
   ) {
     this.url = `${info.assets.root}/${info.assets.js}`;
   }
@@ -40,8 +40,8 @@ export class SimpleEngine implements CevalEngine {
         'error',
         err => {
           console.error(err);
-          this.failed = true;
-          this.progress?.();
+          this.failed = err.error;
+          this.status?.({ error: String(this.failed) });
         },
         true,
       );

--- a/ui/ceval/src/engines/stockfishWebEngine.ts
+++ b/ui/ceval/src/engines/stockfishWebEngine.ts
@@ -1,4 +1,4 @@
-import { Work, CevalEngine, CevalState, BrowserEngineInfo } from '../types';
+import { Work, CevalEngine, CevalState, BrowserEngineInfo, EngineNotifier } from '../types';
 import { Protocol } from '../protocol';
 import { objectStorage } from 'common/objectStorage';
 import { sharedWasmMemory } from '../util';
@@ -11,14 +11,14 @@ export class StockfishWebEngine implements CevalEngine {
 
   constructor(
     readonly info: BrowserEngineInfo,
-    readonly progress?: (download?: { bytes: number; total: number }, error?: string) => void,
+    readonly status?: EngineNotifier,
     readonly variantMap?: (v: string) => string,
   ) {
     this.protocol = new Protocol(variantMap);
     this.boot().catch(e => {
       console.error(e);
       this.failed = e;
-      progress?.(undefined, e.message);
+      this.status?.({ error: String(e) });
     });
   }
 
@@ -56,7 +56,7 @@ export class StockfishWebEngine implements CevalEngine {
           }, 2000);
         } else {
           console.error(msg);
-          this.progress?.(undefined, msg);
+          this.status?.({ error: msg });
         }
       };
       let nnueBuffer = await nnueStore?.get(nnueFilename).catch(() => undefined);
@@ -66,7 +66,7 @@ export class StockfishWebEngine implements CevalEngine {
 
         req.open('get', lichess.assetUrl(`lifat/nnue/${nnueFilename}`, { noVersion: true }), true);
         req.responseType = 'arraybuffer';
-        req.onprogress = e => this.progress?.({ bytes: e.loaded, total: e.total });
+        req.onprogress = e => this.status?.({ download: { bytes: e.loaded, total: e.total } });
 
         nnueBuffer = await new Promise((resolve, reject) => {
           req.onerror = () => reject(new Error(`NNUE download failed: ${req.status}`));
@@ -76,7 +76,7 @@ export class StockfishWebEngine implements CevalEngine {
           };
           req.send();
         });
-        this.progress?.();
+        this.status?.();
         nnueStore?.put(nnueFilename, nnueBuffer!).catch(() => console.warn('IDB store failed'));
       }
       module.setNnueBuffer(nnueBuffer!);

--- a/ui/ceval/src/types.ts
+++ b/ui/ceval/src/types.ts
@@ -47,6 +47,11 @@ export interface BrowserEngineInfo extends EngineInfo {
   assets: { root?: string; js?: string; wasm?: string; version?: string };
 }
 
+export type EngineNotifier = (status?: {
+  download?: { bytes: number; total: number };
+  error?: string;
+}) => void;
+
 export enum CevalState {
   Initial,
   Loading,

--- a/ui/ceval/src/util.ts
+++ b/ui/ceval/src/util.ts
@@ -1,3 +1,5 @@
+import { type Dialog, domDialog } from 'common/dialog';
+
 export function isEvalBetter(a: Tree.ClientEval, b: Tree.ClientEval): boolean {
   return a.depth > b.depth || (a.depth === b.depth && a.nodes > b.nodes);
 }
@@ -33,3 +35,24 @@ export const sharedWasmMemory = (lo: number, hi = 32767): WebAssembly.Memory => 
     }
   }
 };
+
+export function showEngineError(engine: string, error: string) {
+  domDialog({
+    class: 'engine-error',
+    htmlText:
+      `<h2>${lichess.escapeHtml(engine)} <bad>error</bad></h2><pre tabindex="0" class="err">` +
+      `${lichess.escapeHtml(error)}</pre><h2>Things to try</h2><ul>` +
+      '<li>Decrease memory slider in engine settings</li><li>Clear site settings for lichess.org</li>' +
+      '<li>Select another engine</li><li>Update your browser</li></ul>',
+  }).then((dlg: Dialog) => {
+    const select = () =>
+      setTimeout(() => {
+        const range = document.createRange();
+        range.selectNodeContents(dlg.view.querySelector('.err')!);
+        window.getSelection()?.removeAllRanges();
+        window.getSelection()?.addRange(range);
+      }, 0);
+    dlg.view.querySelector('.err')?.addEventListener('focus', select);
+    dlg.showModal();
+  });
+}


### PR DESCRIPTION
- styled to pre-select error text on focus
- now used throughout the engine family
- if unnecessarily dialogs are shown due to spurious stderr text from some random engine, we can spot fix. but we want to hear about any exceptions.