### PR TITLE
Puzzles: do not show online status of players

### DIFF
--- a/ui/puzzle/src/view/side.ts
+++ b/ui/puzzle/src/view/side.ts
@@ -89,6 +89,7 @@ function gameInfos(ctrl: Controller, game: PuzzleGame, puzzle: Puzzle): VNode {
           const user = {
             ...p,
             rating: ctrl.showRatings ? p.rating : undefined,
+            line: false,
           };
           return h('div.player.color-icon.is.text.' + p.color, userLink(user));
         }),


### PR DESCRIPTION
before
<img width="281" alt="image" src="https://github.com/lichess-org/lila/assets/56031107/0d2032ab-7a4b-4485-b66c-c5d96a40e6f0">
after
<img width="331" alt="image" src="https://github.com/lichess-org/lila/assets/56031107/dc1073e7-b139-4bdf-929e-55d372e08730">
