### PR TITLE
Dont allow rules when challenging BOT

### DIFF
--- a/app/controllers/Challenge.scala
+++ b/app/controllers/Challenge.scala
@@ -278,6 +278,8 @@ final class Challenge(
               limit.challenge(req.ipAddress, rateLimited, cost = if me.isApiHog then 0 else 1):
                 env.user.repo.enabledById(username).flatMap {
                   case None => JsonBadRequest(jsonError(s"No such user: $username"))
+                  case Some(destUser) if destUser.isBot && !config.rules.isEmpty =>
+                    JsonBadRequest(jsonError("Rules not applicable for bots"))
                   case Some(destUser) =>
                     val cost = if me.isApiHog then 0 else if destUser.isBot then 1 else 5
                     limit.challengeBot(req.ipAddress, rateLimited, cost = if me.isBot then 1 else 0):


### PR DESCRIPTION
Here's a proposal for how to handle #15318

With the fix,
it won't be possible to set rules when challenging a BOT account:
```
curl -H "authorization: Bearer lip_yulia" \
    http://localhost:8080/api/challenge/Bot0 \
    -d 'clock.limit=600&clock.increment=15&rules=noGiveTime'
```
```json
{"error":"Rules not applicable for bots"}
```