### PR TITLE
HTML will now wrap to the next line instead of overlapping

### DIFF
--- a/ui/pagelets/css/coach/_show.scss
+++ b/ui/pagelets/css/coach/_show.scss
@@ -29,6 +29,10 @@
 
     section {
       font-size: 1.2em;
+
+      .content a {
+        @extend %break-word;
+      }
     }
 
     @include breakpoint($mq-not-xx-small) {


### PR DESCRIPTION
This should fix any hyperlink that is attached along with the content.
I was thinking of applying the styling directly to the section tag instead of the a tag (that has content as parent) but felt this is more precise and should fix the current issue. Let me know if this needs to be changed.

Before fix:
![image](https://github.com/lichess-org/lila/assets/19169630/290660dd-bcfe-4586-bdb7-bc5779d58954)

After fix:
![image](https://github.com/lichess-org/lila/assets/19169630/7142bc66-7ba0-4906-b5bb-65ac012374df)
