### PR TITLE
Apply player replacements also for Push PGN

### DIFF
--- a/modules/relay/src/main/RelayPush.scala
+++ b/modules/relay/src/main/RelayPush.scala
@@ -42,7 +42,7 @@ final class RelayPush(sync: RelaySync, api: RelayApi, irc: lila.irc.IrcApi)(usin
   private def push(rt: RelayRound.WithTour, games: Vector[RelayGame]) =
     workQueue(rt.round.id):
       sync
-        .updateStudyChapters(rt, games)
+        .updateStudyChapters(rt, rt.tour.players.fold(games)(_.update(games)))
         .map: res =>
           SyncLog.event(res.nbMoves, none)
         .recover:


### PR DESCRIPTION
When creating a broadcast,
it is possible to specify player replacements which will happen for rounds belonging to the broadcast, i.e `<player name> = <fide id>`

This works for rounds which uses Sync URL, i.e fetched PGN, but it doesn't apply to PGN which is being pushed.

This Pull Request applies player replacements also for pushed PGN.

Note, maybe this isn't desired... Maybe not applying replacements on pushed PGNs was a deliberate choice... :sweat_smile:



<details>
<summary>scala-cli reproducer PushPgn.scala</summary>

```scala
//> using scala 3.4.0
//> using dep io.github.tors42:chariot:0.0.84

@main
def main() =

  val lichessApi = "http://localhost:8080"
  val token      = "lip_diego"

  val client = chariot.Client.basic(conf => conf.api(lichessApi))
    .withToken(token)

  val broadcast = client.broadcasts().create(p => p
    .name("Broadcast Name")
    .shortDescription("Short Broadcast Description")
    .longDescription("Looooong Broadcast Description")
    .players("""
      Player One / 2222 / WIM / Substitute Uno
      """)).get()

  val round = client.broadcasts().createRound(broadcast.id(),
    p => p.name("Round Name")).get()

  val pushPgn = """
    [White "Player One"]
    [WhiteElo "1111"]
    [WhiteTitle "WFM"]
    [Black "Player Two"]
    [BlackElo "1500"]
    [BlackTitle "FM"]
    [Result "1-0"]

    1 d4 d5 1-0
    """

  client.broadcasts().pushPgnByRoundId(round.id(), pushPgn)

  val exportedPgn = String.join("\n",
    client.broadcasts().exportOneRoundPgn(round.id())
      .stream().map(pgn => pgn.toString()).toList())

  println(exportedPgn)
```

After fix applied, White player tags are replaced:
```
$ ./scala-cli PushPgn.scala 
Compiling project (Scala 3.4.0, JVM (22))
Compiled project (Scala 3.4.0, JVM (22))
[Event "Round Name: Substitute Uno - Player Two"]
[Site "http://localhost:8080/study/iEHsCgWk/9fEcr2lv"]
[White "Substitute Uno"]
[Black "Player Two"]
[Result "1-0"]
[BlackElo "1500"]
[BlackTitle "FM"]
[WhiteElo "2222"]
[WhiteTitle "WIM"]
[Variant "Standard"]
[ECO "D00"]
[Opening "Queen's Pawn Game"]
[Annotator "http://localhost:8080/@/Diego"]
[UTCDate "2024.03.25"]
[UTCTime "18:51:58"]

1. d4 d5 1-0
```

</details>


 
