### PR TITLE
increase the top navigation margin a little

### DIFF
--- a/ui/common/css/abstract/_variables.scss
+++ b/ui/common/css/abstract/_variables.scss
@@ -17,7 +17,7 @@ $site-header-short-height: 40px;
 $site-header-sticky-max-width: 1780px;
 $site-header-height: var(--site-header-height);
 $site-header-margin: var(--site-header-margin);
-$site-header-outer-height: calc($site-header-height + $site-header-margin + var(--sticky-gap));
+$site-header-outer-height: calc($site-header-height + $site-header-margin + var(--sticky-gap) + 1em);
 
 $main-margin: var(--main-margin);
 $main-max-width: 1300px !default;


### PR DESCRIPTION
close #14953

Solves the problem of being too close together in the navigation bar, and even solves the stylus problem for streamers

note: I was only able to test it using the stylus
due to the build problem that exists at the moment, I was unable to test on gitpod