### PR TITLE
Fix insights aggregation by opening

### DIFF
--- a/modules/insight/src/main/AggregationPipeline.scala
+++ b/modules/insight/src/main/AggregationPipeline.scala
@@ -261,7 +261,7 @@ final private class AggregationPipeline(store: InsightStorage)(using
                 $doc(F.provisional.$ne(true))
               }
         ) -> {
-          sortDate ::: limitGames :: (metric.match
+          sortDate ::: limitGames :: ((metric.match
             case M.MeanCpl =>
               List(
                 projectForMove,
@@ -407,9 +407,9 @@ final private class AggregationPipeline(store: InsightStorage)(using
                   GroupFunction("$avg", $divide("$" + F.moves("v"), TimeVariance.intFactor))
                 ) :::
                 List(includeSomeGameIds)
-            ::: dimension.match
-              case D.OpeningVariation | D.OpeningFamily => List(sortNb, limit(12))
-              case _                                    => Nil
+          ) ::: dimension.match
+            case D.OpeningVariation | D.OpeningFamily => List(sortNb, limit(12))
+            case _                                    => Nil
           ).flatten
         }
         pipeline


### PR DESCRIPTION
https://lichess.org/insights/thibault/acpl/openingFamily currently includes all openings and is not filtered.

Bug introduced by a scalafmt rewrite https://github.com/lichess-org/lila/commit/1aae0c7b022f9e505e1ca7fec3b32efeef9f9981.