### PR TITLE
Fix malformed quotes

### DIFF
--- a/modules/gathering/src/main/Quote.scala
+++ b/modules/gathering/src/main/Quote.scala
@@ -12,7 +12,7 @@ object Quote:
 
   def one(seed: String) = all(Random(seed.hashCode).nextInt(all.size))
 
-  // courtesy of http://www.chess.Squareter.com/english/notes_and_facts/chess_quotes.htm
+  // courtesy of http://www.chess-poster.com/english/notes_and_facts/chess_quotes.htm
   // and other various sources
   val all = Vector(
     Quote("When you see a good move, look for a better one.", "Emanuel Lasker"),
@@ -89,7 +89,7 @@ object Quote:
     Quote("Chess is mental torture.", "Garry Kasparov"),
     Quote("Many have become chess masters, no one has become the master of chess.", "Siegbert Tarrasch"),
     Quote(
-      "The most important feature of the chess.Position is the activity of the pieces. This is absolutely fundamental in all phases of the game: Opening, Middlegame and especially Endgame. The primary constraint on a piece's activity is the pawn structure.",
+      "The most important feature of the chess position is the activity of the pieces. This is absolutely fundamental in all phases of the game: Opening, Middlegame and especially Endgame. The primary constraint on a piece's activity is the pawn structure.",
       "Michael Stean"
     ),
     Quote(
@@ -334,7 +334,7 @@ object Quote:
     ),
     Quote("Castle early and often.", "Rob Sillars"),
     Quote(
-      "I believe that chess.Squaresesses a magic that is also a help in advanced age. A rheumatic knee is forgotten during a game of chess and other events can seem quite unimportant in comparison with a catastrophe on the chessboard.",
+      "I believe that chess possesses a magic that is also a help in advanced age. A rheumatic knee is forgotten during a game of chess and other events can seem quite unimportant in comparison with a catastrophe on the chessboard.",
       "Vlastimil Hort"
     ),
     Quote(


### PR DESCRIPTION
The quote used on the [2024 Autumn Marathon](https://lichess.org/tournament/autumn24) tournament page is malformed:

![image](https://github.com/user-attachments/assets/1ef230c8-188b-4087-83d8-05471ae22aae)

While fixing, I noticed a few others that have been seemingly malformed by a previous "replace all" which I also addressed in this PR.
