### PR TITLE
change 'tactical puzzle' to 'training puzzle'

### DIFF
--- a/translation/source/activity.xml
+++ b/translation/source/activity.xml
@@ -11,8 +11,8 @@
     <item quantity="other">Practised %1$s positions on %2$s</item>
   </plurals>
   <plurals name="solvedNbPuzzles">
-    <item quantity="one">Solved %s tactical puzzle</item>
-    <item quantity="other">Solved %s tactical puzzles</item>
+    <item quantity="one">Solved %s training puzzle</item>
+    <item quantity="other">Solved %s training puzzles</item>
   </plurals>
   <plurals name="playedNbGames">
     <item quantity="one">Played %1$s %2$s game</item>


### PR DESCRIPTION
There is a wide range of puzzle themes on Lichess, but I thought this term 'tactical' was a bit misleading. You can get defensive puzzles, puzzles that restore equality etc. I changed the word tactical->training like in the URL as a replacement and I believe this is a better broader term