### PR TITLE
Ublog: fix Lichess name color on light mode

### DIFF
--- a/ui/bits/css/ublog/_card.scss
+++ b/ui/bits/css/ublog/_card.scss
@@ -35,14 +35,17 @@
       bottom: 0;
     }
     @include padding-direction(0.2em, 0.5em, 0.3em, 0.5em);
+    --c-ublog-post-card-over-image: #ddd;
+    @include if-light {
+      --c-ublog-post-card-over-image: #333;
+    }
 
     background: rgba(0, 0, 0, 0.65);
-    color: #ddd;
+    color: --c-ublog-post-card-over-image;
     text-shadow: 0 1px 1px black;
 
     @include if-light {
       background: rgba(255, 255, 255, 0.65);
-      color: #333;
       text-shadow: 0 1px 1px white;
     }
     opacity: 1;


### PR DESCRIPTION
Otherwise the color defined with `@include` was more specific and overwrote the special color for lichess

also cc @schlawg because it's probably not the way to do it, but it avoids `!important`.