### PR TITLE
Fix #15217: Board options missing on mobile web

### DIFF
--- a/ui/round/css/_moves-col1.scss
+++ b/ui/round/css/_moves-col1.scss
@@ -68,10 +68,6 @@
     }
   }
 
-  .buttons {
-    display: none;
-  }
-
   .result {
     margin: 0;
     font-weight: bold;
@@ -104,5 +100,9 @@
 
   .status {
     display: none;
+  }
+
+  .fbt {
+    line-height: 2.3rem;
   }
 }


### PR DESCRIPTION
<img width="500" alt="" src="https://github.com/lichess-org/lila/assets/126312812/9fa471a5-c9c9-43dc-8b1c-3ca84b4d50e5">

Media query:

https://github.com/lichess-org/lila/blob/611d7eea1d2afebf07aa2ceed3bb524f8a5b2166/ui/round/css/_layout.scss#L4-L7

or `@media (max-width: 799.29px) and (orientation: portrait)`

#15217 