### PR TITLE
update min firefox version for credentialless

### DIFF
--- a/app/Env.scala
+++ b/app/Env.scala
@@ -127,11 +127,6 @@ final class Env(
     default = false,
     text = "Use external piece images".some
   )
-  val firefoxOriginTrial = memo.settingStore[String](
-    "firefoxOriginTrial",
-    default = "",
-    text = "Firefox COEP:credentialless origin trial token. Empty to disable.".some
-  )
   import lila.memo.SettingStore.Regex.given
   import scala.util.matching.Regex
   val credentiallessUaRegex = memo.settingStore[Regex](

--- a/app/controllers/Dev.scala
+++ b/app/controllers/Dev.scala
@@ -32,7 +32,6 @@ final class Dev(env: Env) extends LilaController(env):
     env.tournament.reloadEndpointSetting,
     env.tutor.nbAnalysisSetting,
     env.tutor.parallelismSetting,
-    env.firefoxOriginTrial,
     env.credentiallessUaRegex,
     env.relay.proxyDomainRegex,
     env.relay.proxyHostPort,

--- a/app/http/CtrlExtensions.scala
+++ b/app/http/CtrlExtensions.scala
@@ -25,7 +25,7 @@ trait CtrlExtensions extends ControllerHelpers:
     def enableSharedArrayBuffer(using req: RequestHeader): Result = {
       if HTTPRequest.isChrome96Plus(req) then
         result.withHeaders("Cross-Origin-Embedder-Policy" -> "credentialless")
-      else if HTTPRequest.isFirefox114Plus(req) && env.firefoxOriginTrial.get().nonEmpty then
+      else if HTTPRequest.isFirefox119Plus(req) && env.firefoxOriginTrial.get().nonEmpty then
         result.withHeaders(
           "Origin-Trial"                 -> env.firefoxOriginTrial.get(),
           "Cross-Origin-Embedder-Policy" -> "credentialless"

--- a/app/http/CtrlExtensions.scala
+++ b/app/http/CtrlExtensions.scala
@@ -25,11 +25,8 @@ trait CtrlExtensions extends ControllerHelpers:
     def enableSharedArrayBuffer(using req: RequestHeader): Result = {
       if HTTPRequest.isChrome96Plus(req) then
         result.withHeaders("Cross-Origin-Embedder-Policy" -> "credentialless")
-      else if HTTPRequest.isFirefox119Plus(req) && env.firefoxOriginTrial.get().nonEmpty then
-        result.withHeaders(
-          "Origin-Trial"                 -> env.firefoxOriginTrial.get(),
-          "Cross-Origin-Embedder-Policy" -> "credentialless"
-        )
+      else if HTTPRequest.isFirefox119Plus(req) then
+        result.withHeaders("Cross-Origin-Embedder-Policy"    -> "credentialless")
       else result.withHeaders("Cross-Origin-Embedder-Policy" -> "require-corp")
     }.withHeaders("Cross-Origin-Opener-Policy" -> "same-origin")
     def noCache: Result = result.withHeaders(

--- a/modules/common/src/main/HTTPRequest.scala
+++ b/modules/common/src/main/HTTPRequest.scala
@@ -39,7 +39,7 @@ object HTTPRequest:
 
   val isChrome96Plus                               = UaMatcher("""Chrome/(?:\d{3,}|9[6-9])""")
   val isChrome113Plus                              = UaMatcher("""Chrome/(?:11[3-9]|1[2-9]\d)""")
-  val isFirefox114Plus                             = UaMatcher("""Firefox/(?:11[4-9]|1[2-9]\d)""")
+  val isFirefox119Plus                             = UaMatcher("""Firefox/(?:119|1[2-9]\d)""")
   val isMobileBrowser                              = UaMatcher("""(?i)iphone|ipad|ipod|android.+mobile""")
   def isLichessMobile(ua: UserAgent): Boolean      = ua.value startsWith "Lichess Mobile/"
   def isLichessMobile(req: RequestHeader): Boolean = userAgent(req).exists(isLichessMobile)


### PR DESCRIPTION
Fix what seems like a firefox origin trial expiration that prevents cross origin isolation on prod.