### PR TITLE
Remove unnecessary type annotation

### DIFF
--- a/modules/core/src/main/lilaism/LilaLibraryExtensions.scala
+++ b/modules/core/src/main/lilaism/LilaLibraryExtensions.scala
@@ -32,7 +32,7 @@ trait LilaLibraryExtensions extends CoreExports:
   extension [A](self: Option[A])
 
     def toTryWith(err: => Exception): Try[A] =
-      self.fold[Try[A]](scala.util.Failure(err))(scala.util.Success.apply)
+      self.fold(scala.util.Failure(err))(scala.util.Success.apply)
 
     def toTry(err: => String): Try[A] = toTryWith(LilaException(err))
 


### PR DESCRIPTION
We have better type inference since 3.3.0