### PR TITLE
Fix movetime graph not filling entire canvas area

### DIFF
--- a/ui/chart/src/common.ts
+++ b/ui/chart/src/common.ts
@@ -28,6 +28,7 @@ export const axisOpts = (xmin: number, xmax: number): ChartOptions<'line'>['scal
     type: 'linear',
     min: xmin,
     max: xmax,
+    offset: false,
   },
   y: {
     // Set equidistant max and min to center the graph at y=0.

--- a/ui/chart/src/movetime.ts
+++ b/ui/chart/src/movetime.ts
@@ -177,9 +177,8 @@ export default async function (el: HTMLCanvasElement, data: AnalyseData, trans: 
       animations: animation(800 / labels.length - 1),
       scales: axisOpts(
         firstPly + 1,
-        // Make totalseries slightly smaller than moveseries to fill more of the canvas
         // Omit game-ending action to sync acpl and movetime charts
-        labels.length - (showTotal ? 2 : labels[labels.length - 1].includes('-') ? 1 : 0),
+        labels.length - (labels[labels.length - 1].includes('-') ? 1 : 0),
       ),
       plugins: {
         tooltip: {


### PR DESCRIPTION
| Before |  After |
| --- | --- |
|![old](https://github.com/lichess-org/lila/assets/53343585/7da7364b-5a07-403e-9e23-90639a1b9378) | ![new](https://github.com/lichess-org/lila/assets/53343585/5017dadc-5408-4360-9d36-cf864de797fc)|