### PR TITLE
API include tour url in all round responses

### DIFF
--- a/modules/relay/src/main/JsonView.scala
+++ b/modules/relay/src/main/JsonView.scala
@@ -27,9 +27,9 @@ final class JsonView(
         "name"        -> t.name,
         "slug"        -> t.slug,
         "description" -> t.description,
-        "createdAt"   -> t.createdAt
+        "createdAt"   -> t.createdAt,
+        "url"         -> s"$baseUrl${t.path}"
       )
-      .add("url" -> s"$baseUrl${t.path}".some)
       .add("tier" -> t.tier)
       .add("image" -> t.image.map(id => RelayTour.thumbnail(picfitUrl, id, _.Size.Large)))
 

--- a/modules/relay/src/main/JsonView.scala
+++ b/modules/relay/src/main/JsonView.scala
@@ -29,6 +29,7 @@ final class JsonView(
         "description" -> t.description,
         "createdAt"   -> t.createdAt
       )
+      .add("url" -> s"$baseUrl${t.path}".some)
       .add("tier" -> t.tier)
       .add("image" -> t.image.map(id => RelayTour.thumbnail(picfitUrl, id, _.Size.Large)))
 
@@ -56,7 +57,6 @@ final class JsonView(
     Json
       .toJsObject(tour)
       .add("markup" -> tour.markup.map(markup(tour)))
-      .add("url" -> s"$baseUrl${tour.path}".some)
       .add("teamTable" -> tour.teamTable)
       .add("leaderboard" -> tour.autoLeaderboard)
 


### PR DESCRIPTION
It was only being included in fullTour but it would be helpful to always include