### PR TITLE
Improve ux of long underboard translations

### DIFF
--- a/app/views/analyse/replay.scala
+++ b/app/views/analyse/replay.scala
@@ -118,20 +118,33 @@ def replay(
                   lila.game.GameExt
                     .analysable(game)
                     .option(
-                      span(role := "tab", cls := "computer-analysis", dataPanel := "computer-analysis")(
+                      span(
+                        role      := "tab",
+                        cls       := "computer-analysis",
+                        dataPanel := "computer-analysis",
+                        title     := trans.site.computerAnalysis.txt()
+                      )(
                         trans.site.computerAnalysis()
                       )
                     ),
                   (!game.isPgnImport).option(
                     frag(
                       (game.ply > 1)
-                        .option(span(role := "tab", dataPanel := "move-times")(trans.site.moveTimes())),
+                        .option(
+                          span(role := "tab", dataPanel := "move-times", title := trans.site.moveTimes.txt())(
+                            trans.site.moveTimes()
+                          )
+                        ),
                       cross.isDefined.option(
-                        span(role := "tab", dataPanel := "ctable")(trans.site.crosstable())
+                        span(role := "tab", dataPanel := "ctable", title := trans.site.crosstable.txt())(
+                          trans.site.crosstable()
+                        )
                       )
                     )
                   ),
-                  span(role := "tab", dataPanel := "fen-pgn")(trans.study.shareAndExport())
+                  span(role := "tab", dataPanel := "fen-pgn", title := trans.study.shareAndExport.txt())(
+                    trans.study.shareAndExport()
+                  )
                 ),
                 div(cls := "analyse__underboard__panels")(
                   lila.game.GameExt

--- a/app/views/analyse/replay.scala
+++ b/app/views/analyse/replay.scala
@@ -122,29 +122,20 @@ def replay(
                         role      := "tab",
                         cls       := "computer-analysis",
                         dataPanel := "computer-analysis",
-                        title     := trans.site.computerAnalysis.txt()
-                      )(
-                        trans.site.computerAnalysis()
+                        textAndTitle(trans.site.computerAnalysis)
                       )
                     ),
                   (!game.isPgnImport).option(
                     frag(
-                      (game.ply > 1)
-                        .option(
-                          span(role := "tab", dataPanel := "move-times", title := trans.site.moveTimes.txt())(
-                            trans.site.moveTimes()
-                          )
-                        ),
+                      (game.ply > 1).option(
+                        span(role := "tab", dataPanel := "move-times", textAndTitle(trans.site.moveTimes))
+                      ),
                       cross.isDefined.option(
-                        span(role := "tab", dataPanel := "ctable", title := trans.site.crosstable.txt())(
-                          trans.site.crosstable()
-                        )
+                        span(role := "tab", dataPanel := "ctable", textAndTitle(trans.site.crosstable))
                       )
                     )
                   ),
-                  span(role := "tab", dataPanel := "fen-pgn", title := trans.study.shareAndExport.txt())(
-                    trans.study.shareAndExport()
-                  )
+                  span(role := "tab", dataPanel := "fen-pgn", textAndTitle(trans.study.shareAndExport))
                 ),
                 div(cls := "analyse__underboard__panels")(
                   lila.game.GameExt

--- a/modules/ui/src/main/scalatags.scala
+++ b/modules/ui/src/main/scalatags.scala
@@ -8,6 +8,7 @@ import scalalib.Render
 import scalatags.Text.all.*
 import scalatags.Text.{ Aggregate, Cap, GenericAttr }
 import scalatags.text.Builder
+import lila.core.i18n.{ I18nKey, Translate }
 
 // collection of lila attrs
 trait ScalatagsAttrs:
@@ -166,5 +167,10 @@ trait ScalatagsExtensions:
     val value = Builder.GenericAttrValueSource(v)
     t.setAttr("title", value)
     t.setAttr("aria-label", value)
+
+  def textAndTitle(i18n: I18nKey)(using Translate): Modifier = (t: Builder) =>
+    val value = Builder.GenericAttrValueSource(i18n.txt())
+    t.setAttr("title", Builder.GenericAttrValueSource(i18n.txt()))
+    t.addChild(i18n())
 
 object ScalatagsExtensions extends ScalatagsExtensions

--- a/ui/analyse/css/_round-underboard.scss
+++ b/ui/analyse/css/_round-underboard.scss
@@ -15,7 +15,7 @@ $col2-panel-height: 240px;
     align-items: flex-start;
 
     > span {
-      @extend %roboto, %box-radius-top, %page-text;
+      @extend %roboto, %box-radius-top, %page-text, %ellipsis;
 
       flex: 1 1 0;
       text-align: center;
@@ -24,8 +24,6 @@ $col2-panel-height: 240px;
       cursor: pointer;
       position: relative;
       white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
 
       &:hover {
         background: $c-body-gradient;

--- a/ui/analyse/css/_round-underboard.scss
+++ b/ui/analyse/css/_round-underboard.scss
@@ -23,6 +23,9 @@ $col2-panel-height: 240px;
       padding: 0.4em 0.1em;
       cursor: pointer;
       position: relative;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
 
       &:hover {
         background: $c-body-gradient;


### PR DESCRIPTION
When using translations, underboard tab controls can break lines and look like this:

<img width="529" alt="Screenshot 2024-08-19 at 00 14 59" src="https://github.com/user-attachments/assets/e0b763aa-253d-4c84-bd00-017a4757f9ef">

After this PR it should look like this forced to be only on 1 line:

<img width="740" alt="Screenshot 2024-08-19 at 00 29 17" src="https://github.com/user-attachments/assets/54466462-10da-467c-b394-8684b01eb9f2">

Another option would be forcing all tab headers to have same height, tell me if you'd prefer to go this way

p.s. I'm not too much into Scala, didn't build the project, just found another `title :=` example in views and repeated the pattern to show the hover tooltip, hope those `.txt()` should work