### PR TITLE
Mod comms: more accurate highlighting of public chat messages

### DIFF
--- a/app/views/mod/communication.scala
+++ b/app/views/mod/communication.scala
@@ -132,7 +132,7 @@ def communication(
         else
           ul(cls := "public_chats")(
             publicLines.reverse.map: line =>
-              li(cls := "line author")(
+              li(
                 line.date.fold[Frag]("[OLD]")(momentFromNowServer),
                 " ",
                 line.from.map:
@@ -147,7 +147,7 @@ def communication(
                   case PublicSource.Ublog(id) => a(href := routes.Ublog.redirect(id))("User blog #", id)
                 ,
                 nbsp,
-                span(cls := "message")(Analyser.highlightBad(line.text))
+                span(cls := "line author")(span(cls := "message")(Analyser.highlightBad(line.text)))
               )
           )
         ,


### PR DESCRIPTION
Allow to click on the source of the public message without adding it to a note.

Nested span needed to keep JS note pasting working

```js
// lila/ui/mod/src/mod.inquiry.ts

  $('#communication').on('click', '.line.author, .post.author', function (this: HTMLElement) {
    // Need to take username from the communication page so that when being in inquiry for user A and checking communication of user B
    // the notes cannot be mistakenly attributed to user A.
    const username = $('#communication').find('.title').text().split(' ')[0];
    const message = $(this).find('.message').text();
    addToNote(`${username}: "${message}"`);
  });
```