### PR TITLE
LPV: fix border comment color

### DIFF
--- a/ui/common/css/component/_lichess-pgn-viewer.scss
+++ b/ui/common/css/component/_lichess-pgn-viewer.scss
@@ -20,7 +20,7 @@
   --c-lpv-current-move: #{$m-primary_bg--mix-70};
   --c-lpv-move-hover: #{$m-primary_bg--mix-30};
   --c-lpv-border: #{$c-border};
-  --c-lpv-side-border: hsl(37deg, 5%, 13%); //#{$c-border-page};
+  --c-lpv-side-border: #{$c-border-page};
   --c-lpv-inaccuracy: #{$c-inaccuracy};
   --c-lpv-mistake: #{$c-mistake};
   --c-lpv-blunder: #{$c-blunder};


### PR DESCRIPTION
It was still using a fixed color used, probably for debug (CF git blame)

before:
![Screenshot 2024-07-04 at 12 38 17](https://github.com/lichess-org/lila/assets/56031107/93fc15c6-b024-45eb-a799-5245496426f7)
![Screenshot 2024-07-04 at 12 38 28](https://github.com/lichess-org/lila/assets/56031107/c125fa22-b44e-4377-bbac-519172ae64ca)

after:
![Screenshot 2024-07-04 at 12 43 40](https://github.com/lichess-org/lila/assets/56031107/1a17360c-3281-4c4d-95df-5efcf1cddc7f)
![Screenshot 2024-07-04 at 12 43 48](https://github.com/lichess-org/lila/assets/56031107/db7bd1a5-6f32-4979-8820-f8dff824f844)