### PR TITLE
Increase tour create rate-limit for lichess user

### DIFF
--- a/app/controllers/Tournament.scala
+++ b/app/controllers/Tournament.scala
@@ -213,7 +213,8 @@ final class Tournament(env: Env, apiC: => Api)(using akka.stream.Materializer) e
       fail: => Fu[Result]
   )(create: => Fu[Result])(using me: Me, req: RequestHeader): Fu[Result] =
     val cost =
-      if isGranted(_.ManageTournament) then 2
+      if me.is(UserId.lichess) then 1
+      else if isGranted(_.ManageTournament) then 2
       else if me.hasTitle ||
         env.streamer.liveStreamApi.isStreaming(me) ||
         me.isVerified ||


### PR DESCRIPTION
See https://hq.lichess.ovh/#narrow/stream/8-dev/topic/variant.20tournament.20scheduler.20getting.20rate-limited for additional context.

Basically, the `isGranted(_.ManageTournament)` doesn't apply when using the API with a token that doesn't have `web:mod` perms but I'm not sure creating a token with those perms just for creating tournaments is a good idea.

Adding a separate exception for Lichess seems like the simplest solution.

Also gave it a cost of 1 instead of 2 for a total limit of 240/day. It's not strictly necessary rn since the variant teams currently only create around 50/day but it's probably better to have some buffer, especially since there are 8 variant teams, some of which currently don't create a lot of tournaments, the limit is also shared for Swiss tournaments, and we may occasionally want to create a lot more tournaments with the Lichess user for certain special events.