### PR TITLE
Increase comm burst score threshold

### DIFF
--- a/modules/report/src/main/ReportThresholds.scala
+++ b/modules/report/src/main/ReportThresholds.scala
@@ -39,6 +39,6 @@ private object ReportThresholds:
   def makeDiscordSetting(store: lila.memo.SettingStore.Builder) =
     store[Int](
       "discordScoreThreshold",
-      default = 80,
+      default = 100,
       text = "Discord score threshold. Comm reports with higher scores are notified in Discord".some
     )


### PR DESCRIPTION
A bit spammy. With critical being 84 it will currently generate a burst even if there are mods instantly on it, so going over that seems wise. 