### PR TITLE
Delete earlier moves#12986 WIP 

### DIFF
--- a/app/views/analyse/jsI18n.scala
+++ b/app/views/analyse/jsI18n.scala
@@ -81,6 +81,7 @@ object jsI18n:
         trans.deleteFromHere,
         trans.forceVariation,
         trans.copyVariationPgn,
+        trans.deleteEarlierMoves,
         // practice (also uses checkmate, draw)
         trans.practiceWithComputer,
         trans.puzzle.goodMove,

--- a/app/views/board/userAnalysisI18n.scala
+++ b/app/views/board/userAnalysisI18n.scala
@@ -84,6 +84,7 @@ object userAnalysisI18n:
     trans.deleteFromHere,
     trans.forceVariation,
     trans.copyVariationPgn,
+    trans.deleteEarlierMoves,
     // practice (also uses checkmate, draw)
     trans.practiceWithComputer,
     trans.puzzle.goodMove,

--- a/modules/i18n/src/main/I18nKeys.scala
+++ b/modules/i18n/src/main/I18nKeys.scala
@@ -4,7 +4,7 @@ package lila.i18n
 // format: OFF
 object I18nKeys:
   val `playWithAFriend` = I18nKey("playWithAFriend")
-  val `studyFromHere` = I18nKey("studyFromHere")
+  val `deleteEarlierMoves` = I18nKey("deleteEarlierMoves")
   val `playWithTheMachine` = I18nKey("playWithTheMachine")
   val `toInviteSomeoneToPlayGiveThisUrl` = I18nKey("toInviteSomeoneToPlayGiveThisUrl")
   val `gameOver` = I18nKey("gameOver")

--- a/modules/i18n/src/main/I18nKeys.scala
+++ b/modules/i18n/src/main/I18nKeys.scala
@@ -4,6 +4,7 @@ package lila.i18n
 // format: OFF
 object I18nKeys:
   val `playWithAFriend` = I18nKey("playWithAFriend")
+  val `studyFromHere` = I18nKey("studyFromHere")
   val `playWithTheMachine` = I18nKey("playWithTheMachine")
   val `toInviteSomeoneToPlayGiveThisUrl` = I18nKey("toInviteSomeoneToPlayGiveThisUrl")
   val `gameOver` = I18nKey("gameOver")

--- a/translation/source/site.xml
+++ b/translation/source/site.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
   <string name="playWithAFriend">Play with a friend</string>
-  <string name="studyFromHere">Study from here</string>
+  <string name="deleteEarlierMoves">Delete earlier moves</string>
   <string name="playWithTheMachine">Play with the computer</string>
   <string name="toInviteSomeoneToPlayGiveThisUrl">To invite someone to play, give this URL</string>
   <string name="gameOver">Game Over</string>

--- a/translation/source/site.xml
+++ b/translation/source/site.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
   <string name="playWithAFriend">Play with a friend</string>
+  <string name="studyFromHere">Study from here</string>
   <string name="playWithTheMachine">Play with the computer</string>
   <string name="toInviteSomeoneToPlayGiveThisUrl">To invite someone to play, give this URL</string>
   <string name="gameOver">Game Over</string>

--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -582,16 +582,17 @@ export default class AnalyseCtrl {
     if (this.study) this.study.deleteNode(path);
   }
 
-  studyFromHere(path: Tree.Path): void {
-    // * Invert the path
+  //? Does this work with synthetic = false(real games?)
+  deleteEarlierMoves(path: Tree.Path): void {
     const node = this.tree.nodeAtPath(path);
     if (!node) return;
-
     this.tree = makeTree(node);
-
-    this.path = treePath.root;
-
+    if (!this.synthetic) {
+      console.log('game is not synthetic, its a real game');
+      //Why does it not work for a real game
+    }
     this.redraw();
+    this.study?.xhrReload();
   }
 
   promote(path: Tree.Path, toMainline: boolean): void {

--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -583,12 +583,15 @@ export default class AnalyseCtrl {
   }
 
   studyFromHere(path: Tree.Path): void {
+    // * Invert the path
     const node = this.tree.nodeAtPath(path);
     if (!node) return;
-    // How do I delete from current node backwards to root vs deleteNode which deletes from current node forwards to end?
-    console.log('tree root is=', (this.tree.root = node));
-    //print the fen
-    console.log('fen is=', node.fen);
+
+    this.tree = makeTree(node);
+
+    this.path = treePath.root;
+
+    this.redraw();
   }
 
   promote(path: Tree.Path, toMainline: boolean): void {

--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -582,6 +582,15 @@ export default class AnalyseCtrl {
     if (this.study) this.study.deleteNode(path);
   }
 
+  studyFromHere(path: Tree.Path): void {
+    const node = this.tree.nodeAtPath(path);
+    if (!node) return;
+    // How do I delete from current node backwards to root vs deleteNode which deletes from current node forwards to end?
+    console.log('tree root is=', (this.tree.root = node));
+    //print the fen
+    console.log('fen is=', node.fen);
+  }
+
   promote(path: Tree.Path, toMainline: boolean): void {
     this.tree.promoteAt(path, toMainline);
     this.jump(path);

--- a/ui/analyse/src/socket.ts
+++ b/ui/analyse/src/socket.ts
@@ -37,6 +37,7 @@ interface GameUpdate {
 export type StudySocketSendParams =
   | [t: 'setPath', d: ReqPosition]
   | [t: 'deleteNode', d: ReqPosition & { jumpTo: string }]
+  | [t: 'deleteEarlierMoves', d: ReqPosition & { jumpTo: string }]
   | [t: 'promote', d: ReqPosition & { toMainline: boolean }]
   | [t: 'forceVariation', d: ReqPosition & { force: boolean }]
   | [t: 'shapes', d: ReqPosition & { shapes: Tree.Shape[] }]

--- a/ui/analyse/src/study/studyCtrl.ts
+++ b/ui/analyse/src/study/studyCtrl.ts
@@ -52,6 +52,7 @@ interface Handlers {
   addNode(
     d: WithWhoAndPos & { d: string; n: Tree.Node; o: Opening; s: boolean; relay?: StudyChapterRelay },
   ): void;
+  deleteEarlierMoves(d: WithWhoAndPos): void;
   deleteNode(d: WithWhoAndPos): void;
   promote(d: WithWhoAndPos & { toMainline: boolean }): void;
   liking(d: WithWho & { l: { likes: number; me: boolean } }): void;
@@ -486,6 +487,14 @@ export default class StudyCtrl {
         jumpTo: this.ctrl.path,
       }),
     );
+  deleteEarlierMoves = (path: Tree.Path) =>
+    this.makeChange(
+      'deleteEarlierMoves',
+      this.addChapterId({
+        path,
+        jumpTo: this.ctrl.path,
+      }),
+    );
   promote = (path: Tree.Path, toMainline: boolean) =>
     this.makeChange(
       'promote',
@@ -599,6 +608,16 @@ export default class StudyCtrl {
       if (!this.ctrl.tree.pathExists(d.p.path)) return this.xhrReload();
       this.ctrl.tree.deleteNodeAt(position.path);
       if (this.vm.mode.sticky) this.ctrl.jump(this.ctrl.path);
+      this.redraw();
+    },
+    deleteEarlierMoves: d => {
+      const position = d.p,
+        who = d.w;
+      this.setMemberActive(who);
+      if (this.wrongChapter(d)) return;
+      if (who && who.s === lichess.sri) return;
+      if (!this.ctrl.tree.pathExists(d.p.path)) return this.xhrReload();
+      if (this.vm.mode.sticky) this.ctrl.jump(position.path);
       this.redraw();
     },
     promote: d => {

--- a/ui/analyse/src/treeView/contextMenu.ts
+++ b/ui/analyse/src/treeView/contextMenu.ts
@@ -92,7 +92,7 @@ function view(opts: Opts, coords: Coords): VNode {
       ),
       //* Create a button labelled 'study from here' that creates a study from the current node
       // strange issue whereby the moves cannot be played after the studyFromHere button is clicked
-      action(licon.StudyBoard, trans('studyFromHere'), () => ctrl.studyFromHere(opts.path)),
+      action(licon.StudyBoard, trans('deleteEarlierMoves'), () => ctrl.deleteEarlierMoves(opts.path)),
     ],
   );
 }

--- a/ui/analyse/src/treeView/contextMenu.ts
+++ b/ui/analyse/src/treeView/contextMenu.ts
@@ -90,6 +90,9 @@ function view(opts: Opts, coords: Coords): VNode {
       action(licon.Clipboard, trans('copyVariationPgn'), () =>
         navigator.clipboard.writeText(renderVariationPgn(opts.root.tree.getNodeList(opts.path))),
       ),
+      //* Create a button labelled 'study from here' that creates a study from the current node
+      //How do I make a new post request to /study/as with the current node as the pgn?
+      action(licon.StudyBoard, trans('studyFromHere'), () => ctrl.studyFromHere(opts.path)),
     ],
   );
 }

--- a/ui/analyse/src/treeView/contextMenu.ts
+++ b/ui/analyse/src/treeView/contextMenu.ts
@@ -91,7 +91,7 @@ function view(opts: Opts, coords: Coords): VNode {
         navigator.clipboard.writeText(renderVariationPgn(opts.root.tree.getNodeList(opts.path))),
       ),
       //* Create a button labelled 'study from here' that creates a study from the current node
-      //How do I make a new post request to /study/as with the current node as the pgn?
+      // strange issue whereby the moves cannot be played after the studyFromHere button is clicked
       action(licon.StudyBoard, trans('studyFromHere'), () => ctrl.studyFromHere(opts.path)),
     ],
   );


### PR DESCRIPTION
I would like to get some feedback on adding a new button delete earlier moves #12986. It currently works(I think :) ) but the problem is that when used outside the analysis board, when the moves are deleted and you go to create the study from the game, the side view shows the supposed to be deleted moves. Any ideas on why this happens? I thought maybe it was a socket issue so I modified analyse/socket.ts but that did not fix the issue. Thanks 