### PR TITLE
avoid fen roundtrip for CloudEval.GetSinglePvEval

### DIFF
--- a/modules/evalCache/src/main/EvalCacheApi.scala
+++ b/modules/evalCache/src/main/EvalCacheApi.scala
@@ -21,10 +21,7 @@ final class EvalCacheApi(coll: AsyncCollFailingSilently, cacheApi: lila.memo.Cac
             _.map { JsonView.writeEval(_, fen) }
           .addEffect(monitorRequest(fen))
 
-  val getSinglePvEval: CloudEval.GetSinglePvEval = (variant, fen) =>
-    Id.from(variant, fen)
-      .so: id =>
-        getEval(id, MultiPv(1))
+  val getSinglePvEval: CloudEval.GetSinglePvEval = sit => getEval(Id(sit), MultiPv(1))
 
   private def monitorRequest(fen: Fen.Full)(res: Option[Any]) =
     Fen

--- a/modules/evalCache/src/main/EvalCacheEntry.scala
+++ b/modules/evalCache/src/main/EvalCacheEntry.scala
@@ -1,6 +1,7 @@
 package lila.evalCache
 
 import chess.format.{ BinaryFen, Fen }
+import chess.Situation
 import chess.variant.Variant
 
 import lila.core.chess.MultiPv
@@ -22,5 +23,7 @@ case class EvalCacheEntry(
 
 opaque type Id = BinaryFen
 object Id extends TotalWrapper[Id, BinaryFen]:
+  def apply(sit: Situation): Id = Id(BinaryFen.writeNormalized(sit))
+
   def from(variant: Variant, fen: Fen.Full): Option[Id] =
-    Fen.read(variant, fen).map(sit => Id(BinaryFen.writeNormalized(sit)))
+    Fen.read(variant, fen).map(Id.apply)

--- a/modules/fishnet/src/main/FishnetEvalCache.scala
+++ b/modules/fishnet/src/main/FishnetEvalCache.scala
@@ -50,7 +50,7 @@ final private class FishnetEvalCache(getSinglePvEval: CloudEval.GetSinglePvEval)
         _ => fuccess(Nil),
         _.zipWithIndex
           .parallel: (sit, index) =>
-            getSinglePvEval(game.variant, Fen.write(sit)).dmap2 { index -> _ }
+            getSinglePvEval(sit).dmap2 { index -> _ }
           .map(_.flatten)
       )
 

--- a/modules/tree/src/main/eval.scala
+++ b/modules/tree/src/main/eval.scala
@@ -1,8 +1,8 @@
 package lila.tree
 
 import cats.data.NonEmptyList
-import chess.format.{ Fen, Uci }
-import chess.variant.Variant
+import chess.format.Uci
+import chess.Situation
 
 case class Eval(cp: Option[Eval.Cp], mate: Option[Eval.Mate], best: Option[Uci]):
 
@@ -107,4 +107,4 @@ case class Pv(score: Score, moves: Moves)
 case class CloudEval(pvs: NonEmptyList[Pv], knodes: Knodes, depth: lila.core.chess.Depth, by: UserId)
 
 object CloudEval:
-  type GetSinglePvEval = (Variant, Fen.Full) => Fu[Option[CloudEval]]
+  type GetSinglePvEval = Situation => Fu[Option[CloudEval]]


### PR DESCRIPTION
submitted as pr, to not immediately add more churn to debugging the queue saturation