### PR TITLE
Consistently disable the rematch button

### DIFF
--- a/ui/round/src/view/button.ts
+++ b/ui/round/src/view/button.ts
@@ -45,7 +45,7 @@ function analysisButton(ctrl: RoundController): VNode | false {
 function rematchButtons(ctrl: RoundController): LooseVNodes {
   const d = ctrl.data,
     me = !!d.player.offeringRematch,
-    disabled = !me && !d.opponent.onGame && (!!d.clock || !d.player.user || !d.opponent.user),
+    disabled = !me && !d.opponent.onGame,
     them = !!d.opponent.offeringRematch && !disabled,
     noarg = ctrl.noarg;
   if (!game.rematchable(d)) return [];
@@ -74,10 +74,9 @@ function rematchButtons(ctrl: RoundController): LooseVNodes {
             else if (d.player.offeringRematch) {
               d.player.offeringRematch = false;
               ctrl.socket.send('rematch-no');
-            } else if (d.opponent.onGame || !d.clock) {
+            } else if (d.opponent.onGame) {
               d.player.offeringRematch = true;
               ctrl.socket.send('rematch-yes');
-              if (!disabled && !d.opponent.onGame) ctrl.challengeRematch();
             }
           },
           ctrl.redraw,


### PR DESCRIPTION
Resolves #14093 

Disable the rematch button when the opponent leaves, regardless of clock existence. This will allow for a consistent "Rematch" button state.

This also resolves the issue of duplicate API challenge events in games (as shown in the linked issue). The duplicate challenge event was caused because the socket sends `rematch-yes` by default, and if the rematch button was not disabled with the opponent no longer on the game, `ctrl.challengeRematch` was *also* being called.

Additionally removes the check for  `!d.player.user || !d.opponent.user` as part of the Rematch disable qualifiers. From what I can tell (and through testing) this is dead code that does not affect the disabled rematch button state. I assume at one point this was to possibly not allow anonymous or ai rematches -- both of which are allowed right now (regardless of clock) on prod.

Tested these changes with timed and untimed games vs standard, bots, ai, and anon players.