### PR TITLE
Uppercase second word in "Puzzle themes" menu-item

### DIFF
--- a/translation/source/puzzle.xml
+++ b/translation/source/puzzle.xml
@@ -2,7 +2,7 @@
 
 <resources>
   <string name="puzzles">Puzzles</string>
-  <string name="puzzleThemes">Puzzle themes</string>
+  <string name="puzzleThemes">Puzzle Themes</string>
   <string name="recommended">Recommended</string>
   <string name="phases">Phases</string>
   <string name="motifs">Motifs</string>


### PR DESCRIPTION
Closes https://github.com/lichess-org/lila/issues/15659.

This is done to align with the other menu-items having all their first letter uppercased in all words. I have done the necessary change in [Crowdin](https://crowdin.com/editor/lichess/86/en-enus?view=comfortable#13772l) as well I think?

![CleanShot 2024-07-28 at 11 13 59](https://github.com/user-attachments/assets/d282f47a-30b1-4bd1-94fb-bd1935293ce1)
