### PR TITLE
Improve lobby accessibility

### DIFF
--- a/ui/lobby/src/view/correspondence.ts
+++ b/ui/lobby/src/view/correspondence.ts
@@ -13,6 +13,7 @@ function renderSeek(ctrl: LobbyController, seek: Seek): VNode {
     {
       key: seek.id,
       attrs: {
+        role: 'button',
         title:
           seek.action === 'joinSeek'
             ? noarg('joinTheGame') + ' - ' + perfNames[seek.perf.key]

--- a/ui/lobby/src/view/pools.ts
+++ b/ui/lobby/src/view/pools.ts
@@ -23,18 +23,25 @@ export function render(ctrl: LobbyController) {
     .map(pool => {
       const active = !!member && member.id === pool.id,
         transp = !!member && !active;
-      return h('div', { class: { active, transp: !active && transp }, attrs: { 'data-id': pool.id } }, [
-        h('div.clock', `${pool.lim}+${pool.inc}`),
-        active && member.range && ctrl.opts.showRatings
-          ? h('div.range', member.range.replace('-', '–'))
-          : h('div.perf', pool.perf),
-        active ? spinner() : null,
-      ]);
+      return h(
+        'div',
+        {
+          class: { active, transp: !active && transp },
+          attrs: { role: 'button', 'data-id': pool.id },
+        },
+        [
+          h('div.clock', `${pool.lim}+${pool.inc}`),
+          active && member.range && ctrl.opts.showRatings
+            ? h('div.range', member.range.replace('-', '–'))
+            : h('div.perf', pool.perf),
+          active ? spinner() : null,
+        ],
+      );
     })
     .concat(
       h(
         'div.custom',
-        { class: { transp: !!member }, attrs: { 'data-id': 'custom' } },
+        { class: { transp: !!member }, attrs: { role: 'button', 'data-id': 'custom' } },
         ctrl.trans.noarg('custom'),
       ),
     );

--- a/ui/lobby/src/view/realTime/list.ts
+++ b/ui/lobby/src/view/realTime/list.ts
@@ -15,6 +15,7 @@ function renderHook(ctrl: LobbyController, hook: Hook) {
       key: hook.id,
       class: { disabled: !!hook.disabled },
       attrs: {
+        role: 'button',
         title: hook.disabled
           ? ''
           : hook.action === 'join'


### PR DESCRIPTION
Some quick `role: 'button'` additions to various divs used in the lobby. This will alert screen readers and screen reader-adjacent technologies (e.g. the popular voice tool [rango](https://rango.click/#/)) that these divs are clickable, although to achieve full accessibility we would need to make them focusable and responsive to enter/spacebar key presses. Better to just refactor these divs into proper `<button>`s one day probably.