### PR TITLE
 Put function definition on a separate line 

### DIFF
--- a/modules/fide/src/main/Federation.scala
+++ b/modules/fide/src/main/Federation.scala
@@ -43,8 +43,8 @@ object Federation:
       .option(str.toUpperCase)
       .orElse(bySlug.get(str).orElse(bySlug.get(nameToSlug(str))))
 
-  lazy val bySlug: Map[String, Id] = names
-    .map: (id, name) =>
+  lazy val bySlug: Map[String, Id] =
+    names.map: (id, name) =>
       nameToSlug(name) -> id
 
   val names: Map[Id, Name] = Map(


### PR DESCRIPTION
I don't have a big opinion on this, but for consistency, and (IMO)
makes it a lot easier to read the definition as I don't have to
visually scan the line looking for `=`. This should apply for all
non one liner functions.