### PR TITLE
Use OpenOrScoped TeamApi.show

### DIFF
--- a/app/controllers/TeamApi.scala
+++ b/app/controllers/TeamApi.scala
@@ -31,7 +31,7 @@ final class TeamApi(env: Env, apiC: => Api) extends LilaController(env):
         _     <- env.user.lightUserApi.preloadMany(pager.currentPageResults.flatMap(_.publicLeaders))
       yield pager
 
-  def show(id: TeamId) = OpenOrScoped(): ctx?=>
+  def show(id: TeamId) = OpenOrScoped(): ctx ?=>
     JsonOptionOk:
       api
         .teamEnabled(id)

--- a/app/controllers/TeamApi.scala
+++ b/app/controllers/TeamApi.scala
@@ -31,7 +31,7 @@ final class TeamApi(env: Env, apiC: => Api) extends LilaController(env):
         _     <- env.user.lightUserApi.preloadMany(pager.currentPageResults.flatMap(_.publicLeaders))
       yield pager
 
-  def show(id: TeamId) = Open:
+  def show(id: TeamId) = OpenOrScoped(): ctx?=>
     JsonOptionOk:
       api
         .teamEnabled(id)

--- a/modules/chat/src/main/ChatApi.scala
+++ b/modules/chat/src/main/ChatApi.scala
@@ -10,7 +10,7 @@ import lila.core.shutup.PublicSource
 import lila.memo.CacheApi.*
 import lila.security.{ Flood, Granter }
 import lila.user.{ FlairApi, Me, User, UserRepo, given }
-import lila.core.chat.{OnTimeout, OnReinstate}
+import lila.core.chat.{ OnTimeout, OnReinstate }
 
 final class ChatApi(
     coll: Coll,


### PR DESCRIPTION
When I try the `/api/team/<teamid>` endpoint, the `joined` flag seems to always be `false`.
I've noticed this earlier too, but got sidetracked when trying to figure out what was happening - and now I saw the #15022 Pull Request which adds the private team description in the response if user is authenticated and member.
From the example screenshot in #15022 it seems that this somehow works without this fix - so I'm not sure what is going on here... :sweat_smile:  

Example request from user "ana" which is member in team "diegoteam",
```
curl --header "authorization: Bearer lip_ana" http://localhost:8080/api/team/diegoteam
```

Response without fix:
```
{"id":"diegoteam", ... , "joined":false,"requested":false}
```

Response with fix:
```
{"id":"diegoteam", ... ,"joined":true,"requested":false,"descriptionPrivate":"This is the private description of the team"}
```


Relates: #15022