### PR TITLE
ui/learn: Do not initialize level if navigating to level map

### DIFF
--- a/ui/learn/src/ctrl.ts
+++ b/ui/learn/src/ctrl.ts
@@ -28,7 +28,7 @@ export class LearnCtrl {
     window.addEventListener('hashchange', () => {
       this.setStageLevelFromHash();
       this.sideCtrl.updateCategId();
-      this.runCtrl.initializeLevel();
+      if (this.opts.stageId !== null) this.runCtrl.initializeLevel();
       this.redraw();
     });
   }


### PR DESCRIPTION
Closes #15535. Thanks @fitztrev for surfacing and finding the issue! I think the cleanest fix is here: whenever some hash navigation occurred, we were initializing the level. We don't actually need to initialize a level if we are navigating to the main Learn page. 