### PR TITLE
Country name Turkey officially changed to Turkiye

### DIFF
--- a/modules/user/src/main/Flags.scala
+++ b/modules/user/src/main/Flags.scala
@@ -260,7 +260,7 @@ object Flags:
     C("TM", "Turkmenistan"),
     C("TN", "Tunisia"),
     C("TO", "Tonga"),
-    C("TR", "Turkey"),
+    C("TR", "Turkiye"),
     C("TT", "Trinidad and Tobago"),
     C("TV", "Tuvalu"),
     C("TW", "Taiwan"),


### PR DESCRIPTION
Country named Turkey before officially changed its name to Turkiye. 

Some related news and sources for confirmation: 
1) https://www.un.org/en/about-us/member-states/turkiye
2) https://turkiye.un.org/en/184798-turkeys-name-changed-t%C3%BCrkiye
3) https://www.theguardian.com/world/2022/jun/03/turkey-changes-name-to-turkiye-as-other-name-is-for-the-birds


