### PR TITLE
Fix user profile actions hamburger icon removed on transp background

### DIFF
--- a/ui/bits/css/user/_show.scss
+++ b/ui/bits/css/user/_show.scss
@@ -93,9 +93,10 @@
       }
       &:hover {
         > a {
-          @extend %box-radius-top, %dropdown-shadow;
+          @extend %box-radius-top;
           background: $c-bg-header-dropdown;
           color: $c-font-clear;
+          box-shadow: -1px 5px 6px rgba(0, 0, 0, 0.3);
         }
         .dropdown-window {
           visibility: visible;


### PR DESCRIPTION
When using a transparent background the user profile actions hamburger icon disappears when hovered. This is due to [%dropdown-shadow](https://github.com/lichess-org/lila/blob/67057907e67974841044ce9c498d942a683478d5/ui/common/css/abstract/_extends.scss#L106-L111) including the [back-blur](https://github.com/lichess-org/lila/blob/67057907e67974841044ce9c498d942a683478d5/ui/common/css/abstract/_mixins.scss#L87-L99) mixin if the background is transparent, which resets the ::before `content`.

Issue:
![Screenshot_20240628_091536](https://github.com/lichess-org/lila/assets/3620552/c99b2925-1287-4297-bfad-0a1fd1d98bbd)

To keep the shadow (and icon), it seemed like the most straight-forward approach was to just include box-shadow directly instead of extending from dropdown-shadow.