### PR TITLE
Only add swiss JSON "stats" field if exists

### DIFF
--- a/modules/swiss/src/main/SwissJson.scala
+++ b/modules/swiss/src/main/SwissJson.scala
@@ -26,11 +26,12 @@ final class SwissJson(
   import lila.gathering.ConditionHandlers.JSONHandlers.*
 
   def api(swiss: Swiss, verdicts: WithVerdicts)(using lang: Lang) = statsApi(swiss).map { stats =>
-    swissJsonBase(swiss) ++ Json.obj(
-      "verdicts" -> verdictsFor(verdicts, swiss.perfType),
-      "stats"    -> stats,
-      "rated"    -> swiss.settings.rated
-    )
+    swissJsonBase(swiss) ++ Json
+      .obj(
+        "verdicts" -> verdictsFor(verdicts, swiss.perfType),
+        "rated"    -> swiss.settings.rated
+      )
+      .add("stats" -> stats)
   }
 
   def apply(


### PR DESCRIPTION
Background: Swiss tournaments have stats, like how many games, wins per color, draws etc.

Problem: In the API, the `"stats"` field can be `null` when there exists no stats yet.

Suggestion: Don't include `"stats"` field when no stats exists.

Alternative: Generate an "all 0s"/empty stats object.

Reproducers:

Create (needs existing team id, here 'yulias')

    $ curl \
        -d 'clock.limit=180&clock.increment=2&nbRounds=3' \
        -H "authorization: Bearer lip_yulia" \
        http://localhost:8080/api/swiss/new/yulias | jq

<details>
<summary>create response</summary>

```json
{
  "id": "WVP78M6P",
  "createdBy": "yulia",
  "startsAt": "2024-08-18T06:52:46.262Z",
  "name": "Alekseev",
  "clock": {
    "limit": 180,
    "increment": 2
  },
  "variant": "standard",
  "round": 0,
  "nbRounds": 3,
  "nbPlayers": 0,
  "nbOngoing": 0,
  "status": "created",
  "nextRound": {
    "at": "2024-08-18T06:52:46.262Z",
    "in": 349
  },
  "verdicts": {
    "list": [],
    "accepted": true
  },
  "stats": null,
  "rated": true
}
```
</details>

Get (needs existing swiss id, here 'WVP78M6P')

    $ curl http://localhost:8080/api/swiss/WVP78M6P | jq

<details>
<summary>get response</summary>

```json
{
  "id": "WVP78M6P",
  "createdBy": "yulia",
  "startsAt": "2024-08-18T06:52:46.262Z",
  "name": "Alekseev",
  "clock": {
    "limit": 180,
    "increment": 2
  },
  "variant": "standard",
  "round": 0,
  "nbRounds": 3,
  "nbPlayers": 0,
  "nbOngoing": 0,
  "status": "created",
  "nextRound": {
    "at": "2024-08-18T06:54:47.518Z",
    "in": 45
  },
  "verdicts": {
    "list": [],
    "accepted": true
  },
  "stats": null,
  "rated": true
}
```
</details>

With the commit included:

    $ curl http://localhost:8080/api/swiss/WVP78M6P

<details>
<summary>get response - no "stats" field</summary>

```json
{
  "id": "WVP78M6P",
  "createdBy": "yulia",
  "startsAt": "2024-08-18T06:52:46.262Z",
  "name": "Alekseev",
  "clock": {
    "limit": 180,
    "increment": 2
  },
  "variant": "standard",
  "round": 0,
  "nbRounds": 3,
  "nbPlayers": 0,
  "nbOngoing": 0,
  "status": "created",
  "nextRound": {
    "at": "2024-08-18T06:56:48.906Z",
    "in": 9
  },
  "verdicts": {
    "list": [],
    "accepted": true
  },
  "rated": true
}
```
</details>