### PR TITLE
Fix FidePSync to read FIDE's ridiculous woman inactive flag

### DIFF
--- a/modules/fide/src/main/FidePlayerSync.scala
+++ b/modules/fide/src/main/FidePlayerSync.scala
@@ -139,7 +139,7 @@ final private class FidePlayerSync(repo: FideRepo, ws: StandaloneWSClient)(using
         title  = string(84, 89).flatMap(PlayerTitle.get)
         wTitle = string(89, 105).flatMap(PlayerTitle.get)
         year   = number(152, 156).filter(_ > 1000)
-        flags  = string(158, 159)
+        flags  = string(158, 160)
       yield FidePlayer(
         id = FideId(id),
         name = PlayerName(name),
@@ -150,7 +150,7 @@ final private class FidePlayerSync(repo: FideRepo, ws: StandaloneWSClient)(using
         rapid = number(126, 132),
         blitz = number(139, 145),
         year = year,
-        inactive = flags.contains("i").option(true),
+        inactive = flags.isDefined.some,
         fetchedAt = nowInstant
       )
 


### PR DESCRIPTION
Apparently, FIDE has three flags for inactive players:

> FLAG - flag of inactivity (I - inactive, WI - woman inactive, w - woman)

That means if the flag contains anything, the player is inactive.

I have a [test](https://github.com/lenguyenthanh/fide/blob/a1e1e02060f6bbf16d60db92b5cc328a8a4540a0/modules/crawler/src/test/scala/CrawlerTest.scala#L18) and a similar [fix](https://github.com/lenguyenthanh/fide/blob/a1e1e02060f6bbf16d60db92b5cc328a8a4540a0/modules/crawler/src/main/scala/Crawler.scala#L94) in [fide](https://github.com/lenguyenthanh/fide).