### PR TITLE
Bus: refactor channel declaration to be shorter

### DIFF
--- a/modules/core/src/main/bus.scala
+++ b/modules/core/src/main/bus.scala
@@ -3,4 +3,9 @@ package bus
 
 type Channel = String
 
-final class WithChannel[T](val channel: Channel)
+// constructor is private so instances can only be created by extending the `GivenChannel` trait
+final class WithChannel[T](private val key: Channel):
+  def channel: Channel = key
+
+transparent trait GivenChannel[T](val channel: Channel):
+  given WithChannel[T] = WithChannel[T](channel)

--- a/modules/core/src/main/fishnet.scala
+++ b/modules/core/src/main/fishnet.scala
@@ -21,8 +21,7 @@ enum Bus:
       userId: UserId,
       official: Boolean
   )
-object Bus:
-  given bus.WithChannel[Bus] = bus.WithChannel[Bus]("fishnet")
+object Bus extends bus.GivenChannel[Bus]("fishnet")
 
 type AnalysisAwaiter = (Seq[GameId], FiniteDuration) => Funit
 

--- a/modules/core/src/main/forum.scala
+++ b/modules/core/src/main/forum.scala
@@ -13,8 +13,7 @@ enum BusForum:
   // erasing = blanking, still in db but with empty text
   case ErasePosts(ids: List[ForumPostId])
 
-object BusForum:
-  given bus.WithChannel[BusForum] = bus.WithChannel[BusForum]("forumPost")
+object BusForum extends bus.GivenChannel[BusForum]("forumPost")
 
 trait ForumPost:
   val id: ForumPostId

--- a/modules/core/src/main/misc.scala
+++ b/modules/core/src/main/misc.scala
@@ -9,12 +9,10 @@ import lila.core.id.GameId
 
 package streamer:
   case class StreamStart(userId: UserId, streamerName: String)
-  object StreamStart:
-    given bus.WithChannel[StreamStart] = bus.WithChannel[StreamStart]("streamStart")
+  object StreamStart extends bus.GivenChannel[StreamStart]("streamStart")
 
   case class StreamersOnline(streamers: Iterable[(UserId, String)])
-  object StreamersOnline:
-    given bus.WithChannel[StreamersOnline] = bus.WithChannel[StreamersOnline]("streamersOnline")
+  object StreamersOnline extends bus.GivenChannel[StreamersOnline]("streamersOnline")
 
 package map:
   case class Tell(id: String, msg: Any)
@@ -28,21 +26,17 @@ package clas:
     case AreKidsInSameClass(kid1: UserId, kid2: UserId, promise: Promise[Boolean])
     case IsTeacherOf(teacher: UserId, student: UserId, promise: Promise[Boolean])
     case ClasMatesAndTeachers(kid: UserId, promise: Promise[Set[UserId]])
-  object ClasBus:
-    given bus.WithChannel[ClasBus] = bus.WithChannel[ClasBus]("clas")
+  object ClasBus extends bus.GivenChannel[ClasBus]("clas")
 
 package puzzle:
   case class StormRun(userId: UserId, score: Int)
-  object StormRun:
-    given bus.WithChannel[StormRun] = bus.WithChannel[StormRun]("stormRun")
+  object StormRun extends bus.GivenChannel[StormRun]("stormRun")
 
   case class RacerRun(userId: UserId, score: Int)
-  object RacerRun:
-    given bus.WithChannel[RacerRun] = bus.WithChannel[RacerRun]("racerRun")
+  object RacerRun extends bus.GivenChannel[RacerRun]("racerRun")
 
   case class StreakRun(userId: UserId, score: Int)
-  object StreakRun:
-    given bus.WithChannel[StreakRun] = bus.WithChannel[StreakRun]("streakRun")
+  object StreakRun extends bus.GivenChannel[StreakRun]("streakRun")
 
 package lpv:
   import _root_.chess.format.pgn.PgnStr
@@ -60,9 +54,7 @@ package mailer:
       gameId: GameId
   )
   case class CorrespondenceOpponents(userId: UserId, opponents: List[CorrespondenceOpponent])
-  object CorrespondenceOpponents:
-    given bus.WithChannel[CorrespondenceOpponents] =
-      bus.WithChannel[CorrespondenceOpponents]("dailyCorrespondenceNotif")
+  object CorrespondenceOpponents extends bus.GivenChannel[CorrespondenceOpponents]("dailyCorrespondenceNotif")
 
 package evaluation:
   case class AutoCheck(userId: UserId)

--- a/modules/core/src/main/misc.scala
+++ b/modules/core/src/main/misc.scala
@@ -56,10 +56,6 @@ package mailer:
   case class CorrespondenceOpponents(userId: UserId, opponents: List[CorrespondenceOpponent])
   object CorrespondenceOpponents extends bus.GivenChannel[CorrespondenceOpponents]("dailyCorrespondenceNotif")
 
-package evaluation:
-  case class AutoCheck(userId: UserId)
-  case class Refresh(userId: UserId)
-
 package plan:
   case class ChargeEvent(username: UserName, cents: Int, percent: Int, date: Instant)
   case class MonthInc(userId: UserId, months: Int)


### PR DESCRIPTION
using a trait and extending it instead of a class.

Made the `WithChannel`constructor private so instances can only be created by extending the `GivenChannel` trait