### PR TITLE
Bump lila-search client 3.0.1

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -26,7 +26,7 @@ object Dependencies {
   val lettuce     = "io.lettuce"                    % "lettuce-core"                    % "6.4.0.RELEASE"
   val nettyTransport =
     ("io.netty" % s"netty-transport-native-$notifier" % "4.1.113.Final").classifier(s"$os-$arch")
-  val lilaSearch  = "org.lichess.search"         %% "client"        % "3.0.0"
+  val lilaSearch  = "org.lichess.search"         %% "client"        % "3.0.1"
   val munit       = "org.scalameta"              %% "munit"         % "1.0.1" % Test
   val uaparser    = "org.uaparser"               %% "uap-scala"     % "0.18.0"
   val apacheText  = "org.apache.commons"          % "commons-text"  % "1.12.0"


### PR DESCRIPTION
Routine release for lila-search client
[GitHub Release Notes](https://github.com/lichess-org/lila-search/releases/tag/v3.0.1)