### PR TITLE
Correct name "Asturias" in Flags.scala 

### DIFF
--- a/modules/user/src/main/Flags.scala
+++ b/modules/user/src/main/Flags.scala
@@ -94,7 +94,7 @@ object Flags:
     C("ES", "Spain"),
     C("ES-AN", "Andalusia"),
     C("ES-AR", "Aragon"),
-    C("ES-AS", "Asturia"),
+    C("ES-AS", "Asturias"),
     C("ES-CT", "Catalonia"),
     C("ES-EU", "Basque Country"),
     C("ES-GA", "Galicia"),


### PR DESCRIPTION
Correct name Asturia -> Asturias
https://en.wikipedia.org/wiki/Asturias