### PR TITLE
Don't wrap token with single-quotes

### DIFF
--- a/app/views/dgt.scala
+++ b/app/views/dgt.scala
@@ -61,7 +61,7 @@ object dgt:
     )
 
   def play(token: AccessToken)(using PageContext) =
-    layout("play", s"'${token.plain.value}'".some)(
+    layout("play", s"${token.plain.value}".some)(
       div(id := "dgt-play-zone")(pre(id := "dgt-play-zone-log")),
       div(cls := "dgt__play__help")(
         h2(iconTag(licon.InfoCircle, ifMoveNotDetected())),


### PR DESCRIPTION
The DGT play functionality failed with "error: No such token" message.
It seems it's because the token is wrapped within single-quotes.
This Pull Request removes the quotes.

Resolves: #15000