### PR TITLE
fix: add missing i18n keys for expand/collapse variations

### DIFF
--- a/modules/analyse/src/main/ui/AnalyseI18n.scala
+++ b/modules/analyse/src/main/ui/AnalyseI18n.scala
@@ -300,6 +300,8 @@ final class GameAnalyseI18n(helpers: Helpers, board: AnalyseI18n):
         site.promoteVariation,
         site.makeMainLine,
         site.deleteFromHere,
+        site.collapseVariations,
+        site.expandVariations,
         site.forceVariation,
         site.copyVariationPgn,
         // practice (also uses checkmate, draw)


### PR DESCRIPTION
before:
![image](https://github.com/lichess-org/lila/assets/67279312/925f2d60-29f5-49bd-9640-454e08e521e7)
after:
![Screenshot from 2024-07-03 10-27-47](https://github.com/lichess-org/lila/assets/67279312/4c0c9de6-c65a-4166-afab-ecc41f893d14)
