### PR TITLE
Bump scala 3.5.0-RC7

### DIFF
--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -6,7 +6,7 @@ object BuildSettings {
   import Dependencies._
 
   val lilaVersion        = "4.0"
-  val globalScalaVersion = "3.5.0-RC4"
+  val globalScalaVersion = "3.5.0-RC7"
 
   def buildSettings =
     Defaults.coreDefaultSettings ++ Seq(
@@ -47,7 +47,7 @@ object BuildSettings {
     "-Ybackend-parallelism:16", // https://github.com/scala/scala3/pull/15392
     // "-nowarn", // during migration
     // "-rewrite",
-    "-source:3.6-migration",
+    "-source:3.7",
     "-indent",
     // "-explaintypes",
     // "-explain",


### PR DESCRIPTION
Also set `-source:3.7` as they delay [new givens prioritization scheme](https://github.com/scala/scala3/pull/19300https://github.com/scala/scala3/pull/19300) to scala 3.7. And We want to keep using this new scheme as We already migrated to this scheme.

reference: https://contributors.scala-lang.org/t/3-5-0-release-thread/6666/40