### PR TITLE
Fixes no puzzle history console error

### DIFF
--- a/ui/puzzle/src/puzzle.dashboard.ts
+++ b/ui/puzzle/src/puzzle.dashboard.ts
@@ -24,6 +24,9 @@ interface RadarData {
 export function initModule(data: RadarData) {
   const canvas = document.querySelector('.puzzle-dashboard__radar') as HTMLCanvasElement;
   const d = data.radar;
+
+  if (!d?.datasets.length) return;
+
   d.datasets[0] = {
     ...d.datasets[0],
     ...{


### PR DESCRIPTION
Resolves: #16101

Adds a check to see if there is any puzzle history.


The Puzzle Dashboard page will console error if no puzzle have been played in the timeframe.
https://lichess.org/training/dashboard/30/dashboard