### PR TITLE
bigger activation window for well-intentioned but occasional streamers

### DIFF
--- a/modules/streamer/src/main/StreamerApi.scala
+++ b/modules/streamer/src/main/StreamerApi.scala
@@ -146,14 +146,14 @@ final class StreamerApi(
       coll.update.one($id(s.id), $set("picture" -> pic.id)).void
     }
 
-  // unapprove after a week if you never streamed
+  // unapprove after 6 weeks if you never streamed (was originally 1 week)
   def autoDemoteFakes: Funit =
     coll.update
       .one(
         $doc(
           "liveAt" $exists false,
           "approval.granted" -> true,
-          "approval.lastGrantedAt" $lt nowInstant.minusWeeks(1)
+          "approval.lastGrantedAt" $lt nowInstant.minusWeeks(6)
         ),
         $set(
           "approval.granted" -> false,


### PR DESCRIPTION
Even if the ratio of additional fake streamers in limbo versus support instances reduced is like 100x1, this might still be worth it.

Case in point, timochka_cutie in Ukraine was re-approved this week (a measure that has been taken multiple times over the past year), but still has no `liveAt` in the db and will not be able to stream for another month. With the 1 week window, we'd have to re-approve him before that happens.