### PR TITLE
up diagnostic form cap to 100k

### DIFF
--- a/modules/forum/src/main/ForumForm.scala
+++ b/modules/forum/src/main/ForumForm.scala
@@ -51,7 +51,7 @@ final private[forum] class ForumForm(
         t => inOwnTeam || promotion.test(t, previousText)
       )
 
-  val diagnostic = Form(single("text" -> nonEmptyText(maxLength = 30000)))
+  val diagnostic = Form(single("text" -> nonEmptyText(maxLength = 100000)))
 
 object ForumForm:
 


### PR DESCRIPTION
I originally raised this to 30k on the sly, but I might need even more than that. And since it's getting up there, time for a PR I suppose. Although we only keep the most recent 100 log events in the clientside idb, some of them can be quite large such as:
```
2024-02-09 08:48:44.875 #3f6cfcb - /meX6rbWk/black - Uncaught TypeError: Cannot read properties of undefined (reading 'trim') - (lichess1.org/assets/_oQtF03/compiled/analysisBoard.min.js:1:25518)
TypeError: Cannot read properties of undefined (reading 'trim')
at $e.received (lichess1.org/assets/_oQtF03/compiled/analysisBoard.min.js:1:25518)
at lichess1.org/assets/_oQtF03/compiled/analysisBoard.min.js:5:5181
at A.print.A.printErr (lichess1.org/assets/_b6939d/npm/stockfish-nnue.wasm/stockfish.js:11:468)
at M (lichess1.org/assets/_b6939d/npm/stockfish-nnue.wasm/stockfish.js:25:94)
at bc (lichess1.org/assets/_b6939d/npm/stockfish-nnue.wasm/stockfish.js:105:169)
at I (lichess1.org/assets/_b6939d/npm/stockfish-nnue.wasm/stockfish.js:134:237)
at wasm://wasm/030e702e:wasm-function[477]:0x53a00
at wasm://wasm/030e702e:wasm-function[479]:0x53caa
at wasm://wasm/030e702e:wasm-function[303]:0x2f2cd
at Xc.b.<computed> (lichess1.org/assets/_b6939d/npm/stockfish-nnue.wasm/stockfish.js:126:279)
```
This is useful information and I don't see anything to be gained by throwing wrenches into the gathering process.