### PR TITLE
Fix analysis button on practice lesson boards changing current tab

### DIFF
--- a/ui/analyse/src/view/components.ts
+++ b/ui/analyse/src/view/components.ts
@@ -284,11 +284,8 @@ export function renderControls(ctrl: AnalyseCtrl) {
           else if (action === 'explorer') ctrl.toggleExplorer();
           else if (action === 'practice') ctrl.togglePractice();
           else if (action === 'menu') ctrl.actionMenu.toggle();
-          else if (action === 'analysis' && ctrl.studyPractice) {
-            if (!window.open(ctrl.studyPractice.analysisUrl(), '_blank', 'noopener')) {
-              window.location.href = ctrl.studyPractice.analysisUrl(); //safari
-            }
-          }
+          else if (action === 'analysis' && ctrl.studyPractice)
+            window.open(ctrl.studyPractice.analysisUrl(), '_blank', 'noopener');
         }, ctrl.redraw),
       ),
     },


### PR DESCRIPTION
This reverts commit 035867a2603cb1276ddcd564f48471e8766db39f, and fixes #15306.

I assume there was a bug in Safari that this commit fixed, but that bug no longer seems to apply. I tested this change in Safari 17.5:

before: 
https://github.com/lichess-org/lila/assets/14306627/4ac57896-4b98-4fa1-b5cd-e8fc3b4ad231

after: 
https://github.com/lichess-org/lila/assets/14306627/38e0d375-73f9-40a0-b43c-c6e462d2f993