### PR TITLE
Use better solution to apply correct link color to DGT board page

### DIFF
--- a/modules/web/src/main/ui/DgtUi.scala
+++ b/modules/web/src/main/ui/DgtUi.scala
@@ -20,20 +20,18 @@ final class DgtUi(helpers: Helpers):
         p(trd.thisPageAllowsConnectingDgtBoard()),
         br,
         br,
-        st.section(
-          h2(trd.dgtBoardRequirements()),
-          br,
-          p(trd.toConnectTheDgtBoard(s"LiveChess $liveChessVersion")),
-          p(
-            trd.downloadHere(
-              a(href := "https://www.livechesscloud.com/software/")(s"LiveChess $liveChessVersion")
-            )
-          ),
-          p(
-            trd.ifLiveChessRunningOnThisComputer(
-              "LiveChess",
-              a(href := "http://localhost:1982/doc/index.html")(trd.openingThisLink())
-            )
+        h2(trd.dgtBoardRequirements()),
+        br,
+        p(trd.toConnectTheDgtBoard(s"LiveChess $liveChessVersion")),
+        p(
+          trd.downloadHere(
+            a(href := "https://www.livechesscloud.com/software/")(s"LiveChess $liveChessVersion")
+          )
+        ),
+        p(
+          trd.ifLiveChessRunningOnThisComputer(
+            "LiveChess",
+            a(href := "http://localhost:1982/doc/index.html")(trd.openingThisLink())
           )
         ),
         p(

--- a/ui/bits/css/_account.scss
+++ b/ui/bits/css/_account.scss
@@ -160,6 +160,7 @@
 
   section a {
     text-decoration: none;
+    color: inherit;
   }
 
   h2 {


### PR DESCRIPTION
```
section a {
    text-decoration: none;
    color: inherit;
}
```
This was being used for the account preferences like zen mode and show player ratings, so #15429 is not a solution.