### PR TITLE
Ensure flagged users do not appear on TV

### DIFF
--- a/modules/db/src/main/Env.scala
+++ b/modules/db/src/main/Env.scala
@@ -6,6 +6,8 @@ import com.softwaremill.tagging.*
 import com.typesafe.config.Config
 import play.api.Configuration
 import reactivemongo.api.*
+import lila.core.LightUser.GetterSync
+import lila.core.user.UserApi
 
 import lila.common.Lilakka
 
@@ -15,7 +17,9 @@ trait YoloDb
 @Module
 final class Env(
     appConfig: Configuration,
-    shutdown: CoordinatedShutdown
+    shutdown: CoordinatedShutdown,
+    lightUserSync: GetterSync,
+    userApi: UserApi
 )(using Executor):
 
   private val driver = new AsyncDriver(appConfig.get[Config]("mongodb").some)


### PR DESCRIPTION
This pull request addresses issue #14858, which highlights the problem of flagged accounts appearing on TV. The solution implemented ensures that users who are flagged will not be featured on TV.

Changes Made:

	•	Modified tv/src/main/Env.scala:
	•	Modified tv/src/main/TvSyncActor.scala:


Credit to tors42 for providing the initial solution and code snippets.