### PR TITLE
show study chapter coords

### DIFF
--- a/ui/@types/lichess/index.d.ts
+++ b/ui/@types/lichess/index.d.ts
@@ -305,6 +305,7 @@ declare namespace Editor {
     orientation?: Color;
     onChange?: (fen: string) => void;
     inlineCastling?: boolean;
+    coordinates?: boolean;
   }
 
   export interface OpeningPosition {

--- a/ui/analyse/src/study/chapterNewForm.ts
+++ b/ui/analyse/src/study/chapterNewForm.ts
@@ -198,6 +198,7 @@ export function view(ctrl: StudyChapterNewForm): VNode {
                           inlineCastling: true,
                           orientation: currentChapter.setup.orientation,
                           onChange: ctrl.editorFen,
+                          coordinates: true,
                         };
                         ctrl.editor = await lichess.asset.loadEsm<LichessEditor>('editor', { init: data });
                         ctrl.editorFen(ctrl.editor.getFen());

--- a/ui/editor/src/chessground.ts
+++ b/ui/editor/src/chessground.ts
@@ -120,7 +120,7 @@ function makeConfig(ctrl: EditorCtrl): CgConfig {
   return {
     fen: ctrl.initialFen,
     orientation: ctrl.options.orientation || 'white',
-    coordinates: !ctrl.cfg.embed,
+    coordinates: ctrl.options.coordinates !== false,
     autoCastle: false,
     addPieceZIndex: ctrl.cfg.is3d,
     movable: {


### PR DESCRIPTION
close #14204

i'm not sure why `coordinates` was coupled with the `embed` value so I created a new type field. hopefully, this didn't break somewhere else
![image](https://github.com/lichess-org/lila/assets/61736812/92cc12a6-ae3b-46ea-9515-abef05e2051e)

![image](https://github.com/lichess-org/lila/assets/61736812/13eb80cb-ab02-44d9-967d-7be39b6329dc)

