### PR TITLE
show the selected timespan on page load in user rating graph

### DIFF
--- a/ui/chart/src/chart.ratingHistory.ts
+++ b/ui/chart/src/chart.ratingHistory.ts
@@ -247,10 +247,9 @@ export function initModule({ data, singlePerfName }: Opts) {
     site.pubsub.on('chart.panning', () => {
       slider.set([chart.scales.x.min, chart.scales.x.max], false, true);
     });
+    const activeIfDuration = (d: duration.Duration) => (initial.isSame(endDate.subtract(d)) ? 'active' : '');
     const timeBtn = (b: { t: TimeButton; duration: duration.Duration }) =>
-      initial.isSame(endDate.subtract(b.duration))
-        ? `<button class = "btn-rack__btn active">${b.t}</button>`
-        : `<button class = "btn-rack__btn">${b.t}</button>`;
+      `<button class = "btn-rack__btn ${activeIfDuration(b.duration)}">${b.t}</button>`;
 
     const buttons: { t: TimeButton; duration: duration.Duration }[] = [
       { t: '1m', duration: dayjs.duration(1, 'months') },

--- a/ui/chart/src/chart.ratingHistory.ts
+++ b/ui/chart/src/chart.ratingHistory.ts
@@ -247,7 +247,11 @@ export function initModule({ data, singlePerfName }: Opts) {
     site.pubsub.on('chart.panning', () => {
       slider.set([chart.scales.x.min, chart.scales.x.max], false, true);
     });
-    const timeBtn = (t: string) => `<button class = "btn-rack__btn">${t}</button>`;
+    const timeBtn = (b: { t: TimeButton; duration: duration.Duration }) =>
+      initial.isSame(endDate.subtract(b.duration))
+        ? `<button class = "btn-rack__btn active">${b.t}</button>`
+        : `<button class = "btn-rack__btn">${b.t}</button>`;
+
     const buttons: { t: TimeButton; duration: duration.Duration }[] = [
       { t: '1m', duration: dayjs.duration(1, 'months') },
       { t: '3m', duration: dayjs.duration(3, 'months') },
@@ -259,7 +263,7 @@ export function initModule({ data, singlePerfName }: Opts) {
     $('.time-selector-buttons').html(
       buttons
         .filter(b => startDate.isBefore(endDate.subtract(b.duration)) || b.t == 'all')
-        .map(b => timeBtn(b.t))
+        .map(b => timeBtn(b))
         .join(''),
     );
     const btnClick = (min: number) => {


### PR DESCRIPTION
When the user rating graph initially loads, it does not display the selected timespan. This pull request addresses this issue.
Before:
![image](https://github.com/lichess-org/lila/assets/67279312/1794d222-6c24-4159-b6e1-fa9377ee8197)
After:
![image](https://github.com/lichess-org/lila/assets/67279312/08c0ee16-ef4e-4ae1-8479-d2a13514c0aa)
