### PR TITLE
Fixed infinite scroll not working on tournament history

### DIFF
--- a/modules/tournament/src/main/TournamentRepo.scala
+++ b/modules/tournament/src/main/TournamentRepo.scala
@@ -114,7 +114,6 @@ final class TournamentRepo(val coll: Coll, playerCollName: CollName)(using Execu
         sort = $sort.desc("startsAt"),
         _.sec
       )
-      .withNbResults(fuccess(Int.MaxValue))
 
   def isUnfinished(tourId: TourId): Fu[Boolean] =
     coll.exists($id(tourId) ++ unfinishedSelect)


### PR DESCRIPTION
Fixes #14822 
Easy fix but hard to find. ( Hopefully it doesn't break any other functionality)