### PR TITLE
Fix for Racing kings#14116

### DIFF
--- a/ui/analyse/src/practice/practiceCtrl.ts
+++ b/ui/analyse/src/practice/practiceCtrl.ts
@@ -138,7 +138,6 @@ export function make(root: AnalyseCtrl, playableDepth: () => number): PracticeCt
     if ((root.data.game.variant.key === 'racingKings') && (root.data.game.player === 'black')) {
       return root.turnColor() !== root.bottomColor();
     }
-    console.log("computer plays black");
     return root.turnColor() === root.bottomColor();
   }
 

--- a/ui/analyse/src/practice/practiceCtrl.ts
+++ b/ui/analyse/src/practice/practiceCtrl.ts
@@ -8,6 +8,7 @@ import { defined, prop, Prop } from 'common';
 import { altCastles } from 'chess';
 import { parseUci } from 'chessops/util';
 import { makeSan } from 'chessops/san';
+import { colors } from 'chessground/types';
 
 declare type Verdict = 'goodMove' | 'inaccuracy' | 'mistake' | 'blunder';
 
@@ -134,6 +135,10 @@ export function make(root: AnalyseCtrl, playableDepth: () => number): PracticeCt
   }
 
   function isMyTurn(): boolean {
+    if ((root.data.game.variant.key === 'racingKings') && (root.data.game.player === 'black')) {
+      return root.turnColor() !== root.bottomColor();
+    }
+    console.log("computer plays black");
     return root.turnColor() === root.bottomColor();
   }
 


### PR DESCRIPTION
Racing kings has one board orientation which causes the user to have to flip the board if they wish to play black and the computer play white in 'practice with computer' mode. Described in [issue](https://github.com/lichess-org/lila/issues/14116). I have tested the fix locally by playing a racing kings game as black vs computer and then analysing it after in 'practice with computer' mode. The computer plays the white pieces without me needing to flip the board. 