### PR TITLE
Handling plurals and removing 'and'

### DIFF
--- a/app/views/clas/clas.scala
+++ b/app/views/clas/clas.scala
@@ -56,11 +56,10 @@ object clas:
       else renderClasses(current),
       (closed || others.nonEmpty) option div(cls := "clas-index__others")(
         a(href := s"${clasRoutes.index}?closed=${!closed}")(
-          "And ",
           others.size.localize,
           " ",
           if closed then "active" else "archived",
-          " classes"
+          if others.size == 1 then " class" else " classes"
         )
       )
     )


### PR DESCRIPTION
This change resolves issue #14622 by removing the word 'and'. Also this code now displays '_1 archived class_' when singular and '_n archived classes_' when multiple.
Adding tested screenshots.
![image](https://github.com/lichess-org/lila/assets/19169630/fa17ce4c-83c8-4543-8af6-89fbc23cf8d8)
![image](https://github.com/lichess-org/lila/assets/19169630/b323a54f-668c-4e12-90fe-491e4cc20778)
