### PR TITLE
hack lichess into streamer presence

### DIFF
--- a/modules/streamer/src/main/Streaming.scala
+++ b/modules/streamer/src/main/Streaming.scala
@@ -26,7 +26,7 @@ final private class Streaming(
     for
       streamerIds <- api.allListedIds
       activeIds = streamerIds.filter { id =>
-        liveStreams.has(id) || isOnline(id.userId)
+        liveStreams.has(id) || isOnline(id.userId) || id.value == "lichess"
       }
       streamers <- api.byIds(activeIds)
       (twitchStreams, youTubeStreams) <-


### PR DESCRIPTION
This is a hack for Candidates today. Ideally we'd assemble the list of pinned streamers from ongoing broadcasts before calling twitch & youtube, but here I'm just hard coding lichess.

It's the agreed upon workflow - we cannot require the lichess user be online.