### PR TITLE
Make importer depends on game instead of round

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -270,7 +270,7 @@ lazy val setup = module("setup",
 )
 
 lazy val importer = module("importer",
-  Seq(round),
+  Seq(game),
   tests.bundle ++ reactivemongo.bundle
 )
 
@@ -345,7 +345,7 @@ lazy val fide = module("fide",
 )
 
 lazy val study = module("study",
-  Seq(explorer),
+  Seq(explorer, round),
   Seq(scalatags, lettuce) ++ tests.bundle ++ reactivemongo.bundle ++ Seq(scalacheck, munitCheck, testKit)
 ).dependsOn(common % "test->test")
 


### PR DESCRIPTION
Also add round as a dependency for Study as result.

I believe `study` shouldn't depend on round either, but for now it depends on `round.TreeBuilder` and `round.WithFlags`. We should them to `importer` (maybe 🤔) and remove `round` from `study`