### PR TITLE
fixup: of  Premove during "confirm move" #15402

### DIFF
--- a/ui/round/src/ctrl.ts
+++ b/ui/round/src/ctrl.ts
@@ -739,6 +739,10 @@ export default class RoundController implements MoveRootCtrl {
       site.sound.play('confirmation');
     } else this.jump(this.ply);
     this.cancelMove();
+    //cancel premove when you cancel move
+    if (!v && toSubmit) {
+      this.chessground.cancelPremove();
+    }
     if (toSubmit) this.setLoading(true, 300);
   };
 


### PR DESCRIPTION
Cancel premoves when move confirmation is enabled and the move is canceled.

Fixes #15402

v is also a pretty bad variable name, but I did not touch it in case there was a convention or something.