### PR TITLE
Submit form on enter instead of toggling password

### DIFF
--- a/modules/ui/src/main/helper/Form3.scala
+++ b/modules/ui/src/main/helper/Form3.scala
@@ -184,7 +184,7 @@ final class Form3(formHelper: FormHelper & I18nHelper, flairApi: FlairApi):
     group(field, content): f =>
       div(cls := "password-wrapper")(
         input(f, typ = "password")(required)(modifiers),
-        reveal.option(button(cls := "password-reveal", dataIcon := Icon.Eye))
+        reveal.option(button(cls := "password-reveal", tpe := "button", dataIcon := Icon.Eye))
       )
 
   def passwordComplexityMeter(labelContent: Frag): Frag =


### PR DESCRIPTION
With the recent password visibility toggle addition, when enter is pressed the password visibility toggle is "clicked" revealing the password instead of submitting the form. This PR fixes that.