### PR TITLE
Add type for study chapter tabs

### DIFF
--- a/ui/analyse/src/plugins/studyTour.ts
+++ b/ui/analyse/src/plugins/studyTour.ts
@@ -1,6 +1,6 @@
 import AnalyseCtrl from '../ctrl';
 import Shepherd from 'shepherd.js';
-import { StudyTour, Tab } from '../study/interfaces';
+import { ChapterTab, StudyTour, Tab } from '../study/interfaces';
 
 export function initModule(): StudyTour {
   return {
@@ -161,7 +161,7 @@ export function initModule(): StudyTour {
     lichess.pubsub.on('analyse.close-all', tour.cancel);
   }
 
-  function chapter(setTab: (tab: string) => void) {
+  function chapter(setTab: (tab: ChapterTab) => void) {
     const viewSel = 'dialog div.dialog-content';
 
     const tour = new Shepherd.Tour({
@@ -182,7 +182,7 @@ export function initModule(): StudyTour {
       enabled: true,
     };
 
-    const onTab = (tab: string): Shepherd.Step.StepOptionsWhen => {
+    const onTab = (tab: ChapterTab): Shepherd.Step.StepOptionsWhen => {
       return {
         'before-show': () => setTab(tab),
       };

--- a/ui/analyse/src/study/chapterNewForm.ts
+++ b/ui/analyse/src/study/chapterNewForm.ts
@@ -3,14 +3,14 @@ import { defined, prop, Prop, toggle } from 'common';
 import * as licon from 'common/licon';
 import { snabDialog } from 'common/dialog';
 import { bind, bindSubmit, onInsert, looseH as h } from 'common/snabbdom';
-import { storedStringProp } from 'common/storage';
+import { storedProp } from 'common/storage';
 import * as xhr from 'common/xhr';
 import { VNode } from 'snabbdom';
 import AnalyseCtrl from '../ctrl';
 import { StudySocketSend } from '../socket';
 import { spinnerVdom as spinner } from 'common/spinner';
 import { option } from '../view/util';
-import { ChapterData, ChapterMode, Orientation, StudyChapterMeta, StudyTour } from './interfaces';
+import { ChapterData, ChapterMode, ChapterTab, Orientation, StudyChapterMeta, StudyTour } from './interfaces';
 import { importPgn, variants as xhrVariants } from './studyXhr';
 
 export const modeChoices = [
@@ -28,7 +28,12 @@ export class StudyChapterNewForm {
   variants: Variant[] = [];
   isOpen = toggle(false);
   initial = toggle(false);
-  tab = storedStringProp('analyse.study.form.tab', 'init');
+  tab = storedProp<ChapterTab>(
+    'analyse.study.form.tab',
+    'init',
+    str => str as ChapterTab,
+    v => v,
+  );
   editor: LichessEditor | null = null;
   editorFen: Prop<Fen | null> = prop(null);
   isDefaultName = toggle(true);
@@ -89,7 +94,7 @@ export function view(ctrl: StudyChapterNewForm): VNode {
   const trans = ctrl.root.trans,
     study = ctrl.root.study!;
   const activeTab = ctrl.tab();
-  const makeTab = (key: string, name: string, title: string) =>
+  const makeTab = (key: ChapterTab, name: string, title: string) =>
     h(
       'span.' + key,
       {

--- a/ui/analyse/src/study/interfaces.ts
+++ b/ui/analyse/src/study/interfaces.ts
@@ -6,13 +6,14 @@ import { Opening } from '../explorer/interfaces';
 import AnalyseCtrl from '../ctrl';
 
 export type Tab = 'intro' | 'members' | 'chapters';
+export type ChapterTab = 'init' | 'edit' | 'game' | 'fen' | 'pgn';
 export type ToolTab = 'tags' | 'comments' | 'glyphs' | 'serverEval' | 'share' | 'multiBoard';
 export type RelayTab = 'overview' | 'schedule' | 'leaderboard';
 export type Visibility = 'public' | 'unlisted' | 'private';
 
 export interface StudyTour {
   study(ctrl: AnalyseCtrl): void;
-  chapter(cb: (tab: string) => void): void;
+  chapter(cb: (tab: ChapterTab) => void): void;
 }
 
 export interface StudyVm {


### PR DESCRIPTION
Add a type for a study's chapter tabs like the one for study tabs.

https://github.com/lichess-org/lila/blob/d58f24d66ce56da2ca3bf92680d5c4eaa5151ecc/ui/analyse/src/study/interfaces.ts#L8

Noticed while working on #14358