### PR TITLE
tweak asset hash links

### DIFF
--- a/modules/web/src/main/AssetManifest.scala
+++ b/modules/web/src/main/AssetManifest.scala
@@ -93,7 +93,12 @@ final class AssetManifest(environment: Environment, net: NetConfig)(using ws: St
       .as[JsObject]
       .value
       .map { (k, asset) =>
-        val hashedName = (asset \ "hash").as[String]
+        val hash   = (asset \ "hash").as[String]
+        val name   = k.substring(k.lastIndexOf('/') + 1)
+        val extPos = name.indexOf('.')
+        val hashedName =
+          if extPos < 0 then s"${name}.$hash"
+          else s"${name.slice(0, extPos)}.$hash${name.substring(extPos)}"
         (k, s"hashed/$hashedName")
       }
       .toMap

--- a/ui/analyse/package.json
+++ b/ui/analyse/package.json
@@ -45,7 +45,7 @@
       "src/plugins/analyse.study.tour.ts"
     ],
     "sync": {
-      "node_modules/@yaireo/tagify/dist/tagify.min.js": "public/npm/tagify",
+      "node_modules/@yaireo/tagify/dist/tagify.min.js": "public/npm",
       "node_modules/sortablejs/modular/sortable.esm.js": "public/npm"
     }
   }

--- a/ui/analyse/src/study/topics.ts
+++ b/ui/analyse/src/study/topics.ts
@@ -74,7 +74,7 @@ export const formView = (ctrl: TopicsCtrl, userId?: string): VNode =>
 
 function setupTagify(elm: HTMLInputElement | HTMLTextAreaElement, userId?: string) {
   site.asset.loadCssPath('bits.tagify');
-  site.asset.loadIife('npm/tagify/tagify.min.js').then(() => {
+  site.asset.loadIife('npm/tagify.min.js').then(() => {
     const tagi = (tagify = new window.Tagify(elm, { pattern: /.{2,}/, maxTags: 30 }));
     let abortCtrl: AbortController | undefined; // for aborting the call
     tagi.on('input', e => {

--- a/ui/bits/src/exports/crop.ts
+++ b/ui/bits/src/exports/crop.ts
@@ -12,7 +12,7 @@ export function wireCropDialog(
     site.asset.loadEsm('bits.cropDialog'); // preload
     return;
   }
-  const init = structuredClone(opts);
+  const init = { ...opts };
 
   if (!init.onCropped) init.onCropped = () => site.reload();
 

--- a/ui/site/package.json
+++ b/ui/site/package.json
@@ -27,7 +27,9 @@
     "hashed": [
       "font/lichess.woff",
       "font/lichess.woff2",
-      "lifat/background/montage*.webp"
+      "lifat/background/montage*.webp",
+      "npm/*",
+      "javascripts/**"
     ]
   }
 }

--- a/ui/site/src/asset.ts
+++ b/ui/site/src/asset.ts
@@ -8,9 +8,15 @@ const assetVersion = memoize(() => document.body.getAttribute('data-asset-versio
 export const url = (path: string, opts: AssetUrlOpts = {}) => {
   const base = opts.documentOrigin ? window.location.origin : opts.pathOnly ? '' : baseUrl();
   const version = opts.version === false ? '' : `_${opts.version ?? assetVersion()}/`;
-  const hashed = opts.version !== false && site.manifest.hashed[path];
-  return `${base}/assets/${hashed ? `hashed/${hashed}` : `${version}${path}`}`;
+  const hash = opts.version !== false && site.manifest.hashed[path];
+  return `${base}/assets/${hash ? asHashed(path, hash) : `${version}${path}`}`;
 };
+
+function asHashed(path: string, hash: string) {
+  const name = path.slice(path.lastIndexOf('/') + 1);
+  const extPos = name.indexOf('.');
+  return `hashed/${extPos < 0 ? `${name}.${hash}` : `${name.slice(0, extPos)}.${hash}${name.slice(extPos)}`}`;
+}
 
 // bump flairs version if a flair is changed only (not added or removed)
 export const flairSrc = (flair: Flair) => url(`flair/img/${flair}.webp`, { version: '_____2' });


### PR DESCRIPTION
- hash top level files in npm
- hash javascripts
- tweak hashed filenames to include the original basename
- back off from base64url to hex encoding for the hash part. 32 bits is plenty and hex is easier to type/search/remember