### PR TITLE
Add ability to set time and increment in challenge query link

### DIFF
--- a/ui/lobby/src/ctrl.ts
+++ b/ui/lobby/src/ctrl.ts
@@ -75,6 +75,17 @@ export default class LobbyController {
       const forceOptions: ForceSetupOptions = {};
       const urlParams = new URLSearchParams(location.search);
       const friendUser = urlParams.get('user') ?? undefined;
+      const minutesPerSide = urlParams.get('minutesPerSide');
+      const increment = urlParams.get('increment');
+
+      if (minutesPerSide) {
+        forceOptions.time = parseInt(minutesPerSide);
+      }
+
+      if (increment) {
+        forceOptions.increment = parseInt(increment);
+      }
+
       if (locationHash === 'hook') {
         if (urlParams.get('time') === 'realTime') {
           this.tab = 'real_time';

--- a/ui/lobby/src/interfaces.ts
+++ b/ui/lobby/src/interfaces.ts
@@ -143,4 +143,6 @@ export interface ForceSetupOptions {
   variant?: VariantKey;
   fen?: string;
   timeMode?: TimeMode;
+  time?: number;
+  increment?: number;
 }

--- a/ui/lobby/src/setupCtrl.ts
+++ b/ui/lobby/src/setupCtrl.ts
@@ -103,8 +103,10 @@ export default class SetupController {
     this.variant = propWithEffect(forceOptions?.variant || storeProps.variant, this.onDropdownChange);
     this.fen = this.propWithApply(forceOptions?.fen || storeProps.fen);
     this.timeMode = propWithEffect(forceOptions?.timeMode || storeProps.timeMode, this.onDropdownChange);
-    this.timeV = this.propWithApply(sliderInitVal(storeProps.time, timeVToTime, 100)!);
-    this.incrementV = this.propWithApply(sliderInitVal(storeProps.increment, incrementVToIncrement, 100)!);
+    this.timeV = this.propWithApply(sliderInitVal(forceOptions?.time || storeProps.time, timeVToTime, 100)!);
+    this.incrementV = this.propWithApply(
+      sliderInitVal(forceOptions?.increment || storeProps.increment, incrementVToIncrement, 100)!,
+    );
     this.daysV = this.propWithApply(sliderInitVal(storeProps.days, daysVToDays, 20)!);
     this.gameMode = this.propWithApply(storeProps.gameMode);
     this.ratingMin = this.propWithApply(storeProps.ratingMin);


### PR DESCRIPTION
When I originally started developing this feature, my intent was to close https://github.com/lichess-org/lila/issues/15628, but I missed the key part of that issue in regards to that wanting to have "a forced template". Nevertheless, I think that being able to specify time and increment using query parameters is a good addition.

https://github.com/lichess-org/lila/assets/58905488/57a904e0-f1dc-4a9a-b70f-f123dfc496b1

