### PR TITLE
Remove actor.forum.search from base.conf

### DIFF
--- a/conf/base.conf
+++ b/conf/base.conf
@@ -447,9 +447,6 @@ hub {
     }
     renderer = "renderer"
     captcher = ${game.captcher.name}
-    forum {
-      search = ${forumSearch.actor.name}
-    }
     team.search = ${teamSearch.actor.name}
     fishnet = ${fishnet.actor.name}
     timeline {


### PR DESCRIPTION
lila run currently not working

> [error] Caused by: com.typesafe.config.ConfigException$UnresolvedSubstitution: base.conf @ jar:file:/lila/target/bg-jobs/sbt_5cadf719/job-1/target/5086a3aa/6e009ac9/lila_3-4.0.jar!/base.conf: 451: Could not resolve substitution to a value: ${forumSearch.actor.name}

`forumSearch.actor.name` config removed in 5c94dc2a9c8988ab59e04882ca9db615415833fc