### PR TITLE
add symbol specifying user age in user tooltip

### DIFF
--- a/modules/user/src/main/ui/UserShow.scala
+++ b/modules/user/src/main/ui/UserShow.scala
@@ -91,7 +91,7 @@ final class UserShow(helpers: Helpers, bits: UserBits):
       div(cls := "upt__details")(
         span(
           trans.site.nbGames.plural(u.count.game, u.count.game.localize),
-          " Joined ",
+          " • Joined ",
           momentFromNowOnce(u.createdAt)
         ),
         (Granter.opt(_.UserModView) && (u.lameOrTroll || u.enabled.no || u.marks.rankban))


### PR DESCRIPTION
![image](https://github.com/lichess-org/lila/assets/134517889/3811312c-1159-4aba-8f99-ac980d6a4ba4)
fixes #15445 