### PR TITLE
Fix regression: remove puzzle theme menu from puzzle streak

### DIFF
--- a/ui/puzzle/src/view/theme.ts
+++ b/ui/puzzle/src/view/theme.ts
@@ -14,7 +14,9 @@ export default function theme(ctrl: PuzzleCtrl): MaybeVNode {
   if (data.replay) return showEditor ? h('div.puzzle__side__theme', editor(ctrl)) : null;
   const puzzleMenu = (v: VNode): VNode =>
     h('a', { attrs: { href: router.withLang(`/training/${angle.opening ? 'openings' : 'themes'}`) } }, v);
-  return !ctrl.streak && ctrl.isDaily
+  return ctrl.streak
+    ? null
+    : ctrl.isDaily
     ? h(
         'div.puzzle__side__theme.puzzle__side__theme--daily',
         puzzleMenu(h('h2', ctrl.trans.noarg('dailyPuzzle'))),


### PR DESCRIPTION
Fixes a code regression (introduced in a76f4c3a1577ed0ffc0c722833c6bbd2f1aeabb9 -> `ui/puzzle/src/view/theme.ts`) which is causing the "puzzle theme" menu to be displayed when playing Puzzle Streak. This menu should only be displayed when playing normal non-daily training puzzles.

![image](https://github.com/lichess-org/lila/assets/3620552/e74f8955-a894-4d30-bf19-df2dcc602adf)
