### PR TITLE
remove comma from team leaders

### DIFF
--- a/app/views/team/show.scala
+++ b/app/views/team/show.scala
@@ -74,11 +74,8 @@ object show:
               t.publicLeaders.nonEmpty option p(
                 teamLeaders.pluralSame(t.publicLeaders.size),
                 ": ",
-                fragList(
-                  t.publicLeaders.toList.map: l =>
-                    userIdLink(l.some),
-                  " "
-                )
+                t.publicLeaders.toList.map: l =>
+                  userIdLink(l.some)
               ),
               info.ledByMe option a(
                 dataIcon := licon.InfoCircle,

--- a/app/views/team/show.scala
+++ b/app/views/team/show.scala
@@ -74,8 +74,11 @@ object show:
               t.publicLeaders.nonEmpty option p(
                 teamLeaders.pluralSame(t.publicLeaders.size),
                 ": ",
-                fragList(t.publicLeaders.toList.map: l =>
-                  userIdLink(l.some))
+                fragList(
+                  t.publicLeaders.toList.map: l =>
+                    userIdLink(l.some),
+                  " "
+                )
               ),
               info.ledByMe option a(
                 dataIcon := licon.InfoCircle,

--- a/app/views/team/show.scala
+++ b/app/views/team/show.scala
@@ -74,7 +74,7 @@ object show:
               t.publicLeaders.nonEmpty option p(
                 teamLeaders.pluralSame(t.publicLeaders.size),
                 ": ",
-                t.publicLeaders.toList.map: l =>
+                t.publicLeaders.map: l =>
                   userIdLink(l.some)
               ),
               info.ledByMe option a(

--- a/ui/site/css/team/_show.scss
+++ b/ui/site/css/team/_show.scss
@@ -61,6 +61,7 @@ $section-margin-more: 5vh;
     .user-link {
       display: inline-block;
       vertical-align: bottom;
+      padding-#{$end-direction}: 0.25em;
     }
   }
 


### PR DESCRIPTION
close #14089

![image](https://github.com/lichess-org/lila/assets/61736812/2a517c02-8a27-494c-9412-fe24c3ff4805)

![image](https://github.com/lichess-org/lila/assets/61736812/1930564e-bd7f-42e5-bfec-37deaf608430)

i had used `" "` instead of `""`  

i could also do something like 
```scala
                fragList(
                  t.publicLeaders.toList.map: l =>
                    userIdLink(l.some),
                  ""
                )
```

and 

```css
    .user-link {
      display: inline-block;
      vertical-align: bottom;
      padding-#{$end-direction}: 0.25em;
    }
```

not sure what would be best