### PR TITLE
Only show custom rules section when there are custom rules

### DIFF
--- a/modules/challenge/src/main/ui/ChallengeUi.scala
+++ b/modules/challenge/src/main/ui/ChallengeUi.scala
@@ -75,9 +75,11 @@ final class ChallengeUi(helpers: Helpers):
           modeName(c.mode)
         )
       ),
-      div(cls := "rules")(
-        h2("Custom rules:"),
-        div(fragList(c.rules.toList.map(showRule), "/"))
+      c.rules.nonEmpty.option(
+        div(cls := "rules")(
+          h2("Custom rules:"),
+          div(fragList(c.rules.toList.map(showRule), "/"))
+        )
       )
     )
 


### PR DESCRIPTION
The vast majority of challenges will not have custom rules and are left with an empty "Custom rules:" section. PR brings in changes so this section is only displayed if there are custom rules to show.

![image](https://github.com/user-attachments/assets/577f0a3d-2dc5-450e-a35f-c29a354258cf)

