### PR TITLE
Relay: Fix show score in popup

### DIFF
--- a/ui/analyse/src/study/relay/relayPlayers.ts
+++ b/ui/analyse/src/study/relay/relayPlayers.ts
@@ -308,7 +308,7 @@ const renderPlayerTipHead = (ctrl: RelayPlayers, p: StudyPlayer | RelayPlayer): 
         playerFed(p.fed),
         ...(p.rating ? [`${p.rating}`, isRelayPlayer(p) ? ratingDiff(p) : undefined] : []),
       ]),
-      isRelayPlayer(p) ? h('div', [p.score, ' / ', p.played]) : undefined,
+      isRelayPlayer(p) && p.score != null ? h('div', `${p.score}/${p.played}`) : undefined,
     ]),
   ]);
 


### PR DESCRIPTION
problems showing 0 and hiding "/N" when not showing results

