### PR TITLE
FIX broadcasterURL

### DIFF
--- a/modules/relay/src/main/ui/FormUi.scala
+++ b/modules/relay/src/main/ui/FormUi.scala
@@ -216,8 +216,8 @@ final class FormUi(helpers: Helpers, ui: RelayUi, tourUi: RelayTourUi):
           )(form3.input(_))(cls := "relay-form__sync relay-form__sync-ids none"),
           div(cls := "form-group relay-form__sync relay-form__sync-push none")(
             p(
-              "Send your local games to Lichess using ",
-              a(href := "https://github.com/lichess-org/broadcaster")(lila.relay.broadcasterUrl),
+              "Send your local games to Lichess using the ",
+              a(href := broadcasterUrl)("Lichess Broadcaster App"),
               "."
             )
           ),


### PR DESCRIPTION
I think it looks a little strange in lichess.dev
![image](https://github.com/lichess-org/lila/assets/9739913/c0f76222-0f91-49ee-aace-497ee3edf8d5)

See https://lichess.org/page/broadcaster-app but click for https://github.com/lichess-org/broadcaster