### PR TITLE
Personal Token - Re-check scopes upon validation

### DIFF
--- a/modules/oauth/src/main/ui/TokenUi.scala
+++ b/modules/oauth/src/main/ui/TokenUi.scala
@@ -124,7 +124,7 @@ final class TokenUi(helpers: Helpers)(
                           id,
                           s"${form("scopes").name}[]",
                           value = scope.key,
-                          checked = form.value.exists(_.scopes.contains(scope.key)),
+                          checked = form.data.valuesIterator.contains(scope.key),
                           disabled = disabled
                         )
                       ),


### PR DESCRIPTION
Inspect form data Map to see if a key (like "scopes[0]" or "scopes[1]") has a mapping to a value such as "email:read"

Resolves: #15765


Note, maybe it is bad form to inspect the data map like this,
and that the data is supposed to have been made available in some other manner (i.e some Play Framework "mapping" logic) - or this is fine... :sweat_smile: 