### PR TITLE
Acpl chart study spinner redo

### DIFF
--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -817,14 +817,15 @@ export default class AnalyseCtrl {
     this.tree.merge(data.tree);
     this.data.analysis = data.analysis;
     if (data.analysis)
-      data.analysis.partial = !!treeOps.findInMainline(
-        data.tree,
-        n => !n.eval && !!n.children.length && n.ply <= 300,
-      );
+      data.analysis.partial = !!treeOps.findInMainline(data.tree, this.partialAnalysisCallback);
     if (data.division) this.data.game.division = data.division;
     if (this.retro) this.retro.onMergeAnalysisData();
     lichess.pubsub.emit('analysis.server.progress', this.data);
     this.redraw();
+  }
+
+  partialAnalysisCallback(n: Tree.Node) {
+    return !n.eval && !!n.children.length && n.ply <= 300 && n.ply > 0;
   }
 
   playUci(uci: Uci, uciQueue?: Uci[]) {

--- a/ui/analyse/src/interfaces.ts
+++ b/ui/analyse/src/interfaces.ts
@@ -127,7 +127,7 @@ export interface Analysis {
   id: string;
   white: AnalysisSide;
   black: AnalysisSide;
-  partial: boolean;
+  partial?: boolean;
 }
 
 export interface AnalysisSide {

--- a/ui/chart/src/interface.ts
+++ b/ui/chart/src/interface.ts
@@ -36,7 +36,7 @@ export interface AnalyseData {
     startedAtTurn?: number;
   };
   analysis?: {
-    partial: boolean;
+    partial?: boolean;
   };
   clock?: {
     running: boolean;

--- a/ui/site/src/component/pubsub.ts
+++ b/ui/site/src/component/pubsub.ts
@@ -1,18 +1,11 @@
-const subs: Dictionary<(() => void)[]> = Object.create(null);
+const subs: Dictionary<Set<() => void>> = Object.create(null);
 
 const pubsub: Pubsub = {
   on(name: string, cb) {
-    (subs[name] = subs[name] || []).push(cb);
+    (subs[name] = subs[name] || new Set()).add(cb);
   },
   off(name: string, cb) {
-    const cbs = subs[name];
-    if (cbs)
-      for (const i in cbs) {
-        if (cbs[i] === cb) {
-          cbs.splice(Number(i), 1);
-          break;
-        }
-      }
+    subs[name]?.delete(cb);
   },
   emit(name: string, ...args: any[]) {
     for (const fn of subs[name] || []) fn.apply(null, args);


### PR DESCRIPTION
Redo of https://github.com/lichess-org/lila/pull/14549 

1. I've tried to include the spinner for as long as study analysis is going, simulating extra moves that sometimes happen during broadcasts. In my testing, it works.
2. Fixes https://github.com/lichess-org/lila/issues/14565
3. I erroneously committed a pubsub function that would keep being added to the callback stack everytime a view was called. To save myself and others from future similar mistakes, I've made the pubsub callbacks a set instead of an array. I don't see any reason why you would need to execute the same function multiple times within one pubsub event so I don't think this borks anything but again, I may be wrong.