### PR TITLE
Fixes Variant: Standard not working on `/games/search`

### DIFF
--- a/modules/gameSearch/src/main/GameSearchForm.scala
+++ b/modules/gameSearch/src/main/GameSearchForm.scala
@@ -89,7 +89,7 @@ private[gameSearch] case class SearchData(
       winner = players.cleanWinner,
       loser = players.cleanLoser,
       winnerColor = winnerColor,
-      perf = perf,
+      perf = if (perf.exists(_ == 5)) Range(1.some, 6.some) else Range(perf,perf),
       source = source,
       rated = mode.flatMap(Mode.apply).map(_.rated),
       turns = Range(turnsMin, turnsMax),

--- a/modules/gameSearch/src/main/GameSearchForm.scala
+++ b/modules/gameSearch/src/main/GameSearchForm.scala
@@ -106,7 +106,7 @@ private[gameSearch] case class SearchData(
       sorting = Sorting(sortOrDefault.field, sortOrDefault.order)
     )
 
-  def nonEmptyQuery = Some(query.pp).filter(_.nonEmpty)
+  def nonEmptyQuery = Some(query).filter(_.nonEmpty)
 
 private[gameSearch] case class SearchPlayer(
     a: Option[UserStr] = None,

--- a/modules/gameSearch/src/main/GameSearchForm.scala
+++ b/modules/gameSearch/src/main/GameSearchForm.scala
@@ -89,7 +89,9 @@ private[gameSearch] case class SearchData(
       winner = players.cleanWinner,
       loser = players.cleanLoser,
       winnerColor = winnerColor,
-      perf = if(perf.exists(_==5)) List(1,2,3,4,6) else perf.toList,// 1,2,3,4,6 are the perf types for standard games
+      perf =
+        if perf.exists(_ == 5) then List(1, 2, 3, 4, 6)
+        else perf.toList, // 1,2,3,4,6 are the perf types for standard games
       source = source,
       rated = mode.flatMap(Mode.apply).map(_.rated),
       turns = Range(turnsMin, turnsMax),

--- a/modules/gameSearch/src/main/GameSearchForm.scala
+++ b/modules/gameSearch/src/main/GameSearchForm.scala
@@ -89,7 +89,7 @@ private[gameSearch] case class SearchData(
       winner = players.cleanWinner,
       loser = players.cleanLoser,
       winnerColor = winnerColor,
-      perf = if (perf.exists(_ == 5)) Range(1.some, 6.some) else Range(perf,perf),
+      perf = if(perf.exists(_==5)) List(1,2,3,4,6) else perf.toList,// 1,2,3,4,6 are the perf types for standard games
       source = source,
       rated = mode.flatMap(Mode.apply).map(_.rated),
       turns = Range(turnsMin, turnsMax),
@@ -106,7 +106,7 @@ private[gameSearch] case class SearchData(
       sorting = Sorting(sortOrDefault.field, sortOrDefault.order)
     )
 
-  def nonEmptyQuery = Some(query).filter(_.nonEmpty)
+  def nonEmptyQuery = Some(query.pp).filter(_.nonEmpty)
 
 private[gameSearch] case class SearchPlayer(
     a: Option[UserStr] = None,

--- a/modules/gameSearch/src/main/Query.scala
+++ b/modules/gameSearch/src/main/Query.scala
@@ -13,7 +13,7 @@ case class Query(
     winner: Option[UserId] = None,
     loser: Option[UserId] = None,
     winnerColor: Option[Int] = None,
-    perf: Range[Int] = Range.none,
+    perf: List[Int] = List.empty,
     source: Option[Int] = None,
     status: Option[Int] = None,
     turns: Range[Int] = Range.none,

--- a/modules/gameSearch/src/main/Query.scala
+++ b/modules/gameSearch/src/main/Query.scala
@@ -13,7 +13,7 @@ case class Query(
     winner: Option[UserId] = None,
     loser: Option[UserId] = None,
     winnerColor: Option[Int] = None,
-    perf: Option[Int] = None,
+    perf: Range[Int] = Range.none,
     source: Option[Int] = None,
     status: Option[Int] = None,
     turns: Range[Int] = Range.none,


### PR DESCRIPTION
Fixes #14299 . Along with the corresponding pr to `lila-search` (https://github.com/lichess-org/lila-search/pull/184)