### PR TITLE
Set min height for Tournament winners

### DIFF
--- a/ui/lobby/css/_layout.scss
+++ b/ui/lobby/css/_layout.scss
@@ -20,7 +20,7 @@
   &__wide-winners {
     min-height: 20em;
   }
-  
+
   @include mq-at-least-col2 {
     --cols: 2; // ui/lobby/src/main.ts
     grid-template-columns: repeat(2, 1fr);

--- a/ui/lobby/css/_layout.scss
+++ b/ui/lobby/css/_layout.scss
@@ -16,7 +16,11 @@
   &__winners {
     min-height: 20em;
   }
-
+  //sets min height when we disable Show player ratings and there is only Tournament winners box to display
+  &__wide-winners {
+    min-height: 20em;
+  }
+  
   @include mq-at-least-col2 {
     --cols: 2; // ui/lobby/src/main.ts
     grid-template-columns: repeat(2, 1fr);


### PR DESCRIPTION
Set minimum height when only Tournament winners is getting displayed in the lobby screen. This will fix #14864   .Adding screenshots before and after code change for reference:
Before :
![image](https://github.com/lichess-org/lila/assets/19169630/519ad209-e6b7-40fa-a59a-f6d4f6454e66)

After :

![image](https://github.com/lichess-org/lila/assets/19169630/e321eecf-ce91-4b5b-be91-e7db57b7a20f)
