### PR TITLE
Bus: use safer version for Class

### DIFF
--- a/modules/core/src/main/misc.scala
+++ b/modules/core/src/main/misc.scala
@@ -19,9 +19,12 @@ package map:
   case class Exists(id: String, promise: Promise[Boolean])
 
 package clas:
-  case class AreKidsInSameClass(kid1: UserId, kid2: UserId, promise: Promise[Boolean])
-  case class IsTeacherOf(teacher: UserId, student: UserId, promise: Promise[Boolean])
-  case class ClasMatesAndTeachers(kid: UserId, promise: Promise[Set[UserId]])
+  enum ClasBus:
+    case AreKidsInSameClass(kid1: UserId, kid2: UserId, promise: Promise[Boolean])
+    case IsTeacherOf(teacher: UserId, student: UserId, promise: Promise[Boolean])
+    case ClasMatesAndTeachers(kid: UserId, promise: Promise[Set[UserId]])
+  object ClasBus:
+    given bus.WithChannel[ClasBus] = bus.WithChannel[ClasBus]("clas")
 
 package puzzle:
   case class StormRun(userId: UserId, score: Int)

--- a/modules/msg/src/main/MsgSearch.scala
+++ b/modules/msg/src/main/MsgSearch.scala
@@ -5,7 +5,7 @@ import reactivemongo.api.bson.*
 import lila.common.Bus
 import lila.core.LightUser
 import lila.db.dsl.{ *, given }
-import lila.core.misc.clas.ClasMatesAndTeachers
+import lila.core.misc.clas.ClasBus
 
 import lila.core.user.KidMode
 import lila.core.userId.UserSearch
@@ -35,7 +35,7 @@ final class MsgSearch(
 
   private def forKid(q: String)(using me: Me): Fu[MsgSearch.Result] = for
     threads  <- searchThreads(q)
-    allMates <- Bus.ask[Set[UserId]]("clas") { ClasMatesAndTeachers(me, _) }
+    allMates <- Bus.safeAsk[Set[UserId], ClasBus] { ClasBus.ClasMatesAndTeachers(me, _) }
     lower   = q.toLowerCase
     mateIds = allMates.view.filter(_.value.startsWith(lower)).toList.take(15)
     mates <- lightUserApi.asyncMany(mateIds)

--- a/modules/msg/src/main/MsgSecurity.scala
+++ b/modules/msg/src/main/MsgSecurity.scala
@@ -2,7 +2,7 @@ package lila.msg
 
 import lila.common.Bus
 import lila.db.dsl.{ *, given }
-import lila.core.misc.clas.{ AreKidsInSameClass, IsTeacherOf }
+import lila.core.misc.clas.ClasBus
 import lila.core.team.IsLeaderOf
 import lila.memo.RateLimit
 import lila.core.perm.Granter
@@ -175,7 +175,8 @@ final private class MsgSecurity(
       if !isNew || !hasKid then fuTrue
       else
         (orig.isKid, dest.isKid) match
-          case (true, true)  => Bus.ask[Boolean]("clas") { AreKidsInSameClass(orig.id, dest.id, _) }
+          case (true, true) =>
+            Bus.safeAsk[Boolean, ClasBus] { ClasBus.AreKidsInSameClass(orig.id, dest.id, _) }
           case (false, true) => isTeacherOf(orig.id, dest.id)
           case (true, false) => isTeacherOf(dest.id, orig.id)
           case _             => fuFalse
@@ -184,7 +185,7 @@ final private class MsgSecurity(
     isTeacherOf(contacts.orig.id, contacts.dest.id)
 
   private def isTeacherOf(teacher: UserId, student: UserId): Fu[Boolean] =
-    Bus.ask[Boolean]("clas") { IsTeacherOf(teacher, student, _) }
+    Bus.safeAsk[Boolean, ClasBus] { ClasBus.IsTeacherOf(teacher, student, _) }
 
   private def isLeaderOf(contacts: Contacts) =
     Bus.ask[Boolean]("teamIsLeaderOf") { IsLeaderOf(contacts.orig.id, contacts.dest.id, _) }


### PR DESCRIPTION
Finally getting around moving more Bus to the safer API

Tests:
- [x] Messaging teacher/student student/teacher for `ClasBus.IsTeacherOf`
- [x] Messaging student/student  `ClasBus.AreKidsInSameClass`
- [x] inbox message search for `ClasMatesAndTeachers`