### PR TITLE
Revert grab cursor

### DIFF
--- a/ui/common/css/theme/board/_chessground.scss
+++ b/ui/common/css/theme/board/_chessground.scss
@@ -7,6 +7,10 @@ cg-board {
   left: 0;
   user-select: none;
   line-height: 0;
+
+  .manipulable & {
+    cursor: pointer;
+  }
 }
 
 cg-board::before {
@@ -125,14 +129,10 @@ piece {
   background-size: cover;
   z-index: z('cg__piece');
   will-change: transform;
-
-  .manipulable & {
-    cursor: pointer;
-    cursor: grab;
-  }
+  pointer-events: none;
 
   &.dragging {
-    cursor: grabbing;
+    cursor: move;
     z-index: z('cg__piece.dragging') !important;
   }
 


### PR DESCRIPTION
Reverts 7caf56434dedb0240c67927e97db2afe02d4b385.

Without "pointer-events: none", the target square isn't highlighted anymore when dragging a piece around. The cursor change also doesn't make sense when using click to move and also makes piece positions visible in blind mode. Some people also have reported the cursor change to lag.

Most of those issues probably can be fixed but until then, I think it's best to revert the change for now.

See also the discussion on Zulip: https://hq.lichess.ovh/#narrow/stream/8-dev/topic/hand.20grab.20cursor