### PR TITLE
Fix retro "Review {color} mistakes" not working at times

### DIFF
--- a/ui/analyse/src/retrospect/retroView.ts
+++ b/ui/analyse/src/retrospect/retroView.ts
@@ -186,6 +186,13 @@ const feedback = {
                 ),
           ),
           h('div.choices.end', [
+            h(
+              'a',
+              {
+                hook: bind('click', ctrl.flip),
+              },
+              ctrl.noarg(ctrl.color === 'white' ? 'reviewBlackMistakes' : 'reviewWhiteMistakes'),
+            ),
             nothing
               ? null
               : h(
@@ -195,13 +202,6 @@ const feedback = {
                   },
                   ctrl.noarg('doItAgain'),
                 ),
-            h(
-              'a',
-              {
-                hook: bind('click', ctrl.flip),
-              },
-              ctrl.noarg(ctrl.color === 'white' ? 'reviewBlackMistakes' : 'reviewWhiteMistakes'),
-            ),
           ]),
         ]),
       ]),


### PR DESCRIPTION
When using "Learn from your mistakes" and one of the players *doesn't* have mistakes, the "Review *{color}* mistakes" button doesn't work the *second* time around.

**Video of the problem**
https://github.com/lichess-org/lila/assets/3620552/c153fd2e-982b-4d63-a7bb-598acea3460a

I'm not sure I know 100% what's going on or if I can even explain it properly, but it seems that when the "Do it again" `<a>` element appears (with a click binding set to `ctrl.reset`) and then is removed (when `nothing == true`),  the `ctrl.reset` binding is then being "bound" to the "Review *{color}* mistakes"  `<a>` element (which should always be bound to `ctrl.flip`).

I'm probably overlooking the proper solution, but here are the multiple ways I have found that "fix" the problem. 
1. Flip the display order of "Do it again" and "Review *{color}* mistakes" so that "Review *{color}* mistakes" appears first as it's an element that is never removed.
2. Make the `<a>` elements unique (by giving a unique class to each - which wouldn't be used in styling but purely to make them different). 
3. Use an empty HTML tag instead of `null` when `nothing == true`.
4. Make the "Do it again" `<a>` element text blank when it should not be displayed.

In this PR, I settled on option 1 as it felt *less* hacky? I'd still like to get a better understanding of why it's happening though.

**Video of the fix**
https://github.com/lichess-org/lila/assets/3620552/cf8529f1-5c13-4dc1-8505-5571478f8c2d