### PR TITLE
Remove forum index eraser when gdpred users

### DIFF
--- a/modules/api/src/main/AccountClosure.scala
+++ b/modules/api/src/main/AccountClosure.scala
@@ -69,7 +69,6 @@ final class AccountClosure(
       case Some(user) =>
         userRepo.setEraseAt(user)
         email.gdprErase(user)
-        lila.common.Bus.publish(lila.core.user.GDPRErase(user), "gdprErase")
         Right(s"Erasing all data about $username in 24h")
     }
 

--- a/modules/core/src/main/forum.scala
+++ b/modules/core/src/main/forum.scala
@@ -9,8 +9,6 @@ import lila.core.userId.*
 enum BusForum:
   case CreatePost(post: ForumPostMini)
   case RemovePost(id: ForumPostId, by: Option[UserId], text: String, asAdmin: Boolean)(using val me: MyId)
-  // erasing = blanking, still in db but with empty text
-  case ErasePosts(ids: List[ForumPostId])
 
 object BusForum extends bus.GivenChannel[BusForum]("forumPost")
 

--- a/modules/core/src/main/user.scala
+++ b/modules/core/src/main/user.scala
@@ -160,7 +160,6 @@ object user:
   case class LightPerf(user: LightUser, perfKey: PerfKey, rating: IntRating, progress: IntRatingDiff)
 
   case class ChangeEmail(id: UserId, email: EmailAddress)
-  case class GDPRErase(user: User)
 
   trait UserApi:
     def byId[U: UserIdOf](u: U): Fu[Option[User]]

--- a/modules/forum/src/main/Env.scala
+++ b/modules/forum/src/main/Env.scala
@@ -63,8 +63,7 @@ final class Env(
   lazy val forumAccess = wire[ForumAccess]
 
   lila.common.Bus.subscribeFun("team", "gdprErase"):
-    case lila.core.team.TeamCreate(t)   => categApi.makeTeam(t.id, t.name, t.userId)
-    case lila.core.user.GDPRErase(user) => postApi.eraseFromSearchIndex(user)
+    case lila.core.team.TeamCreate(t) => categApi.makeTeam(t.id, t.name, t.userId)
 
 private type RecentTeamPostsType                   = TeamId => Fu[List[ForumPostMiniView]]
 opaque type RecentTeamPosts <: RecentTeamPostsType = RecentTeamPostsType

--- a/modules/forum/src/main/ForumPostApi.scala
+++ b/modules/forum/src/main/ForumPostApi.scala
@@ -223,11 +223,6 @@ final class ForumPostApi(
       .one($id(post.id), post.erase)
       .void
 
-  def eraseFromSearchIndex(user: User): Funit =
-    postRepo.coll
-      .distinctEasy[ForumPostId, List]("_id", $doc("userId" -> user.id), _.sec)
-      .map(ids => Bus.pub(BusForum.ErasePosts(ids)))
-
   def teamIdOfPostId(postId: ForumPostId): Fu[Option[TeamId]] =
     postRepo.coll.byId[ForumPost](postId).flatMapz { post =>
       categRepo.coll.primitiveOne[TeamId]($id(post.categId), "team")

--- a/modules/forumSearch/src/main/Env.scala
+++ b/modules/forumSearch/src/main/Env.scala
@@ -5,11 +5,8 @@ import play.api.Configuration
 
 import lila.common.autoconfig.{ *, given }
 import lila.core.config.ConfigName
-import lila.core.forum.BusForum
 import lila.search.client.SearchClient
 import lila.search.spec.Query
-
-import BusForum.*
 
 @Module
 private class ForumSearchConfig(@ConfigName("paginator.max_per_page") val maxPerPage: MaxPerPage)
@@ -24,6 +21,3 @@ final class Env(appConfig: Configuration, client: SearchClient)(using Executor):
     paginatorBuilder(Query.forum(text.take(100), troll), page)
 
   private lazy val paginatorBuilder = lila.search.PaginatorBuilder(api, config.maxPerPage)
-
-  lila.common.Bus.sub[BusForum]:
-    case ErasePosts(ids) => client.deleteByIds(index, ids.map(_.value))


### PR DESCRIPTION
As We already erased posts from database, and lila-search-ingestor handles the rest

Follow up #15992 