### PR TITLE
restore hovering to show puzzle id

### DIFF
--- a/ui/puz/css/_history.scss
+++ b/ui/puz/css/_history.scss
@@ -38,7 +38,7 @@
       visibility: hidden;
     }
 
-    &:hover .storm__history__round__id {
+    &:hover .puz-history__round__id {
       color: $c-font;
       visibility: visible;
     }


### PR DESCRIPTION
Currently hovering does not change the visibilety. Probably broken during some refactoring. 

After : 
https://github.com/user-attachments/assets/15a93102-312a-4fb5-b9a6-32887a279948


The fact that there is both a puz and a puzzle folder is a _bit_ confusing. Not sure what the intended diffrence between the files is. The change I made applies to both Storm and Racer.


https://github.com/lichess-org/lila/blob/2cc706c09468f95eb05d84771a703e845b5dc637/ui/puz/css/_history.scss
https://github.com/lichess-org/lila/blob/2cc706c09468f95eb05d84771a703e845b5dc637/ui/puzzle/css/_history.scss