### PR TITLE
Hide .site-title on mobile layout

### DIFF
--- a/ui/common/css/header/_title.scss
+++ b/ui/common/css/header/_title.scss
@@ -35,6 +35,10 @@
     display: none;
   }
 
+  @media (max-width: at-least($xx-small)) {
+    display: none;
+  }
+
   @media (min-width: at-least($xx-small)) {
     .site-icon {
       display: block;


### PR DESCRIPTION
As described in the issue, `.site-title` is "visible" on mobile layouts and can be inadvertently tapped bringing you back to the homepage. This PR hides `.site-title` on mobile layouts. Tested.

Fixes #15274 