### PR TITLE
Study: up max_plies to 600

### DIFF
--- a/modules/study/src/main/Node.scala
+++ b/modules/study/src/main/Node.scala
@@ -2,7 +2,7 @@ package lila.study
 
 object Node:
 
-  val MAX_PLIES = 400
+  val MAX_PLIES = 600
 
   object BsonFields:
     val ply            = "p"


### PR DESCRIPTION
Close #14637

- Makes the same value of the games [played](https://github.com/lichess-org/lila/blob/6c52b5363d0185b579754123db488822e2771dfa/modules/game/src/main/Game.scala#L604) and [imported](https://github.com/lichess-org/lila/blob/6c52b5363d0185b579754123db488822e2771dfa/modules/importer/src/main/ImporterForm.scala#L42)
   - Making it possible to import the game played from lichess to studies
- Solve the [World Cup](https://lichess.org/broadcast/2023-fide-womens-world-blitz-championship/round-16/icV7Z1EB/p1elo9yr) problem (219 moves)
   - Reducing the possibility of it happening again
- reduces users a little from complaining about little

I know it's to reduce DoS, but it's also affecting the content area unfortunately