### PR TITLE
Broadcast Public Notes

### DIFF
--- a/ui/analyse/css/study/relay/_tour.scss
+++ b/ui/analyse/css/study/relay/_tour.scss
@@ -272,6 +272,9 @@ $hover-bg: $m-primary_bg--mix-30;
       content: $licon-InfoCircle;
       font-size: 2.5em;
     }
+    &.pinned::before {
+      content: $licon-RadioTower;
+    }
     small {
       color: $c-font-dim;
     }

--- a/ui/analyse/src/study/relay/relayTourView.ts
+++ b/ui/analyse/src/study/relay/relayTourView.ts
@@ -314,7 +314,8 @@ const header = (ctx: RelayViewContext) => {
   const { ctrl, relay, allowVideo } = ctx;
   const d = relay.data,
     group = d.group,
-    embedVideo = d.videoUrls && allowVideo;
+    embedVideo = d.videoUrls && allowVideo,
+    studyD = ctrl.study?.data.description;
 
   return [
     h('div.relay-tour__header', [
@@ -340,6 +341,7 @@ const header = (ctx: RelayViewContext) => {
               : undefined,
       ),
     ]),
+    studyD && h('div.relay-tour__note.pinned', h('div', [h('div', studyD)])),
     d.note &&
       h(
         'div.relay-tour__note',


### PR DESCRIPTION
I had an idea here: since we have the admin note
Maybe we can add information for viewers (sometimes chat can be complicated)

![Screenshot 2024-08-27 14 57 56](https://github.com/user-attachments/assets/a1f76a47-0201-4f12-9aab-3fff9998b2fc)

In this case we can use "Pinned study comment" to save space and have information even when it is not in multiboard