### PR TITLE
if fideID == 0 no set link

### DIFF
--- a/ui/analyse/src/study/playerBars.ts
+++ b/ui/analyse/src/study/playerBars.ts
@@ -54,7 +54,7 @@ function renderPlayer(
         playerFed(player?.fed),
         player && userTitle(player),
         player &&
-          (fideId
+          (fideId && fideId != '0'
             ? h('a.name', { attrs: { href: `/fide/${fideId}/redirect` } }, player.name)
             : h('span.name', player.name)),
         rating && h('span.elo', `${rating}`),

--- a/ui/analyse/src/study/relay/relayLeaderboard.ts
+++ b/ui/analyse/src/study/relay/relayLeaderboard.ts
@@ -70,7 +70,7 @@ const renderPlayers = (
         h('tr', [
           h(
             'th',
-            player.fideId
+            player.fideId && player.fideId != 0
               ? h('a', { attrs: { href: `/fide/${player.fideId}/redirect` } }, [
                   playerFed(expandFederation(player)),
                   userTitle(player),

--- a/ui/analyse/src/study/relay/relayLeaderboard.ts
+++ b/ui/analyse/src/study/relay/relayLeaderboard.ts
@@ -70,7 +70,7 @@ const renderPlayers = (
         h('tr', [
           h(
             'th',
-            player.fideId && player.fideId != 0
+            player.fideId
               ? h('a', { attrs: { href: `/fide/${player.fideId}/redirect` } }, [
                   playerFed(expandFederation(player)),
                   userTitle(player),

--- a/ui/analyse/src/study/studyTags.ts
+++ b/ui/analyse/src/study/studyTags.ts
@@ -53,7 +53,9 @@ const editable = (value: string, submit: (v: string, el: HTMLInputElement) => vo
 type TagRow = (string | VNode)[];
 
 const fixed = ([key, value]: [string, string]) =>
-  key.endsWith('FideId') ? h('a', { attrs: { href: `/fide/${value}/redirect` } }, value) : fixedValue(value);
+  key.endsWith('FideId') && value != '0'
+    ? h('a', { attrs: { href: `/fide/${value}/redirect` } }, value)
+    : fixedValue(value);
 
 const fixedValue = (value: string) => h('span', value);
 


### PR DESCRIPTION
Due to autoreplace, sometimes we need to put the replacement with `= 0` to not identify the person
let's try to disable the automatic link to ID 0