### PR TITLE
acpl chart: fix christmastree hover bug

### DIFF
--- a/ui/chart/src/acpl.ts
+++ b/ui/chart/src/acpl.ts
@@ -200,14 +200,14 @@ const glyphProperties = (node: Tree.Node): { advice?: Advice; color?: string } =
 
 const toBlurArray = (player: Player) => player.blurs?.bits?.split('') ?? [];
 
-function christmasTree(chart: Chart, mainline: Tree.Node[], hoverColors: string[]) {
+function christmasTree(chart: AcplChart, mainline: Tree.Node[], hoverColors: string[]) {
   $('div.advice-summary').on('mouseenter', 'div.symbol', function (this: HTMLElement) {
     const symbol = this.getAttribute('data-symbol');
     const playerColorBit = this.getAttribute('data-color') == 'white' ? 1 : 0;
     const acplDataset = chart.data.datasets[0];
     if (symbol == '??' || symbol == '?!' || symbol == '?') {
-      acplDataset.hoverBackgroundColor = hoverColors;
-      acplDataset.borderColor = hoverColors;
+      acplDataset.pointHoverBackgroundColor = hoverColors;
+      acplDataset.pointBorderColor = hoverColors;
       const points = mainline
         .map((node, i) =>
           node.glyphs?.some(glyph => glyph.symbol == symbol) && (node.ply & 1) == playerColorBit
@@ -220,9 +220,9 @@ function christmasTree(chart: Chart, mainline: Tree.Node[], hoverColors: string[
     }
   });
   $('div.advice-summary').on('mouseleave', 'div.symbol', function (this: HTMLElement) {
-    if (chart.getActiveElements().length) chart.setActiveElements([]);
-    chart.data.datasets[0].hoverBackgroundColor = orangeAccent;
-    chart.data.datasets[0].borderColor = orangeAccent;
+    chart.setActiveElements([]);
+    chart.data.datasets[0].pointHoverBackgroundColor = orangeAccent;
+    chart.data.datasets[0].pointBorderColor = orangeAccent;
     chart.update('none');
   });
 }

--- a/ui/chart/src/interface.ts
+++ b/ui/chart/src/interface.ts
@@ -1,6 +1,6 @@
 import { Chart } from 'chart.js';
 
-export interface PlyChart extends Chart {
+export interface PlyChart extends Chart<'line'> {
   selectPly(ply: number, isMainline: boolean): void;
 }
 


### PR DESCRIPTION
Steps to reproduce:
1. Have a game where the first played move is inaccurate or worse.
2. Hovering over the advice changes the chart line color to the color of the first move's judgment.

Reproducible here https://lichess.org/Ne9qZ9Fy (or any other objectively bad opening like the Grob)