### PR TITLE
Remove older glyphs and comments when merging old analysis data with new

### DIFF
--- a/ui/tree/src/ops.ts
+++ b/ui/tree/src/ops.ts
@@ -68,7 +68,8 @@ export function countChildrenAndComments(node: Tree.Node) {
 export function merge(n1: Tree.Node, n2: Tree.Node): void {
   if (n2.eval) n1.eval = n2.eval;
   if (n2.glyphs) n1.glyphs = n2.glyphs;
-  n2.comments &&
+  else delete n1.glyphs;
+  if (n2.comments) {
     n2.comments.forEach(function (c) {
       if (!n1.comments) n1.comments = [c];
       else if (
@@ -78,6 +79,7 @@ export function merge(n1: Tree.Node, n2: Tree.Node): void {
       )
         n1.comments.push(c);
     });
+  } else delete n1.comments;
   n2.children.forEach(function (c) {
     const existing = childById(n1, c.id);
     if (existing) merge(existing, c);


### PR DESCRIPTION
Fixes #14696 and #15616

[False blunder on move 56 gets removed](https://github.com/user-attachments/assets/ef130536-dec3-45b9-b6b7-459968f3f919)

False blunder on move 56 gets removed in the video

See this https://github.com/lichess-org/lila/issues/15616#issuecomment-2200744183 comment on how to reproduce this issue

I don't know why the line under blunder containing the variation line `56...b3 57.cxb3` doesn't get removed.