### PR TITLE
Improve broadcast date filtering

### DIFF
--- a/modules/relay/src/main/RelayPager.scala
+++ b/modules/relay/src/main/RelayPager.scala
@@ -118,7 +118,7 @@ final class RelayPager(
     // Special case of querying so that users can filter broadcasts by year
     val yearOpt = """\b(20)\d{2}\b""".r.findFirstIn(query)
     val selector = yearOpt.foldLeft(textSelector): (selector, year) =>
-      selector ++ $doc("name".$regex(s".*\\b$year\\b.*"))
+      selector ++ "name".$regex(s"\\b$year\\b")
 
     forSelector(
       selector = selector,

--- a/modules/relay/src/main/RelayPager.scala
+++ b/modules/relay/src/main/RelayPager.scala
@@ -6,6 +6,8 @@ import lila.db.dsl.{ *, given }
 import lila.memo.CacheApi
 import lila.relay.RelayTour.WithLastRound
 
+import reactivemongo.api.bson.*
+
 final class RelayPager(
     tourRepo: RelayTourRepo,
     roundRepo: RelayRoundRepo,
@@ -111,8 +113,38 @@ final class RelayPager(
 
   def search(query: String, page: Int): Fu[Paginator[WithLastRound]] =
     val day = 1000L * 3600 * 24
+    // val selector = $text(query) ++ selectors.officialPublic
+    // Special case of querying so that users can filter broadcasts by year
+    val yearPattern = """\b(20)\d{2}\b""".r
+    val yearOpt     = yearPattern.findFirstIn(query)
+
+    // Build the text search selector
+    val textSelector = $text(query) ++ selectors.officialPublic
+
+    val selector = yearOpt match
+      case Some(year) =>
+        textSelector ++ //$or(
+          BSONDocument(
+            "$expr" -> BSONDocument(
+              "$regexMatch" -> BSONDocument(
+                "input" -> BSONDocument(
+                  "$dateToString" -> BSONDocument(
+                    "format" -> BSONString("%Y-%m-%dT%H:%M:%S"),
+                    "date"   -> BSONString("$createdAt")
+                  )
+                ),
+                "regex" -> BSONString(year)  // The year needs to be a BSONString
+              )
+            )
+          )//,
+          // BSONDocument("createdAt" -> BSONDocument("$regex" -> s".*$year.*")),
+        //   BSONDocument("name"      -> BSONDocument("$regex" -> s".*\\b$year\\b.*"))
+        // )
+      case None =>
+        textSelector
+      
     forSelector(
-      selector = $text(query) ++ selectors.officialPublic,
+      selector = selector,
       page = page,
       onlyKeepGroupFirst = false,
       addFields = $doc(


### PR DESCRIPTION
fixes #16040 

The issue seems to be because of MongoDB's underlying text search whose tokenisation doesn't prioritise the year enough to filter out tournaments titled with a different year. Being totally new to Scala and Mongo, I don't know if this is the right solution and what performance implications it may have, but it's a suggestion if the ability for users to easily filter on a year appearing in the tournament name is sufficiently important. Tested with a broadcast titled "British Championships 2024" where "championship 2021" would match under production code, and not match after the proposed change.