### PR TITLE
-Board editor : Remove half unused En Passant options visible under Safari

### DIFF
--- a/ui/editor/src/ctrl.ts
+++ b/ui/editor/src/ctrl.ts
@@ -165,8 +165,7 @@ export default class EditorCtrl {
         : [null, null];
     return Array.from(filesEnPassant)
       .filter(e => rank1![e] === 'x' && rank2![e] === 'x')
-      .map(e => String.fromCharCode('a'.charCodeAt(0) + e) + (turn === 'w' ? '6' : '3'))
-      .sort();
+      .map(e => String.fromCharCode('a'.charCodeAt(0) + e) + (turn === 'w' ? '6' : '3'));
   }
 
   getState(): EditorState {

--- a/ui/editor/src/view.ts
+++ b/ui/editor/src/view.ts
@@ -179,19 +179,20 @@ function controls(ctrl: EditorCtrl, state: EditorState): VNode {
               value: ctrl.epSquare ? makeSquare(ctrl.epSquare) : '',
             },
           },
-          ['', ...[3, 6].flatMap(r => 'abcdefgh'.split('').map(f => f + r))].map(key =>
-            h(
-              'option',
-              {
-                attrs: {
-                  value: key,
-                  selected: (key ? parseSquare(key) : undefined) === ctrl.epSquare,
-                  hidden: Boolean(key && !state.enPassantOptions.includes(key)),
-                  disabled: Boolean(key && !state.enPassantOptions.includes(key)) /*Safari*/,
+          ['', ...[ctrl.turn === 'black' ? 3 : 6].flatMap(r => 'abcdefgh'.split('').map(f => f + r))].map(
+            key =>
+              h(
+                'option',
+                {
+                  attrs: {
+                    value: key,
+                    selected: (key ? parseSquare(key) : undefined) === ctrl.epSquare,
+                    hidden: Boolean(key && !state.enPassantOptions.includes(key)),
+                    disabled: Boolean(key && !state.enPassantOptions.includes(key)) /*Safari*/,
+                  },
                 },
-              },
-              key,
-            ),
+                key,
+              ),
           ),
         ),
       ]),


### PR DESCRIPTION
-Remove an unused sort()

Relates to #14139 and PR #14165 

Notes : 

- I can cut half the option of the select (the opposite color possible en passant), as it is safe to do so and the bug mentioned in PR 14165 cannot occur due to enPassant pawn being reset when changing color.

- Sort isn't used as the values checked against don't need to be sorted anymore (since they are not calculated to be shown, but to be compared against).