### PR TITLE
"Practice with computer" defaults the player to white (and computer to black) in Racing Kings games #14116

### DIFF
--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -277,6 +277,10 @@ export default class AnalyseCtrl {
     return opposite(this.bottomColor());
   }
 
+  playerColor(): Color {
+    return this.data.game.player;
+  }
+
   bottomColor(): Color {
     if (this.data.game.variant.key === 'racingKings') return this.flipped ? 'black' : 'white';
     return this.flipped ? opposite(this.data.orientation) : this.data.orientation;

--- a/ui/analyse/src/practice/practiceCtrl.ts
+++ b/ui/analyse/src/practice/practiceCtrl.ts
@@ -136,7 +136,11 @@ export function make(root: AnalyseCtrl, playableDepth: () => number): PracticeCt
   }
 
   function isMyTurn(): boolean {
-    return root.turnColor() === root.playerColor();
+    if (root.data.game.variant.key === 'racingKings'){
+      return root.turnColor() === root.playerColor();
+    } else {
+      return root.turnColor() === root.bottomColor();
+    }
   }
 
   function checkCeval() {

--- a/ui/analyse/src/practice/practiceCtrl.ts
+++ b/ui/analyse/src/practice/practiceCtrl.ts
@@ -136,7 +136,7 @@ export function make(root: AnalyseCtrl, playableDepth: () => number): PracticeCt
   }
 
   function isMyTurn(): boolean {
-    if (root.data.game.variant.key === 'racingKings'){
+    if (root.data.game.variant.key === 'racingKings') {
       return root.turnColor() === root.playerColor();
     } else {
       return root.turnColor() === root.bottomColor();

--- a/ui/analyse/src/practice/practiceCtrl.ts
+++ b/ui/analyse/src/practice/practiceCtrl.ts
@@ -136,11 +136,10 @@ export function make(root: AnalyseCtrl, playableDepth: () => number): PracticeCt
   }
 
   function isMyTurn(): boolean {
-    if (root.data.game.variant.key === 'racingKings') {
-      return root.turnColor() === root.playerColor();
-    } else {
-      return root.turnColor() === root.bottomColor();
-    }
+    return (
+      root.turnColor() ===
+      (root.data.game.variant.key === 'racingKings' ? root.playerColor() : root.bottomColor())
+    );
   }
 
   function checkCeval() {

--- a/ui/analyse/src/practice/practiceCtrl.ts
+++ b/ui/analyse/src/practice/practiceCtrl.ts
@@ -136,7 +136,7 @@ export function make(root: AnalyseCtrl, playableDepth: () => number): PracticeCt
   }
 
   function isMyTurn(): boolean {
-    return root.turnColor() === root.playerColor(); // root.data.game.player;
+    return root.turnColor() === root.playerColor();
   }
 
   function checkCeval() {

--- a/ui/analyse/src/practice/practiceCtrl.ts
+++ b/ui/analyse/src/practice/practiceCtrl.ts
@@ -136,7 +136,7 @@ export function make(root: AnalyseCtrl, playableDepth: () => number): PracticeCt
   }
 
   function isMyTurn(): boolean {
-    return root.turnColor() === root.bottomColor();
+    return root.turnColor() === root.playerColor(); // root.data.game.player;
   }
 
   function checkCeval() {


### PR DESCRIPTION
Superseded by: https://github.com/lichess-org/lila/pull/14820 (WIP)
See conversation: https://discord.com/channels/280713822073913354/352976626558042122/1215336087292223488

## Before and After: Local (After code change) and Lichess.org (which is before code change)

Uploading LICHESS BEFORE AND AFTER.mp4…




[Original Issue](https://github.com/lichess-org/lila/issues/14116):

>  Exact URL of where the bug happened
> 
> https://lichess.org/rBvFqWnG
> 
> Steps to reproduce the bug
> 
> Play a Racing Kings game as black
> Load the game in analysis view.
> Attempt to "Practice with computer" from some point in the game
> What did you expect to happen?
> 
> I should be playing the black pieces, and the computer playing white.
> 
> What happened instead?
> 
> I am playing the white pieces, and the computer is playing black.
> 
> Operating system
> 
> Windows 11
> 
> Browser and version (or alternate access method)
> 
> Chrome 119
> 
> Additional information
> 
> The "Practice with computer" feature appears to select which color is played by player and which by computer based on board orientation. Racing Kings flips the board orientation to white no matter which color you are playing, so when you click "Practice with computer" it has you play white.
> 
> You can get around this by manually flipping the board, but then everything is upside down. When my opponent resigns/runs out of time I often like to play the rest of the game out against the computer, and it would be nice to be able to do that in the normal orientation when I'm playing Racing Kings as black.