### PR TITLE
Fix #15288: The password strength text overlaps the password field on mobile browser

### DIFF
--- a/ui/bits/css/_auth.scss
+++ b/ui/bits/css/_auth.scss
@@ -59,4 +59,8 @@
   .form-group {
     margin-bottom: 1rem;
   }
+
+  .password-complexity {
+    margin-top: 1rem;
+  }
 }


### PR DESCRIPTION
Before
<img width="500" alt="" src="https://github.com/lichess-org/lila/assets/126312812/f1ad627c-33ed-4510-92ba-fe79a6842902">

After
<img width="500" alt="" src="https://github.com/lichess-org/lila/assets/126312812/0babf34f-4c69-4a88-b564-0e9a57043319">

#15288 