### PR TITLE
players' table tweaks

### DIFF
--- a/modules/relay/src/main/RelayPlayer.scala
+++ b/modules/relay/src/main/RelayPlayer.scala
@@ -147,9 +147,11 @@ private final class RelayPlayerApi(
               fidePlayer <- fidePlayerOpt
               r          <- player.rating.orElse(fidePlayer.ratingOf(tc))
               p = Elo.Player(r, fidePlayer.kFactorOf(tc))
-              games = player.games.flatMap: g =>
-                g.opponent.rating.map: opRating =>
-                  Elo.Game(g.outcome.flatMap(_.winner.map(_ == g.color)), opRating)
+              games = for
+                g        <- player.games
+                outcome  <- g.outcome
+                opRating <- g.opponent.rating
+              yield Elo.Game(outcome.winner.map(_ == g.color), opRating)
             yield player.copy(ratingDiff = games.nonEmpty.option(Elo.computeRatingDiff(p, games)))
           .map: newPlayer =>
             id -> (newPlayer | player)

--- a/ui/analyse/src/study/relay/relayPlayers.ts
+++ b/ui/analyse/src/study/relay/relayPlayers.ts
@@ -90,6 +90,9 @@ const renderPlayers = (ctrl: RelayPlayers, players: RelayPlayer[]): VNode => {
   const withRating = !!players.find(p => p.rating);
   const withScores = !!players.find(p => p.score);
   const defaultSort = { attrs: { 'data-sort-default': 1 } };
+  const sortByBoth = (x?: number, y?: number) => ({
+    attrs: { 'data-sort': (x || 0) * 100000 + (y || 0) },
+  });
   return h(
     'table.relay-tour__players.slist.slist-invert.slist-pad',
     {
@@ -120,10 +123,16 @@ const renderPlayers = (ctrl: RelayPlayers, players: RelayPlayer[]): VNode => {
                 [playerFed(player.fed), userTitle(player), player.name],
               ),
             ),
-            h('td', withRating && player.rating ? [`${player.rating}`, ratingDiff(player)] : undefined),
+            withRating
+              ? h(
+                  'td',
+                  sortByBoth(player.rating, player.score * 10),
+                  player.rating ? [`${player.rating}`, ratingDiff(player)] : undefined,
+                )
+              : undefined,
             withScores
-              ? h('td', { attrs: { 'data-sort': player.score } }, `${player.score}/${player.played}`)
-              : h('td', `${player.played}`),
+              ? h('td', sortByBoth(player.score * 10, player.rating), `${player.score}/${player.played}`)
+              : h('td', sortByBoth(player.played, player.rating), `${player.played}`),
           ]),
         ),
       ),

--- a/ui/analyse/src/study/relay/relayPlayers.ts
+++ b/ui/analyse/src/study/relay/relayPlayers.ts
@@ -100,9 +100,8 @@ const renderPlayers = (ctrl: RelayPlayers, players: RelayPlayer[]): VNode => {
         'thead',
         h('tr', [
           h('th', 'Player'),
-          withRating ? h('th', defaultSort, 'Elo') : undefined,
-          ctrl.showScores && h('th', 'Score'),
-          h('th', 'Games'),
+          withRating ? h('th', !ctrl.showScores && defaultSort, 'Elo') : undefined,
+          ctrl.showScores ? h('th', defaultSort, 'Score') : h('th', 'Games'),
         ]),
       ),
       h(
@@ -122,8 +121,9 @@ const renderPlayers = (ctrl: RelayPlayers, players: RelayPlayer[]): VNode => {
               ),
             ),
             h('td', withRating && player.rating ? [`${player.rating}`, ratingDiff(player)] : undefined),
-            ctrl.showScores && h('td', `${player.score}`),
-            h('td', `${player.played}`),
+            ctrl.showScores
+              ? h('td', { attrs: { 'data-sort': player.score } }, `${player.score}/${player.played}`)
+              : h('td', `${player.played}`),
           ]),
         ),
       ),


### PR DESCRIPTION
* Sort by score by default when the leaderboard is enabled.
* Merge `Games` column into `Score`. Data in the format of `Score/Games` e.g. `3.5/5` 
  It takes up too much space. The games column doesn't really benefit from sorting.