### PR TITLE
Random color seeks

### DIFF
--- a/app/controllers/Setup.scala
+++ b/app/controllers/Setup.scala
@@ -153,7 +153,7 @@ final class Setup(
             me       <- ctx.me.so(env.user.api.withPerfs)
             blocking <- ctx.me.so(env.relation.api.fetchBlocking(_))
             uniqId = author.fold(_.value, u => s"sri:${u.id}")
-            res <- config.fixColor
+            res <- config
               .hook(reqSri | Sri(uniqId), me, sid = uniqId.some, lila.core.pool.Blocking(blocking))
               .match
                 case Left(hook) =>

--- a/modules/lobby/src/main/Biter.scala
+++ b/modules/lobby/src/main/Biter.scala
@@ -8,8 +8,7 @@ import lila.core.user.{ GameUsers, WithPerf }
 final private class Biter(
     userApi: lila.core.user.UserApi,
     gameRepo: lila.core.game.GameRepo,
-    newPlayer: lila.core.game.NewPlayer,
-    fixedColor: scalalib.cache.ExpireSetMemo[GameId]
+    newPlayer: lila.core.game.NewPlayer
 )(using Executor)(using idGenerator: lila.core.game.IdGenerator):
 
   def apply(hook: Hook, sri: Sri, user: Option[LobbyUser]): Fu[JoinHook] =
@@ -26,7 +25,7 @@ final private class Biter(
     for
       users <- userApi.gamePlayersAny(ByColor(lobbyUserOption.map(_.id), hook.userId), hook.perfType)
       (joiner, owner) = users.toPair
-      ownerColor <- assignCreatorColor(owner, joiner, hook.realColor)
+      ownerColor <- assignCreatorColor(owner, joiner)
       game <- idGenerator.withUniqueId:
         makeGame(
           hook,
@@ -35,7 +34,6 @@ final private class Biter(
       _ <- gameRepo.insertDenormalized(game)
     yield
       lila.mon.lobby.hook.join.increment()
-      rememberIfFixedColor(hook.realColor, game)
       JoinHook(sri, hook, game, ownerColor)
 
   private def join(seek: Seek, lobbyUser: LobbyUser): Fu[JoinSeek] =
@@ -44,31 +42,17 @@ final private class Biter(
         .gamePlayersLoggedIn(ByColor(lobbyUser.id, seek.user.id), seek.perfType)
         .orFail(s"No such seek users: $seek")
       (joiner, owner) = users.toPair
-      ownerColor <- assignCreatorColor(owner.some, joiner.some, seek.realColor)
+      ownerColor <- assignCreatorColor(owner.some, joiner.some)
       game <- idGenerator.withUniqueId:
         makeGame(
           seek,
           ownerColor.fold(ByColor(owner, joiner), ByColor(joiner, owner)).map(some)
         )
       _ <- gameRepo.insertDenormalized(game)
-    yield
-      rememberIfFixedColor(seek.realColor, game)
-      JoinSeek(joiner.id, seek, game, ownerColor)
+    yield JoinSeek(joiner.id, seek, game, ownerColor)
 
-  private def rememberIfFixedColor(color: TriColor, game: Game) =
-    if color != TriColor.Random
-    then fixedColor.put(game.id)
-
-  private def assignCreatorColor(
-      creatorUser: Option[WithPerf],
-      joinerUser: Option[WithPerf],
-      color: TriColor
-  ): Fu[Color] =
-    color match
-      case TriColor.Random =>
-        userApi.firstGetsWhite(creatorUser.map(_.id), joinerUser.map(_.id)).map { Color.fromWhite(_) }
-      case TriColor.White => fuccess(chess.White)
-      case TriColor.Black => fuccess(chess.Black)
+  private def assignCreatorColor(creatorUser: Option[WithPerf], joinerUser: Option[WithPerf]): Fu[Color] =
+    userApi.firstGetsWhite(creatorUser.map(_.id), joinerUser.map(_.id)).map { Color.fromWhite(_) }
 
   private def makeGame(hook: Hook, users: GameUsers) = lila.core.game
     .newGame(

--- a/modules/lobby/src/main/SeekApi.scala
+++ b/modules/lobby/src/main/SeekApi.scala
@@ -56,7 +56,7 @@ final class SeekApi(
       .foldLeft(List.empty[Seek] -> Set.empty[String]) {
         case ((res, h), seek) if seek.user.id == user.id => (seek :: res, h)
         case ((res, h), seek) =>
-          val seekH = List(seek.variant, seek.daysPerTurn, seek.mode, seek.color, seek.user.id).mkString(",")
+          val seekH = List(seek.variant, seek.daysPerTurn, seek.mode, seek.user.id).mkString(",")
           if h contains seekH then (res, h)
           else (seek :: res, h + seekH)
       }

--- a/modules/setup/src/main/AiConfig.scala
+++ b/modules/setup/src/main/AiConfig.scala
@@ -19,7 +19,8 @@ case class AiConfig(
     color: TriColor,
     fen: Option[Fen.Full] = None
 ) extends Config
-    with Positional:
+    with Positional
+    with WithColor:
 
   val strictFen = true
 

--- a/modules/setup/src/main/ApiAiConfig.scala
+++ b/modules/setup/src/main/ApiAiConfig.scala
@@ -17,7 +17,8 @@ final case class ApiAiConfig(
     level: Int,
     fen: Option[Fen.Full] = None
 ) extends Config
-    with Positional:
+    with Positional
+    with WithColor:
 
   val strictFen = false
 

--- a/modules/setup/src/main/Config.scala
+++ b/modules/setup/src/main/Config.scala
@@ -25,12 +25,7 @@ private[setup] trait Config:
   // Game variant code
   val variant: Variant
 
-  // Creator player color
-  val color: TriColor
-
   def hasClock = timeMode == TimeMode.RealTime
-
-  lazy val creatorColor = color.resolve()
 
   def makeGame(v: Variant): ChessGame =
     ChessGame(situation = Situation(v), clock = makeClock.map(_.toClock))
@@ -59,6 +54,14 @@ private[setup] trait Config:
 
   def perfType: PerfType = lila.rating.PerfType(variant, makeSpeed)
   def perfKey            = perfType.key
+
+trait WithColor:
+  self: Config =>
+
+  // creator player color
+  def color: TriColor
+
+  lazy val creatorColor = color.resolve()
 
 trait Positional:
   self: Config =>

--- a/modules/setup/src/main/FriendConfig.scala
+++ b/modules/setup/src/main/FriendConfig.scala
@@ -17,7 +17,8 @@ case class FriendConfig(
     color: TriColor,
     fen: Option[Fen.Full] = None
 ) extends HumanConfig
-    with Positional:
+    with Positional
+    with WithColor:
 
   val strictFen = false
 

--- a/modules/setup/src/main/HookConfig.scala
+++ b/modules/setup/src/main/HookConfig.scala
@@ -16,7 +16,6 @@ case class HookConfig(
     increment: Clock.IncrementSeconds,
     days: Days,
     mode: Mode,
-    color: TriColor,
     ratingRange: RatingRange
 ) extends HumanConfig:
 
@@ -24,17 +23,7 @@ case class HookConfig(
     if me.isEmpty then this
     else copy(ratingRange = ratingRange.withinLimits(perf.intRating, 500))
 
-  def fixColor = copy(
-    color =
-      if mode == Mode.Rated &&
-        variantsWhereWhiteIsBetter(variant) &&
-        color != TriColor.Random
-      then TriColor.Random
-      else color
-  )
-
-  def >> =
-    (variant.id, timeMode.id, time, increment, days, mode.id.some, ratingRange.toString.some, color.name).some
+  def >> = (variant.id, timeMode.id, time, increment, days, mode.id.some, ratingRange.toString.some).some
 
   def withTimeModeString(tc: Option[String]) =
     tc match
@@ -101,8 +90,7 @@ object HookConfig extends BaseHumanConfig:
       i: Clock.IncrementSeconds,
       d: Days,
       m: Option[Int],
-      e: Option[String],
-      c: String
+      e: Option[String]
   ) =
     val realMode = m.fold(Mode.default)(Mode.orDefault)
     new HookConfig(
@@ -112,8 +100,7 @@ object HookConfig extends BaseHumanConfig:
       increment = i,
       days = d,
       mode = realMode,
-      ratingRange = e.fold(RatingRange.default)(RatingRange.orDefault),
-      color = TriColor(c).err(s"Invalid color $c")
+      ratingRange = e.fold(RatingRange.default)(RatingRange.orDefault)
     )
 
   def default(auth: Boolean): HookConfig = default.copy(mode = Mode(auth))
@@ -125,8 +112,7 @@ object HookConfig extends BaseHumanConfig:
     increment = Clock.IncrementSeconds(3),
     days = Days(2),
     mode = Mode.default,
-    ratingRange = RatingRange.default,
-    color = TriColor.default
+    ratingRange = RatingRange.default
   )
 
   import lila.db.BSON
@@ -142,7 +128,6 @@ object HookConfig extends BaseHumanConfig:
         increment = r.get("i"),
         days = r.get("d"),
         mode = Mode.orDefault(r.int("m")),
-        color = TriColor.Random,
         ratingRange = r.strO("e").flatMap(RatingRange.parse).getOrElse(RatingRange.default)
       )
 

--- a/modules/setup/src/main/HookConfig.scala
+++ b/modules/setup/src/main/HookConfig.scala
@@ -58,7 +58,6 @@ case class HookConfig(
             variant = variant,
             clock = clock,
             mode = if lila.core.game.allowRated(variant, clock.some) then mode else Mode.Casual,
-            color = color.name,
             user = user,
             blocking = blocking,
             sid = sid,
@@ -71,7 +70,6 @@ case class HookConfig(
               variant = variant,
               daysPerTurn = makeDaysPerTurn,
               mode = mode,
-              color = color.name,
               user = u,
               blocking = blocking,
               ratingRange = ratingRange

--- a/modules/setup/src/main/Processor.scala
+++ b/modules/setup/src/main/Processor.scala
@@ -26,13 +26,12 @@ final private[setup] class Processor(
   yield pov
 
   def hook(
-      configBase: HookConfig,
+      config: HookConfig,
       sri: lila.core.socket.Sri,
       sid: Option[String],
       blocking: lila.core.pool.Blocking
   )(using me: Option[UserWithPerfs]): Fu[Processor.HookResult] =
     import Processor.HookResult.*
-    val config = configBase.fixColor
     config.hook(sri, me, sid, blocking) match
       case Left(hook) =>
         fuccess:

--- a/modules/setup/src/main/SetupForm.scala
+++ b/modules/setup/src/main/SetupForm.scala
@@ -66,8 +66,7 @@ object SetupForm:
       "increment"   -> increment,
       "days"        -> days,
       "mode"        -> mode(me.isDefined),
-      "ratingRange" -> optional(ratingRange),
-      "color"       -> color
+      "ratingRange" -> optional(ratingRange)
     )(HookConfig.from)(_.>>)
       .verifying("Invalid clock", _.validClock)
       .verifying("Can't create rated unlimited game", !_.isRatedUnlimited)
@@ -79,9 +78,8 @@ object SetupForm:
       "days"        -> optional(days),
       "variant"     -> optional(boardApiVariantKeys),
       "rated"       -> optional(boolean),
-      "color"       -> optional(color),
       "ratingRange" -> optional(ratingRange)
-    )((t, i, d, v, r, c, g) =>
+    )((t, i, d, v, r, g) =>
       HookConfig(
         variant = Variant.orDefault(v),
         timeMode = if d.isDefined then TimeMode.Correspondence else TimeMode.RealTime,
@@ -89,7 +87,6 @@ object SetupForm:
         increment = i | Clock.IncrementSeconds(5),
         days = d | Days(7),
         mode = chess.Mode(~r),
-        color = lila.lobby.TriColor.orDefault(c),
         ratingRange = g.fold(RatingRange.default)(RatingRange.orDefault)
       )
     )(_ => none)

--- a/ui/lobby/css/app/_hook-list.scss
+++ b/ui/lobby/css/app/_hook-list.scss
@@ -62,7 +62,7 @@
     @media (max-width: at-most($xx-small)) {
       padding: 1em 0.4em;
 
-      &:nth-child(3) {
+      &:nth-child(2) {
         max-width: 13vw;
         direction: rtl;
         text-align: left;
@@ -79,14 +79,8 @@
     background: $m-bg--fade-50;
 
     &:first-child {
-      width: 16px;
+      padding-inline-start: 2em;
     }
-
-    &:first-child ::before {
-      font-size: 1.2em;
-      line-height: 1.3;
-    }
-
     &:last-child ::before {
       margin-inline-end: 8px;
       line-height: 0.9;
@@ -100,12 +94,8 @@
     @media (max-width: at-most($xx-small)) {
       padding: 0.5em 0.4em;
 
-      &:first-child {
-        padding-inline-start: 0.7em;
-      }
-
       // player name
-      &:nth-child(2) {
+      &:first-child {
         @include ellipsis;
         max-width: 25vw;
       }

--- a/ui/lobby/src/interfaces.ts
+++ b/ui/lobby/src/interfaces.ts
@@ -32,7 +32,6 @@ export interface Hook {
   u?: string; // username
   rating?: number;
   ra?: 1; // rated
-  c?: Color;
   action: 'cancel' | 'join';
   disabled?: boolean;
 }
@@ -43,7 +42,6 @@ export interface Seek {
   rating: number;
   mode: number;
   days?: number;
-  color: string;
   perf: {
     key: Exclude<Perf, 'fromPosition'>;
   };

--- a/ui/lobby/src/seekRepo.ts
+++ b/ui/lobby/src/seekRepo.ts
@@ -10,8 +10,10 @@ export function sort(ctrl: LobbyController) {
 }
 
 export function initAll(ctrl: LobbyController) {
-  ctrl.data.seeks.forEach(function (seek) {
+  ctrl.data.seeks.forEach(seek => {
     seek.action = ctrl.me && seek.username === ctrl.me.username ? 'cancelSeek' : 'joinSeek';
+    console.log(ctrl.me, seek);
+    console.log(ctrl.me?.username, seek.username, seek.action);
   });
   sort(ctrl);
 }

--- a/ui/lobby/src/view/correspondence.ts
+++ b/ui/lobby/src/view/correspondence.ts
@@ -22,7 +22,6 @@ function renderSeek(ctrl: LobbyController, seek: Seek): VNode {
       },
     },
     tds([
-      h('span.is.color-icon.' + (seek.color || 'random')),
       seek.rating
         ? h('span.ulpt', { attrs: { 'data-href': '/@/' + seek.username } }, seek.username)
         : 'Anonymous',
@@ -61,7 +60,7 @@ export default function (ctrl: LobbyController): MaybeVNodes {
         'thead',
         h(
           'tr',
-          ['', 'player', 'rating', 'time', 'mode'].map(header => h('th', ctrl.trans(header))),
+          ['player', 'rating', 'time', 'mode'].map(header => h('th', ctrl.trans(header))),
         ),
       ),
       h(

--- a/ui/lobby/src/view/realTime/chart.ts
+++ b/ui/lobby/src/view/realTime/chart.ts
@@ -65,15 +65,14 @@ function renderPlot(ctrl: LobbyController, hook: Hook) {
 }
 
 function renderHook(ctrl: LobbyController, hook: Hook): string {
-  const color = hook.c || 'random';
   let html = '<div class="inner">';
   if (hook.rating) {
-    html += '<a class="opponent ulpt is color-icon ' + color + '" href="/@/' + hook.u + '">';
+    html += '<a class="opponent ulpt is color-icon" href="/@/' + hook.u + '">';
     html += ' ' + hook.u;
     if (ctrl.opts.showRatings) html += ' (' + hook.rating + (hook.prov ? '?' : '') + ')';
     html += '</a>';
   } else {
-    html += '<span class="opponent anon ' + color + '">' + ctrl.trans('anonymous') + '</span>';
+    html += '<span class="opponent anon">' + ctrl.trans('anonymous') + '</span>';
   }
   html += '<div class="inner-clickable">';
   html += `<div>${hook.clock}</div>`;

--- a/ui/lobby/src/view/realTime/list.ts
+++ b/ui/lobby/src/view/realTime/list.ts
@@ -25,7 +25,6 @@ function renderHook(ctrl: LobbyController, hook: Hook) {
       },
     },
     tds([
-      h('span.is.color-icon.' + (hook.c || 'random')),
       hook.rating
         ? h('span.ulink.ulpt', { attrs: { 'data-href': '/@/' + hook.u } }, hook.u)
         : noarg('anonymous'),
@@ -76,7 +75,6 @@ export const render = (ctrl: LobbyController, allHooks: Hook[]) => {
       'thead',
       h('tr', [
         h('th'),
-        h('th', ctrl.trans('player')),
         h(
           'th',
           {

--- a/ui/lobby/src/view/setup/components/colorButtons.ts
+++ b/ui/lobby/src/view/setup/components/colorButtons.ts
@@ -27,7 +27,7 @@ const renderBlindModeColorPicker = (ctrl: LobbyController) => [
   ),
 ];
 
-export const colorButtons = (ctrl: LobbyController) => {
+export const createButtons = (ctrl: LobbyController) => {
   const { setupCtrl } = ctrl;
 
   const enabledColors: (Color | 'random')[] = [];
@@ -35,9 +35,10 @@ export const colorButtons = (ctrl: LobbyController) => {
     enabledColors.push('random');
 
     const randomColorOnly =
-      setupCtrl.gameType !== 'ai' &&
-      setupCtrl.gameMode() === 'rated' &&
-      variantsWhereWhiteIsBetter.includes(setupCtrl.variant());
+      setupCtrl.gameType === 'hook' ||
+      (setupCtrl.gameType !== 'ai' &&
+        setupCtrl.gameMode() === 'rated' &&
+        variantsWhereWhiteIsBetter.includes(setupCtrl.variant()));
     if (!randomColorOnly) enabledColors.push('white', 'black');
   }
 
@@ -52,7 +53,7 @@ export const colorButtons = (ctrl: LobbyController) => {
               `button.button.button-metal.color-submits__button.${key}`,
               {
                 attrs: { disabled: !enabledColors.includes(key), title: name, value: key },
-                on: { click: () => ctrl.setupCtrl.submit(key) },
+                on: { click: () => setupCtrl.submit(key) },
               },
               h('i'),
             ),

--- a/ui/lobby/src/view/setup/modal.ts
+++ b/ui/lobby/src/view/setup/modal.ts
@@ -7,7 +7,7 @@ import { variantPicker } from './components/variantPicker';
 import { timePickerAndSliders } from './components/timePickerAndSliders';
 import { gameModeButtons } from './components/gameModeButtons';
 import { ratingDifferenceSliders } from './components/ratingDifferenceSliders';
-import { colorButtons } from './components/colorButtons';
+import { createButtons } from './components/colorButtons';
 import { ratingView } from './components/ratingView';
 import { fenInput } from './components/fenInput';
 import { levelButtons } from './components/levelButtons';
@@ -31,7 +31,7 @@ const views = {
       timePickerAndSliders(ctrl),
       gameModeButtons(ctrl),
       ratingDifferenceSliders(ctrl),
-      colorButtons(ctrl),
+      createButtons(ctrl),
     ]),
   ],
   friend: (ctrl: LobbyController): MaybeVNodes => [
@@ -42,7 +42,7 @@ const views = {
       fenInput(ctrl),
       timePickerAndSliders(ctrl, true),
       gameModeButtons(ctrl),
-      colorButtons(ctrl),
+      createButtons(ctrl),
     ]),
   ],
   ai: (ctrl: LobbyController): MaybeVNodes => [
@@ -52,7 +52,7 @@ const views = {
       fenInput(ctrl),
       timePickerAndSliders(ctrl, true),
       ...levelButtons(ctrl),
-      colorButtons(ctrl),
+      createButtons(ctrl),
     ]),
   ],
 };

--- a/ui/lobby/src/view/util.ts
+++ b/ui/lobby/src/view/util.ts
@@ -2,9 +2,7 @@ import { h } from 'snabbdom';
 import { MaybeVNodes } from 'common/snabbdom';
 
 export function tds(bits: MaybeVNodes): MaybeVNodes {
-  return bits.map(function (bit) {
-    return h('td', [bit]);
-  });
+  return bits.map(bit => h('td', [bit]));
 }
 
 export const perfNames = {


### PR DESCRIPTION
Removes the option to select black or white pieces when creating a public seek. Color choice remains available for games with AI and direct challenges.

Fixed color in public seeks is being used to play as white exclusively, and has little legit use cases.