### PR TITLE
Don't show highlow tooltip if percentile is 0.0

### DIFF
--- a/modules/perfStat/src/main/PerfStatUi.scala
+++ b/modules/perfStat/src/main/PerfStatUi.scala
@@ -234,8 +234,8 @@ final class PerfStatUi(helpers: Helpers)(communityMenu: Context ?=> Frag):
     import stat.perfType
     def titleOf(v: Double) = trans.site.betterThanPercentPlayers.txt(s"$v%", perfType.trans)
     st.section(cls := "highlow split")(
-      highlowSide(tps.highestRating(_), stat.highest, pctHigh.map(titleOf), "green", u),
-      highlowSide(tps.lowestRating(_), stat.lowest, pctLow.map(titleOf), "red", u)
+      highlowSide(tps.highestRating(_), stat.highest, pctHigh.filter(_ != 0.0).map(titleOf), "green", u),
+      highlowSide(tps.lowestRating(_), stat.lowest, pctLow.filter(_ != 0.0).map(titleOf), "red", u)
     )
 
   private def fromTo(s: lila.perfStat.Streak, u: User)(using Translate): Frag =


### PR DESCRIPTION
When visiting `{user}/perf/correspondence`, if their rating is not provisional and they have high/low rating stats then the tooltip displays the following:

![before](https://github.com/user-attachments/assets/cf8f2851-df2f-4117-a110-0265383f38a5)

This is because Correspondence is not included in the weekly rating distribution. Updated code to filter out 0.0 so the highlow tooltip is removed in this case. This matches the filtering done to remove the top perf section which indicates what percentage of players you are better than ([here](https://github.com/lichess-org/lila/blob/dbdf7da02fb705262f0e54f195cf5dab91b972ce/modules/perfStat/src/main/PerfStatUi.scala#L114)).

**After**
![after](https://github.com/user-attachments/assets/ceb3223e-5b52-4c4a-b594-46d3f74cb96c)
