### PR TITLE
flatten blog tiers

### DIFF
--- a/modules/ublog/src/main/UblogRank.scala
+++ b/modules/ublog/src/main/UblogRank.scala
@@ -39,10 +39,10 @@ object UblogRank:
     val verboseOptions = List(
       HIDDEN  -> "Hidden",
       VISIBLE -> "Unlisted",
-      LOW     -> "Low (30 day penalty)",
+      LOW     -> "Low (-7 day penalty)",
       NORMAL  -> "Normal",
-      HIGH    -> "High (10 day bonus)",
-      BEST    -> "Best (15 day bonus)"
+      HIGH    -> "High (5 day bonus)",
+      BEST    -> "Best (7 day bonus)"
     )
     def name(tier: Tier) = options.collectFirst {
       case (t, n) if t == tier => n
@@ -59,10 +59,10 @@ object UblogRank:
     import Tier.*
     liveAt minusMonths (if tier < LOW || !hasImage then 3 else 0) plusHours:
       val tierBase = 24 * tier.match
-        case LOW    => -30
+        case LOW    => -7
         case NORMAL => 0
-        case HIGH   => 10
-        case BEST   => 15
+        case HIGH   => 5
+        case BEST   => 7
         case _      => 0
 
       val adjustBonus = 24 * days


### PR DESCRIPTION
This PR comes from my observation of mods managing content-blog and the constant shuffling of anyone at normal tier to high tier just to give them a shot at front paging (i.e. welcome them into the club). In a sense, high tier has become the new normal tier, normal tier is the new low/unlisted. And those tiers might as well not even exist. It's a race to the top resulting in an insular community of high visibility coaching ad purveyors, the membership in which much be meticulously micromanaged by our content team.

I would like to try an experiment where we flatten things a bit, and yes we will likely front page crap more often, but I think it's an acceptable tradeoff with increased opportunities for normal (and even low) tier bloggers to get some visibility or at least redeem themselves from past transgressions.

It is unlikely (without bot armies) for a normal tier blogger to effectively penetrate the +10 rank date advantage clique given our rating calculations.