### PR TITLE
Honor show ratings setings in puzzle history

### DIFF
--- a/modules/storm/src/main/StormJson.scala
+++ b/modules/storm/src/main/StormJson.scala
@@ -60,6 +60,7 @@ object StormJson:
       "moveEvent"   -> p.moveEvent,
       "highlight"   -> p.highlight,
       "is3d"        -> p.is3d,
-      "animation"   -> p.animationMillisForSpeedPuzzles
+      "animation"   -> p.animationMillisForSpeedPuzzles,
+      "ratings"     -> p.showRatings
     )
   }

--- a/ui/puz/src/interfaces.ts
+++ b/ui/puz/src/interfaces.ts
@@ -8,6 +8,7 @@ export interface PuzCtrl {
   run: Run;
   filters: PuzFilters;
   trans: Trans;
+  pref: PuzPrefs;
 }
 
 export interface PuzPrefs {
@@ -18,6 +19,7 @@ export interface PuzPrefs {
   moveEvent: number;
   highlight: boolean;
   animation: number;
+  ratings: boolean;
 }
 
 export type UserMove = (orig: Key, dest: Key) => void;

--- a/ui/puz/src/view/history.ts
+++ b/ui/puz/src/view/history.ts
@@ -62,7 +62,7 @@ export default (ctrl: PuzCtrl): VNode => {
             h('span.puz-history__round__meta', [
               h('span.puz-history__round__result', [
                 h(round.win ? 'good' : 'bad', Math.round(round.millis / 1000) + 's'),
-                h('rating', round.puzzle.rating),
+                ctrl.pref.ratings ? h('rating', round.puzzle.rating) : '',
               ]),
               h('span.puz-history__round__id', '#' + round.puzzle.id),
             ]),


### PR DESCRIPTION
After deactivating the show ratings on my user I just noticed that on puzzle racer and puzzle storm history the puzzle rating is show despite having it deactivated. On other puzzle training the rating is not show.

The behaviour with this MR is the following: 

**With show ratings activated:**
![Show ratings](https://github.com/lichess-org/lila/assets/1160726/c3dcd344-0905-45c8-95d9-f3074eb8f1ba)
**With show ratings deactivated:**
![Hide ratings](https://github.com/lichess-org/lila/assets/1160726/9f3900b2-1366-4d12-ba81-0d00552c9a91)

Note this is my first PR on the project and I'm not sure if I followed all the contribution guides.
Let me know if there is something I should fix/improve. 

Thanks for such amazin project!

