### PR TITLE
round robin and log ws failures to idb, add ttl

### DIFF
--- a/ui/@types/lichess/index.d.ts
+++ b/ui/@types/lichess/index.d.ts
@@ -79,6 +79,7 @@ interface Lichess {
 
 interface LichessLog {
   (...args: any[]): Promise<void>;
+  trace(...args: any[]): Promise<void>;
   clear(): Promise<void>;
   get(): Promise<string>;
 }
@@ -199,7 +200,7 @@ interface Pubsub {
 }
 
 interface LichessStorageHelper {
-  make(k: string): LichessStorage;
+  make(k: string, ttl?: number): LichessStorage;
   boolean(k: string): LichessBooleanStorage;
   get(k: string): string | null;
   set(k: string, v: string): void;

--- a/ui/@types/lichess/index.d.ts
+++ b/ui/@types/lichess/index.d.ts
@@ -79,7 +79,6 @@ interface Lichess {
 
 interface LichessLog {
   (...args: any[]): Promise<void>;
-  trace(...args: any[]): Promise<void>;
   clear(): Promise<void>;
   get(): Promise<string>;
 }

--- a/ui/site/src/component/log.ts
+++ b/ui/site/src/component/log.ts
@@ -44,10 +44,6 @@ export default function makeLog(): LichessLog {
     await store?.put(nextKey, msg);
   };
 
-  log.trace = async (...args: any[]) => {
-    lichess.log(new Error().stack?.split('\n').slice(2).join('\n'), args);
-  };
-
   log.clear = async () => {
     await ready;
     await store?.clear();

--- a/ui/site/src/component/log.ts
+++ b/ui/site/src/component/log.ts
@@ -44,6 +44,10 @@ export default function makeLog(): LichessLog {
     await store?.put(nextKey, msg);
   };
 
+  log.trace = async (...args: any[]) => {
+    lichess.log(new Error().stack?.split('\n').slice(2).join('\n'), args);
+  };
+
   log.clear = async () => {
     await ready;
     await store?.clear();

--- a/ui/site/src/component/socket.ts
+++ b/ui/site/src/component/socket.ts
@@ -62,7 +62,7 @@ export default class StrongSocket {
   tryOtherUrl = false;
   autoReconnect = true;
   nbConnects = 0;
-  storage: LichessStorage;
+  storage: LichessStorage = makeStorage.make('surl17', 30 * 60 * 1000);
   private _sign?: string;
   private resendWhenOpen: [string, any, any][] = [];
   private baseUrls = document.body.dataset.socketDomains!.split(',');
@@ -89,9 +89,6 @@ export default class StrongSocket {
     version: number | false,
     settings: Partial<Settings> = {},
   ) {
-    const socketChangeTtl = Number(document.body.dataset.socketChangeTtl);
-    this.storage = makeStorage.make('surl17', socketChangeTtl > 0 ? socketChangeTtl : 30 * 60 * 1000);
-
     this.settings = {
       receive: settings.receive,
       events: settings.events || {},

--- a/ui/site/src/component/socket.ts
+++ b/ui/site/src/component/socket.ts
@@ -62,9 +62,10 @@ export default class StrongSocket {
   tryOtherUrl = false;
   autoReconnect = true;
   nbConnects = 0;
-  storage: LichessStorage = makeStorage.make('surl17');
+  storage: LichessStorage;
   private _sign?: string;
   private resendWhenOpen: [string, any, any][] = [];
+  private baseUrls = document.body.dataset.socketDomains!.split(',');
 
   static defaultOptions: Options = {
     idle: false,
@@ -88,6 +89,9 @@ export default class StrongSocket {
     version: number | false,
     settings: Partial<Settings> = {},
   ) {
+    const socketChangeTtl = Number(document.body.dataset.socketChangeTtl);
+    this.storage = makeStorage.make('surl17', socketChangeTtl > 0 ? socketChangeTtl : 30 * 60 * 1000);
+
     this.settings = {
       receive: settings.receive,
       events: settings.events || {},
@@ -121,13 +125,7 @@ export default class StrongSocket {
     try {
       const ws = (this.ws = new WebSocket(fullUrl));
       ws.onerror = e => this.onError(e);
-      ws.onclose = () => {
-        this.pubsub.emit('socket.close');
-        if (this.autoReconnect) {
-          this.debug('Will autoreconnect in ' + this.options.autoReconnectDelay);
-          this.scheduleConnect(this.options.autoReconnectDelay);
-        }
-      };
+      ws.onclose = e => this.onClose(e, fullUrl);
       ws.onopen = () => {
         this.debug('connected to ' + fullUrl);
         this.onSuccess();
@@ -148,7 +146,7 @@ export default class StrongSocket {
         this.handle(m);
       };
     } catch (e) {
-      this.onError(e);
+      this.onClose({ code: 4000, reason: String(e) } as CloseEvent, fullUrl);
     }
     this.scheduleConnect(this.options.pingMaxLag);
   };
@@ -197,7 +195,11 @@ export default class StrongSocket {
     this.connectSchedule = setTimeout(() => {
       document.body.classList.add('offline');
       document.body.classList.remove('online');
-      this.tryOtherUrl = true;
+      if (!this.tryOtherUrl) {
+        // if this was set earlier, we've already logged the error
+        this.tryOtherUrl = true;
+        lichess.log(`socket.ts: Timeout ${delay}ms, rotating to ${this.baseUrl()}`);
+      }
       this.connect();
     }, delay);
   };
@@ -294,6 +296,17 @@ export default class StrongSocket {
   onError = (e: unknown) => {
     this.options.debug = true;
     this.debug(`error: ${e} ${JSON.stringify(e)}`); // e not always from lila
+  };
+
+  onClose = (e: CloseEvent, url: string) => {
+    this.pubsub.emit('socket.close');
+    if (this.autoReconnect) {
+      this.debug('Will autoreconnect in ' + this.options.autoReconnectDelay);
+      this.scheduleConnect(this.options.autoReconnectDelay);
+    }
+    if (e.wasClean && e.code < 1002) return;
+
+    lichess.log(`socket.ts: Unclean close ${e.code} ${url} ${e.reason}`);
     this.tryOtherUrl = true;
     clearTimeout(this.pingSchedule);
   };
@@ -319,12 +332,16 @@ export default class StrongSocket {
   };
 
   baseUrl = () => {
-    const baseUrls = document.body.dataset.socketDomains!.split(',');
     let url = this.storage.get();
-    if (!url || this.tryOtherUrl) {
-      url = baseUrls[Math.floor(Math.random() * baseUrls.length)];
+    if (!url) {
+      url = this.baseUrls[Math.floor(Math.random() * this.baseUrls.length)];
+      this.storage.set(url);
+    } else if (this.tryOtherUrl) {
+      const i = this.baseUrls.findIndex(u => u === url);
+      url = this.baseUrls[(i + 1) % this.baseUrls.length];
       this.storage.set(url);
     }
+    this.tryOtherUrl = false;
     return url;
   };
 

--- a/ui/site/src/component/storage.ts
+++ b/ui/site/src/component/storage.ts
@@ -16,12 +16,16 @@ const builder = (storage: Storage): LichessStorageHelper => {
     remove: (k: string) => storage.removeItem(k),
     make: (k: string, ttl?: number) => {
       const bdKey = ttl && `${k}--bd`;
+      const remove = () => {
+        api.remove(k);
+        if (bdKey) api.remove(bdKey);
+      };
       return {
         get: () => {
           if (!bdKey) return api.get(k);
           const birthday = Number(api.get(bdKey));
           if (!birthday) api.set(bdKey, String(Date.now()));
-          else if (Date.now() - birthday > ttl) api.remove(k);
+          else if (Date.now() - birthday > ttl) remove();
           return api.get(k);
         },
         set: (v: any) => {
@@ -29,10 +33,7 @@ const builder = (storage: Storage): LichessStorageHelper => {
           if (bdKey) api.set(bdKey, String(Date.now()));
         },
         fire: (v?: string) => api.fire(k, v),
-        remove: () => {
-          api.remove(k);
-          if (bdKey) api.remove(bdKey);
-        },
+        remove,
         listen: (f: (e: LichessStorageEvent) => void) =>
           window.addEventListener('storage', e => {
             if (e.key !== k || e.storageArea !== storage || e.newValue === null) return;


### PR DESCRIPTION
- round robin (rather than random) selection of socket name on failures
- random selection of socket name on ttl expiry
- ttl is every 30 minutes ~~but can be given in millis with `data-socket-change-ttl` attribute~~
- call `lichess.log` when rotating socket names due to error
- i believe there are scenarios where an unclean close can happen without an `error` event. on the other hand we always get `'close'` events for a successfully constructed socket. so all our failure logic is just in `onClose` now, and we call that manually when the socket cannot be constructed.
