### PR TITLE
Make bookmark game icon visible without hover

### DIFF
--- a/ui/round/css/_meta.scss
+++ b/ui/round/css/_meta.scss
@@ -81,13 +81,3 @@
     margin-top: 0.2em;
   }
 }
-
-@media (hover: hover) {
-  .game__meta .bookmark {
-    display: none;
-  }
-
-  .game__meta:hover .bookmark {
-    display: block;
-  }
-}


### PR DESCRIPTION
The icon should not be only shown on hover. It's likely many users are unaware about this bookmark game feature because by default it is hidden. For most users, currently checking whether a game is already bookmarked takes unnecessary effort, and for keyboard users (no mouse or touchpad) it is impossible.


https://github.com/lichess-org/lila/assets/126312812/fc52b8fa-22ea-403f-8a10-b0cf9ae5e4d7





