### PR TITLE
Align the background grid in right-to-left languages.

### DIFF
--- a/ui/common/css/dir/_rtl.scss
+++ b/ui/common/css/dir/_rtl.scss
@@ -30,3 +30,13 @@ $transform-direction: -1;
   direction: ltr;
   text-align: left;
 }
+
+#dasher_app .background #gallery {
+  right: -430px !important;
+}  
+
+@media (max-width: 650px) {
+  #dasher_app .background #gallery {
+    right: -100px !important;
+  }  
+}


### PR DESCRIPTION
When on a RTL language (Arabic, Persian, ..) the Settings ~ Background ~ Image shows the grid on a misplaced location. This fixes the issue on both >650 and <650 screen sizes. 

fixes #14532