### PR TITLE
Alias broadcast pgn push to /api prefix

### DIFF
--- a/conf/routes
+++ b/conf/routes
@@ -267,6 +267,7 @@ GET   /broadcast/round/$roundId<\w{8}>/edit   controllers.RelayRound.edit(roundI
 POST  /broadcast/round/$roundId<\w{8}>/edit   controllers.RelayRound.update(roundId)
 POST  /broadcast/round/$roundId<\w{8}>/reset  controllers.RelayRound.reset(roundId)
 POST  /broadcast/round/$roundId<\w{8}>/push   controllers.RelayRound.push(roundId)
+POST  /api/broadcast/round/$roundId<\w{8}>/push controllers.RelayRound.push(roundId)
 GET   /broadcast/:ts/:rs/$roundId<\w{8}>.pgn  controllers.RelayRound.pgn(ts, rs, roundId)
 GET   /api/broadcast/round/$roundId<\w{8}>.pgn controllers.RelayRound.apiPgn(roundId)
 GET   /api/stream/broadcast/round/$roundId<\w{8}>.pgn controllers.RelayRound.stream(roundId)


### PR DESCRIPTION
Prevents CORS error

![image](https://github.com/lichess-org/lila/assets/271432/a3ecab9c-803f-4cfe-80a8-f58d5fafdf83)

Similar PR to #14241 