### PR TITLE
List() -> Nil

### DIFF
--- a/modules/common/src/test/StringTest.scala
+++ b/modules/common/src/test/StringTest.scala
@@ -55,9 +55,9 @@ class StringTest extends munit.FunSuite:
   }
 
   test("richText Not find forum post path") {
-    assertEquals(extractPosts("yes/no/maybe"), List())
-    assertEquals(extractPosts("go/to/some/very/long/path"), List())
-    assertEquals(extractPosts("Answer me yes/no?"), List())
+    assertEquals(extractPosts("yes/no/maybe"), Nil)
+    assertEquals(extractPosts("go/to/some/very/long/path"), Nil)
+    assertEquals(extractPosts("Answer me yes/no?"), Nil)
   }
 
   test("noShouting") {

--- a/modules/fishnet/src/test/UciToSanTest.scala
+++ b/modules/fishnet/src/test/UciToSanTest.scala
@@ -24,8 +24,8 @@ final class UciToSanTest extends munit.FunSuite:
     val uciAnalysis = Analysis(
       Analysis.Id(GameId("ke5ssdgj")),
       List(
-        Info(1, Eval(Some(Cp(12)), None, None), List()),
-        Info(2, Eval(Some(Cp(36)), None, None), List()),
+        Info(1, Eval(Some(Cp(12)), None, None), Nil),
+        Info(2, Eval(Some(Cp(36)), None, None), Nil),
         Info(
           3,
           Eval(Some(Cp(22)), None, None),
@@ -48,8 +48,8 @@ final class UciToSanTest extends munit.FunSuite:
             )
           )
         ),
-        Info(4, Eval(Some(Cp(-30)), None, None), List()),
-        Info(5, Eval(Some(Cp(-48)), None, None), List()),
+        Info(4, Eval(Some(Cp(-30)), None, None), Nil),
+        Info(5, Eval(Some(Cp(-48)), None, None), Nil),
         Info(
           6,
           Eval(Some(Cp(-80)), None, None),
@@ -69,19 +69,19 @@ final class UciToSanTest extends munit.FunSuite:
             )
           )
         ),
-        Info(7, Eval(Some(Cp(-22)), None, None), List()),
-        Info(8, Eval(Some(Cp(-64)), None, None), List()),
-        Info(9, Eval(Some(Cp(-38)), None, None), List()),
-        Info(10, Eval(Some(Cp(-56)), None, None), List()),
-        Info(11, Eval(Some(Cp(-48)), None, None), List()),
-        Info(12, Eval(Some(Cp(-48)), None, None), List()),
-        Info(13, Eval(Some(Cp(-52)), None, None), List()),
-        Info(14, Eval(Some(Cp(-98)), None, None), List()),
-        Info(15, Eval(Some(Cp(-56)), None, None), List()),
-        Info(16, Eval(Some(Cp(-98)), None, None), List()),
-        Info(17, Eval(Some(Cp(-54)), None, None), List()),
-        Info(18, Eval(Some(Cp(-96)), None, None), List()),
-        Info(19, Eval(Some(Cp(-96)), None, None), List()),
+        Info(7, Eval(Some(Cp(-22)), None, None), Nil),
+        Info(8, Eval(Some(Cp(-64)), None, None), Nil),
+        Info(9, Eval(Some(Cp(-38)), None, None), Nil),
+        Info(10, Eval(Some(Cp(-56)), None, None), Nil),
+        Info(11, Eval(Some(Cp(-48)), None, None), Nil),
+        Info(12, Eval(Some(Cp(-48)), None, None), Nil),
+        Info(13, Eval(Some(Cp(-52)), None, None), Nil),
+        Info(14, Eval(Some(Cp(-98)), None, None), Nil),
+        Info(15, Eval(Some(Cp(-56)), None, None), Nil),
+        Info(16, Eval(Some(Cp(-98)), None, None), Nil),
+        Info(17, Eval(Some(Cp(-54)), None, None), Nil),
+        Info(18, Eval(Some(Cp(-96)), None, None), Nil),
+        Info(19, Eval(Some(Cp(-96)), None, None), Nil),
         Info(
           20,
           Eval(Some(Cp(-113)), None, None),
@@ -203,7 +203,7 @@ final class UciToSanTest extends munit.FunSuite:
             )
           )
         ),
-        Info(26, Eval(Some(Cp(-2165)), None, None), List()),
+        Info(26, Eval(Some(Cp(-2165)), None, None), Nil),
         Info(
           27,
           Eval(Some(Cp(-2731)), None, None),
@@ -233,7 +233,7 @@ final class UciToSanTest extends munit.FunSuite:
           )
         ),
         Info(28, Eval(None, Some(Mate(2)), None), SanStr.from(List("h4f2", "e2d3", "c6b4"))),
-        Info(29, Eval(None, Some(Mate(-2)), None), List())
+        Info(29, Eval(None, Some(Mate(-2)), None), Nil)
       ),
       0,
       now,

--- a/modules/memo/src/main/Picfit.scala
+++ b/modules/memo/src/main/Picfit.scala
@@ -94,7 +94,7 @@ final class PicfitApi(coll: Coll, val url: PicfitUrl, ws: StandaloneWSClient, co
     def store(image: PicfitImage, part: SourcePart): Funit =
       ws
         .url(s"${config.endpointPost}/upload")
-        .post(Source(part.copy[ByteSource](filename = image.id.value, key = "data") :: List()))(using
+        .post(Source(part.copy[ByteSource](filename = image.id.value, key = "data") :: Nil))(using
           WSBodyWritables.bodyWritable
         )
         .flatMap:

--- a/modules/streamer/src/main/YouTubeApi.scala
+++ b/modules/streamer/src/main/YouTubeApi.scala
@@ -20,7 +20,7 @@ final private class YouTubeApi(
     net: NetConfig
 )(using Executor, akka.stream.Materializer):
 
-  private var lastResults: List[YouTube.Stream] = List()
+  private var lastResults: List[YouTube.Stream] = Nil
 
   private case class Tuber(streamer: Streamer, youTube: Streamer.YouTube)
 


### PR DESCRIPTION
Replace list constructions that use `List()` with `Nil`.

In Scala 2, some compiler magic converts `List()` into Nil and so the code is equivalent.  However, apparently Dotty forgot to implement this optimization, and so List() requires several allocations before ultimately returning Nil.

See scala/scala#10876.