### PR TITLE
Show error message when Java is not installed

### DIFF
--- a/lila
+++ b/lila
@@ -29,6 +29,10 @@ cat << "BANNER"
                                                    |___/
 BANNER
 
+if ! command -v java; then
+    echo "Cannot find Java, is it installed?"
+    exit 1
+fi
 version=$(java -version 2>&1 | awk -F '"' '/version/ {print $2}')
 echo Java "$version"
 


### PR DESCRIPTION
Before, if an executable named "java" wasn't found, lila would simply print "Java " and exit (no matter what command line arguments were added) due to the version string being blank.  This is confusing and frustrating, so this commit fixes that by printing an error message