### PR TITLE
Profile, fix dropdown button covering others when screen too narrow

### DIFF
--- a/ui/bits/css/user/_show.scss
+++ b/ui/bits/css/user/_show.scss
@@ -28,7 +28,7 @@
 
     .number-menu {
       flex: 0 1 auto;
-      overflow: hidden;
+      overflow-x: auto;
       margin: 0 0 0.2em 1em;
     }
 


### PR DESCRIPTION
before

https://github.com/lichess-org/lila/assets/56031107/62237fc3-873d-4bd5-8c2a-7c4e5c43757c


after

https://github.com/lichess-org/lila/assets/56031107/21665abd-b943-4248-bab1-c2e2f6f95fe1

The scroll bar does look a bit big, and is non-native, not sure if that was worth changing