### PR TITLE
Prevent imgur gallery links from attempting to be embedded

### DIFF
--- a/ui/msg/src/view/enhance.ts
+++ b/ui/msg/src/view/enhance.ts
@@ -4,7 +4,7 @@ import { linkRegex, linkReplace, newLineRegex, expandMentions } from 'common/ric
 import { escapeHtml } from 'common';
 export { isMoreThanText } from 'common/richText';
 
-const imgurRegex = /https?:\/\/(?:i\.)?imgur\.com\/(\w{7})(?:\.jpe?g|\.png|\.gif)?/;
+export const imgurRegex = /https?:\/\/(?:i\.)?imgur\.com\/(?!gallery\b)(\w{7})(?:\.jpe?g|\.png|\.gif)?/;
 const giphyRegex =
   /https:\/\/(?:media\.giphy\.com\/media\/|giphy\.com\/gifs\/(?:\w+-)*)(\w+)(?:\/giphy\.gif)?/;
 const teamMessageRegex =

--- a/ui/msg/tests/enhance.test.ts
+++ b/ui/msg/tests/enhance.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from 'vitest';
+import { enhance, imgurRegex } from '../src/view/enhance';
+
+describe('test imgur matching', () => {
+  test.each([
+    ['https://i.imgur.com/HFn4lkh.jpeg', 'https://i.imgur.com/HFn4lkh.jpg'],
+    ['http://imgur.com/HFn4lkh.png', 'https://i.imgur.com/HFn4lkh.jpg'],
+  ])('embed individual images', (input, link) => {
+    expect(imgurRegex.test(input)).toBe(true);
+    expect(enhance(input)).toBe(
+      `<a target="_blank" rel="noopener nofollow noreferrer" href="${link}"><img src="${link}"/></a>`,
+    );
+  });
+
+  test.each([
+    ['https://imgur.com/a/this-inUquB9', 'imgur.com/a/this-inUquB9'],
+    [
+      'https://imgur.com/gallery/lichess-is-down-404-image-HFn4lkh',
+      'imgur.com/gallery/lichess-is-down-404-image-HFn4lkh',
+    ],
+  ])('albums and galleries should not be embedded', (input, link) => {
+    expect(imgurRegex.test(input)).toBe(false);
+    expect(enhance(input)).toBe(
+      `<a target="_blank" rel="noopener nofollow noreferrer" href="${input}">${link}</a>`,
+    );
+  });
+});


### PR DESCRIPTION
They use the 7-character word "gallery" in the url which was being matched in the current regex

| Before | After |
| - | - |
| ![image](https://github.com/user-attachments/assets/da389943-2521-41b7-b750-6b4b200f91f4) | ![image](https://github.com/user-attachments/assets/d551bf24-a925-4428-92a8-d0a56520d0cf) |