### PR TITLE
fix for massive single line on bot page

### DIFF
--- a/app/views/user/bots.scala
+++ b/app/views/user/bots.scala
@@ -38,26 +38,27 @@ object bots:
             )
       )
 
-  private def botTable(users: List[User.WithPerfs])(using ctx: Context) = div(cls := "bots__list")(
-    users.map: u =>
-      div(cls := "bots__list__entry")(
-        div(cls := "bots__list__entry__desc")(
-          div(cls := "bots__list__entry__head")(
-            userLink(u),
-            ctx.pref.showRatings option div(cls := "bots__list__entry__rating"):
-              u.perfs.bestAny3Perfs.map { showPerfRating(u.perfs, _) }
+  private def botTable(users: List[User.WithPerfs])(using ctx: Context) =
+    div(cls := "bots__list", style := "overflow-wrap: anywhere")(
+      users.map: u =>
+        div(cls := "bots__list__entry")(
+          div(cls := "bots__list__entry__desc")(
+            div(cls := "bots__list__entry__head")(
+              userLink(u),
+              ctx.pref.showRatings option div(cls := "bots__list__entry__rating"):
+                u.perfs.bestAny3Perfs.map { showPerfRating(u.perfs, _) }
+            ),
+            u.profile
+              .ifTrue(ctx.kid.no)
+              .ifTrue(!u.marks.troll || ctx.is(u))
+              .flatMap(_.nonEmptyBio)
+              .map { bio => td(shorten(bio, 400)) }
           ),
-          u.profile
-            .ifTrue(ctx.kid.no)
-            .ifTrue(!u.marks.troll || ctx.is(u))
-            .flatMap(_.nonEmptyBio)
-            .map { bio => td(shorten(bio, 400)) }
-        ),
-        a(
-          dataIcon := licon.Swords,
-          cls      := List("bots__list__entry__play button button-empty text" -> true),
-          st.title := trans.challenge.challengeToPlay.txt(),
-          href     := s"${routes.Lobby.home}?user=${u.username}#friend"
-        )(trans.play())
-      )
-  )
+          a(
+            dataIcon := licon.Swords,
+            cls      := List("bots__list__entry__play button button-empty text" -> true),
+            st.title := trans.challenge.challengeToPlay.txt(),
+            href     := s"${routes.Lobby.home}?user=${u.username}#friend"
+          )(trans.play())
+        )
+    )

--- a/app/views/user/bots.scala
+++ b/app/views/user/bots.scala
@@ -39,7 +39,7 @@ object bots:
       )
 
   private def botTable(users: List[User.WithPerfs])(using ctx: Context) =
-    div(cls := "bots__list", style := "overflow-wrap: anywhere")(
+    div(cls := "bots__list")(
       users.map: u =>
         div(cls := "bots__list__entry")(
           div(cls := "bots__list__entry__desc")(

--- a/app/views/user/bots.scala
+++ b/app/views/user/bots.scala
@@ -38,27 +38,26 @@ object bots:
             )
       )
 
-  private def botTable(users: List[User.WithPerfs])(using ctx: Context) =
-    div(cls := "bots__list")(
-      users.map: u =>
-        div(cls := "bots__list__entry")(
-          div(cls := "bots__list__entry__desc")(
-            div(cls := "bots__list__entry__head")(
-              userLink(u),
-              ctx.pref.showRatings option div(cls := "bots__list__entry__rating"):
-                u.perfs.bestAny3Perfs.map { showPerfRating(u.perfs, _) }
-            ),
-            u.profile
-              .ifTrue(ctx.kid.no)
-              .ifTrue(!u.marks.troll || ctx.is(u))
-              .flatMap(_.nonEmptyBio)
-              .map { bio => td(shorten(bio, 400)) }
+  private def botTable(users: List[User.WithPerfs])(using ctx: Context) = div(cls := "bots__list")(
+    users.map: u =>
+      div(cls := "bots__list__entry")(
+        div(cls := "bots__list__entry__desc")(
+          div(cls := "bots__list__entry__head")(
+            userLink(u),
+            ctx.pref.showRatings option div(cls := "bots__list__entry__rating"):
+              u.perfs.bestAny3Perfs.map { showPerfRating(u.perfs, _) }
           ),
-          a(
-            dataIcon := licon.Swords,
-            cls      := List("bots__list__entry__play button button-empty text" -> true),
-            st.title := trans.challenge.challengeToPlay.txt(),
-            href     := s"${routes.Lobby.home}?user=${u.username}#friend"
-          )(trans.play())
-        )
-    )
+          u.profile
+            .ifTrue(ctx.kid.no)
+            .ifTrue(!u.marks.troll || ctx.is(u))
+            .flatMap(_.nonEmptyBio)
+            .map { bio => td(shorten(bio, 400)) }
+        ),
+        a(
+          dataIcon := licon.Swords,
+          cls      := List("bots__list__entry__play button button-empty text" -> true),
+          st.title := trans.challenge.challengeToPlay.txt(),
+          href     := s"${routes.Lobby.home}?user=${u.username}#friend"
+        )(trans.play())
+      )
+  )

--- a/ui/site/css/user/_list-bot.scss
+++ b/ui/site/css/user/_list-bot.scss
@@ -8,7 +8,6 @@
   }
 
   &__list {
-    overflow-wrap: anywhere;
     &__entry {
       @extend %flex-center-nowrap;
       gap: $block-gap;
@@ -20,6 +19,7 @@
       }
 
       &__desc {
+        @extend %break-word;
         flex: 1 1 auto;
       }
 

--- a/ui/site/css/user/_list-bot.scss
+++ b/ui/site/css/user/_list-bot.scss
@@ -8,6 +8,7 @@
   }
 
   &__list {
+    overflow-wrap: anywhere;
     &__entry {
       @extend %flex-center-nowrap;
       gap: $block-gap;


### PR DESCRIPTION
Fix for #14336. 'overflow-wrap: anywhere' is applied to both featured bots and community bots. See attached screenshot 
![Screenshot 2023-12-31 at 16 41 56](https://github.com/lichess-org/lila/assets/20873258/1881be9f-1612-46e5-9400-f78ebfa6ade0)
