### PR TITLE
ui/learn: Clear scenario timeouts when switching levels

### DIFF
--- a/ui/learn/src/levelCtrl.ts
+++ b/ui/learn/src/levelCtrl.ts
@@ -57,6 +57,8 @@ export class LevelCtrl {
     readonly opts: LevelOpts,
     readonly redraw: () => void,
   ) {
+    timeouts.clearTimeouts();
+
     this.isAppleLevel = prop(blueprint.apples?.length > 0);
     this.items = makeItems({ apples: blueprint.apples });
     this.chess = makeChess(blueprint.fen, blueprint.emptyApples ? [] : this.items.appleKeys());


### PR DESCRIPTION
quick bugfix for something that pointed out in zulip, where switching levels quickly was causing some bugs.