### PR TITLE
Fix bg color scheme (dark/light/system) for embeds

### DIFF
--- a/app/views/base/embed.scala
+++ b/app/views/base/embed.scala
@@ -8,18 +8,19 @@ def embed(title: String, cssModule: String, modules: EsmList = Nil)(body: Modifi
   frag(
     layout.ui.doctype,
     layout.ui.htmlTag(using ctx.lang)(
+      cls := ctx.bg,
       head(
         layout.ui.charset,
         layout.ui.viewport,
         layout.ui.metaCsp(basicCsp.withNonce(ctx.nonce).withInlineIconFont),
         st.headTitle(title),
-        layout.ui.systemThemeEmbedScript,
+        (ctx.bg == "system").option(layout.ui.systemThemeScript(ctx.nonce.some)),
         layout.ui.pieceSprite(ctx.pieceSet.name),
         cssTag("theme-light"), // includes both light & dark colors
         cssTag(cssModule),
         layout.ui.modulesPreload(modules, isInquiry = false)
       ),
-      st.body(cls := s"${ctx.bg} highlight ${ctx.boardClass}")(
+      st.body(cls := s"highlight ${ctx.boardClass}")(
         layout.ui.dataSoundSet := lila.pref.SoundSet.silent.key,
         layout.ui.dataAssetUrl,
         layout.ui.dataAssetVersion := assetVersion.value,

--- a/app/views/base/layout.scala
+++ b/app/views/base/layout.scala
@@ -46,14 +46,6 @@ object layout:
         s"""<meta name="theme-color" media="(prefers-color-scheme: dark)" content="${ctx.pref.themeColorDark}">""" +
         s"""<meta name="theme-color" content="${ctx.pref.themeColor}">"""
 
-  private def systemThemeScript(using ctx: PageContext) =
-    (ctx.pref.bg === lila.pref.Pref.Bg.SYSTEM).option(
-      embedJsUnsafe(
-        "if (window.matchMedia('(prefers-color-scheme: light)')?.matches) " +
-          "document.documentElement.classList.add('light');"
-      )(ctx.nonce)
-    )
-
   private def boardPreload(using ctx: Context) = frag(
     preload(assetUrl(s"images/board/${ctx.pref.currentTheme.file}"), "image", crossorigin = false),
     ctx.pref.is3d.option(
@@ -135,12 +127,12 @@ object layout:
             modules ++ pageModule.so(module => jsPageModule(module.name)),
             isInquiry = ctx.data.inquiry.isDefined
           ),
-          systemThemeScript
+          (ctx.pref.bg === lila.pref.Pref.Bg.SYSTEM).so(systemThemeScript(ctx.nonce))
         ),
         st.body(
           cls := {
             val baseClass =
-              s"${pref.currentBg} ${current2dTheme.cssClass} ${pref.currentTheme3d.cssClass} ${pref.currentPieceSet3d.toString} coords-${pref.coordsClass}"
+              s"${current2dTheme.cssClass} ${pref.currentTheme3d.cssClass} ${pref.currentPieceSet3d.toString} coords-${pref.coordsClass}"
             List(
               baseClass              -> true,
               "dark-board"           -> (pref.bg == lila.pref.Pref.Bg.DARKBOARD),

--- a/modules/web/src/main/views/layout.scala
+++ b/modules/web/src/main/views/layout.scala
@@ -28,9 +28,11 @@ final class layout(helpers: Helpers, assetHelper: lila.web.ui.AssetFullHelper)(
     s"""<meta http-equiv="Content-Security-Policy" content="${lila.web.ContentSecurityPolicy.render(csp)}">"""
   def metaCsp(csp: Option[ContentSecurityPolicy])(using Context, Option[Nonce]): Frag =
     metaCsp(csp.getOrElse(defaultCsp))
-  val systemThemeEmbedScript = raw:
-    "<script>if (window.matchMedia('(prefers-color-scheme: light)')?.matches) " +
-      "document.documentElement.classList.add('light');</script>"
+  def systemThemeScript(nonce: Option[Nonce]) =
+    embedJsUnsafe(
+      "if (window.matchMedia('(prefers-color-scheme: light)')?.matches) " +
+        "document.documentElement.classList.add('light');"
+    )(nonce)
   def pieceSprite(name: String): Frag =
     link(id := "piece-sprite", href := assetUrl(s"piece-css/$name.css"), rel := "stylesheet")
 

--- a/ui/common/src/theme.ts
+++ b/ui/common/src/theme.ts
@@ -5,5 +5,3 @@ export const currentTheme = () => {
   else if (dataTheme === 'light') return 'light';
   else return 'dark';
 };
-export const supportsSystemTheme = () =>
-  window.matchMedia('(prefers-color-scheme: light)').media !== 'not all';


### PR DESCRIPTION
Fixes #15172

The theme now needs to be set on the html tag instead of the body. And the system theme script needs a nonce.

Also removed the unused `supportsSystemTheme` JS function.