### PR TITLE
node 20 for github lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,10 +19,15 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
         with:
-          run_install: true
+          run_install: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
       - uses: github/codeql-action/init@v3
         with:
           languages: javascript
       - uses: github/codeql-action/analyze@v3
+      - run: pnpm install
       - run: pnpm run lint
       - run: pnpm run check-format


### PR DESCRIPTION
Change node version to 20 from default 18 to match with https://github.com/lichess-org/lila/blob/3c4c0d144caad0fecac9bd82a0772af1bb691c4d/package.json#L22 recommended node version.