### PR TITLE
AcceptsJson to work with httpie's default --json header

### DIFF
--- a/modules/common/src/main/HTTPRequest.scala
+++ b/modules/common/src/main/HTTPRequest.scala
@@ -103,7 +103,7 @@ object HTTPRequest:
   def accepts(req: RequestHeader): Option[String] = req.headers.get(HeaderNames.ACCEPT)
   def acceptsNdJson(req: RequestHeader)           = accepts(req) contains "application/x-ndjson"
   def acceptsJson(req: RequestHeader) = accepts(req).exists: a =>
-    (a contains "application/json") || startsWithLichobileAccepts(a)
+    a.startsWith("application/json") || startsWithLichobileAccepts(a)
   def acceptsCsv(req: RequestHeader)             = accepts(req) contains "text/csv"
   def isEventSource(req: RequestHeader): Boolean = accepts(req) contains "text/event-stream"
   def isProgrammatic(req: RequestHeader) =

--- a/modules/common/src/main/HTTPRequest.scala
+++ b/modules/common/src/main/HTTPRequest.scala
@@ -103,7 +103,7 @@ object HTTPRequest:
   def accepts(req: RequestHeader): Option[String] = req.headers.get(HeaderNames.ACCEPT)
   def acceptsNdJson(req: RequestHeader)           = accepts(req) contains "application/x-ndjson"
   def acceptsJson(req: RequestHeader) = accepts(req).exists: a =>
-    a == "application/json" || startsWithLichobileAccepts(a)
+    (a contains "application/json") || startsWithLichobileAccepts(a)
   def acceptsCsv(req: RequestHeader)             = accepts(req) contains "text/csv"
   def isEventSource(req: RequestHeader): Boolean = accepts(req) contains "text/event-stream"
   def isProgrammatic(req: RequestHeader) =


### PR DESCRIPTION
[httpie's --json flag](https://httpie.io/docs/cli/explicit-json) sends this Accept header by default

```
"Accept": "application/json, */*;q=0.5"
```
```bash
http --json httpbin.org/get
```

Example, this sends that header but doesn't return JSON.

```bash
http --json https://lichess.org/broadcast/-/lZo9v6Nu
```