### PR TITLE
Only show `Popularity stats` if is official

### DIFF
--- a/ui/analyse/src/study/relay/interfaces.ts
+++ b/ui/analyse/src/study/relay/interfaces.ts
@@ -39,6 +39,7 @@ export interface RelayTour {
   image?: string;
   teamTable?: boolean;
   leaderboard?: boolean;
+  tier?: number;
 }
 
 export interface RelaySync {

--- a/ui/analyse/src/study/relay/relayTourView.ts
+++ b/ui/analyse/src/study/relay/relayTourView.ts
@@ -313,7 +313,7 @@ const makeTabs = (ctrl: AnalyseCtrl) => {
     makeTab('boards', 'Boards'),
     relay.teams && makeTab('teams', 'Teams'),
     relay.data.tour.leaderboard ? makeTab('leaderboard', 'Leaderboard') : undefined,
-    study.members.myMember() && relay.data.tour.official
+    (study.members.myMember() && relay.data.tour.tier)
       ? h(
           'a.text',
           { attrs: { ...dataIcon(licon.LineGraph), href: `/broadcast/${relay.data.tour.id}/stats` } },

--- a/ui/analyse/src/study/relay/relayTourView.ts
+++ b/ui/analyse/src/study/relay/relayTourView.ts
@@ -313,7 +313,7 @@ const makeTabs = (ctrl: AnalyseCtrl) => {
     makeTab('boards', 'Boards'),
     relay.teams && makeTab('teams', 'Teams'),
     relay.data.tour.leaderboard ? makeTab('leaderboard', 'Leaderboard') : undefined,
-    study.members.myMember()
+    study.members.myMember() && relay.data.tour.official
       ? h(
           'a.text',
           { attrs: { ...dataIcon(licon.LineGraph), href: `/broadcast/${relay.data.tour.id}/stats` } },

--- a/ui/analyse/src/study/relay/relayTourView.ts
+++ b/ui/analyse/src/study/relay/relayTourView.ts
@@ -313,7 +313,7 @@ const makeTabs = (ctrl: AnalyseCtrl) => {
     makeTab('boards', 'Boards'),
     relay.teams && makeTab('teams', 'Teams'),
     relay.data.tour.leaderboard ? makeTab('leaderboard', 'Leaderboard') : undefined,
-    (study.members.myMember() && relay.data.tour.tier)
+    study.members.myMember() && relay.data.tour.tier
       ? h(
           'a.text',
           { attrs: { ...dataIcon(licon.LineGraph), href: `/broadcast/${relay.data.tour.id}/stats` } },


### PR DESCRIPTION
If it only works in official mode why do I need to show it to non-official