### PR TITLE
Don't dox poster info in forum post search results

### DIFF
--- a/app/views/forum/search.scala
+++ b/app/views/forum/search.scala
@@ -27,7 +27,7 @@ object search:
         table(cls := "slist slist-pad search__results")(
           (pager.nbResults > 0).option(
             tbody(cls := "infinite-scroll")(
-              pager.currentPageResults.map { viewWithRead =>
+              pager.currentPageResults.map: viewWithRead =>
                 val view = viewWithRead.view
                 val info =
                   td(cls := "info")(
@@ -50,13 +50,9 @@ object search:
                       ),
                       info
                     )
-                  else
-                    frag(
-                      td("[You can't access this team forum post]"),
-                      info
-                    )
+                  else td("[You can't access this team forum post]")
                 )
-              },
+              ,
               pagerNextTable(pager, n => routes.ForumPost.search(text, n).url)
             )
           )

--- a/app/views/forum/search.scala
+++ b/app/views/forum/search.scala
@@ -50,7 +50,7 @@ object search:
                       ),
                       info
                     )
-                  else td("[You can't access this team forum post]")
+                  else td(colspan := "2")("[You can't access this team forum post]")
                 )
               ,
               pagerNextTable(pager, n => routes.ForumPost.search(text, n).url)


### PR DESCRIPTION
e.g. Searching for your username gives you results about who is talking about you behind your back in private team forums. Even if the contents are not visible, the poster is, and it's an avenue for trolls to harass them.