### PR TITLE
add “system engines” to analysis page

### DIFF
--- a/modules/web/src/main/ContentSecurityPolicy.scala
+++ b/modules/web/src/main/ContentSecurityPolicy.scala
@@ -7,7 +7,7 @@ object ContentSecurityPolicy:
   def basic(assetDomain: AssetDomain, connectSrcs: List[String]) =
     lila.ui.ContentSecurityPolicy(
       defaultSrc = List("'self'", assetDomain.value),
-      connectSrc = "'self'" :: "blob:" :: "data:" :: connectSrcs,
+      connectSrc = "'self'" :: "blob:" :: "data:" :: "ws://localhost:8017" :: connectSrcs,
       styleSrc = List("'self'", "'unsafe-inline'", assetDomain.value),
       frameSrc = List("'self'", assetDomain.value, "www.youtube.com", "player.twitch.tv", "player.vimeo.com"),
       workerSrc = List("'self'", assetDomain.value, "blob:"),

--- a/ui/ceval/css/_settings.scss
+++ b/ui/ceval/css/_settings.scss
@@ -35,6 +35,12 @@
       margin-inline-start: 1ch;
     }
 
+    input {
+      flex: 1 4 auto;
+      width: 100%;
+      margin-inline-start: 1ch;
+    }
+
     input[type='range'],
     span {
       cursor: pointer;

--- a/ui/ceval/src/ctrl.ts
+++ b/ui/ceval/src/ctrl.ts
@@ -41,6 +41,9 @@ export default class CevalCtrl {
   showEnginePrefs: Toggle = toggle(false);
   customSearch?: Search;
 
+  addingSystem = false;
+  private systemEngines = site.storage.make('system-engines');
+
   private worker: CevalEngine | undefined;
 
   constructor(opts: CevalOpts) {
@@ -244,7 +247,14 @@ export default class CevalCtrl {
     this.opts.onSelectEngine?.();
   };
 
-  setHovering = (fen: FEN, uci?: Uci): void => {
+  getSystemEngines() {
+    return JSON.parse(this.systemEngines.get() ?? '[]') as { name: string; cmd: string[] }[];
+  }
+  addSystemEngine(name: string, cmd: string[]): void {
+    this.systemEngines.set(JSON.stringify([...this.getSystemEngines(), { name, cmd }]));
+  }
+
+  setHovering = (fen: FEN, uci?: Uci) => {
     this.hovering(uci ? { fen, uci } : null);
     this.opts.setAutoShapes();
   };

--- a/ui/ceval/src/engines/systemEngine.ts
+++ b/ui/ceval/src/engines/systemEngine.ts
@@ -1,0 +1,64 @@
+import { Protocol } from '../protocol';
+import { Work, CevalState, CevalEngine, SystemEngineInfo, EngineNotifier } from '../types';
+
+export class SystemEngine implements CevalEngine {
+  private failed = false;
+  private protocol = new Protocol();
+  private socket: WebSocket | undefined;
+  url: string;
+
+  constructor(
+    private info: SystemEngineInfo,
+    private status?: EngineNotifier | undefined,
+  ) {}
+
+  getInfo(): SystemEngineInfo {
+    return this.info;
+  }
+
+  getState(): CevalState {
+    return !this.socket
+      ? CevalState.Initial
+      : this.failed
+      ? CevalState.Failed
+      : !this.protocol.engineName
+      ? CevalState.Loading
+      : this.protocol.isComputing()
+      ? CevalState.Computing
+      : CevalState.Idle;
+  }
+
+  start(work: Work): void {
+    this.protocol.compute(work);
+
+    if (!this.socket) {
+      this.socket = new WebSocket('ws://localhost:8017');
+      this.socket.addEventListener('message', e => this.protocol.received(e.data));
+      this.socket.addEventListener('error', () => {
+        this.failed = true;
+        this.status?.({ error: 'WebSocket error.' });
+      });
+      this.socket.addEventListener('close', () => {
+        this.failed = true;
+        this.status?.({ error: 'Engine crashed or unavailable.' });
+      });
+      this.socket.addEventListener('open', () => {
+        this.socket?.send(JSON.stringify(this.info.cmd));
+        this.protocol.connected(cmd => this.socket?.send(cmd));
+      });
+    }
+  }
+
+  stop(): void {
+    this.protocol.compute(undefined);
+  }
+
+  engineName(): string | undefined {
+    return this.protocol.engineName;
+  }
+
+  destroy(): void {
+    this.socket?.close();
+    this.socket = undefined;
+  }
+}

--- a/ui/ceval/src/types.ts
+++ b/ui/ceval/src/types.ts
@@ -27,7 +27,7 @@ export interface Work {
 export interface EngineInfo {
   id: string;
   name: string;
-  tech?: 'HCE' | 'NNUE' | 'EXTERNAL';
+  tech?: 'HCE' | 'NNUE' | 'EXTERNAL' | 'SYSTEM';
   short?: string;
   variants?: VariantKey[];
   minThreads?: number;
@@ -47,6 +47,10 @@ export interface BrowserEngineInfo extends EngineInfo {
   assets: { root?: string; js?: string; wasm?: string; version?: string; nnue?: string[] };
   requires: Requires[];
   obsoletedBy?: Feature;
+}
+
+export interface SystemEngineInfo extends EngineInfo {
+  cmd: string[];
 }
 
 export type Requires = Feature | 'allowLsfw'; // lsfw = lila-stockfish-web

--- a/ui/common/src/controls.ts
+++ b/ui/common/src/controls.ts
@@ -36,11 +36,11 @@ export function rangeConfig(read: () => number, write: (value: number) => void):
     insert: (v: VNode) => {
       const el = v.elm as HTMLInputElement;
       el.value = '' + read();
-      el.addEventListener('input', _ => write(parseInt(el.value)));
+      el.addEventListener('input', _ => write(el.valueAsNumber));
       el.addEventListener('mouseout', _ => el.blur());
     },
     update: (_, v: VNode) => {
-      (v.elm as HTMLInputElement).value = `${read()}`; // force redraw on external value change
+      (v.elm as HTMLInputElement).valueAsNumber = read(); // force redraw on external value change
     },
   };
 }


### PR DESCRIPTION
This allows people to use engines installed on their computer on Lichess (without the server roundtrip) with the help of a very simple companion program. It is fairly basic currently, but it would be nice to allow choosing the UCI options on the Lichess website itself and also to take the engine’s display name from UCI too.

To test it, it should be easy to set up a Deno server like the following:

<details><summary><strong><code>main.ts</code> (Deno TypeScript)</strong></summary>

~~~ TypeScript
import {TextLineStream} from "jsr:@std/streams@1.0.0"

let encoder = new TextEncoder()

Deno.serve({port: 8017}, request =>
{
	let {socket, response} = Deno.upgradeWebSocket(request)
	
	let process: Deno.ChildProcess | undefined
	let writer: WritableStreamDefaultWriter<Uint8Array> | undefined
	
	socket.addEventListener("close", async () =>
	{
		writer?.close()
		
		await new Promise(f => setTimeout(f, 1000))
		try { process?.kill() }
		catch { }
		
		await new Promise(resolve => setTimeout(resolve, 1000))
		try { process?.kill("SIGKILL") }
		catch { }
	})
	
	socket.addEventListener("message", async ({data}) =>
	{
		if (!process)
		{
			let command = JSON.parse(data) as string[]
			process = new Deno.Command(command[0], {args: command.slice(1), stdin: "piped", stdout: "piped", stderr: "null"}).spawn()
			writer = process.stdin.getWriter()
			
			for await (let line of process.stdout.pipeThrough(new TextDecoderStream()).pipeThrough(new TextLineStream()))
				try { socket.send(line) }
				catch { }
			try { socket.close() }
			catch { }
		}
		
		writer?.write(encoder.encode(data + "\n")).catch(() => { })
	})
	
	return response
})
~~~

</details>

~~~
deno run -A main.ts
~~~

Then, from the Lichess analysis board, click on the cog icon at the top right, then choose “Add System Engine”, and write the engine’s command (e.g. `stockfish`, `/home/zamfofex/engines/lc0`, `C:\Users\Zamfofex\Engines\lc0.exe`, etc.) then click “Add”. (Arguments are allowed, but optional, of course.)

The Deno TypeScript code is temporary. It would be nice to provide a simple program that will set itself on the user’s system tray, and also check the `Origin` header and also the URL’s `pathname` to make sure the request comes from Lichess (otherwise, any website can run arbitrary programs on the user’s computer!) Of course, such a companion program doesn’t need to be written in TypeScript, it can be written in C or Rust, for example.