### PR TITLE
Hide donate button when opening search on smaller screens

### DIFF
--- a/ui/cli/css/_clinput.scss
+++ b/ui/cli/css/_clinput.scss
@@ -33,7 +33,8 @@ body.clinput #top {
   }
 
   @media (max-width: at-most($x-small)) {
-    .site-title {
+    .site-title,
+    .site-title-nav__donate {
       display: none;
     }
   }


### PR DESCRIPTION
Hides the donate button when opening search on smaller screens. The point at which it is hidden is the same as for the Lichess logo. Fixes #15366.