### PR TITLE
Add margin to underboard in 3d case

### DIFF
--- a/ui/analyse/css/study/relay/_layout.scss
+++ b/ui/analyse/css/study/relay/_layout.scss
@@ -91,6 +91,9 @@ main.analyse.is-relay:not(.has-relay-tour) {
       'relay-admin  .     .';
     .analyse__underboard {
       margin-top: unset;
+      .is3d & {
+        margin-top: calc($analyse-block-gap * 2);
+      }
     }
     .eval-chart-and-training {
       flex-wrap: nowrap;


### PR DESCRIPTION
An attempt to fix the underboard top margin in the 3d case. Fixes #15147.

Before:
![image](https://github.com/lichess-org/lila/assets/12655228/be684afa-9ca6-4524-b390-ffca184726c8)

After:
![image](https://github.com/lichess-org/lila/assets/12655228/acfa375d-67ce-40c6-8656-50d81bed53da)
