### PR TITLE
game blurs are read from DB using the wrong BSON handler

### DIFF
--- a/modules/analyse/src/main/AccuracyPercent.scala
+++ b/modules/analyse/src/main/AccuracyPercent.scala
@@ -11,7 +11,7 @@ import lila.tree.{ Analysis, Eval, WinPercent }
 opaque type AccuracyPercent = Double
 object AccuracyPercent extends OpaqueDouble[AccuracyPercent]:
 
-  given lila.db.NoDbHandler[AccuracyPercent] with {}
+  given lila.db.NoBSONWriter[AccuracyPercent] with {}
   given Percent[AccuracyPercent] = Percent.of(AccuracyPercent)
 
   extension (a: AccuracyPercent)

--- a/modules/analyse/src/main/AccuracyPercent.scala
+++ b/modules/analyse/src/main/AccuracyPercent.scala
@@ -12,6 +12,7 @@ opaque type AccuracyPercent = Double
 object AccuracyPercent extends OpaqueDouble[AccuracyPercent]:
 
   given lila.db.NoBSONWriter[AccuracyPercent] with {}
+  given lila.db.NoBSONReader[AccuracyPercent] with {}
   given Percent[AccuracyPercent] = Percent.of(AccuracyPercent)
 
   extension (a: AccuracyPercent)

--- a/modules/db/src/main/Handlers.scala
+++ b/modules/db/src/main/Handlers.scala
@@ -16,15 +16,15 @@ trait Handlers:
   def toBdoc[A](a: A)(using writer: BSONDocumentWriter[A]): Option[BSONDocument] = writer.writeOpt(a)
 
   // free writer for all types with TotalWrapper
-  // unless they are given an instance of lila.db.NoDbHandler[T]
+  // unless they are given an instance of lila.db.NoBSONWriter[T]
   given opaqueWriter[T, A](using
       rs: SameRuntime[T, A],
       writer: BSONWriter[A]
-  )(using NotGiven[NoDbHandler[T]]): BSONWriter[T] with
+  )(using NotGiven[NoBSONWriter[T]]): BSONWriter[T] with
     def writeTry(t: T) = writer.writeTry(rs(t))
 
-  // free writer for all types with TotalWrapper
-  // unless they are given an instance of lila.db.NoDbHandler[T]
+  // free reader for all types with TotalWrapper
+  // unless they are given an instance of lila.db.NoBSONReader[T]
   given opaqueReader[T, A](using
       sr: SameRuntime[A, T],
       reader: BSONReader[A]
@@ -32,13 +32,13 @@ trait Handlers:
     def readTry(bson: BSONValue) = reader.readTry(bson).map(sr.apply)
 
   given NoBSONReader[Blurs] with {}
-  given NoDbHandler[Blurs] with  {}
+  given NoBSONWriter[Blurs] with {}
 
   given userIdOfWriter[U: UserIdOf](using writer: BSONWriter[UserId]): BSONWriter[U] with
     inline def writeTry(u: U) = writer.writeTry(u.id)
-  given noUserIdOf[A: lila.core.userId.UserIdOf]: NoDbHandler[A] with {}
+  given noUserIdOf[A: lila.core.userId.UserIdOf]: NoBSONWriter[A] with {}
 
-  given NoDbHandler[UserId] with {}
+  given NoBSONWriter[UserId] with {}
   given userIdHandler: BSONHandler[UserId] = stringIsoHandler
 
   given dateTimeHandler: BSONHandler[LocalDateTime] = quickHandler[LocalDateTime](
@@ -177,9 +177,9 @@ trait Handlers:
     { case (a, b) => BSONArray(a, b) }
   )
 
-  given NoDbHandler[chess.Square] with {} // no default opaque handler for chess.Square
+  given NoBSONWriter[chess.Square] with {} // no default opaque handler for chess.Square
 
-  given lila.db.NoDbHandler[lila.core.user.Me] with {}
+  given lila.db.NoBSONWriter[lila.core.user.Me] with {}
 
   def chessPosKeyHandler: BSONHandler[chess.Square] = tryHandler(
     { case BSONString(str) => chess.Square.fromKey(str).toTry(s"No such key $str") },

--- a/modules/db/src/main/Handlers.scala
+++ b/modules/db/src/main/Handlers.scala
@@ -31,8 +31,8 @@ trait Handlers:
   )(using NotGiven[NoBSONReader[T]]): BSONReader[T] with
     def readTry(bson: BSONValue) = reader.readTry(bson).map(sr.apply)
 
-  given NoBSONReader[Blurs] with {}
-  given NoBSONWriter[Blurs] with {}
+  // given NoBSONReader[Blurs] with {}
+  // given NoBSONWriter[Blurs] with {}
 
   given userIdOfWriter[U: UserIdOf](using writer: BSONWriter[UserId]): BSONWriter[U] with
     inline def writeTry(u: U) = writer.writeTry(u.id)
@@ -178,8 +178,10 @@ trait Handlers:
   )
 
   given NoBSONWriter[chess.Square] with {} // no default opaque handler for chess.Square
+  given NoBSONReader[chess.Square] with {} // no default opaque handler for chess.Square
 
   given lila.db.NoBSONWriter[lila.core.user.Me] with {}
+  given lila.db.NoBSONReader[lila.core.user.Me] with {}
 
   def chessPosKeyHandler: BSONHandler[chess.Square] = tryHandler(
     { case BSONString(str) => chess.Square.fromKey(str).toTry(s"No such key $str") },

--- a/modules/db/src/main/Handlers.scala
+++ b/modules/db/src/main/Handlers.scala
@@ -31,8 +31,8 @@ trait Handlers:
   )(using NotGiven[NoBSONReader[T]]): BSONReader[T] with
     def readTry(bson: BSONValue) = reader.readTry(bson).map(sr.apply)
 
-  // given NoBSONReader[Blurs] with {}
-  // given NoBSONWriter[Blurs] with {}
+  given NoBSONReader[Blurs] with {}
+  given NoBSONWriter[Blurs] with {}
 
   given userIdOfWriter[U: UserIdOf](using writer: BSONWriter[UserId]): BSONWriter[U] with
     inline def writeTry(u: U) = writer.writeTry(u.id)

--- a/modules/db/src/main/package.scala
+++ b/modules/db/src/main/package.scala
@@ -5,7 +5,8 @@ import reactivemongo.api.commands.WriteResult
 export lila.core.lilaism.Lilaism.{ *, given }
 export lila.common.extensions.*
 
-trait NoDbHandler[A] // don't create default BSON handlers for this type
+trait NoDbHandler[A]  // don't create default BSONWiter for this type
+trait NoBSONReader[A] // don't create default BSONReader for this type
 
 def recoverDuplicateKey[A](f: WriteResult => A): PartialFunction[Throwable, A] =
   case wr: WriteResult if isDuplicateKey(wr) => f(wr)

--- a/modules/db/src/main/package.scala
+++ b/modules/db/src/main/package.scala
@@ -5,7 +5,7 @@ import reactivemongo.api.commands.WriteResult
 export lila.core.lilaism.Lilaism.{ *, given }
 export lila.common.extensions.*
 
-trait NoDbHandler[A]  // don't create default BSONWiter for this type
+trait NoBSONWriter[A] // don't create default BSONWiter for this type
 trait NoBSONReader[A] // don't create default BSONReader for this type
 
 def recoverDuplicateKey[A](f: WriteResult => A): PartialFunction[Throwable, A] =

--- a/modules/game/src/main/Blurs.scala
+++ b/modules/game/src/main/Blurs.scala
@@ -9,8 +9,6 @@ import lila.core.game.Blurs as apply
 
 object Blurs:
 
-  given lila.db.NoDbHandler[Blurs] with {}
-
   import reactivemongo.api.bson.*
   private[game] given blursHandler: BSONHandler[Blurs] = lila.db.dsl.tryHandler[Blurs](
     {

--- a/modules/game/src/test/BlurTest.scala
+++ b/modules/game/src/test/BlurTest.scala
@@ -1,7 +1,7 @@
 package lila.game
 
 import lila.core.game.Blurs
-import lila.game.Blurs.{ addAtMoveIndex, * }
+import lila.game.Blurs.{ *, given }
 import lila.db.BSON
 import lila.db.dsl.{ given, * }
 import reactivemongo.api.bson.*

--- a/modules/game/src/test/BlurTest.scala
+++ b/modules/game/src/test/BlurTest.scala
@@ -1,8 +1,9 @@
 package lila.game
 
 import lila.core.game.Blurs
-import lila.game.Blurs.{ given, * }
+import lila.game.Blurs.{ addAtMoveIndex, * }
 import lila.db.BSON
+import lila.db.dsl.{ given, * }
 import reactivemongo.api.bson.*
 
 class BlurTest extends munit.FunSuite:
@@ -18,11 +19,21 @@ class BlurTest extends munit.FunSuite:
   val bigBlur = fromMoveIndexes(0 until 40)
 
   test("BSON handler, lil blur"):
-    val bson = blursHandler.writeOpt(lilBlur).get
+    val bson = lila.game.Blurs.blursHandler.writeOpt(lilBlur).get
     assertEquals(bson, BSONInteger(15))
-    assertEquals(lilBlur, blursHandler.readOpt(bson).get)
+    assertEquals(lilBlur, lila.game.Blurs.blursHandler.readOpt(bson).get)
 
   test("BSON handler, big blur"):
-    val bson = blursHandler.writeOpt(bigBlur).get
+    val bson = lila.game.Blurs.blursHandler.writeOpt(bigBlur).get
     assertEquals(bson, BSONLong(1099511627775L))
-    assertEquals(bigBlur, blursHandler.readOpt(bson).get)
+    assertEquals(bigBlur, lila.game.Blurs.blursHandler.readOpt(bson).get)
+
+  test("read int using blursHandler"):
+    val bson = BSONInteger(-285641920)
+    val read = lila.game.Blurs.blursHandler.readOpt(bson).get
+    assertEquals(read.nb, 18)
+
+  test("read int using auto handler"):
+    val bson = BSONInteger(-285641920)
+    val read = summon[BSONReader[Blurs]].readOpt(bson).get
+    assertEquals(read.nb, 18)

--- a/modules/game/src/test/BlurTest.scala
+++ b/modules/game/src/test/BlurTest.scala
@@ -1,0 +1,28 @@
+package lila.game
+
+import lila.core.game.Blurs
+import lila.game.Blurs.{ given, * }
+import lila.db.BSON
+import reactivemongo.api.bson.*
+
+class BlurTest extends munit.FunSuite:
+
+  def fromMoveIndexes(indexes: Iterable[Int]): Blurs =
+    indexes.foldLeft(Blurs(0L)): (b, i) =>
+      b.addAtMoveIndex(i)
+
+  test("addAtMoveIndex"):
+    assertEquals(fromMoveIndexes(List(1, 2, 3, 6, 8)).binaryString, "011100101")
+
+  val lilBlur = fromMoveIndexes(0 until 4)
+  val bigBlur = fromMoveIndexes(0 until 40)
+
+  test("BSON handler, lil blur"):
+    val bson = blursHandler.writeOpt(lilBlur).get
+    assertEquals(bson, BSONInteger(15))
+    assertEquals(lilBlur, blursHandler.readOpt(bson).get)
+
+  test("BSON handler, big blur"):
+    val bson = blursHandler.writeOpt(bigBlur).get
+    assertEquals(bson, BSONLong(1099511627775L))
+    assertEquals(bigBlur, blursHandler.readOpt(bson).get)

--- a/modules/insight/src/main/model.scala
+++ b/modules/insight/src/main/model.scala
@@ -37,7 +37,7 @@ case class InsightMove(
 opaque type ClockPercent = Double
 object ClockPercent extends OpaqueDouble[ClockPercent]:
 
-  given lila.db.NoDbHandler[WinPercent] with {}
+  given lila.db.NoBSONWriter[WinPercent] with {}
   given Percent[ClockPercent] = Percent.of(ClockPercent)
 
   extension (a: ClockPercent) def toInt = Percent.toInt(a)

--- a/modules/insight/src/main/model.scala
+++ b/modules/insight/src/main/model.scala
@@ -38,6 +38,7 @@ opaque type ClockPercent = Double
 object ClockPercent extends OpaqueDouble[ClockPercent]:
 
   given lila.db.NoBSONWriter[WinPercent] with {}
+  given lila.db.NoBSONReader[WinPercent] with {}
   given Percent[ClockPercent] = Percent.of(ClockPercent)
 
   extension (a: ClockPercent) def toInt = Percent.toInt(a)

--- a/modules/tutor/src/main/model.scala
+++ b/modules/tutor/src/main/model.scala
@@ -58,6 +58,7 @@ opaque type GoodPercent = Double
 object GoodPercent extends OpaqueDouble[GoodPercent]:
   given Percent[GoodPercent] = Percent.of(GoodPercent)
   given lila.db.NoBSONWriter[GoodPercent] with {}
+  given lila.db.NoBSONReader[GoodPercent] with {}
   extension (a: GoodPercent) def toInt         = Percent.toInt(a)
   def apply(a: Double, b: Double): GoodPercent = GoodPercent(100 * a / b)
 

--- a/modules/tutor/src/main/model.scala
+++ b/modules/tutor/src/main/model.scala
@@ -57,7 +57,7 @@ enum TutorMetric[V](val metric: InsightMetric):
 opaque type GoodPercent = Double
 object GoodPercent extends OpaqueDouble[GoodPercent]:
   given Percent[GoodPercent] = Percent.of(GoodPercent)
-  given lila.db.NoDbHandler[GoodPercent] with {}
+  given lila.db.NoBSONWriter[GoodPercent] with {}
   extension (a: GoodPercent) def toInt         = Percent.toInt(a)
   def apply(a: Double, b: Double): GoodPercent = GoodPercent(100 * a / b)
 


### PR DESCRIPTION
modules/game/src/main/Blurs.scala

the `given lila.db.NoDbHandler[Blurs] with {}` is now ignored (since https://github.com/scala/scala3/issues/20843) and as a result blurs are read using `opaqueReader` instead of `blursHandler`.

The last test fails because of it.