### PR TITLE
use ucinewgame instead of destroying ceval between puzzles (fixes #16067)

### DIFF
--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -755,7 +755,7 @@ export default class AnalyseCtrl {
   startCeval = throttle(800, () => {
     if (this.ceval?.enabled()) {
       if (this.canUseCeval()) {
-        this.ceval.start(this.path, this.nodeList, this.threatMode());
+        this.ceval.start(this.path, this.nodeList, undefined, this.threatMode());
         this.evalCache.fetch(this.path, this.ceval.search.multiPv);
       } else this.ceval.stop();
     }

--- a/ui/ceval/src/protocol.ts
+++ b/ui/ceval/src/protocol.ts
@@ -6,6 +6,7 @@ export class Protocol {
 
   private work: Work | undefined;
   private currentEval: Tree.LocalEval | undefined;
+  private gameId: string | undefined;
   private expectedPvs = 1;
 
   private nextWork: Work | undefined;
@@ -169,6 +170,9 @@ export class Protocol {
       this.setOption('Threads', this.work.threads);
       this.setOption('Hash', this.work.hashSize || 16);
       this.setOption('MultiPV', Math.max(1, this.work.multiPv));
+
+      if (this.gameId && this.gameId !== this.work.gameId) this.send('ucinewgame');
+      this.gameId = this.work.gameId;
 
       this.send(['position fen', this.work.initialFen, 'moves', ...this.work.moves].join(' '));
       const [by, value] = Object.entries(this.work.search)[0];

--- a/ui/ceval/src/types.ts
+++ b/ui/ceval/src/types.ts
@@ -11,6 +11,7 @@ export interface Work {
   variant: VariantKey;
   threads: number;
   hashSize: number | undefined;
+  gameId: string | undefined; // send ucinewgame when changed
   stopRequested: boolean;
 
   path: string;
@@ -107,6 +108,7 @@ export interface PvBoard {
 export interface Started {
   path: string;
   steps: Step[];
+  gameId: string | undefined;
   threatMode: boolean;
 }
 

--- a/ui/puzzle/src/ctrl.ts
+++ b/ui/puzzle/src/ctrl.ts
@@ -97,6 +97,35 @@ export default class PuzzleCtrl implements ParentCtrl {
       redraw,
     );
 
+    this.ceval = new CevalCtrl({
+      redraw: this.redraw,
+      variant: {
+        short: 'Std',
+        name: 'Standard',
+        key: 'standard',
+      },
+      externalEngines:
+        this.data.externalEngines?.map(engine => ({
+          ...engine,
+          endpoint: this.opts.externalEngineEndpoint,
+        })) || [],
+      initialFen: undefined, // always standard starting position
+      possible: true,
+      emit: (ev, work) => {
+        this.tree.updateAt(work.path, node => {
+          if (work.threatMode) {
+            const threat = ev;
+            if (!node.threat || node.threat.depth <= threat.depth) node.threat = threat;
+          } else if (!node.ceval || node.ceval.depth <= ev.depth) node.ceval = ev;
+          if (work.path === this.path) {
+            this.setAutoShapes();
+            this.redraw();
+          }
+        });
+      },
+      setAutoShapes: this.setAutoShapes,
+    });
+
     this.keyboardHelp = propWithEffect(location.hash === '#keyboard', this.redraw);
     keyboard(this);
 
@@ -210,8 +239,6 @@ export default class PuzzleCtrl implements ParentCtrl {
       g.setShapes([]);
       this.showGround(g);
     });
-
-    this.instanciateCeval();
   };
 
   position = (): Chess => {
@@ -456,38 +483,6 @@ export default class PuzzleCtrl implements ParentCtrl {
     }
   };
 
-  instanciateCeval = (): void => {
-    this.ceval?.destroy();
-    this.ceval = new CevalCtrl({
-      redraw: this.redraw,
-      variant: {
-        short: 'Std',
-        name: 'Standard',
-        key: 'standard',
-      },
-      externalEngines:
-        this.data.externalEngines?.map(engine => ({
-          ...engine,
-          endpoint: this.opts.externalEngineEndpoint,
-        })) || [],
-      initialFen: undefined, // always standard starting position
-      possible: true,
-      emit: (ev, work) => {
-        this.tree.updateAt(work.path, node => {
-          if (work.threatMode) {
-            const threat = ev;
-            if (!node.threat || node.threat.depth <= threat.depth) node.threat = threat;
-          } else if (!node.ceval || node.ceval.depth <= ev.depth) node.ceval = ev;
-          if (work.path === this.path) {
-            this.setAutoShapes();
-            this.redraw();
-          }
-        });
-      },
-      setAutoShapes: this.setAutoShapes,
-    });
-  };
-
   setAutoShapes = (): void =>
     this.withGround(g =>
       g.setAutoShapes(
@@ -505,7 +500,9 @@ export default class PuzzleCtrl implements ParentCtrl {
     if (this.ceval.enabled() && this.canUseCeval()) this.doStartCeval();
   };
 
-  private doStartCeval = throttle(800, () => this.ceval.start(this.path, this.nodeList, this.threatMode()));
+  private doStartCeval = throttle(800, () =>
+    this.ceval.start(this.path, this.nodeList, this.data.puzzle.id, this.threatMode()),
+  );
 
   nextNodeBest = () => treeOps.withMainlineChild(this.node, n => n.eval?.best);
 


### PR DESCRIPTION
This doesn't fix whatever the underlying issue is, but completely tearing down and recreating ceval (with potentially a huge hash table and many threads) should be avoided anyway.