### PR TITLE
Fix wrapping text in markdown lists

### DIFF
--- a/ui/common/css/component/_markdown.scss
+++ b/ui/common/css/component/_markdown.scss
@@ -26,21 +26,20 @@
     ol,
     ul {
       margin: $element-margin 0;
-      padding-#{$start-direction}: 0.5em;
+      padding-#{$start-direction}: 2em;
     }
 
     li ol,
     li ul {
       margin: 0;
-      padding-#{$start-direction}: 2em;
     }
 
     ol > li {
-      list-style: decimal inside;
+      list-style: decimal;
     }
 
     ul > li {
-      list-style: disc inside;
+      list-style: disc;
     }
 
     li p {


### PR DESCRIPTION
Can be seen on [the Changelog page](https://lichess.org/changelog)

| Before | After |
| - | - |
| ![image](https://github.com/lichess-org/lila/assets/271432/ae845a8f-3cc3-477d-90e6-a9cb271cf056) | ![image](https://github.com/lichess-org/lila/assets/271432/47e4693e-b9e1-4c48-87f2-7f45fe7d41db) |
