### PR TITLE
Board editor: export position as image

### DIFF
--- a/ui/editor/css/_editor.scss
+++ b/ui/editor/css/_editor.scss
@@ -23,11 +23,6 @@
       display: flex;
       align-items: center;
 
-      strong {
-        width: 80px;
-        flex: 0 0 auto;
-      }
-
       input {
         margin-#{$start-direction}: 1rem;
         flex: 1 1 100%;

--- a/ui/editor/css/_editor.scss
+++ b/ui/editor/css/_editor.scss
@@ -23,6 +23,11 @@
       display: flex;
       align-items: center;
 
+      strong {
+        width: 80px;
+        flex: 0 0 auto;
+      }
+
       input {
         margin-#{$start-direction}: 1rem;
         flex: 1 1 100%;

--- a/ui/editor/src/ctrl.ts
+++ b/ui/editor/src/ctrl.ts
@@ -190,8 +190,8 @@ export default class EditorCtrl {
     return `${this.cfg.baseUrl}/${urlFen(fen)}${variant}${orientationParam}`;
   }
 
-  makeImageUrl = (fen: string, orientation: Color = 'white'): string =>
-    `${lichess.asset.baseUrl()}/export/fen.gif?fen=${urlFen(fen)}&color=${orientation}`;
+  makeImageUrl = (fen: string): string =>
+    `${lichess.asset.baseUrl()}/export/fen.gif?fen=${urlFen(fen)}&color=${this.bottomColor()}`;
 
   bottomColor = (): Color =>
     this.chessground ? this.chessground.state.orientation : this.options.orientation || 'white';

--- a/ui/editor/src/ctrl.ts
+++ b/ui/editor/src/ctrl.ts
@@ -190,6 +190,11 @@ export default class EditorCtrl {
     return `${this.cfg.baseUrl}/${urlFen(fen)}${variant}${orientationParam}`;
   }
 
+  makeImageUrl(fen: string, orientation: Color = 'white'): string {
+    const url = `https://lichess1.org/export/fen.gif?fen=${fen}&color=${orientation}`;
+    return url;
+  }
+
   bottomColor(): Color {
     return this.chessground ? this.chessground.state.orientation : this.options.orientation || 'white';
   }

--- a/ui/editor/src/ctrl.ts
+++ b/ui/editor/src/ctrl.ts
@@ -191,7 +191,7 @@ export default class EditorCtrl {
   }
 
   makeImageUrl(fen: string, orientation: Color = 'white'): string {
-    const url = `https://lichess1.org/export/fen.gif?fen=${fen}&color=${orientation}`;
+    const url = `${lichess.asset.baseUrl()}/export/fen.gif?fen=${urlFen(fen)}&color=${orientation}`;
     return url;
   }
 

--- a/ui/editor/src/ctrl.ts
+++ b/ui/editor/src/ctrl.ts
@@ -190,14 +190,11 @@ export default class EditorCtrl {
     return `${this.cfg.baseUrl}/${urlFen(fen)}${variant}${orientationParam}`;
   }
 
-  makeImageUrl(fen: string, orientation: Color = 'white'): string {
-    const url = `${lichess.asset.baseUrl()}/export/fen.gif?fen=${urlFen(fen)}&color=${orientation}`;
-    return url;
-  }
+  makeImageUrl = (fen: string, orientation: Color = 'white'): string =>
+    `${lichess.asset.baseUrl()}/export/fen.gif?fen=${urlFen(fen)}&color=${orientation}`;
 
-  bottomColor(): Color {
-    return this.chessground ? this.chessground.state.orientation : this.options.orientation || 'white';
-  }
+  bottomColor = (): Color =>
+    this.chessground ? this.chessground.state.orientation : this.options.orientation || 'white';
 
   setCastlingToggle(id: CastlingToggle, value: boolean): void {
     if (this.castlingToggles[id] != value) this.castlingRights = undefined;

--- a/ui/editor/src/view.ts
+++ b/ui/editor/src/view.ts
@@ -321,9 +321,8 @@ function inputs(ctrl: EditorCtrl, fen: string): VNode | undefined {
       'a',
       {
         attrs: {
-          href: ctrl.makeImageUrl(fen, ctrl.bottomColor()), // Replace 'yourImageUrl' with the actual URL you want to link to
-          target: '_blank', // Optional: Opens the link in a new tab
-          rel: 'noopener noreferrer', // Optional: Security measure for opening new tabs
+          href: ctrl.makeImageUrl(fen, ctrl.bottomColor()),
+          rel: 'noopener noreferrer',
         },
       },
       'SCREENSHOT',

--- a/ui/editor/src/view.ts
+++ b/ui/editor/src/view.ts
@@ -317,6 +317,14 @@ function inputs(ctrl: EditorCtrl, fen: string): VNode | undefined {
         attrs: { readonly: true, spellcheck: 'false', value: ctrl.makeEditorUrl(fen, ctrl.bottomColor()) },
       }),
     ]),
+    h('p', [
+      h('strong.name', 'IMAGE'),
+      //add an image from the following url <meta property="og:image"
+      //"https://lichess1.org/export/fen.gif?fen=8%2F8%2F8%2F3k4%2F8%2F8%2F8%2F5RQK%20w%20-%20-%200%201&color=white" />
+      h('input.copyable.autoselect', {
+        attrs: { readonly: true, spellcheck: 'false', value: ctrl.makeImageUrl(fen, ctrl.bottomColor()) },
+      }),
+    ]),
   ]);
 }
 

--- a/ui/editor/src/view.ts
+++ b/ui/editor/src/view.ts
@@ -317,15 +317,7 @@ function inputs(ctrl: EditorCtrl, fen: string): VNode | undefined {
         attrs: { readonly: true, spellcheck: 'false', value: ctrl.makeEditorUrl(fen, ctrl.bottomColor()) },
       }),
     ]),
-    h(
-      'a',
-      {
-        attrs: {
-          href: ctrl.makeImageUrl(fen),
-        },
-      },
-      'SCREENSHOT',
-    ),
+    h('a', { attrs: { href: ctrl.makeImageUrl(fen) } }, 'SCREENSHOT'),
   ]);
 }
 

--- a/ui/editor/src/view.ts
+++ b/ui/editor/src/view.ts
@@ -321,8 +321,7 @@ function inputs(ctrl: EditorCtrl, fen: string): VNode | undefined {
       'a',
       {
         attrs: {
-          href: ctrl.makeImageUrl(fen, ctrl.bottomColor()),
-          rel: 'noopener noreferrer',
+          href: ctrl.makeImageUrl(fen),
         },
       },
       'SCREENSHOT',

--- a/ui/editor/src/view.ts
+++ b/ui/editor/src/view.ts
@@ -319,8 +319,6 @@ function inputs(ctrl: EditorCtrl, fen: string): VNode | undefined {
     ]),
     h('p', [
       h('strong.name', 'IMAGE'),
-      //add an image from the following url <meta property="og:image"
-      //"https://lichess1.org/export/fen.gif?fen=8%2F8%2F8%2F3k4%2F8%2F8%2F8%2F5RQK%20w%20-%20-%200%201&color=white" />
       h('input.copyable.autoselect', {
         attrs: { readonly: true, spellcheck: 'false', value: ctrl.makeImageUrl(fen, ctrl.bottomColor()) },
       }),

--- a/ui/editor/src/view.ts
+++ b/ui/editor/src/view.ts
@@ -317,12 +317,17 @@ function inputs(ctrl: EditorCtrl, fen: string): VNode | undefined {
         attrs: { readonly: true, spellcheck: 'false', value: ctrl.makeEditorUrl(fen, ctrl.bottomColor()) },
       }),
     ]),
-    h('p', [
-      h('strong.name', 'IMAGE'),
-      h('input.copyable.autoselect', {
-        attrs: { readonly: true, spellcheck: 'false', value: ctrl.makeImageUrl(fen, ctrl.bottomColor()) },
-      }),
-    ]),
+    h(
+      'a',
+      {
+        attrs: {
+          href: ctrl.makeImageUrl(fen, ctrl.bottomColor()), // Replace 'yourImageUrl' with the actual URL you want to link to
+          target: '_blank', // Optional: Opens the link in a new tab
+          rel: 'noopener noreferrer', // Optional: Security measure for opening new tabs
+        },
+      },
+      'SCREENSHOT',
+    ),
   ]);
 }
 


### PR DESCRIPTION
Displays the url for the image which can be easily copy and pasted. URL updates as the position is updated. I think its probably better than displaying the image itself as that might mess up the UI. Close #14521 
<img width="1300" alt="Screenshot 2024-01-24 at 21 57 31" src="https://github.com/lichess-org/lila/assets/20873258/94e740d2-2211-4c82-917a-41140ac21acf">
