### PR TITLE
Margin fix for buttons on puzzle dashboard

### DIFF
--- a/ui/puzzle/css/_dashboard.scss
+++ b/ui/puzzle/css/_dashboard.scss
@@ -69,6 +69,7 @@
 
     @include breakpoint($mq-not-x-small) {
       margin-top: 1em;
+      margin-left: 0;
     }
 
     &:first-child {

--- a/ui/puzzle/css/_dashboard.scss
+++ b/ui/puzzle/css/_dashboard.scss
@@ -46,6 +46,7 @@
 
   &__metrics {
     display: flex;
+    gap: 1em;
 
     @include breakpoint($mq-not-x-small) {
       flex-direction: column;
@@ -64,18 +65,7 @@
     padding: 0.4em 0.7em 0.6em 0.7em;
     text-transform: uppercase;
     flex: 0 0 23.5%;
-    margin-#{$start-direction}: 2%;
     cursor: default;
-
-    @include breakpoint($mq-not-x-small) {
-      margin-top: 1em;
-      margin-left: 0;
-    }
-
-    &:first-child {
-      margin-#{$start-direction}: 0;
-      margin-top: 0;
-    }
 
     strong {
       @extend %roboto;


### PR DESCRIPTION
Line 67: `margin-#{$start-direction}: 2%;` is applied by default.

Fix is to ensure that the `--win`, `--perf` and `--fix` buttons have `margin-left: 0` and aligned with first child button when `@media` breakpoint is applied.

Fixes #14535