### PR TITLE
Add anchor ids next to markdown headers

### DIFF
--- a/modules/common/src/main/MarkdownRender.scala
+++ b/modules/common/src/main/MarkdownRender.scala
@@ -2,6 +2,7 @@ package lila.common
 
 import chess.format.pgn.PgnStr
 import com.vladsch.flexmark.ast.{ AutoLink, Image, Link, LinkNode }
+import com.vladsch.flexmark.ext.anchorlink.AnchorLinkExtension
 import com.vladsch.flexmark.ext.autolink.AutolinkExtension
 import com.vladsch.flexmark.ext.gfm.strikethrough.StrikethroughExtension
 import com.vladsch.flexmark.ext.tables.{ TableBlock, TablesExtension }
@@ -51,6 +52,7 @@ final class MarkdownRender(
 ):
 
   private val extensions = java.util.ArrayList[Extension]()
+  if header then extensions.add(AnchorLinkExtension.create())
   if table then
     extensions.add(TablesExtension.create())
     extensions.add(MarkdownRender.tableWrapperExtension)
@@ -73,7 +75,8 @@ final class MarkdownRender(
 
   // configurable
   if table then options.set(TablesExtension.CLASS_NAME, "slist")
-  if !header then options.set(Parser.HEADING_PARSER, Boolean.box(false))
+  if header then options.set(AnchorLinkExtension.ANCHORLINKS_WRAP_TEXT, Boolean.box(false))
+  else options.set(Parser.HEADING_PARSER, Boolean.box(false))
   if !blockQuote then options.set(Parser.BLOCK_QUOTE_PARSER, Boolean.box(false))
   if !list then options.set(Parser.LIST_BLOCK_PARSER, Boolean.box(false))
 

--- a/modules/common/src/test/MarkdownTest.scala
+++ b/modules/common/src/test/MarkdownTest.scala
@@ -7,7 +7,8 @@ import lila.core.misc.lpv.LpvEmbed
 
 class MarkdownTest extends munit.FunSuite:
 
-  val render: Markdown => Html = new MarkdownRender(assetDomain = AssetDomain("lichess1.org").some)("test")
+  val render: Markdown => Html =
+    new MarkdownRender(assetDomain = AssetDomain("lichess1.org").some, header = true)("test")
 
   test("autolinks add rel") {
     val md = Markdown("https://example.com")
@@ -86,5 +87,12 @@ class MarkdownTest extends munit.FunSuite:
       Html:
         s"""<p>foo <div data-pgn="$chapterPgn" class="lpv--autostart is2d">$chapterUrl</div> bar</p>
 """
+    )
+  }
+  test("anchorlink added for headings") {
+    assertEquals(
+      render(Markdown("# heading")),
+      Html("""<h1><a href="#heading" id="heading"></a>heading</h1>
+""")
     )
   }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -62,7 +62,7 @@ object Dependencies {
     val version = "0.64.8"
     val bundle =
       ("com.vladsch.flexmark" % "flexmark" % version) ::
-        List("ext-tables", "ext-autolink", "ext-gfm-strikethrough", "html2md-converter").map { ext =>
+        List("ext-tables", "ext-anchorlink", "ext-autolink", "ext-gfm-strikethrough", "html2md-converter").map { ext =>
           "com.vladsch.flexmark" % s"flexmark-$ext" % version
         }
   }


### PR DESCRIPTION
For linking to specific sections on pages

| markdown                | rendered as html                                            |
|-------------------------|---------------------------------------------------------|
| ```## test ``` | ```<h2><a href="#test" id="test"></a>test</h2> ``` |
