### PR TITLE
Use reduceOption instead of foldLeft[Option]

### DIFF
--- a/modules/puzzle/src/main/JsonView.scala
+++ b/modules/puzzle/src/main/JsonView.scala
@@ -187,10 +187,7 @@ final class JsonView(
           )
           (game, branch :: branches)
       }
-      branchList.foldLeft[Option[tree.Branch]](None) {
-        case (None, branch)        => branch.some
-        case (Some(child), branch) => Some(branch.addChild(child))
-      }
+      branchList.reduceOption((child, branch) => branch.addChild(child))
 
 object JsonView:
 


### PR DESCRIPTION
They're equivalent as example below:

```scala
val xs = List(1,2,3,4)

xs.foldLeft[Option[Int]](None) {
  case (None, y) => Some(y)
  case (Some(x), y) => Some(x + 2*y)
} // Some(19)

xs.reduceOption((x, y) => x + 2*y) // Some(19)
```