### PR TITLE
Adds `overflow-wrap` to prevent overflow of study__metadata table rows

### DIFF
--- a/ui/analyse/css/study/panel/_metadata.scss
+++ b/ui/analyse/css/study/panel/_metadata.scss
@@ -52,6 +52,7 @@
 
   td {
     padding: 0;
+    overflow-wrap: anywhere;
   }
 
   input,


### PR DESCRIPTION
Fixes #16060 

Result on Chrome Version 129.0.6668.59 (Official Build) (arm64) below: 

https://github.com/user-attachments/assets/3f697865-8903-4402-9af0-8ec9ca7500ed

Note that this requires Opera 67+ (one higher than the 66+ listed as having 'reasonable support' on the README) and Safari 15.4+ (vs. the 11.1+ listed as having 'reasonable support').