### PR TITLE
Fix Issue #14000: Blog like button is cut off on Safari

### DIFF
--- a/ui/pagelets/css/ublog/_post.scss
+++ b/ui/pagelets/css/ublog/_post.scss
@@ -68,7 +68,8 @@
     font-weight: bold;
     cursor: pointer;
     &::before {
-      margin: 0 0.4em;
+      margin-right: 0.4em;
+      margin-left: 0.5em;
       content: $licon-HeartOutline;
     }
     &.ublog-post__like--liked::before {


### PR DESCRIPTION
**Changes**
I increased the left margin of the like button to prevent the heart in the like button from clipping in Safari. (Issue #14000 )

**Other Effects**
I tested the changes on Safari 17.3.1, Firefox 123.0, and Chrome 122.0.6261.94.

The author, info icon, and date move to the left and the like button, view count, report button, and language tag move to the right. The change is very slight.

original and edited comparison
<img width="635" alt="originalUi" src="https://github.com/lichess-org/lila/assets/126312812/356950c7-e904-4a13-8031-5c441f1589fd">
<img width="635" alt="EditedUi" src="https://github.com/lichess-org/lila/assets/126312812/c39ecb36-a8bf-47f1-b3cc-6bdbd4a895be">

the post in the screenshot is https://lichess.org/@/NoelStuder/blog/mastering-chess-puzzles/JfdYnKby