### PR TITLE
Put the uname in its proper place

### DIFF
--- a/ui/common/src/userLink.ts
+++ b/ui/common/src/userLink.ts
@@ -57,7 +57,7 @@ export const userTitle = (u: HasTitle): VNode | undefined =>
     ? h('span.utitle', u.title == 'BOT' ? { attrs: { 'data-bot': true } } : {}, [u.title, '\xa0'])
     : undefined;
 
-export const fullName = (u: AnyUser) => [userTitle(u), u.name, userFlair(u)];
+export const fullName = (u: AnyUser) => [userTitle(u), h('span.uname', {}, u.name), userFlair(u)];
 
 export const userRating = (u: HasRating): string | undefined => {
   if (u.rating) {


### PR DESCRIPTION
Sometimes we may want to make something special in the name, but we don't want to interfere with the flair or title.

