### PR TITLE
remove useless code

### DIFF
--- a/modules/relay/src/main/RelayTour.scala
+++ b/modules/relay/src/main/RelayTour.scala
@@ -89,12 +89,7 @@ object RelayTour:
   ):
     def nonEmpty          = List(format, tc, fideTc, location, players, website, standings).flatten.nonEmpty
     override def toString = List(format, tc, fideTc, location, players).mkString(" | ")
-    lazy val fideTcOrGuess: FideTC = fideTc |
-      tc
-        .map(_.trim.toLowerCase.replace("classical", "standard"))
-        .flatMap: tcStr =>
-          FideTC.values.find(tc => tcStr.contains(tc.toString))
-        .|(FideTC.standard)
+    lazy val fideTcOrGuess: FideTC = fideTc | FideTC.standard
 
   case class Dates(start: Instant, end: Option[Instant])
 


### PR DESCRIPTION
fideTC is already selected by default as standard
old tournaments are saying they are in standard and not other modes I don't see anything that `tc` currently helps resolve

not to mention that tc has another use since there is fidetc