### PR TITLE
Add "outlook.com.au" to email whitelist

### DIFF
--- a/modules/security/src/main/DisposableEmailDomain.scala
+++ b/modules/security/src/main/DisposableEmailDomain.scala
@@ -114,6 +114,7 @@ private object DisposableEmailDomain:
       "lavabit.com",
       "love.com" /* AOL */,
       "outlook.com",
+      "outlook.com.au",
       "pobox.com",
       "rocketmail.com" /* Yahoo */,
       "safe-mail.net",


### PR DESCRIPTION
Simple change - Just adds outlook.com.au to the whitelist.

This domain's a bit rare, but I do have it and it's run by Microsoft.