### PR TITLE
LPV movelist: make past moves font color same as upcoming moves

### DIFF
--- a/ui/common/css/component/_lichess-pgn-viewer.scss
+++ b/ui/common/css/component/_lichess-pgn-viewer.scss
@@ -10,6 +10,9 @@
   --c-lpv-bg-pane: #{$m-bg-zebra2--fade-1};
   --c-lpv-pgn-text: #{$c-bg-zebra2};
   --c-lpv-font: #{$c-font};
+  // TODO: erase or replace with `--c-lpv-past-moves` when lpv-pgn-viewer > 2.1.0 is out
+  --c-lpv-font-accent: #{$c-font};
+
   --c-lpv-font-shy: #{$c-font-dim};
   --c-lpv-accent-over: #{$c-over};
   --c-lpv-fbt-hover: #{$m-primary_bg--mix-75};


### PR DESCRIPTION
making a PR just to post the before/after

before:
![Screenshot 2024-07-03 at 18 37 03](https://github.com/lichess-org/lila/assets/56031107/4a5634a8-1dd5-4883-9ecc-914641f912fb)
![Screenshot 2024-07-03 at 18 37 12](https://github.com/lichess-org/lila/assets/56031107/e95d60ad-a7dc-4989-964f-d4c3009f4323)

after:
![Screenshot 2024-07-03 at 18 37 29](https://github.com/lichess-org/lila/assets/56031107/d48bda6c-4488-47d0-83fc-c2890ee950cd)
![Screenshot 2024-07-03 at 18 37 41](https://github.com/lichess-org/lila/assets/56031107/378b00c9-a398-475a-8daa-704cc97ed882)
