### PR TITLE
Bus: migrate more components to new API

### DIFF
--- a/app/controllers/Puzzle.scala
+++ b/app/controllers/Puzzle.scala
@@ -229,7 +229,7 @@ final class Puzzle(env: Env, apiC: => Api) extends LilaController(env):
     }
 
   private def setStreakResult(userId: UserId, score: Int) =
-    lila.common.Bus.publish(lila.core.misc.puzzle.StreakRun(userId, score), "streakRun")
+    lila.common.Bus.pub(lila.core.misc.puzzle.StreakRun(userId, score))
     env.user.api.addPuzRun("streak", userId, score)
 
   def apiStreak = Anon:

--- a/modules/activity/src/main/Env.scala
+++ b/modules/activity/src/main/Env.scala
@@ -6,6 +6,7 @@ import com.softwaremill.tagging.*
 import lila.core.config.*
 import lila.core.round.CorresMoveEvent
 import lila.core.misc.streamer.StreamStart
+import lila.core.misc.puzzle.RacerRun
 import lila.common.Bus
 import lila.core.forum.BusForum
 
@@ -45,13 +46,13 @@ final class Env(
     "stormRun" -> { case lila.core.misc.puzzle.StormRun(userId, score) =>
       write.storm(userId, score)
     },
-    "racerRun" -> { case lila.core.misc.puzzle.RacerRun(userId, score) =>
-      write.racer(userId, score)
-    },
     "streakRun" -> { case lila.core.misc.puzzle.StreakRun(userId, score) =>
       write.streak(userId, score)
     }
   )
+  Bus.sub[RacerRun]:
+    case RacerRun(userId, score) =>
+      write.racer(userId, score)
 
   Bus.subscribeFun(
     "ublogPost",

--- a/modules/activity/src/main/Env.scala
+++ b/modules/activity/src/main/Env.scala
@@ -6,7 +6,7 @@ import com.softwaremill.tagging.*
 import lila.core.config.*
 import lila.core.round.CorresMoveEvent
 import lila.core.misc.streamer.StreamStart
-import lila.core.misc.puzzle.RacerRun
+import lila.core.misc.puzzle.{ RacerRun, StormRun, StreakRun }
 import lila.common.Bus
 import lila.core.forum.BusForum
 
@@ -42,14 +42,16 @@ final class Env(
     },
     "finishPuzzle" -> { case res: lila.puzzle.Puzzle.UserResult =>
       write.puzzle(res)
-    },
-    "stormRun" -> { case lila.core.misc.puzzle.StormRun(userId, score) =>
-      write.storm(userId, score)
-    },
-    "streakRun" -> { case lila.core.misc.puzzle.StreakRun(userId, score) =>
-      write.streak(userId, score)
     }
   )
+  Bus.sub[StreakRun]:
+    case StreakRun(userId, score) =>
+      write.streak(userId, score)
+
+  Bus.sub[StormRun]:
+    case StormRun(userId, score) =>
+      write.storm(userId, score)
+
   Bus.sub[RacerRun]:
     case RacerRun(userId, score) =>
       write.racer(userId, score)

--- a/modules/activity/src/main/Env.scala
+++ b/modules/activity/src/main/Env.scala
@@ -5,6 +5,7 @@ import com.softwaremill.tagging.*
 
 import lila.core.config.*
 import lila.core.round.CorresMoveEvent
+import lila.core.misc.streamer.StreamStart
 import lila.common.Bus
 import lila.core.forum.BusForum
 
@@ -61,7 +62,6 @@ final class Env(
     "plan",
     "relation",
     "startStudy",
-    "streamStart",
     "swissFinish"
   ):
     case lila.core.ublog.UblogPost.Create(post)       => write.ublogPost(post)
@@ -75,8 +75,10 @@ final class Env(
       scheduler.scheduleOnce(5 minutes) { write.study(id) }
     case lila.core.team.TeamCreate(t)                   => write.team(t.id, t.userId)
     case lila.core.team.JoinTeam(id, userId)            => write.team(id, userId)
-    case lila.core.misc.streamer.StreamStart(userId, _) => write.streamStart(userId)
     case lila.core.swiss.SwissFinish(swissId, ranking)  => write.swiss(swissId, ranking)
+
+  Bus.sub[StreamStart]:
+    case StreamStart(userId, _) => write.streamStart(userId)
 
   Bus.sub[BusForum]:
     case BusForum.CreatePost(post) => write.forumPost(post)

--- a/modules/activity/src/main/Env.scala
+++ b/modules/activity/src/main/Env.scala
@@ -73,9 +73,9 @@ final class Env(
     case lila.core.study.StartStudy(id)               =>
       // wait some time in case the study turns private
       scheduler.scheduleOnce(5 minutes) { write.study(id) }
-    case lila.core.team.TeamCreate(t)                   => write.team(t.id, t.userId)
-    case lila.core.team.JoinTeam(id, userId)            => write.team(id, userId)
-    case lila.core.swiss.SwissFinish(swissId, ranking)  => write.swiss(swissId, ranking)
+    case lila.core.team.TeamCreate(t)                  => write.team(t.id, t.userId)
+    case lila.core.team.JoinTeam(id, userId)           => write.team(id, userId)
+    case lila.core.swiss.SwissFinish(swissId, ranking) => write.swiss(swissId, ranking)
 
   Bus.sub[StreamStart]:
     case StreamStart(userId, _) => write.streamStart(userId)

--- a/modules/core/src/main/misc.scala
+++ b/modules/core/src/main/misc.scala
@@ -11,8 +11,10 @@ package streamer:
   case class StreamStart(userId: UserId, streamerName: String)
   object StreamStart:
     given bus.WithChannel[StreamStart] = bus.WithChannel[StreamStart]("streamStart")
-  
+
   case class StreamersOnline(streamers: Iterable[(UserId, String)])
+  object StreamersOnline:
+    given bus.WithChannel[StreamersOnline] = bus.WithChannel[StreamersOnline]("streamersOnline")
 
 package map:
   case class Tell(id: String, msg: Any)

--- a/modules/core/src/main/misc.scala
+++ b/modules/core/src/main/misc.scala
@@ -9,6 +9,9 @@ import lila.core.id.GameId
 
 package streamer:
   case class StreamStart(userId: UserId, streamerName: String)
+  object StreamStart:
+    given bus.WithChannel[StreamStart] = bus.WithChannel[StreamStart]("streamStart")
+  
   case class StreamersOnline(streamers: Iterable[(UserId, String)])
 
 package map:

--- a/modules/core/src/main/misc.scala
+++ b/modules/core/src/main/misc.scala
@@ -31,6 +31,9 @@ package clas:
 package puzzle:
   case class StormRun(userId: UserId, score: Int)
   case class RacerRun(userId: UserId, score: Int)
+  object RacerRun:
+    given bus.WithChannel[RacerRun] = bus.WithChannel[RacerRun]("racerRun")
+
   case class StreakRun(userId: UserId, score: Int)
 
 package lpv:

--- a/modules/core/src/main/misc.scala
+++ b/modules/core/src/main/misc.scala
@@ -30,11 +30,16 @@ package clas:
 
 package puzzle:
   case class StormRun(userId: UserId, score: Int)
+  object StormRun:
+    given bus.WithChannel[StormRun] = bus.WithChannel[StormRun]("stormRun")
+
   case class RacerRun(userId: UserId, score: Int)
   object RacerRun:
     given bus.WithChannel[RacerRun] = bus.WithChannel[RacerRun]("racerRun")
 
   case class StreakRun(userId: UserId, score: Int)
+  object StreakRun:
+    given bus.WithChannel[StreakRun] = bus.WithChannel[StreakRun]("streakRun")
 
 package lpv:
   import _root_.chess.format.pgn.PgnStr

--- a/modules/core/src/main/misc.scala
+++ b/modules/core/src/main/misc.scala
@@ -57,6 +57,9 @@ package mailer:
       gameId: GameId
   )
   case class CorrespondenceOpponents(userId: UserId, opponents: List[CorrespondenceOpponent])
+  object CorrespondenceOpponents:
+    given bus.WithChannel[CorrespondenceOpponents] =
+      bus.WithChannel[CorrespondenceOpponents]("dailyCorrespondenceNotif")
 
 package evaluation:
   case class AutoCheck(userId: UserId)

--- a/modules/mailer/src/main/Env.scala
+++ b/modules/mailer/src/main/Env.scala
@@ -5,6 +5,8 @@ import com.softwaremill.macwire.*
 import play.api.Configuration
 
 import lila.common.config.*
+import lila.common.Bus
+import lila.core.misc.mailer.CorrespondenceOpponents
 
 @Module
 final class Env(
@@ -32,7 +34,7 @@ final class Env(
 
   lazy val automaticEmail = wire[AutomaticEmail]
 
-  lila.common.Bus.subscribeFuns(
+  Bus.subscribeFuns(
     "fishnet" -> { case lila.core.fishnet.NewKey(userId, key) =>
       automaticEmail.onFishnetKey(userId, key)
     },
@@ -44,8 +46,8 @@ final class Env(
     },
     "planExpire" -> { case lila.core.misc.plan.PlanExpire(userId) =>
       automaticEmail.onPatronStop(userId)
-    },
-    "dailyCorrespondenceNotif" -> { case lila.core.misc.mailer.CorrespondenceOpponents(userId, opponents) =>
-      automaticEmail.dailyCorrespondenceNotice(userId, opponents)
     }
   )
+  Bus.sub[CorrespondenceOpponents]:
+    case CorrespondenceOpponents(userId, opponents) =>
+      automaticEmail.dailyCorrespondenceNotice(userId, opponents)

--- a/modules/notify/src/main/Env.scala
+++ b/modules/notify/src/main/Env.scala
@@ -38,19 +38,17 @@ final class Env(
   val getAllows = GetNotifyAllows(api.prefs.allows)
 
   // api actor
-  Bus.subscribeFuns(
-    "notify" -> {
-      case lila.core.notify.NotifiedBatch(userIds) => api.markAllRead(userIds)
-      case lila.core.game.CorresAlarmEvent(userId, pov, opponent) =>
-        api.notifyOne(userId, CorresAlarm(pov.game.id, opponent))
-    },
-    "streamStart" -> { case lila.core.misc.streamer.StreamStart(userId, streamerName) =>
+  Bus.subscribeFun("notify"):
+    case lila.core.notify.NotifiedBatch(userIds) => api.markAllRead(userIds)
+    case lila.core.game.CorresAlarmEvent(userId, pov, opponent) =>
+      api.notifyOne(userId, CorresAlarm(pov.game.id, opponent))
+
+  Bus.sub[lila.core.misc.streamer.StreamStart]:
+    case lila.core.misc.streamer.StreamStart(userId, streamerName) =>
       subsRepo
         .subscribersOnlineSince(userId, 7)
         .map: subs =>
           api.notifyMany(subs, StreamStart(userId, streamerName))
-    }
-  )
 
   lazy val cli = wire[NotifyCli]
 

--- a/modules/racer/src/main/RacerApi.scala
+++ b/modules/racer/src/main/RacerApi.scala
@@ -92,7 +92,7 @@ final class RacerApi(
       race.players.foreach: player =>
         lila.mon.racer.score(lobby = race.isLobby, auth = player.user.isDefined).record(player.score)
         player.user.ifTrue(player.score > 0).foreach { user =>
-          Bus.publish(lila.core.misc.puzzle.RacerRun(user.id, player.score), "racerRun")
+          Bus.pub(lila.core.misc.puzzle.RacerRun(user.id, player.score))
           userApi.addPuzRun("racer", user.id, player.score)
         }
       publish(race)

--- a/modules/round/src/main/CorrespondenceEmail.scala
+++ b/modules/round/src/main/CorrespondenceEmail.scala
@@ -23,7 +23,7 @@ final private class CorrespondenceEmail(gameRepo: GameRepo, userRepo: UserRepo, 
 
   private def run() =
     opponentStream
-      .map { Bus.publish(_, "dailyCorrespondenceNotif") }
+      .map { Bus.pub(_) }
       .runWith(LilaStream.sinkCount)
       .addEffect(lila.mon.round.correspondenceEmail.emails.record(_))
       .monSuccess(_.round.correspondenceEmail.time)

--- a/modules/socket/src/main/RemoteSocket.scala
+++ b/modules/socket/src/main/RemoteSocket.scala
@@ -13,6 +13,7 @@ import lila.common.{ Bus, Lilakka }
 import lila.core.relation.{ Follow, UnFollow }
 import lila.core.round.Mlat
 import lila.core.security.CloseAccount
+import lila.core.misc.streamer.StreamersOnline
 import lila.core.socket.remote.*
 import lila.core.socket.{ SocketRequester as _, * }
 
@@ -68,8 +69,7 @@ final class RemoteSocket(
     "shadowban",
     "impersonate",
     "relation",
-    "onlineApiUsers",
-    "streamersOnline"
+    "onlineApiUsers"
   ) {
     case SendTos(userIds, payload) =>
       val connectedUsers = userIds.intersect(onlineUserIds.get)
@@ -101,9 +101,10 @@ final class RemoteSocket(
       if value then onlineUserIds.getAndUpdate(_ + userId)
     case Follow(u1, u2)   => send(Out.follow(u1, u2))
     case UnFollow(u1, u2) => send(Out.unfollow(u1, u2))
-    case lila.core.misc.streamer.StreamersOnline(streamers) =>
-      send(Out.streamersOnline(streamers))
   }
+  Bus.sub[StreamersOnline]:
+    case StreamersOnline(streamers) =>
+      send(Out.streamersOnline(streamers))
 
   final class StoppableSender(val conn: PubSub[String, String], channel: Channel) extends Sender:
     def apply(msg: String)               = if !stopping then super.sendTo(channel, msg)

--- a/modules/storm/src/main/StormDay.scala
+++ b/modules/storm/src/main/StormDay.scala
@@ -59,7 +59,7 @@ final class StormDayApi(coll: Coll, highApi: StormHighApi, userApi: lila.core.us
     lila.mon.storm.run.score(user.isDefined).record(data.score)
     user.so: u =>
       if mobile || sign.check(u, ~data.signed) then
-        Bus.publish(lila.core.misc.puzzle.StormRun(u.id, data.score), "stormRun")
+        Bus.pub(lila.core.misc.puzzle.StormRun(u.id, data.score))
         highApi.get(u.id).flatMap { prevHigh =>
           val todayId = Id.today(u.id)
           coll

--- a/modules/streamer/src/main/Streaming.scala
+++ b/modules/streamer/src/main/Streaming.scala
@@ -57,11 +57,9 @@ final private class Streaming(
   private val streamStartOnceEvery = scalalib.cache.OnceEvery[UserId](2 hour)
 
   private def publishStreams(streamers: List[Streamer], newStreams: LiveStreams) =
-    Bus.publish(
+    Bus.pub:
       lila.core.misc.streamer
-        .StreamersOnline(newStreams.streams.map(s => (s.streamer.userId, s.streamer.name.value))),
-      "streamersOnline"
-    )
+        .StreamersOnline(newStreams.streams.map(s => (s.streamer.userId, s.streamer.name.value)))
     if newStreams != liveStreams then
       newStreams.streams
         .filterNot { s =>

--- a/modules/streamer/src/main/Streaming.scala
+++ b/modules/streamer/src/main/Streaming.scala
@@ -70,10 +70,7 @@ final private class Streaming(
         .foreach { s =>
           import s.streamer.userId
           if streamStartOnceEvery(userId) then
-            Bus.publish(
-              lila.core.misc.streamer.StreamStart(userId, s.streamer.name.value),
-              "streamStart"
-            )
+            Bus.pub(lila.core.misc.streamer.StreamStart(userId, s.streamer.name.value))
         }
     liveStreams = newStreams
     streamers.foreach { streamer =>


### PR DESCRIPTION

tests:
- [ ] `StreamStart`
- [ ] `StreamersOnline`
- [x] `RacerRun`
- [x] `StreakRun` and `StormRun`
- [x] `dailyCorrespondenceNotif`

Couldn't test the streamer parts, the rest work and supposedly the new typing is supposed to make the two first one very likely to work too 😅 