### PR TITLE
Lila search 3.0.0 for real

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -26,7 +26,7 @@ object Dependencies {
   val lettuce     = "io.lettuce"                    % "lettuce-core"                    % "6.4.0.RELEASE"
   val nettyTransport =
     ("io.netty" % s"netty-transport-native-$notifier" % "4.1.112.Final").classifier(s"$os-$arch")
-  val lilaSearch  = "org.lichess.search"         %% "client"        % "3.0.0-RC10"
+  val lilaSearch  = "org.lichess.search"         %% "client"        % "3.0.0"
   val munit       = "org.scalameta"              %% "munit"         % "1.0.1" % Test
   val uaparser    = "org.uaparser"               %% "uap-scala"     % "0.17.0"
   val apacheText  = "org.apache.commons"          % "commons-text"  % "1.12.0"


### PR DESCRIPTION
The protocol is still the same so We don't need to redeploy `lila-search`. 

Just update to have the same Scala 3.5.0.