### PR TITLE
rating hided no click

### DIFF
--- a/ui/pagelets/css/user/_sub-rating.scss
+++ b/ui/pagelets/css/user/_sub-rating.scss
@@ -20,6 +20,10 @@
       @include transition;
     }
 
+    &[href=""] {
+      pointer-events: none;
+    }
+
     &[href]:hover {
       background: mix($c-bg-box, $c-bg-page, 50%);
 


### PR DESCRIPTION
When the rating is disabled. The href is empty
Maybe it's better to disable the click so no one finds it strange.