### PR TITLE
use disused importGameCaveat2 key

### DIFF
--- a/app/views/game/importGame.scala
+++ b/app/views/game/importGame.scala
@@ -54,7 +54,7 @@ object importGame:
             disabled = ctx.isAnon
           ),
                              a(cls := "text", dataIcon := licon.InfoCircle, href := routes.Study.allDefault(1)):
-            trans.importGameCaveat2()
+            trans.importGameDataPrivacyWarning()
           ,
           form3.action(form3.submit(trans.importGame(), licon.UploadCloud.some))
         )

--- a/app/views/game/importGame.scala
+++ b/app/views/game/importGame.scala
@@ -53,6 +53,9 @@ object importGame:
             help = Some(analyseHelp),
             disabled = ctx.isAnon
           ),
+                             a(cls := "text", dataIcon := licon.InfoCircle, href := routes.Study.allDefault(1)):
+            trans.importGameCaveat2()
+          ,
           form3.action(form3.submit(trans.importGame(), licon.UploadCloud.some))
         )
       )

--- a/modules/i18n/src/main/I18nKeys.scala
+++ b/modules/i18n/src/main/I18nKeys.scala
@@ -296,7 +296,7 @@ object I18nKeys:
   val `importGame` = I18nKey("importGame")
   val `importGameExplanation` = I18nKey("importGameExplanation")
   val `importGameCaveat` = I18nKey("importGameCaveat")
-  val `importGameCaveat2` = I18nKey("importGameCaveat2")
+  val `importGameDataPrivacyWarning` = I18nKey("importGameDataPrivacyWarning")
   val `thisIsAChessCaptcha` = I18nKey("thisIsAChessCaptcha")
   val `clickOnTheBoardToMakeYourMove` = I18nKey("clickOnTheBoardToMakeYourMove")
   val `captcha.fail` = I18nKey("captcha.fail")

--- a/translation/source/site.xml
+++ b/translation/source/site.xml
@@ -406,7 +406,7 @@
   <string name="importGameExplanation">Paste a game PGN to get a browsable replay,
 computer analysis, game chat and public shareable URL.</string>
   <string name="importGameCaveat">Variations will be erased. To keep them, import the PGN via a study.</string>
-  <string name="importGameCaveat2">This PGN can be accessed by the public. To import a game privately, use a study.</string>
+  <string name="importGameDataPrivacyWarning">This PGN can be accessed by the public. To import a game privately, use a study.</string>
   <plurals name="nbImportedGames">
     <item quantity="one">%s imported game</item>
     <item quantity="other">%s imported games</item>


### PR DESCRIPTION
in my previous pr on data privacy on importing games #14110 I mixed up the importgame caveats at the bottom of the page and as a result duplicated the first caveat, and that was removed later. Now I add importgame 2nd caveat on data privacy (differentiates) so Is better.