### PR TITLE
feat: toggle for wiki opening info display

### DIFF
--- a/modules/analyse/src/main/ui/AnalyseUi.scala
+++ b/modules/analyse/src/main/ui/AnalyseUi.scala
@@ -47,7 +47,14 @@ final class AnalyseUi(helpers: Helpers)(externalEngineEndpoint: String):
                   )(v.name)
                 }
               ),
-              pov.game.variant.standard.option(div(cls := "analyse__wiki"))
+              pov.game.variant.standard.option(
+                div(cls := "analyse__wiki empty")(
+                  fieldset(cls := "form-fieldset form-fieldset--toggle")(
+                    legend(tabindex := 0)("WikiBook"),
+                    div(cls := "analyse__wiki-text")
+                  )
+                )
+              )
             )
           ),
           div(cls := "analyse__board main-board")(chessgroundBoard),

--- a/modules/analyse/src/main/ui/AnalyseUi.scala
+++ b/modules/analyse/src/main/ui/AnalyseUi.scala
@@ -49,7 +49,7 @@ final class AnalyseUi(helpers: Helpers)(externalEngineEndpoint: String):
               ),
               pov.game.variant.standard.option(
                 div(cls := "analyse__wiki empty")(
-                  fieldset(cls := "form-fieldset form-fieldset--toggle")(
+                  fieldset(cls := "form-fieldset form-fieldset--toggle", id := "wikibook-field")(
                     legend(tabindex := 0)("WikiBook"),
                     div(cls := "analyse__wiki-text")
                   )

--- a/modules/analyse/src/main/ui/AnalyseUi.scala
+++ b/modules/analyse/src/main/ui/AnalyseUi.scala
@@ -48,11 +48,9 @@ final class AnalyseUi(helpers: Helpers)(externalEngineEndpoint: String):
                 }
               ),
               pov.game.variant.standard.option(
-                div(cls := "analyse__wiki empty")(
-                  fieldset(cls := "form-fieldset form-fieldset--toggle", id := "wikibook-field")(
-                    legend(tabindex := 0)("WikiBook"),
-                    div(cls := "analyse__wiki-text")
-                  )
+                fieldset(cls := "analyse__wiki empty toggle-box toggle-box--toggle", id := "wikibook-field")(
+                  legend(tabindex := 0)("WikiBook"),
+                  div(cls := "analyse__wiki-text")
                 )
               )
             )

--- a/modules/ui/src/main/helper/Form3.scala
+++ b/modules/ui/src/main/helper/Form3.scala
@@ -201,9 +201,9 @@ final class Form3(formHelper: FormHelper & I18nHelper, flairApi: FlairApi):
   def fieldset(legend: Frag, toggle: Option[Boolean] = none): Tag =
     st.fieldset(
       cls := List(
-        "form-fieldset"             -> true,
-        "form-fieldset--toggle"     -> toggle.isDefined,
-        "form-fieldset--toggle-off" -> toggle.has(false)
+        "toggle-box"             -> true,
+        "toggle-box--toggle"     -> toggle.isDefined,
+        "toggle-box--toggle-off" -> toggle.has(false)
       )
     )(st.legend(toggle.map(_ => tabindex := 0))(legend))
 

--- a/ui/analyse/css/_side.scss
+++ b/ui/analyse/css/_side.scss
@@ -22,6 +22,14 @@
         flex: 1 1 0;
         padding: 0.5em 1em 0 0;
       }
+
+      &.empty {
+        visibility: hidden;
+      }
+
+      .form-fieldset {
+        padding: 1rem 1rem 0 1rem;
+      }
     }
   }
   &--wiki .analyse__side {
@@ -30,6 +38,7 @@
   }
   &__wiki {
     overflow-y: auto;
+    scrollbar-gutter: stable both-edges;
     p {
       text-align: justify;
       line-height: 1.5;

--- a/ui/analyse/css/_side.scss
+++ b/ui/analyse/css/_side.scss
@@ -33,6 +33,7 @@
   }
   &__wiki {
     overflow-y: auto;
+    padding: 1rem 1rem 0 1rem;
     scrollbar-gutter: stable both-edges;
 
     p {
@@ -50,10 +51,4 @@
       margin-bottom: 0.7rem;
     }
   }
-}
-
-#wikibook-field {
-  padding: 1rem 1rem 0 1rem;
-  overflow-y: auto;
-  scrollbar-gutter: stable both-edges;
 }

--- a/ui/analyse/css/_side.scss
+++ b/ui/analyse/css/_side.scss
@@ -16,19 +16,14 @@
       }
     }
     .analyse__wiki {
-      margin-top: 2vh;
+      margin: 2vh 0;
       flex: 1 1 auto;
       @include mq-at-least-col3 {
         flex: 1 1 0;
-        padding: 0.5em 1em 0 0;
       }
 
       &.empty {
         visibility: hidden;
-      }
-
-      .form-fieldset {
-        padding: 1rem 1rem 0 1rem;
       }
     }
   }

--- a/ui/analyse/css/_side.scss
+++ b/ui/analyse/css/_side.scss
@@ -51,3 +51,9 @@
     }
   }
 }
+
+#wikibook-field {
+  padding: 1rem 1rem 0 1rem;
+  overflow-y: auto;
+  scrollbar-gutter: stable both-edges;
+}

--- a/ui/analyse/css/_side.scss
+++ b/ui/analyse/css/_side.scss
@@ -39,6 +39,7 @@
   &__wiki {
     overflow-y: auto;
     scrollbar-gutter: stable both-edges;
+
     p {
       text-align: justify;
       line-height: 1.5;

--- a/ui/analyse/css/build/analyse.free.scss
+++ b/ui/analyse/css/build/analyse.free.scss
@@ -1,4 +1,5 @@
 @import '../analyse.abstract';
 @import '../../../common/css/component/mselect';
+@import '../../../common/css/form/form3';
 
 @import '../analyse.free';

--- a/ui/analyse/css/build/analyse.free.scss
+++ b/ui/analyse/css/build/analyse.free.scss
@@ -1,5 +1,5 @@
 @import '../analyse.abstract';
 @import '../../../common/css/component/mselect';
-@import '../../../common/css/form/form3';
+@import '../../../common/css/component/toggle-box';
 
 @import '../analyse.free';

--- a/ui/analyse/src/view/main.ts
+++ b/ui/analyse/src/view/main.ts
@@ -20,6 +20,7 @@ import {
   renderTools,
   renderUnderboard,
 } from './components';
+import { wikiToggleBox } from '../wiki';
 
 export default function (deps?: typeof studyDeps) {
   return function (ctrl: AnalyseCtrl): VNode {
@@ -51,7 +52,10 @@ function analyseView(ctrl: AnalyseCtrl, deps?: typeof studyDeps): VNode {
           'aside.analyse__side',
           {
             hook: onInsert(elm => {
-              ctrl.opts.$side && ctrl.opts.$side.length && $(elm).replaceWith(ctrl.opts.$side);
+              if (ctrl.opts.$side && ctrl.opts.$side.length) {
+                $(elm).replaceWith(ctrl.opts.$side);
+                wikiToggleBox();
+              }
             }),
           },
           ctrl.studyPractice

--- a/ui/analyse/src/wiki.ts
+++ b/ui/analyse/src/wiki.ts
@@ -5,7 +5,8 @@ export type WikiTheory = (nodes: Tree.Node[]) => void;
 export default function wikiTheory(): WikiTheory {
   const cache = new Map<string, string>();
   const show = (html: string) => {
-    $('.analyse__wiki').html(html).toggleClass('empty', !html);
+    $('.analyse__wiki').toggleClass('empty', !html);
+    $('.analyse__wiki-text').html(html);
     site.pubsub.emit('chat.resize');
   };
 
@@ -13,7 +14,7 @@ export default function wikiTheory(): WikiTheory {
     `${Math.floor((node.ply + 1) / 2)}${node.ply % 2 === 1 ? '._' : '...'}`;
 
   const wikiBooksUrl = 'https://en.wikibooks.org';
-  const apiArgs = 'redirects&origin=*&action=query&prop=extracts&formatversion=2&format=json&exchars=1200';
+  const apiArgs = 'redirects&origin=*&action=query&prop=extracts&formatversion=2&format=json&exchars=1000';
 
   const removeEmptyParagraph = (html: string) => html.replace(/<p>(<br \/>|\s)*<\/p>/g, '');
 
@@ -73,5 +74,5 @@ export default function wikiTheory(): WikiTheory {
 }
 
 export function wikiClear() {
-  $('.analyse__wiki').html('').toggleClass('empty', true);
+  $('.analyse__wiki').toggleClass('empty', true);
 }

--- a/ui/analyse/src/wiki.ts
+++ b/ui/analyse/src/wiki.ts
@@ -12,7 +12,7 @@ export default function wikiTheory(): WikiTheory {
 
   $(window).on('load', () => {
     const wikiBookField = $('#wikibook-field').first();
-    const wikiBookStorageKey = 'anlayse.wikibooks.display';
+    const wikiBookStorageKey = 'analyse.wikibooks.display';
     const toggleWikiBookStorage = () => site.storage.boolean(wikiBookStorageKey).toggle();
 
     if (!site.storage.boolean(wikiBookStorageKey).getOrDefault(true)) {

--- a/ui/analyse/src/wiki.ts
+++ b/ui/analyse/src/wiki.ts
@@ -2,6 +2,27 @@ import debounce from 'common/debounce';
 
 export type WikiTheory = (nodes: Tree.Node[]) => void;
 
+export function wikiToggleBox() {
+  $('#wikibook-field').each(function (this: HTMLElement) {
+    const wikiBookStorage = site.storage.boolean('analyse.wikibooks.display');
+    const toggleWikiBook = () => {
+      this.classList.toggle('toggle-box--toggle-off');
+      wikiBookStorage.toggle();
+    };
+
+    if (!wikiBookStorage.getOrDefault(true)) {
+      this.classList.add('toggle-box--toggle-off');
+    } else {
+      wikiBookStorage.set(true);
+    }
+
+    $(this)
+      .children('legend')
+      .on('click', () => toggleWikiBook())
+      .on('keypress', e => e.key == 'Enter' && toggleWikiBook());
+  });
+}
+
 export default function wikiTheory(): WikiTheory {
   const cache = new Map<string, string>();
   const show = (html: string) => {
@@ -9,26 +30,6 @@ export default function wikiTheory(): WikiTheory {
     $('.analyse__wiki-text').html(html);
     site.pubsub.emit('chat.resize');
   };
-
-  $(window).on('load', () => {
-    const wikiBookField = $('#wikibook-field').first();
-    const wikiBookStorage = site.storage.boolean('analyse.wikibooks.display');
-    const toggleWikiBook = () => {
-      wikiBookField.toggleClass('toggle-box--toggle-off');
-      wikiBookStorage.toggle();
-    };
-
-    if (!wikiBookStorage.getOrDefault(true)) {
-      wikiBookField.addClass('toggle-box--toggle-off');
-    } else {
-      wikiBookStorage.set(true);
-    }
-
-    $(wikiBookField)
-      .children('legend')
-      .on('click', () => toggleWikiBook())
-      .on('keypress', e => e.key == 'Enter' && toggleWikiBook());
-  });
 
   const plyPrefix = (node: Tree.Node) =>
     `${Math.floor((node.ply + 1) / 2)}${node.ply % 2 === 1 ? '._' : '...'}`;

--- a/ui/analyse/src/wiki.ts
+++ b/ui/analyse/src/wiki.ts
@@ -1,25 +1,24 @@
 import debounce from 'common/debounce';
+import { storedBooleanPropWithEffect } from 'common/storage';
 
 export type WikiTheory = (nodes: Tree.Node[]) => void;
 
 export function wikiToggleBox() {
   $('#wikibook-field').each(function (this: HTMLElement) {
-    const wikiBookStorage = site.storage.boolean('analyse.wikibooks.display');
-    const toggleWikiBook = () => {
-      this.classList.toggle('toggle-box--toggle-off');
-      wikiBookStorage.toggle();
-    };
+    const box = this;
 
-    if (!wikiBookStorage.getOrDefault(true)) {
-      this.classList.add('toggle-box--toggle-off');
-    } else {
-      wikiBookStorage.set(true);
-    }
+    const state = storedBooleanPropWithEffect('analyse.wikibooks.display', true, value =>
+      box.classList.toggle('toggle-box--toggle-off', value),
+    );
 
-    $(this)
+    const toggle = () => state(!state());
+
+    if (!state()) box.classList.add('toggle-box--toggle-off');
+
+    $(box)
       .children('legend')
-      .on('click', () => toggleWikiBook())
-      .on('keypress', e => e.key == 'Enter' && toggleWikiBook());
+      .on('click', toggle)
+      .on('keypress', e => e.key == 'Enter' && toggle());
   });
 }
 

--- a/ui/analyse/src/wiki.ts
+++ b/ui/analyse/src/wiki.ts
@@ -10,6 +10,23 @@ export default function wikiTheory(): WikiTheory {
     site.pubsub.emit('chat.resize');
   };
 
+  $(window).on('load', () => {
+    const wikiBookField = $('#wikibook-field').first();
+    const wikiBookStorageKey = 'anlayse.wikibooks.display';
+    const toggleWikiBookStorage = () => site.storage.boolean(wikiBookStorageKey).toggle();
+
+    if (!site.storage.boolean(wikiBookStorageKey).getOrDefault(true)) {
+      wikiBookField.addClass('form-fieldset--toggle-off');
+    } else {
+      site.storage.boolean(wikiBookStorageKey).set(true);
+    }
+
+    $(wikiBookField)
+      .children('legend')
+      .on('click', () => toggleWikiBookStorage())
+      .on('keypress', e => e.key == 'Enter' && toggleWikiBookStorage());
+  });
+
   const plyPrefix = (node: Tree.Node) =>
     `${Math.floor((node.ply + 1) / 2)}${node.ply % 2 === 1 ? '._' : '...'}`;
 

--- a/ui/analyse/src/wiki.ts
+++ b/ui/analyse/src/wiki.ts
@@ -12,26 +12,29 @@ export default function wikiTheory(): WikiTheory {
 
   $(window).on('load', () => {
     const wikiBookField = $('#wikibook-field').first();
-    const wikiBookStorageKey = 'analyse.wikibooks.display';
-    const toggleWikiBookStorage = () => site.storage.boolean(wikiBookStorageKey).toggle();
+    const wikiBookStorage = site.storage.boolean('analyse.wikibooks.display');
+    const toggleWikiBook = () => {
+      wikiBookField.toggleClass('toggle-box--toggle-off');
+      wikiBookStorage.toggle();
+    };
 
-    if (!site.storage.boolean(wikiBookStorageKey).getOrDefault(true)) {
-      wikiBookField.addClass('form-fieldset--toggle-off');
+    if (!wikiBookStorage.getOrDefault(true)) {
+      wikiBookField.addClass('toggle-box--toggle-off');
     } else {
-      site.storage.boolean(wikiBookStorageKey).set(true);
+      wikiBookStorage.set(true);
     }
 
     $(wikiBookField)
       .children('legend')
-      .on('click', () => toggleWikiBookStorage())
-      .on('keypress', e => e.key == 'Enter' && toggleWikiBookStorage());
+      .on('click', () => toggleWikiBook())
+      .on('keypress', e => e.key == 'Enter' && toggleWikiBook());
   });
 
   const plyPrefix = (node: Tree.Node) =>
     `${Math.floor((node.ply + 1) / 2)}${node.ply % 2 === 1 ? '._' : '...'}`;
 
   const wikiBooksUrl = 'https://en.wikibooks.org';
-  const apiArgs = 'redirects&origin=*&action=query&prop=extracts&formatversion=2&format=json&exchars=1000';
+  const apiArgs = 'redirects&origin=*&action=query&prop=extracts&formatversion=2&format=json&exchars=1200';
 
   const removeEmptyParagraph = (html: string) => html.replace(/<p>(<br \/>|\s)*<\/p>/g, '');
 

--- a/ui/bits/css/ublog/_form.scss
+++ b/ui/bits/css/ublog/_form.scss
@@ -8,7 +8,7 @@
     padding-left: var(---box-padding);
     padding-right: var(---box-padding);
   }
-  .form-fieldset {
+  .toggle-box {
     @extend %box-margin-horiz;
   }
   &__delete {

--- a/ui/common/css/component/_toggle-box.scss
+++ b/ui/common/css/component/_toggle-box.scss
@@ -1,0 +1,48 @@
+.toggle-box {
+  @extend %box-radius;
+  border: $border;
+  background: $c-bg-zebra;
+  padding: 1rem 1rem 0 1rem;
+  overflow-y: auto;
+  scrollbar-gutter: stable both-edges;
+
+  legend {
+    @extend %box-radius;
+    background: $c-bg-zebra;
+    padding: 0.5em 1.5em;
+    text-align: right;
+    font-size: 1.2em;
+    user-select: none;
+  }
+}
+
+.toggle-box--toggle {
+  legend {
+    border-top: $border;
+    cursor: pointer;
+    &::after {
+      content: '▲';
+      margin-left: 1ch;
+    }
+  }
+}
+
+.toggle-box--toggle-off {
+  background: none;
+  border-width: 1px 0 0 0;
+  padding-top: 0;
+  legend {
+    border: $border;
+    background: none;
+    &:hover {
+      @extend %box-neat;
+      background: $c-bg-zebra;
+    }
+    &::after {
+      content: '▼';
+    }
+  }
+  > *:not(legend) {
+    display: none;
+  }
+}

--- a/ui/common/css/component/_toggle-box.scss
+++ b/ui/common/css/component/_toggle-box.scss
@@ -2,9 +2,8 @@
   @extend %box-radius;
   border: $border;
   background: $c-bg-zebra;
-  padding: 1rem 1rem 0 1rem;
-  overflow-y: auto;
-  scrollbar-gutter: stable both-edges;
+  margin: 1rem 0 3rem 0;
+  padding: 2rem 2rem 0 2rem;
 
   legend {
     @extend %box-radius;
@@ -15,7 +14,6 @@
     user-select: none;
   }
 }
-
 .toggle-box--toggle {
   legend {
     border-top: $border;
@@ -26,7 +24,6 @@
     }
   }
 }
-
 .toggle-box--toggle-off {
   background: none;
   border-width: 1px 0 0 0;

--- a/ui/common/css/form/_form3.scss
+++ b/ui/common/css/form/_form3.scss
@@ -1,5 +1,6 @@
 @import 'cmn-toggle';
 @import '../component/flash';
+@import '../component/toggle-box';
 
 .form-group {
   margin-bottom: 3rem;
@@ -112,50 +113,4 @@ textarea.form-control {
   margin-bottom: 1rem;
   border: 0;
   border-top: $border;
-}
-
-.form-fieldset {
-  @extend %box-radius;
-  border: $border;
-  background: $c-bg-zebra;
-  margin: 1rem 0 3rem 0;
-  padding: 2rem 2rem 0 2rem;
-
-  legend {
-    @extend %box-radius;
-    background: $c-bg-zebra;
-    padding: 0.5em 1.5em;
-    text-align: right;
-    font-size: 1.2em;
-    user-select: none;
-  }
-}
-.form-fieldset--toggle {
-  legend {
-    border-top: $border;
-    cursor: pointer;
-    &::after {
-      content: '▲';
-      margin-left: 1ch;
-    }
-  }
-}
-.form-fieldset--toggle-off {
-  background: none;
-  border-width: 1px 0 0 0;
-  padding-top: 0;
-  legend {
-    border: $border;
-    background: none;
-    &:hover {
-      @extend %box-neat;
-      background: $c-bg-zebra;
-    }
-    &::after {
-      content: '▼';
-    }
-  }
-  > *:not(legend) {
-    display: none;
-  }
 }

--- a/ui/site/src/boot.ts
+++ b/ui/site/src/boot.ts
@@ -114,8 +114,8 @@ export function boot() {
       el.setAttribute('content', el.getAttribute('content') + ',maximum-scale=1.0');
     }
 
-    $('.form-fieldset--toggle').each(function (this: HTMLFieldSetElement) {
-      const toggle = () => this.classList.toggle('form-fieldset--toggle-off');
+    $('.toggle-box--toggle').each(function (this: HTMLFieldSetElement) {
+      const toggle = () => this.classList.toggle('toggle-box--toggle-off');
       $(this)
         .children('legend')
         .on('click', toggle)


### PR DESCRIPTION
Closes #10769 

This PR implements:
1. A toggleable fieldset display for Wikibook opening details on the Analysis page.
2. User preference is stored as site storage with key: **analyse.wikibooks.display**

Local Test Link: http://localhost:9663/analysis

Other implementation discussions in the comments