### PR TITLE
Better chart grid color on light mode for rating graph and distribution

### DIFF
--- a/ui/chart/src/common.ts
+++ b/ui/chart/src/common.ts
@@ -15,7 +15,7 @@ export const orangeAccent = '#d85000';
 export const whiteFill = lightTheme ? 'rgba(255,255,255,0.7)' : 'rgba(255,255,255,0.3)';
 export const blackFill = lightTheme ? 'rgba(0,0,0,0.2)' : 'rgba(0,0,0,1)';
 export const fontColor = lightTheme ? '#2F2F2F' : 'hsl(0, 0%, 73%)';
-export const gridColor = '#404040';
+export const gridColor = lightTheme ? '#ccc' : '#404040';
 export const hoverBorderColor = lightTheme ? gridColor : 'white';
 export const tooltipBgColor = lightTheme ? 'rgba(255, 255, 255, 0.8)' : 'rgba(22, 21, 18, 0.7)';
 

--- a/ui/insight/src/chart.ts
+++ b/ui/insight/src/chart.ts
@@ -152,13 +152,13 @@ function scaleBuilder(d: InsightData): ChartOptions<'bar'>['scales'] {
       type: 'category',
       ticks: { color: tooltipFontColor },
       grid: {
-        color: light ? '#cccccc' : gridColor,
+        color: gridColor,
       },
     },
     y1: {
       max: percent ? 1 : undefined,
       grid: {
-        color: light ? '#cccccc' : gridColor,
+        color: gridColor,
       },
       ticks: {
         color: tooltipFontColor,


### PR DESCRIPTION
The better color was already in use for insights. Color taken from highchart version, consultable here: https://web.archive.org/web/20200108113001/https://lichess.org/@/thibault

before
![Screenshot 2024-01-06 at 19 45 26](https://github.com/lichess-org/lila/assets/56031107/24f84fe9-fbe0-4524-b1da-dd61d71590e9)

after
![Screenshot 2024-01-06 at 19 45 38](https://github.com/lichess-org/lila/assets/56031107/98888a31-9fb5-4dca-8bd7-e02ca6fe76ee)


before
![Screenshot 2024-01-06 at 19 47 27](https://github.com/lichess-org/lila/assets/56031107/6eb300fa-16ed-4b87-ab99-951dbd8ff891)

after
![Screenshot 2024-01-06 at 19 47 50](https://github.com/lichess-org/lila/assets/56031107/80131b02-b5b5-49d1-8aa9-19476fc02613)


Well done @allanjoseph98 btw for finishing the migration! 🎉