### PR TITLE
simple polls to gather feedback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .sbtopts
 .jvmopts
 .bsp
+.pnpm-store
 .bloop/
 .metals/
 .pnpm-store/

--- a/app/Env.scala
+++ b/app/Env.scala
@@ -26,6 +26,7 @@ final class Env(
     val search: lila.search.Env,
     val gameSearch: lila.gameSearch.Env,
     val timeline: lila.timeline.Env,
+    val ask: lila.ask.Env,
     val forum: lila.forum.Env,
     val forumSearch: lila.forumSearch.Env,
     val team: lila.team.Env,
@@ -189,6 +190,7 @@ final class EnvBoot(
   lazy val search: lila.search.Env           = wire[lila.search.Env]
   lazy val gameSearch: lila.gameSearch.Env   = wire[lila.gameSearch.Env]
   lazy val timeline: lila.timeline.Env       = wire[lila.timeline.Env]
+  lazy val ask: lila.ask.Env                 = wire[lila.ask.Env]
   lazy val forum: lila.forum.Env             = wire[lila.forum.Env]
   lazy val forumSearch: lila.forumSearch.Env = wire[lila.forumSearch.Env]
   lazy val team: lila.team.Env               = wire[lila.team.Env]

--- a/app/LilaComponents.scala
+++ b/app/LilaComponents.scala
@@ -98,6 +98,7 @@ final class LilaComponents(
   lazy val analyse: Analyse               = wire[Analyse]
   lazy val api: Api                       = wire[Api]
   lazy val appealC: appeal.Appeal         = wire[appeal.Appeal]
+  lazy val ask: Ask                       = wire[Ask]
   lazy val auth: Auth                     = wire[Auth]
   lazy val blog: Blog                     = wire[Blog]
   lazy val dailyFeed: DailyFeed           = wire[DailyFeed]

--- a/app/controllers/Ask.scala
+++ b/app/controllers/Ask.scala
@@ -1,0 +1,121 @@
+package controllers
+
+import play.api.data.Form
+import play.api.data.Forms.single
+import views.*
+
+import lila.app.{ given, * }
+import lila.ask.Ask
+
+final class Ask(env: Env) extends LilaController(env):
+
+  def view(aid: Ask.ID, view: Option[String], tally: Boolean) = Open: _ ?=>
+    env.ask.repo
+      .getAsync(aid)
+      .flatMap:
+        case Some(ask) => Ok.page(html.ask.renderOne(ask, paramToList(view), tally))
+        case _         => fuccess(NotFound(s"Ask $aid not found"))
+
+  def picks(aid: Ask.ID, picks: Option[String], view: Option[String], anon: Boolean) =
+    Open: _ ?=>
+      effectiveId(aid, anon).flatMap:
+        case Some(id) =>
+          env.ask.repo
+            .setPicks(aid, id, paramToList(picks))
+            .map:
+              case Some(ask) => Ok(html.ask.renderOne(ask, paramToList(view)))
+              case _         => NotFound(s"Ask $aid not found")
+        case _ => authenticationFailed
+
+  def form(aid: Ask.ID, view: Option[String], anon: Boolean) = OpenBody: _ ?=>
+    effectiveId(aid, anon).flatMap:
+      case Some(id) =>
+        env.ask.repo
+          .setForm(aid, id, feedbackForm.bindFromRequest().value)
+          .map:
+            case Some(ask) => Ok(html.ask.renderOne(ask, paramToList(view)))
+            case _         => NotFound(s"Ask $aid not found")
+      case _ => authenticationFailed
+
+  def unset(aid: Ask.ID, view: Option[String], anon: Boolean) = Open: _ ?=>
+    effectiveId(aid, anon).flatMap:
+      case Some(id) =>
+        env.ask.repo
+          .unset(aid, id)
+          .map:
+            case Some(ask) => Ok(html.ask.renderOne(ask, paramToList(view)))
+            case _         => NotFound(s"Ask $aid not found")
+      case _ => authenticationFailed
+
+  def admin(aid: Ask.ID) = Auth { ctx ?=> me ?=>
+    env.ask.repo
+      .getAsync(aid)
+      .map:
+        case Some(ask) => Ok(html.askAdmin.renderOne(ask))
+        case _         => NotFound(s"Ask $aid not found")
+  }
+
+  def byUser(username: UserStr) = Auth { ctx ?=> me ?=>
+    Ok.pageAsync:
+      for
+        user <- env.user.lightUser(username.id)
+        asks <- env.ask.repo.byUser(username.id)
+        if (me is user) || isGranted(_.ModerateForum)
+      yield html.askAdmin.show(asks, user.get)
+  }
+
+  def json(aid: Ask.ID) = Auth { _ ?=> me ?=>
+    env.ask.repo
+      .getAsync(aid)
+      .map:
+        case Some(ask) =>
+          if (me is ask.creator) || isGranted(_.ModerateForum) then JsonOk(ask.toJson)
+          else JsonBadRequest(jsonError(s"Not authorized to view ask $aid"))
+        case _ => JsonBadRequest(jsonError(s"Ask $aid not found"))
+  }
+
+  def delete(aid: Ask.ID) = Auth { _ ?=> me ?=>
+    env.ask.repo
+      .getAsync(aid)
+      .map:
+        case Some(ask) =>
+          if (me is ask.creator) || isGranted(_.ModerateForum) then
+            env.ask.repo.delete(aid)
+            Ok(lila.ask.AskEmbed.askNotFoundFrag)
+          else Unauthorized
+        case _ => NotFound(s"Ask id ${aid} not found")
+  }
+
+  def conclude(aid: Ask.ID) = authorized(aid, env.ask.repo.conclude)
+
+  def reset(aid: Ask.ID) = authorized(aid, env.ask.repo.reset)
+
+  private def effectiveId(aid: Ask.ID, anon: Boolean)(using ctx: Context) =
+    ctx.myId match
+      case Some(u) => fuccess((if anon then Ask.anonHash(u.toString, aid) else u.toString).some)
+      case _ =>
+        env.ask.repo
+          .isOpen(aid)
+          .map:
+            case true  => Ask.anonHash(ctx.ip.toString, aid).some
+            case false => none[String]
+
+  private def authorized(aid: Ask.ID, action: lila.ask.Ask.ID => Fu[Option[lila.ask.Ask]]) =
+    Auth { _ ?=> me ?=>
+      env.ask.repo
+        .getAsync(aid)
+        .flatMap:
+          case Some(ask) =>
+            if (me is ask.creator) || isGranted(_.ModerateForum) then
+              action(ask._id).map:
+                case Some(newAsk) => Ok(html.ask.renderOne(newAsk))
+                case _            => NotFound(s"Ask id ${aid} not found")
+            else fuccess(Unauthorized)
+          case _ => fuccess(NotFound(s"Ask id $aid not found"))
+    }
+
+  private def paramToList(param: Option[String]) =
+    param map (_ split ('-') filter (_ nonEmpty) map (_ toInt) toVector)
+
+  private val feedbackForm =
+    Form[String](single("text" -> lila.common.Form.cleanNonEmptyText(maxLength = 80)))

--- a/app/controllers/Ask.scala
+++ b/app/controllers/Ask.scala
@@ -13,19 +13,18 @@ final class Ask(env: Env) extends LilaController(env):
     env.ask.repo
       .getAsync(aid)
       .flatMap:
-        case Some(ask) => Ok.page(html.ask.renderOne(ask, paramToList(view), tally))
+        case Some(ask) => Ok.page(html.ask.renderOne(ask, intVec(view), tally))
         case _         => fuccess(NotFound(s"Ask $aid not found"))
 
-  def picks(aid: Ask.ID, picks: Option[String], view: Option[String], anon: Boolean) =
-    Open: _ ?=>
-      effectiveId(aid, anon).flatMap:
-        case Some(id) =>
-          env.ask.repo
-            .setPicks(aid, id, paramToList(picks))
-            .map:
-              case Some(ask) => Ok(html.ask.renderOne(ask, paramToList(view)))
-              case _         => NotFound(s"Ask $aid not found")
-        case _ => authenticationFailed
+  def picks(aid: Ask.ID, picks: Option[String], view: Option[String], anon: Boolean) = Open: _ ?=>
+    effectiveId(aid, anon).flatMap:
+      case Some(id) =>
+        env.ask.repo
+          .setPicks(aid, id, intVec(picks))
+          .map:
+            case Some(ask) => Ok(html.ask.renderOne(ask, intVec(view)))
+            case _         => NotFound(s"Ask $aid not found")
+      case _ => authenticationFailed
 
   def form(aid: Ask.ID, view: Option[String], anon: Boolean) = OpenBody: _ ?=>
     effectiveId(aid, anon).flatMap:
@@ -33,7 +32,7 @@ final class Ask(env: Env) extends LilaController(env):
         env.ask.repo
           .setForm(aid, id, feedbackForm.bindFromRequest().value)
           .map:
-            case Some(ask) => Ok(html.ask.renderOne(ask, paramToList(view)))
+            case Some(ask) => Ok(html.ask.renderOne(ask, intVec(view)))
             case _         => NotFound(s"Ask $aid not found")
       case _ => authenticationFailed
 
@@ -43,48 +42,47 @@ final class Ask(env: Env) extends LilaController(env):
         env.ask.repo
           .unset(aid, id)
           .map:
-            case Some(ask) => Ok(html.ask.renderOne(ask, paramToList(view)))
+            case Some(ask) => Ok(html.ask.renderOne(ask, intVec(view)))
             case _         => NotFound(s"Ask $aid not found")
       case _ => authenticationFailed
 
-  def admin(aid: Ask.ID) = Auth { ctx ?=> me ?=>
+  def admin(aid: Ask.ID) = Auth: _ ?=>
     env.ask.repo
       .getAsync(aid)
       .map:
         case Some(ask) => Ok(html.askAdmin.renderOne(ask))
         case _         => NotFound(s"Ask $aid not found")
-  }
 
-  def byUser(username: UserStr) = Auth { ctx ?=> me ?=>
-    Ok.pageAsync:
-      for
-        user <- env.user.lightUser(username.id)
-        asks <- env.ask.repo.byUser(username.id)
-        if (me is user) || isGranted(_.ModerateForum)
-      yield html.askAdmin.show(asks, user.get)
-  }
+  def byUser(username: UserStr) = Auth: _ ?=>
+    me ?=>
+      Ok.pageAsync:
+        for
+          user <- env.user.lightUser(username.id)
+          asks <- env.ask.repo.byUser(username.id)
+          if (me is user) || isGranted(_.ModerateForum)
+        yield html.askAdmin.show(asks, user.get)
 
-  def json(aid: Ask.ID) = Auth { _ ?=> me ?=>
-    env.ask.repo
-      .getAsync(aid)
-      .map:
-        case Some(ask) =>
-          if (me is ask.creator) || isGranted(_.ModerateForum) then JsonOk(ask.toJson)
-          else JsonBadRequest(jsonError(s"Not authorized to view ask $aid"))
-        case _ => JsonBadRequest(jsonError(s"Ask $aid not found"))
-  }
+  def json(aid: Ask.ID) = Auth: _ ?=>
+    me ?=>
+      env.ask.repo
+        .getAsync(aid)
+        .map:
+          case Some(ask) =>
+            if (me is ask.creator) || isGranted(_.ModerateForum) then JsonOk(ask.toJson)
+            else JsonBadRequest(jsonError(s"Not authorized to view ask $aid"))
+          case _ => JsonBadRequest(jsonError(s"Ask $aid not found"))
 
-  def delete(aid: Ask.ID) = Auth { _ ?=> me ?=>
-    env.ask.repo
-      .getAsync(aid)
-      .map:
-        case Some(ask) =>
-          if (me is ask.creator) || isGranted(_.ModerateForum) then
-            env.ask.repo.delete(aid)
-            Ok(lila.ask.AskEmbed.askNotFoundFrag)
-          else Unauthorized
-        case _ => NotFound(s"Ask id ${aid} not found")
-  }
+  def delete(aid: Ask.ID) = Auth: _ ?=>
+    me ?=>
+      env.ask.repo
+        .getAsync(aid)
+        .map:
+          case Some(ask) =>
+            if (me is ask.creator) || isGranted(_.ModerateForum) then
+              env.ask.repo.delete(aid)
+              Ok(lila.ask.AskEmbed.askNotFoundFrag)
+            else Unauthorized
+          case _ => NotFound(s"Ask id ${aid} not found")
 
   def conclude(aid: Ask.ID) = authorized(aid, env.ask.repo.conclude)
 
@@ -100,8 +98,8 @@ final class Ask(env: Env) extends LilaController(env):
             case true  => Ask.anonHash(ctx.ip.toString, aid).some
             case false => none[String]
 
-  private def authorized(aid: Ask.ID, action: lila.ask.Ask.ID => Fu[Option[lila.ask.Ask]]) =
-    Auth { _ ?=> me ?=>
+  private def authorized(aid: Ask.ID, action: lila.ask.Ask.ID => Fu[Option[lila.ask.Ask]]) = Auth: _ ?=>
+    me ?=>
       env.ask.repo
         .getAsync(aid)
         .flatMap:
@@ -112,10 +110,9 @@ final class Ask(env: Env) extends LilaController(env):
                 case _            => NotFound(s"Ask id ${aid} not found")
             else fuccess(Unauthorized)
           case _ => fuccess(NotFound(s"Ask id $aid not found"))
-    }
 
-  private def paramToList(param: Option[String]) =
-    param map (_ split ('-') filter (_ nonEmpty) map (_ toInt) toVector)
+  private def intVec(param: Option[String]) =
+    param.map(_.split('-').filter(_.nonEmpty).map(_.toInt).toVector)
 
   private val feedbackForm =
     Form[String](single("text" -> lila.common.Form.cleanNonEmptyText(maxLength = 80)))

--- a/app/views/ask.scala
+++ b/app/views/ask.scala
@@ -1,0 +1,272 @@
+package views.html
+
+import scala.collection.mutable
+import scala.util.Random.shuffle
+
+import controllers.routes
+import scalatags.Text.TypedTag
+import lila.app.templating.Environment.{ given, * }
+import lila.app.ui.ScalatagsTemplate.{ *, given }
+import lila.ask.Ask
+import lila.ask.AskEmbed
+import lila.security.{ Granter, Permission }
+
+object ask:
+
+  def render(frag: Frag)(using PageContext): Frag =
+    val ids = extractIds(frag, Nil)
+    if ids.isEmpty then frag
+    else
+      RawFrag:
+        AskEmbed.bake(
+          frag.render,
+          ids.map: id =>
+            env.ask.repo.get(id) match
+              case Some(ask) =>
+                div(cls := s"ask-container${ask.isStretch so " stretch"}", renderOne(ask)).render
+              case None =>
+                p("<not found>").render
+        )
+
+  def renderOne(ask: Ask, prevView: Option[Vector[Int]] = None, tallyView: Boolean = false)(using
+      Context
+  ): Frag =
+    RenderAsk(ask, prevView, tallyView).render
+
+  def renderGraph(ask: Ask)(using Context): Frag =
+    if ask.isRanked then RenderAsk(ask, None, true).rankGraphBody
+    else RenderAsk(ask, None, true).pollGraphBody
+
+  private def extractIds(frag: Modifier, ids: List[Ask.ID]): List[Ask.ID] = frag match
+    case StringFrag(s)  => ids ++ AskEmbed.extractIds(s)
+    case RawFrag(f)     => ids ++ AskEmbed.extractIds(f)
+    case t: TypedTag[?] => t.modifiers.flatten.foldLeft(ids)((acc, mod) => extractIds(mod, acc))
+    case _              => ids
+
+private case class RenderAsk(
+    ask: Ask,
+    prevView: Option[Vector[Int]],
+    tallyView: Boolean
+)(using ctx: Context):
+  val voterId = ctx.myId.fold(ask.toAnon(ctx.ip))(why => ask.toAnon(why.userId))
+
+  val view = prevView getOrElse:
+    if ask.isRandom then shuffle(ask.choices.indices.toList)
+    else ask.choices.indices.toList
+
+  def render =
+    fieldset(
+      cls                                   := s"ask${ask.isAnon so " anon"}",
+      id                                    := ask._id,
+      ask.hasPickFor(voterId) option (value := "")
+    )(
+      header,
+      ask.isConcluded option label(s"${ask.form.so(_ size) max ask.picks.so(_ size)} responses"),
+      ask.choices.nonEmpty option (
+        if ask.isRanked then
+          if ask.isConcluded || tallyView then rankGraphBody
+          else rankBody
+        else if ask.isConcluded || tallyView then pollGraphBody
+        else pollBody
+      ),
+      footer
+    )
+
+  def header =
+    val viewParam = view.mkString("-")
+    legend(
+      span(cls := "ask__header")(
+        label(
+          ask.question,
+          !tallyView option (
+            if ask.isConcluded then span("(Results)")
+            else if ask.isRanked then span("(Drag to sort)")
+            else if ask.isMulti then span("(Choose all that apply)")
+            else span("(Choose one)")
+          )
+        ),
+        maybeDiv(
+          "url-actions",
+          ask.isTally option button(
+            cls        := (if tallyView then "view" else "tally"),
+            formmethod := "GET",
+            formaction := routes.Ask.view(ask._id, viewParam.some, !tallyView)
+          ),
+          ctx.myId
+            .contains(ask.creator) || ctx.me.so(Granter(Permission.Shusher)(using _)) option button(
+            cls        := "admin",
+            formmethod := "GET",
+            formaction := routes.Ask.admin(ask._id),
+            title      := trans.edit.txt()(using ctx.lang)
+          ),
+          (ask.hasPickFor(voterId) || ask.hasFeedbackFor(voterId)) && !ask.isConcluded option button(
+            cls        := "unset",
+            formaction := routes.Ask.unset(ask._id, viewParam.some, ask.isAnon),
+            title      := trans.delete.txt()(using ctx.lang)
+          )
+        ),
+        maybeDiv(
+          "properties",
+          ask.isTraceable option button(
+            cls   := "property trace",
+            title := "Participants can see who voted for what"
+          ),
+          ask.isAnon option button(
+            cls   := "property anon",
+            title := "Your identity is anonymized and secure"
+          ),
+          ask.isOpen option button(cls := "property open", title := "Anyone can participate")
+        )
+      )
+    )
+
+  def footer =
+    div(cls := "ask__footer")(
+      ask.footer map (label(_)),
+      ask.isForm && !ask.isConcluded && voterId.nonEmpty option Seq(
+        input(
+          cls         := "form-text",
+          tpe         := "text",
+          maxlength   := 80,
+          placeholder := "80 characters max",
+          value       := ~ask.feedbackFor(voterId)
+        ),
+        div(cls := "form-submit")(input(cls := "button", tpe := "button", value := "Submit"))
+      ),
+      ask.isConcluded && ask.form.exists(_.size > 0) option frag:
+        ask.form.map: fmap =>
+          div(cls := "form-results")(
+            ask.footer map (label(_)),
+            fmap.toSeq flatMap:
+              case (user, text) => Seq(div(ask.isTraceable so s"$user:"), div(text))
+          )
+    )
+
+  def pollBody = choiceContainer:
+    val picks = ask.picksFor(voterId)
+    val sb    = new mutable.StringBuilder("choice ")
+    if ask.isCheckbox then sb ++= "cbx " else sb ++= "btn "
+    if ask.isMulti then sb ++= "multiple " else sb ++= "exclusive "
+    if ask.isStretch then sb ++= "stretch "
+    (view map ask.choices).zipWithIndex map:
+      case (choiceText, choice) =>
+        val selected = picks.exists(_ contains choice)
+        if ask.isCheckbox then
+          label(
+            cls   := sb.toString + (if selected then "selected" else "enabled"),
+            title := tooltip(choice),
+            value := choice
+          )(input(tpe := "checkbox", selected option checked), choiceText)
+        else
+          button(
+            cls   := sb.toString + (if selected then "selected" else "enabled"),
+            title := tooltip(choice),
+            value := choice
+          )(choiceText)
+
+  def rankBody = choiceContainer:
+    validRanking.zipWithIndex map:
+      case (choice, index) =>
+        val sb = new mutable.StringBuilder("choice btn rank")
+        if ask.isStretch then sb ++= " stretch"
+        if ask.hasPickFor(voterId) then sb ++= " submitted"
+        div(cls := sb.toString, value := choice, draggable := true)(
+          div(s"${index + 1}"),
+          label(ask.choices(choice)),
+          i
+        )
+
+  def pollGraphBody =
+    div(cls := "ask__graph")(frag:
+      val totals = ask.totals
+      val max    = totals.max
+      totals.zipWithIndex flatMap:
+        case (total, choice) =>
+          val pct  = if max == 0 then 0 else total * 100 / max
+          val hint = tooltip(choice)
+          Seq(
+            div(title := hint)(ask.choices(choice)),
+            div(cls := "votes-text", title := hint)(pluralize("vote", total)),
+            div(cls := "set-width", title := hint, css("width") := s"$pct%")(nbsp)
+          )
+    )
+
+  def rankGraphBody =
+    div(cls := "ask__rank-graph")(frag:
+      val tooltipVec = rankedTooltips
+      ask.averageRank.zipWithIndex
+        .sortWith((i, j) => i._1 < j._1)
+        .flatMap:
+          case (avgIndex, choice) =>
+            val lastIndex = ask.choices.size - 1
+            val pct       = (lastIndex - avgIndex) / lastIndex * 100
+            val hint      = tooltipVec(choice)
+            Seq(
+              div(title := hint)(ask.choices(choice)),
+              div(cls := "set-width", title := hint, style := s"width: $pct%")(nbsp)
+            )
+    )
+
+  def maybeDiv(clz: String, tags: Option[Frag]*) =
+    if tags.toList.flatten.nonEmpty then div(cls := clz, tags) else emptyFrag
+
+  def choiceContainer =
+    val sb = new mutable.StringBuilder("ask__choices")
+    if ask.isVertical then sb ++= " vertical"
+    if ask.isStretch then sb ++= " stretch"
+    div(cls := sb.toString)
+
+  def tooltip(choice: Int) =
+    val sb         = new mutable.StringBuilder(256)
+    val choiceText = ask.choices(choice)
+    val hasPick    = ask.hasPickFor(voterId)
+
+    val count     = ask.count(choiceText)
+    val isAuthor  = ctx.myId.contains(ask.creator)
+    val isShusher = ctx.me.so(Granter(Permission.Shusher)(using _))
+
+    if !ask.isRanked then
+      if ask.isConcluded || tallyView then
+        sb ++= pluralize("vote", count)
+        if ask.isTraceable || isShusher then sb ++= s"\n\n${whoPicked(choice)}"
+      else
+        if isAuthor || ask.isTally then sb ++= pluralize("vote", count)
+        if ask.isTraceable && ask.isTally || isShusher then sb ++= s"\n\n${whoPicked(choice)}"
+
+    if sb.isEmpty then choiceText else sb.toString
+
+  def rankedTooltips =
+    val respondents = ask.picks so (picks => picks.size)
+    val rankM       = ask.rankMatrix
+    val notables = List(
+      0 -> "ranked this first",
+      1 -> "chose this in their top two",
+      2 -> "chose this in their top three",
+      3 -> "chose this in their top four",
+      4 -> "chose this in their top five"
+    )
+    ask.choices.zipWithIndex map { case (choiceText, choice) =>
+      val sb = new mutable.StringBuilder(s"$choiceText:\n\n")
+      notables filter (_._1 < rankM.length - 1) map:
+        case (i, text) => sb ++= s"  ${rankM(choice)(i)} $text\n"
+      sb.toString
+    }
+
+  def pluralize(item: String, n: Int) =
+    s"${if n == 0 then "No" else n} ${item}${if n != 1 then "s" else ""}"
+
+  def whoPicked(choice: Int, max: Int = 100) =
+    val who = ask.whoPicked(choice)
+    if ask.isAnon then s"${who.size} votes"
+    else who.take(max).mkString("", ", ", (who.length > max) so ", and others...")
+
+  def validRanking =
+    val initialOrder =
+      if ask.isRandom then shuffle((0 until ask.choices.size).toVector)
+      else (0 until ask.choices.size).toVector
+    ask.picksFor(voterId).fold(initialOrder) { r =>
+      if r == Vector.empty || r.distinct.sorted != initialOrder.sorted then
+        voterId so (id => env.ask.repo.setPicks(ask._id, id, Vector.empty[Int].some))
+        initialOrder
+      else r
+    }

--- a/app/views/askAdmin.scala
+++ b/app/views/askAdmin.scala
@@ -1,0 +1,66 @@
+package views.html
+
+import controllers.routes
+import lila.app.templating.Environment.{ given, * }
+import lila.app.ui.ScalatagsTemplate.{ *, given }
+import lila.ask.Ask
+import views.html.ask.*
+
+object askAdmin:
+
+  def show(asks: List[Ask], user: lila.common.LightUser)(using Me, PageContext) =
+    views.html.base.layout(
+      title = s"${user.titleName} polls",
+      moreJs = jsModuleInit("ask"),
+      moreCss = cssTag("ask"),
+      csp = defaultCsp.withInlineIconFont.some
+    ):
+      val askmap = asks.sortBy(_.createdAt).groupBy(_.url)
+      main(cls := "page-small box box-pad")(
+        h1(s"${user.titleName} polls"),
+        askmap.keys.map(url => showAsks(url, askmap.get(url).get)) toSeq
+      )
+
+  def showAsks(urlopt: Option[String], asks: List[Ask])(using Me, Context) =
+    div(
+      hr,
+      h2(
+        urlopt match
+          case Some(url) => div(a(href := url)(url))
+          case None      => "no url"
+      ),
+      br,
+      asks map renderOne
+    )
+
+  def renderOne(ask: Ask)(using Context)(using me: Me) =
+    div(cls := "ask-admin")(
+      a(name := ask._id),
+      div(cls := "header")(
+        ask.question,
+        div(cls := "url-actions")(
+          button(formaction := routes.Ask.delete(ask._id))("Delete"),
+          button(formaction := routes.Ask.reset(ask._id))("Reset"),
+          !ask.isConcluded option button(formaction := routes.Ask.conclude(ask._id))("Conclude"),
+          a(href := routes.Ask.json(ask._id))("JSON")
+        )
+      ),
+      div(cls := "inset")(
+        isGranted(_.ModerateForum) option property("id:", ask._id),
+        !me.is(ask.creator) option property("creator:", ask.creator),
+        property("created at:", showInstant(ask.createdAt)),
+        ask.tags.nonEmpty option property("tags:", ask.tags.mkString(", ")),
+        p,
+        renderGraph(ask)
+      ),
+      frag:
+        ask.form.map: fbmap =>
+          div(cls := "inset-box")(
+            fbmap.toSeq map:
+              case (uid, fb) if uid.startsWith("anon-") => p(s"anon: $fb")
+              case (uid, fb)                            => p(s"$uid: $fb")
+          )
+    )
+
+  def property(name: String, value: String) =
+    div(cls := "prop")(div(cls := "name")(name), div(cls := "value")(value))

--- a/app/views/forum/post.scala
+++ b/app/views/forum/post.scala
@@ -106,7 +106,7 @@ object post:
         frag:
           val postFrag = div(cls := s"forum-post__message expand-text")(
             if post.erased then "<Comment deleted by user>"
-            else body
+            else views.html.ask.render(body)
           )
           if hide then
             div(cls := "forum-post__blocked")(
@@ -126,7 +126,7 @@ object post:
               cls            := "post-text-area edit-post-box",
               minlength      := 3,
               required
-            )(post.text),
+            )(env.ask.embed.unfreeze(post.text)),
             div(cls := "edit-buttons")(
               a(
                 cls   := "edit-post-cancel",

--- a/app/views/forum/topic.scala
+++ b/app/views/forum/topic.scala
@@ -73,6 +73,7 @@ object topic:
       formWithCaptcha: Option[FormWithCaptcha],
       unsub: Option[Boolean],
       canModCateg: Boolean,
+      hasAsks: Boolean = false,
       formText: Option[String] = None
   )(using ctx: PageContext) =
     views.html.base.layout(
@@ -80,9 +81,13 @@ object topic:
       moreJs = frag(
         jsModule("forum"),
         formWithCaptcha.isDefined option captchaTag,
-        jsModule("expandText")
+        jsModule("expandText"),
+        hasAsks option jsModuleInit("ask")
       ),
-      moreCss = cssTag("forum"),
+      moreCss = frag(
+        cssTag("forum"),
+        hasAsks option cssTag("ask")
+      ),
       openGraph = lila.app.ui
         .OpenGraph(
           title = topic.name,

--- a/app/views/lobby/home.scala
+++ b/app/views/lobby/home.scala
@@ -17,19 +17,22 @@ object home:
     views.html.base.layout(
       title = "",
       fullTitle = s"$siteName • ${trans.freeOnlineChess.txt()}".some,
-      moreJs = jsModuleInit(
-        "lobby",
-        Json
-          .obj("data" -> data, "i18n" -> i18nJsObject(i18nKeys))
-          .add("hideRatings" -> !ctx.pref.showRatings)
-          .add("hasUnreadLichessMessage", hasUnreadLichessMessage)
-          .add(
-            "playban",
-            playban.map: pb =>
-              Json.obj("minutes" -> pb.mins, "remainingSeconds" -> (pb.remainingSeconds + 3))
-          )
+      moreJs = frag(
+        jsModuleInit(
+          "lobby",
+          Json
+            .obj("data" -> data, "i18n" -> i18nJsObject(i18nKeys))
+            .add("hideRatings" -> !ctx.pref.showRatings)
+            .add("hasUnreadLichessMessage", hasUnreadLichessMessage)
+            .add(
+              "playban",
+              playban.map: pb =>
+                Json.obj("minutes" -> pb.mins, "remainingSeconds" -> (pb.remainingSeconds + 3))
+            )
+        ),
+        homepage.hasAsks option jsModuleInit("ask")
       ),
-      moreCss = cssTag("lobby"),
+      moreCss = frag(cssTag("lobby"), homepage.hasAsks option cssTag("ask")),
       openGraph = lila.app.ui
         .OpenGraph(
           image = assetUrl("logo/lichess-tile-wide.png").some,

--- a/app/views/timeline.scala
+++ b/app/views/timeline.scala
@@ -50,6 +50,14 @@ object timeline:
               title := topicName
             )(shorten(topicName, 30))
           )
+        case AskConcluded(userId, question, url) =>
+          trans.askConcluded(
+            userLink(userId),
+            a(
+              href  := url,
+              title := question
+            )(shorten(question, 30))
+          )
         case UblogPost(userId, id, slug, title) =>
           trans.ublog.xPublishedY(
             userLink(userId),

--- a/app/views/ublog/post.scala
+++ b/app/views/ublog/post.scala
@@ -19,12 +19,14 @@ object post:
       others: List[UblogPost.PreviewPost],
       liked: Boolean,
       followable: Boolean,
-      followed: Boolean
+      followed: Boolean,
+      hasAsks: Boolean
   )(using ctx: PageContext) =
     views.html.base.layout(
-      moreCss = cssTag("ublog"),
+      moreCss = frag(cssTag("ublog"), hasAsks option cssTag("ask")),
       moreJs = frag(
         jsModule("expandText"),
+        hasAsks option jsModuleInit("ask"),
         ctx.isAuth option jsModule("ublog")
       ),
       title = s"${trans.ublog.xBlog.txt(user.username)} • ${post.title}",
@@ -106,7 +108,7 @@ object post:
               a(href := routes.Ublog.topic(topic.url, 1))(topic.value)
           ),
           strong(cls := "ublog-post__intro")(post.intro),
-          div(cls := "ublog-post__markup expand-text")(markup),
+          div(cls := "ublog-post__markup expand-text")(views.html.ask.render(markup)),
           div(cls := "ublog-post__footer")(
             post.live && ~post.discuss option a(
               href     := routes.Ublog.discuss(post.id),

--- a/bin/download-lifat
+++ b/bin/download-lifat
@@ -8,8 +8,6 @@ lifat_dir="${LIFAT_DIR:-lifat}"
 mkdir -p "$lifat_dir"
 lifat_commit_dir=$(realpath "$lifat_dir")/lifat-$commit
 
-mkdir -p "$lifat_dir"
-
 if [ ! -d "$lifat_commit_dir" ]; then
 	git init "$lifat_commit_dir"
 	cd "$lifat_commit_dir"

--- a/build.sbt
+++ b/build.sbt
@@ -67,7 +67,7 @@ lazy val modules = Seq(
   study, studySearch, fishnet, explorer, learn, plan,
   event, coach, practice, evalCache, irwin,
   activity, relay, streamer, bot, clas, swiss, storm, racer,
-  ublog, tutor, opening
+  ublog, tutor, opening, ask
 )
 
 lazy val moduleRefs = modules map projectToRef
@@ -131,12 +131,12 @@ lazy val coordinate = module("coordinate",
 )
 
 lazy val blog = module("blog",
-  Seq(timeline),
+  Seq(timeline, ask),
   Seq(prismic) ++ tests.bundle ++ reactivemongo.bundle
 )
 
 lazy val ublog = module("ublog",
-  Seq(timeline),
+  Seq(timeline, ask),
   Seq(bloomFilter) ++ tests.bundle ++ reactivemongo.bundle
 )
 
@@ -403,8 +403,13 @@ lazy val msg = module("msg",
   reactivemongo.bundle
 )
 
+lazy val ask = module("ask",
+  Seq(common, db, memo, hub),
+  reactivemongo.bundle
+)
+
 lazy val forum = module("forum",
-  Seq(mod),
+  Seq(mod, ask),
   reactivemongo.bundle
 )
 

--- a/conf/routes
+++ b/conf/routes
@@ -577,6 +577,18 @@ GET   /api/stream/irwin                controllers.Irwin.eventStream
 # Kaladin
 GET   /kaladin                         controllers.Irwin.kaladin
 
+# Ask
+GET   /ask/:id                         controllers.Ask.view(id: String, view: Option[String], tally: Boolean ?= false)
+POST  /ask/picks/:id                   controllers.Ask.picks(id: String, picks: Option[String], view: Option[String], anon: Boolean ?= false)
+POST  /ask/form/:id                controllers.Ask.form(id: String, view: Option[String], anon: Boolean ?= false)
+POST  /ask/conclude/:id                controllers.Ask.conclude(id: String)
+POST  /ask/unset/:id                   controllers.Ask.unset(id: String, view: Option[String], anon: Boolean ?= false)
+POST  /ask/reset/:id                   controllers.Ask.reset(id: String)
+POST  /ask/delete/:id                  controllers.Ask.delete(id: String)
+GET   /ask/admin/:id                   controllers.Ask.admin(id: String)
+GET   /ask/byUser/:username            controllers.Ask.byUser(username)
+GET   /ask/json/:id                    controllers.Ask.json(id: String)
+
 # Forum
 GET   /forum                           controllers.ForumCateg.index
 GET   /forum/search                    controllers.ForumPost.search(text ?= "", page: Int ?= 1)

--- a/modules/ask/src/main/Ask.scala
+++ b/modules/ask/src/main/Ask.scala
@@ -1,0 +1,180 @@
+package lila.ask
+
+import lila.common.IpAddress
+import alleycats.Zero
+
+case class Ask(
+    _id: Ask.ID,
+    question: String,
+    choices: Ask.Choices,
+    tags: Ask.Tags,
+    creator: UserId,
+    createdAt: java.time.Instant,
+    footer: Option[String], // optional text prompt for forms
+    picks: Option[Ask.Picks],
+    form: Option[Ask.Form],
+    url: Option[String]
+):
+
+  // changes to any of the fields checked in compatible will invalidate votes and form
+  def compatible(a: Ask): Boolean =
+    question == a.question &&
+      choices == a.choices &&
+      footer == a.footer &&
+      creator == a.creator &&
+      isOpen == a.isOpen &&
+      isTraceable == a.isTraceable &&
+      isAnon == a.isAnon &&
+      isRanked == a.isRanked &&
+      isMulti == a.isMulti
+
+  def merge(dbAsk: Ask): Ask =
+    if this.compatible(dbAsk) then // keep votes & form
+      if tags equals dbAsk.tags then dbAsk
+      else dbAsk.copy(tags = tags)
+    else copy(url = dbAsk.url) // discard votes & form
+
+  def participants: Seq[String] = picks match
+    case Some(p) => p.keys.filter(!_.startsWith("anon-")).toSeq
+    case None    => Nil
+
+  lazy val isOpen      = tags contains "open"              // allow votes from anyone (no acct reqired)
+  lazy val isTraceable = tags.exists(_ startsWith "trace") // everyone can see who voted for what
+  lazy val isAnon = !isTraceable && tags.exists(_ startsWith "anon") // hide voters from creator/mods
+  lazy val isTally     = isTraceable || tags.contains("tally") // partial results viewable before conclusion
+  lazy val isConcluded = tags contains "concluded"             // closed poll
+  lazy val isRandom    = tags.exists(_ startsWith "random")    // randomize order of choices
+  lazy val isMulti    = !isRanked && tags.exists(_ startsWith "multi") // multiple choices allowed
+  lazy val isRanked   = tags.exists(_ startsWith "rank")               // drag to sort
+  lazy val isForm     = tags.exists(_ startsWith "form")               // has a form/submit form
+  lazy val isStretch  = tags.exists(_ startsWith "stretch")            // stretch to fill width
+  lazy val isVertical = tags.exists(_ startsWith "vert")               // one choice per row
+  lazy val isCheckbox = !isRanked && isVertical                        // use checkboxes
+
+  def toAnon(user: UserId): Option[String] =
+    Some(if isAnon then Ask.anonHash(user.value, _id) else user.value)
+
+  def toAnon(ip: IpAddress): Option[String] =
+    isOpen option Ask.anonHash(ip.toString, _id)
+
+  // eid = effective id, either a user id or an anonymous hash
+  def hasPickFor(o: Option[String]): Boolean =
+    o so (eid => picks.exists(_ contains eid))
+
+  def picksFor(o: Option[String]): Option[Vector[Int]] =
+    o.flatMap(eid => picks.flatMap(_ get eid))
+
+  def firstPickFor(o: Option[String]): Option[Int] =
+    picksFor(o) flatMap (_ headOption)
+
+  def hasFeedbackFor(o: Option[String]): Boolean =
+    o so (eid => form.exists(_ contains eid))
+
+  def feedbackFor(o: Option[String]): Option[String] =
+    o so (eid => form flatMap (_ get eid))
+
+  def count(choice: Int): Int    = picks.fold(0)(_.values.count(_ contains choice))
+  def count(choice: String): Int = count(choices indexOf choice)
+
+  def whoPicked(choice: String): List[String] = whoPicked(choices indexOf choice)
+  def whoPicked(choice: Int): List[String] = picks getOrElse (Nil) collect {
+    case (uid, ls) if ls contains choice => uid
+  } toList
+
+  def whoPickedAt(choice: Int, rank: Int): List[String] = picks getOrElse (Nil) collect {
+    case (uid, ls) if ls.indexOf(choice) == rank => uid
+  } toList
+
+  @inline private def constrain(index: Int) = index atMost (choices.size - 1) atLeast 0
+
+  def totals: Vector[Int] = picks match
+    case Some(pmap) if choices.nonEmpty && pmap.nonEmpty =>
+      val results = Array.ofDim[Int](choices.size)
+      pmap.values.foreach(_.foreach { it => results(constrain(it)) += 1 })
+      results.toVector
+    case _ =>
+      Vector.fill(choices.size)(0)
+
+  // index of returned vector maps to choices list, values from [0f, choices.size-1f] where 0 is "best" rank
+  def averageRank: Vector[Float] = picks match
+    case Some(pmap) if choices.nonEmpty && pmap.nonEmpty =>
+      val results = Array.ofDim[Int](choices.size)
+      pmap.values.foreach: ranking =>
+        for it <- choices.indices do results(constrain(ranking(it))) += it
+      results.map(_ / pmap.size.toFloat).toVector
+    case _ =>
+      Vector.fill(choices.size)(0f)
+
+  // an [n]x[n-1] matrix M describing response rankings. each element M[i][j] is the number of
+  // respondents who preferred the choice i at rank j or below (effectively in the top j+1 picks)
+  // the rightmost column is omitted as it is always equal to the number of respondents
+  def rankMatrix: Array[Array[Int]] = picks match
+    case Some(pmap) if choices.nonEmpty && pmap.nonEmpty =>
+      val n   = choices.size - 1
+      val mat = Array.ofDim[Int](choices.size, n)
+      pmap.values.foreach: ranking =>
+        for i <- choices.indices do
+          val iRank = ranking.indexOf(i)
+          for j <- iRank until n do mat(i)(j) += (if iRank <= j then 1 else 0)
+      mat
+    case _ =>
+      Array.ofDim[Int](0, 0)
+
+  def toJson: play.api.libs.json.JsObject =
+    play.api.libs.json.Json.obj(
+      "id"       -> _id,
+      "question" -> question,
+      "choices"  -> choices,
+      "tags"     -> tags,
+      "creator"  -> creator.value,
+      "created"  -> createdAt.toString,
+      "footer"   -> footer,
+      "picks"    -> picks,
+      "form"     -> form,
+      "url"      -> url
+    )
+
+object Ask:
+
+  type ID      = String
+  type Tags    = Set[String]
+  type Choices = Vector[String]
+  type Picks   = Map[String, Vector[Int]] // ranked list of indices into Choices vector
+  type Form    = Map[String, String]
+
+  def make(
+      _id: Option[String],
+      question: String,
+      choices: Choices,
+      tags: Tags,
+      creator: UserId,
+      footer: Option[String],
+      url: Option[String]
+  ) = Ask(
+    _id = _id getOrElse (ornicar.scalalib.ThreadLocalRandom nextString 8),
+    question = question,
+    choices = choices,
+    tags = tags,
+    createdAt = java.time.Instant.now(),
+    creator = creator,
+    footer = footer,
+    picks = None,
+    form = None,
+    url = None
+  )
+
+  /*given zeroAsk: Zero[Ask] with
+    def zero = make(
+      _id = "notfound".some,
+      question = "",
+      choices = Vector.empty,
+      tags = Set.empty,
+      creator = UserId(""),
+      footer = None
+    )*/
+
+  def anonHash(text: String, aid: Ask.ID): String =
+    "anon-" + new String(base64.encode(com.roundeights.hasher.Algo.sha1(s"$text-$aid").bytes))
+      .substring(0, 11)
+
+  private val base64 = java.util.Base64.getEncoder().withoutPadding();

--- a/modules/ask/src/main/Ask.scala
+++ b/modules/ask/src/main/Ask.scala
@@ -1,7 +1,6 @@
 package lila.ask
 
 import lila.common.IpAddress
-import alleycats.Zero
 
 case class Ask(
     _id: Ask.ID,
@@ -67,10 +66,10 @@ case class Ask(
   def firstPickFor(o: Option[String]): Option[Int] =
     picksFor(o) flatMap (_ headOption)
 
-  def hasFeedbackFor(o: Option[String]): Boolean =
+  def hasFormFor(o: Option[String]): Boolean =
     o so (eid => form.exists(_ contains eid))
 
-  def feedbackFor(o: Option[String]): Option[String] =
+  def formFor(o: Option[String]): Option[String] =
     o so (eid => form flatMap (_ get eid))
 
   def count(choice: Int): Int    = picks.fold(0)(_.values.count(_ contains choice))
@@ -162,16 +161,6 @@ object Ask:
     form = None,
     url = None
   )
-
-  /*given zeroAsk: Zero[Ask] with
-    def zero = make(
-      _id = "notfound".some,
-      question = "",
-      choices = Vector.empty,
-      tags = Set.empty,
-      creator = UserId(""),
-      footer = None
-    )*/
 
   def anonHash(text: String, aid: Ask.ID): String =
     "anon-" + new String(base64.encode(com.roundeights.hasher.Algo.sha1(s"$text-$aid").bytes))

--- a/modules/ask/src/main/AskEmbed.scala
+++ b/modules/ask/src/main/AskEmbed.scala
@@ -1,0 +1,186 @@
+package lila.ask
+
+import scala.collection.mutable
+
+/* the freeze process transforms form text prior to database storage and creates/updates collection
+ * objects with ask markup. freeze methods return replacement text with magic{id} tags in place
+ * of any Ask markup found. unfreeze methods allow editing by doing the inverse, replacing magic
+ * tags in a previously frozen text with their markup.
+ */
+
+final class AskEmbed(val repo: lila.ask.AskRepo)(using scala.concurrent.ExecutionContext):
+
+  import AskEmbed.*
+  import Ask.*
+
+  def freeze(text: String, creator: UserId): Frozen =
+    val askIntervals = getMarkupIntervals(text)
+    val asks         = askIntervals.map((start, end) => textToAsk(text.substring(start, end), creator))
+
+    val it = asks.iterator
+    val sb = java.lang.StringBuilder(text.length)
+
+    intervalClosure(askIntervals, text.length).map: seg =>
+      if it.hasNext && askIntervals.contains(seg) then sb.append(s"$frozenIdMagic{${it.next()._id}}")
+      else sb.append(text, seg._1, seg._2)
+
+    Frozen(sb.toString, asks)
+
+  // commit flushes the asks to repo and optionally sets the timeline entry link (for poll conclusion)
+  def commit(frozen: Frozen, url: Option[String] = none[String]): Fu[Iterable[Ask]] =
+    frozen.asks map { ask => repo.upsert(ask.copy(url = url)) } parallel
+
+  def freezeAndCommit(text: String, creator: UserId, url: Option[String] = none[String]): Fu[String] =
+    val askIntervals = getMarkupIntervals(text)
+    askIntervals
+      .map((start, end) => repo.upsert(textToAsk(text.substring(start, end), creator, url)))
+      .parallel
+      .map: asks =>
+        val it = asks.iterator
+        val sb = java.lang.StringBuilder(text.length)
+
+        intervalClosure(askIntervals, text.length).map: seg =>
+          if it.hasNext && askIntervals.contains(seg) then sb.append(s"$frozenIdMagic{${it.next()._id}}")
+          else sb.append(text, seg._1, seg._2)
+        sb.toString
+
+  // unfreeze methods replace magic ids with their ask markup to allow user edits
+  def unfreezeAndLoad(text: String): Fu[String] =
+    extractIds(text)
+      .map(repo.getAsync)
+      .parallel
+      .map: asks =>
+        val it = asks.iterator
+        frozenIdRe.replaceAllIn(text, _ => it.next().fold(askNotFoundFrag)(askToText))
+
+  // dont call this without preloading first
+  def unfreeze(text: String): String =
+    val it = extractIds(text).map(repo.get).iterator
+    frozenIdRe.replaceAllIn(text, _ => it.next().fold(askNotFoundFrag)(askToText))
+
+  def isOpen(aid: Ask.ID): Fu[Boolean] = repo.isOpen(aid)
+
+  def stripAsks(text: String, n: Int = -1): String           = AskEmbed.stripAsks(text, n)
+  def bake(text: String, askFrags: Iterable[String]): String = AskEmbed.bake(text, askFrags)
+
+object AskEmbed:
+  val askNotFoundFrag = "&lt;deleted&gt;<br>"
+
+  case class Frozen(text: String, asks: Iterable[Ask])
+
+  def hasAskId(text: String): Boolean = text.contains(frozenIdMagic)
+
+  // remove frozen magic (for summaries)
+  def stripAsks(text: String, n: Int = -1): String =
+    frozenIdRe.replaceAllIn(text, "").take(if n == -1 then text.length else n)
+
+  // combine text fragments with frozen text in proper order
+  def bake(html: String, askFrags: Iterable[String]): String =
+    val tag = if html.slice(0, 1) == "<" then html.slice(1, html.indexOf(">")) else ""
+    val sb  = new java.lang.StringBuilder(html.length + askFrags.foldLeft(0)((x, y) => x + y.length))
+    val magicIntervals = frozenIdRe.findAllMatchIn(html).map(m => (m.start, m.end)).toList
+    val it             = askFrags.iterator
+
+    intervalClosure(magicIntervals, html.length).map: seg =>
+      val text = html.substring(seg._1, seg._2)
+      if it.hasNext && magicIntervals.contains(seg) then
+        if tag.nonEmpty then sb.append(s"</$tag>")
+        sb.append(it.next)
+      else if !(text.isBlank() || text.startsWith(s"</$tag>")) then
+        sb.append(if seg._1 > 0 && tag.nonEmpty then s"<$tag>$text" else text)
+    sb.toString
+
+  def tag(html: String) = html.slice(1, html.indexOf(">"))
+
+  def extractIds(t: String): List[Ask.ID] =
+    frozenOffsets(t) map (off => t.substring(off._1 + 5, off._2 - 1))
+
+  // render ask as markup text
+  private def askToText(ask: Ask): String =
+    val sb = new mutable.StringBuilder(1024)
+    sb ++= s"/poll ${ask.question}\n"
+    sb ++= s"/id{${ask._id}}"
+    if ask.isForm then sb ++= " form"
+    if ask.isOpen then sb ++= " open"
+    if ask.isTraceable then sb ++= " traceable"
+    else
+      if ask.isTally then sb ++= " tally"
+      if ask.isAnon then sb ++= " anon"
+    if ask.isVertical then sb ++= " vertical"
+    if ask.isStretch then sb ++= " stretch"
+    if ask.isRandom then sb ++= " random"
+    if ask.isRanked then sb ++= " ranked"
+    if ask.isMulti then sb ++= " multiple"
+    if ask.isConcluded then sb ++= " concluded"
+    sb ++= "\n"
+    sb ++= ask.choices.map(c => s"$c\n").mkString
+    sb ++= ~ask.footer.map(f => s"? $f\n")
+    sb.toString
+
+  private def textToAsk(segment: String, creator: UserId, url: Option[String] = none[String]): Ask =
+    val tagString = extractTagString(segment)
+    Ask.make(
+      _id = extractIdFromTagString(tagString),
+      question = extractQuestion(segment),
+      choices = extractChoices(segment),
+      tags = extractTagList(tagString map (_ toLowerCase)),
+      creator = creator,
+      footer = extractFooter(segment),
+      url = url
+    )
+
+  type Interval  = (Int, Int) // [start, end) cleaner than regex match objects for our purpose
+  type Intervals = List[Interval]
+
+  // return list of (start, end) indices of ask markups in text.
+  private def getMarkupIntervals(t: String): Intervals =
+    if !t.contains("/poll") then Nil
+    else askRe findAllMatchIn t map (m => (m.start, m.end)) toList
+
+  // return intervals and their complement in [0, upper)
+  private def intervalClosure(intervals: Intervals, upper: Int): Intervals =
+    val points = (0 :: intervals.flatten(i => List(i._1, i._2)) ::: upper :: Nil).distinct.sorted
+    points zip (points tail)
+
+  // https://www.unicode.org/faq/private_use.html
+  private val frozenIdMagic = "\ufdd6\ufdd4\ufdd2\ufdd0"
+  private val frozenIdRe    = s"$frozenIdMagic\\{(\\S{8})}".r
+
+  // magic/id in a frozen text looks like:  ﷖﷔﷒﷐{8 char id}
+  private def frozenOffsets(t: String): List[Interval] =
+    var i = t indexOf frozenIdMagic
+    if i == -1 then Nil
+    else
+      val ids = mutable.ListBuffer[Interval]()
+      while i != -1 && i <= t.length - 14 do // 14 is total magic length
+        ids addOne (i, i + 14)               // (5, 13) delimit id within magic
+        i = t.indexOf(frozenIdMagic, i + 14)
+      ids toList
+
+  private def extractQuestion(t: String): String =
+    questionInAskRe.findFirstMatchIn(t).fold("")(_ group 1) trim
+
+  private def extractTagString(t: String): Option[String] =
+    tagsInAskRe findFirstMatchIn t map (_ group 1) filter (_.nonEmpty)
+
+  private def extractIdFromTagString(o: Option[String]): Option[String] =
+    o flatMap (idInTagsRe findFirstMatchIn _ map (_ group 1))
+
+  private def extractTagList(o: Option[String]): Ask.Tags =
+    o.fold(Set.empty[String])(
+      tagListRe findAllMatchIn _ collect (_ group 1) toSet
+    ) filterNot (_ startsWith "id{")
+
+  private def extractChoices(t: String): Ask.Choices =
+    (choiceInAskRe findAllMatchIn t map (_ group 1 trim) distinct) toVector
+
+  private def extractFooter(t: String): Option[String] =
+    footerInAskRe findFirstMatchIn t map (_ group 1 trim) filter (_.nonEmpty)
+
+  private val askRe           = raw"(?m)^/poll\h+\S.*\R^(?:/.*(?:\R|$$))?(?:(?!/).*\S.*(?:\R|$$))*(?:\?.*)?".r
+  private val questionInAskRe = raw"^/poll\h+(\S.*)".r
+  private val tagsInAskRe     = raw"(?m)^/poll(?:.*)\R^/(.*)$$".r
+  private val idInTagsRe      = raw"\bid\{(\S{8})}".r
+  private val tagListRe       = raw"\h*(\S+)".r
+  private val choiceInAskRe   = raw"(?m)^(?![\?/])(.*\S.*)".r
+  private val footerInAskRe   = raw"(?m)^\?(.*)".r

--- a/modules/ask/src/main/AskRepo.scala
+++ b/modules/ask/src/main/AskRepo.scala
@@ -1,0 +1,174 @@
+package lila.ask
+
+import scala.concurrent.duration.*
+import scala.collection.concurrent.TrieMap
+import reactivemongo.api.bson.*
+
+import lila.db.dsl.{ *, given }
+import lila.hub.actorApi.timeline.{ AskConcluded, Propagate }
+
+/*
+ * who really cares if big polls drift a bit over time? i say make shitty cache coherence a goal!
+ * updates are almost always single fields whereas reads are total so this is a write-thru cache.
+ * always await preload in the controller if you want sync access from scalatags.
+ */
+
+final class AskRepo(
+    askDb: lila.db.AsyncColl,
+    timeline: lila.hub.actors.Timeline,
+    cacheApi: lila.memo.CacheApi
+)(using
+    scala.concurrent.ExecutionContext
+):
+  import Ask.*
+  import AskEmbed.*
+
+  given BSONDocumentHandler[Ask] = Macros.handler[Ask]
+
+  private val cache = cacheApi.sync[Ask.ID, Option[Ask]](
+    name = "ask",
+    initialCapacity = 1000,
+    compute = getDb,
+    default = _ => none[Ask],
+    strategy = lila.memo.Syncache.Strategy.WaitAfterUptime(20 millis),
+    expireAfter = lila.memo.Syncache.ExpireAfter.Access(1 hour)
+  )
+
+  def get(aid: Ask.ID): Option[Ask] = cache.sync(aid)
+
+  def getAsync(aid: Ask.ID): Fu[Option[Ask]] = cache.async(aid)
+
+  def preload(text: String*): Fu[Boolean] =
+    val ids = text.flatMap(AskEmbed.extractIds)
+    ids.map(getAsync).parallel inject ids.nonEmpty
+
+  // vid (voter id) are sometimes anonymous hashes.
+  def setPicks(aid: Ask.ID, vid: String, picks: Option[Vector[Int]]): Fu[Option[Ask]] =
+    update(aid, vid, picks, modifyPicksCached, writePicks)
+
+  def setForm(aid: Ask.ID, vid: String, form: Option[String]): Fu[Option[Ask]] =
+    update(aid, vid, form, modifyFormCached, writeForm)
+
+  def unset(aid: Ask.ID, vid: String): Fu[Option[Ask]] =
+    update(aid, vid, none[Unit], unsetCached, writeUnset)
+
+  def delete(aid: Ask.ID): Funit = askDb: coll =>
+    cache invalidate aid
+    coll.delete.one($id(aid)).void
+
+  def conclude(aid: Ask.ID): Fu[Option[Ask]] = askDb: coll =>
+    coll
+      .findAndUpdateSimplified[Ask]($id(aid), $addToSet("tags" -> "concluded"), fetchNewObject = true)
+      .collect:
+        case Some(ask) =>
+          cache.set(aid, ask.some)
+          if ask.url.nonEmpty && !ask.isAnon then
+            timeline ! Propagate(AskConcluded(ask.creator, ask.question, ~ask.url))
+              .toUsers(ask.participants.map(UserId(_)).toList)
+              .exceptUser(ask.creator)
+          ask.some
+
+  def reset(aid: Ask.ID): Fu[Option[Ask]] = askDb: coll =>
+    coll
+      .findAndUpdateSimplified[Ask](
+        $id(aid),
+        $doc($unset("picks", "form"), $pull("tags" -> "concluded")),
+        fetchNewObject = true
+      )
+      .collect:
+        case Some(ask) =>
+          cache.set(aid, ask.some)
+          ask.some
+
+  def byUser(uid: UserId): Fu[List[Ask]] = askDb: coll =>
+    coll
+      .find($doc("creator" -> uid))
+      .sort($sort desc "createdAt")
+      .cursor[Ask]()
+      .list(50)
+      .map: asks =>
+        asks.map(a => cache.set(a._id, a.some))
+        asks
+
+  def deleteAll(text: String): Funit = askDb: coll =>
+    val ids = AskEmbed.extractIds(text)
+    ids.map(cache.invalidate)
+    if ids.nonEmpty then coll.delete.one($inIds(ids)).void
+    else funit
+
+  // none values (deleted asks) in these lists are still important for sequencing in renders
+  def asksIn(text: String): Fu[List[Option[Ask]]] = askDb: coll =>
+    val ids = AskEmbed.extractIds(text)
+    ids.map(getAsync).parallel inject ids.map(get)
+
+  def isOpen(aid: Ask.ID): Fu[Boolean] = askDb: coll =>
+    getAsync(aid) map (_ exists (_ isOpen))
+
+  // call this after freezeAsync on form submission for edits
+  def setUrl(text: String, url: Option[String]): Funit = askDb: coll =>
+    if !hasAskId(text) then funit
+    else
+      val selector = $inIds(AskEmbed.extractIds(text))
+      coll.update.one(selector, $set("url" -> url), multi = true) >>
+        coll.list(selector).map(_.foreach(ask => cache.set(ask._id, ask.copy(url = url).some)))
+
+  private val emptyPicks = Map.empty[String, Vector[Int]]
+  private val emptyForm  = Map.empty[String, String]
+
+  private def getDb(aid: Ask.ID) = askDb: coll =>
+    coll.byId[Ask](aid)
+
+  private def update[A](
+      aid: Ask.ID,
+      vid: String,
+      value: Option[A],
+      cached: (Ask, String, Option[A]) => Ask,
+      writeField: (Ask.ID, String, Option[A], Boolean) => Fu[Option[Ask]]
+  ) =
+    cache.sync(aid) match
+      case Some(ask) =>
+        val cachedAsk = cached(ask, vid, value)
+        cache.set(aid, cachedAsk.some)
+        writeField(aid, vid, value, false) inject cachedAsk.some
+      case _ =>
+        writeField(aid, vid, value, true) collect:
+          case Some(ask) =>
+            cache.set(aid, ask.some)
+            ask.some
+
+  // hey i know, let's write 17 functions so we can reuse 2 lines of code
+  private def modifyPicksCached(ask: Ask, vid: String, newPicks: Option[Vector[Int]]) =
+    ask.copy(picks = newPicks.fold(ask.picks.fold(emptyPicks)(_ - vid).some): p =>
+      ((ask.picks.getOrElse(emptyPicks) + (vid -> p)).some))
+
+  private def modifyFormCached(ask: Ask, vid: String, newForm: Option[String]) =
+    ask.copy(form = newForm.fold(ask.form.fold(emptyForm)(_ - vid).some): f =>
+      ((ask.form.getOrElse(emptyForm) + (vid -> f)).some))
+
+  private def unsetCached(ask: Ask, vid: String, unused: Option[Unit]) =
+    ask.copy(picks = ask.picks.fold(emptyPicks)(_ - vid).some, form = ask.form.fold(emptyForm)(_ - vid).some)
+
+  private def writePicks(aid: Ask.ID, vid: String, picks: Option[Vector[Int]], fetchNew: Boolean) =
+    updateAsk(aid, picks.fold($unset(s"picks.$vid"))(r => $set(s"picks.$vid" -> r)), fetchNew)
+
+  private def writeForm(aid: Ask.ID, vid: String, form: Option[String], fetchNew: Boolean) =
+    updateAsk(aid, form.fold($unset(s"form.$vid"))(f => $set(s"form.$vid" -> f)), fetchNew)
+
+  private def writeUnset(aid: Ask.ID, vid: String, unused: Option[Unit], fetchNew: Boolean) =
+    updateAsk(aid, $unset(s"picks.$vid", s"form.$vid"), fetchNew)
+
+  private def updateAsk(aid: Ask.ID, update: BSONDocument, fetchNew: Boolean) = askDb: coll =>
+    coll.update.one($and($id(aid), $doc("tags" -> $ne("concluded"))), update) flatMap:
+      case _ => if fetchNew then getAsync(aid) else fuccess(none[Ask])
+
+  // only preserve votes if important fields haven't been altered
+  private[ask] def upsert(ask: Ask): Fu[Ask] = askDb: coll =>
+    coll.byId[Ask](ask._id) flatMap:
+      case Some(dbAsk) =>
+        val mergedAsk = ask merge dbAsk
+        cache.set(ask._id, mergedAsk.some)
+        if dbAsk eq mergedAsk then fuccess(mergedAsk)
+        else coll.update.one($id(ask._id), mergedAsk) inject mergedAsk
+      case _ =>
+        cache.set(ask._id, ask.some)
+        coll.insert.one(ask) inject ask

--- a/modules/ask/src/main/Env.scala
+++ b/modules/ask/src/main/Env.scala
@@ -1,0 +1,15 @@
+package lila.ask
+
+import com.softwaremill.macwire.*
+import com.softwaremill.tagging.@@
+import lila.common.config.*
+
+@Module
+final class Env(
+    db: lila.db.AsyncDb @@ lila.db.YoloDb,
+    timeline: lila.hub.actors.Timeline,
+    cacheApi: lila.memo.CacheApi
+)(using scala.concurrent.ExecutionContext, akka.actor.Scheduler):
+  private lazy val askColl = db(CollName("ask"))
+  lazy val repo            = wire[AskRepo]
+  lazy val embed           = wire[AskEmbed]

--- a/modules/ask/src/main/package.scala
+++ b/modules/ask/src/main/package.scala
@@ -1,0 +1,5 @@
+package lila.ask
+
+export lila.Lila.{ *, given }
+
+private[ask] val logger = lila.log("ask")

--- a/modules/blog/src/main/Env.scala
+++ b/modules/blog/src/main/Env.scala
@@ -16,6 +16,7 @@ final class Env(
     appConfig: Configuration,
     timelineApi: lila.timeline.EntryApi,
     cacheApi: lila.memo.CacheApi,
+    askEmbed: lila.ask.AskEmbed,
     baseUrl: lila.common.config.BaseUrl,
     db: lila.db.Db
 )(using Executor, Scheduler, play.api.libs.ws.StandaloneWSClient):

--- a/modules/common/src/main/MarkdownRender.scala
+++ b/modules/common/src/main/MarkdownRender.scala
@@ -33,7 +33,7 @@ import com.vladsch.flexmark.util.misc.Extension
 import lila.base.RawHtml
 import com.vladsch.flexmark.html.renderer.ResolvedLink
 import chess.format.pgn.PgnStr
-import lila.common.config.AssetDomain
+import lila.common.config.{ AssetDomain, BaseUrl }
 import scala.util.matching.Regex
 
 final class MarkdownRender(
@@ -45,7 +45,8 @@ final class MarkdownRender(
     list: Boolean = false,
     code: Boolean = false,
     pgnExpand: Option[MarkdownRender.PgnSourceExpand] = None,
-    assetDomain: Option[AssetDomain] = None
+    assetDomain: Option[AssetDomain] = None,
+    baseUrl: Option[BaseUrl] = None
 ):
 
   private val extensions = java.util.ArrayList[Extension]()
@@ -83,7 +84,8 @@ final class MarkdownRender(
   private val logger = lila.log("markdown")
 
   private def mentionsToLinks(markdown: Markdown): Markdown =
-    Markdown(RawHtml.atUsernameRegex.replaceAllIn(markdown.value, "[@$1](/@/$1)"))
+    val replaceWith = baseUrl.fold("[@$1](/@/$1)")(base => s"[@$$1](${base.value}/@/$$1)")
+    Markdown(RawHtml.atUsernameRegex.replaceAllIn(markdown.value, replaceWith))
 
   // https://github.com/vsch/flexmark-java/issues/496
   private val tooManyUnderscoreRegex = """(_{4,})""".r

--- a/modules/forum/src/main/Env.scala
+++ b/modules/forum/src/main/Env.scala
@@ -12,6 +12,7 @@ import lila.notify.NotifyApi
 import lila.pref.PrefApi
 import lila.relation.RelationApi
 import lila.user.User
+import lila.ask.AskEmbed
 
 @Module
 final private class ForumConfig(
@@ -37,7 +38,8 @@ final class Env(
     userRepo: lila.user.UserRepo,
     gameRepo: lila.game.GameRepo,
     cacheApi: lila.memo.CacheApi,
-    ws: StandaloneWSClient
+    ws: StandaloneWSClient,
+    askEmbed: AskEmbed
 )(using Executor, Scheduler, akka.stream.Materializer):
 
   private val config = appConfig.get[ForumConfig]("forum")(AutoConfig.loader)

--- a/modules/forum/src/main/ForumExpand.scala
+++ b/modules/forum/src/main/ForumExpand.scala
@@ -5,22 +5,19 @@ import scalatags.Text.all.{ raw, Frag }
 import lila.base.RawHtml
 import lila.common.config
 
-final class ForumTextExpand(using Executor, Scheduler):
+final class ForumTextExpand(askEmbed: lila.ask.AskEmbed)(using Executor, Scheduler):
 
-  private def one(text: String)(using config.NetDomain): Fu[Frag] =
+  private def one(post: ForumPost)(using config.NetDomain): Fu[ForumPost.WithFrag] =
     lila.common.Bus
-      .ask("lpv")(lila.hub.actorApi.lpv.LpvLinkRenderFromText(text, _))
+      .ask("lpv")(lila.hub.actorApi.lpv.LpvLinkRenderFromText(post.text, _))
       .map: linkRender =>
         raw:
           RawHtml.nl2br {
-            RawHtml.addLinks(text, expandImg = true, linkRender = linkRender.some).value
+            RawHtml.addLinks(post.text, expandImg = true, linkRender = linkRender.some).value
           }.value
+      .zip(askEmbed.repo.preload(post.text))
+      .map: (body, _) =>
+        ForumPost.WithFrag(post, body)
 
   def manyPosts(posts: Seq[ForumPost])(using config.NetDomain): Fu[Seq[ForumPost.WithFrag]] =
-    posts
-      .map(_.text)
-      .traverse(one)
-      .map:
-        _ zip posts map { (body, post) =>
-          ForumPost.WithFrag(post, body)
-        }
+    posts.traverse(one)

--- a/modules/forum/src/main/ForumPost.scala
+++ b/modules/forum/src/main/ForumPost.scala
@@ -4,6 +4,7 @@ import ornicar.scalalib.ThreadLocalRandom
 
 import lila.user.{ Me, User }
 import lila.security.Granter
+import lila.ask.AskEmbed
 
 case class OldVersion(text: String, createdAt: Instant)
 
@@ -76,6 +77,8 @@ case class ForumPost(
   def erased = erasedAt.isDefined
 
   def isBy(u: User) = userId.exists(_ == u.id)
+
+  def cleanTake(n: Int): String = AskEmbed.stripAsks(text, n)
 
   override def toString = s"Post($categId/$topicId/$id)"
 

--- a/modules/forum/src/main/model.scala
+++ b/modules/forum/src/main/model.scala
@@ -42,7 +42,7 @@ case class PostView(
     categ: ForumCateg
 ):
 
-  def show         = post.showUserIdOrAuthor + " @ " + topic.name + " - " + post.text.take(80)
+  def show         = post.showUserIdOrAuthor + " @ " + topic.name + " - " + post.cleanTake(80)
   def logFormatted = "%s / %s#%s / %s".format(categ.name, topic.name, post.number, post.text)
 
 object PostView:

--- a/modules/forumSearch/src/main/ForumSearchApi.scala
+++ b/modules/forumSearch/src/main/ForumSearchApi.scala
@@ -28,7 +28,7 @@ final class ForumSearchApi(
     }
 
   private def toDoc(view: PostLiteView) = Json.obj(
-    Fields.body    -> view.post.text.take(10000),
+    Fields.body    -> view.post.cleanTake(10000),
     Fields.topic   -> view.topic.name,
     Fields.author  -> view.post.userId,
     Fields.topicId -> view.topic.id,

--- a/modules/hub/src/main/actorApi.scala
+++ b/modules/hub/src/main/actorApi.scala
@@ -135,6 +135,9 @@ package timeline:
   case class ForumPost(userId: UserId, topicId: ForumTopicId, topicName: String, postId: ForumPostId)
       extends Atom(s"forum:$topicId", false):
     def userIds = List(userId)
+  case class AskConcluded(userId: UserId, question: String, askUrl: String)
+      extends Atom(s"askConcluded:${question}", false):
+    def userIds = List(userId)
   case class UblogPost(userId: UserId, id: UblogPostId, slug: String, title: String)
       extends Atom(s"ublog:$id", false):
     def userIds = List(userId)

--- a/modules/i18n/src/main/I18nKeys.scala
+++ b/modules/i18n/src/main/I18nKeys.scala
@@ -142,6 +142,7 @@ object I18nKeys:
   val `games` = I18nKey("games")
   val `forum` = I18nKey("forum")
   val `xPostedInForumY` = I18nKey("xPostedInForumY")
+  val `askConcluded` = I18nKey("askConcluded")
   val `latestForumPosts` = I18nKey("latestForumPosts")
   val `players` = I18nKey("players")
   val `friends` = I18nKey("friends")

--- a/modules/timeline/src/main/Entry.scala
+++ b/modules/timeline/src/main/Entry.scala
@@ -38,6 +38,7 @@ object Entry:
       case d: TeamJoin      => "team-join"       -> toBson(d)
       case d: TeamCreate    => "team-create"     -> toBson(d)
       case d: ForumPost     => "forum-post"      -> toBson(d)
+      case d: AskConcluded  => "ask-concluded"   -> toBson(d)
       case d: UblogPost     => "ublog-post"      -> toBson(d)
       case d: TourJoin      => "tour-join"       -> toBson(d)
       case d: GameEnd       => "game-end"        -> toBson(d)
@@ -58,6 +59,7 @@ object Entry:
     given teamJoinHandler: BSONDocumentHandler[TeamJoin]           = Macros.handler
     given teamCreateHandler: BSONDocumentHandler[TeamCreate]       = Macros.handler
     given forumPostHandler: BSONDocumentHandler[ForumPost]         = Macros.handler
+    given askConcludedHandler: BSONDocumentHandler[AskConcluded]   = Macros.handler
     given ublogPostHandler: BSONDocumentHandler[UblogPost]         = Macros.handler
     given tourJoinHandler: BSONDocumentHandler[TourJoin]           = Macros.handler
     given gameEndHandler: BSONDocumentHandler[GameEnd]             = Macros.handler
@@ -75,6 +77,7 @@ object Entry:
       "team-join"       -> teamJoinHandler,
       "team-create"     -> teamCreateHandler,
       "forum-post"      -> forumPostHandler,
+      "ask-concluded"   -> askConcludedHandler,
       "ublog-post"      -> ublogPostHandler,
       "tour-join"       -> tourJoinHandler,
       "game-end"        -> gameEndHandler,
@@ -93,6 +96,7 @@ object Entry:
     val teamJoinWrite      = Json.writes[TeamJoin]
     val teamCreateWrite    = Json.writes[TeamCreate]
     val forumPostWrite     = Json.writes[ForumPost]
+    val askConcludedWrite  = Json.writes[AskConcluded]
     val ublogPostWrite     = Json.writes[UblogPost]
     val tourJoinWrite      = Json.writes[TourJoin]
     val gameEndWrite       = Json.writes[GameEnd]
@@ -109,6 +113,7 @@ object Entry:
       case d: TeamJoin      => teamJoinWrite writes d
       case d: TeamCreate    => teamCreateWrite writes d
       case d: ForumPost     => forumPostWrite writes d
+      case d: AskConcluded  => askConcludedWrite writes d
       case d: UblogPost     => ublogPostWrite writes d
       case d: TourJoin      => tourJoinWrite writes d
       case d: GameEnd       => gameEndWrite writes d

--- a/modules/ublog/src/main/Env.scala
+++ b/modules/ublog/src/main/Env.scala
@@ -18,7 +18,8 @@ final class Env(
     shutup: lila.hub.actors.Shutup,
     captcher: lila.hub.actors.Captcher,
     cacheApi: lila.memo.CacheApi,
-    net: NetConfig
+    net: NetConfig,
+    askEmbed: lila.ask.AskEmbed
 )(using Executor, Scheduler, akka.stream.Materializer, play.api.Mode):
 
   export net.{ assetBaseUrl, baseUrl, domain, assetDomain }

--- a/modules/ublog/src/main/UblogApi.scala
+++ b/modules/ublog/src/main/UblogApi.scala
@@ -110,7 +110,7 @@ final class UblogApi(
   def latestPosts(nb: Int): Fu[List[UblogPost.PreviewPost]] =
     colls.post
       .find(
-        $doc("live" -> true, "pinned" -> false, "topics" $ne UblogTopic.offTopic),
+        $doc("live" -> true, "pinned" $ne true, "topics" $ne UblogTopic.offTopic),
         previewPostProjection.some
       )
       .sort($doc("rank" -> -1))

--- a/modules/ublog/src/main/UblogForm.scala
+++ b/modules/ublog/src/main/UblogForm.scala
@@ -66,13 +66,13 @@ object UblogForm:
       move: String
   ):
 
-    def create(user: User) =
+    def create(user: User, updated: Markdown) =
       UblogPost(
         id = UblogPostId(ThreadLocalRandom nextString 8),
         blog = UblogBlog.Id.User(user.id),
         title = title,
         intro = intro,
-        markdown = markdown,
+        markdown = updated,
         language = language.orElse(user.language) | defaultLanguage,
         topics = topics so UblogTopic.fromStrList,
         image = none,
@@ -87,11 +87,11 @@ object UblogForm:
         pinned = none
       )
 
-    def update(user: User, prev: UblogPost) =
+    def update(user: User, prev: UblogPost, updated: Markdown) =
       prev.copy(
         title = title,
         intro = intro,
-        markdown = markdown,
+        markdown = updated,
         image = prev.image.map: i =>
           i.copy(alt = imageAlt, credit = imageCredit),
         language = language | prev.language,

--- a/translation/source/site.xml
+++ b/translation/source/site.xml
@@ -175,6 +175,7 @@
   <string name="games">Games</string>
   <string name="forum">Forum</string>
   <string name="xPostedInForumY">%1$s posted in topic %2$s</string>
+  <string name="askConcluded">%1$s posted results for %2$s</string>
   <string name="latestForumPosts">Latest forum posts</string>
   <string name="players">Players</string>
   <string name="friends">Friends</string>

--- a/ui/chess/src/moveRootCtrl.ts
+++ b/ui/chess/src/moveRootCtrl.ts
@@ -1,8 +1,6 @@
-import { Api as CgApi } from 'chessground/api';
 import * as cg from 'chessground/types';
 
 export interface MoveRootCtrl {
-  chessground: CgApi;
   auxMove: (orig: cg.Key, dest: cg.Key, prom: cg.Role | undefined) => void;
   redraw: () => void;
   flipNow: () => void;
@@ -15,4 +13,10 @@ export interface MoveRootCtrl {
   solve?: () => void;
   blindfold?: (v?: boolean) => boolean;
   speakClock?: () => void;
+}
+
+export interface MoveUpdate {
+  fen: string;
+  canMove: boolean;
+  cg?: CgApi;
 }

--- a/ui/round/src/ctrl.ts
+++ b/ui/round/src/ctrl.ts
@@ -275,8 +275,7 @@ export default class RoundController implements MoveRootCtrl {
     this.chessground.set(config);
     if (s.san && isForwardStep) lichess.sound.move(s);
     this.autoScroll();
-    this.voiceMove?.update(s.fen, this.canMove());
-    this.keyboardMove?.update(s, this.canMove());
+    this.auxUpdate(s.fen);
     lichess.pubsub.emit('ply', ply);
     return true;
   };
@@ -343,6 +342,11 @@ export default class RoundController implements MoveRootCtrl {
       if (this.startPromotion(orig, dest, { premove: false })) return;
     }
     this.sendMove(orig, dest, role, { premove: false });
+  };
+
+  auxUpdate = (fen: string) => {
+    this.voiceMove?.update({ fen, canMove: this.canMove() });
+    this.keyboardMove?.update({ fen, canMove: this.canMove() });
   };
 
   sendMove = (orig: cg.Key, dest: cg.Key, prom: cg.Role | undefined, meta: cg.MoveMetadata) => {
@@ -494,8 +498,7 @@ export default class RoundController implements MoveRootCtrl {
     }
     this.autoScroll();
     this.onChange();
-    this.keyboardMove?.update(step, playedColor != d.player.color);
-    this.voiceMove?.update(step.fen, playedColor != d.player.color);
+    this.auxUpdate(step.fen);
     lichess.sound.move({ ...o, filter: 'music' });
     lichess.sound.saySan(step.san);
     return true; // prevents default socket pubsub
@@ -531,8 +534,7 @@ export default class RoundController implements MoveRootCtrl {
     this.autoScroll();
     this.onChange();
     this.setLoading(false);
-    this.keyboardMove?.update(d.steps[d.steps.length - 1]);
-    this.voiceMove?.update(d.steps[d.steps.length - 1].fen, true);
+    this.auxUpdate(d.steps[d.steps.length - 1].fen);
   };
 
   endWithData = (o: ApiEnd): void => {
@@ -835,11 +837,15 @@ export default class RoundController implements MoveRootCtrl {
 
   setChessground = (cg: CgApi) => {
     this.chessground = cg;
+    const up = { fen: this.stepAt(this.ply).fen, canMove: this.canMove(), cg };
     if (!this.isPlaying()) return;
-    if (this.data.pref.keyboardMove) this.keyboardMove = makeKeyboardMove(this, this.stepAt(this.ply));
+    if (this.data.pref.keyboardMove) {
+      this.keyboardMove ??= makeKeyboardMove(this);
+      this.keyboardMove.update(up);
+    }
     if (this.data.pref.voiceMove) {
-      this.voiceMove?.update(this.stepAt(this.ply).fen, this.canMove(), cg);
-      this.voiceMove ??= makeVoiceMove(this, this.stepAt(this.ply).fen);
+      if (this.voiceMove) this.voiceMove.update(up);
+      else this.voiceMove = makeVoiceMove(this, up);
     }
     if (this.keyboardMove || this.voiceMove) requestAnimationFrame(() => this.redraw());
   };

--- a/ui/site/css/_ask.admin.scss
+++ b/ui/site/css/_ask.admin.scss
@@ -1,0 +1,56 @@
+$c-contrast-font: $c-font-clear; //if($theme-light, #444, #ddd);
+$c-box-border: if($theme-light, #ddd, #484848);
+
+// someone, please delete all of this
+div.ask-admin {
+  width: 100%;
+  font-size: 1rem;
+  div.header {
+    font-size: 1.3em;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+  div.url-actions {
+    display: flex;
+    flex-flow: row-reverse nowrap;
+    a,
+    button {
+      @extend %button-none;
+      font-size: 1em;
+      color: $c-primary;
+      padding: 0.6em 0.8em;
+      margin: 0;
+      &:hover {
+        color: mix($c-primary, $c-contrast-font, 50%);
+        background: mix($c-primary, $c-bg-box, if($theme-light, 10%, 20%));
+      }
+    }
+  }
+  .prop {
+    font-size: 1em;
+    font-weight: bold;
+    display: flex;
+    flex-flow: row nowrap;
+    .name {
+      width: 140px;
+    }
+    .value {
+      font-style: bold;
+      flex: auto;
+    }
+  }
+  .inset {
+    margin: 1em;
+  }
+  .inset-box {
+    padding: 1em;
+    border: solid 1px $c-box-border;
+    background: $c-bg-box;
+    > p {
+      margin-#{$start-direction}: 2em;
+      font-size: 0.8em;
+      text-indent: -2em;
+    }
+  }
+}

--- a/ui/site/css/_ask.scss
+++ b/ui/site/css/_ask.scss
@@ -1,0 +1,380 @@
+$gap: 6px;
+$c-contrast-font: if($theme-light, #444, #ddd);
+$c-neutral: if($theme-light, #ccc, #777);
+$c-box-border: if($theme-light, #ddd, #484848);
+$c-bg-hover: $c-box-border;
+%lighten-hover {
+  color: $c-contrast-font;
+  &:hover {
+    box-shadow: inset 0 0 1px 100px hsla(0, 0%, 100%, if($theme-light, 0.3, 0.1));
+  }
+}
+
+div.ask-container {
+  display: flex;
+  font-size: 1rem;
+
+  &.stretch {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}
+
+fieldset.ask {
+  margin-bottom: 2 * $gap;
+  padding: 0 (3 * $gap) $gap (2 * $gap);
+  width: 100%;
+  line-height: normal;
+  border: solid 1px $c-box-border;
+
+  > label {
+    margin: $gap;
+    flex-basis: 100%;
+    font-weight: bold;
+  }
+
+  & > * {
+    display: flex;
+    align-items: center;
+    flex-direction: row;
+  }
+}
+
+span.ask__header {
+  display: flex;
+  flex: 1 0 100%;
+  column-gap: $gap;
+  justify-content: space-between;
+
+  label {
+    flex: auto;
+    margin-#{$start-direction}: $gap;
+    padding-bottom: $gap;
+    font-size: 1.3em;
+  }
+
+  label span {
+    white-space: nowrap;
+    margin-#{$start-direction}: $gap;
+    font-size: 0.6em;
+  }
+
+  div {
+    display: flex;
+    align-content: center;
+    border: 1px solid $c-box-border;
+    border-radius: 4px;
+    align-self: center;
+  }
+
+  div button {
+    @extend %button-none;
+    padding: 0 0.25em;
+    font-size: 1.2em;
+    font-family: lichess;
+  }
+
+  div.url-actions {
+    border-color: c-dimmer($c-primary, 40%);
+    font-size: 1em;
+    padding: 0.3em;
+  }
+
+  div.url-actions button {
+    padding: 0 $gap / 4;
+    color: $c-link;
+    cursor: pointer;
+
+    &:hover {
+      color: $c-link-hover;
+    }
+
+    &.admin::before {
+      content: $licon-Gear;
+    }
+
+    &.view::before {
+      content: $licon-Pencil;
+    }
+
+    &.tally::before {
+      content: $licon-BarChart;
+    }
+
+    &.unset {
+      color: if($theme-light, #f66, #c33);
+
+      &::before {
+        content: $licon-X;
+      }
+
+      &:hover {
+        color: if($theme-light, #c33, #f66);
+      }
+    }
+  }
+
+  div.properties {
+    font-size: 0.8em;
+    padding: 0.2em;
+  }
+
+  div.properties button {
+    padding: 0 $gap / 2;
+    color: $c-font-dim;
+    cursor: default;
+
+    &.open::before {
+      content: $licon-Group;
+    }
+
+    &.anon::before {
+      content: $licon-Mask;
+    }
+
+    &.trace::before {
+      content: $licon-Search;
+    }
+  }
+}
+
+div.ask__footer {
+  margin: $gap 0;
+  display: grid;
+  grid-template-columns: auto min-content;
+
+  // form prompt
+  label {
+    margin: 0 0 $gap $gap;
+    grid-column: 1/3;
+  }
+
+  .form-text {
+    margin: 0 0 $gap $gap;
+    padding: 0.4em;
+  }
+
+  .form-submit {
+    @extend %data-icon, %flex-around;
+    visibility: hidden;
+
+    input {
+      margin: 0 0 $gap (2 * $gap);
+      padding: $gap 1.2em;
+    }
+
+    &.success {
+      visibility: visible;
+      color: $c-secondary;
+
+      & > input {
+        visibility: hidden;
+      }
+
+      &::after {
+        position: absolute;
+        content: $licon-Checkmark;
+      }
+    }
+
+    &.dirty {
+      visibility: visible;
+    }
+  }
+
+  .form-results {
+    grid-column: 1/3; // wtf is htis?
+    display: grid;
+    grid-template-columns: max-content auto;
+    padding: 0 (2 * $gap) $gap $gap;
+    label {
+      grid-column: 1/3;
+      font-size: 1.3em;
+      margin: 0 0 $gap 0;
+    }
+    div {
+      margin: 0 $gap;
+    }
+  }
+}
+
+div.ask__choices {
+  margin: $gap 0 $gap 0;
+  display: flex;
+  flex-flow: row wrap;
+  align-items: flex-start;
+
+  .choice {
+    display: inline-block;
+    user-select: none;
+    flex: initial;
+    &:focus-within {
+      outline: 1px solid $c-primary;
+    }
+  }
+
+  .choice.cbx {
+    display: flex;
+    flex-flow: row nowrap;
+    align-items: center;
+    margin: 1.5 * $gap $gap 0;
+    &:first-child {
+      margin-top: 0;
+    }
+
+    &.selected,
+    &.enabled {
+      cursor: pointer;
+      > input {
+        cursor: pointer;
+      }
+    }
+    > input {
+      pointer-events: none;
+      min-width: 24px;
+      min-height: 24px;
+      cursor: pointer;
+      margin-#{$end-direction}: $gap;
+    }
+  }
+
+  .choice.btn {
+    @extend %metal, %box-radius;
+    margin: 0 0 $gap $gap;
+    padding: $gap (2 * $gap);
+    text-align: center;
+    border: 1px;
+    border-color: $c-neutral;
+
+    &.enabled {
+      @extend %lighten-hover;
+      cursor: pointer;
+
+      @if $theme-light {
+        background: linear-gradient(hsl(0deg, 0%, 92%) 0%, hsl(0deg, 0%, 86%) 100%);
+      } @else if $theme == 'dark' {
+        background: linear-gradient(hsl(0deg, 0%, 27%) 0%, hsl(0deg, 0%, 19%) 100%);
+      } @else {
+        background: hsla(0deg, 0%, 50%, 0.3);
+      }
+    }
+
+    &.selected {
+      @extend %lighten-hover;
+      cursor: pointer;
+      color: white;
+      background: linear-gradient(hsl(209, 79%, 58%) 0%, hsl(209, 79%, 52%) 100%);
+    }
+
+    &.stretch {
+      flex: auto;
+    }
+  }
+
+  .choice.btn.rank {
+    @extend %lighten-hover;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    cursor: move;
+
+    &.dragging {
+      opacity: 0.3;
+    }
+    ::after {
+      content: '';
+    }
+
+    // rank badge
+    > div {
+      margin-#{$start-direction}: -$gap;
+      margin-#{$end-direction}: $gap;
+      width: 1.7em;
+      height: 1.7em;
+      border-radius: 100%;
+      background: if($theme-light, #bbb, #666);
+      border: 1px solid if($theme-light, #aaa, #666);
+      color: if($theme-light, #ddd, #000);
+      text-align: center;
+      font-size: 0.7em;
+      font-weight: bold;
+    }
+
+    > label {
+      cursor: move;
+    }
+
+    // green rank badge (submitted)
+    &.submitted > div {
+      background: $c-secondary;
+    }
+
+    @if $theme == 'transp' {
+      background: hsla(0deg, 0%, 50%, 0.3);
+    }
+  }
+
+  // vertical ask drag cursor
+  hr {
+    margin: 0 0 $gap ($gap / 2);
+    width: 100%;
+    height: 2px;
+    display: block;
+    border-top: 1px solid $c-neutral;
+    border-bottom: 1px solid $c-box-border;
+  }
+
+  // horizontal ask drag cursor (I-beam)
+  .cursor {
+    margin: 0 0 0 $gap;
+    padding: 0;
+    width: 2 * $gap;
+    text-align: center;
+
+    // I-beam icon
+    &::after {
+      @extend %data-icon;
+      margin-#{$start-direction}: -$gap;
+      font-size: 2.1em;
+      color: if($theme-light, #bbb, $c-font);
+      text-align: center;
+      content: $licon-Ibeam;
+    }
+  }
+
+  &.vertical {
+    flex-flow: column;
+  }
+
+  &.center {
+    align-items: center;
+    justify-content: center;
+  }
+}
+
+div.ask__graph,
+div.ask__rank-graph {
+  margin: 0 $gap (2 * $gap) $gap;
+  display: grid;
+  grid-template-columns: fit-content(40%) max-content auto;
+  grid-auto-rows: 1fr;
+  align-items: center;
+
+  div {
+    margin: $gap $gap 0 $gap;
+    user-select: none;
+  }
+  .votes-text {
+    margin-right: 0;
+    text-align: end;
+  }
+  .set-width {
+    height: 75%;
+    min-width: 0.2em;
+    background: $c-primary;
+  }
+}
+
+div.ask__rank-graph {
+  grid-template-columns: fit-content(40%) auto;
+}

--- a/ui/site/css/build/_ask.scss
+++ b/ui/site/css/build/_ask.scss
@@ -1,0 +1,3 @@
+@import '../../../common/css/plugin';
+@import '../ask';
+@import '../ask.admin';

--- a/ui/site/css/build/ask.ltr.dark.scss
+++ b/ui/site/css/build/ask.ltr.dark.scss
@@ -1,0 +1,3 @@
+@import '../../../common/css/dir/ltr';
+@import '../../../common/css/theme/dark';
+@import 'ask';

--- a/ui/site/css/build/ask.ltr.light.scss
+++ b/ui/site/css/build/ask.ltr.light.scss
@@ -1,0 +1,3 @@
+@import '../../../common/css/dir/ltr';
+@import '../../../common/css/theme/light';
+@import 'ask';

--- a/ui/site/css/build/ask.ltr.transp.scss
+++ b/ui/site/css/build/ask.ltr.transp.scss
@@ -1,0 +1,3 @@
+@import '../../../common/css/dir/ltr';
+@import '../../../common/css/theme/transp';
+@import 'ask';

--- a/ui/site/css/build/ask.rtl.dark.scss
+++ b/ui/site/css/build/ask.rtl.dark.scss
@@ -1,0 +1,3 @@
+@import '../../../common/css/dir/rtl';
+@import '../../../common/css/theme/dark';
+@import 'ask';

--- a/ui/site/css/build/ask.rtl.light.scss
+++ b/ui/site/css/build/ask.rtl.light.scss
@@ -1,0 +1,3 @@
+@import '../../../common/css/dir/rtl';
+@import '../../../common/css/theme/light';
+@import 'ask';

--- a/ui/site/css/build/ask.rtl.transp.scss
+++ b/ui/site/css/build/ask.rtl.transp.scss
@@ -1,0 +1,3 @@
+@import '../../../common/css/dir/rtl';
+@import '../../../common/css/theme/transp';
+@import 'ask';

--- a/ui/site/package.json
+++ b/ui/site/package.json
@@ -69,7 +69,8 @@
         "src/soundMove.ts": "soundMove",
         "src/diagnostic.ts": "diagnostic",
         "src/flairPicker.ts": "flairPicker",
-        "src/dailyFeed.ts": "dailyFeed"
+        "src/dailyFeed.ts": "dailyFeed",
+        "src/ask.ts": "ask"
       }
     },
     "copy": [

--- a/ui/site/src/ask.ts
+++ b/ui/site/src/ask.ts
@@ -1,0 +1,261 @@
+import * as xhr from 'common/xhr';
+import throttle from 'common/throttle';
+
+export default function initModule() {
+  lichess.load.then(() => $('.ask-container').each((_, e: EleLoose) => new Ask(e.firstElementChild!)));
+}
+
+class Ask {
+  el: Element;
+  anon: boolean;
+  submitEl?: Element;
+  feedbackEl?: HTMLInputElement;
+  view: string; // the initial order of picks when 'random' tag is used
+  db: 'clean' | 'hasPicks'; // clean means no picks for this (ask, user) in the db
+  constructor(askEl: Element) {
+    this.el = askEl;
+    this.anon = askEl.classList.contains('anon');
+    this.db = askEl.hasAttribute('value') ? 'hasPicks' : 'clean';
+    this.view = Array.from($('.choice', this.el), e => e?.getAttribute('value')).join('-');
+    wireExclusiveChoices(this);
+    wireMultipleChoices(this);
+    wireRankedChoices(this);
+    wireActions(this);
+    wireFeedback(this);
+    wireSubmit(this);
+  }
+  ranking(): string {
+    return Array.from($('.choice.rank', this.el), e => e?.getAttribute('value')).join('-');
+  }
+  feedbackState(state: 'clean' | 'dirty' | 'success') {
+    this.submitEl?.classList.remove('dirty', 'success');
+    if (state != 'clean') this.submitEl?.classList.add(state);
+  }
+  picksUrl(picks: string): string {
+    return `/ask/picks/${this.el.id}${picks ? `?picks=${picks}&` : '?'}view=${this.view}${
+      this.el.classList.contains('anon') ? '&anon=true' : ''
+    }`;
+  }
+}
+
+function rewire(el: Element | null, frag: string): Ask | undefined {
+  while (el && !el.classList.contains('ask-container')) el = el.parentElement;
+  if (el && frag) {
+    el.innerHTML = frag;
+    return new Ask(el.firstElementChild!);
+  }
+}
+
+function askXhr(req: { ask: Ask; url: string; method?: string; body?: FormData; after?: (_: Ask) => void }) {
+  xhr.textRaw(req.url, { method: req.method ? req.method : 'POST', body: req.body }).then(
+    async (rsp: Response) => {
+      if (rsp.redirected) {
+        if (!rsp.url.startsWith(window.location.origin)) throw new Error(`Bad redirect: ${rsp.url}`);
+        window.location.href = rsp.url;
+        return;
+      }
+      console.log(req.url);
+      const newAsk = rewire(req.ask.el, await xhr.ensureOk(rsp).text());
+      if (req.after) req.after(newAsk!);
+    },
+    (rsp: Response) => {
+      console.log(`Ask failed: ${rsp.status} ${rsp.statusText}`);
+    },
+  );
+}
+
+function wireExclusiveChoices(ask: Ask) {
+  $('.choice.exclusive', ask.el).on('click', function (e: Event) {
+    const el = e.target as Element;
+    askXhr({
+      ask: ask,
+      url: ask.picksUrl(el.classList.contains('selected') ? '' : el.getAttribute('value')!),
+    });
+    e.preventDefault();
+  });
+}
+
+function wireMultipleChoices(ask: Ask) {
+  $('.choice.multiple', ask.el).on('click', function (e: Event) {
+    $(e.target as Element).toggleClass('selected');
+    const picks = $('.choice', ask.el)
+      .filter((_, x) => x.classList.contains('selected'))
+      .get()
+      .map(x => x.getAttribute('value'));
+    askXhr({ ask: ask, url: ask.picksUrl(picks.join('-')) });
+    e.preventDefault();
+  });
+}
+
+function wireFeedback(ask: Ask) {
+  ask.feedbackEl = $('.form-text', ask.el)
+    .on('input', () => ask.feedbackState(ask.feedbackEl?.value == initialFeedback ? 'clean' : 'dirty'))
+    .on('keypress', (e: KeyboardEvent) => {
+      if (
+        e.key != 'Enter' ||
+        e.shiftKey ||
+        e.ctrlKey ||
+        e.altKey ||
+        e.metaKey ||
+        !ask.submitEl?.classList.contains('dirty')
+      )
+        return;
+      $('input', ask.submitEl).trigger('click');
+      e.preventDefault();
+    })
+    .get(0) as HTMLInputElement;
+  const initialFeedback = ask.feedbackEl?.value;
+}
+
+function wireSubmit(ask: Ask) {
+  ask.submitEl = $('.form-submit', ask.el).get(0);
+  if (!ask.submitEl) return;
+  $('input', ask.submitEl).on('click', () => {
+    const path = `/ask/form/${ask.el.id}?view=${ask.view}&anon=${ask.el.classList.contains('anon')}`;
+    const body = ask.feedbackEl?.value ? xhr.form({ text: ask.feedbackEl.value }) : undefined;
+    askXhr({
+      ask: ask,
+      url: path,
+      body: body,
+      after: ask => ask.feedbackState(ask.feedbackEl?.value ? 'success' : 'clean'),
+    });
+  });
+}
+
+function wireActions(ask: Ask) {
+  $('.url-actions button', ask.el).on('click', (e: Event) => {
+    const btn = e.target as HTMLButtonElement;
+    askXhr({ ask: ask, method: btn.formMethod, url: btn.formAction });
+  });
+}
+
+function wireRankedChoices(ask: Ask): void {
+  let initialOrder = ask.ranking();
+  let d: DragContext;
+
+  const container = $('.ask__choices', ask.el);
+  const vertical = container.hasClass('vertical');
+  const [cursorEl, breakEl] = createCursor(vertical);
+  const updateCursor = throttle(100, (d: DragContext, e: DragEvent) => {
+    // avoid processing a delayed drag event after the drop
+    if (!d.isDone) vertical ? updateVCursor(d, e) : updateHCursor(d, e);
+  });
+
+  container
+    .on('dragover', (e: DragEvent) => {
+      e.preventDefault();
+      updateCursor(d, e);
+    })
+    .on('dragleave', (e: DragEvent) => {
+      e.preventDefault();
+      updateCursor(d, e);
+    });
+
+  $('.choice.rank', ask.el) // wire each draggable
+    .on('dragstart', (e: DragEvent) => {
+      e.dataTransfer!.effectAllowed = 'move';
+      e.dataTransfer!.setData('text/plain', '');
+      const dragEl = e.target as Element;
+      dragEl.classList.add('dragging');
+      d = {
+        dragEl: dragEl,
+        parentEl: dragEl.parentElement!,
+        box: dragEl.parentElement!.getBoundingClientRect(),
+        cursorEl: cursorEl!,
+        breakEl: breakEl,
+        choices: Array.from($('.choice.rank', ask.el), e => e!),
+        isDone: false,
+      };
+    })
+    .on('dragend', (e: DragEvent) => {
+      e.preventDefault();
+      d.isDone = true;
+      d.dragEl.classList.remove('dragging');
+      if (d.cursorEl.parentElement != d.parentEl) return;
+      d.parentEl.insertBefore(d.dragEl, d.cursorEl);
+      clearCursor(d);
+
+      const newOrder = ask.ranking();
+      if (newOrder == initialOrder) return;
+      askXhr({
+        ask: ask,
+        url: ask.picksUrl(newOrder),
+        after: () => {
+          initialOrder = newOrder;
+        },
+      });
+    });
+}
+
+type DragContext = {
+  dragEl: Element; // we are dragging this
+  parentEl: Element; // the div.ask__chioces containing the draggables
+  box: DOMRect; // the rectangle containing all draggables
+  cursorEl: Element; // the insertion cursor (I beam div or <hr> depending on mode)
+  breakEl: Element | null; // null if vertical, a div {flex-basis: 100%} if horizontal
+  choices: Array<Element>; // the draggable elements
+  isDone: boolean; // emerge victorious after the onslaught of throttled dragover events
+  data?: any; // used to track dirty state in updateHCursor
+};
+
+function createCursor(vertical: boolean) {
+  if (vertical) return [document.createElement('hr'), null];
+
+  const cursorEl = document.createElement('div');
+  cursorEl.classList.add('cursor');
+  const breakEl = document.createElement('div');
+  breakEl.style.flexBasis = '100%';
+  return [cursorEl, breakEl];
+}
+
+function clearCursor(d: DragContext): void {
+  if (d.cursorEl.parentNode) d.parentEl.removeChild(d.cursorEl);
+  if (d.breakEl?.parentNode) d.parentEl.removeChild(d.breakEl);
+}
+
+function updateHCursor(d: DragContext, e: MouseEvent): void {
+  if (e.x <= d.box.left || e.x >= d.box.right || e.y <= d.box.top || e.y >= d.box.bottom) {
+    clearCursor(d);
+    d.data = null;
+    return;
+  }
+  const rtl = document.dir == 'rtl';
+  let target: { el: Element | null; break: 'beforebegin' | 'afterend' | null } | null = null;
+  for (let i = 0, lastY = 0; i < d.choices.length && !target; i++) {
+    const r = d.choices[i].getBoundingClientRect();
+    const x = r.right - r.width / 2;
+    const y = r.bottom + 4; // +4 because there's (currently) 8 device px between rows
+    const rowBreak = i > 0 && y != lastY;
+    if (rowBreak && e.y <= lastY) target = { el: d.choices[i], break: 'afterend' };
+    else if (e.y <= y && (rtl ? e.x >= x : e.x <= x))
+      target = { el: d.choices[i], break: rowBreak ? 'beforebegin' : null };
+    lastY = y;
+  }
+  if (d.data && target && d.data.el == target.el && d.data.break == target.break) return; // nothing to do here
+
+  d.data = target; // keep last target in context data so we only diddle the DOM when dirty
+
+  if (!target) {
+    d.parentEl.insertBefore(d.cursorEl, null);
+    return;
+  }
+  d.parentEl.insertBefore(d.cursorEl, target.el);
+  if (target.break) {
+    // don't add break when inserting the cursor at the end of a line with no room
+    if (target.break != 'afterend' || d.cursorEl.getBoundingClientRect().top < e.y)
+      d.cursorEl.insertAdjacentElement(target.break, d.breakEl!);
+  } else if (d.breakEl!.parentNode) d.parentEl.removeChild(d.breakEl!);
+}
+
+function updateVCursor(d: DragContext, e: DragEvent): void {
+  if (e.x <= d.box.left || e.x >= d.box.right || e.y <= d.box.top || e.y >= d.box.bottom) {
+    clearCursor(d);
+    return;
+  }
+  let target: Element | null = null;
+  for (let i = 0; i < d.choices.length && !target; i++) {
+    const r = d.choices[i].getBoundingClientRect();
+    if (e.y < r.top + r.height / 2) target = d.choices[i];
+  }
+  d.parentEl.insertBefore(d.cursorEl, target);
+}

--- a/ui/voice/.build/lexicon/move-tr-lex.json
+++ b/ui/voice/.build/lexicon/move-tr-lex.json
@@ -1,7 +1,7 @@
 {
   "partials": {
-    "commands": ["yes", "no", "stop"],
-    "colors": ["green", "blue", "purple", "pink", "yellow", "orange", "white", "brown"],
+    "commands": ["yes", "no"],
+    "colors": ["green", "blue", "purple", "pink", "yellow", "orange", "red", "brown"],
     "numbers": ["1", "2", "3", "4", "5", "6", "7", "8"]
   },
   "entries": [

--- a/ui/voice/.build/lexicon/move-vi-lex.json
+++ b/ui/voice/.build/lexicon/move-vi-lex.json
@@ -1,6 +1,6 @@
 {
   "partials": {
-    "commands": ["yes", "no", "stop"],
+    "commands": ["yes", "no"],
     "colors": ["green", "purple", "red", "pink", "yellow", "orange", "white", "brown"],
     "numbers": ["1", "2", "3", "4", "5", "6", "7", "8"]
   },

--- a/ui/voice/grammar/move-fr.json
+++ b/ui/voice/grammar/move-fr.json
@@ -1,7 +1,7 @@
 {
   "partials": {
-    "commands": ["yes", "no", "stop"],
-    "colors": ["green", "blue", "purple", "pink", "yellow", "orange", "white", "brown"],
+    "commands": ["yes", "no"],
+    "colors": ["green", "blue", "purple", "pink", "yellow", "orange", "red", "brown"],
     "numbers": ["1", "2", "3", "4", "5", "6", "7", "8"]
   },
   "entries": [

--- a/ui/voice/grammar/move-tr.json
+++ b/ui/voice/grammar/move-tr.json
@@ -1,7 +1,7 @@
 {
   "partials": {
-    "commands": ["yes", "no", "stop"],
-    "colors": ["green", "blue", "purple", "pink", "yellow", "orange", "white", "brown"],
+    "commands": ["yes", "no"],
+    "colors": ["green", "blue", "purple", "pink", "yellow", "orange", "red", "brown"],
     "numbers": ["1", "2", "3", "4", "5", "6", "7", "8"]
   },
   "entries": [

--- a/ui/voice/grammar/move-vi.json
+++ b/ui/voice/grammar/move-vi.json
@@ -1,6 +1,6 @@
 {
   "partials": {
-    "commands": ["yes", "no", "stop"],
+    "commands": ["yes", "no"],
     "colors": ["green", "purple", "red", "pink", "yellow", "orange", "white", "brown"],
     "numbers": ["1", "2", "3", "4", "5", "6", "7", "8"]
   },

--- a/ui/voice/src/main.ts
+++ b/ui/voice/src/main.ts
@@ -5,11 +5,20 @@ import { flash } from './view';
 
 export * from './interfaces';
 export * from './move/interfaces';
-export { load as makeVoiceMove } from './move/moveCtrl';
+export { makeVoiceMove } from './move/moveCtrl';
 export { renderVoiceBar } from './view';
 
 export const VOSK_TS_VERSION = '_____1'; // this versions the wasm asset (see vosk.ts)
-export const supportedLangs = [['en', 'English']];
+export const supportedLangs = [
+  ['en', 'English'],
+  /*['fr', 'Français'],
+  ['de', 'Deutsch'],
+  ['tr', 'Türkçe'],
+  ['vi', 'Tiếng Việt'],
+  ['ru', 'Русский'],
+  ['it', 'Italiano'],
+  ['sv', 'Svenska'],*/
+];
 
 export function makeCtrl(opts: {
   redraw: () => void;

--- a/ui/voice/src/move/interfaces.ts
+++ b/ui/voice/src/move/interfaces.ts
@@ -1,15 +1,15 @@
 import { PromotionCtrl } from 'chess/promotion';
+import { MoveUpdate } from 'chess/moveRootCtrl';
 import { VoiceModule } from '../interfaces';
 import * as cg from 'chessground/types';
 
 export interface VoiceMove extends VoiceModule {
-  update: (fen: string, canMove: boolean, chessground?: CgApi) => void;
+  update: (up: MoveUpdate) => void;
   promotionHook: () => (ctrl: PromotionCtrl, roles: cg.Role[] | false) => void;
   listenForResponse: (request: string, action: (v: boolean) => void) => void;
   question: () => QuestionOpts | false;
 }
 
-export interface VoiceMoveOpts {}
 export interface Match {
   cost: number;
   isSan?: boolean;


### PR DESCRIPTION
This is similar to a PR I submitted 18 months ago. It adds poll support which can be enabled in the feed, forums, or ublogs. Polls are allowed in all 3 areas in this PR, but only as a demonstration. I'd like review of the mechanism itself.

The syntax is like zulip but with a few additions that can control behavior and presentation.

```
/poll Your question goes here.
/any of the keywords listed below can go here
choices here
one choice per line like zulip
```

Keywords include:
* `open` - Unauthenticated & incognito users can vote. Without this property, participation requires an account.
* `anon` - Votes, voters, and feedback are anonymous (user id/ip hashing)
* `tally` - Provides voters a button to toggle between the question and current vote totals. This is fun but unscientific.
* `trace` - Anyone can see who voted for what. It's limited to mouse users with hover at present
* `random` - Choices are presented to each user in random order to minimize positional bias
* `multi` - *Choose all that apply* multiple selection. Otherwise choices are exclusive
* `rank` - Choices are ranked via drag & drop
* `form` - Users can enter a small amount of text along with any choice(s). This is most useful for collecting profanity (in tandem with open and anon).
* `vert` - Choices are arranged vertically rather than horizontally. Non-`rank` vert polls will use checkboxes rather than buttons.
* `stretch` - Buttons stretch out horizontally to take full advantage of available space

If you have arguments against this PR, I'd love a chance to hear them and respond if possible. I am not the only team member who would really like to see this in lila.