### PR TITLE
Resolve browser console errors on DGT page

### DIFF
--- a/ui/dgt/src/config.ts
+++ b/ui/dgt/src/config.ts
@@ -3,7 +3,7 @@ export default function () {
     voiceSelector = document.getElementById('dgt-speech-voice') as HTMLSelectElement;
 
   (function populateVoiceList() {
-    if (typeof speechSynthesis === 'undefined') return;
+    if (!voiceSelector || typeof speechSynthesis === 'undefined') return;
     speechSynthesis.getVoices().forEach((voice, i) => {
       const option = document.createElement('option');
       option.value = voice.name;
@@ -67,11 +67,13 @@ export default function () {
     });
   }
 
-  ensureDefaults();
-  populateForm();
+  if (form) {
+    ensureDefaults();
+    populateForm();
 
-  form.addEventListener('submit', (e: Event) => {
-    e.preventDefault();
-    Array.from(new FormData(form).entries()).forEach(([k, v]) => localStorage.setItem(k, v.toString()));
-  });
+    form.addEventListener('submit', (e: Event) => {
+      e.preventDefault();
+      Array.from(new FormData(form).entries()).forEach(([k, v]) => localStorage.setItem(k, v.toString()));
+    });
+  }
 }


### PR DESCRIPTION
Re: https://hq.lichess.ovh/#narrow/stream/8-dev/topic/lila.20ui.20dgt.20exceptions/near/3095335

Resolves the following errors when visiting the dgt page:

From firefox:
![Screenshot_20231209_144404](https://github.com/lichess-org/lila/assets/3620552/9ab96105-c94d-44db-ac93-cce39eaca136)

From chrome:
![Screenshot_20231209_170716](https://github.com/lichess-org/lila/assets/3620552/4f99c92b-788d-4e82-9be7-012cb45943e4)
![Screenshot_20231209_165432](https://github.com/lichess-org/lila/assets/3620552/953e5fd1-6d64-47ed-b1c1-77ed069e1bb2)


