### PR TITLE
Fix crazyhouse analysis overlap

### DIFF
--- a/ui/analyse/css/_zh.scss
+++ b/ui/analyse/css/_zh.scss
@@ -59,11 +59,11 @@ $pocket-height: 60px;
 @include breakpoint($mq-col1) {
   .pocket {
     &-top {
-      margin-bottom: #{-$block-gap};
+      margin-bottom: $block-gap;
     }
 
     &-bottom {
-      margin-top: #{-$block-gap};
+      margin-top: $block-gap;
     }
   }
 }


### PR DESCRIPTION
![image](https://github.com/lichess-org/lila/assets/95964955/3b3db357-d43b-49f1-a1c9-1ffd39a52c98)
Closes #14682 
> Drag and drop for extra pieces is very error prone atleast on phone. Click click functionality would be better.

What about this?