### PR TITLE
Show dates on dedicated feed page

### DIFF
--- a/app/views/dailyFeed.scala
+++ b/app/views/dailyFeed.scala
@@ -43,12 +43,11 @@ object dailyFeed:
       ups.view
         .filter(_.published || editor)
         .map: update =>
-          val exactDateTime = java.time.format.DateTimeFormatter.ofPattern("dd MMM yyyy, HH:mm").format(java.time.LocalDateTime.ofInstant(update.at, java.time.ZoneOffset.UTC))
           div(cls := "daily-feed__update", id := update.id)(
             marker(update.flair),
             div(cls := "daily-feed__update__content")(
               st.section(cls := "daily-feed__update__day")(
-                h2(a(href := s"#${update.id}")(raw(exactDateTime),raw(" UTC ("),span(momentFromNow(update.at)),raw(")"))),
+                h2(a(href := s"#${update.id}")(showEnglishInstant(update.at))),
                 editor option frag(
                   a(
                     href     := routes.DailyFeed.edit(update.id),

--- a/app/views/dailyFeed.scala
+++ b/app/views/dailyFeed.scala
@@ -47,7 +47,7 @@ object dailyFeed:
             marker(update.flair),
             div(cls := "daily-feed__update__content")(
               st.section(cls := "daily-feed__update__day")(
-                h2(a(href := s"#${update.id}")(showEnglishInstant(update.at))),
+                h2(a(href := s"#${update.id}")(showInstant(update.at))),
                 editor option frag(
                   a(
                     href     := routes.DailyFeed.edit(update.id),

--- a/app/views/dailyFeed.scala
+++ b/app/views/dailyFeed.scala
@@ -43,11 +43,12 @@ object dailyFeed:
       ups.view
         .filter(_.published || editor)
         .map: update =>
+          val exactDateTime = java.time.format.DateTimeFormatter.ofPattern("dd MMM yyyy, HH:mm").format(java.time.LocalDateTime.ofInstant(update.at, java.time.ZoneOffset.UTC))
           div(cls := "daily-feed__update", id := update.id)(
             marker(update.flair),
             div(cls := "daily-feed__update__content")(
               st.section(cls := "daily-feed__update__day")(
-                h2(a(href := s"#${update.id}")(momentFromNow(update.at))),
+                h2(a(href := s"#${update.id}")(raw(exactDateTime),raw(" UTC ("),span(momentFromNow(update.at)),raw(")"))),
                 editor option frag(
                   a(
                     href     := routes.DailyFeed.edit(update.id),


### PR DESCRIPTION
Show dates and times instead of time ago on dedicated feed page (lichess.org/feed) #14348