### PR TITLE
Fide: fix database parsing considering women as inactive

### DIFF
--- a/modules/fide/src/main/FidePlayerSync.scala
+++ b/modules/fide/src/main/FidePlayerSync.scala
@@ -157,7 +157,7 @@ final private class FidePlayerSync(repo: FideRepo, ws: StandaloneWSClient)(using
         blitz = rating(139),
         blitzK = kFactor(149),
         year = year,
-        inactive = flags.isDefined.some,
+        inactive = flags.map(_.contains("i")),
         fetchedAt = nowInstant
       )
 

--- a/modules/fide/src/main/FidePlayerSync.scala
+++ b/modules/fide/src/main/FidePlayerSync.scala
@@ -157,7 +157,7 @@ final private class FidePlayerSync(repo: FideRepo, ws: StandaloneWSClient)(using
         blitz = rating(139),
         blitzK = kFactor(149),
         year = year,
-        inactive = flags.map(_.contains("i")),
+        inactive = flags.exists(_.contains("i")).some,
         fetchedAt = nowInstant
       )
 


### PR DESCRIPTION
close https://github.com/lichess-org/lila/issues/15956

The FIDE db contains a flag "w" for women players. I don't get why it's there because there's already a sex field.

Example from the zip file, a woman player, and an inactive woman player.
```
ID Number      Name                                                         Fed Sex Tit  WTit OTit           FOA SRtng SGm SK RRtng RGm Rk BRtng BGm BK B-day Flag
8602980        Hou, Yifan                                                   CHN F   GM   WGM                     2633  3   10 2550  9   10 2529  18  10 1994  w
46668225       Aakarshna C G                                                IND F                                1498  0   20 0     0   0  0     0   0  2002  wi
```

after the fix, Hou Yifan correctly shows up in the player list

<img width="945" alt="image" src="https://github.com/user-attachments/assets/dd681760-7a13-4847-96c9-f063c0699bb5">
