### PR TITLE
Update JSON response format for Broadcast PGN push

### DIFF
--- a/app/controllers/RelayRound.scala
+++ b/app/controllers/RelayRound.scala
@@ -140,7 +140,7 @@ final class RelayRound(
     Found(env.relay.api.byIdWithTourAndStudy(id)): rt =>
       if !rt.study.canContribute(me) then forbiddenJson()
       else
-        given Writes[Tag] = Writes(tag => Json.obj(tag.name.name -> tag.value))
+        given Writes[List[Tag]] = Writes(tags => Json.toJson(tags.map{case t => (t.name.name, t.value)}.toMap))
         env.relay
           .push(rt.withTour, PgnStr(ctx.body.body))
           .map: results =>


### PR DESCRIPTION
Here is a suggestion of a restructuring of the JSON response of the the broadcast PGN push endpoint,
https://lichess.org/api#tag/Broadcasts/operation/broadcastPush

It changes from JSON array of name:value objects,
to a single keys:values object.

Oh, as I'm writing this Pull Request, I realize that the original format might have the benefit of keeping a desired order of the tags... Well, opening the Pull Request anyways - in case order isn't important... :thinking:  

<details>
<summary>Before</summary>

```json
{
  "games": [
    {
      "tags": [
        {
          "White": "Rasmus Svane"
        },
        {
          "WhiteElo": "2632"
        },
        {
          "WhiteTitle": "GM"
        },
        {
          "WhiteTeam": "Germany"
        },
        {
          "Black": "Rajat Makkar"
        },
        {
          "BlackElo": "2453"
        },
        {
          "BlackTitle": "FM"
        },
        {
          "BlackTeam": "France"
        },
        {
          "Result": "1-0"
        }
      ],
      "moves": 2
    },
    {
      "tags": [
        {
          "White": "Joseph Girel"
        },
        {
          "WhiteElo": "2484"
        },
        {
          "WhiteTitle": "IM"
        },
        {
          "WhiteTeam": "France"
        },
        {
          "Black": "Matthias Bluebaum"
        },
        {
          "BlackElo": "2658"
        },
        {
          "BlackTitle": "GM"
        },
        {
          "BlackTeam": "Germany"
        },
        {
          "Result": "0-1"
        }
      ],
      "moves": 2
    }
  ]
}
```
</details>

<details>
<summary>After</summary>

```json
{
  "games": [
    {
      "tags": {
        "White": "Rasmus Svane",
        "Black": "Rajat Makkar",
        "BlackElo": "2453",
        "BlackTeam": "France",
        "BlackTitle": "FM",
        "WhiteTeam": "Germany",
        "Result": "1-0",
        "WhiteElo": "2632",
        "WhiteTitle": "GM"
      },
      "moves": 2
    },
    {
      "tags": {
        "White": "Joseph Girel",
        "Black": "Matthias Bluebaum",
        "BlackElo": "2658",
        "BlackTeam": "Germany",
        "BlackTitle": "GM",
        "WhiteTeam": "France",
        "Result": "0-1",
        "WhiteElo": "2484",
        "WhiteTitle": "IM"
      },
      "moves": 2
    }
  ]
}
```
</details>
