### PR TITLE
Fix error on /editor when using invalid FEN in URL

### DIFF
--- a/ui/editor/src/ctrl.ts
+++ b/ui/editor/src/ctrl.ts
@@ -10,7 +10,7 @@ import { Api as CgApi } from 'chessground/api';
 import { Rules, Square } from 'chessops/types';
 import { SquareSet } from 'chessops/squareSet';
 import { Board } from 'chessops/board';
-import { Setup, Material, RemainingChecks } from 'chessops/setup';
+import { Setup, Material, RemainingChecks, defaultSetup } from 'chessops/setup';
 import { Castles, defaultPosition, setupPosition } from 'chessops/variant';
 import { makeFen, parseFen, parseCastlingFen, INITIAL_FEN, EMPTY_FEN } from 'chessops/fen';
 import { lichessVariant, lichessRules } from 'chessops/compat';
@@ -61,7 +61,10 @@ export default class EditorCtrl {
 
     if (!this.cfg.embed) this.options.orientation = params.get('color') === 'black' ? 'black' : 'white';
 
-    parseFen(this.initialFen).unwrap(this.setSetup);
+    parseFen(this.initialFen).unwrap(this.setSetup, _ => {
+      this.initialFen = INITIAL_FEN;
+      this.setSetup(defaultSetup());
+    });
   }
 
   private nthIndexOf = (haystack: string, needle: string, n: number): number => {


### PR DESCRIPTION
If an invalid FEN is used on /editor, the page breaks due to an uncaught error. This PR fixes that by using `defaultSetup` on error.

Example: 
https://lichess.org/editor/rnbqkbnr/pppp1ppp/4p3/3PP3/PPP2PPP/RNBQKBNR_w_KQkq_-_0_1

Dev screenshot:
![Screenshot_20240308_113546](https://github.com/lichess-org/lila/assets/3620552/287bfe6a-ecd7-41c0-8a9a-2cfd79bae0ef)
