### PR TITLE
support multiple alternative socket domains

### DIFF
--- a/app/views/base/layout.scala
+++ b/app/views/base/layout.scala
@@ -214,8 +214,8 @@ object layout:
   )
 
   private val dataVapid         = attr("data-vapid")
-  private val dataAltSocket     = attr("data-alt-socket")
   private val dataSocketDomains = attr("data-socket-domains") := netConfig.socketDomains.mkString(",")
+  private val dataSocketAlts    = attr("data-socket-alts")    := netConfig.socketAlts.mkString(",")
   private val dataNonce         = attr("data-nonce")
   private val dataAnnounce      = attr("data-announce")
   val dataSoundSet              = attr("data-sound-set")
@@ -309,8 +309,8 @@ object layout:
           dataVapid    := (ctx.isAuth && env.lilaCookie.isRememberMe(ctx.req)) option vapidPublicKey,
           dataUser     := ctx.userId,
           dataSoundSet := pref.currentSoundSet.toString,
-          pref.isUsingAltSocket option (dataAltSocket := netConfig.altSocket.value),
           dataSocketDomains,
+          pref.isUsingAltSocket option dataSocketAlts,
           dataAssetUrl,
           dataAssetVersion := assetVersion,
           dataNonce        := ctx.nonce.ifTrue(sameAssetDomain).map(_.value),

--- a/conf/base.conf
+++ b/conf/base.conf
@@ -13,8 +13,8 @@ mongodb {
 }
 net {
   domain = "localhost:9663"
-  socket.domains = [ "localhost:9664" ]
-  socket.alternate = ""
+  socket.domains = ["localhost:9664"]
+  socket.alts = []
   asset.domain = ${net.domain}
   asset.base_url = "http://"${net.asset.domain}
   asset.base_url_internal = ${net.asset.base_url}
@@ -485,9 +485,9 @@ kamon {
   }
   prometheus {
     buckets {
-      default-buckets = [ 10, 100, 1000, 10000, 100000 ]
-      time-buckets = [ 0.01, 0.05, 0.1, 0.5, 1, 5, 10 ]
-      information-buckets = [ 512, 2048, 16384, 524288, ]
+      default-buckets = [10, 100, 1000, 10000, 100000]
+      time-buckets = [0.01, 0.05, 0.1, 0.5, 1, 5, 10]
+      information-buckets = [512, 2048, 16384, 524288]
     }
   }
   modules {

--- a/modules/common/src/main/config.scala
+++ b/modules/common/src/main/config.scala
@@ -74,7 +74,7 @@ object config:
       @ConfigName("stage.banner") stageBanner: Boolean,
       @ConfigName("site.name") siteName: String,
       @ConfigName("socket.domains") socketDomains: List[String],
-      @ConfigName("socket.alternate") altSocket: NetDomain,
+      @ConfigName("socket.alts") socketAlts: List[String],
       crawlable: Boolean,
       @ConfigName("ratelimit") rateLimit: RateLimit,
       email: EmailAddress

--- a/ui/site/src/component/socket.ts
+++ b/ui/site/src/component/socket.ts
@@ -64,10 +64,13 @@ export default class StrongSocket {
   tryOtherUrl = false;
   autoReconnect = true;
   nbConnects = 0;
-  storage: LichessStorage = makeStorage.make('surl17', 30 * 60 * 1000);
+  storage: LichessStorage = makeStorage.make(
+    document.body.dataset.socketAlternates ? 'surl-alt' : 'surl17',
+    30 * 60 * 1000,
+  );
   private _sign?: string;
   private resendWhenOpen: [string, any, any][] = [];
-  private baseUrls = document.body.dataset.socketDomains!.split(',');
+  private baseUrls = (document.body.dataset.socketAlts || document.body.dataset.socketDomains!).split(',');
   static defaultOptions: Options = {
     idle: false,
     pingMaxLag: 9000, // time to wait for pong before resetting the connection
@@ -344,7 +347,6 @@ export default class StrongSocket {
   };
 
   baseUrl = () => {
-    if (document.body.dataset.altSocket) return document.body.dataset.altSocket;
     let url = this.storage.get();
     if (!url) {
       url = this.baseUrls[Math.floor(Math.random() * this.baseUrls.length)];


### PR DESCRIPTION
So that we can have the Firefox rate-limiting workaround also when using alternative sockets.

Prepared cf-socket0.lichess.org and cf-socket1.lichess.org.

Prepared prod config (but kept the `net.socket.alternate` around just in case).