### PR TITLE
correct the regex, and support if the user sends a link with the new domain

### DIFF
--- a/ui/bits/src/bits.expandText.ts
+++ b/ui/bits/src/bits.expandText.ts
@@ -35,7 +35,7 @@ function toYouTubeEmbedUrl(url: string) {
 }
 
 function toTwitterEmbedUrl(url: string) {
-  const m = url?.match(/(?:https?:\/\/)?(?:www\.)?(?:twitter\.com)\/([^/]+\/status\/\d+)/i);
+  const m = url?.match(/(?:https?:\/\/)?(?:www\.)?(?:twitter\.com|x\.com)\/([^\/]+\/status\/\d+)/i);
   return m && `https://twitter.com/${m[1]}`;
 }
 


### PR DESCRIPTION
The domain is already in use for those who were not logged in and the sharing links already use the new one