### PR TITLE
Latency signal bars aligned in safari.

### DIFF
--- a/ui/common/css/component/_signal.scss
+++ b/ui/common/css/component/_signal.scss
@@ -2,7 +2,7 @@ signal {
   display: inline-block;
   height: 1em;
   width: 1.5em;
-  overflow: visible;
+  overflow: hidden;
   white-space: nowrap;
 }
 


### PR DESCRIPTION
Signal bars aligned in safari. Verified bars look ok in safari, chrome, & Firefox. 

![Screenshot 2024-01-30 at 2 29 28 PM](https://github.com/lichess-org/lila/assets/59802340/1a99c94d-e5c9-438f-ba7d-2969f133380e)
