### PR TITLE
Fix /study/topic error when not logged in

### DIFF
--- a/ui/analyse/src/plugins/analyse.study.topic.form.ts
+++ b/ui/analyse/src/plugins/analyse.study.topic.form.ts
@@ -6,7 +6,7 @@ site.load.then(() => {
   const input = document.getElementById('form3-topics') as HTMLInputElement;
   const tagify = new Tagify(input, {
     pattern: /.{2,}/,
-    maxTags: parseInt(input.dataset['max']!) || 64,
+    maxTags: parseInt(input?.dataset['max'] ?? '64'),
   });
   const doFetch: (term: string) => Promise<string[]> = debounce(
     (term: string) => xhr.json(xhr.url('/study/topic/autocomplete', { term })),


### PR DESCRIPTION
Resolves #15940

Fixes JS error when opening [/study/topic](https://www.lichess.org/study/topic) while not being signed in.

![360066602-d36dad3a-b8ae-4612-b862-ffa999b84783](https://github.com/user-attachments/assets/c679ba0f-19c1-44de-9283-76dd7d5820fa)
