### PR TITLE
remove `anus` from `LameName`

### DIFF
--- a/modules/common/src/main/LameName.scala
+++ b/modules/common/src/main/LameName.scala
@@ -25,7 +25,6 @@ object LameName:
     "1488",
     "8814",
     "administrator",
-    "anus",
     "asshole",
     "bastard",
     "biden",


### PR DESCRIPTION
Removing due to excessive false risk, per previous instances and internal discussion