### PR TITLE
add browser console logging to ui/build

### DIFF
--- a/bin/schlawg-dev
+++ b/bin/schlawg-dev
@@ -3,5 +3,5 @@ cd "$(dirname "${BASH_SOURCE:-$0}")/.."
 
 trap 'tmux kill-session -t muxlog1234 2>/dev/null' EXIT
 tmux new-session -d -s muxlog1234 \
-  'journalctl --user -fu lila -o cat | grep -E -v fishnet & ui/build -cdr & wait; exec bash' \; \
+  'journalctl --user -fu lila -o cat | grep -E -v fishnet & ui/build -cdr=/ui-build & wait; exec bash' \; \
   attach-session -d -t muxlog1234 \;

--- a/bin/schlawg-dev
+++ b/bin/schlawg-dev
@@ -3,5 +3,5 @@ cd "$(dirname "${BASH_SOURCE:-$0}")/.."
 
 trap 'tmux kill-session -t muxlog1234 2>/dev/null' EXIT
 tmux new-session -d -s muxlog1234 \
-  'journalctl --user -fu lila -o cat | grep -E -v fishnet & ui/build -cdr=/ui-build & wait; exec bash' \; \
+  'journalctl --user -fu lila -o cat | grep -E -v fishnet & ui/build -cdrl=/ui-build & wait; exec bash' \; \
   attach-session -d -t muxlog1234 \;

--- a/modules/web/src/main/helper/AssetFullHelper.scala
+++ b/modules/web/src/main/helper/AssetFullHelper.scala
@@ -59,7 +59,9 @@ trait AssetFullHelper:
   def basicCsp(using ctx: Context): ContentSecurityPolicy =
     val sockets = socketDomains.map { x => s"wss://$x${(!ctx.req.secure).so(s" ws://$x")}" }
     // include both ws and wss when insecure because requests may come through a secure proxy
-    val localDev = (!ctx.req.secure).so(List("http://127.0.0.1:3000"))
+    val localDev =
+      (!netConfig.minifiedAssets).so("http://localhost:8666")
+        :: (!ctx.req.secure).so(List("http://127.0.0.1:3000"))
     lila.web.ContentSecurityPolicy.basic(
       netConfig.assetDomain,
       netConfig.assetDomain.value :: sockets ::: explorerEndpoint :: tablebaseEndpoint :: localDev

--- a/ui/.build/package.json
+++ b/ui/.build/package.json
@@ -10,7 +10,6 @@
     "@types/tinycolor2": "^1.4.6",
     "esbuild": "^0.23.1",
     "fast-glob": "^3.3.2",
-    "json5": "^2.2.3",
     "tinycolor2": "^1.6.0",
     "typescript": "^5.6.2"
   },

--- a/ui/.build/readme
+++ b/ui/.build/readme
@@ -5,17 +5,21 @@ ui/build was lovingly crafted from a single block of wood as a personal gift to 
   ui/build can be run from anywhere, does not care about cwd
 
 Options:
-  --clean             clean build artifacts and exit
+  -h, --help          show this help
   -c, --clean-build   clean build artifacts then build
   -d, --debug         build assets with site.debug = true
   -p, --prod          build minified assets (prod builds)
   -w, --watch         build, watch for changes, but terminate on package.json changes
   -r, --rebuild       build, watch, and rebuild on package.json changes
   -n, --no-install    don't run pnpm install (--no-install is incompatible with --rebuild)
+  -l, --log=<url>     monkey patch console.log and POST all messages to <url> (or localhost:8666
+                      if not specified). when used with --watch or --rebuild, ui/build listens on
+                      8666 and displays received json as 'web' over stdout
   --no-color          don't use color in logs
   --no-time           don't log the time
   --no-context        don't log the context
   --update            rebuild ui/build (not performed in normal builds, not even clean ones)
+  --clean             clean build artifacts and exit
   --tsc               run tsc, any of [--tsc, --sass, --esbuild, --copies] will disable the others
   --sass              run sass
   --esbuild           run esbuild
@@ -23,9 +27,11 @@ Options:
 
 Examples:
   ./build --clean            # clean only
-  ./build -c                 # clean build artifacts then build everything
+  ./build -c                 # clean then build everything
   ./build -rc                # recommended for maintainers - clean build, watch, clean rebuild
-  ./build -d                 # build client assets with site.debug = true
+  ./build -d                 # build with site.debug = true
+  ./build -w --log=/path     # build, watch, and patch js console POST to ${location.origin}/path. 
+                             # ui/build listens on 8666, displays received json as 'web' over stdout
   ./build -np                # no pnpm install, build minified
   ./build -cp                # clean, build minified
   ./build analyse site msg   # build analyse, site, and msg packages (as opposed to everything)

--- a/ui/.build/src/console.ts
+++ b/ui/.build/src/console.ts
@@ -1,0 +1,39 @@
+import { createServer, IncomingMessage, ServerResponse } from 'node:http';
+import { env, errorMark, warnMark, colors as c } from './main';
+
+export async function startConsole() {
+  if (!env.debug || !env.watch) return;
+  createServer((req: IncomingMessage, res: ServerResponse) => {
+    if (req.method === 'OPTIONS')
+      return res
+        .writeHead(200, '', {
+          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Methods': 'POST',
+          'Access-Control-Allow-Private-Network': 'true',
+        })
+        .end();
+    if (req.method !== 'POST' || req.url !== '/debug') return res.writeHead(404).end();
+
+    let body = '';
+
+    req.on('data', chunk => (body += chunk.toString()));
+    req.on('end', () => {
+      try {
+        let [[level, val]] = Object.entries<any>(JSON.parse(body));
+        const mark = level === 'error' ? `${errorMark} - ` : level === 'warn' ? `${warnMark} - ` : '';
+        if (!Array.isArray(val)) return;
+        if (val.length <= 1) val = val[0] ?? '';
+        else if (val.every(x => typeof x === 'string')) val = val.join(' ');
+
+        env.log(`${mark}${c.grey(typeof val === 'string' ? val : JSON.stringify(val, undefined, 2))}`, {
+          ctx: 'web',
+        });
+        res
+          .writeHead(200, { 'Access-Control-Allow-Origin': '*', 'Access-Control-Allow-Methods': 'POST' })
+          .end();
+      } catch (_) {
+        res.writeHead(400).end();
+      }
+    });
+  }).listen(8666);
+}

--- a/ui/.build/src/console.ts
+++ b/ui/.build/src/console.ts
@@ -12,7 +12,7 @@ export async function startConsole() {
           'Access-Control-Allow-Private-Network': 'true',
         })
         .end();
-    if (req.method !== 'POST' || req.url !== '/debug') return res.writeHead(404).end();
+    if (req.method !== 'POST') return res.writeHead(404).end();
 
     let body = '';
 

--- a/ui/.build/src/console.ts
+++ b/ui/.build/src/console.ts
@@ -2,7 +2,7 @@ import { createServer, IncomingMessage, ServerResponse } from 'node:http';
 import { env, errorMark, warnMark, colors as c } from './main';
 
 export async function startConsole() {
-  if (!env.debug || !env.watch) return;
+  if (!env.remoteLog || !env.watch) return;
   createServer((req: IncomingMessage, res: ServerResponse) => {
     if (req.method === 'OPTIONS')
       return res
@@ -36,4 +36,12 @@ export async function startConsole() {
       }
     });
   }).listen(8666);
+}
+
+export function jsLogger(): string {
+  const logUrl = typeof env.remoteLog === 'string' ? env.remoteLog : 'http://localhost:8666';
+  return `(function(){const o={log:console.log,info:console.info,warn:console.warn,error:console.error},` +
+    `l=["log","info","warn","error"];for(const s of l)console[s]=(...a)=>r(s,...a);async function ` +
+    `r(s,...a){o[s](...a);if(await fetch("${logUrl}",{method:"POST",body:JSON.stringify({[s]:a})})` +
+    `.then(e=>!e.ok).catch(()=>true))for(const s of l)console[s]=o[s];}})();`;
 }

--- a/ui/.build/src/main.ts
+++ b/ui/.build/src/main.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import fs from 'node:fs';
 import { clean } from './clean';
 import { build, postBuild } from './build';
+import { startConsole } from './console';
 
 // readme should be up to date but this is the definitive list of flags
 const args = [
@@ -66,6 +67,7 @@ export function main(): void {
     env.log('Cleaning then exiting. Use --clean-build or -c to clean then build');
     clean();
   } else {
+    startConsole();
     build(args.filter(x => !x.startsWith('-')));
   }
 }
@@ -232,7 +234,7 @@ class Env {
     if (ctx !== 'tsc' || code === 0)
       this.log(
         `${code === 0 ? 'Done' : colors.red('Failed')}` +
-        (this.watch ? ` - ${colors.grey('Watching')}...` : ''),
+          (this.watch ? ` - ${colors.grey('Watching')}...` : ''),
         {
           ctx: ctx,
         },

--- a/ui/.build/src/main.ts
+++ b/ui/.build/src/main.ts
@@ -14,7 +14,7 @@ const args: Record<string, string> = {
   '--no-color': '',
   '--no-time': '',
   '--no-context': '',
-  '--help': '',
+  '--help': 'h',
   '--rebuild': 'r',
   '--watch': 'w',
   '--prod': 'p',
@@ -23,6 +23,7 @@ const args: Record<string, string> = {
   '--clean': '',
   '--update': '',
   '--no-install': 'n',
+  '--log': 'l',
 };
 
 type Builder = 'sass' | 'tsc' | 'esbuild';
@@ -37,7 +38,7 @@ export function main(): void {
   const oneDashArgs = argv.flatMap(x => oneDashRe.exec(x)?.[1] ?? '').join('').split('');
   oneDashArgs.filter(x => !Object.values(args).includes(x)).forEach(arg => env.exit(`Unknown flag '-${arg}'`));
   argv
-    .filter(x => x.startsWith('--') && !Object.keys(args).includes(x.slice(2)))
+    .filter(x => x.startsWith('--') && !Object.keys(args).includes(x))
     .forEach(arg => env.exit(`Unknown argument '${arg}'`));
 
   if (['--tsc', '--sass', '--esbuild', '--copies'].filter(x => argv.includes(x)).length) {
@@ -54,7 +55,8 @@ export function main(): void {
   env.rebuild = argv.includes('--rebuild') || oneDashArgs.includes('r');
   env.watch = env.rebuild || argv.includes('--watch') || oneDashArgs.includes('w');
   env.prod = argv.includes('--prod') || oneDashArgs.includes('p');
-  env.debug = parseArg('--debug');
+  env.debug = argv.includes('--debug') || oneDashArgs.includes('d');
+  env.remoteLog = parseArg('--log');
   env.clean = argv.some(x => x.startsWith('--clean')) || oneDashArgs.includes('c');
   env.install = !argv.includes('--no-install') && !oneDashArgs.includes('n');
   env.rgb = argv.includes('--rgb');
@@ -126,7 +128,8 @@ class Env {
   rebuild = false;
   clean = false;
   prod = false;
-  debug: string|boolean = false;
+  debug = false;
+  remoteLog: string | boolean = false;
   rgb = false;
   install = true;
   copies = true;

--- a/ui/.build/src/main.ts
+++ b/ui/.build/src/main.ts
@@ -6,69 +6,72 @@ import { build, postBuild } from './build';
 import { startConsole } from './console';
 
 // readme should be up to date but this is the definitive list of flags
-const args = [
-  ['--tsc'],
-  ['--sass'],
-  ['--esbuild'],
-  ['--copies'],
-  ['--no-color'],
-  ['--no-time'],
-  ['--no-context'],
-  ['--help'],
-  ['--rebuild', '-r'],
-  ['--watch', '-w'],
-  ['--prod', '-p'],
-  ['--debug', '-d'],
-  ['--clean-build', '-c'],
-  ['--clean'],
-  ['--update'],
-  ['--no-install', '-n'],
-];
+const args: Record<string, string> = {
+  '--tsc': '',
+  '--sass': '',
+  '--esbuild': '',
+  '--copies': '',
+  '--no-color': '',
+  '--no-time': '',
+  '--no-context': '',
+  '--help': '',
+  '--rebuild': 'r',
+  '--watch': 'w',
+  '--prod': 'p',
+  '--debug': 'd',
+  '--clean-build': 'c',
+  '--clean': '',
+  '--update': '',
+  '--no-install': 'n',
+};
 
-const longArgs = args.map(x => x[0]);
-const shortArgs = args.map(x => x[1] && x[1][1]).filter(x => x);
 type Builder = 'sass' | 'tsc' | 'esbuild';
 
 export function main(): void {
-  const args = ps.argv.slice(2);
-  const oneDashArgs = args.filter(x => /^-([a-z]+)$/.test(x))?.flatMap(x => x.slice(1).split(''));
-  oneDashArgs.filter(x => !shortArgs.includes(x)).forEach(arg => env.exit(`Unknown flag '-${arg}'`));
-  args
-    .filter(x => x.startsWith('--') && !longArgs.includes(x))
+  const argv = ps.argv.slice(2);
+  const oneDashRe = /^-([a-z]+)(?:=[a-zA-Z0-9-_:./]+)?$/;
+  const parseArg = (arg: string): string | boolean => {
+    const it = argv.find(x => x.startsWith(arg) || args[arg] && oneDashRe.exec(x)?.[1]?.includes(args[arg]));
+    return it?.split('=')[1] ?? (it ? true : false);
+  };
+  const oneDashArgs = argv.flatMap(x => oneDashRe.exec(x)?.[1] ?? '').join('').split('');
+  oneDashArgs.filter(x => !Object.values(args).includes(x)).forEach(arg => env.exit(`Unknown flag '-${arg}'`));
+  argv
+    .filter(x => x.startsWith('--') && !Object.keys(args).includes(x.slice(2)))
     .forEach(arg => env.exit(`Unknown argument '${arg}'`));
 
-  if (['--tsc', '--sass', '--esbuild', '--copies'].filter(x => args.includes(x)).length) {
+  if (['--tsc', '--sass', '--esbuild', '--copies'].filter(x => argv.includes(x)).length) {
     // including one or more of these disables the others
-    if (!args.includes('--sass')) env.exitCode.set('sass', false);
-    if (!args.includes('--tsc')) env.exitCode.set('tsc', false);
-    if (!args.includes('--esbuild')) env.exitCode.set('esbuild', false);
-    env.copies = args.includes('--copies');
+    if (!argv.includes('--sass')) env.exitCode.set('sass', false);
+    if (!argv.includes('--tsc')) env.exitCode.set('tsc', false);
+    if (!argv.includes('--esbuild')) env.exitCode.set('esbuild', false);
+    env.copies = argv.includes('--copies');
   }
-  if (args.includes('--no-color')) env.color = undefined;
-  if (args.includes('--no-time')) env.logTime = false;
-  if (args.includes('--no-context')) env.logContext = false;
+  if (argv.includes('--no-color')) env.color = undefined;
+  if (argv.includes('--no-time')) env.logTime = false;
+  if (argv.includes('--no-context')) env.logContext = false;
 
-  env.rebuild = args.includes('--rebuild') || oneDashArgs.includes('r');
-  env.watch = env.rebuild || args.includes('--watch') || oneDashArgs.includes('w');
-  env.prod = args.includes('--prod') || oneDashArgs.includes('p');
-  env.debug = args.includes('--debug') || oneDashArgs.includes('d');
-  env.clean = args.some(x => x.startsWith('--clean')) || oneDashArgs.includes('c');
-  env.install = !args.includes('--no-install') && !oneDashArgs.includes('n');
-  env.rgb = args.includes('--rgb');
+  env.rebuild = argv.includes('--rebuild') || oneDashArgs.includes('r');
+  env.watch = env.rebuild || argv.includes('--watch') || oneDashArgs.includes('w');
+  env.prod = argv.includes('--prod') || oneDashArgs.includes('p');
+  env.debug = parseArg('--debug');
+  env.clean = argv.some(x => x.startsWith('--clean')) || oneDashArgs.includes('c');
+  env.install = !argv.includes('--no-install') && !oneDashArgs.includes('n');
+  env.rgb = argv.includes('--rgb');
 
   if (env.rebuild && !env.install) {
     env.warn(`--rebuild incompatible with --no-install`);
     env.rebuild = false;
   }
 
-  if (args.length === 1 && (args[0] === '--help' || args[0] === '-h')) {
+  if (argv.length === 1 && (argv[0] === '--help' || argv[0] === '-h')) {
     console.log(fs.readFileSync(path.resolve(__dirname, '../readme'), 'utf8'));
-  } else if (args.includes('--clean')) {
+  } else if (argv.includes('--clean')) {
     env.log('Cleaning then exiting. Use --clean-build or -c to clean then build');
     clean();
   } else {
     startConsole();
-    build(args.filter(x => !x.startsWith('-')));
+    build(argv.filter(x => !x.startsWith('-')));
   }
 }
 
@@ -123,7 +126,7 @@ class Env {
   rebuild = false;
   clean = false;
   prod = false;
-  debug = false;
+  debug: string|boolean = false;
   rgb = false;
   install = true;
   copies = true;

--- a/ui/.build/src/manifest.ts
+++ b/ui/.build/src/manifest.ts
@@ -7,6 +7,8 @@ import { env, colors as c, warnMark } from './main';
 import { globArray, globArrays } from './parse';
 import { isUnmanagedAsset } from './copies';
 import { allSources } from './sass';
+import { end } from 'chessground/drag';
+import { jsLogger } from './console';
 
 type Manifest = { [key: string]: { hash?: string; imports?: string[]; mtime?: number } };
 
@@ -104,9 +106,10 @@ async function write() {
     'if (!window.site.info) window.site.info={};',
     `window.site.info.commit='${cps.execSync('git rev-parse -q HEAD', { encoding: 'utf-8' }).trim()}';`,
     `window.site.info.message='${commitMessage}';`,
-    `window.site.debug=${typeof env.debug === 'string' ? `'${env.debug}'` : env.debug};`,
+    `window.site.debug=${env.debug};`,
     'const m=window.site.manifest={css:{},js:{},hashed:{}};',
   ];
+  if (env.remoteLog) clientJs.push(jsLogger());
   for (const [name, info] of Object.entries(current.js)) {
     if (!/common\.[A-Z0-9]{8}/.test(name)) clientJs.push(`m.js['${name}']='${info.hash}';`);
   }

--- a/ui/.build/src/manifest.ts
+++ b/ui/.build/src/manifest.ts
@@ -104,7 +104,7 @@ async function write() {
     'if (!window.site.info) window.site.info={};',
     `window.site.info.commit='${cps.execSync('git rev-parse -q HEAD', { encoding: 'utf-8' }).trim()}';`,
     `window.site.info.message='${commitMessage}';`,
-    `window.site.debug=${env.debug};`,
+    `window.site.debug=${typeof env.debug === 'string' ? `'${env.debug}'` : env.debug};`,
     'const m=window.site.manifest={css:{},js:{},hashed:{}};',
   ];
   for (const [name, info] of Object.entries(current.js)) {

--- a/ui/@types/lichess/index.d.ts
+++ b/ui/@types/lichess/index.d.ts
@@ -4,7 +4,7 @@
 
 // file://./../../site/src/site.ts
 interface Site {
-  debug: boolean;
+  debug: boolean|string;
   info: {
     commit: string;
     message: string;

--- a/ui/bits/src/bits.devMode.ts
+++ b/ui/bits/src/bits.devMode.ts
@@ -21,23 +21,3 @@ export function initModule(): void {
     this.append(tv);
   });
 }
-
-const original = { log: console.log, info: console.info, warn: console.warn, error: console.error };
-const levels: Array<keyof typeof original> = ['log', 'info', 'warn', 'error'];
-const url = typeof site.debug === 'string' ? site.debug : 'http://localhost:8666';
-
-for (const level of levels) console[level] = (...args) => debugLog(level, ...args);
-
-async function debugLog(level: keyof typeof original, ...args: any[]) {
-  original[level](...args);
-  const allGood =
-    await fetch(url, { method: 'POST', body: JSON.stringify({ [level]: args }) })
-      .then(rsp => rsp.ok)
-      .catch(() => false);
-  if (allGood) return;
-
-  // remove our monkey patches, pack up, and go home
-  for (const level of levels) console[level] = original[level];
-  // fetch errors gonna log in the console. reassure curious users it's ok
-  console.log(`cant reach log server at ${url}. this is fine!`);
-}

--- a/ui/bits/src/bits.devMode.ts
+++ b/ui/bits/src/bits.devMode.ts
@@ -21,3 +21,26 @@ export function initModule(): void {
     this.append(tv);
   });
 }
+
+const original = { log: console.log, info: console.info, warn: console.warn, error: console.error };
+const levels: Array<keyof typeof original> = ['log', 'info', 'warn', 'error'];
+
+for (const level of levels) console[level] = (...args) => debugLog(level, ...args);
+
+async function debugLog(level: keyof typeof original, ...args: any[]) {
+  original[level](...args);
+  if (
+    await fetch('http://localhost:8666/debug', {
+      method: 'POST',
+      body: JSON.stringify({ [level]: args }),
+    })
+      .then(rsp => rsp.ok)
+      .catch(() => false)
+  )
+    return;
+
+  // there is no way to suppress some fetch errors in the console. reassure curious users it's ok
+
+  console.log('ui/build console not available on localhost:8666. this is fine!');
+  for (const level of levels) console[level] = original[level];
+}

--- a/ui/ceval/src/protocol.ts
+++ b/ui/ceval/src/protocol.ts
@@ -140,11 +140,12 @@ export class Protocol {
         this.work.emit(this.currentEval);
         if (depth >= 99) this.stop();
       }
-    } else if (command && !['Stockfish', 'id', 'option', 'info'].includes(parts[0])) {
-      // some think it's a bug when they see these in console
-      if (!['No such option: Analysis Contempt', 'No such option: UCI_Variant'].includes(command))
-        console.warn('SF:', command);
-    }
+    } else if (
+      command &&
+      !['Stockfish', 'id', 'option', 'info'].includes(parts[0]) &&
+      !['Analysis Contempt', 'UCI_Variant', 'UCI_AnalyseMode'].includes(command.split(': ')[1])
+    )
+      console.warn(`SF: ${command}`);
   }
 
   private stop(): void {


### PR DESCRIPTION
- `ui/build` watch modes with `-d` flag will log browser console messages over stdout
- useful if you combine build output and lila logs together
- safari does not allow it
- those bothered by a one time error message when connect localhost:8666 fails are encouraged to not use `-d`