### PR TITLE
hide online status when challenging

### DIFF
--- a/ui/lobby/src/view/setup/friendContent.ts
+++ b/ui/lobby/src/view/setup/friendContent.ts
@@ -14,7 +14,7 @@ export default function friendContent(ctrl: LobbyController): MaybeVNodes {
   return [
     h('h2', trans('playWithAFriend')),
     h('div.setup-content', [
-      ctrl.setupCtrl.friendUser ? userLink({ name: ctrl.setupCtrl.friendUser }) : null,
+      ctrl.setupCtrl.friendUser ? userLink({ name: ctrl.setupCtrl.friendUser, line: false }) : null,
       variantPicker(ctrl),
       fenInput(ctrl),
       timePickerAndSliders(ctrl, true),


### PR DESCRIPTION
https://github.com/lichess-org/lila/issues/14153

Couldn't find a way to get the `online` status of the `u` :(