### PR TITLE
Mobile: add the ios badge in FCM data payload

### DIFF
--- a/modules/push/src/main/FirebasePush.scala
+++ b/modules/push/src/main/FirebasePush.scala
@@ -73,7 +73,9 @@ final private class FirebasePush(
               "data" -> toDataKeyValue:
                 data.firebaseMod.match
                   case Some(PushApi.Data.FirebaseMod.NotifOnly(mod)) => mod(data.payload.userData)
-                  case _                                             => data.payload.userData
+                  case _                                             => data.payload.userData ++ (data.iosBadge.map: number =>
+                    "iosBadge" -> number.toString
+                  ),
             )
             .add:
               "notification" -> data.firebaseMod.match


### PR DESCRIPTION
When receiving a data message, it is up to the client application to react to it. So in order to update the badge number, it need needed in the `data` payload.


For https://github.com/lichess-org/mobile/issues/464