### PR TITLE
send diagnostics to lichess from debug dialog

### DIFF
--- a/app/controllers/ForumCateg.scala
+++ b/app/controllers/ForumCateg.scala
@@ -4,9 +4,7 @@ import lila.app.{ given, * }
 import views.*
 import lila.common.config
 import lila.forum.ForumCateg.{ diagnosticId, ublogId }
-import lila.security.Granter
 import lila.team.Team
-import org.checkerframework.checker.units.qual.s
 
 final class ForumCateg(env: Env) extends LilaController(env) with ForumController:
 
@@ -22,8 +20,8 @@ final class ForumCateg(env: Env) extends LilaController(env) with ForumControlle
       yield Ok(page)
 
   def show(slug: ForumCategId, page: Int) = Open:
-    if slug == ublogId && !Granter.opt(_.ModerateForum) then Redirect(routes.Ublog.communityAll())
-    else if slug == diagnosticId && !Granter.opt(_.ModerateForum) then notFound
+    if slug == ublogId && !isGrantedOpt(_.ModerateForum) then Redirect(routes.Ublog.communityAll())
+    else if slug == diagnosticId && !isGrantedOpt(_.ModerateForum) then notFound
     else
       NotForKids:
         Reasonable(page, config.Max(50), notFound):

--- a/app/controllers/ForumCateg.scala
+++ b/app/controllers/ForumCateg.scala
@@ -3,7 +3,10 @@ package controllers
 import lila.app.{ given, * }
 import views.*
 import lila.common.config
+import lila.forum.ForumCateg.{ diagnosticId, ublogId }
+import lila.security.Granter
 import lila.team.Team
+import org.checkerframework.checker.units.qual.s
 
 final class ForumCateg(env: Env) extends LilaController(env) with ForumController:
 
@@ -19,8 +22,8 @@ final class ForumCateg(env: Env) extends LilaController(env) with ForumControlle
       yield Ok(page)
 
   def show(slug: ForumCategId, page: Int) = Open:
-    if slug == lila.forum.ForumCateg.ublogId
-    then Redirect(routes.Ublog.communityAll())
+    if slug == ublogId && !Granter.opt(_.ModerateForum) then Redirect(routes.Ublog.communityAll())
+    else if slug == diagnosticId && !Granter.opt(_.ModerateForum) then notFound
     else
       NotForKids:
         Reasonable(page, config.Max(50), notFound):

--- a/app/controllers/ForumTopic.scala
+++ b/app/controllers/ForumTopic.scala
@@ -1,10 +1,14 @@
 package controllers
 
+import play.api.data.Form
+import play.api.data.Forms.*
 import play.api.libs.json.*
+
 import views.*
 
 import lila.app.{ given, * }
 import lila.common.IpAddress
+import lila.forum.ForumCateg.diagnosticId
 
 final class ForumTopic(env: Env) extends LilaController(env) with ForumController:
 
@@ -51,23 +55,27 @@ final class ForumTopic(env: Env) extends LilaController(env) with ForumControlle
   def show(categId: ForumCategId, slug: String, page: Int) = Open:
     NotForKids:
       Found(topicApi.show(categId, slug, page)): (categ, topic, posts) =>
-        for
-          unsub       <- ctx.me soUse env.timeline.status(s"forum:${topic.id}")
-          canRead     <- access.isGrantedRead(categ.slug)
-          canWrite    <- access.isGrantedWrite(categ.slug, tryingToPostAsMod = true)
-          canModCateg <- access.isGrantedMod(categ.slug)
-          inOwnTeam   <- ~(categ.team, ctx.me).mapN(env.team.api.isLeader(_, _))
-          form <- ctx.me
-            .filter(_ => canWrite && topic.open && !topic.isOld)
-            .soUse: _ ?=>
-              forms.postWithCaptcha(inOwnTeam) map some
-          _ <- env.user.lightUserApi preloadMany posts.currentPageResults.flatMap(_.post.userId)
-          res <-
-            if canRead then
-              Ok.page(html.forum.topic.show(categ, topic, posts, form, unsub, canModCateg = canModCateg))
-                .map(_.withCanonical(routes.ForumTopic.show(categ.slug, topic.slug, page)))
-            else notFound
-        yield res
+        val isMine = ctx.me.exists(_ is UserId(slug)) // golf me
+        if categId == diagnosticId && !isMine && !isGrantedOpt(_.ModerateForum)
+        then notFound
+        else
+          for
+            unsub       <- ctx.me soUse env.timeline.status(s"forum:${topic.id}")
+            canRead     <- access.isGrantedRead(categ.slug)
+            canWrite    <- access.isGrantedWrite(categ.slug, tryingToPostAsMod = true)
+            canModCateg <- access.isGrantedMod(categ.slug)
+            inOwnTeam   <- ~(categ.team, ctx.me).mapN(env.team.api.isLeader(_, _))
+            form <- ctx.me
+              .filter(_ => canWrite && topic.open && !topic.isOld)
+              .soUse: _ ?=>
+                forms.postWithCaptcha(inOwnTeam) map some
+            _ <- env.user.lightUserApi preloadMany posts.currentPageResults.flatMap(_.post.userId)
+            res <-
+              if canRead then
+                Ok.page(html.forum.topic.show(categ, topic, posts, form, unsub, canModCateg))
+                  .map(_.withCanonical(routes.ForumTopic.show(categ.slug, topic.slug, page)))
+              else notFound
+          yield res
 
   def close(categId: ForumCategId, slug: String) = Auth { _ ?=> me ?=>
     TopicGrantModBySlug(categId, slug):
@@ -91,3 +99,32 @@ final class ForumTopic(env: Env) extends LilaController(env) with ForumControlle
       usernames <- env.user.repo usernamesByIds userIds
     yield Ok(Json.toJson(usernames.sortBy(_.toLowerCase)))
   }
+
+  def diagnostic = AuthBody { ctx ?=> me ?=>
+    NoBot:
+      val slug = me.userId.value
+      Form(single("text" -> nonEmptyText)).bindFromRequest().value match
+        case None => BadRequest("Invalid form")
+        case Some(text) =>
+          env.forum.topicRepo.existsByTree(diagnosticId, slug) flatMap:
+            case true => showDiagnostic(slug, text)
+            case false =>
+              FoundPage(env.forum.categRepo byId diagnosticId): categ =>
+                forms.anyCaptcha map { html.forum.topic.makeDiagnostic(categ, forms.topic(false), _, text) }
+  }
+
+  def clearDiagnostic(slug: String) = Auth { _ ?=> me ?=>
+    if slug != me.userId.value && !isGranted(_.ModerateForum) then notFound
+    else env.forum.topicApi.removeTopic(diagnosticId, slug) inject Redirect(routes.ForumCateg.index)
+  }
+
+  private def showDiagnostic(slug: String, formText: String)(using Context, Me) =
+    Found(topicApi.showLastPage(diagnosticId, slug)): (categ, topic, posts) =>
+      val lastPage = topicApi.lastPage(topic)
+      for
+        form <- forms.postWithCaptcha(false) map some
+        _    <- env.user.lightUserApi preloadMany posts.currentPageResults.flatMap(_.post.userId)
+        res <-
+          Ok.page(html.forum.topic.show(categ, topic, posts, form, None, true, formText.some))
+            .map(_.withCanonical(s"${routes.ForumTopic.show(categ.slug, slug, lastPage)}#reply"))
+      yield res

--- a/app/controllers/ForumTopic.scala
+++ b/app/controllers/ForumTopic.scala
@@ -55,8 +55,7 @@ final class ForumTopic(env: Env) extends LilaController(env) with ForumControlle
   def show(categId: ForumCategId, slug: String, page: Int) = Open:
     NotForKids:
       Found(topicApi.show(categId, slug, page)): (categ, topic, posts) =>
-        val isMine = ctx.me.exists(_ is UserId(slug)) // golf me
-        if categId == diagnosticId && !isMine && !isGrantedOpt(_.ModerateForum)
+        if categId == diagnosticId && !ctx.is(UserId(slug)) && !isGrantedOpt(_.ModerateForum)
         then notFound
         else
           for

--- a/app/controllers/ForumTopic.scala
+++ b/app/controllers/ForumTopic.scala
@@ -1,11 +1,7 @@
 package controllers
 
-import play.api.data.Form
-import play.api.data.Forms.*
 import play.api.libs.json.*
-
 import views.*
-
 import lila.app.{ given, * }
 import lila.common.IpAddress
 import lila.forum.ForumCateg.diagnosticId
@@ -102,7 +98,7 @@ final class ForumTopic(env: Env) extends LilaController(env) with ForumControlle
   def diagnostic = AuthBody { ctx ?=> me ?=>
     NoBot:
       val slug = me.userId.value
-      Form(single("text" -> nonEmptyText)).bindFromRequest().value match
+      env.forum.forms.diagnostic.bindFromRequest().value match
         case None => BadRequest("Invalid form")
         case Some(text) =>
           env.forum.topicRepo.existsByTree(diagnosticId, slug) flatMap:

--- a/app/controllers/ForumTopic.scala
+++ b/app/controllers/ForumTopic.scala
@@ -55,7 +55,7 @@ final class ForumTopic(env: Env) extends LilaController(env) with ForumControlle
   def show(categId: ForumCategId, slug: String, page: Int) = Open:
     NotForKids:
       Found(topicApi.show(categId, slug, page)): (categ, topic, posts) =>
-        if categId == diagnosticId && !ctx.is(UserId(slug)) && !isGrantedOpt(_.ModerateForum)
+        if categId == diagnosticId && !ctx.is(UserStr(slug)) && !isGrantedOpt(_.ModerateForum)
         then notFound
         else
           for

--- a/app/controllers/ForumTopic.scala
+++ b/app/controllers/ForumTopic.scala
@@ -112,7 +112,7 @@ final class ForumTopic(env: Env) extends LilaController(env) with ForumControlle
   }
 
   def clearDiagnostic(slug: String) = Auth { _ ?=> me ?=>
-    if slug != me.userId.value && !isGranted(_.ModerateForum) then notFound
+    if me.isnt(UserStr(slug)) && !isGranted(_.ModerateForum) then notFound
     else env.forum.topicApi.removeTopic(diagnosticId, slug) inject Redirect(routes.ForumCateg.index)
   }
 

--- a/app/views/forum/categ.scala
+++ b/app/views/forum/categ.scala
@@ -122,19 +122,18 @@ object categ:
         )
       ),
       tbody:
+        val isMod = isGranted(_.ModerateForum)
         categs.map: view =>
           view.lastPost.map: (topic, post, page) =>
-            val canBrowse = isGranted(_.ModerateForum) || !view.categ.hidden
-            val postLink  = s"${routes.ForumTopic.show(view.slug, topic.slug, page)}#${post.number}"
-            val categLink =
+            val canBrowse = isMod || !view.categ.hidden
+            val postUrl   = s"${routes.ForumTopic.show(view.slug, topic.slug, page)}#${post.number}"
+            val categUrl =
               if canBrowse then routes.ForumCateg.show(view.slug).url
               else routes.ForumTopic.show(view.slug, topic.slug, 1).url
             tr(
-              td(cls := "subject")(h2(a(href := categLink)(view.name)), p(view.desc)),
+              td(cls := "subject")(h2(a(href := categUrl)(view.name)), p(view.desc)),
               td(cls := "right")((if canBrowse then view.nbTopics else 1).localize),
               td(cls := "right")((if canBrowse then view.nbPosts else topic.nbPosts).localize),
-              td(
-                frag(a(href := postLink)(momentFromNow(post.createdAt)), br, trans.by(bits.authorLink(post)))
-              )
+              td(a(href := postUrl)(momentFromNow(post.createdAt)), br, trans.by(bits.authorLink(post)))
             )
     )

--- a/app/views/forum/categ.scala
+++ b/app/views/forum/categ.scala
@@ -126,7 +126,9 @@ object categ:
           view.lastPost.map: (topic, post, page) =>
             val canBrowse = isGranted(_.ModerateForum) || !view.categ.hidden
             val postLink  = s"${routes.ForumTopic.show(view.slug, topic.slug, page)}#${post.number}"
-            val categLink = if !canBrowse then postLink else s"${routes.ForumCateg.show(view.slug)}"
+            val categLink =
+              if canBrowse then routes.ForumCateg.show(view.slug).url
+              else routes.ForumTopic.show(view.slug, topic.slug, 1).url
             tr(
               td(cls := "subject")(h2(a(href := categLink)(view.name)), p(view.desc)),
               td(cls := "right")((if canBrowse then view.nbTopics else 1).localize),

--- a/app/views/forum/categ.scala
+++ b/app/views/forum/categ.scala
@@ -5,7 +5,7 @@ import controllers.team.routes.{ Team as teamRoutes }
 import lila.app.templating.Environment.{ given, * }
 import lila.app.ui.ScalatagsTemplate.{ *, given }
 import lila.common.paginator.Paginator
-import lila.forum.{ ForumTopic, ForumCateg, CategView, TopicView }
+import lila.forum.{ CategView, TopicView }
 
 import controllers.routes
 
@@ -37,7 +37,7 @@ object categ:
       )
 
   def show(
-      categ: ForumCateg,
+      categ: lila.forum.ForumCateg,
       topics: Paginator[TopicView],
       canWrite: Boolean,
       stickyPosts: List[TopicView]

--- a/app/views/forum/topic.scala
+++ b/app/views/forum/topic.scala
@@ -8,11 +8,12 @@ import play.api.data.Form
 
 import lila.app.templating.Environment.{ given, * }
 import lila.app.ui.ScalatagsTemplate.{ *, given }
+import lila.common.Captcha
 import lila.common.paginator.Paginator
 
 object topic:
 
-  def form(categ: lila.forum.ForumCateg, form: Form[?], captcha: lila.common.Captcha)(using PageContext) =
+  def form(categ: lila.forum.ForumCateg, form: Form[?], captcha: Captcha)(using PageContext) =
     views.html.base.layout(
       title = "New forum topic",
       moreCss = cssTag("forum"),
@@ -71,7 +72,8 @@ object topic:
       posts: Paginator[lila.forum.ForumPost.WithFrag],
       formWithCaptcha: Option[FormWithCaptcha],
       unsub: Option[Boolean],
-      canModCateg: Boolean
+      canModCateg: Boolean,
+      formText: Option[String] = None
   )(using ctx: PageContext) =
     views.html.base.layout(
       title = s"${topic.name} • page ${posts.currentPage}/${posts.nbPages} • ${categ.name}",
@@ -90,20 +92,23 @@ object topic:
         .some,
       csp = defaultCsp.withInlineIconFont.withTwitter.some
     ):
+      import lila.forum.ForumCateg.diagnosticId
+      val isDiagnostic = categ.id == diagnosticId && (canModCateg || ctx.me.exists(topic.isAuthor))
+      val headerText   = if isDiagnostic then s"Troubleshooting" else topic.name
+      val backLink =
+        if isDiagnostic && !canModCateg then routes.ForumCateg.index.url
+        else
+          topic.ublogId.fold(s"${routes.ForumCateg.show(categ.slug)}"): id =>
+            routes.Ublog.redirect(id).url
+
       val teamOnly = categ.team.filterNot(isMyTeamSync)
       val pager = views.html.base.bits
         .paginationByQuery(routes.ForumTopic.show(categ.slug, topic.slug, 1), posts, showPost = true)
       main(cls := "forum forum-topic page-small box box-pad")(
         boxTop(
-          h1(
-            a(
-              href := topic.ublogId.fold(s"${routes.ForumCateg.show(categ.slug)}") { id =>
-                routes.Ublog.redirect(id).url
-              },
-              dataIcon := licon.LessThan,
-              cls      := "text"
-            ),
-            topic.name
+          h1(a(href := backLink, dataIcon := licon.LessThan, cls := "text"), headerText),
+          isDiagnostic option postForm(action := routes.ForumTopic.clearDiagnostic(topic.slug))(
+            button(cls := "button button-red")("erase diagnostics")
           )
         ),
         pager,
@@ -178,7 +183,9 @@ object topic:
                 "Forum etiquette"
               ).some
             ): f =>
-              form3.textarea(f, klass = "post-text-area")(rows := 10, bits.dataTopic := topic.id),
+              form3.textarea(f, klass = "post-text-area")(rows := 10, bits.dataTopic := topic.id)(
+                formText
+              ),
             views.html.base.captcha(form, captcha),
             form3.actions(
               a(href := routes.ForumCateg.show(categ.slug))(trans.cancel()),
@@ -191,6 +198,36 @@ object topic:
               form3.submit(trans.reply())
             )
           )
+      )
+
+  def makeDiagnostic(categ: lila.forum.ForumCateg, form: Form[?], captcha: Captcha, text: String)(using
+      PageContext
+  )(using me: Me) =
+    views.html.base.layout(
+      title = "Diagnostic report",
+      moreCss = cssTag("forum"),
+      moreJs = frag(
+        jsModule("forum"),
+        captchaTag
+      )
+    ):
+      main(cls := "forum forum-topic topic-form page-small box box-pad")(
+        boxTop(h1(dataIcon := licon.BubbleConvo, cls := "text")("Troubleshooting")),
+        st.section(cls := "warning")(
+          h2(dataIcon := licon.CautionTriangle, cls := "text")(trans.important()),
+          p("Unsolicited diagnostic reports will not be seen."),
+          p("Feel free to remove lines that are private or not relevant.")
+        ),
+        postForm(cls := "form3", action := routes.ForumTopic.create(categ.slug))(
+          form3.group(form("post")("text"), trans.message())(
+            form3.textarea(_, klass = "post-text-area")(rows := 10)(text)
+          ),
+          form3.group(form("name"), "")(
+            form3.input(_, typ = "hidden")(value := me.username.value)
+          ),
+          views.html.base.captcha(form("post"), captcha),
+          form3.actions(form3.submit("submit"))
+        )
       )
 
   private def deleteModal =

--- a/app/views/forum/topic.scala
+++ b/app/views/forum/topic.scala
@@ -92,10 +92,9 @@ object topic:
         .some,
       csp = defaultCsp.withInlineIconFont.withTwitter.some
     ):
-      import lila.forum.ForumCateg.diagnosticId
-      val isDiagnostic = categ.id == diagnosticId && (canModCateg || ctx.me.exists(topic.isAuthor))
-      val headerText   = if isDiagnostic then s"Diagnostics" else topic.name
-      val backLink =
+      val isDiagnostic = categ.isDiagnostic && (canModCateg || ctx.me.exists(topic.isAuthor))
+      val headerText   = if isDiagnostic then "Diagnostics" else topic.name
+      val backUrl =
         if isDiagnostic && !canModCateg then routes.ForumCateg.index.url
         else
           topic.ublogId.fold(s"${routes.ForumCateg.show(categ.slug)}"): id =>
@@ -106,7 +105,7 @@ object topic:
         .paginationByQuery(routes.ForumTopic.show(categ.slug, topic.slug, 1), posts, showPost = true)
       main(cls := "forum forum-topic page-small box box-pad")(
         boxTop(
-          h1(a(href := backLink, dataIcon := licon.LessThan, cls := "text"), headerText),
+          h1(a(href := backUrl, dataIcon := licon.LessThan, cls := "text"), headerText),
           isDiagnostic option postForm(action := routes.ForumTopic.clearDiagnostic(topic.slug))(
             button(cls := "button button-red")("erase diagnostics")
           )

--- a/app/views/forum/topic.scala
+++ b/app/views/forum/topic.scala
@@ -215,8 +215,8 @@ object topic:
         boxTop(h1(dataIcon := licon.BubbleConvo, cls := "text")("Troubleshooting")),
         st.section(cls := "warning")(
           h2(dataIcon := licon.CautionTriangle, cls := "text")(trans.important()),
-          p("Unsolicited diagnostic reports will not be seen."),
-          p("Feel free to remove lines that are private or not relevant.")
+          p("Noone can see this forum except you and the Lichess moderators."),
+          p("Unsolicited diagnostic reports will be ignored.")
         ),
         postForm(cls := "form3", action := routes.ForumTopic.create(categ.slug))(
           form3.group(form("post")("text"), trans.message())(

--- a/app/views/forum/topic.scala
+++ b/app/views/forum/topic.scala
@@ -94,7 +94,7 @@ object topic:
     ):
       import lila.forum.ForumCateg.diagnosticId
       val isDiagnostic = categ.id == diagnosticId && (canModCateg || ctx.me.exists(topic.isAuthor))
-      val headerText   = if isDiagnostic then s"Troubleshooting" else topic.name
+      val headerText   = if isDiagnostic then s"Diagnostics" else topic.name
       val backLink =
         if isDiagnostic && !canModCateg then routes.ForumCateg.index.url
         else
@@ -212,11 +212,11 @@ object topic:
       )
     ):
       main(cls := "forum forum-topic topic-form page-small box box-pad")(
-        boxTop(h1(dataIcon := licon.BubbleConvo, cls := "text")("Troubleshooting")),
+        boxTop(h1(dataIcon := licon.BubbleConvo, cls := "text")("Diagnostics")),
         st.section(cls := "warning")(
           h2(dataIcon := licon.CautionTriangle, cls := "text")(trans.important()),
-          p("Noone can see this forum except you and the Lichess moderators."),
-          p("Unsolicited diagnostic reports will be ignored.")
+          p("Unsolicited reports will be ignored."),
+          p("Only you and the Lichess moderators can see this forum.")
         ),
         postForm(cls := "form3", action := routes.ForumTopic.create(categ.slug))(
           form3.group(form("post")("text"), trans.message())(

--- a/app/views/forum/topic.scala
+++ b/app/views/forum/topic.scala
@@ -221,9 +221,7 @@ object topic:
           form3.group(form("post")("text"), trans.message())(
             form3.textarea(_, klass = "post-text-area")(rows := 10)(text)
           ),
-          form3.group(form("name"), "")(
-            form3.input(_, typ = "hidden")(value := me.username.value)
-          ),
+          form3.hidden("name", me.username.value),
           views.html.base.captcha(form("post"), captcha),
           form3.actions(form3.submit("submit"))
         )

--- a/bin/mongodb/diagnostic-categ.js
+++ b/bin/mongodb/diagnostic-categ.js
@@ -56,12 +56,3 @@ const diagnostic = {
 };
 
 db.f_categ.insertOne(diagnostic);
-
-const id = () => {
-  let id = '';
-  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-  while (id.length < 8) {
-    id += chars.charAt(Math.floor(Math.random() * chars.length));
-  }
-  return id;
-};

--- a/bin/mongodb/diagnostic-categ.js
+++ b/bin/mongodb/diagnostic-categ.js
@@ -1,0 +1,67 @@
+// prepare forum collections to allow "send diagnostics to lichess" feature
+
+const makeId = () => {
+  let id = '';
+  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  while (id.length < 8) {
+    id += chars.charAt(Math.floor(Math.random() * chars.length));
+  }
+  return id;
+};
+
+const topic = {
+  _id: makeId(),
+  name: 'lichess',
+  slug: 'lichess',
+  userId: 'lichess',
+  categId: 'diagnostic',
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  updatedAtTroll: new Date(),
+  nbPosts: 1,
+  nbPostsTroll: 1,
+  troll: false,
+  closed: false,
+};
+
+db.f_topic.insertOne(topic).insertedId;
+
+const post = {
+  _id: makeId(),
+  text: '',
+  troll: false,
+  createdAt: new Date(),
+  userId: 'lichess',
+  author: 'lichess',
+  topicId: topic._id,
+  categId: 'diagnostic',
+  number: 1,
+  topic: 'none',
+};
+
+db.f_topic.updateOne({ _id: topic._id }, { $set: { lastPostId: post._id, lastPostIdTroll: post._id } });
+
+const diagnostic = {
+  _id: 'diagnostic',
+  name: 'Diagnostic',
+  desc: 'Your diagnostic reports',
+  nbTopics: 1,
+  nbPosts: 1,
+  nbTopicsTroll: 1,
+  nbPostsTroll: 1,
+  lastPostId: post._id,
+  lastPostIdTroll: post._id,
+  hidden: true,
+  quiet: true,
+};
+
+db.f_categ.insertOne(diagnostic);
+
+const id = () => {
+  let id = '';
+  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  while (id.length < 8) {
+    id += chars.charAt(Math.floor(Math.random() * chars.length));
+  }
+  return id;
+};

--- a/conf/routes
+++ b/conf/routes
@@ -588,10 +588,12 @@ GET   /forum/:categSlug/:slug          controllers.ForumTopic.show(categSlug, sl
 POST  /forum/:categSlug/:slug/close    controllers.ForumTopic.close(categSlug, slug)
 POST  /forum/:categSlug/:slug/sticky   controllers.ForumTopic.sticky(categSlug, slug)
 POST  /forum/:categSlug/:slug/new      controllers.ForumPost.create(categSlug, slug, page: Int ?= 1)
-POST  /forum/delete/:id     controllers.ForumPost.delete(id)
+POST  /forum/delete/:id                controllers.ForumPost.delete(id)
 POST  /forum/:categSlug/react/:id/:reaction/:v controllers.ForumPost.react(categSlug, id, reaction, v: Boolean)
 POST  /forum/post/:id                  controllers.ForumPost.edit(id)
 GET   /forum/redirect/post/:id         controllers.ForumPost.redirect(id)
+POST  /diagnostic                      controllers.ForumTopic.diagnostic
+POST  /diagnostic/clear/:slug          controllers.ForumTopic.clearDiagnostic(slug)
 
 # Msg compat
 POST  /inbox/new                       controllers.Msg.compatCreate

--- a/modules/forum/src/main/ForumCateg.scala
+++ b/modules/forum/src/main/ForumCateg.scala
@@ -24,7 +24,8 @@ case class ForumCateg(
   def lastPostId(forUser: Option[User]): ForumPostId =
     if forUser.exists(_.marks.troll) then lastPostIdTroll else lastPostId
 
-  def isTeam = team.nonEmpty
+  def isTeam       = team.nonEmpty
+  def isDiagnostic = id == ForumCateg.diagnosticId
 
   def withPost(topic: ForumTopic, post: ForumPost): ForumCateg =
     copy(

--- a/modules/forum/src/main/ForumCateg.scala
+++ b/modules/forum/src/main/ForumCateg.scala
@@ -37,11 +37,22 @@ case class ForumCateg(
       lastPostIdTroll = if topic.isTooBig then lastPostIdTroll else post.id
     )
 
+  def withoutTopic(topic: ForumTopic, lastPostId: ForumPostId, lastPostIdTroll: ForumPostId): ForumCateg =
+    copy(
+      nbTopics = nbTopics - 1,
+      nbTopicsTroll = nbTopicsTroll - 1,
+      nbPosts = nbPosts - topic.nbPosts,
+      nbPostsTroll = nbPostsTroll - topic.nbPostsTroll,
+      lastPostId = lastPostId,
+      lastPostIdTroll = lastPostIdTroll
+    )
+
   def slug = id
 
 object ForumCateg:
 
-  val ublogId = ForumCategId("community-blog-discussions")
+  val ublogId      = ForumCategId("community-blog-discussions")
+  val diagnosticId = ForumCategId("diagnostic")
 
   def isTeamSlug(id: ForumCategId) = id.value.startsWith("team-")
 

--- a/modules/forum/src/main/ForumCategRepo.scala
+++ b/modules/forum/src/main/ForumCategRepo.scala
@@ -9,11 +9,10 @@ final private class ForumCategRepo(val coll: Coll)(using Executor):
   def byId(id: ForumCategId) = coll.byId[ForumCateg](id)
 
   def visibleWithTeams(teams: Iterable[TeamId], isMod: Boolean = false): Fu[List[ForumCateg]] =
-    val notTeam = $doc("team" $exists false)
     coll
       .find(
         $or(
-          if isMod then notTeam else notTeam ++ $doc("hidden" $ne true),
+          $doc("team" $exists false) ++ (!isMod).so($doc("hidden" $ne true)),
           $doc("team" $in teams)
         )
       )

--- a/modules/forum/src/main/ForumCategRepo.scala
+++ b/modules/forum/src/main/ForumCategRepo.scala
@@ -9,10 +9,11 @@ final private class ForumCategRepo(val coll: Coll)(using Executor):
   def byId(id: ForumCategId) = coll.byId[ForumCateg](id)
 
   def visibleWithTeams(teams: Iterable[TeamId], isMod: Boolean = false): Fu[List[ForumCateg]] =
+    val notTeam = $doc("team" $exists false)
     coll
       .find(
         $or(
-          $doc("team" $exists false) ++ (if isMod then $doc() else $doc("hidden" $ne true)),
+          if isMod then notTeam else notTeam ++ $doc("hidden" $ne true),
           $doc("team" $in teams)
         )
       )

--- a/modules/forum/src/main/ForumCategRepo.scala
+++ b/modules/forum/src/main/ForumCategRepo.scala
@@ -8,11 +8,11 @@ final private class ForumCategRepo(val coll: Coll)(using Executor):
 
   def byId(id: ForumCategId) = coll.byId[ForumCateg](id)
 
-  def visibleWithTeams(teams: Iterable[TeamId]): Fu[List[ForumCateg]] =
+  def visibleWithTeams(teams: Iterable[TeamId], isMod: Boolean = false): Fu[List[ForumCateg]] =
     coll
       .find(
         $or(
-          $doc("hidden" $ne true, "team" $exists false),
+          $doc("team" $exists false) ++ (if isMod then $doc() else $doc("hidden" $ne true)),
           $doc("team" $in teams)
         )
       )

--- a/modules/forum/src/main/ForumForm.scala
+++ b/modules/forum/src/main/ForumForm.scala
@@ -51,6 +51,8 @@ final private[forum] class ForumForm(
         t => inOwnTeam || promotion.test(t, previousText)
       )
 
+  val diagnostic = Form(single("text" -> nonEmptyText(maxLength = 9000)))
+
 object ForumForm:
 
   case class PostData(

--- a/modules/forum/src/main/ForumPost.scala
+++ b/modules/forum/src/main/ForumPost.scala
@@ -116,10 +116,10 @@ object ForumPost:
       categId: ForumCategId,
       userId: Option[UserId], // anon mod posts
       text: String,
-      number: Int,
-      lang: Option[String],
-      troll: Boolean,
-      modIcon: Option[Boolean] = None
+      number: Int = 1,
+      lang: Option[String] = none,
+      troll: Boolean = false,
+      modIcon: Option[Boolean] = none
   ): ForumPost =
     ForumPost(
       _id = ForumPostId(ThreadLocalRandom nextString idSize),

--- a/modules/forum/src/main/ForumPostApi.scala
+++ b/modules/forum/src/main/ForumPostApi.scala
@@ -67,9 +67,7 @@ final class ForumPostApi(
                 _ toFollowersOf me toUsers topicUserIds exceptUser me withTeam categ.team
               }
             else if categ.id == ForumCateg.diagnosticId then
-              timeline ! Propagate(TimelinePost(me, topic.id, topic.name, post.id)).pipe {
-                _ toUsers topicUserIds
-              }
+              timeline ! Propagate(TimelinePost(me, topic.id, topic.name, post.id)).toUsers(topicUserIds)
             lila.mon.forum.post.create.increment()
             mentionNotifier.notifyMentionedUsers(post, topic)
             Bus.publish(CreatePost(post), "forumPost")

--- a/modules/forum/src/main/ForumPostApi.scala
+++ b/modules/forum/src/main/ForumPostApi.scala
@@ -66,10 +66,10 @@ final class ForumPostApi(
               timeline ! Propagate(TimelinePost(me, topic.id, topic.name, post.id)).pipe {
                 _ toFollowersOf me toUsers topicUserIds exceptUser me withTeam categ.team
               }
-            else if categ.id == ForumCateg.diagnosticId then
+            else if categ.isDiagnostic then
               timeline ! Propagate(TimelinePost(me, topic.id, topic.name, post.id)).toUsers(topicUserIds)
             lila.mon.forum.post.create.increment()
-            mentionNotifier.notifyMentionedUsers(post, topic)
+            if !categ.isDiagnostic then mentionNotifier.notifyMentionedUsers(post, topic)
             Bus.publish(CreatePost(post), "forumPost")
             post
       }

--- a/modules/forum/src/main/ForumPostApi.scala
+++ b/modules/forum/src/main/ForumPostApi.scala
@@ -8,7 +8,6 @@ import lila.hub.actorApi.timeline.{ ForumPost as TimelinePost, Propagate }
 import lila.hub.actorApi.shutup.{ PublicSource, RecordPublicText, RecordTeamForumMessage }
 import lila.security.{ Granter as MasterGranter }
 import lila.user.{ Me, User }
-import lila.i18n.I18nKeys.learn.thenPlaceTheKnights
 
 final class ForumPostApi(
     postRepo: ForumPostRepo,

--- a/modules/forum/src/main/ForumTopic.scala
+++ b/modules/forum/src/main/ForumTopic.scala
@@ -82,7 +82,7 @@ object ForumTopic:
       slug: String,
       name: String,
       userId: UserId,
-      troll: Boolean,
+      troll: Boolean = false,
       ublogId: Option[String] = None
   ): ForumTopic = ForumTopic(
     _id = ForumTopicId(ThreadLocalRandom nextString idSize),

--- a/ui/site/css/_diagnostic.scss
+++ b/ui/site/css/_diagnostic.scss
@@ -25,6 +25,17 @@
     color: $c-good;
   }
 
+  .actions {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    column-gap: 1em;
+  }
+
+  .spacer {
+    flex-grow: 1;
+  }
+
   pre {
     width: 100%;
     font-size: 12px;

--- a/ui/site/src/diagnostic.ts
+++ b/ui/site/src/diagnostic.ts
@@ -3,6 +3,7 @@ import { domDialog } from 'common/dialog';
 import * as licon from 'common/licon';
 
 export default async function initModule() {
+  const ops = processQueryParams();
   const logs = await lichess.log.get();
   const text =
     `Browser: ${navigator.userAgent}\n` +
@@ -13,12 +14,11 @@ export default async function initModule() {
     `Engine: ${lichess.storage.get('ceval.engine')}, ` +
     `Threads: ${lichess.storage.get('ceval.threads')}` +
     (logs ? `\n\n${logs}` : '');
-
-  const ops = processQueryParams();
+  const escaped = lichess.escapeHtml(text);
   const flash = ops > 0 ? `<p class="good">Changes applied</p>` : '';
   const submit = document.body.dataset.user
     ? `<form method="post" action="/diagnostic">
-      <input type="hidden" name="text" value="${lichess.escapeHtml(text)}"/>
+      <input type="hidden" name="text" value="${escaped}"/>
       <button type="submit" class="button">send to lichess</button></form>`
     : '';
   const clear = logs ? `<button class="button button-empty button-red">clear logs</button>` : '';
@@ -28,7 +28,7 @@ export default async function initModule() {
     cssPath: 'diagnostic',
     htmlText: `
       <h2>Diagnostics</h2>${flash}
-      <pre tabindex="0" class="err">${lichess.escapeHtml(text)}</pre>
+      <pre tabindex="0" class="err">${escaped}</pre>
       <span class="actions"> ${clear} <div class="spacer"></div> ${copy} ${submit} </span>`,
   });
   const select = () =>
@@ -50,25 +50,22 @@ export default async function initModule() {
   dlg.showModal();
 }
 
-const storageProxy: { [key: string]: (val?: string) => boolean } = {
-  wsPing: (val?: string) => {
-    const storageKey = 'socket.ping.interval';
-    if (!val) lichess.storage.remove(storageKey);
-    else if (parseInt(val) > 249) lichess.storage.set(storageKey, val);
-    else return false;
-    return true;
+const storageProxy: { [key: string]: { storageKey: string; validate: (val?: string) => boolean } } = {
+  wsPing: {
+    storageKey: 'socket.ping.interval',
+    validate: (val?: string) => parseInt(val ?? '') > 249,
   },
-  wsHost: (val?: string) => {
-    const storageKey = 'socket.host';
-    if (!val) lichess.storage.remove(storageKey);
-    /*if (val.match(/^[a-z0-9-]+\.lichess\.org$/))*/ else lichess.storage.set(storageKey, val);
-    return true;
+  wsHost: {
+    storageKey: 'socket.host',
+    validate: (val?: string) => val?.endsWith('.lichess.org') ?? false,
   },
-  allowLsfw: (val?: string) => {
-    const storageKey = 'ceval.lsfw.forceEnable';
-    if (!val) lichess.storage.remove(storageKey);
-    else lichess.storage.set(storageKey, val);
-    return true;
+  allowLsfw: {
+    storageKey: 'ceval.lsfw.forceEnable',
+    validate: (val?: string) => val === 'true' || val === 'false',
+  },
+  logWindow: {
+    storageKey: 'log.window',
+    validate: (val?: string) => parseInt(val ?? '') >= 0,
   },
 };
 
@@ -76,15 +73,22 @@ const ops: { [op: string]: (val?: string) => boolean } = {
   set: (data: string) => {
     try {
       const kv = atob(data).split('=');
-      return storageProxy[kv[0]]?.(kv[1]) ?? false;
+      const proxy = storageProxy[kv[0]];
+      if (proxy?.validate(kv[1])) {
+        lichess.log(`storage set ${kv[0]}=${kv[1]}`);
+        lichess.storage.set(proxy.storageKey, kv[1]);
+        return true;
+      }
     } catch (_) {
       console.warn('Invalid base64', data);
-      return false;
     }
+    return false;
   },
   unset: (val: string) => {
-    if (!val) for (const key in storageProxy) storageProxy[key]?.();
-    else if (val in storageProxy) storageProxy[val]();
+    lichess.log(`storage unset ${val ? val : 'all'}`);
+
+    if (!val) for (const key in storageProxy) lichess.storage.remove(storageProxy[key].storageKey);
+    else if (val in storageProxy) lichess.storage.remove(storageProxy[val].storageKey);
     else return false;
     return true;
   },

--- a/ui/site/src/diagnostic.ts
+++ b/ui/site/src/diagnostic.ts
@@ -9,22 +9,27 @@ export default async function initModule() {
     `Cores: ${navigator.hardwareConcurrency}, ` +
     `Touch: ${isTouchDevice()} ${navigator.maxTouchPoints}, ` +
     `Screen: ${window.screen.width}x${window.screen.height}, ` +
-    `Lang: ${navigator.language}\n` +
+    `Lang: ${navigator.language}, ` +
     `Engine: ${lichess.storage.get('ceval.engine')}, ` +
     `Threads: ${lichess.storage.get('ceval.threads')}` +
     (logs ? `\n\n${logs}` : '');
 
   const ops = processQueryParams();
-  const flash = ops > 0 ? `<p class="good">${ops} settings applied</p>` : '';
+  const flash = ops > 0 ? `<p class="good">Changes applied</p>` : '';
+  const submit = document.body.dataset.user
+    ? `<form method="post" action="/diagnostic">
+      <input type="hidden" name="text" value="${lichess.escapeHtml(text)}"/>
+      <button type="submit" class="button">send to lichess</button></form>`
+    : '';
+  const clear = logs ? `<button class="button button-empty button-red">clear logs</button>` : '';
+  const copy = `<button class="button copy" data-icon="${licon.Clipboard}"> copy</button>`;
   const dlg = await domDialog({
     class: 'diagnostic',
     cssPath: 'diagnostic',
-    htmlText:
-      `<h2>Diagnostics</h2>${flash}<pre tabindex="0" class="err">${lichess.escapeHtml(text)}</pre>` +
-      '<span><button class="copy button">copy to clipboard</button>' +
-      (logs
-        ? '&nbsp;&nbsp;<button class="clear button button-empty button-red">clear logs</button></span>'
-        : '</span>'),
+    htmlText: `
+      <h2>Diagnostics</h2>${flash}
+      <pre tabindex="0" class="err">${lichess.escapeHtml(text)}</pre>
+      <span class="actions"> ${clear} <div class="spacer"></div> ${copy} ${submit} </span>`,
   });
   const select = () =>
     setTimeout(() => {
@@ -36,53 +41,61 @@ export default async function initModule() {
   $('.err', dlg.view).on('focus', select);
   $('.clear', dlg.view).on('click', () => lichess.log.clear().then(dlg.close));
   $('.copy', dlg.view).on('click', () =>
-    navigator.clipboard
-      .writeText(text)
-      .then(() =>
-        $('.copy', dlg.view).replaceWith($(`<span>COPIED <i data-icon='${licon.Checkmark}'/></span>`)),
-      ),
+    navigator.clipboard.writeText(text).then(() => {
+      const copied = $(`<div data-icon="${licon.Checkmark}" class="good"> COPIED</div>`);
+      $('.copy', dlg.view).before(copied);
+      setTimeout(() => copied.remove(), 2000);
+    }),
   );
   dlg.showModal();
 }
+
+const storageProxy: { [key: string]: (val?: string) => boolean } = {
+  wsPing: (val?: string) => {
+    const storageKey = 'socket.ping.interval';
+    if (!val) lichess.storage.remove(storageKey);
+    else if (parseInt(val) > 249) lichess.storage.set(storageKey, val);
+    else return false;
+    return true;
+  },
+  wsHost: (val?: string) => {
+    const storageKey = 'socket.host';
+    if (!val) lichess.storage.remove(storageKey);
+    /*if (val.match(/^[a-z0-9-]+\.lichess\.org$/))*/ else lichess.storage.set(storageKey, val);
+    return true;
+  },
+  allowLsfw: (val?: string) => {
+    const storageKey = 'ceval.lsfw.forceEnable';
+    if (!val) lichess.storage.remove(storageKey);
+    else lichess.storage.set(storageKey, val);
+    return true;
+  },
+};
+
+const ops: { [op: string]: (val?: string) => boolean } = {
+  set: (data: string) => {
+    try {
+      const kv = atob(data).split('=');
+      return storageProxy[kv[0]]?.(kv[1]) ?? false;
+    } catch (_) {
+      console.warn('Invalid base64', data);
+      return false;
+    }
+  },
+  unset: (val: string) => {
+    if (!val) for (const key in storageProxy) storageProxy[key]?.();
+    else if (val in storageProxy) storageProxy[val]();
+    else return false;
+    return true;
+  },
+};
 
 function processQueryParams() {
   let changed = 0;
   for (const p of location.hash.split('?')[1]?.split('&') ?? []) {
     const op = p.indexOf('=') > -1 ? p.slice(0, p.indexOf('=')) : p;
-    if (op in operations) changed += operations[op](p.slice(op.length + 1));
-    else console.error('Invalid query op', op);
+    if (op in ops) changed += ops[op](p.slice(op.length + 1)) ? 1 : 0;
+    else console.warn('Invalid query op', op);
   }
   return changed;
 }
-
-const operations: { [op: string]: (val?: string) => number } = {
-  reset: (val: string) => {
-    if (!val) {
-      lichess.storage.remove('socket.ping.interval');
-      lichess.storage.remove('socket.host');
-      return 2;
-    } else if (val === 'wsPing') lichess.storage.remove('socket.ping.interval');
-    else if (val === 'wsHost') lichess.storage.remove('socket.host');
-    else return 0;
-    return 1;
-  },
-  set: (data: string) => {
-    try {
-      const kv = atob(data).split('=');
-      if (kv[0] === 'wsPing') {
-        const interval = parseInt(kv[1]);
-        if (interval > 249) {
-          lichess.storage.set('socket.ping.interval', `${interval}`);
-          return 1;
-        }
-      } else if (kv[0] === 'wsHost' && kv[1]?.length > 4) {
-        lichess.storage.set('socket.host', kv[1]);
-        return 1;
-      }
-      console.error('Invalid query set payload', kv);
-    } catch (_) {
-      console.error('Invalid base64', data);
-    }
-    return 0;
-  },
-};

--- a/ui/site/src/forum.ts
+++ b/ui/site/src/forum.ts
@@ -189,4 +189,5 @@ lichess.load.then(() => {
     replyStorage.remove();
     submittingReply = true;
   });
+  if (replyEl?.value) replyEl.scrollIntoView(); // scrollto if pre-populated
 });


### PR DESCRIPTION
- Before using this code, you must run `mongosh lichess bin/mongodb/diagnostic-categ.js` or `lila-db-seed/spamdb/spamdb.py`
- The #debug dialog gets a _send to lichess_ button.

![image](https://github.com/lichess-org/lila/assets/101470903/76e40b71-19ac-4cf4-8d53-15be1212f562)

- It takes you to a post/topic creation page with the dialog's contents prepopulated in the form.

![image](https://github.com/lichess-org/lila/assets/101470903/009717d7-4b1b-4087-8298-98ee1db91b60)

- The new `diagnostic` category is only browseable with `Permission.ModerateForum`. Others will see it if they have an active diagnostics thread, but the category link just points to their topic. Regular users can't access and don't know about any other troubleshooting threads.

![image](https://github.com/lichess-org/lila/assets/101470903/45027f4a-c976-495b-8793-03058b673f32)

- Users and mods may delete these threads at any time.

![image](https://github.com/lichess-org/lila/assets/101470903/aae3154e-2cfa-411c-a5d5-a0320e72d49e)
