### PR TITLE
Fixes sound slider CSS to remove logs

### DIFF
--- a/ui/dasher/css/_dasher.scss
+++ b/ui/dasher/css/_dasher.scss
@@ -172,8 +172,8 @@
       margin: 1rem;
       padding-top: 0;
       padding-bottom: 0;
-      writing-mode: bt-lr;
-      -webkit-appearance: slider-vertical;
+      writing-mode: vertical-lr;
+      direction: rtl;
     }
 
     &.silent input[type='range'] {


### PR DESCRIPTION
Resolves: #16073

Fixes Non-Standard and deprecated CSS issues with `writing-mode: bt-lr;` and `-webkit-appearance: slider-vertical`.

![image](https://github.com/user-attachments/assets/be338ad9-7546-4601-a660-712a322b8e9b)
