### PR TITLE
adding pad to lobby container ensures symmetry

### DIFF
--- a/ui/lobby/css/_lobby.scss
+++ b/ui/lobby/css/_lobby.scss
@@ -17,6 +17,10 @@ body {
 
 #main-wrap {
   ---main-max-width: 1400px;
+
+  @media (max-width: $small) {
+    padding: 0 0.8em;
+  }
 }
 
 %lobby__side__more {


### PR DESCRIPTION
Spot the difference.

<img width="958" alt="side-by-side-LIVE-vs-LOCAL" src="https://github.com/user-attachments/assets/c909f025-2670-4a40-8c40-e8b0877d6036">

---
A tiny bit of padding for the lobby's container div ensures that symmetry is maintained on smaller viewports. 