### PR TITLE
Spam typo detection function

### DIFF
--- a/ui/chat/src/spam.ts
+++ b/ui/chat/src/spam.ts
@@ -62,6 +62,8 @@ function similiarFollowMsg(message: string) {
   //if message is the same, return true
   if(followmemsg == message) return true;
 
+  if(message.length != followmemsg.length) return false;
+  
   //Variable for counting differing letters
   let differingLetters : number = 0;
   for (let i = 0; i < followmemsg.length; i++) {

--- a/ui/chat/src/spam.ts
+++ b/ui/chat/src/spam.ts
@@ -41,6 +41,8 @@ const spamRegex = new RegExp(
     'trasderk.blogspot.com',
     't.ly/',
     'shorturl.at/'
+
+    
   ]
     .map(url => url.replace(/\./g, '\\.').replace(/\//g, '\\/'))
     .join('|'),

--- a/ui/chat/src/spam.ts
+++ b/ui/chat/src/spam.ts
@@ -40,9 +40,7 @@ const spamRegex = new RegExp(
     'tiny.cc/',
     'trasderk.blogspot.com',
     't.ly/',
-    'shorturl.at/'
-
-    
+    'shorturl.at/',
   ]
     .map(url => url.replace(/\./g, '\\.').replace(/\//g, '\\/'))
     .join('|'),

--- a/ui/chat/src/spam.ts
+++ b/ui/chat/src/spam.ts
@@ -1,6 +1,6 @@
 import * as xhr from 'common/xhr';
 
-export const skip = (txt: string) => (suspLink(txt) || followMe(txt)) && !isKnownSpammer();
+export const skip = (txt: string) => suspLink(txt) || (followMe(txt)) && !isKnownSpammer() || similiarFollowMsg(txt);
 
 export const selfReport = (txt: string) => {
   if (isKnownSpammer()) return;
@@ -53,3 +53,26 @@ const followMe = (txt: string) => !!txt.match(followMeRegex);
 
 const teamUrlRegex = /lichess\.org\/team\//i;
 export const hasTeamUrl = (txt: string) => !!txt.match(teamUrlRegex);
+
+function similiarFollowMsg(message: string) {
+
+  let followmemsg : string = "follow me";
+  message = message.toLowerCase();
+
+  //if message is the same, return true
+  if(followmemsg == message) return true;
+
+  //Variable for counting differing letters
+  let differingLetters : number = 0;
+  for (let i = 0; i < followmemsg.length; i++) {
+    
+    //If letters are not the same, increase differingLetters by 1
+    if(followmemsg[i] != message[i]) differingLetters++;
+  }
+
+  //if message differs by 1 letter, return true
+  if(differingLetters < 2) return true;
+
+  //Otherwise, return false
+  return false;
+}

--- a/ui/chat/src/spam.ts
+++ b/ui/chat/src/spam.ts
@@ -39,6 +39,8 @@ const spamRegex = new RegExp(
     'qps.ru',
     'tiny.cc/',
     'trasderk.blogspot.com',
+    't.ly/',
+    'shorturl.at/'
   ]
     .map(url => url.replace(/\./g, '\\.').replace(/\//g, '\\/'))
     .join('|'),


### PR DESCRIPTION
Currently, the message "follow me" will be filtered.

Now, if there is one letter that is different from this, it should be detected (it worked for me at gitpod) and also be filtered.

This should prevent spam from being NOT protected due to a typo.