### PR TITLE
Upgrade chartjs for opening, puzzle dashboard

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -437,17 +437,17 @@ importers:
         specifier: ^3.1.6
         version: 3.1.6
       chart.js:
-        specifier: '=3.9.1'
-        version: 3.9.1
-      chartjs-adapter-date-fns:
-        specifier: '=2.0.1'
-        version: 2.0.1(chart.js@3.9.1)
+        specifier: '=4.4.0'
+        version: 4.4.0
+      chartjs-adapter-dayjs-4:
+        specifier: ^1.0.4
+        version: 1.0.4(chart.js@4.4.0)(dayjs@1.11.10)
       common:
         specifier: workspace:*
         version: link:../common
-      date-fns:
-        specifier: ^2.29.3
-        version: 2.29.3
+      dayjs:
+        specifier: ^1.11.10
+        version: 1.11.10
       debounce-promise:
         specifier: ^3.1.2
         version: 3.1.2
@@ -488,8 +488,8 @@ importers:
         specifier: workspace:*
         version: link:../ceval
       chart.js:
-        specifier: '=3.9.1'
-        version: 3.9.1
+        specifier: '=4.4.0'
+        version: 4.4.0
       chess:
         specifier: workspace:*
         version: link:../chess
@@ -2305,10 +2305,6 @@ packages:
     engines: {node: '>=10'}
     dev: false
 
-  /chart.js@3.9.1:
-    resolution: {integrity: sha512-Ro2JbLmvg83gXF5F4sniaQ+lTbSv18E+TIf2cOeiH1Iqd2PGFOtem+DUufMZsCJwFE7ywPOpfXFBwRTGq7dh6w==}
-    dev: false
-
   /chart.js@4.4.0:
     resolution: {integrity: sha512-vQEj6d+z0dcsKLlQvbKIMYFHd3t8W/7L2vfJIbYcfyPcRx92CsHqECpueN8qVGNlKyDcr5wBrYAYKnfu/9Q1hQ==}
     engines: {pnpm: '>=7'}
@@ -2316,12 +2312,15 @@ packages:
       '@kurkle/color': 0.3.2
     dev: false
 
-  /chartjs-adapter-date-fns@2.0.1(chart.js@3.9.1):
-    resolution: {integrity: sha512-v3WV9rdnQ05ce3A0ZCjzUekJCAbfm6+3HqSoeY2BIkdMYZoYr/4T+ril1tZyDl869lz6xdNVMXejUFT9YKpw4A==}
+  /chartjs-adapter-dayjs-4@1.0.4(chart.js@4.4.0)(dayjs@1.11.10):
+    resolution: {integrity: sha512-yy9BAYW4aNzPVrCWZetbILegTRb7HokhgospPoC3b5iZ5qdlqNmXts2KdSp6AqnjkPAp/YWyHDxLvIvwt5x81w==}
+    engines: {node: '>=10'}
     peerDependencies:
-      chart.js: '>=2.8.0'
+      chart.js: '>=4.0.1'
+      dayjs: ^1.9.7
     dependencies:
-      chart.js: 3.9.1
+      chart.js: 4.4.0
+      dayjs: 1.11.10
     dev: false
 
   /chartjs-plugin-datalabels@2.2.0(chart.js@4.4.0):
@@ -2495,6 +2494,10 @@ packages:
   /date-fns@2.29.3:
     resolution: {integrity: sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==}
     engines: {node: '>=0.11'}
+    dev: false
+
+  /dayjs@1.11.10:
+    resolution: {integrity: sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ==}
     dev: false
 
   /debounce-promise@3.1.2:

--- a/ui/opening/package.json
+++ b/ui/opening/package.json
@@ -7,10 +7,10 @@
   "license": "AGPL-3.0-or-later",
   "dependencies": {
     "@types/debounce-promise": "^3.1.6",
-    "chart.js": "=3.9.1",
-    "chartjs-adapter-date-fns": "=2.0.1",
+    "chart.js": "=4.4.0",
+    "chartjs-adapter-dayjs-4": "^1.0.4",
     "common": "workspace:*",
-    "date-fns": "^2.29.3",
+    "dayjs": "^1.11.10",
     "debounce-promise": "^3.1.2",
     "lichess-pgn-viewer": "^2.0.1"
   },

--- a/ui/opening/src/chart.ts
+++ b/ui/opening/src/chart.ts
@@ -1,11 +1,10 @@
 import * as chart from 'chart.js';
-import 'chartjs-adapter-date-fns';
-import { addMonths } from 'date-fns';
+import 'chartjs-adapter-dayjs-4';
+import dayjs from 'dayjs';
 import { OpeningPage } from './interfaces';
 
 chart.Chart.register(
   chart.LineController,
-  chart.CategoryScale,
   chart.LinearScale,
   chart.PointElement,
   chart.LineElement,
@@ -15,18 +14,17 @@ chart.Chart.register(
   chart.TimeScale,
 );
 
-const firstDate = new Date('2017-01-01');
+const firstDate = dayjs('2017-01-01');
 
 export const renderHistoryChart = (data: OpeningPage) => {
   if (!data.history.find(p => p > 0)) return;
-  const canvas = document.querySelector('.opening__popularity__chart') as HTMLCanvasElement;
+  const canvas = $('.opening__popularity__chart')[0] as HTMLCanvasElement;
   new chart.Chart(canvas, {
     type: 'line',
     data: {
-      labels: data.history.map((_, i) => addMonths(firstDate, i)),
       datasets: [
         {
-          data: data.history,
+          data: data.history.map((n, i) => ({ x: firstDate.add(i, 'M').valueOf(), y: n })),
           borderColor: 'hsla(37,74%,43%,1)',
           backgroundColor: 'hsla(37,74%,43%,0.5)',
           fill: true,
@@ -39,7 +37,7 @@ export const renderHistoryChart = (data: OpeningPage) => {
         x: {
           type: 'time',
           time: {
-            tooltipFormat: 'MMMM yyyy',
+            tooltipFormat: 'MMMM YYYY',
           },
           display: false,
         },
@@ -52,16 +50,12 @@ export const renderHistoryChart = (data: OpeningPage) => {
       },
       // https://www.chartjs.org/docs/latest/configuration/responsive.html
       // responsive: false, // just doesn't work
-      hover: {
+      interaction: {
         mode: 'index',
         intersect: false,
       },
-      plugins: {
-        tooltip: {
-          mode: 'index',
-          intersect: false,
-        },
-      },
+      parsing: false,
+      normalized: true,
     },
   });
 };

--- a/ui/puzzle/package.json
+++ b/ui/puzzle/package.json
@@ -12,17 +12,17 @@
   "author": "Thibault Duplessis",
   "license": "AGPL-3.0-or-later",
   "dependencies": {
+    "board": "workspace:*",
     "ceval": "workspace:*",
-    "chart.js": "=3.9.1",
+    "chart.js": "=4.4.0",
     "chess": "workspace:*",
     "chessops": "^0.12.7",
     "common": "workspace:*",
     "keyboardMove": "workspace:*",
-    "voice": "workspace:*",
     "nvui": "workspace:*",
-    "board": "workspace:*",
     "snabbdom": "^3.5.1",
-    "tree": "workspace:*"
+    "tree": "workspace:*",
+    "voice": "workspace:*"
   },
   "scripts": {
     "compile": "tsc",

--- a/ui/puzzle/src/dashboard.ts
+++ b/ui/puzzle/src/dashboard.ts
@@ -29,7 +29,7 @@ export function initModule(data: RadarData) {
     ...{
       backgroundColor: 'rgba(189,130,35,0.2)',
       borderColor: 'rgba(189,130,35,1)',
-      pointBackgroundColor: 'rgb(189,130,35,1)',
+      pointBackgroundColor: 'rgba(189,130,35,1)',
     },
   };
   const fontColor = currentTheme() === 'dark' ? '#bababa' : '#4d4d4d';
@@ -47,6 +47,9 @@ export function initModule(data: RadarData) {
           ticks: {
             color: fontColor,
             showLabelBackdrop: false, // hide square behind text
+            format: {
+              useGrouping: false,
+            },
           },
           pointLabels: {
             color: fontColor,


### PR DESCRIPTION
|  | Before (kB)  | After (kB) |
|---|---|---|
|opening.min.js| 414 | 274  |
| puzzle.dashboard.min.js| 183 | 156 |

Other changes:
1. Replace date-fns with dayjs for huge space savings
2. Remove thousands separator for ratings in puzzle dashboard for consistency with the rest of the site.