### PR TITLE
fix: use single column on mobile forum search 

### DIFF
--- a/modules/forum/src/main/ui/PostUi.scala
+++ b/modules/forum/src/main/ui/PostUi.scala
@@ -189,7 +189,7 @@ final class PostUi(helpers: Helpers, bits: ForumBits):
                       br,
                       bits.authorLink(view.post)
                     )
-                  tr(cls := "paginated")(
+                  tr(cls := "paginated stack-row")(
                     if viewWithRead.canRead then
                       frag(
                         td(

--- a/ui/common/css/component/_slist.scss
+++ b/ui/common/css/component/_slist.scss
@@ -105,3 +105,15 @@
     }
   }
 }
+
+@media (max-width: 640px) {
+  .stack-row {
+    display: flex;
+    flex-direction: column;
+  }
+  .stack-row td {
+    width: 100%;
+    padding-inline-start: var(---box-padding);
+    padding-inline-end: var(---box-padding);
+  }
+}

--- a/ui/common/css/component/_slist.scss
+++ b/ui/common/css/component/_slist.scss
@@ -106,11 +106,12 @@
   }
 }
 
-@media (max-width: 640px) {
+@media (max-width: at-most($xx-small)) {
   .stack-row {
     display: flex;
     flex-direction: column;
   }
+
   .stack-row td {
     width: 100%;
     padding-inline-start: var(---box-padding);


### PR DESCRIPTION
fixes #15915 

<img width="380" alt="Screenshot 2024-09-28 at 11 40 50" src="https://github.com/user-attachments/assets/74fbba7c-d5e4-45ec-9566-86cd8d85d3d6">
