### PR TITLE
Added additional suspicious URL Shorteners to spam

### DIFF
--- a/ui/chat/src/spam.ts
+++ b/ui/chat/src/spam.ts
@@ -41,6 +41,8 @@ const spamRegex = new RegExp(
     'trasderk.blogspot.com',
     't.ly/',
     'shorturl.at/'
+
+    
   ]
     .map(url => url.replace(/\./g, '\\.').replace(/\//g, '\\/'))
     .join('|'),

--- a/ui/chat/src/spam.ts
+++ b/ui/chat/src/spam.ts
@@ -40,9 +40,7 @@ const spamRegex = new RegExp(
     'tiny.cc/',
     'trasderk.blogspot.com',
     't.ly/',
-    'shorturl.at/'
-
-    
+    'shorturl.at/',
   ]
     .map(url => url.replace(/\./g, '\\.').replace(/\//g, '\\/'))
     .join('|'),

--- a/ui/chat/src/spam.ts
+++ b/ui/chat/src/spam.ts
@@ -39,6 +39,8 @@ const spamRegex = new RegExp(
     'qps.ru',
     'tiny.cc/',
     'trasderk.blogspot.com',
+    't.ly/',
+    'shorturl.at/'
   ]
     .map(url => url.replace(/\./g, '\\.').replace(/\//g, '\\/'))
     .join('|'),


### PR DESCRIPTION
I discovered a rise of several url shorteners that are used to hide suspicious or NSFW urls.
I added those to the spam regex, so those will be filtered in lichess.


Those pages were:
t.ly
shorturl.at