### PR TITLE
FIX/Puzzle Repetition Bug

### DIFF
--- a/ui/voice/css/_voice.scss
+++ b/ui/voice/css/_voice.scss
@@ -43,9 +43,15 @@ $c-mic-bg-hover: if($theme == 'light', $c-font-dimmer, transparent);
   }
 
   @keyframes flash {
-    0% { background-color: $c-bg-zebra2; }
-    50% { background-color: #cc333388; }
-    100% { background-color: $c-bg-zebra2; }
+    0% {
+      background-color: $c-bg-zebra2;
+    }
+    50% {
+      background-color: #cc333388;
+    }
+    100% {
+      background-color: $c-bg-zebra2;
+    }
   }
 }
 
@@ -85,9 +91,15 @@ button#microphone-button {
   }
 
   @keyframes pulseListening {
-    0% { border-color: transparent; }
-    50% { border-color: $c-primary; }
-    100% { border-color: transparent; }
+    0% {
+      border-color: transparent;
+    }
+    50% {
+      border-color: $c-primary;
+    }
+    100% {
+      border-color: transparent;
+    }
   }
 }
 

--- a/ui/voice/src/move/moveCtrl.ts
+++ b/ui/voice/src/move/moveCtrl.ts
@@ -67,11 +67,11 @@ export function initModule(opts: { root: MoveRootCtrl; ui: VoiceCtrl; initialFen
     draw: as(['ok'], () => setConfirm('draw', v => v && root.offerDraw?.(true, true))),
     resign: as(['ok'], () => setConfirm('resign', v => v && root.resign?.(true, true))),
     takeback: as(['ok'], () => setConfirm('takeback', v => v && root.takebackYes?.())),
-    rematch: as(['ok','clear'], () => root.rematch?.(true)),
-    next: as(['ok','clear'], () => root.nextPuzzle?.()),
-    upvote: as(['ok','clear'], () => root.vote?.(true)),
-    downvote: as(['ok','clear'], () => root.vote?.(false)),
-    solve: as(['ok','clear'], () => root.solve?.()),
+    rematch: as(['ok', 'clear'], () => root.rematch?.(true)),
+    next: as(['ok', 'clear'], () => root.nextPuzzle?.()),
+    upvote: as(['ok', 'clear'], () => root.vote?.(true)),
+    downvote: as(['ok', 'clear'], () => root.vote?.(false)),
+    solve: as(['ok', 'clear'], () => root.solve?.()),
     clock: as(['ok'], () => root.speakClock?.()),
     blindfold: as(['ok'], () => root.blindfold?.(!root.blindfold())),
   };
@@ -129,7 +129,6 @@ export function initModule(opts: { root: MoveRootCtrl; ui: VoiceCtrl; initialFen
 
       const results = [];
       for (const handler of listenHandlers) {
-
         results.push(...handler(heard));
 
         if (results.includes('ok')) {
@@ -195,13 +194,15 @@ export function initModule(opts: { root: MoveRootCtrl; ui: VoiceCtrl; initialFen
     }
     console.info('handleAmbiguity', `matched '${heard}' to '${chosen}' among`, choices);
     submit(chosen);
-    return ['ok','clear'];
+    return ['ok', 'clear'];
   }
 
   function handleMove(phrase: string): ListenResult[] {
     if (phrase.trim().length < 3) return [];
-    if (selection() && chooseMoves(matchMany(phrase, spreadMap(squares)))) return ['ok','clear'];
-    return chooseMoves(matchMany(phrase, [...spreadMap(moves), ...spreadMap(squares)])) ? ['ok','clear'] : [];
+    if (selection() && chooseMoves(matchMany(phrase, spreadMap(squares)))) return ['ok', 'clear'];
+    return chooseMoves(matchMany(phrase, [...spreadMap(moves), ...spreadMap(squares)]))
+      ? ['ok', 'clear']
+      : [];
   }
 
   // see the README.md in ui/voice/.build to decrypt these variable names.
@@ -337,7 +338,7 @@ export function initModule(opts: { root: MoveRootCtrl; ui: VoiceCtrl; initialFen
       const arrowTime = choiceTimeout ? timer() : undefined;
       cg.setShapes(
         colorsPref() ? coloredArrows([...choices], arrowTime) : numberedArrows([...choices], arrowTime),
-      );        
+      );
     }
     cg.redrawAll();
     return true;
@@ -495,8 +496,8 @@ export function initModule(opts: { root: MoveRootCtrl; ui: VoiceCtrl; initialFen
     return p === '' || p === undefined
       ? undefined
       : cg.state.turnColor === 'white'
-      ? p.toUpperCase() === p
-      : p.toLowerCase() === p;
+        ? p.toUpperCase() === p
+        : p.toLowerCase() === p;
   }
 
   function clearMoveProgress() {
@@ -542,10 +543,10 @@ export function initModule(opts: { root: MoveRootCtrl; ui: VoiceCtrl; initialFen
     return command?.key === 'resign'
       ? mkOpts('Confirm resignation', licon.FlagOutline)
       : command?.key === 'draw'
-      ? mkOpts('Confirm draw offer', licon.OneHalf)
-      : command?.key === 'takeback'
-      ? mkOpts('Confirm takeback request', licon.Back)
-      : false;
+        ? mkOpts('Confirm draw offer', licon.OneHalf)
+        : command?.key === 'takeback'
+          ? mkOpts('Confirm takeback request', licon.Back)
+          : false;
   }
 
   function prefNodes() {
@@ -580,8 +581,8 @@ export function initModule(opts: { root: MoveRootCtrl; ui: VoiceCtrl; initialFen
     return tags === undefined
       ? entries
       : intersect
-      ? entries.filter(e => e.tags.every(tag => tags.includes(tag)))
-      : entries.filter(e => e.tags.some(tag => tags.includes(tag)));
+        ? entries.filter(e => e.tags.every(tag => tags.includes(tag)))
+        : entries.filter(e => e.tags.some(tag => tags.includes(tag)));
   }
 
   function wordTok(word: string) {


### PR DESCRIPTION
**puzzle-repetition-bug fix** 
Improves upon the safeguard to verify that the next puzzle selected isn't the same as the previously played puzzle or a puzzle recently played in the near past. This bug occurs to me and my mates quite frequently when we're training, so Instead of posting an issue- I decided to fix it. It features better handling of previously played puzzles, and does ID verification to assure that the next puzzle the user is given, is not a repetition. This would happen occasionally due to the handling originally being quite loose in terms of puzzle delivery. I have also implemented a max-sequential constant set at 10, to keep lila running smooth- preventing it from potential overflow in memory usage.


P.S. I also ran `prettier --write 'ui/voice/css/_voice.scss' 'ui/voice/src/move/moveCtrl.ts'` in an attempt to rid of the returned linting error for the Lint test in @schlawg commit. It seems the Lint test is pretty strict lol.