### PR TITLE
shift-b toggles blindfold

### DIFF
--- a/app/views/site/help.scala
+++ b/app/views/site/help.scala
@@ -44,6 +44,7 @@ object help:
           header(trans.other()),
           flip,
           zen,
+          row(frag(kbd("shift"), kbd("B")), "Toggle blindfold mode"),
           helpDialog
         )
       )
@@ -60,6 +61,7 @@ object help:
           header(trans.other()),
           flip,
           zen,
+          row(frag(kbd("shift"), kbd("B")), "Toggle blindfold mode"),
           helpDialog
         )
       )

--- a/ui/puzzle/src/keyboard.ts
+++ b/ui/puzzle/src/keyboard.ts
@@ -32,7 +32,7 @@ export default (ctrl: PuzzleCtrl) =>
     .bind('?', () => ctrl.keyboardHelp(!ctrl.keyboardHelp()))
     .bind('f', ctrl.flip)
     .bind('n', ctrl.nextPuzzle)
-    .bind('b', () => ctrl.blindfold(!ctrl.blindfold()));
+    .bind('B', () => ctrl.blindfold(!ctrl.blindfold()));
 
 export const view = (ctrl: PuzzleCtrl) =>
   snabDialog({

--- a/ui/round/src/keyboard.ts
+++ b/ui/round/src/keyboard.ts
@@ -26,6 +26,7 @@ export const init = (ctrl: RoundController) =>
     })
     .bind('f', ctrl.flipNow)
     .bind('z', () => lichess.pubsub.emit('zen'))
+    .bind('B', () => ctrl.blindfold(!ctrl.blindfold()))
     .bind('?', () => {
       ctrl.keyboardHelp = !ctrl.keyboardHelp;
       ctrl.redraw();


### PR DESCRIPTION
I am sympathetic to those used to the permanent mode. In games, `shift-B` would make toggling easier for players who are used to the dedicated blindfold account flow and find accessing the board menu at the start of each game to be a chore. This shortcut should have a reduced likelihood of mistaken blindfold activation compared to `b`.
