### PR TITLE
space between username and rating

### DIFF
--- a/ui/common/src/userLink.ts
+++ b/ui/common/src/userLink.ts
@@ -38,7 +38,7 @@ export const userLink = (u: AnyUser): VNode =>
       class: { 'user-link': true, ulpt: u.name != 'ghost', online: !!u.online },
       attrs: { href: `/@/${u.name}`, ...u.attrs },
     },
-    [userLine(u), ...fullName(u), userRating(u)],
+    [userLine(u), ...fullName(u), u.rating && ` ${userRating(u)} `],
   );
 
 export const userFlair = (u: HasFlair): VNode | undefined =>


### PR DESCRIPTION
close #14256

![image](https://github.com/lichess-org/lila/assets/61736812/0b146938-0e4b-45a9-9301-69405a52b6e6)

noticed that in the the normal game view there are two spaces between the ratings that's why i went with this
![image](https://github.com/lichess-org/lila/assets/61736812/5f8ff2d0-7d20-449a-afbc-aff9fc2c39af)
