### PR TITLE
fix bloop stale build launching issue

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,4 +4,4 @@ resolvers += Resolver.url(
 )(Resolver.ivyStylePatterns)
 addSbtPlugin("com.typesafe.play" % "sbt-plugin"   % "2.8.18-lila_1.21") // scala2 branch
 addSbtPlugin("org.scalameta"     % "sbt-scalafmt" % "2.5.2")
-addSbtPlugin("ch.epfl.scala"     % "sbt-bloop"    % "1.5.12")
+addSbtPlugin("ch.epfl.scala"     % "sbt-bloop"    % "1.5.11")


### PR DESCRIPTION
roll back to plugin version that doesn't generate different `runtimeConfig` classpaths in sbt bloopInstall jsons