### PR TITLE
Personal export: include dubious chats and timeouts

### DIFF
--- a/modules/api/src/main/Env.scala
+++ b/modules/api/src/main/Env.scala
@@ -53,6 +53,8 @@ final class Env(
     modEnv: lila.mod.Env,
     notifyEnv: lila.notify.Env,
     appealApi: lila.appeal.AppealApi,
+    shutupEnv: lila.shutup.Env,
+    modLogApi: lila.mod.ModlogApi,
     activityWriteApi: lila.activity.ActivityWriteApi,
     ublogApi: lila.ublog.UblogApi,
     picfitUrl: lila.memo.PicfitUrl,

--- a/modules/mod/src/main/ModlogApi.scala
+++ b/modules/mod/src/main/ModlogApi.scala
@@ -245,6 +245,18 @@ final class ModlogApi(repo: ModlogRepo, userRepo: UserRepo, ircApi: IrcApi, pres
       "action" -> Modlog.unbooster
     )
 
+  def timeoutPersonalExport(userId: UserId): Fu[List[Modlog]] =
+    coll.tempPrimary
+      .find(
+        $doc(
+          "user"   -> userId,
+          "action" -> Modlog.chatTimeout
+        )
+      )
+      .sort($sort desc "date")
+      .cursor[Modlog]()
+      .list(100)
+
   def userHistory(userId: UserId): Fu[List[Modlog]] =
     coll.find($doc("user" -> userId)).sort($sort desc "date").cursor[Modlog]().list(60)
 


### PR DESCRIPTION
Tested. I could import `modLogApi` directly but not `shutupApi`, I'm not sure why but I assumes it's because it was not yet initialised at that point.