### PR TITLE
Add text specifying user age in user tooltip

### DIFF
--- a/modules/user/src/main/ui/UserShow.scala
+++ b/modules/user/src/main/ui/UserShow.scala
@@ -91,7 +91,7 @@ final class UserShow(helpers: Helpers, bits: UserBits):
       div(cls := "upt__details")(
         span(
           trans.site.nbGames.plural(u.count.game, u.count.game.localize),
-          " ",
+          " Joined ",
           momentFromNowOnce(u.createdAt)
         ),
         (Granter.opt(_.UserModView) && (u.lameOrTroll || u.enabled.no))


### PR DESCRIPTION
Added "Joined" before the user's age in the user tooltip to make info clearer