### PR TITLE
Go to move which sender was looking at when message was sent in broadcasts

### DIFF
--- a/ui/chat/src/ctrl.ts
+++ b/ui/chat/src/ctrl.ts
@@ -97,11 +97,19 @@ export default class ChatCtrl {
   post = (text: string): boolean => {
     text = text.trim();
     if (!text) return false;
+    if (text.startsWith('<<<<')) return false;
     if (text == 'You too!' && !this.data.lines.some(l => l.u != this.data.userId)) return false;
     if (text.length > 140) {
       alert('Max length: 140 chars. ' + text.length + ' chars used.');
       return false;
     }
+
+    if (site.analysis?.study?.relay && !site.analysis.study.relay.tourShow()) {
+      let chapterId = site.analysis.study.currentChapter().id;
+      let ply = site.analysis.study.currentNode().ply;
+      text = '<<<<' + chapterId + '|' + ply + '>>>> ' + text;
+    }
+
     site.pubsub.emit('socket.send', 'talk', text);
     return true;
   };

--- a/ui/chat/src/discussion.ts
+++ b/ui/chat/src/discussion.ts
@@ -3,6 +3,7 @@ import * as enhance from 'common/richText';
 import { userLink } from 'common/userLink';
 import * as spam from './spam';
 import { Line } from './interfaces';
+import { bind } from 'common/snabbdom';
 import { h, thunk, VNode, VNodeData } from 'snabbdom';
 import { lineAction as modLineAction, report } from './moderation';
 import { presetView } from './preset';
@@ -188,6 +189,16 @@ const userThunk = (name: string, title?: string, patron?: boolean, flair?: Flair
   userLink({ name, title, patron, line: !!patron, flair });
 
 function renderLine(ctrl: ChatCtrl, line: Line): VNode {
+  if (line.t.startsWith('<<<<') && site.analysis?.study?.relay) {
+    const parts = line.t.match(/^<<<<([^|]+)\|([^|]+)>>>>\s(.+)$/);
+    if (parts) {
+      const [_, chapterId, ply, text] = parts;
+      line.t = text;
+      line.chapterId = chapterId;
+      line.ply = parseInt(ply);
+    }
+  }
+
   const textNode = renderText(line.t, ctrl.opts.enhance);
 
   if (line.u === 'lichess') return h('li.system', textNode);
@@ -204,6 +215,20 @@ function renderLine(ctrl: ChatCtrl, line: Line): VNode {
       .match(enhance.userPattern)
       ?.find(mention => mention.trim().toLowerCase() == `@${ctrl.data.userId}`);
 
+  const plyy =
+    site.analysis?.study?.relay && line.chapterId !== undefined && line.ply !== undefined
+      ? h(
+          'button',
+          {
+            hook: bind('click', () => {
+              site.analysis.study.setChapter(line.chapterId);
+              site.analysis.jumpToMain(line.ply);
+            }),
+            attrs: { title: `Jump to move ${line.chapterId}#${line.ply}` },
+          },
+          ' -->',
+        )
+      : null;
   return h(
     'li',
     {
@@ -214,7 +239,7 @@ function renderLine(ctrl: ChatCtrl, line: Line): VNode {
       },
     },
     ctrl.moderation
-      ? [line.u ? modLineAction() : null, userNode, ' ', textNode]
+      ? [line.u ? modLineAction() : null, userNode, ' ', textNode, plyy]
       : [
           myUserId && line.u && myUserId != line.u
             ? h('action.flag', {
@@ -224,6 +249,7 @@ function renderLine(ctrl: ChatCtrl, line: Line): VNode {
           userNode,
           ' ',
           textNode,
+          plyy,
         ],
   );
 }

--- a/ui/chat/src/interfaces.ts
+++ b/ui/chat/src/interfaces.ts
@@ -52,6 +52,8 @@ export interface Line {
   p?: boolean; // patron
   f?: Flair;
   title?: string;
+  chapterId?: string;
+  ply?: number;
 }
 
 export interface Permissions {


### PR DESCRIPTION
#15029
I am not sure if this is the right way to call these functions using `site.analysis.study...` as I don't see it any other place in the ui code.
[Screencast from 20-06-24 07:35:58 PM IST.webm](https://github.com/lichess-org/lila/assets/95964955/c171af68-11c3-4598-9d11-b167eed89dde)
