### PR TITLE
Simplify and fix modlog for ublog ranking adjustment

### DIFF
--- a/app/controllers/Ublog.scala
+++ b/app/controllers/Ublog.scala
@@ -155,12 +155,12 @@ final class Ublog(env: Env) extends LilaController(env):
 
   }
 
-  private def logModAction(post: UblogPost, action: String, logInludingMe: Boolean = false)(using
+  private def logModAction(post: UblogPost, action: String, logIncludingMe: Boolean = false)(using
       ctx: Context,
       me: Me
   ): Funit =
     isGrantedOpt(_.ModerateBlog).so:
-      (logInludingMe || !me.is(post.created.by)) so {
+      (logIncludingMe || !me.is(post.created.by)) so {
         env.user.repo.byId(post.created.by) flatMapz { user =>
           env.mod.logApi.blogPostEdit(Suspect(user), post.id, post.title, action)
         }
@@ -205,7 +205,7 @@ final class Ublog(env: Env) extends LilaController(env):
               _ <- logModAction(
                 post,
                 s"${~rankAdjustDays} days${pinned so " and pinned to top"} rank adjustement",
-                logInludingMe = true
+                logIncludingMe = true
               )
               _ <- env.ublog.rank.recomputePostRank(post)
             yield Redirect(urlOfPost(post)).flashSuccess

--- a/modules/mod/src/main/Modlog.scala
+++ b/modules/mod/src/main/Modlog.scala
@@ -81,7 +81,6 @@ case class Modlog(
     case Modlog.setKidMode          => "set kid mode"
     case Modlog.weakPassword        => "log in with weak password"
     case Modlog.blankedPassword     => "log in with blanked password"
-    case Modlog.ublogRankAdjust     => "adjust ublog post rank"
     case a                          => a
 
   override def toString = s"$mod $showAction $user $details"
@@ -163,7 +162,6 @@ object Modlog:
   val setKidMode          = "setKidMode"
   val weakPassword        = "weakPassword"
   val blankedPassword     = "blankedPassword"
-  val ublogRankAdjust     = "ublogRankAdjust"
 
   private val explainRegex = """^[\w-]{3,}+: (.++)$""".r
   def explain(e: Modlog) = (e.index has "team") so ~e.details match

--- a/modules/mod/src/main/ModlogApi.scala
+++ b/modules/mod/src/main/ModlogApi.scala
@@ -225,14 +225,6 @@ final class ModlogApi(repo: ModlogRepo, userRepo: UserRepo, ircApi: IrcApi, pres
   def appealPost(user: UserId)(using me: Me) = add:
     Modlog(me, user.some, Modlog.appealPost, details = none)
 
-  def ublogRankAdjust(user: UserId, postId: UblogPostId, adjust: Int, pinned: Boolean)(using me: Me) = add:
-    Modlog(
-      me.some,
-      Modlog.ublogRankAdjust,
-      details = s"""
-  $postId by $user adjusted by $adjust days${pinned so " and pinned to top"} by ${me.username}""".some
-    )
-
   def wasUnengined(sus: Suspect) = coll.exists:
     $doc(
       "user"   -> sus.user.id,


### PR DESCRIPTION
Use blogPostEdit log action for rank adjustement

Which also fix the issue where the modlog would be posted on the mod account instead of the poster account.

Delete ublogRankAdjust mod log. Too few actions made, and not recorded at the right place to bother with backward compatibility. Actions were discussed and copied to zulip.

run afterwards ```db.modlog.delete({"action": "ublogRankAdjust"})``` (data saved to zulip for accountability)