### PR TITLE
Add a default prismic configuration so that lila does not crash

### DIFF
--- a/conf/base.conf
+++ b/conf/base.conf
@@ -496,5 +496,8 @@ kamon {
     prometheus-reporter.enabled = yes
   }
 }
+prismic {
+  api_url = ""
+}
 # Don't let play manage its own PID file
 pidfile.path = "/dev/null"


### PR DESCRIPTION
When I try to start lichess by typing `run` in the lila shell, it crashes with

`com.typesafe.config.ConfigException$Missing: merge of system properties,application.conf @ jar:file:(...): 1: No configuration setting found for key 'prismic'`
( [full output](https://gist.github.com/phihag/a1b95a0fa8516e6acf90ff3d92457fcb#file-gistfile1-txt) ).

Adding this empty configuration (which should work fine for the developers who don't interact with prismic) fixes the issue.
