### PR TITLE
show donate link to non-patrons on zenable pages

### DIFF
--- a/app/views/base/layout.scala
+++ b/app/views/base/layout.scala
@@ -416,7 +416,7 @@ object layout:
           ctx.blind option h2("Navigation"),
           !ctx.isAppealUser option frag(
             topnav(),
-            ctx.kid.no && ctx.me.exists(!_.isPatron) && !zenable option a(cls := "site-title-nav__donate")(
+            ctx.kid.no && ctx.me.exists(!_.isPatron) option a(cls := "site-title-nav__donate")(
               href := routes.Plan.index
             )(trans.patron.donate())
           )


### PR DESCRIPTION
It should still be hidden along with the rest of nav when zen mode is actually enabled.