### PR TITLE
not hide select team in broadcast

### DIFF
--- a/ui/analyse/css/study/panel/_multiboard.scss
+++ b/ui/analyse/css/study/panel/_multiboard.scss
@@ -30,8 +30,10 @@
     }
 
     select {
-      @media (max-width: at-most($small)) {
-        display: none;
+      &:not(.study__multiboard__teams) {
+        @media (max-width: at-most($small)) {
+          display: none;
+        }
       }
       max-width: 25vw;
       margin-inline-end: 1ch;

--- a/ui/analyse/css/study/panel/_multiboard.scss
+++ b/ui/analyse/css/study/panel/_multiboard.scss
@@ -30,7 +30,7 @@
     }
 
     select {
-      &:not(.study__multiboard__teams) {
+      &.study__multiboard__pager__max-per-page {
         @media (max-width: at-most($small)) {
           display: none;
         }

--- a/ui/analyse/src/study/multiBoard.ts
+++ b/ui/analyse/src/study/multiBoard.ts
@@ -128,7 +128,7 @@ function renderPagerNav(pager: Paginator<ChapterPreview>, ctrl: MultiBoardCtrl):
     pagerButton('last', licon.JumpLast, ctrl.lastPage, page < pager.nbPages, ctrl),
     teamSelector(ctrl),
     h(
-      'select.study__multiboard__boardpage',
+      'select.study__multiboard__pager__max-per-page',
       { hook: bind('change', (e: Event) => ctrl.setMaxPerPage((e.target as HTMLOptionElement).value)) },
       [4, 6, 8, 10, 12, 16, 20, 24, 32].map(nb =>
         h('option', { attrs: { value: nb, selected: nb == max } }, `${nb} per page`),
@@ -142,7 +142,7 @@ const teamSelector = (ctrl: MultiBoardCtrl) => {
   const currentTeam = ctrl.teamSelect();
   return allTeams.length
     ? h(
-      'select.study__multiboard__teams',
+      'select',
       {
         hook: bind('change', e => ctrl.teamSelect((e.target as HTMLOptionElement).value), ctrl.redraw),
       },

--- a/ui/analyse/src/study/multiBoard.ts
+++ b/ui/analyse/src/study/multiBoard.ts
@@ -128,7 +128,7 @@ function renderPagerNav(pager: Paginator<ChapterPreview>, ctrl: MultiBoardCtrl):
     pagerButton('last', licon.JumpLast, ctrl.lastPage, page < pager.nbPages, ctrl),
     teamSelector(ctrl),
     h(
-      'select',
+      'select.study__multiboard__boardpage',
       { hook: bind('change', (e: Event) => ctrl.setMaxPerPage((e.target as HTMLOptionElement).value)) },
       [4, 6, 8, 10, 12, 16, 20, 24, 32].map(nb =>
         h('option', { attrs: { value: nb, selected: nb == max } }, `${nb} per page`),
@@ -141,17 +141,15 @@ const teamSelector = (ctrl: MultiBoardCtrl) => {
   const allTeams = ctrl.computeTeamList();
   const currentTeam = ctrl.teamSelect();
   return allTeams.length
-    ? h('div.study__multiboard__teams', [
-      h(
-        'select',
-        {
-          hook: bind('change', e => ctrl.teamSelect((e.target as HTMLOptionElement).value), ctrl.redraw),
-        },
-        ['All teams', ...allTeams].map((t, i) =>
-          h('option', { attrs: { value: i ? t : '', selected: i && t == currentTeam } }, t),
-        ),
+    ? h(
+      'select.study__multiboard__teams',
+      {
+        hook: bind('change', e => ctrl.teamSelect((e.target as HTMLOptionElement).value), ctrl.redraw),
+      },
+      ['All teams', ...allTeams].map((t, i) =>
+        h('option', { attrs: { value: i ? t : '', selected: i && t == currentTeam } }, t),
       ),
-    ])
+    )
     : undefined;
 };
 


### PR DESCRIPTION
Hiding the team selector makes mobile players' vision worse It's better not to hide

In short: if I select a board and go back to the multiboard I only see one team and not all (until I refresh the page)