### PR TITLE
Fix NewTree takeMainlineWhile test

### DIFF
--- a/modules/study/src/test/Helpers.scala
+++ b/modules/study/src/test/Helpers.scala
@@ -26,28 +26,27 @@ object Helpers:
   extension (newBranch: NewBranch)
     def toBranch(children: Option[NewTree]): Branch = Branch(
       newBranch.id,
-      newBranch.metas.ply,
+      newBranch.ply,
       newBranch.move,
-      newBranch.metas.fen,
-      newBranch.metas.check,
-      newBranch.metas.dests,
-      newBranch.metas.drops,
-      newBranch.metas.eval,
-      newBranch.metas.shapes,
-      newBranch.metas.comments,
-      newBranch.metas.gamebook,
-      newBranch.metas.glyphs,
+      newBranch.fen,
+      newBranch.check,
+      newBranch.dests,
+      newBranch.drops,
+      newBranch.eval,
+      newBranch.shapes,
+      newBranch.comments,
+      newBranch.gamebook,
+      newBranch.glyphs,
       children.fold(Branches.empty)(_.toBranches),
-      newBranch.metas.opening,
+      newBranch.opening,
       newBranch.comp,
-      newBranch.metas.clock,
-      newBranch.metas.crazyData,
+      newBranch.clock,
+      newBranch.crazyData,
       newBranch.forceVariation
     )
 
   extension (newTree: NewTree)
     def toBranch: Branch = newTree.value.toBranch(newTree.child)
-    def toRoot: Root     = ??? // newTree.value.toBranch(newTree.child)
     def toBranches: Branches =
       val variations = newTree.variations.map(_.toNode.toBranch)
       Branches(newTree.value.toBranch(newTree.child) :: variations)
@@ -55,20 +54,20 @@ object Helpers:
   extension (newRoot: NewRoot)
     def toRoot =
       Root(
-        newRoot.metas.ply,
-        newRoot.metas.fen,
-        newRoot.metas.check,
-        newRoot.metas.dests,
-        newRoot.metas.drops,
-        newRoot.metas.eval,
-        newRoot.metas.shapes,
-        newRoot.metas.comments,
-        newRoot.metas.gamebook,
-        newRoot.metas.glyphs,
+        newRoot.ply,
+        newRoot.fen,
+        newRoot.check,
+        newRoot.dests,
+        newRoot.drops,
+        newRoot.eval,
+        newRoot.shapes,
+        newRoot.comments,
+        newRoot.gamebook,
+        newRoot.glyphs,
         newRoot.tree.fold(Branches.empty)(_.toBranches),
-        newRoot.metas.opening,
-        newRoot.metas.clock,
-        newRoot.metas.crazyData
+        newRoot.opening,
+        newRoot.clock,
+        newRoot.crazyData
       )
 
   extension (comments: Comments)

--- a/modules/study/src/test/StudyArbitraries.scala
+++ b/modules/study/src/test/StudyArbitraries.scala
@@ -10,6 +10,7 @@ import org.scalacheck.{ Arbitrary, Gen }
 import chess.bitboard.Bitboard
 import lila.tree.{ NewTree, NewRoot, NewBranch, Metas }
 import lila.tree.Node.{ Comments, Comment, Shapes, Shape }
+import org.scalacheck.Cogen
 
 object StudyArbitraries:
 
@@ -17,6 +18,9 @@ object StudyArbitraries:
   type RootWithPath = (NewRoot, UciPath)
   given Arbitrary[RootWithPath]    = Arbitrary(genRootWithPath(Situation(chess.variant.Standard)))
   given Arbitrary[Option[NewTree]] = Arbitrary(genTree(Situation(chess.variant.Standard)))
+
+  // TODO remove after new scalachess version
+  given Cogen[Centis] = Cogen(_.value.toLong)
 
   def genRoot(seed: Situation): Gen[NewRoot] =
     for

--- a/modules/study/src/test/newTreeTest.scala
+++ b/modules/study/src/test/newTreeTest.scala
@@ -87,16 +87,14 @@ class NewTreeTest extends munit.ScalaCheckSuite:
     forAll: (root: NewRoot, c: Option[Centis]) =>
       val oldRoot = root.toRoot
       oldRoot.updateMainlineLast(_.copy(clock = c)).toNewRoot == root.updateMainlineLast(_.copy(clock = c))
-
-  // override def scalaCheckInitialSeed = "OhayJX-NSkjod3-vTDxYsY2XWp5pjWu1LJK8_ruPi9F="
-  // test("takeMainlineWhile"):
-  //   forAll: (root: NewRoot, c: Option[Centis]) =>
-  //     val oldRoot = root.clearVariations.toRoot
-  //     val x = oldRoot.takeMainlineWhile(x => x.clock == c).toNewRoot
-  //     val y = root.clearVariations.takeMainlineWhile(x => x.metas.clock == c)
-  //     y.size >= 2 ==> {
-  //       x == y
-  //     }
+  test("takeMainlineWhile"):
+    forAll: (root: NewRoot, f: Centis => Boolean) =>
+      val c = root
+      val x = c.toRoot.takeMainlineWhile(_.clock.exists(f)).toNewRoot
+      val y = c.takeMainlineWhile(_.metas.clock.exists(f))
+      // The current tree always take the first child of the root despite the predicate
+      // so, We have to ignore the case where the first child doesn't satisfy the predicate
+      c.tree.exists(_.value.clock.exists(f)) ==> (x == y)
 
   test("current tree's bug with takeMainlineWhile".ignore):
     val pgn     = "1. d4 d5 2. e4 e5"

--- a/modules/study/src/test/newTreeTest.scala
+++ b/modules/study/src/test/newTreeTest.scala
@@ -98,6 +98,12 @@ class NewTreeTest extends munit.ScalaCheckSuite:
   //       x == y
   //     }
 
+  test("current tree's bug with takeMainlineWhile".ignore):
+    val pgn     = "1. d4 d5 2. e4 e5"
+    val newRoot = NewPgnImport(pgn, Nil).toOption.get.root
+    val oldRoot = newRoot.toRoot
+    assert(oldRoot.takeMainlineWhile(_.clock.isDefined).children.isEmpty)
+
   test("clearVariations"):
     forAll: (root: NewRoot) =>
       val oldRoot = root.toRoot

--- a/modules/study/src/test/newTreeTest.scala
+++ b/modules/study/src/test/newTreeTest.scala
@@ -87,14 +87,15 @@ class NewTreeTest extends munit.ScalaCheckSuite:
     forAll: (root: NewRoot, c: Option[Centis]) =>
       val oldRoot = root.toRoot
       oldRoot.updateMainlineLast(_.copy(clock = c)).toNewRoot == root.updateMainlineLast(_.copy(clock = c))
+
   test("takeMainlineWhile"):
-    forAll: (root: NewRoot, f: Centis => Boolean) =>
+    forAll: (root: NewRoot, f: Option[Centis] => Boolean) =>
       val c = root
-      val x = c.toRoot.takeMainlineWhile(_.clock.exists(f)).toNewRoot
-      val y = c.takeMainlineWhile(_.metas.clock.exists(f))
+      val x = c.toRoot.takeMainlineWhile(b => f(b.clock)).toNewRoot
+      val y = c.takeMainlineWhile(b => f(b.clock))
       // The current tree always take the first child of the root despite the predicate
       // so, We have to ignore the case where the first child doesn't satisfy the predicate
-      c.tree.exists(_.value.clock.exists(f)) ==> (x == y)
+      c.tree.exists(b => f(b.value.clock)) ==> (x == y)
 
   test("current tree's bug with takeMainlineWhile".ignore):
     val pgn     = "1. d4 d5 2. e4 e5"


### PR DESCRIPTION
When trying to make `takeMainlineWhile` function works for the NewTree, I found a subtle bug in the current Tree: it always take the first child of the root despite the predicate as demonstrated in the first commit.
