### PR TITLE
Fix team battle jump to page

### DIFF
--- a/ui/tournament/src/view/battle.ts
+++ b/ui/tournament/src/view/battle.ts
@@ -127,7 +127,7 @@ function teamTr(ctrl: TournamentController, battle: TeamBattle, team: RankedTeam
             const href = (e.target as HTMLElement).getAttribute('data-href');
             if (href) {
               ctrl.jumpToPageOf(href.slice(3));
-              ctrl.redraw;
+              ctrl.redraw();
             }
           }),
         },


### PR DESCRIPTION
When clicking the top username next to the team scores, `jumpToPageOf` that user is called but the redraw doesn't actually happen. See https://lichess.org/tournament/5WDVB4Li