### PR TITLE
Fix lobby modals closing after opening

### DIFF
--- a/ui/lobby/src/view/table.ts
+++ b/ui/lobby/src/view/table.ts
@@ -25,13 +25,7 @@ export default function table(ctrl: LobbyController) {
             {
               class: { active: ctrl.setupCtrl.gameType === gameType, disabled },
               attrs: { type: 'button' },
-              hook: disabled
-                ? {}
-                : bind(
-                    site.blindMode ? 'click' : 'mousedown',
-                    () => ctrl.setupCtrl.openModal(gameType),
-                    ctrl.redraw,
-                  ),
+              hook: disabled ? {} : bind('click', () => ctrl.setupCtrl.openModal(gameType), ctrl.redraw),
             },
             trans(transKey),
           ),


### PR DESCRIPTION
I'm able to recreate #16195 but only if long pressing the button and then releasing. Adjusted the trigger to happen on `click` instead of `mousedown` as that aligns with other modal bindings and resolves the issue.

Resolves #16195