### PR TITLE
Filter Standard from bestRatedPerf

### DIFF
--- a/modules/user/src/main/UserPerfs.scala
+++ b/modules/user/src/main/UserPerfs.scala
@@ -61,7 +61,7 @@ case class UserPerfs(
   def hasEstablishedRating(pt: PerfType) = apply(pt).established
 
   def bestRatedPerf: Option[Perf.Typed] =
-    val ps    = perfs.filter(_._1 != PerfType.Puzzle)
+    val ps    = perfs.filter(p => p._1 != PerfType.Puzzle && p._1 != PerfType.Standard)
     val minNb = math.max(1, ps.foldLeft(0)(_ + _._2.nb) / 10)
     ps
       .foldLeft(none[(PerfType, Perf)]):


### PR DESCRIPTION
On the "Friends" and "Favorite Opponent" pages it shows the best perf rating of the friend/opponent. For some users, this will show the actual "_Standard_" PerfType rating instead of one of the PerfTypes that composes "Standard" (Bullet, Blitz, Rapid, Classical, Correspondence). The average lichess doesn't know what "Standard" is as it does not appear on their profile anywhere.

For example:
If following [maia1](https://lichess.org/@/maia1) this will be seen on your Friends page:
![image](https://github.com/lichess-org/lila/assets/3620552/9bb601a8-42f6-4d4d-b6ab-6854de9a39bf)

The best perf shows up as the "Standard" perf with a rating (1426). This doesn't match any rating shown on maia1's (visible) profile, so could cause some confusion.

This PR filters out the "Standard" PerfType from `bestRatedPerfs`. Tested locally with db-seed data.
