### PR TITLE
Re-introduce NoDbHandler

### DIFF
--- a/modules/analyse/src/main/AccuracyPercent.scala
+++ b/modules/analyse/src/main/AccuracyPercent.scala
@@ -11,8 +11,7 @@ import lila.tree.{ Analysis, Eval, WinPercent }
 opaque type AccuracyPercent = Double
 object AccuracyPercent extends OpaqueDouble[AccuracyPercent]:
 
-  given lila.db.NoBSONWriter[AccuracyPercent] with {}
-  given lila.db.NoBSONReader[AccuracyPercent] with {}
+  given lila.db.NoDbHandler[AccuracyPercent] with {}
   given Percent[AccuracyPercent] = Percent.of(AccuracyPercent)
 
   extension (a: AccuracyPercent)

--- a/modules/db/src/main/Handlers.scala
+++ b/modules/db/src/main/Handlers.scala
@@ -31,8 +31,7 @@ trait Handlers:
   )(using NotGiven[NoBSONReader[T]]): BSONReader[T] with
     def readTry(bson: BSONValue) = reader.readTry(bson).map(sr.apply)
 
-  given NoBSONReader[Blurs] with {}
-  given NoBSONWriter[Blurs] with {}
+  given NoDbHandler[Blurs] with {}
 
   given userIdOfWriter[U: UserIdOf](using writer: BSONWriter[UserId]): BSONWriter[U] with
     inline def writeTry(u: U) = writer.writeTry(u.id)
@@ -177,11 +176,9 @@ trait Handlers:
     { case (a, b) => BSONArray(a, b) }
   )
 
-  given NoBSONWriter[chess.Square] with {} // no default opaque handler for chess.Square
-  given NoBSONReader[chess.Square] with {} // no default opaque handler for chess.Square
+  given NoDbHandler[chess.Square] with {} // no default opaque handler for chess.Square
 
-  given lila.db.NoBSONWriter[lila.core.user.Me] with {}
-  given lila.db.NoBSONReader[lila.core.user.Me] with {}
+  given NoDbHandler[lila.core.user.Me] with {}
 
   def chessPosKeyHandler: BSONHandler[chess.Square] = tryHandler(
     { case BSONString(str) => chess.Square.fromKey(str).toTry(s"No such key $str") },

--- a/modules/db/src/main/package.scala
+++ b/modules/db/src/main/package.scala
@@ -7,6 +7,7 @@ export lila.common.extensions.*
 
 trait NoBSONWriter[A] // don't create default BSONWiter for this type
 trait NoBSONReader[A] // don't create default BSONReader for this type
+trait NoDbHandler[A] extends NoBSONWriter[A] with NoBSONReader[A]
 
 def recoverDuplicateKey[A](f: WriteResult => A): PartialFunction[Throwable, A] =
   case wr: WriteResult if isDuplicateKey(wr) => f(wr)

--- a/modules/insight/src/main/model.scala
+++ b/modules/insight/src/main/model.scala
@@ -37,8 +37,7 @@ case class InsightMove(
 opaque type ClockPercent = Double
 object ClockPercent extends OpaqueDouble[ClockPercent]:
 
-  given lila.db.NoBSONWriter[WinPercent] with {}
-  given lila.db.NoBSONReader[WinPercent] with {}
+  given lila.db.NoDbHandler[WinPercent] with {}
   given Percent[ClockPercent] = Percent.of(ClockPercent)
 
   extension (a: ClockPercent) def toInt = Percent.toInt(a)

--- a/modules/tutor/src/main/model.scala
+++ b/modules/tutor/src/main/model.scala
@@ -57,8 +57,7 @@ enum TutorMetric[V](val metric: InsightMetric):
 opaque type GoodPercent = Double
 object GoodPercent extends OpaqueDouble[GoodPercent]:
   given Percent[GoodPercent] = Percent.of(GoodPercent)
-  given lila.db.NoBSONWriter[GoodPercent] with {}
-  given lila.db.NoBSONReader[GoodPercent] with {}
+  given lila.db.NoDbHandler[GoodPercent] with {}
   extension (a: GoodPercent) def toInt         = Percent.toInt(a)
   def apply(a: Double, b: Double): GoodPercent = GoodPercent(100 * a / b)
 


### PR DESCRIPTION
For types that don't want default opaque reader and writer, We can provide NoDbHandler instead provide both NoBSONReader and NoBSONWriter

follow up #15755 