### PR TITLE
Add link to Mastodon account

### DIFF
--- a/public/oops/scheduled-maintenance.html
+++ b/public/oops/scheduled-maintenance.html
@@ -103,7 +103,8 @@
       </div>
       <div class="more">
         To get updates on the maintenance,<br />
-        join <a href="https://twitter.com/lichess">@lichess on Twitter</a> or
+        join <a href="https://twitter.com/lichess">@lichess on Twitter</a>,
+        <a href="https://mastodon.online/@lichess">@lichess on Mastodon</a> or
         <a href="https://discord.gg/lichess">the lichess Discord</a>.<br />
         <div class="hide-for-mobile">To pass the time, try out this minigame:</div>
         <div class="game">


### PR DESCRIPTION
Added link to Mastodon page account (instanced from mastodon.online) link in line 107 of lila/public/oops/scheduled-maintenance.html