### PR TITLE
Add game division to game json export

### DIFF
--- a/app/controllers/Game.scala
+++ b/app/controllers/Game.scala
@@ -148,7 +148,8 @@ final class Game(env: Env, apiC: => Api) extends LilaController(env):
       pgnInJson = getBool("pgnInJson"),
       delayMoves = delayMovesFromReq,
       lastFen = getBool("lastFen"),
-      accuracy = getBool("accuracy")
+      accuracy = getBool("accuracy"),
+      division = getBoolOpt("division") | extended
     )
 
   private[controllers] def delayMovesFromReq(using RequestHeader) =

--- a/modules/api/src/main/GameApiV2.scala
+++ b/modules/api/src/main/GameApiV2.scala
@@ -12,7 +12,7 @@ import lila.common.{ HTTPRequest, LightUser }
 import lila.db.dsl.{ *, given }
 import lila.game.JsonView.given
 import lila.game.PgnDump.WithFlags
-import lila.game.{ Game, Query, Pov }
+import lila.game.{ Game, Query, Pov, Divider }
 import lila.team.GameTeams
 import lila.tournament.Tournament
 import lila.user.{ Me, User }
@@ -30,7 +30,8 @@ final class GameApiV2(
     annotator: lila.analyse.Annotator,
     getLightUser: LightUser.Getter,
     realPlayerApi: RealPlayerApi,
-    gameProxy: GameProxyRepo
+    gameProxy: GameProxyRepo,
+    division: Divider
 )(using Executor, akka.actor.ActorSystem):
 
   import GameApiV2.*
@@ -303,6 +304,7 @@ final class GameApiV2(
       ))
     .add("lastFen" -> flags.lastFen.option(Fen.write(g.chess.situation)))
     .add("lastMove" -> flags.lastFen.option(g.lastMoveKeys))
+    .add("division" -> flags.division.option(division(g, initialFen)))
 
   private def gameLightUsers(game: Game): Future[ByColor[(lila.game.Player, Option[LightUser])]] =
     game.players.traverse(_.userId so getLightUser).dmap(game.players.zip(_))

--- a/modules/game/src/main/PgnDump.scala
+++ b/modules/game/src/main/PgnDump.scala
@@ -175,7 +175,8 @@ object PgnDump:
       pgnInJson: Boolean = false,
       delayMoves: Boolean = false,
       lastFen: Boolean = false,
-      accuracy: Boolean = false
+      accuracy: Boolean = false,
+      division: Boolean = false
   ):
     def applyDelay[M](moves: Seq[M]): Seq[M] =
       if !delayMoves then moves


### PR DESCRIPTION
closes #14503

`division` is independent of `analysis`. Both the site and lichobile use it for movetime graphs even if there is no analysis available. Therefore, I've made `division` an independent field in case it's required in the future. I hope that's alright.