### PR TITLE
Add createdAt in broadcast api response

### DIFF
--- a/modules/relay/src/main/JsonView.scala
+++ b/modules/relay/src/main/JsonView.scala
@@ -20,16 +20,18 @@ final class JsonView(baseUrl: BaseUrl, markup: RelayMarkup, leaderboardApi: Rela
         "id"          -> t.id,
         "name"        -> t.name,
         "slug"        -> t.slug,
-        "description" -> t.description
+        "description" -> t.description,
+        "createdAt"   -> t.createdAt
       )
       .add("official" -> t.official)
 
   given OWrites[RelayRound] = OWrites: r =>
     Json
       .obj(
-        "id"   -> r.id,
-        "name" -> r.name,
-        "slug" -> r.slug
+        "id"        -> r.id,
+        "name"      -> r.name,
+        "slug"      -> r.slug,
+        "createdAt" -> r.createdAt
       )
       .add("finished" -> r.finished)
       .add("ongoing" -> (r.hasStarted && !r.finished))


### PR DESCRIPTION
Adds `createdAt` for both the broadcast tournament and round info.

Use case is to be able to show this in a client UI to help when displaying lots of rounds.