### PR TITLE
Restore old tourney scheduling behavior

### DIFF
--- a/modules/tournament/src/main/Schedule.scala
+++ b/modules/tournament/src/main/Schedule.scala
@@ -393,13 +393,13 @@ object Schedule:
   /** Given a list of existing schedules and a list of possible new plans, returns a subset of the possible
     * plans that do not conflict with either the existing schedules or with themselves.
     */
-  private[tournament] def pruneConflicts(
+  private[tournament] def pruneConflicts[A <: ScheduleWithInterval](
       existingSchedules: Iterable[ScheduleWithInterval],
-      possibleNewPlans: Iterable[Plan]
-  ): List[Plan] =
+      possibleNewPlans: Iterable[A]
+  ): List[A] =
     var allPlannedSchedules = existingSchedules.toList
     possibleNewPlans
-      .foldLeft(List[Plan]()): (newPlans, p) =>
+      .foldLeft(List[A]()): (newPlans, p) =>
         if p.conflictsWith(allPlannedSchedules) then newPlans
         else
           allPlannedSchedules = p :: allPlannedSchedules


### PR DESCRIPTION
(temporarily) restore old tourney scheduling logic.

This scheduling is non-deterministic when two tourneys abutt each-other, but will eventually work since the schedule is tried frequently.

This commit goes against the long term plan of making the tourney schedule consistent, clear and deterministic.  The long term plan is to ignore conflicts caused by the staggered start of a tourney (probably by pruning using planned start time) and to display tourneys using their unstaggered starts on the tourney page.

So this commit will be reverted, but is needed short term.


Fixes #16048.
