### PR TITLE
Tournament Scheduler: Simplify private "at" method

### DIFF
--- a/modules/tournament/src/main/TournamentScheduler.scala
+++ b/modules/tournament/src/main/TournamentScheduler.scala
@@ -513,11 +513,11 @@ Thank you all, you rock!""".some,
 
   /** Get a [[LocalDateTime]].
     *
-    * Returns None exactly when hour is outside 0-23.
+    * Returns None exactly when hour is outside 0-23 or if minutes is outside 0-59.
     */
-  private def atUnsafe(day: LocalDate, hour: Int): Option[LocalDateTime] =
-    try at(day, hour.asInstanceOf[ValidHour]).some
+  private def atUnsafe(day: LocalDate, hour: Int, minute: Int = 0): Option[LocalDateTime] =
+    try LocalDateTime.of(day, LocalTime.of(hour, minute)).some
     catch
       case e: Exception =>
-        logger.error(s"Failed to schedule due to invalid time '$hour:00'", e)
+        logger.error(s"Failed to schedule due to invalid time '$hour:$minute'", e)
         None

--- a/modules/tournament/src/main/TournamentScheduler.scala
+++ b/modules/tournament/src/main/TournamentScheduler.scala
@@ -5,7 +5,7 @@ import chess.StartingPosition
 import java.time.DayOfWeek.*
 import java.time.Month.*
 import java.time.temporal.TemporalAdjusters
-import java.time.{ LocalDate, LocalDateTime }
+import java.time.{ LocalDate, LocalDateTime, LocalTime }
 
 import lila.common.LilaScheduler
 import lila.core.i18n.Translator
@@ -130,7 +130,7 @@ private object TournamentScheduler:
     // all dates UTC
     List(
       List( // legendary tournaments!
-        at(birthday.withYear(today.getYear), 12).map(orNextYear).map { date =>
+        at(birthday.withYear(today.getYear), 12).pipe(orNextYear).pipe { date =>
           val yo = date.getYear - 2010
           Schedule(Unique, Rapid, Standard, none, date).plan {
             _.copy(
@@ -147,7 +147,7 @@ Thank you all, you rock!""".some,
             )
           }
         }
-      ).flatten,
+      ),
       List( // yearly tournaments!
         secondWeekOf(JANUARY).withDayOfWeek(MONDAY)      -> Bullet,
         secondWeekOf(FEBRUARY).withDayOfWeek(TUESDAY)    -> SuperBlitz,
@@ -162,7 +162,7 @@ Thank you all, you rock!""".some,
         secondWeekOf(NOVEMBER).withDayOfWeek(FRIDAY)     -> Classical,
         secondWeekOf(DECEMBER).withDayOfWeek(SATURDAY)   -> HyperBullet
       ).flatMap { (day, speed) =>
-        at(day, 17).filter(farFuture.isAfter).map { date =>
+        at(day, 17).some.filter(farFuture.isAfter).map { date =>
           Schedule(Yearly, speed, Standard, none, date).plan
         }
       },
@@ -176,7 +176,7 @@ Thank you all, you rock!""".some,
         secondWeekOf(JULY).withDayOfWeek(WEDNESDAY)    -> Horde,
         secondWeekOf(AUGUST).withDayOfWeek(THURSDAY)   -> ThreeCheck
       ).flatMap { (day, variant) =>
-        at(day, 17).filter(farFuture.isAfter).map { date =>
+        at(day, 17).some.filter(farFuture.isAfter).map { date =>
           Schedule(Yearly, SuperBlitz, variant, none, date).plan
         }
       },
@@ -190,10 +190,8 @@ Thank you all, you rock!""".some,
             month.lastWeek.withDayOfWeek(FRIDAY)    -> Classical,
             month.lastWeek.withDayOfWeek(SATURDAY)  -> HyperBullet,
             month.lastWeek.withDayOfWeek(SUNDAY)    -> UltraBullet
-          ).flatMap { (day, speed) =>
-            at(day, 17).map { date =>
-              Schedule(Monthly, speed, Standard, none, date).plan
-            }
+          ).map { (day, speed) =>
+            Schedule(Monthly, speed, Standard, none, at(day, 17)).plan
           },
           List( // monthly variant tournaments!
             month.lastWeek.withDayOfWeek(MONDAY)    -> Chess960,
@@ -204,8 +202,8 @@ Thank you all, you rock!""".some,
             month.lastWeek.withDayOfWeek(SATURDAY)  -> Atomic,
             month.lastWeek.withDayOfWeek(SUNDAY)    -> Horde,
             month.lastWeek.withDayOfWeek(SUNDAY)    -> ThreeCheck
-          ).flatMap { (day, variant) =>
-            at(day, 19).map { date =>
+          ).map { (day, variant) =>
+            at(day, 19).pipe { date =>
               Schedule(
                 Monthly,
                 if variant == Chess960 || variant == Crazyhouse then Blitz else SuperBlitz,
@@ -223,8 +221,8 @@ Thank you all, you rock!""".some,
             month.firstWeek.withDayOfWeek(FRIDAY)    -> Classical,
             month.firstWeek.withDayOfWeek(SATURDAY)  -> HyperBullet,
             month.firstWeek.withDayOfWeek(SUNDAY)    -> UltraBullet
-          ).flatMap: (day, speed) =>
-            at(day, 16).map: date =>
+          ).map: (day, speed) =>
+            at(day, 16).pipe: date =>
               Schedule(Shield, speed, Standard, none, date).plan(TournamentShield.make(speed.toString)),
           List( // shield variant tournaments!
             month.secondWeek.withDayOfWeek(SUNDAY)   -> Chess960,
@@ -235,8 +233,8 @@ Thank you all, you rock!""".some,
             month.thirdWeek.withDayOfWeek(FRIDAY)    -> Atomic,
             month.thirdWeek.withDayOfWeek(SATURDAY)  -> Horde,
             month.thirdWeek.withDayOfWeek(SUNDAY)    -> ThreeCheck
-          ).flatMap: (day, variant) =>
-            at(day, 16).map: date =>
+          ).map: (day, variant) =>
+            at(day, 16).pipe: date =>
               Schedule(Shield, Blitz, variant, none, date).plan(TournamentShield.make(variant.name))
         ).flatten
       },
@@ -248,8 +246,8 @@ Thank you all, you rock!""".some,
         nextFriday    -> Classical,
         nextSaturday  -> HyperBullet,
         nextSunday    -> UltraBullet
-      ).flatMap { (day, speed) =>
-        at(day, 17).map { date =>
+      ).map { (day, speed) =>
+        at(day, 17).pipe { date =>
           Schedule(Weekly, speed, Standard, none, date.pipe(orNextWeek)).plan
         }
       },
@@ -262,8 +260,8 @@ Thank you all, you rock!""".some,
         nextSaturday  -> Atomic,
         nextSunday    -> Horde,
         nextSunday    -> Chess960
-      ).flatMap { (day, variant) =>
-        at(day, 19).map { date =>
+      ).map { (day, variant) =>
+        at(day, 19).pipe { date =>
           Schedule(
             Weekly,
             if variant == Chess960 || variant == Crazyhouse then Blitz else SuperBlitz,
@@ -276,72 +274,70 @@ Thank you all, you rock!""".some,
       List( // week-end elite tournaments!
         nextSaturday -> SuperBlitz,
         nextSunday   -> Bullet
-      ).flatMap { (day, speed) =>
-        at(day, 17).map { date =>
-          Schedule(Weekend, speed, Standard, none, date.pipe(orNextWeek)).plan
-        }
+      ).map { (day, speed) =>
+        Schedule(Weekend, speed, Standard, none, at(day, 17).pipe(orNextWeek)).plan
       },
       // Note: these should be scheduled close to the hour of weekly or weekend tournaments
       // to avoid two dailies being cancelled in a row from a single higher importance tourney
       List( // daily tournaments!
-        at(today, 16).map { date =>
+        at(today, 16).pipe { date =>
           Schedule(Daily, Bullet, Standard, none, date.pipe(orTomorrow)).plan
         },
-        at(today, 17).map { date =>
+        at(today, 17).pipe { date =>
           Schedule(Daily, SuperBlitz, Standard, none, date.pipe(orTomorrow)).plan
         },
-        at(today, 18).map { date =>
+        at(today, 18).pipe { date =>
           Schedule(Daily, Blitz, Standard, none, date.pipe(orTomorrow)).plan
         },
-        at(today, 19).map { date =>
+        at(today, 19).pipe { date =>
           Schedule(Daily, Rapid, Standard, none, date.pipe(orTomorrow)).plan
         },
-        at(today, 20).map { date =>
+        at(today, 20).pipe { date =>
           Schedule(Daily, HyperBullet, Standard, none, date.pipe(orTomorrow)).plan
         },
-        at(today, 21).map { date =>
+        at(today, 21).pipe { date =>
           Schedule(Daily, UltraBullet, Standard, none, date.pipe(orTomorrow)).plan
         }
-      ).flatten,
+      ),
       // Note: these should be scheduled close to the hour of weekly variant tournaments
       // to avoid two dailies being cancelled in a row from a single higher importance tourney
       List( // daily variant tournaments!
-        at(today, 20).map { date =>
+        at(today, 20).pipe { date =>
           Schedule(Daily, Blitz, Crazyhouse, none, date.pipe(orTomorrow)).plan
         },
-        at(today, 21).map { date =>
+        at(today, 21).pipe { date =>
           Schedule(Daily, Blitz, Chess960, none, date.pipe(orTomorrow)).plan
         },
-        at(today, 22).map { date =>
+        at(today, 22).pipe { date =>
           Schedule(Daily, SuperBlitz, KingOfTheHill, none, date.pipe(orTomorrow)).plan
         },
-        at(today, 23).map { date =>
+        at(today, 23).pipe { date =>
           Schedule(Daily, SuperBlitz, Atomic, none, date.pipe(orTomorrow)).plan
         },
-        at(today, 0).map { date =>
+        at(today, 0).pipe { date =>
           Schedule(Daily, SuperBlitz, Antichess, none, date.pipe(orTomorrow)).plan
         },
-        at(tomorrow, 1).map { date =>
+        at(tomorrow, 1).pipe { date =>
           Schedule(Daily, SuperBlitz, ThreeCheck, none, date).plan
         },
-        at(tomorrow, 2).map { date =>
+        at(tomorrow, 2).pipe { date =>
           Schedule(Daily, SuperBlitz, Horde, none, date).plan
         },
-        at(tomorrow, 3).map { date =>
+        at(tomorrow, 3).pipe { date =>
           Schedule(Daily, SuperBlitz, RacingKings, none, date).plan
         }
-      ).flatten,
+      ),
       List( // eastern tournaments!
-        at(today, 4).map { date =>
+        at(today, 4).pipe { date =>
           Schedule(Eastern, Bullet, Standard, none, date.pipe(orTomorrow)).plan
         },
-        at(today, 5).map { date =>
+        at(today, 5).pipe { date =>
           Schedule(Eastern, SuperBlitz, Standard, none, date.pipe(orTomorrow)).plan
         },
-        at(today, 6).map { date =>
+        at(today, 6).pipe { date =>
           Schedule(Eastern, Blitz, Standard, none, date.pipe(orTomorrow)).plan
         }
-      ).flatten, {
+      ), {
         {
           for
             halloween    <- StartingPosition.presets.halloween
@@ -363,16 +359,16 @@ Thank you all, you rock!""".some,
           )
       }.flatMap { (hour, opening) =>
         List(
-          at(today, hour).map { date =>
+          atUnsafe(today, hour).map { date =>
             Schedule(Hourly, Bullet, Standard, opening.fen.some, date.pipe(orTomorrow)).plan
           },
-          at(today, hour + 1).map { date =>
+          atUnsafe(today, hour + 1).map { date =>
             Schedule(Hourly, SuperBlitz, Standard, opening.fen.some, date.pipe(orTomorrow)).plan
           },
-          at(today, hour + 2).map { date =>
+          atUnsafe(today, hour + 2).map { date =>
             Schedule(Hourly, Blitz, Standard, opening.fen.some, date.pipe(orTomorrow)).plan
           },
-          at(today, hour + 3).map { date =>
+          atUnsafe(today, hour + 3).map { date =>
             Schedule(Hourly, Rapid, Standard, opening.fen.some, date.pipe(orTomorrow)).plan
           }
         ).flatten
@@ -498,9 +494,30 @@ Thank you all, you rock!""".some,
   private def atTopOfHour(rightNow: LocalDateTime, hourDelta: Int): LocalDateTime =
     rightNow.plusHours(hourDelta).withMinute(0)
 
-  private def at(day: LocalDate, hour: Int, minute: Int = 0): Option[LocalDateTime] =
-    try Some(day.atStartOfDay.plusHours(hour).plusMinutes(minute))
+  private type ValidHour = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 |
+    18 | 19 | 20 | 21 | 22 | 23
+
+  /** Get a [[LocalDateTime]].
+    *
+    * Note: This is safe -- impl throws only when hour is outside 0-23 or if day is null, and neither
+    * condition can occur here.
+    * {{{
+    * assert {
+    *   val hourRange = java.time.temporal.ChronoField.HOUR_OF_DAY.range()
+    *   hourRange.getMinimum == 0 && hourRange.getMaximum == 23
+    * }
+    * }}}
+    */
+  private def at(day: LocalDate, hour: ValidHour): LocalDateTime =
+    LocalDateTime.of(day, LocalTime.of(hour, 0))
+
+  /** Get a [[LocalDateTime]].
+    *
+    * Returns None exactly when hour is outside 0-23.
+    */
+  private def atUnsafe(day: LocalDate, hour: Int): Option[LocalDateTime] =
+    try at(day, hour.asInstanceOf[ValidHour]).some
     catch
       case e: Exception =>
-        logger.error("failed to schedule", e)
+        logger.error(s"Failed to schedule due to invalid time '$hour:00'", e)
         None

--- a/modules/tournament/src/main/TournamentScheduler.scala
+++ b/modules/tournament/src/main/TournamentScheduler.scala
@@ -359,16 +359,16 @@ Thank you all, you rock!""".some,
           )
       }.flatMap { (hour, opening) =>
         List(
-          atUnsafe(today, hour).map { date =>
+          atOption(today, hour).map { date =>
             Schedule(Hourly, Bullet, Standard, opening.fen.some, date.pipe(orTomorrow)).plan
           },
-          atUnsafe(today, hour + 1).map { date =>
+          atOption(today, hour + 1).map { date =>
             Schedule(Hourly, SuperBlitz, Standard, opening.fen.some, date.pipe(orTomorrow)).plan
           },
-          atUnsafe(today, hour + 2).map { date =>
+          atOption(today, hour + 2).map { date =>
             Schedule(Hourly, Blitz, Standard, opening.fen.some, date.pipe(orTomorrow)).plan
           },
-          atUnsafe(today, hour + 3).map { date =>
+          atOption(today, hour + 3).map { date =>
             Schedule(Hourly, Rapid, Standard, opening.fen.some, date.pipe(orTomorrow)).plan
           }
         ).flatten
@@ -515,7 +515,7 @@ Thank you all, you rock!""".some,
     *
     * Returns None exactly when hour is outside 0-23 or if minutes is outside 0-59.
     */
-  private def atUnsafe(day: LocalDate, hour: Int, minute: Int = 0): Option[LocalDateTime] =
+  private def atOption(day: LocalDate, hour: Int, minute: Int = 0): Option[LocalDateTime] =
     try LocalDateTime.of(day, LocalTime.of(hour, minute)).some
     catch
       case e: Exception =>


### PR DESCRIPTION
`at()` does not generally need to return an Option. Reflecting the intention of the method, we now specify hours/minutes exactly instead of adjusting a LocalDateTime.

The existing impl returns Some[LocalDateTime] for nearly any hour value, even though arbitrary values (such as negatives) are not an intended use case of `at`.