### PR TITLE
Align API resp block/unblock with follow/unfollow

### DIFF
--- a/app/controllers/Relation.scala
+++ b/app/controllers/Relation.scala
@@ -29,9 +29,7 @@ final class Relation(env: Env, apiC: => Api) extends LilaController(env):
       ,
       Ok:
         Json.obj(
-          "followable" -> followable,
-          "following"  -> relation.contains(true),
-          "blocking"   -> relation.contains(false)
+          "ok" -> true
         )
     )
   yield res


### PR DESCRIPTION
Use the same simple JSON response as follow/unfollow:
```json
{
    "ok": true
}
```

Looks like the endpoint was enabled in da4dd06 for mobile (and non-mobile).

The above change looks compatible, as mobile seems to only check status code - lichess-org/mobile/commit/e78bf2f

https://github.com/lichess-org/mobile/blob/main/lib/src/model/relation/relation_repository.dart#L44-L66

```dart
...
  Future<void> block(UserId userId) async {
    final uri = Uri(path: '/api/rel/block/$userId');
    final response = await client.post(uri);

    if (response.statusCode >= 400) {
      throw http.ClientException(
        'Failed to block user: ${response.statusCode}',
        uri,
      );
    }
  }

  Future<void> unblock(UserId userId) async {
    final uri = Uri(path: '/api/rel/unblock/$userId');
    final response = await client.post(uri);

    if (response.statusCode >= 400) {
      throw http.ClientException(
        'Failed to unblock user: ${response.statusCode}',
        uri,
      );
    }
  }
...