### PR TITLE
Chartjs fixes part2

### DIFF
--- a/app/views/user/show/page.scala
+++ b/app/views/user/show/page.scala
@@ -82,7 +82,7 @@ object page:
       info.ratingChart.map: rc =>
         jsModuleInit(
           "chart.ratingHistory",
-          s"{data:$rc,perfIndex:${RatingChartApi.bestPerfIndex(info.user)}}"
+          s"{data:$rc}"
         ),
       withSearch option jsModule("gameSearch"),
       isGranted(_.UserModView) option jsModule("mod.user")

--- a/modules/history/src/main/RatingChartApi.scala
+++ b/modules/history/src/main/RatingChartApi.scala
@@ -48,8 +48,6 @@ final class RatingChartApi(
 
 object RatingChartApi:
 
-  def bestPerfIndex(user: User.WithPerfs): Int = user.perfs.bestRatedPerf.so(perfTypes indexOf _.perfType)
-
   import lila.rating.PerfType.*
   private val perfTypes = List(
     Bullet,

--- a/ui/chart/src/ratingHistory.ts
+++ b/ui/chart/src/ratingHistory.ts
@@ -23,7 +23,6 @@ import dayOfYear from 'dayjs/plugin/dayOfYear';
 interface Opts {
   data: PerfRatingHistory[];
   singlePerfName?: string;
-  perfIndex?: number;
 }
 
 type TsAndRating = { ts: number; rating: number };
@@ -64,7 +63,7 @@ const styles: ChartPerf[] = [
 
 const oneDay = 24 * 60 * 60 * 1000;
 
-export function initModule({ data, singlePerfName, perfIndex }: Opts) {
+export function initModule({ data, singlePerfName }: Opts) {
   $('.spinner').remove();
 
   const $el = $('canvas.rating-history');
@@ -73,12 +72,12 @@ export function initModule({ data, singlePerfName, perfIndex }: Opts) {
     $el.hide();
     return;
   }
-  const allData = makeDatasets(1, { data, singlePerfName, perfIndex }, singlePerfIndex);
+  const allData = makeDatasets(1, { data, singlePerfName }, singlePerfIndex);
   let startDate = dayjs(allData.startDate);
   const endDate = dayjs(allData.endDate);
   if (startDate.diff(endDate, 'D') < 1) startDate = startDate.subtract(1, 'day');
-  const weeklyData = makeDatasets(7, { data, singlePerfName, perfIndex }, singlePerfIndex);
-  const biweeklyData = makeDatasets(14, { data, singlePerfName, perfIndex }, singlePerfIndex);
+  const weeklyData = makeDatasets(7, { data, singlePerfName }, singlePerfIndex);
+  const biweeklyData = makeDatasets(14, { data, singlePerfName }, singlePerfIndex);
   const threeMonthsAgo = endDate.subtract(3, 'M');
   const initial = startDate < threeMonthsAgo ? threeMonthsAgo : startDate;
   let zoomedOut = initial.isSame(threeMonthsAgo);

--- a/ui/chart/src/ratingHistory.ts
+++ b/ui/chart/src/ratingHistory.ts
@@ -304,6 +304,7 @@ function smoothDates(data: TsAndRating[], step: number, begin: number) {
   const reversed = data.slice().reverse();
   const allDates: number[] = [];
   for (let i = begin; i <= end; i += oneStep) allDates.push(i);
+  if (!allDates.find(d => d == end)) allDates.push(end);
   const result: Point[] = [];
   for (let j = 1; j < allDates.length; j++) {
     const match = reversed.find(x => x.ts <= allDates[j]);

--- a/ui/chart/src/ratingHistory.ts
+++ b/ui/chart/src/ratingHistory.ts
@@ -42,23 +42,26 @@ Chart.defaults.font = fontFamily();
 dayjs.extend(duration);
 dayjs.extend(dayOfYear);
 
+const shortDash = [3];
+const noDash: number[] = [];
+const longDash = [10, 5];
 // order from RatingChartApi
 const styles: ChartPerf[] = [
-  { color: '#56B4E9', borderDash: [], symbol: 'circle', name: 'Bullet' },
-  { color: '#0072B2', borderDash: [], symbol: 'rectRot', name: 'Blitz' },
-  { color: '#009E73', borderDash: [], symbol: 'rect', name: 'Rapid' },
-  { color: '#459f3b', borderDash: [], symbol: 'triangle', name: 'Classical' },
-  { color: '#F0E442', borderDash: [3], symbol: 'triangle', name: 'Correspondence' },
-  { color: '#E69F00', borderDash: [3], symbol: 'circle', name: 'Chess960' },
-  { color: '#D55E00', borderDash: [3], symbol: 'rectRot', name: 'KingOfTheHill' },
-  { color: '#CC79A7', borderDash: [3], symbol: 'rect', name: 'ThreeCheck' },
-  { color: '#DF5353', borderDash: [3], symbol: 'triangle', name: 'Antichess' },
-  { color: '#66558C', borderDash: [3], symbol: 'triangle', name: 'Atomic' },
-  { color: '#99E699', borderDash: [10], symbol: 'circle', name: 'Horde' },
-  { color: '#FFAEAA', borderDash: [3], symbol: 'rectRot', name: 'RacingKings' },
-  { color: '#56B4E9', borderDash: [10], symbol: 'rectRounded', name: 'Crazyhouse' },
-  { color: '#0072B2', borderDash: [10], symbol: 'triangle', name: 'Puzzle' },
-  { color: '#009E73', borderDash: [10], symbol: 'triangle', name: 'UltraBullet' },
+  { color: '#56B4E9', borderDash: noDash, symbol: 'circle', name: 'Bullet' },
+  { color: '#0072B2', borderDash: noDash, symbol: 'rectRot', name: 'Blitz' },
+  { color: '#009E73', borderDash: noDash, symbol: 'rect', name: 'Rapid' },
+  { color: '#459f3b', borderDash: noDash, symbol: 'triangle', name: 'Classical' },
+  { color: '#F0E442', borderDash: shortDash, symbol: 'triangle', name: 'Correspondence' },
+  { color: '#E69F00', borderDash: shortDash, symbol: 'circle', name: 'Chess960' },
+  { color: '#D55E00', borderDash: shortDash, symbol: 'rectRot', name: 'KingOfTheHill' },
+  { color: '#CC79A7', borderDash: shortDash, symbol: 'rect', name: 'ThreeCheck' },
+  { color: '#DF5353', borderDash: shortDash, symbol: 'triangle', name: 'Antichess' },
+  { color: '#66558C', borderDash: shortDash, symbol: 'triangle', name: 'Atomic' },
+  { color: '#99E699', borderDash: longDash, symbol: 'circle', name: 'Horde' },
+  { color: '#FFAEAA', borderDash: shortDash, symbol: 'rectRot', name: 'RacingKings' },
+  { color: '#56B4E9', borderDash: longDash, symbol: 'rectRounded', name: 'Crazyhouse' },
+  { color: '#0072B2', borderDash: longDash, symbol: 'triangle', name: 'Puzzle' },
+  { color: '#009E73', borderDash: longDash, symbol: 'triangle', name: 'UltraBullet' },
 ];
 
 const oneDay = 24 * 60 * 60 * 1000;

--- a/ui/chart/src/ratingHistory.ts
+++ b/ui/chart/src/ratingHistory.ts
@@ -23,7 +23,7 @@ import dayOfYear from 'dayjs/plugin/dayOfYear';
 interface Opts {
   data: PerfRatingHistory[];
   singlePerfName?: string;
-  perfIndex: number;
+  perfIndex?: number;
 }
 
 type TsAndRating = { ts: number; rating: number };
@@ -59,7 +59,7 @@ const styles: ChartPerf[] = [
   { color: '#FFAEAA', borderDash: [3], symbol: 'rectRot', name: 'RacingKings' },
   { color: '#56B4E9', borderDash: [10], symbol: 'rectRounded', name: 'Crazyhouse' },
   { color: '#0072B2', borderDash: [10], symbol: 'triangle', name: 'Puzzle' },
-  { color: '#009E73', borderDash: [10], symbol: 'triangle', name: 'Ultrabullet' },
+  { color: '#009E73', borderDash: [10], symbol: 'triangle', name: 'UltraBullet' },
 ];
 
 const oneDay = 24 * 60 * 60 * 1000;

--- a/ui/common/css/component/_chart.scss
+++ b/ui/common/css/component/_chart.scss
@@ -21,6 +21,12 @@
     display: inline-flex;
     text-transform: uppercase;
     border: $border;
+
+    &.active {
+      background-color: if($theme-light, #dbebfc, #262421);
+      color: $c-font;
+      text-shadow: none !important;
+    }
   }
 
   /* Functional styling;


### PR DESCRIPTION
1. Fix perf chart not showing for variants. Edit- Closes #14394
2. Remove best perf index for user profiles. Was previously used in highcharts to construct a mini-graph of the user's best perf to display along with the time selector. Currently unusable with nouislider.
3. Change time-selector-button active color to be less harsh.