### PR TITLE
Remove hopscotch dependency, use shepherd.js

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -493,9 +493,6 @@ importers:
       flatpickr:
         specifier: ^4.6.13
         version: 4.6.13
-      hopscotch:
-        specifier: ^0.3.1
-        version: 0.3.1
       lichess-pgn-viewer:
         specifier: ^2.0.1
         version: 2.0.1
@@ -610,6 +607,9 @@ importers:
       nvui:
         specifier: workspace:*
         version: link:../nvui
+      shepherd.js:
+        specifier: ^11.2.0
+        version: 11.2.0
       snabbdom:
         specifier: 3.5.1
         version: 3.5.1
@@ -3098,10 +3098,6 @@ packages:
     engines: {node: '>= 0.4.0'}
     dependencies:
       function-bind: 1.1.1
-    dev: false
-
-  /hopscotch@0.3.1:
-    resolution: {integrity: sha512-XBvxhh1awi7lWzNP9Os2J8c/Ql66IPKnUn7L3hvqPaEa0Fk2S81mo0n2T/RxE2aNoHitVmn5Bl5C9J63iEWvSw==}
     dev: false
 
   /html-encoding-sniffer@3.0.0:

--- a/ui/@types/lichess/index.d.ts
+++ b/ui/@types/lichess/index.d.ts
@@ -39,7 +39,6 @@ interface Site {
     jsModule(name: string): string;
     loadIife(path: string, opts?: AssetUrlOpts): Promise<void>;
     loadEsm<T, ModuleOpts = any>(name: string, opts?: { init?: ModuleOpts; url?: AssetUrlOpts }): Promise<T>;
-    hopscotch: any;
     userComplete(opts: UserCompleteOpts): Promise<UserComplete>;
   };
   idleTimer(delay: number, onIdle: () => void, onWakeUp: () => void): void;
@@ -303,7 +302,6 @@ interface Window {
   $as<T>(cash: Cash): T;
   readonly chrome?: unknown;
   readonly moment: any;
-  readonly hopscotch: any;
   readonly stripeHandler: any;
   readonly Stripe: any;
   readonly Textcomplete: any;

--- a/ui/pagelets/package.json
+++ b/ui/pagelets/package.json
@@ -30,7 +30,6 @@
     "debounce-promise": "^3.1.2",
     "emoji-mart": "^5.5.2",
     "flatpickr": "^4.6.13",
-    "hopscotch": "^0.3.1",
     "lichess-pgn-viewer": "^2.0.1",
     "prop-types": "^15.8.1",
     "tablesort": "^5.3.0",
@@ -81,10 +80,6 @@
       {
         "src": "node_modules/cropperjs/dist/cropper.min.css",
         "dest": "../../public/npm"
-      },
-      {
-        "src": "node_modules/hopscotch/dist/**",
-        "dest": "../../public/npm/hopscotch/dist"
       },
       {
         "src": "../../node_modules/chessground/dist/chessground.min.js",

--- a/ui/pagelets/src/user.ts
+++ b/ui/pagelets/src/user.ts
@@ -41,30 +41,6 @@ export function initModule(opts: { i18n: I18nDict }): void {
     });
   });
 
-  if ($('#perfStat.correspondence .view_games').length && site.once('user-correspondence-view-games'))
-    site.asset.hopscotch().then(() => {
-      window.hopscotch
-        .configure({
-          i18n: {
-            nextBtn: 'OK, got it',
-          },
-        })
-        .startTour({
-          id: 'correspondence-games',
-          showPrevButton: true,
-          isTourBubble: false,
-          steps: [
-            {
-              title: 'Recently finished games',
-              content:
-                'Would you like to display the list of your correspondence games, sorted by completion date?',
-              target: $('#perfStat.correspondence .view_games')[0],
-              placement: 'bottom',
-            },
-          ],
-        });
-    });
-
   $('.user-show .angles').each(function (this: HTMLElement) {
     const $angles = $(this),
       $content = $('.angle-content'),

--- a/ui/round/package.json
+++ b/ui/round/package.json
@@ -20,13 +20,15 @@
     "voice": "workspace:*",
     "nvui": "workspace:*",
     "board": "workspace:*",
+    "shepherd.js": "^11.2.0",
     "snabbdom": "3.5.1"
   },
   "lichess": {
     "modules": {
       "esm": {
         "src/main.ts": "round",
-        "src/plugins/nvui.ts": "round.nvui"
+        "src/plugins/nvui.ts": "round.nvui",
+        "src/plugins/tour.ts": "round.tour"
       }
     }
   }

--- a/ui/round/src/ctrl.ts
+++ b/ui/round/src/ctrl.ts
@@ -46,6 +46,7 @@ import {
   MoveMetadata,
   Position,
   NvuiPlugin,
+  RoundTour,
 } from './interfaces';
 import { defined, Toggle, toggle } from 'common';
 import { Redraw } from 'common/snabbdom';
@@ -593,27 +594,15 @@ export default class RoundController implements MoveRootCtrl {
   challengeRematch = async () => {
     await xhr.challengeRematch(this.data.game.id);
     site.pubsub.emit('challenge-app.open');
-    if (site.once('rematch-challenge'))
-      setTimeout(() => {
-        site.asset.hopscotch(function () {
-          window.hopscotch
-            .configure({
-              i18n: { doneBtn: 'OK, got it' },
-            })
-            .startTour({
-              id: 'rematch-challenge',
-              showPrevButton: true,
-              steps: [
-                {
-                  title: 'Challenged to a rematch',
-                  content: 'Your opponent is offline, but they can accept this challenge later!',
-                  target: '#challenge-app',
-                  placement: 'bottom',
-                },
-              ],
-            });
-        });
+    if (site.once('rematch-challenge')) {
+      setTimeout(async () => {
+        const [tour] = await Promise.all([
+          site.asset.loadEsm<RoundTour>('round.tour'),
+          site.asset.loadCssPath('shepherd'),
+        ]);
+        tour.corresRematchOffline();
       }, 1000);
+    }
   };
 
   private makeCorrespondenceClock = (): void => {

--- a/ui/round/src/interfaces.ts
+++ b/ui/round/src/interfaces.ts
@@ -187,3 +187,7 @@ export interface MoveMetadata {
 }
 
 export type Position = 'top' | 'bottom';
+
+export interface RoundTour {
+  corresRematchOffline: () => void;
+}

--- a/ui/round/src/plugins/tour.ts
+++ b/ui/round/src/plugins/tour.ts
@@ -1,0 +1,31 @@
+import { RoundTour } from '../interfaces';
+import Shepherd from 'shepherd.js';
+
+export function initModule(): RoundTour {
+  return {
+    corresRematchOffline,
+  };
+
+  function corresRematchOffline() {
+    const tour = new Shepherd.Tour();
+
+    tour.addStep({
+      title: 'Challenged to a rematch',
+      text: 'Your opponent is offline, but they can accept this challenge later!',
+      attachTo: {
+        element: 'button.rematch',
+        on: 'bottom',
+      },
+      buttons: [
+        {
+          action() {
+            return this.next();
+          },
+          text: 'Ok, got it',
+        },
+      ],
+    });
+
+    tour.start();
+  }
+}

--- a/ui/site/src/assets.ts
+++ b/ui/site/src/assets.ts
@@ -84,15 +84,6 @@ export const userComplete = async (opts: UserCompleteOpts): Promise<UserComplete
   return userComplete as UserComplete;
 };
 
-export const hopscotch = () => {
-  return Promise.all([
-    loadCss('npm/hopscotch/dist/css/hopscotch.min.css'),
-    loadIife('npm/hopscotch/dist/js/hopscotch.min.js', {
-      noVersion: true,
-    }),
-  ]);
-};
-
 export function embedChessground() {
   return import(url('npm/chessground.min.js'));
 }


### PR DESCRIPTION
[hopscotch](https://www.npmjs.com/package/hopscotch) isn't maintained anymore. Our implementation actually doesn't appear to be working because neither of the selectors that it tried to attach to exist.

The first time you send a rematch to someone in a correspondence game and they are offline, it used to give a message. This PR recreates that but using [shepherd.js](https://shepherdjs.dev/), which is what we use for the guided tours on Studies.

![rematch](https://github.com/lichess-org/lila/assets/271432/67eeb513-3f82-49a1-8f6b-b2800cfa823b)
