### PR TITLE
Daily feed: add infinite scroll

### DIFF
--- a/app/controllers/DailyFeed.scala
+++ b/app/controllers/DailyFeed.scala
@@ -10,13 +10,15 @@ import lila.blog.DailyFeed.Update
 
 final class DailyFeed(env: Env) extends LilaController(env):
 
-  def api = env.blog.dailyFeed
+  def api       = env.blog.dailyFeed
+  def paginator = env.blog.dailyFeedPaginator
 
-  def index = Open:
-    for
-      updates <- api.recent
-      page    <- renderPage(html.dailyFeed.index(updates))
-    yield Ok(page)
+  def index(page: Int) = Open:
+    Reasonable(page):
+      for
+        updates      <- paginator.recent(page)
+        renderedPage <- renderPage(html.dailyFeed.index(updates))
+      yield Ok(renderedPage)
 
   def createForm = Secure(_.DailyFeed) { _ ?=> _ ?=>
     Ok.pageAsync(html.dailyFeed.create(api.form(none)))
@@ -53,7 +55,7 @@ final class DailyFeed(env: Env) extends LilaController(env):
 
   def delete(id: String) = Secure(_.DailyFeed) { _ ?=> _ ?=>
     Found(api.get(id)): up =>
-      api.delete(up.id) inject Redirect(routes.DailyFeed.index).flashSuccess
+      api.delete(up.id) inject Redirect(routes.DailyFeed.index(1)).flashSuccess
   }
 
   def atom = Anon:

--- a/app/views/dailyFeed.scala
+++ b/app/views/dailyFeed.scala
@@ -7,6 +7,7 @@ import lila.app.ui.ScalatagsTemplate.{ *, given }
 import lila.blog.DailyFeed.Update
 import play.api.data.Form
 import play.api.i18n.Lang
+import lila.common.paginator.Paginator
 import scalatags.text.Builder
 import scalatags.generic.Frag
 
@@ -17,10 +18,10 @@ object dailyFeed:
       title = title,
       active = "news",
       moreCss = cssTag("dailyFeed"),
-      moreJs = edit option frag(jsModule("flatpickr"), jsModule("dailyFeed"))
+      moreJs = frag(infiniteScrollTag, edit option jsModule("flatpickr"), edit option jsModule("dailyFeed"))
     )
 
-  def index(updates: List[Update])(using PageContext) =
+  def index(ups: Paginator[Update])(using PageContext) =
     layout("Updates"):
       div(cls := "daily-feed box box-pad")(
         boxTop(
@@ -35,15 +36,15 @@ object dailyFeed:
           )
         ),
         standardFlash,
-        updateList(updates, editor = isGranted(_.DailyFeed))
+        updates(ups, editor = isGranted(_.DailyFeed))
       )
 
-  def updateList(ups: List[Update], editor: Boolean)(using Context) =
-    div(cls := "daily-feed__updates"):
-      ups.view
+  def updates(ups: Paginator[Update], editor: Boolean)(using Context) =
+    div(cls := "daily-feed__updates infinite-scroll")(
+      ups.currentPageResults.view
         .filter(_.published || editor)
         .map: update =>
-          div(cls := "daily-feed__update", id := update.id)(
+          div(cls := "daily-feed__update paginated", id := update.id)(
             marker(update.flair),
             div(cls := "daily-feed__update__content")(
               st.section(cls := "daily-feed__update__day")(
@@ -61,7 +62,9 @@ object dailyFeed:
               div(cls := "daily-feed__update__markup")(rawHtml(update.rendered))
             )
           )
-        .toList
+        .toList,
+      pagerNext(ups, np => routes.DailyFeed.index(np).url)
+    )
 
   val lobbyUpdates = renderCache[List[Update]](1 minute): ups =>
     div(cls := "daily-feed__updates")(
@@ -88,7 +91,7 @@ object dailyFeed:
       main(cls := "daily-feed page-small box box-pad")(
         boxTop(
           h1(
-            a(href := routes.DailyFeed.index)("Daily Feed"),
+            a(href := routes.DailyFeed.index(1))("Daily Feed"),
             " • ",
             "New update!"
           )
@@ -103,7 +106,7 @@ object dailyFeed:
         div(cls := "box box-pad")(
           boxTop(
             h1(
-              a(href := routes.DailyFeed.index)("Lichess update"),
+              a(href := routes.DailyFeed.index(1))("Lichess update"),
               " • ",
               semanticDate(update.at)
             )
@@ -111,10 +114,7 @@ object dailyFeed:
           standardFlash,
           postForm(cls := "content_box_content form3", action := routes.DailyFeed.update(update.id)):
             inForm(form)
-        ),
-        br,
-        div(cls := "box box-pad")(
-          updateList(List(update), editor = true),
+          ,
           postForm(action := routes.DailyFeed.delete(update.id))(cls := "daily-feed__delete"):
             submitButton(cls := "button button-red button-empty confirm")("Delete")
         )
@@ -155,7 +155,7 @@ object dailyFeed:
     import views.html.base.atom.{ atomDate, category }
     views.html.base.atom(
       elems = ups,
-      htmlCall = routes.DailyFeed.index,
+      htmlCall = routes.DailyFeed.index(1),
       atomCall = routes.DailyFeed.atom,
       title = "Lichess updates feed",
       updated = ups.headOption.map(_.at)
@@ -166,7 +166,7 @@ object dailyFeed:
         link(
           rel  := "alternate",
           tpe  := "text/html",
-          href := s"$netBaseUrl${routes.DailyFeed.index}#${up.id}"
+          href := s"$netBaseUrl${routes.DailyFeed.index(1)}#${up.id}"
         ),
         tag("title")(up.title),
         tag("content")(tpe := "html")(up.rendered)

--- a/app/views/site/page.scala
+++ b/app/views/site/page.scala
@@ -216,7 +216,7 @@ $('#asset-version-message').text(lichess.info.message);"""
       main(cls := "page-menu")(
         views.html.site.bits.pageMenuSubnav(
           a(activeCls("about"), href := "/about")(trans.aboutX("lichess.org")),
-          a(activeCls("news"), href := routes.DailyFeed.index)("Lichess updates"),
+          a(activeCls("news"), href := routes.DailyFeed.index(1))("Lichess updates"),
           a(activeCls("faq"), href := routes.Main.faq)(trans.faq.faqAbbreviation()),
           a(activeCls("contact"), href := routes.Main.contact)(trans.contact.contact()),
           a(activeCls("tos"), href := routes.ContentPage.tos)(trans.termsOfService()),

--- a/conf/routes
+++ b/conf/routes
@@ -124,7 +124,7 @@ GET   /blog/community/$lang<[\w-]{2,6}>.atom controllers.Ublog.communityAtom(lan
 GET   /blog/:id/:slug                  controllers.Blog.show(id, slug, ref: Option[String] ?= None)
 GET   /blog/prismic-preview            controllers.Blog.preview(token)
 
-GET   /feed                            controllers.DailyFeed.index
+GET   /feed                            controllers.DailyFeed.index(page: Int ?= 1)
 GET   /feed/new                        controllers.DailyFeed.createForm
 POST  /feed/new                        controllers.DailyFeed.create
 GET   /feed/:id/edit                  controllers.DailyFeed.edit(id)

--- a/modules/blog/src/main/DailyFeed.scala
+++ b/modules/blog/src/main/DailyFeed.scala
@@ -4,8 +4,10 @@ import reactivemongo.api.bson.*
 import reactivemongo.api.bson.Macros.Annotations.Key
 import java.time.format.{ DateTimeFormatter, FormatStyle }
 import lila.db.dsl.{ *, given }
+import lila.common.paginator.Paginator
+import lila.db.paginator.Adapter
 import lila.memo.CacheApi
-import lila.common.config.Max
+import lila.common.config.{ Max, MaxPerPage }
 import play.api.data.Form
 import lila.user.Me
 
@@ -26,8 +28,9 @@ object DailyFeed:
     def published           = public && at.isBeforeNow
     def future              = at.isAfterNow
 
-  private val renderer      = lila.common.MarkdownRender(autoLink = false, strikeThrough = true)
-  private val dateFormatter = DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM)
+  private val renderer              = lila.common.MarkdownRender(autoLink = false, strikeThrough = true)
+  private val dateFormatter         = DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM)
+  given BSONDocumentHandler[Update] = Macros.handler
 
   type GetLastUpdates = () => List[Update]
 
@@ -39,8 +42,6 @@ final class DailyFeed(coll: Coll, cacheApi: CacheApi)(using Executor):
   import DailyFeed.*
 
   private val max = Max(50)
-
-  private given BSONDocumentHandler[Update] = Macros.handler
 
   private object cache:
     private var mutableLastUpdates: List[Update] = Nil
@@ -61,9 +62,7 @@ final class DailyFeed(coll: Coll, cacheApi: CacheApi)(using Executor):
 
   export cache.lastUpdate
 
-  def recent: Fu[List[Update]] = cache.store.get({})
-
-  def recentPublished = recent.map(_.filter(_.published))
+  def recentPublished = cache.store.get({}).map(_.filter(_.published))
 
   def get(id: ID): Fu[Option[Update]] = coll.byId[Update](id)
 
@@ -88,3 +87,20 @@ final class DailyFeed(coll: Coll, cacheApi: CacheApi)(using Executor):
         lila.user.FlairApi.formPair(anyFlair = true)
       )(UpdateData.apply)(unapply)
     from.fold(form)(u => form.fill(UpdateData(u.content, u.public, u.at, u.flair)))
+
+final class DailyFeedPaginatorBuilder(
+    coll: Coll
+)(using Executor):
+  import DailyFeed.*
+
+  def recent(page: Int): Fu[Paginator[Update]] =
+    Paginator(
+      adapter = Adapter[Update](
+        collection = coll,
+        selector = $empty,
+        projection = none,
+        sort = $sort.desc("at")
+      ),
+      page,
+      MaxPerPage(25)
+    )

--- a/modules/blog/src/main/Env.scala
+++ b/modules/blog/src/main/Env.scala
@@ -28,7 +28,8 @@ final class Env(
 
   lazy val lastPostCache = wire[LastPostCache]
 
-  private val feedColl = db(CollName("daily_feed"))
-  val dailyFeed        = wire[DailyFeed]
+  private val feedColl   = db(CollName("daily_feed"))
+  val dailyFeed          = wire[DailyFeed]
+  val dailyFeedPaginator = wire[DailyFeedPaginatorBuilder]
 
   export dailyFeed.lastUpdate

--- a/modules/ublog/src/main/UblogPost.scala
+++ b/modules/ublog/src/main/UblogPost.scala
@@ -23,7 +23,7 @@ case class UblogPost(
     likes: UblogPost.Likes,
     views: UblogPost.Views,
     rankAdjustDays: Option[Int],
-    pinned: Option[Boolean],
+    pinned: Option[Boolean]
 ) extends UblogPost.BasePost:
 
   def isBy[U: UserIdOf](u: U) = created.by is u

--- a/ui/site/css/_dailyFeed.scss
+++ b/ui/site/css/_dailyFeed.scss
@@ -70,8 +70,4 @@ $c-contours: mix($c-brag, $c-shade, 80%);
       }
     }
   }
-
-  &__delete {
-    text-align: $end-direction;
-  }
 }


### PR DESCRIPTION
Did not touched the cache for the homepage. 25 updates per page was chosen a bit arbitrarily, but felt ok.

When editing update, removed the rendered preview which was redundant, and made the code slightly easier to refactor.

Tested.

close https://github.com/lichess-org/lila/issues/14478