### PR TITLE
Upgrade chart.js to fix crash on analysis

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -278,17 +278,17 @@ importers:
         specifier: workspace:*
         version: link:../ceval
       chart.js:
-        specifier: 4.4.3
-        version: 4.4.3
+        specifier: 4.4.4
+        version: 4.4.4
       chartjs-adapter-dayjs-4:
         specifier: ^1.0.4
-        version: 1.0.4(chart.js@4.4.3)(dayjs@1.11.13)
+        version: 1.0.4(chart.js@4.4.4)(dayjs@1.11.13)
       chartjs-plugin-datalabels:
         specifier: ^2.2.0
-        version: 2.2.0(chart.js@4.4.3)
+        version: 2.2.0(chart.js@4.4.4)
       chartjs-plugin-zoom:
         specifier: ^2.0.1
-        version: 2.0.1(chart.js@4.4.3)
+        version: 2.0.1(chart.js@4.4.4)
       common:
         specifier: workspace:*
         version: link:../common
@@ -1387,6 +1387,10 @@ packages:
 
   chart.js@4.4.3:
     resolution: {integrity: sha512-qK1gkGSRYcJzqrrzdR6a+I0vQ4/R+SoODXyAjscQ/4mzuNzySaMCd+hyVxitSY1+L2fjPD1Gbn+ibNqRmwQeLw==}
+    engines: {pnpm: '>=8'}
+
+  chart.js@4.4.4:
+    resolution: {integrity: sha512-emICKGBABnxhMjUjlYRR12PmOXhJ2eJjEHL2/dZlWjxRAZT1D8xplLFq5M0tMQK8ja+wBS/tuVEJB5C6r7VxJA==}
     engines: {pnpm: '>=8'}
 
   chartjs-adapter-dayjs-4@1.0.4:
@@ -3005,18 +3009,31 @@ snapshots:
     dependencies:
       '@kurkle/color': 0.3.2
 
+  chart.js@4.4.4:
+    dependencies:
+      '@kurkle/color': 0.3.2
+
   chartjs-adapter-dayjs-4@1.0.4(chart.js@4.4.3)(dayjs@1.11.13):
     dependencies:
       chart.js: 4.4.3
+      dayjs: 1.11.13
+
+  chartjs-adapter-dayjs-4@1.0.4(chart.js@4.4.4)(dayjs@1.11.13):
+    dependencies:
+      chart.js: 4.4.4
       dayjs: 1.11.13
 
   chartjs-plugin-datalabels@2.2.0(chart.js@4.4.3):
     dependencies:
       chart.js: 4.4.3
 
-  chartjs-plugin-zoom@2.0.1(chart.js@4.4.3):
+  chartjs-plugin-datalabels@2.2.0(chart.js@4.4.4):
     dependencies:
-      chart.js: 4.4.3
+      chart.js: 4.4.4
+
+  chartjs-plugin-zoom@2.0.1(chart.js@4.4.4):
+    dependencies:
+      chart.js: 4.4.4
       hammerjs: 2.0.8
 
   check-error@2.1.1: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -410,11 +410,11 @@ importers:
         specifier: workspace:^
         version: link:../chart
       chart.js:
-        specifier: 4.4.3
-        version: 4.4.3
+        specifier: 4.4.4
+        version: 4.4.4
       chartjs-plugin-datalabels:
         specifier: ^2.2.0
-        version: 2.2.0(chart.js@4.4.3)
+        version: 2.2.0(chart.js@4.4.4)
       common:
         specifier: workspace:*
         version: link:../common
@@ -533,11 +533,11 @@ importers:
         specifier: ^3.1.9
         version: 3.1.9
       chart.js:
-        specifier: 4.4.3
-        version: 4.4.3
+        specifier: 4.4.4
+        version: 4.4.4
       chartjs-adapter-dayjs-4:
         specifier: ^1.0.4
-        version: 1.0.4(chart.js@4.4.3)(dayjs@1.11.13)
+        version: 1.0.4(chart.js@4.4.4)(dayjs@1.11.13)
       common:
         specifier: workspace:*
         version: link:../common
@@ -587,8 +587,8 @@ importers:
         specifier: workspace:*
         version: link:../ceval
       chart.js:
-        specifier: 4.4.3
-        version: 4.4.3
+        specifier: 4.4.4
+        version: 4.4.4
       chess:
         specifier: workspace:*
         version: link:../chess
@@ -1384,10 +1384,6 @@ packages:
   chalk@5.3.0:
     resolution: {integrity: sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
-
-  chart.js@4.4.3:
-    resolution: {integrity: sha512-qK1gkGSRYcJzqrrzdR6a+I0vQ4/R+SoODXyAjscQ/4mzuNzySaMCd+hyVxitSY1+L2fjPD1Gbn+ibNqRmwQeLw==}
-    engines: {pnpm: '>=8'}
 
   chart.js@4.4.4:
     resolution: {integrity: sha512-emICKGBABnxhMjUjlYRR12PmOXhJ2eJjEHL2/dZlWjxRAZT1D8xplLFq5M0tMQK8ja+wBS/tuVEJB5C6r7VxJA==}
@@ -3005,27 +3001,14 @@ snapshots:
 
   chalk@5.3.0: {}
 
-  chart.js@4.4.3:
-    dependencies:
-      '@kurkle/color': 0.3.2
-
   chart.js@4.4.4:
     dependencies:
       '@kurkle/color': 0.3.2
-
-  chartjs-adapter-dayjs-4@1.0.4(chart.js@4.4.3)(dayjs@1.11.13):
-    dependencies:
-      chart.js: 4.4.3
-      dayjs: 1.11.13
 
   chartjs-adapter-dayjs-4@1.0.4(chart.js@4.4.4)(dayjs@1.11.13):
     dependencies:
       chart.js: 4.4.4
       dayjs: 1.11.13
-
-  chartjs-plugin-datalabels@2.2.0(chart.js@4.4.3):
-    dependencies:
-      chart.js: 4.4.3
 
   chartjs-plugin-datalabels@2.2.0(chart.js@4.4.4):
     dependencies:

--- a/ui/chart/package.json
+++ b/ui/chart/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@juggle/resize-observer": "^3.4.0",
     "ceval": "workspace:*",
-    "chart.js": "4.4.3",
+    "chart.js": "4.4.4",
     "chartjs-adapter-dayjs-4": "^1.0.4",
     "chartjs-plugin-datalabels": "^2.2.0",
     "chartjs-plugin-zoom": "^2.0.1",

--- a/ui/insight/package.json
+++ b/ui/insight/package.json
@@ -13,7 +13,7 @@
   "license": "AGPL-3.0-or-later",
   "dependencies": {
     "chart": "workspace:^",
-    "chart.js": "4.4.3",
+    "chart.js": "4.4.4",
     "chartjs-plugin-datalabels": "^2.2.0",
     "common": "workspace:*",
     "snabbdom": "3.5.1"

--- a/ui/opening/package.json
+++ b/ui/opening/package.json
@@ -7,7 +7,7 @@
   "license": "AGPL-3.0-or-later",
   "dependencies": {
     "@types/debounce-promise": "^3.1.9",
-    "chart.js": "4.4.3",
+    "chart.js": "4.4.4",
     "chartjs-adapter-dayjs-4": "^1.0.4",
     "common": "workspace:*",
     "dayjs": "^1.11.10",

--- a/ui/puzzle/package.json
+++ b/ui/puzzle/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "board": "workspace:*",
     "ceval": "workspace:*",
-    "chart.js": "4.4.3",
+    "chart.js": "4.4.4",
     "chess": "workspace:*",
     "chessops": "^0.14.1",
     "common": "workspace:*",


### PR DESCRIPTION
Upgrades chart.js to `4.4.4` to fix a crash that can happen when rendering the analysis chart. To recreate the crash you need to request analysis or view a game that has already been analyzed (generally with a longer move list), resize the board while the analysis graph is rendering, and while resizing hover the mouse in the chart area.

This was a known issue with the tooltip positioner in chart.js which has been resolved in `4.4.4` [here](https://github.com/chartjs/Chart.js/pull/11863). 

Tested change in local development instance and working as expected.

**Video of issue in local dev instance**

https://github.com/user-attachments/assets/563dd655-7efa-4dfe-9756-122bf2f8b428



