### PR TITLE
Show Swiss position in API

### DIFF
--- a/modules/gathering/src/main/GatheringJson.scala
+++ b/modules/gathering/src/main/GatheringJson.scala
@@ -1,0 +1,24 @@
+package lila.gathering
+
+import play.api.libs.json.*
+import chess.format.Fen
+import lila.common.Json.given
+
+object GatheringJson:
+
+  def position(fen: Fen.Standard): JsObject =
+    Thematic.byFen(fen) match
+      case Some(pos) =>
+        Json
+          .obj(
+            "eco"  -> pos.eco,
+            "name" -> pos.name,
+            "fen"  -> pos.fen,
+            "url"  -> pos.url
+          )
+      case None =>
+        Json
+          .obj(
+            "name" -> "Custom position",
+            "fen"  -> fen
+          )

--- a/modules/swiss/src/main/SwissJson.scala
+++ b/modules/swiss/src/main/SwissJson.scala
@@ -1,5 +1,6 @@
 package lila.swiss
 
+import chess.format.Fen
 import play.api.i18n.Lang
 import play.api.libs.json.*
 
@@ -179,6 +180,7 @@ object SwissJson:
       })
       .add("isRecentlyFinished" -> swiss.isRecentlyFinished)
       .add("password" -> swiss.settings.password.isDefined)
+      .add("position" -> swiss.settings.position.map(fullFen => positionJson(fullFen.opening)))
 
   private[swiss] def playerJson(swiss: Swiss, view: SwissPlayer.View): JsObject =
     playerJsonBase(view, performance = false) ++ Json
@@ -295,6 +297,24 @@ object SwissJson:
       "rating" -> player.rating,
       "user"   -> player.user
     )
+
+  // duplicate modules/tournament/src/main/JsonView.scala
+  private[swiss] def positionJson(fen: Fen.Standard): JsObject =
+    lila.gathering.Thematic.byFen(fen) match
+      case Some(pos) =>
+        Json
+          .obj(
+            "eco"  -> pos.eco,
+            "name" -> pos.name,
+            "fen"  -> pos.fen,
+            "url"  -> pos.url
+          )
+      case None =>
+        Json
+          .obj(
+            "name" -> "Custom position",
+            "fen"  -> fen
+          )
 
   private given Writes[SwissRoundNumber]  = Writes(n => JsNumber(n.value))
   private given Writes[SwissPoints]       = Writes(p => JsNumber(BigDecimal(p.value)))

--- a/modules/swiss/src/main/SwissJson.scala
+++ b/modules/swiss/src/main/SwissJson.scala
@@ -10,6 +10,7 @@ import lila.core.socket.SocketVersion
 import lila.db.dsl.{ *, given }
 import lila.gathering.Condition.WithVerdicts
 import lila.gathering.GreatPlayer
+import lila.gathering.GatheringJson.*
 import lila.quote.Quote.given
 
 final class SwissJson(
@@ -180,7 +181,7 @@ object SwissJson:
       })
       .add("isRecentlyFinished" -> swiss.isRecentlyFinished)
       .add("password" -> swiss.settings.password.isDefined)
-      .add("position" -> swiss.settings.position.map(fullFen => positionJson(fullFen.opening)))
+      .add("position" -> swiss.settings.position.map(fullFen => position(fullFen.opening)))
 
   private[swiss] def playerJson(swiss: Swiss, view: SwissPlayer.View): JsObject =
     playerJsonBase(view, performance = false) ++ Json
@@ -297,24 +298,6 @@ object SwissJson:
       "rating" -> player.rating,
       "user"   -> player.user
     )
-
-  // duplicate modules/tournament/src/main/JsonView.scala
-  private[swiss] def positionJson(fen: Fen.Standard): JsObject =
-    lila.gathering.Thematic.byFen(fen) match
-      case Some(pos) =>
-        Json
-          .obj(
-            "eco"  -> pos.eco,
-            "name" -> pos.name,
-            "fen"  -> pos.fen,
-            "url"  -> pos.url
-          )
-      case None =>
-        Json
-          .obj(
-            "name" -> "Custom position",
-            "fen"  -> fen
-          )
 
   private given Writes[SwissRoundNumber]  = Writes(n => JsNumber(n.value))
   private given Writes[SwissPoints]       = Writes(p => JsNumber(BigDecimal(p.value)))

--- a/modules/tournament/src/main/ApiJsonView.scala
+++ b/modules/tournament/src/main/ApiJsonView.scala
@@ -6,6 +6,7 @@ import lila.common.Json.given
 import lila.core.i18n.Translate
 import lila.gathering.Condition
 import lila.gathering.ConditionHandlers.JSONHandlers.given
+import lila.gathering.GatheringJson.*
 import lila.rating.PerfType
 
 final class ApiJsonView(lightUserApi: lila.core.user.LightUserApi)(using Executor):
@@ -63,7 +64,7 @@ final class ApiJsonView(lightUserApi: lila.core.user.LightUserApi)(using Executo
       .add("onlyTitled", tour.conditions.titled.isDefined)
       .add("teamMember", tour.conditions.teamMember.map(_.teamId))
       .add("private", tour.isPrivate)
-      .add("position", tour.position.map(positionJson))
+      .add("position", tour.position.map(position))
       .add("schedule", tour.schedule.map(scheduleJson))
       .add(
         "teamBattle",

--- a/modules/tournament/src/main/JsonView.scala
+++ b/modules/tournament/src/main/JsonView.scala
@@ -16,6 +16,7 @@ import lila.core.i18n.Translate
 import lila.core.socket.SocketVersion
 import lila.core.user.LightUserApi
 import lila.gathering.{ Condition, ConditionHandlers, GreatPlayer }
+import lila.gathering.GatheringJson.*
 import lila.memo.CacheApi.*
 import lila.memo.SettingStore
 import lila.rating.PerfType
@@ -114,7 +115,7 @@ final class JsonView(
           .add("spotlight" -> tour.spotlight)
           .add("berserkable" -> tour.berserkable)
           .add("noStreak" -> tour.noStreak)
-          .add("position" -> tour.position.ifTrue(full).map(positionJson))
+          .add("position" -> tour.position.ifTrue(full).map(position))
           .add("verdicts" -> verdicts.map(verdictsFor(_, tour.perfType)))
           .add("schedule" -> tour.schedule.map(scheduleJson))
           .add("private" -> tour.isPrivate)
@@ -557,23 +558,6 @@ object JsonView:
       "limit"     -> clock.limitSeconds,
       "increment" -> clock.incrementSeconds
     )
-
-  private[tournament] def positionJson(fen: Fen.Standard): JsObject =
-    lila.gathering.Thematic.byFen(fen) match
-      case Some(pos) =>
-        Json
-          .obj(
-            "eco"  -> pos.eco,
-            "name" -> pos.name,
-            "fen"  -> pos.fen,
-            "url"  -> pos.url
-          )
-      case None =>
-        Json
-          .obj(
-            "name" -> "Custom position",
-            "fen"  -> fen
-          )
 
   private[tournament] given OWrites[Spotlight] = OWrites: s =>
     Json


### PR DESCRIPTION
Background: Swiss tournaments can have custom positions, i.e games start from a FEN.

Problem: In the API, there is no `"position"` field in the "create swiss" and "get swiss" operations.

Suggestion: Include `"position"` field when a custom position exists.

Reproducers:

Create (needs existing team id, here 'yulias')

    $ curl \
        -d 'rated=false&clock.limit=180&clock.increment=2&nbRounds=3&variant=standard&position=rnbqkbnr%2Fpppp1ppp%2F4p3%2F8%2F4P3%2F8%2FPPPP1PPP%2FRNBQKBNR+w+KQkq+-' \
        -H "authorization: Bearer lip_yulia" \
        http://localhost:8080/api/swiss/new/yulias | jq

<details>
<summary>create response</summary>

```json
{
  "id": "2wexQyFc",
  "createdBy": "yulia",
  "startsAt": "2024-08-18T08:57:41.030552736Z",
  "name": "Gunina",
  "clock": {
    "limit": 180,
    "increment": 2
  },
  "variant": "standard",
  "round": 0,
  "nbRounds": 3,
  "nbPlayers": 0,
  "nbOngoing": 0,
  "status": "created",
  "nextRound": {
    "at": "2024-08-18T08:57:41.03049833Z",
    "in": 600
  },
  "verdicts": {
    "list": [],
    "accepted": true
  },
  "stats": null,
  "rated": false
}
```
</details>

Get (needs existing swiss id, here '2wexQyFc')

    $ curl http://localhost:8080/api/swiss/2wexQyFc | jq

<details>
<summary>get response</summary>

```json
{
  "id": "2wexQyFc",
  "createdBy": "yulia",
  "startsAt": "2024-08-18T08:57:41.03Z",
  "name": "Gunina",
  "clock": {
    "limit": 180,
    "increment": 2
  },
  "variant": "standard",
  "round": 0,
  "nbRounds": 3,
  "nbPlayers": 0,
  "nbOngoing": 0,
  "status": "created",
  "nextRound": {
    "at": "2024-08-18T08:57:41.03Z",
    "in": 567
  },
  "verdicts": {
    "list": [],
    "accepted": true
  },
  "stats": null,
  "rated": false
}
```
</details>

With the commit included:

    $ curl \
        -d 'rated=false&clock.limit=180&clock.increment=2&nbRounds=3&variant=standard&position=rnbqkbnr%2Fpppp1ppp%2F4p3%2F8%2F4P3%2F8%2FPPPP1PPP%2FRNBQKBNR+w+KQkq+-' \
        -H "authorization: Bearer lip_yulia" \
        http://localhost:8080/api/swiss/new/yulias | jq

<details>
<summary>create response - known/named FEN</summary>

```json
{
  "id": "UvF9ICqp",
  "createdBy": "yulia",
  "startsAt": "2024-08-18T08:59:57.075598264Z",
  "name": "Palme",
  "clock": {
    "limit": 180,
    "increment": 2
  },
  "variant": "standard",
  "round": 0,
  "nbRounds": 3,
  "nbPlayers": 0,
  "nbOngoing": 0,
  "status": "created",
  "nextRound": {
    "at": "2024-08-18T08:59:57.075545288Z",
    "in": 600
  },
  "position": {
    "eco": "C00",
    "name": "French Defense",
    "fen": "rnbqkbnr/pppp1ppp/4p3/8/4P3/8/PPPP1PPP/RNBQKBNR w KQkq -",
    "url": "https://lichess.org/opening/French_Defense"
  },
  "verdicts": {
    "list": [],
    "accepted": true
  },
  "stats": null,
  "rated": false
}
```
</details>


    $ curl \
        -d 'rated=false&clock.limit=180&clock.increment=2&nbRounds=3&variant=standard&position=rnbqkbnr%2F8%2F8%2F8%2F8%2F8%2F8%2FRNBQKBNR+w+KQkq+-' \
        -H "authorization: Bearer lip_yulia" \
        http://localhost:8080/api/swiss/new/yulias | jq



<details>
<summary>create response - no pawns FEN</summary>

```json
{
  "id": "Zra2y6CI",
  "createdBy": "yulia",
  "startsAt": "2024-08-18T09:01:49.545046494Z",
  "name": "Szabó",
  "clock": {
    "limit": 180,
    "increment": 2
  },
  "variant": "standard",
  "round": 0,
  "nbRounds": 3,
  "nbPlayers": 0,
  "nbOngoing": 0,
  "status": "created",
  "nextRound": {
    "at": "2024-08-18T09:01:49.545033073Z",
    "in": 600
  },
  "position": {
    "name": "Custom position",
    "fen": "rnbqkbnr/8/8/8/8/8/8/RNBQKBNR w KQkq -"
  },
  "verdicts": {
    "list": [],
    "accepted": true
  },
  "stats": null,
  "rated": false
}
```
</details>