### PR TITLE
Fix historical username regex

### DIFF
--- a/modules/core/src/main/userId.scala
+++ b/modules/core/src/main/userId.scala
@@ -57,7 +57,7 @@ object userId:
     extension (e: UserName) def str = UserStr(e)
     given UserIdOf[UserName]        = n => UserId(n.value.toLowerCase)
     // what existing usernames are like
-    val historicalRegex     = "(?i)[a-z0-9_][a-z0-9_-]{0,28}[a-z0-9]".r
+    val historicalRegex     = "[a-zA-Z0-9_-]{2,30}".r
     val anonymous: UserName = "Anonymous"
     val lichess: UserName   = "lichess"
     val anonMod: String     = "A Lichess Moderator"

--- a/modules/user/src/test/UserTest.scala
+++ b/modules/user/src/test/UserTest.scala
@@ -7,11 +7,9 @@ class UserTest extends munit.FunSuite:
 
   def canSignup(str: String) =
     import lila.user.nameRules.*
-    newUsernamePrefix.pattern
-      .matcher(str)
-      .matches && newUsernameSuffix.pattern
-      .matcher(str)
-      .matches &&
+    newUsernameRegex.pattern.matcher(str).matches &&
+    newUsernamePrefix.pattern.matcher(str).matches &&
+    newUsernameSuffix.pattern.matcher(str).matches &&
     newUsernameChars.pattern.matcher(str).matches &&
     newUsernameLetters.pattern.matcher(str).matches
 
@@ -22,19 +20,39 @@ class UserTest extends munit.FunSuite:
     assert(couldBeUsername("0foo"))
     assert(couldBeUsername("_foo"))
     assert(couldBeUsername("__foo"))
-    assert(!couldBeUsername("-foo"))
+    assert(couldBeUsername("-foo"))
   }
 
   test("username regex bad prefix: cannot signup") {
     assert(!canSignup("000"))
     assert(!canSignup("0foo"))
     assert(!canSignup("_foo"))
+    assert(!canSignup("__foo"))
     assert(!canSignup("-foo"))
   }
 
-  test("username regex bad suffix") {
-    assert(!couldBeUsername("a_"))
-    assert(!couldBeUsername("a_"))
+  test("username regex bad suffix: can login") {
+    assert(couldBeUsername("a_"))
+    assert(couldBeUsername("a-"))
+  }
+
+  test("username regex bad suffix: cannot signup") {
+    assert(!canSignup("a_"))
+    assert(!canSignup("a-"))
+  }
+
+  test("username regex bad length: cannot login") {
+    assert(!couldBeUsername(""))
+    assert(!couldBeUsername("a"))
+    assert(!couldBeUsername("A123456789012345678901234567890"))
+    assert(!couldBeUsername("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))
+  }
+
+  test("username regex bad length: cannot signup") {
+    assert(!canSignup(""))
+    assert(!canSignup("a"))
+    assert(!canSignup("A123456789012345678901234567890"))
+    assert(!canSignup("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))
   }
 
   test("username regex too many consecutive non-letter chars") {
@@ -52,8 +70,22 @@ class UserTest extends munit.FunSuite:
     assert(canSignup("Ksean222"))
   }
 
-  test("username regex OK things") {
+  test("username regex ok names: can login") {
     assert(couldBeUsername("g-foo"))
     assert(couldBeUsername("G_FOo"))
-    assert(couldBeUsername("g-foo"))
+    assert(couldBeUsername("g-foO"))
+    assert(couldBeUsername("FOOO"))
+    assert(couldBeUsername("AB"))
+    assert(couldBeUsername("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))
+    assert(couldBeUsername("A12345678901234567890123456789"))
+  }
+
+  test("username regex ok names: can signup") {
+    assert(canSignup("g-foo"))
+    assert(canSignup("G_FOo"))
+    assert(canSignup("g-foO"))
+    assert(canSignup("FOOO"))
+    assert(canSignup("AB"))
+    assert(canSignup("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))
+    assert(canSignup("A12345678901234567890123456789"))
   }


### PR DESCRIPTION
There are also plenty (around 1.4k that have played rated games) of names starting or ending with a dash. Although only 2 are still actively playing rated games.

~~All users that have ever played a rated game match the new regex.~~

Edit: Actually, that's not quite true, there are 3 names that are too long. But they haven't played a rated game since at least 2022, possibly longer. So I guess might be fine to ignore?