### PR TITLE
Fix API validation response when joining team

### DIFF
--- a/modules/web/src/main/CtrlErrors.scala
+++ b/modules/web/src/main/CtrlErrors.scala
@@ -32,7 +32,7 @@ trait CtrlErrors extends ControllerHelpers:
         .mapValues: errors =>
           JsArray:
             errors.map: e =>
-              JsString(I18nKey(e.message).txt(e.args.mkString))
+              JsString(I18nKey(e.message).txt(e.args*))
         .toMap
     json.validate(jsonGlobalErrorRenamer).getOrElse(json)
 

--- a/modules/web/src/main/CtrlErrors.scala
+++ b/modules/web/src/main/CtrlErrors.scala
@@ -32,7 +32,7 @@ trait CtrlErrors extends ControllerHelpers:
         .mapValues: errors =>
           JsArray:
             errors.map: e =>
-              JsString(I18nKey(e.message).txt(e.args))
+              JsString(I18nKey(e.message).txt(e.args.mkString))
         .toMap
     json.validate(jsonGlobalErrorRenamer).getOrElse(json)
 


### PR DESCRIPTION
Closes https://github.com/lichess-org/lila/issues/15761.

This change should not be taking lightly as it will affect all API responses using this function. 

To put it short, `e.args` is a `Seq[Matchable]`. Without these changes, `toString()` gets called which is causing this to output `ArraySeq(30)`, where `30` is the element in the sequence. If the sequence contained more elements, such as `60`, it would ouput `ArraySeq(30, 60)`. 

By doing `mkString` it will concatenate all elements of the sequence into a string. We might want to do `mkString(", ")` to comma-separate each element if there are more than one. Going back to my example of `ArraySeq(30, 60`), the output would look like `Must be at least 30, 60 characters long`. That output does not make sense in this context, but its worth thinking about for other usages.

![CleanShot 2024-07-27 at 12 49 13](https://github.com/user-attachments/assets/d5278de7-bae0-4893-a678-4b3e999c7c7b)
