### PR TITLE
Implement tests for game.Event.PossibleMoves

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -237,7 +237,7 @@ lazy val user = module("user",
 
 lazy val game = module("game",
   Seq(tree, rating, memo),
-  Seq(compression) ++ tests.bundle
+  Seq(compression) ++ tests.bundle ++ Seq(scalacheck, munitCheck, chess.testKit)
 )
 
 lazy val gameSearch = module("gameSearch",

--- a/modules/game/src/main/Event.scala
+++ b/modules/game/src/main/Event.scala
@@ -155,6 +155,7 @@ object Event:
     )
 
   object PossibleMoves:
+    // We need to keep this implementation for compatibility
     def json(moves: Map[Square, Bitboard]): JsValue =
       if moves.isEmpty then JsNull
       else

--- a/modules/game/src/test/EventTest.scala
+++ b/modules/game/src/test/EventTest.scala
@@ -1,0 +1,34 @@
+package lila.game
+
+import chess.*
+import chess.bitboard.Bitboard
+
+import cats.syntax.all.*
+import chess.CoreArbitraries.given
+import org.scalacheck.Prop.{ forAll, propBoolean }
+import play.api.libs.json.*
+
+class EventTest extends munit.ScalaCheckSuite:
+
+  test("PossibleMoves anti regression"):
+    val moves = Map(Square.E2 -> Bitboard(List(Square.E4, Square.D4, Square.E3)))
+    val str   = stringFromPossibleMoves(moves)
+    // If We somehow change the order of destinations, We may need to update this test
+    assertEquals(str, "e2e3d4e4")
+
+  test("PossibleMoves with empty map"):
+    assertEquals(Event.PossibleMoves.json(Map.empty), JsNull)
+
+  test("PossibleMoves writes every square"):
+    forAll: (m: Map[Square, Bitboard]) =>
+      m.nonEmpty ==> {
+        val str          = stringFromPossibleMoves(m)
+        val totalSquares = m.values.foldLeft(0)(_ + _.count) + m.size
+        // str length = total squares * 2 + spaces in between
+        assertEquals(str.length, totalSquares * 2 + m.size - 1)
+      }
+
+  private def stringFromPossibleMoves(moves: Map[Square, Bitboard]): String =
+    Event.PossibleMoves.json(moves) match
+      case JsString(str) => str
+      case _             => failSuite("Expected JsString")


### PR DESCRIPTION
To prevent: https://github.com/lichess-org/lila/pull/15699

We should add more tests to cover `game.Event`. I'll eventually do them all if no one interested in.