### PR TITLE
Make homepage layout consistent with the addition of feeds

### DIFF
--- a/ui/lobby/css/_layout.scss
+++ b/ui/lobby/css/_layout.scss
@@ -8,12 +8,14 @@
   &__tournaments,
   &__simuls,
   &__leaderboard,
-  &__winners {
+  &__winners,
+  &__feed {
     max-height: 20em;
   }
   // this helps in empty dev mode
   &__leaderboard,
-  &__winners {
+  &__winners,
+  &__feed {
     min-height: 20em;
   }
 
@@ -82,9 +84,10 @@
       'side   app     app     table'
       'tv     blog    blog    puzzle'
       'tv     support support puzzle'
-      'feed   feed    tours   tours'
-      'feed   feed    leader  winner'
-      'about  about   leader  winner';
+      'leader feed    feed    winner'
+      '.      tours   tours   .     '
+      '.      about   about   .     ';
+
 
     &__start {
       justify-content: center;


### PR DESCRIPTION
Makes the layout of the homepage consistent with the new feed feature. See https://discord.com/channels/280713822073913354/1186468247927804035/1186468247927804035 for a more detailed explanation

I put the feed above tournaments to remain consistent with the ordering already used for smaller screens; however, when I was asking some people if they preferred the look of feed above tournaments or tournaments above feed, everyone said they preferred tournaments above feed, so that might be worth looking into as well. 
I also added feed to the min and max-height stuff used for other elements on the home page as I ran into some weird stuff while reordering the grid, but in the current order this isn't strictly necessary as feed is in between leaderboard and winners which already have min and max heights. Just useful for future development.

However, for now this will just make the homepage look like this: 
![image](https://github.com/ijhchess/lila/assets/42898357/da043172-73b2-418d-8d63-fc13692698ed)
