### PR TITLE
Checkbox improvements

### DIFF
--- a/ui/common/css/form/_cmn-toggle.scss
+++ b/ui/common/css/form/_cmn-toggle.scss
@@ -18,6 +18,7 @@
   height: 24px;
   border: 1px solid $c-border;
   border-radius: 24px;
+  background-clip: padding-box;
 
   &::before,
   &::after {
@@ -66,7 +67,7 @@
   cursor: not-allowed !important;
 }
 
-.cmn-toggle:focus:not(:disabled) + label {
+.cmn-toggle:focus-visible:not(:disabled) + label {
   @extend %focus-shadow;
 }
 


### PR DESCRIPTION
This PR addresses two issues with the checkboxes.

1. When you check and then uncheck a checkbox the focus indicator (glowing background) remains active until you click away. This can be quickly seen by disabling the checkbox in a chat field. `focus-visible` fixes this while also still showing a focus indicator when tabbing as well.

2. The checkboxes have always looked a little fuzzy to me due to the color bleed around the edges. Fixed using `background-clip`.

**Before**
![light-before-off](https://github.com/user-attachments/assets/e06a1e57-7e16-422c-8032-40449d32dd6a)
![dark-before-off](https://github.com/user-attachments/assets/2e29cd3b-eacf-4122-97e0-d6df89fc4111)

**After**
![light-after-off](https://github.com/user-attachments/assets/758f2816-7f89-4b1c-9da9-67240872ac33)
![dark-after-off](https://github.com/user-attachments/assets/0835c8d1-92a4-4221-a8b7-4e6ec7f73a33)
