### PR TITLE
Remove Tags From Video Card Info

### DIFF
--- a/app/views/video/bits.scala
+++ b/app/views/video/bits.scala
@@ -19,12 +19,7 @@ object bits:
       span(cls := "reveal")(
         span(cls := "full-title")(vv.video.title),
         span(cls := "author")(vv.video.author),
-        span(cls := "target")(vv.video.targets.map(lila.video.Target.name).mkString(", ")),
-        span(cls := "tags")(
-          vv.video.tags.map { tag =>
-            span(dataIcon := licon.Tag)(tag.capitalize)
-          }
-        )
+        span(cls := "target")(vv.video.targets.map(lila.video.Target.name).mkString(", "))
       )
     )
 

--- a/ui/pagelets/css/_video.scss
+++ b/ui/pagelets/css/_video.scss
@@ -69,7 +69,7 @@
       position: absolute;
       top: 100%;
       width: 100%;
-      height: 80%;
+      height: fit-content;
       border-top: $border;
       z-index: 1;
       padding: 10px 10px 0 10px;
@@ -123,10 +123,6 @@
       text-align: center;
       display: block;
       margin-bottom: 0.8em;
-    }
-
-    .tags span {
-      display: block;
     }
   }
 


### PR DESCRIPTION
<img width="242" alt="Screenshot 2024-02-26 221859" src="https://github.com/lichess-org/lila/assets/53013571/bfe1b73d-05db-4347-b53e-18f4fddd645a">

Fixes #14741
As proposed in #14743 