### PR TITLE
chartjs: Polyfill resizeObserver for safari 12

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -181,6 +181,9 @@ importers:
 
   ui/chart:
     dependencies:
+      '@juggle/resize-observer':
+        specifier: ^3.4.0
+        version: 3.4.0
       '@types/highcharts':
         specifier: '=4.2.57'
         version: 4.2.57
@@ -1591,6 +1594,10 @@ packages:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.0
       '@jridgewell/sourcemap-codec': 1.4.14
+    dev: false
+
+  /@juggle/resize-observer@3.4.0:
+    resolution: {integrity: sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==}
     dev: false
 
   /@kurkle/color@0.3.2:

--- a/ui/chart/package.json
+++ b/ui/chart/package.json
@@ -9,6 +9,7 @@
   "module": "dist/game.js",
   "types": "dist/game.d.ts",
   "dependencies": {
+    "@juggle/resize-observer": "^3.4.0",
     "@types/highcharts": "=4.2.57",
     "ceval": "workspace:*",
     "chart.js": "4.4.0",
@@ -25,7 +26,8 @@
       "esm": {
         "src/ratingDistribution.ts": "chart.ratingDistribution",
         "src/ratingHistory.ts": "chart.ratingHistory",
-        "src/game.ts": "chart.game"
+        "src/game.ts": "chart.game",
+        "src/resizePolyfill.ts": "chart.resizePolyfill"
       }
     }
   }

--- a/ui/chart/src/acpl.ts
+++ b/ui/chart/src/acpl.ts
@@ -23,13 +23,14 @@ import {
   tooltipBgColor,
   whiteFill,
   axisOpts,
+  resizePolyfill,
 } from './common';
 import division from './division';
 import { AcplChart, AnalyseData, Player } from './interface';
 import ChartDataLabels from 'chartjs-plugin-datalabels';
 
+resizePolyfill();
 Chart.register(LineController, LinearScale, PointElement, LineElement, Tooltip, Filler, ChartDataLabels);
-
 export default async function (
   el: HTMLCanvasElement,
   data: AnalyseData,

--- a/ui/chart/src/common.ts
+++ b/ui/chart/src/common.ts
@@ -109,6 +109,10 @@ export function animation(duration: number): ChartOptions<'line'>['animations'] 
   };
 }
 
+export async function resizePolyfill() {
+  if ('ResizeObserver' in window === false) lichess.loadEsm('chart.resizePolyfill');
+}
+
 export async function loadHighcharts(tpe: string) {
   if (highchartsPromise) return highchartsPromise;
   const file = tpe === 'highstock' ? 'highstock.js' : 'highcharts.js';

--- a/ui/chart/src/common.ts
+++ b/ui/chart/src/common.ts
@@ -94,7 +94,7 @@ export function animation(duration: number): ChartOptions<'line'>['animations'] 
       easing: 'easeOutQuad',
       duration: duration,
       from: NaN, // the point is initially skipped
-      delay: ctx => ctx.dataIndex * duration,
+      delay: ctx => (ctx.mode == 'resize' ? 0 : ctx.dataIndex * duration),
     },
     y: {
       type: 'number',
@@ -104,7 +104,7 @@ export function animation(duration: number): ChartOptions<'line'>['animations'] 
         !ctx.dataIndex
           ? ctx.chart.scales.y.getPixelForValue(100)
           : ctx.chart.getDatasetMeta(ctx.datasetIndex).data[ctx.dataIndex - 1].getProps(['y'], true).y,
-      delay: ctx => ctx.dataIndex * duration,
+      delay: ctx => (ctx.mode == 'resize' ? 0 : ctx.dataIndex * duration),
     },
   };
 }

--- a/ui/chart/src/game.ts
+++ b/ui/chart/src/game.ts
@@ -1,11 +1,11 @@
 import { ChartGame, AcplChart } from './interface';
 import movetime from './movetime';
 import acpl from './acpl';
-import { gridColor, tooltipBgColor, fontFamily, maybeChart } from './common';
+import { gridColor, tooltipBgColor, fontFamily, maybeChart, resizePolyfill } from './common';
 
 export { type ChartGame, type AcplChart };
 
-export { gridColor, tooltipBgColor, fontFamily, maybeChart };
+export { gridColor, tooltipBgColor, fontFamily, maybeChart, resizePolyfill };
 
 export function initModule(): ChartGame {
   return {

--- a/ui/chart/src/movetime.ts
+++ b/ui/chart/src/movetime.ts
@@ -23,10 +23,12 @@ import {
   tooltipBgColor,
   whiteFill,
   axisOpts,
+  resizePolyfill,
 } from './common';
 import { AnalyseData, Player, PlyChart } from './interface';
 import division from './division';
 
+resizePolyfill();
 Chart.register(LineController, LinearScale, PointElement, LineElement, Tooltip, BarElement, BarController);
 
 export default async function (el: HTMLCanvasElement, data: AnalyseData, trans: Trans, hunter: boolean) {

--- a/ui/chart/src/ratingDistribution.ts
+++ b/ui/chart/src/ratingDistribution.ts
@@ -1,5 +1,5 @@
 import { Point } from 'chart.js/dist/core/core.controller';
-import { animation, fontFamily, gridColor, hoverBorderColor } from './common';
+import { animation, fontFamily, gridColor, hoverBorderColor, resizePolyfill } from './common';
 import { DistributionData } from './interface';
 import {
   Chart,
@@ -15,6 +15,7 @@ import {
 } from 'chart.js';
 import ChartDataLabels from 'chartjs-plugin-datalabels';
 
+resizePolyfill();
 Chart.register(LineController, LinearScale, PointElement, LineElement, Tooltip, Filler, ChartDataLabels);
 
 export async function initModule(data: DistributionData) {

--- a/ui/chart/src/resizePolyfill.ts
+++ b/ui/chart/src/resizePolyfill.ts
@@ -1,0 +1,5 @@
+import { ResizeObserver } from '@juggle/resize-observer';
+// See Chart.js issue #8414
+export default async function initModule() {
+  window.ResizeObserver = ResizeObserver;
+}

--- a/ui/insight/src/chart.ts
+++ b/ui/insight/src/chart.ts
@@ -15,10 +15,11 @@ import {
   ChartOptions,
 } from 'chart.js';
 import { currentTheme } from 'common/theme';
-import { gridColor, tooltipBgColor, fontFamily, maybeChart } from 'chart';
+import { gridColor, tooltipBgColor, fontFamily, maybeChart, resizePolyfill } from 'chart';
 import ChartDataLabels from 'chartjs-plugin-datalabels';
 import { formatNumber } from './table';
 
+resizePolyfill();
 Chart.register(BarController, CategoryScale, LinearScale, BarElement, Tooltip, Legend, ChartDataLabels);
 Chart.defaults.font = fontFamily();
 


### PR DESCRIPTION
Needs to be tested on Safari 12 using BrowserStack. Would appreciate it if any of the maintainers could test for me.

Lazily loads a resizeObserver polyfil. As per https://github.com/chartjs/Chart.js/issues/8414, seems to be the only barrier to entry for chartjs for older browsers.
Fixes #14102