### PR TITLE
Dont send move to lila fishnet if the game is finished

### DIFF
--- a/modules/fishnet/src/main/FishnetPlayer.scala
+++ b/modules/fishnet/src/main/FishnetPlayer.scala
@@ -20,21 +20,23 @@ final class FishnetPlayer(
 ):
 
   def apply(game: Game): Funit =
-    game.aiLevel
-      .so: level =>
-        LilaFuture.delay(delayFor(game) | 0.millis) {
-          openingBook(game, level).flatMap {
-            case Some(move) =>
-              uciMemo
-                .sign(game)
-                .map: sign =>
-                  Bus.publish(Tell(game.id.value, FishnetPlay(move, sign)), "roundSocket")
-            case None => makeWork(game, level).addEffect(redis.request).void
+    if game.finished then funit
+    else
+      game.aiLevel
+        .so: level =>
+          LilaFuture.delay(delayFor(game) | 0.millis) {
+            openingBook(game, level).flatMap {
+              case Some(move) =>
+                uciMemo
+                  .sign(game)
+                  .map: sign =>
+                    Bus.publish(Tell(game.id.value, FishnetPlay(move, sign)), "roundSocket")
+              case None => makeWork(game, level).addEffect(redis.request).void
+            }
           }
+        .recover { case e: Exception =>
+          logger.info(e.getMessage)
         }
-      .recover { case e: Exception =>
-        logger.info(e.getMessage)
-      }
 
   private val delayFactor  = 0.011f
   private val defaultClock = Clock(Clock.LimitSeconds(300), Clock.IncrementSeconds(0))


### PR DESCRIPTION
Lila always send the last move to `lila-fishnet` even when the game is finished. This causes extra works for `lila-fishnet` and `fishnet` clients.

Example logs from `lila-fishnet`
```
Feb 28 08:21:10 starr lila-fishnet[3697036]: 2024-02-28 08:21:10,900 [io-compute-26] WARN  lila.fishnet.App - HTTP/1.1 POST /fishnet/move/Yuh568ZX Headers(content-type: application/json, accept: */*, authorization: <REDACTED>, user-agent: fishnet-linux-x86_64/2.7.0, host: starr.vrack.lichess.ovh:9665, content-length: 73) body="{"fishnet":{"version":"2.7.0","apikey":"sirch"},"move":{"bestmove":null}}"
Feb 28 08:21:10 starr lila-fishnet[3697036]: 2024-02-28 08:21:10,901 [io-compute-26] WARN  lila.fishnet.App - HTTP/1.1 422 Unprocessable Entity Headers(Content-Length: 29, Content-Type: text/plain; charset=UTF-8) body="The request body was invalid."
Feb 28 08:21:16 starr lila-fishnet[3697036]: 2024-02-28 08:21:16,879 [io-compute-0] INFO  lila.fishnet.App - Timeout move: id:Yuh568ZX game:YGkJ2EOF variant:standard level:2 tries:3 created:2024-02-28T08:21:00.864290Z acquired:Some(by sirch at 2024-02-28T08:21:10.894817Z) move: e2e4 e7e5 g1f3 b8c6 d2d4 f7f6 d4d5 c6a5 c1d2 b7b6 b2b4 a5c4 f1c4 c8b7 b1c3 h7h5 c3b5 g8e7 d5d6 d8c8 d6e7 b7e4 e7f8q e8f8 e1h1 c8e8 f3e5 f6e5 b5c7 e8g6 c7a8 e4a8 d1f3 g6f5 f3f5 f8e7 f5f7 e7d8 d2g5 d8c8 f7g7 h8d8 g7e5 a8b7 g5d8 h5h4 e5c7
Feb 28 08:21:16 starr lila-fishnet[3697036]: 2024-02-28 08:21:16,880 [io-compute-0] WARN  lila.fishnet.App - Give up move due to clean up: id:Yuh568ZX game:YGkJ2EOF variant:standard level:2 tries:3 created:2024-02-28T08:21:00.864290Z acquired:Some(by sirch at 2024-02-28T08:21:10.894817Z) move: e2e4 e7e5 g1f3 b8c6 d2d4 f7f6 d4d5 c6a5 c1d2 b7b6 b2b4 a5c4 f1c4 c8b7 b1c3 h7h5 c3b5 g8e7 d5d6 d8c8 d6e7 b7e4 e7f8q e8f8 e1h1 c8e8 f3e5 f6e5 b5c7 e8g6 c7a8 e4a8 d1f3 g6f5 f3f5 f8e7 f5f7 e7d8 d2g5 d8c8 f7g7 h8d8 g7e5 a8b7 g5d8 h5h4 e5c7
```