### PR TITLE
Fix Video Reveal Menu Overflow Cutoff

### DIFF
--- a/ui/pagelets/css/_video.scss
+++ b/ui/pagelets/css/_video.scss
@@ -80,6 +80,7 @@
 
     &:hover .reveal {
       transform: translateY(-100%);
+      overflow-y: scroll;
       opacity: 1;
     }
 


### PR DESCRIPTION
![image](https://github.com/lichess-org/lila/assets/53013571/e2cf84fc-3a4a-48d4-8ece-fba98d30990a)
Added scrollbar reveal-menus that are too large
Fixes #14741 