### PR TITLE
fix: minimum width for uncommon openings percentage bar

### DIFF
--- a/modules/opening/src/main/ui/OpeningBits.scala
+++ b/modules/opening/src/main/ui/OpeningBits.scala
@@ -28,7 +28,10 @@ final class OpeningBits(helpers: Helpers):
           val canFollow = page.query.uci.isEmpty || page.wiki.exists(_.hasMarkup)
           a(cls := "opening__next", href := queryUrl(next.query), (!canFollow).option(noFollow))(
             span(cls := "opening__next__popularity"):
-              span(style := s"width:${percentNumber(next.percent)}%", title := "Popularity"):
+              span(
+                style := s"width:${percentNumber(Math.max(next.percent, 10))}%",
+                title := "Popularity"
+              ):
                 s"${Math.round(next.percent)}%"
             ,
             span(cls := "opening__next__title")(


### PR DESCRIPTION
The percentage label for uncommon openings isn't easy to read.

<img width="1201" alt="Screenshot 2024-09-14 at 22 25 32" src="https://github.com/user-attachments/assets/25bc59a7-0bcf-4f38-b191-993a12e68b6c">
