### PR TITLE
Fix #14854: Rating Hidden: Red Mark text overflow in mini profile

### DIFF
--- a/ui/common/css/component/_power-tip.scss
+++ b/ui/common/css/component/_power-tip.scss
@@ -25,7 +25,7 @@
 
     height: 83px;
     body.no-rating & {
-      height: 30px;
+      height: unset;
     }
     padding: 0.4em 0.5em 0.3em 0.5em;
     border-bottom: $border;


### PR DESCRIPTION
#14854 

Issue present with other languages besides pt-pt.

<img width="400" alt="" src="https://github.com/lichess-org/lila/assets/126312812/39071bca-a8d2-4771-9529-6ba0bee6ad86">



