### PR TITLE
Fix Issue #14957: Crazyhouse pocket takes a lot of space on analysis board

### DIFF
--- a/ui/analyse/css/_zh.scss
+++ b/ui/analyse/css/_zh.scss
@@ -45,7 +45,7 @@ $pocket-height: 60px;
   }
 
   @include mq-at-least-col3 {
-    grid-template-rows: $pocket-height $meta-height $chat-height $pocket-height;
+    grid-template-rows: $pocket-height auto auto $pocket-height;
     grid-template-areas:
       'side    . board gauge pocket-top'
       'side    . board gauge tools'


### PR DESCRIPTION
#14957 

https://github.com/lichess-org/lila/assets/126312812/f997541a-8abe-4605-91b7-dbd0252c49ea

The bug happens during the second media query, which is `min-width: 1259.3px`

https://github.com/lichess-org/lila/assets/126312812/a1e9b97c-d4b5-44d6-8cd2-980d1dcb5a41

