### PR TITLE
Do not add UTCDate, UTCTime tags to study chapter PGNDumps

### DIFF
--- a/modules/study/src/main/PgnDump.scala
+++ b/modules/study/src/main/PgnDump.scala
@@ -66,8 +66,6 @@ final class PgnDump(
       val genTags = List(
         Tag(_.Event, s"${study.name}: ${chapter.name}"),
         Tag(_.Site, chapterUrl(study.id, chapter.id)),
-        Tag(_.UTCDate, Tag.UTCDate.format.print(chapter.createdAt)),
-        Tag(_.UTCTime, Tag.UTCTime.format.print(chapter.createdAt)),
         Tag(_.Variant, chapter.setup.variant.name.capitalize),
         Tag(_.ECO, opening.fold("?")(_.eco)),
         Tag(_.Opening, opening.fold("?")(_.name)),

--- a/modules/study/src/main/PgnDump.scala
+++ b/modules/study/src/main/PgnDump.scala
@@ -76,6 +76,11 @@ final class PgnDump(
           Tag(_.FEN, chapter.root.fen.value),
           Tag("SetUp", "1")
         )
+      ) ::: (!chapter.tags.exists(_.Date)).so(
+        List(
+          Tag(_.UTCDate, Tag.UTCDate.format.print(chapter.createdAt)),
+          Tag(_.UTCTime, Tag.UTCTime.format.print(chapter.createdAt))
+        )
       ) :::
         flags.source.so(List(Tag("Source", chapterUrl(study.id, chapter.id)))) :::
         flags.orientation.so(List(Tag("Orientation", chapter.setup.orientation.name))) :::


### PR DESCRIPTION
This PR tries to solve issue:

https://github.com/lichess-org/lila/issues/14023

by not adding UTCDate, UTCTime tags to study chapter PGNDumps.

Related forum topic:
https://lichess.org/forum/lichess-feedback/why-games-dates-always-change-to-the-current-after-downloading-chaptersstudies?page=1
