### PR TITLE
Add java/jdk sanity checks

### DIFF
--- a/lila
+++ b/lila
@@ -32,6 +32,19 @@ BANNER
 version=$(java -version 2>&1 | awk -F '"' '/version/ {print $2}')
 echo Java "$version"
 
+javabin=$(which java)
+
+if [ -z "$JAVA_HOME" ]; then
+    echo "Warning, JAVA_HOME is unset"
+elif [ "$JAVA_HOME/bin/java" != "$javabin" ]; then
+    echo "Warning, JAVA_HOME [$JAVA_HOME] is not the same as java on PATH [$javabin]"
+fi
+
+if ! $(java --list-modules | grep -q jdk.compiler -); then
+    echo Warning, $javabin is missing module jdk.compiler - this can happen if you mistakenly use a JRE instead of a JDK.
+fi
+
+
 command="sbt $java_env $@"
 echo $command
 $command


### PR DESCRIPTION
There have been some questions about `error: release version 21 not supported` in onboarding channel.
Having the `lila` shell script output warnings on unusual java configuration could perhaps help.

Warn if JAVA_HOME is unset.
Warn if JAVA_HOME is set, but differs from the java command on PATH.
Warn if the java command on PATH doesnt contain the module jdk.compiler.

```
$ export JAVA_HOME=""
$ ./lila
Java 21.0.2
Warning, JAVA_HOME is unset
sbt -Dreactivemongo.api.bson.document.strict=false
```

```
$ export JAVA_HOME="."
$ ./lila
Java 21.0.2
Warning, JAVA_HOME [.] is not the same as java on PATH [/opt/java/openjdk/bin/java]
sbt -Dreactivemongo.api.bson.document.strict=false
```

```
$ export JAVA_HOME="/opt/java/jre"
$ export PATH=$JAVA_HOME/bin:$PATH
$ ./lila
Java 21.0.2
Warning, /opt/java/jre/bin/java is missing module jdk.compiler - this can happen if you mistakenly use a JRE instead of a JDK.
sbt -Dreactivemongo.api.bson.document.strict=false
```