### PR TITLE
Puzzle: only show feedback on your moves

### DIFF
--- a/ui/puzzle/src/autoShape.ts
+++ b/ui/puzzle/src/autoShape.ts
@@ -72,14 +72,13 @@ export default function (opts: Opts): DrawShape[] {
       });
     } else shapes = shapes.concat(makeAutoShapesFromUci(opposite(color), n.threat.pvs[0].moves[0], 'red'));
   }
-  const feedback = feedbackAnnotation(n, opts.nodeList[opts.nodeList.length - 2]);
+  const feedback = feedbackAnnotation(n);
   return shapes.concat(annotationShapes(n)).concat(feedback ? annotationShapes(feedback) : []);
 }
 
-function feedbackAnnotation(n: Tree.Node, prev?: Tree.Node): Tree.Node | undefined {
+function feedbackAnnotation(n: Tree.Node): Tree.Node | undefined {
   let glyph: Tree.Glyph | undefined;
-  const node = n.puzzle ? n : prev?.puzzle ? prev : undefined;
-  switch (node?.puzzle) {
+  switch (n.puzzle) {
     case 'good':
     case 'win':
       glyph = { id: 7, name: 'good', symbol: '✓' };
@@ -87,5 +86,5 @@ function feedbackAnnotation(n: Tree.Node, prev?: Tree.Node): Tree.Node | undefin
     case 'fail':
       glyph = { id: 4, name: 'fail', symbol: '✗' };
   }
-  return node && glyph && { ...node, glyphs: [glyph] };
+  return glyph && { ...n, glyphs: [glyph] };
 }


### PR DESCRIPTION
Consistent feedback requested it, and prior behavior was a bit strange, especially after capture where the checkmark would now be on the piece of the opposite color.

This has the side-effect of effectively disabling the checkmark for users with animation set to "none", and I'd argue it's better and consistent.

See attached videos for the before and after.

With move animation set to `normal`
| before | after |
|--------|--------|
| ![](https://github.com/user-attachments/assets/90a717d7-d49e-4924-b8d6-c43cc43b1e46) |  ![](https://github.com/user-attachments/assets/76777402-9832-4f04-85e7-a3289b34982f)

With move animation set to `none`
| before | after |
|--------|--------|
| ![](https://github.com/user-attachments/assets/842697b0-71da-44fb-a32f-8b04aa121f8d)|  ![](https://github.com/user-attachments/assets/aec30915-3b19-4ba2-be6c-ae1ccb0a38b1)
