### PR TITLE
Verify github signature

### DIFF
--- a/app/LilaComponents.scala
+++ b/app/LilaComponents.scala
@@ -119,6 +119,7 @@ final class LilaComponents(
   lazy val forumPost: ForumPost           = wire[ForumPost]
   lazy val forumTopic: ForumTopic         = wire[ForumTopic]
   lazy val game: Game                     = wire[Game]
+  lazy val github: Github                 = wire[Github]
   lazy val i18n: I18n                     = wire[I18n]
   lazy val importer: Importer             = wire[Importer]
   lazy val insight: Insight               = wire[Insight]

--- a/app/controllers/Github.scala
+++ b/app/controllers/Github.scala
@@ -45,7 +45,6 @@ final class Github(env: Env)(using ws: StandaloneWSClient) extends LilaControlle
       lila.log("github").info(s"Signature: $signature")
       lila.log("github").info(s"Body: $body")
 
-      val keys: JsObject = ???
       if !env.net.isProd && false then Future.successful(Json.parse(body).asRight) // todo handle exception
       else
         githubPublicKeys.get {}.flatMap {
@@ -57,7 +56,6 @@ final class Github(env: Env)(using ws: StandaloneWSClient) extends LilaControlle
                 val keyStr = key("key").as[String]
                 keyStr.pp
                 val publicKey        = getPublicKeyFromPEM(keyStr)
-                val body: String = ???
                 val isSignatureValid = verifySignature(body, signature, publicKey)
 
                 lila.log("github").info(s"Signature verification result: ${isSignatureValid}")

--- a/app/controllers/Github.scala
+++ b/app/controllers/Github.scala
@@ -71,8 +71,12 @@ final class Github(env: Env)(using ws: StandaloneWSClient) extends LilaControlle
     keyFactory.generatePublic(keySpec)
 
   private def verifySignature(body: String, signature: String, publicKey: PublicKey): Boolean =
-    val sig = Signature.getInstance("SHA256withECDSA")
-    sig.initVerify(publicKey)
-    sig.update(body.getBytes(StandardCharsets.UTF_8))
-    val signatureBytes = Base64.getDecoder.decode(signature)
-    sig.verify(signatureBytes)
+    try
+      val sig = Signature.getInstance("SHA256withECDSA")
+      sig.initVerify(publicKey)
+      sig.update(body.getBytes(StandardCharsets.UTF_8))
+      val signatureBytes = Base64.getDecoder.decode(signature)
+      sig.verify(signatureBytes)
+    catch case e: Exception =>
+      lila.log("github").warn(s"Failed to verify signature: $signature, publicKey: $publicKey, body: $body", e)
+      false

--- a/app/controllers/Github.scala
+++ b/app/controllers/Github.scala
@@ -1,0 +1,95 @@
+package controllers
+
+import play.api.data.*
+import play.api.libs.json.*
+import play.api.libs.ws.JsonBodyReadables.*
+import play.api.libs.ws.StandaloneWSClient
+import play.api.mvc.*
+
+import lila.app.{ *, given }
+import lila.common.HTTPRequest
+
+import lila.core.net.Bearer
+import lila.web.{ WebForms, StaticContent }
+
+import java.nio.charset.StandardCharsets
+import java.security.*
+import java.security.spec.*
+import java.util.Base64
+
+final class Github(env: Env)(using ws: StandaloneWSClient) extends LilaController(env):
+
+  def secretScanning = Action.async(checkSignature): req =>
+    req.body.asOpt[List[lila.oauth.AccessTokenApi.GithubSecretScan]] match
+      case Some(scans) =>
+        env.oAuth.tokenApi
+          .secretScanning(scans)
+          .flatMap:
+            _.traverse: (token, url) =>
+              env.msg.api.systemPost(token.userId, lila.msg.MsgPreset.apiTokenRevoked(url))
+        NoContent
+      case None => BadRequest(jsonError("JSON does not match expected format"))
+
+  val checkSignature = parse.using { req =>
+    req.pp
+    req.headers.pp
+
+    val body = parse.raw.map { raw =>
+      val body = raw.asBytes().map(_.utf8String).getOrElse("")
+      body // "foo"
+    }
+
+    val identifier = req.headers.get("Github-Public-Key-Identifier").getOrElse("")
+    val signature  = req.headers.get("Github-Public-Key-Signature").getOrElse("")
+
+    lila.log("github").info(s"Identifier: $identifier")
+    lila.log("github").info(s"Signature: $signature")
+    lila.log("github").info(s"Body: $body")
+
+    if !env.net.isProd && false then parse.json
+    else
+      githubPublicKeys.get {}.map {
+        case Some(keys) =>
+          keys("public_keys")
+            .as[List[JsObject]]
+            .find(_("key_identifier").as[String] == identifier) match
+            case Some(key) =>
+              val keyStr = key("key").as[String]
+              keyStr.pp
+              val publicKey        = getPublicKeyFromPEM(keyStr)
+              val isSignatureValid = verifySignature(body, signature, publicKey)
+
+              lila.log("github").info(s"Signature verification result: ${isSignatureValid}")
+
+              if isSignatureValid then parse.json
+              else BadRequest(jsonError("Signature verification failed"))
+            case None => BadRequest(jsonError("Public key not found"))
+        case None => BadRequest(jsonError("Failed to fetch public keys"))
+      }
+  }
+
+  private lazy val githubPublicKeys = env.memo.cacheApi.unit[Option[JsValue]]:
+    _.refreshAfterWrite(1.minute).buildAsyncFuture: _ =>
+      ws.url("https://api.github.com/meta/public_keys/secret_scanning")
+        .get()
+        .map:
+          case res if res.status == 200 => res.body[JsValue].some
+          case _                        => none
+        .recoverDefault
+
+  def getPublicKeyFromPEM(pem: String): PublicKey =
+    val publicKeyPEM = pem
+      .replace("-----BEGIN PUBLIC KEY-----", "")
+      .replace("-----END PUBLIC KEY-----", "")
+      .replaceAll("\\s", "")
+    val encoded    = Base64.getDecoder.decode(publicKeyPEM)
+    val keySpec    = new X509EncodedKeySpec(encoded)
+    val keyFactory = KeyFactory.getInstance("EC")
+    keyFactory.generatePublic(keySpec)
+
+  def verifySignature(body: String, signature: String, publicKey: PublicKey): Boolean =
+    val sig = Signature.getInstance("SHA256withECDSA")
+    sig.initVerify(publicKey)
+    sig.update(body.getBytes(StandardCharsets.UTF_8))
+    val signatureBytes = Base64.getDecoder.decode(signature)
+    sig.verify(signatureBytes)

--- a/app/controllers/Github.scala
+++ b/app/controllers/Github.scala
@@ -57,6 +57,7 @@ final class Github(env: Env)(using ws: StandaloneWSClient) extends LilaControlle
               val keyStr = key("key").as[String]
               keyStr.pp
               val publicKey        = getPublicKeyFromPEM(keyStr)
+              val body: String = ???
               val isSignatureValid = verifySignature(body, signature, publicKey)
 
               lila.log("github").info(s"Signature verification result: ${isSignatureValid}")

--- a/app/controllers/Github.scala
+++ b/app/controllers/Github.scala
@@ -31,7 +31,7 @@ final class Github(env: Env)(using ws: StandaloneWSClient) extends LilaControlle
         NoContent
       case None => BadRequest(jsonError("JSON does not match expected format"))
 
-  val checkSignature = parse.using { req =>
+  val checkSignature: BodyParser[JsValue] = parse.using { req =>
     req.pp
     req.headers.pp
 

--- a/app/controllers/Github.scala
+++ b/app/controllers/Github.scala
@@ -29,7 +29,7 @@ final class Github(env: Env)(using ws: StandaloneWSClient) extends LilaControlle
             _.traverse: (token, url) =>
               env.msg.api.systemPost(token.userId, lila.msg.MsgPreset.apiTokenRevoked(url))
         NoContent
-      case None => BadRequest(jsonError("JSON does not match expected format"))
+      case None => badRequest("JSON does not match expected format")
 
   private val checkSignature: BodyParser[JsValue] = parse.using: req =>
     parse.raw.validateM: raw =>
@@ -45,7 +45,7 @@ final class Github(env: Env)(using ws: StandaloneWSClient) extends LilaControlle
         .fold(fuccess(badRequest("missing data").asLeft))(identity)
 
   private def badRequest(msg: String): Result =
-    BadRequest(Json.obj("error" -> msg))
+    BadRequest(jsonError(msg))
 
   private def verify(body: String, signature: String, identifier: String): Future[Boolean] =
     githubPublicKeys

--- a/app/controllers/Github.scala
+++ b/app/controllers/Github.scala
@@ -16,6 +16,7 @@ import java.nio.charset.StandardCharsets
 import java.security.*
 import java.security.spec.*
 import java.util.Base64
+import play.api.libs.streams.Accumulator
 
 final class Github(env: Env)(using ws: StandaloneWSClient) extends LilaController(env):
 
@@ -62,8 +63,8 @@ final class Github(env: Env)(using ws: StandaloneWSClient) extends LilaControlle
           lila.log("github").info(s"Signature verification result: ${isSignatureValid}")
 
           if isSignatureValid then parse.json
-          else BadRequest(jsonError("Signature verification failed"))
-        case None => BadRequest(jsonError("Public key not found"))
+          else _ => Accumulator.done(BadRequest(jsonError("Signature verification failed")).asLeft)
+        case None => _ => Accumulator.done(BadRequest(jsonError("Public key not found")).asLeft)
   }
 
   private lazy val githubPublicKeys = env.memo.cacheApi.unit[Option[JsValue]]:

--- a/app/controllers/Github.scala
+++ b/app/controllers/Github.scala
@@ -42,7 +42,7 @@ final class Github(env: Env)(using ws: StandaloneWSClient) extends LilaControlle
           verify(b, s, i).map:
             case true  => Json.parse(b).asRight
             case false => badRequest("Signature verification failed").asLeft
-        .fold(fuccess(badRequest("missing data").asLeft))(identity)
+        .fold(fuccess(badRequest("Missing headers for signature verification").asLeft))(identity)
 
   private def badRequest(msg: String): Result =
     BadRequest(jsonError(msg))

--- a/app/controllers/Github.scala
+++ b/app/controllers/Github.scala
@@ -2,16 +2,11 @@ package controllers
 
 import play.api.data.*
 import play.api.libs.json.*
-import play.api.libs.streams.Accumulator
 import play.api.libs.ws.JsonBodyReadables.*
 import play.api.libs.ws.StandaloneWSClient
 import play.api.mvc.*
 
 import lila.app.{ *, given }
-import lila.common.HTTPRequest
-
-import lila.core.net.Bearer
-import lila.web.{ WebForms, StaticContent }
 
 import java.nio.charset.StandardCharsets
 import java.security.*

--- a/app/controllers/Main.scala
+++ b/app/controllers/Main.scala
@@ -141,13 +141,3 @@ final class Main(
             .map(url => JsonOk(Json.obj("imageUrl" -> url)))
       case None => JsonBadRequest(jsonError("Image content only"))
   }
-
-  def githubSecretScanning =
-    AnonBodyOf(parse.json):
-      _.asOpt[List[lila.oauth.AccessTokenApi.GithubSecretScan]].so: scans =>
-        env.oAuth.tokenApi
-          .secretScanning(scans)
-          .flatMap:
-            _.traverse: (token, url) =>
-              env.msg.api.systemPost(token.userId, lila.msg.MsgPreset.apiTokenRevoked(url))
-          .as(NoContent)

--- a/conf/routes
+++ b/conf/routes
@@ -831,7 +831,7 @@ GET   /verify-title                    controllers.Main.verifyTitle
 GET   /InstantChess.com                controllers.Main.instantChess
 GET   /daily-puzzle-slack              controllers.Main.dailyPuzzleSlackApp
 POST  /upload/image/user/:rel          controllers.Main.uploadImage(rel)
-POST  /github/secret-scanning          controllers.Main.githubSecretScanning
+POST  /github/secret-scanning          controllers.Github.secretScanning
 
 # Technical
 GET   /run/captcha/$id<\w{8}>          controllers.Main.captchaCheck(id: GameId)


### PR DESCRIPTION
[Github docs here](https://docs.github.com/en/code-security/secret-scanning/secret-scanning-partner-program#implement-signature-verification-in-your-secret-alert-service)


To test:

```bash
curl -X POST "http://localhost:8080/github/secret-scanning" \
     -H "Content-Type: application/json" \
     -H "Github-Public-Key-Identifier: bcb53661c06b4728e59d897fb6165d5c9cda0fd9cdf9d09ead458168deb7518c" \
     -H "Github-Public-Key-Signature: MEQCIQDaMKqrGnE27S0kgMrEK0eYBmyG0LeZismAEz/BgZyt7AIfXt9fErtRS4XaeSt/AO1RtBY66YcAdjxji410VQV4xg==" \
     -d '[{"source":"commit","token":"some_token","type":"some_type","url":"https://example.com/base-repo-url/"}]'
```