### PR TITLE
Explicitly zoom rating history chart on initial load after slider creation

### DIFF
--- a/ui/chart/src/ratingHistory.ts
+++ b/ui/chart/src/ratingHistory.ts
@@ -272,6 +272,7 @@ export function initModule({ data, singlePerfName }: Opts) {
       if (min) btnClick(Math.max(startDate.valueOf(), endDate.subtract(min.duration).valueOf()));
       this.classList.add('active');
     });
+    chart.zoomScale('x', { min: initial.valueOf(), max: endDate.valueOf() });
   }
 }
 


### PR DESCRIPTION
Fixes #14683 in my testing.

But I created the issue for future tracking just in case.