### PR TITLE
dont break bloop until this has more bake time

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ lazy val root = Project("lila", file("."))
 organization         := "org.lichess"
 Compile / run / fork := true
 javaOptions ++= Seq("-Xms64m", "-Xmx512m", "-Dlogger.file=conf/logger.dev.xml")
-ThisBuild / usePipelining := true
+// ThisBuild / usePipelining := true
 // shorter prod classpath
 scriptClasspath             := Seq("*")
 Compile / resourceDirectory := baseDirectory.value / "conf"


### PR DESCRIPTION
This is an option, always compiling with sbt first before running bloop is another.