### PR TITLE
hide rather than clear server eval when analysis disabled

### DIFF
--- a/ui/analyse/src/autoShape.ts
+++ b/ui/analyse/src/autoShape.ts
@@ -132,6 +132,7 @@ function hiliteVariations(ctrl: AnalyseCtrl, autoShapes: DrawShape[]) {
   const isGamebookEditor = chap?.gamebook && !ctrl.study?.gamebookPlay();
 
   for (const [i, node] of ctrl.node.children.entries()) {
+    if (!ctrl.showComputer() && node.comp) continue;
     const userShape = findShape(node.uci, ctrl.node.shapes);
 
     if (userShape && i === ctrl.fork.selected()) autoShapes.push({ ...userShape }); // so we can hilite it

--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -769,7 +769,7 @@ export default class AnalyseCtrl {
       !this.study?.gamebookPlay() &&
       !this.retro &&
       this.variationArrowsProp() &&
-      this.node.children.length > 1
+      this.node.children.filter(x => this.showComputer() || !x.comp).length > 1
     );
   }
 
@@ -794,7 +794,6 @@ export default class AnalyseCtrl {
 
   private onToggleComputer() {
     if (!this.showComputer()) {
-      this.tree.removeComputerVariations();
       if (this.ceval.enabled()) this.toggleCeval();
     }
     this.resetAutoShapes();
@@ -812,7 +811,6 @@ export default class AnalyseCtrl {
   mergeAnalysisData(data: ServerEvalData) {
     if (this.study && this.study.data.chapter.id !== data.ch) return;
     this.tree.merge(data.tree);
-    if (!this.showComputer()) this.tree.removeComputerVariations();
     this.data.analysis = data.analysis;
     if (data.analysis)
       data.analysis.partial = !!treeOps.findInMainline(

--- a/ui/analyse/src/treeView/columnView.ts
+++ b/ui/analyse/src/treeView/columnView.ts
@@ -39,7 +39,7 @@ function emptyMove(conceal?: Conceal): VNode {
 }
 
 function renderChildrenOf(ctx: Ctx, node: Tree.Node, opts: Opts): MaybeVNodes | undefined {
-  const cs = node.children,
+  const cs = node.children.filter(x => ctx.showComputer || !x.comp),
     main = cs[0];
   if (!main) return;
   const conceal = opts.noConceal

--- a/ui/analyse/src/treeView/inlineView.ts
+++ b/ui/analyse/src/treeView/inlineView.ts
@@ -15,7 +15,7 @@ import {
 } from './common';
 
 function renderChildrenOf(ctx: Ctx, node: Tree.Node, opts: Opts): MaybeVNodes | undefined {
-  const cs = node.children,
+  const cs = node.children.filter(x => ctx.showComputer || !x.comp),
     main = cs[0];
   if (!main) return;
   if (opts.isMainline) {


### PR DESCRIPTION
fix #14123 for basic analysis.

There are still some oddities with disabling analysis in studies, where evals and comments disappear but eval variations and annotations remain. Hiding the variations and annotations would require a significant change to server study analysis code so a case should be made that it's even worth it.