### PR TITLE
Fix rating diff being `undefined` when solving unrated puzzles

### DIFF
--- a/ui/puzzle/src/ctrl.ts
+++ b/ui/puzzle/src/ctrl.ts
@@ -398,6 +398,8 @@ export default class PuzzleCtrl implements ParentCtrl {
       this.data.user.provisional = next.user.provisional;
       this.round = res.round;
       if (res.round?.ratingDiff) this.session.setRatingDiff(this.data.puzzle.id, res.round.ratingDiff);
+    } else {
+      this.session.setRatingDiff(this.data.puzzle.id, 0);
     }
     if (win) lichess.sound.say('Success!');
     if (next) {


### PR DESCRIPTION
Fixes https://github.com/lichess-org/lila/issues/14393.

I would assume this bug is a regression from something else done recently. This is my first time interacting with the codebase, so I lack the full picture of where this regression potentially happened, and whether my changes are a feasible solution to the problem.

| master | this PR | 
|------------ |----|
| ![CleanShot 2024-01-06 at 12 42 12](https://github.com/lichess-org/lila/assets/58905488/e45e007d-5047-48b0-a079-2ce64ff2ac26.png) | ![CleanShot 2024-01-06 at 12 41 02](https://github.com/lichess-org/lila/assets/58905488/ddc3fb69-a487-4d89-9093-d6e52ac1e5d5.png) |

