### PR TITLE
Add focus indicator when tabbed on password reveal button

### DIFF
--- a/ui/common/css/form/_password.scss
+++ b/ui/common/css/form/_password.scss
@@ -19,6 +19,10 @@
   float: right;
   margin-right: 1em;
   margin-top: -2.2em;
+
+  &:focus-visible {
+    outline: 2px solid $c-primary;
+  }
 }
 .password-reveal.revealed {
   color: $c-bad;


### PR DESCRIPTION
Adds a focus indicator to the password reveal button specifically when tabbed on to add context on where you are in the form.

![image](https://github.com/lichess-org/lila/assets/3620552/4e697099-818e-4059-a122-95a9c9f9549d)
