### PR TITLE
Fix relation check on challenges

### DIFF
--- a/modules/challenge/src/main/ChallengeGranter.scala
+++ b/modules/challenge/src/main/ChallengeGranter.scala
@@ -2,7 +2,7 @@ package lila.challenge
 
 import lila.core.i18n.I18nKey.challenge as trans
 import lila.rating.PerfType
-import lila.core.relation.{ Block, Follow }
+import lila.core.relation.Relation.{ Block, Follow }
 
 import lila.core.i18n.Translate
 


### PR DESCRIPTION
`relation.Follow/`/`relation.Block` are the bus message, so the check currently ignores blocks and doesn't allow friends. Seems like it was broken in https://github.com/lichess-org/lila/commit/cc17923c539db40e9bf9e9d93c019b35f183d14f#diff-7427dafff9a8a406b95922a6bff3b2b582ad573b08e2eff7e1139163acb6b84e. Didn't find any other places with the same issue at first glance.