### PR TITLE
Try to fix ci

### DIFF
--- a/modules/relation/src/main/RelationApi.scala
+++ b/modules/relation/src/main/RelationApi.scala
@@ -190,7 +190,7 @@ final class RelationApi(
   def isBlockedByAny(by: Iterable[UserId])(using me: Option[Me]): Fu[Boolean] =
     me.ifTrue(by.nonEmpty)
       .so: me =>
-        coll.exists($doc("_id".$in(by.map(makeId(_, me.id)))))
+        coll.exists($doc("_id".$in(by.map(makeId(_, me.userId)))))
 
   def searchFollowedBy(u: UserId, term: UserSearch, max: Int): Fu[List[UserId]] =
     repo


### PR DESCRIPTION
Fix ci: https://github.com/lichess-org/lila/actions/runs/10334049938/job/28607066309#step:5:194
```
[error] -- [E007] Type Mismatch Error: /home/runner/work/lila/lila/modules/relation/src/main/RelationApi.scala:193:52 
[error] 193 |        coll.exists($doc("_id".$in(by.map(makeId(_, me.id)))))
[error]     |                                                    ^^
[error]     |Found:    (me : lila.core.user.Me)
[error]     |Required: ?{ id: ? }
[error]     |Note that implicit extension methods cannot be applied because they are ambiguous;
[error]     |both given instance given_UserIdOf_Me in object Me and given instance given_Conversion_Me_User in object Me provide an extension method `id` on (me : lila.core.user.Me)
```

Not sure why I can't reproduce this locally.