### PR TITLE
Make position evaluation glyphs available via shortcuts

### DIFF
--- a/app/views/site/help.scala
+++ b/app/views/site/help.scala
@@ -103,7 +103,8 @@ object help:
             row(kbd("g"), trans.study.annotateWithGlyphs()),
             row(kbd("n"), trans.study.nextChapter()),
             row(kbd("p"), trans.study.prevChapter()),
-            row(frag((1 to 6).map(kbd(_))), trans.toggleGlyphAnnotations())
+            row(frag((1 to 6).map(kbd(_))), trans.toggleGlyphAnnotations()),
+            row(frag(kbd("shift"), (1 to 8).map(kbd(_))), trans.togglePositionAnnotations())
           ),
           header(trans.mouseTricks()),
           tr(

--- a/modules/i18n/src/main/I18nKeys.scala
+++ b/modules/i18n/src/main/I18nKeys.scala
@@ -560,6 +560,7 @@ object I18nKeys:
   val `toggleVariationArrows` = I18nKey("toggleVariationArrows")
   val `cyclePreviousOrNextVariation` = I18nKey("cyclePreviousOrNextVariation")
   val `toggleGlyphAnnotations` = I18nKey("toggleGlyphAnnotations")
+  val `togglePositionAnnotations` = I18nKey("togglePositionAnnotations")
   val `variationArrowsInfo` = I18nKey("variationArrowsInfo")
   val `playSelectedMove` = I18nKey("playSelectedMove")
   val `newTournament` = I18nKey("newTournament")

--- a/translation/source/site.xml
+++ b/translation/source/site.xml
@@ -705,6 +705,7 @@
   <string name="toggleVariationArrows">Toggle variation arrows</string>
   <string name="cyclePreviousOrNextVariation">Cycle previous/next variation</string>
   <string name="toggleGlyphAnnotations">Toggle glyph annotations</string>
+  <string name="togglePositionAnnotations">Toggle position annotations</string>
   <string name="variationArrowsInfo">Variation arrows let you navigate without using the move list.</string>
   <string name="playSelectedMove">play selected move</string>
   <string name="newTournament">New tournament</string>

--- a/translation/source/site.xml
+++ b/translation/source/site.xml
@@ -704,7 +704,7 @@
   <string name="keyNextBranch">Next branch</string>
   <string name="toggleVariationArrows">Toggle variation arrows</string>
   <string name="cyclePreviousOrNextVariation">Cycle previous/next variation</string>
-  <string name="toggleGlyphAnnotations">Toggle glyph annotations</string>
+  <string name="toggleGlyphAnnotations">Toggle move annotations</string>
   <string name="togglePositionAnnotations">Toggle position annotations</string>
   <string name="variationArrowsInfo">Variation arrows let you navigate without using the move list.</string>
   <string name="playSelectedMove">play selected move</string>

--- a/ui/analyse/src/keyboard.ts
+++ b/ui/analyse/src/keyboard.ts
@@ -126,7 +126,12 @@ export const bind = (ctrl: AnalyseCtrl) => {
     // navigation for next and prev chapters
     kbd.bind('p', ctrl.study.goToPrevChapter);
     kbd.bind('n', ctrl.study.goToNextChapter);
+    // ! ? !! ?? !? ?!
     for (let i = 1; i < 7; i++) kbd.bind(i.toString(), () => ctrl.study?.glyphForm.toggleGlyph(i));
+    // = (equality)
+    kbd.bind('shift+1', () => ctrl.study?.glyphForm.toggleGlyph(10));
+    // ∞ ⩲ ⩱ ± ∓ +- -+
+    for (let i = 2; i < 9; i++) kbd.bind(`shift+${i}`, () => ctrl.study?.glyphForm.toggleGlyph(11 + i));
   }
 };
 

--- a/ui/analyse/src/keyboard.ts
+++ b/ui/analyse/src/keyboard.ts
@@ -128,10 +128,9 @@ export const bind = (ctrl: AnalyseCtrl) => {
     kbd.bind('n', ctrl.study.goToNextChapter);
     // ! ? !! ?? !? ?!
     for (let i = 1; i < 7; i++) kbd.bind(i.toString(), () => ctrl.study?.glyphForm.toggleGlyph(i));
-    // = (equality)
-    kbd.bind('shift+1', () => ctrl.study?.glyphForm.toggleGlyph(10));
-    // ∞ ⩲ ⩱ ± ∓ +- -+
-    for (let i = 2; i < 9; i++) kbd.bind(`shift+${i}`, () => ctrl.study?.glyphForm.toggleGlyph(11 + i));
+    // = ∞ ⩲ ⩱ ± ∓ +- -+
+    for (let i = 1; i < 9; i++)
+      kbd.bind(`shift+${i}`, () => ctrl.study?.glyphForm.toggleGlyph(i == 1 ? 10 : 11 + i));
   }
 };
 


### PR DESCRIPTION
When using lichess to analyze openings or solve chess studies, one needs to frequently select a position evaluation annotation like `=` (equal) or `+-` (white is winning) – much more frequent than _Zugzwang_ or similar symbols; more times than the existing move annotation glyphs (`?!` `?` `!!` etc.).

Use Shift+1 to Shift+8 for these, analogous to 1 to 6 for the move annotations.

Likely, the help text for move annotations should be changed (no chess player knows what a _glyph annotation_ is, but a _move annotation_ is widely known), but as I am unfamiliar with the i18n system, I'll leave that for a future PR.
