### PR TITLE
Paypal: consider SUSPENDED subscription status as cancelled

### DIFF
--- a/modules/plan/src/main/PayPalClient.scala
+++ b/modules/plan/src/main/PayPalClient.scala
@@ -116,7 +116,9 @@ final private class PayPalClient(
 
   def getSubscription(id: PayPalSubscriptionId): Fu[Option[PayPalSubscription]] =
     getOne[PayPalSubscription](s"${path.subscriptions}/$id") recover {
-      case CantParseException(json, _) if json.str("status").has("CANCELLED") => none
+      case CantParseException(json, _)
+          if json.str("status").exists(status => status == "CANCELLED" || status == "SUSPENDED") =>
+        none
     }
 
   def getEvent(id: PayPalEventId): Fu[Option[PayPalEvent]] =


### PR DESCRIPTION
According to https://www.paypal-community.com/t5/Transactions-Archives/Subscription-Paused-by-paypal/td-p/2964741
> Suspended: If the funding source for a subscription (i.e. the card or bank account) is removed, all connected subscriptions will be automatically cancelled or suspended. If the subscription is suspended, it will remain as such until the funding source is updated.

Crucially could NOT test locally. Fix is based on prod Error log.

close https://github.com/lichess-org/lila/issues/14354