### PR TITLE
Fix topic creation insert order

### DIFF
--- a/modules/forum/src/main/ForumTopicApi.scala
+++ b/modules/forum/src/main/ForumTopicApi.scala
@@ -107,9 +107,9 @@ final private class ForumTopicApi(
         case Some(dup) => fuccess(dup)
         case None =>
           for
-            _ <- postRepo.coll.insert.one(post)
             _ <- topicRepo.coll.insert.one(topic.withPost(post))
             _ <- categRepo.coll.update.one($id(categ.id), categ.withPost(topic, post))
+            _ <- postRepo.coll.insert.one(post)
           yield
             promotion.save(me, post.text)
             val text = s"${topic.name} ${post.text}"

--- a/modules/forum/src/main/ForumTopicApi.scala
+++ b/modules/forum/src/main/ForumTopicApi.scala
@@ -155,9 +155,9 @@ final private class ForumTopicApi(
     }
 
   private def makeNewTopic(categ: ForumCateg, topic: ForumTopic, post: ForumPost) = for
-    _ <- postRepo.coll.insert.one(post)
     _ <- topicRepo.coll.insert.one(topic.withPost(post))
     _ <- categRepo.coll.update.one($id(categ.id), categ.withPost(topic, post))
+    _ <- postRepo.coll.insert.one(post)
   yield Bus.pub(CreatePost(post.mini))
 
   def getSticky(categ: ForumCateg, forUser: Option[User]): Fu[List[TopicView]] =


### PR DESCRIPTION
Fix the insert order by: topic then category then post. If We insert post first, sometime lila-search-ingestor is received change event before We finished insert topic which causes some fail ingestion.