### PR TITLE
Fix single game PGN push

### DIFF
--- a/modules/relay/src/main/RelaySync.scala
+++ b/modules/relay/src/main/RelaySync.scala
@@ -59,7 +59,7 @@ final private class RelaySync(
       chapters: List[Chapter],
       nbGames: Int
   ): Option[Chapter] =
-    if chapters.sizeIs > nbGames || game.looksLikeLichess
+    if nbGames == 1 || chapters.sizeIs > nbGames || game.looksLikeLichess
     then chapters.find(c => game.staticTagsMatch(c.tags))
     else chapters.find(_.relay.exists(_.index == game.index))
 


### PR DESCRIPTION
After this commit https://github.com/lichess-org/lila/commit/5c57bd77f1d7f22833c89ff5ed130fdaba9982fb, lila is only showing the most recently-pushed PGN.

This PR is an incomplete fix though (help needed). It restores the ability to push individual games and I can push a subset of a round's games -- but I can't push all the games.

This is the [script to reproduce](https://github.com/fitztrev/broadcaster/blob/main/sample-data/generate/pusher.sh). Parts A + B work, but Part C returns `{ "error": "Game 2 matches with Chapter 1" }`