### PR TITLE
Default study icon to study board if a flair is not selected

### DIFF
--- a/modules/study/src/main/ui/StudyBits.scala
+++ b/modules/study/src/main/ui/StudyBits.scala
@@ -52,7 +52,6 @@ final class StudyBits(helpers: Helpers):
         div(cls := "study__icon")(
           s.study.flair
             .map(iconFlair)
-            .orElse(userFlairSync(s.study.ownerId))
             .getOrElse(iconTag(Icon.StudyBoard))
         ),
         div(


### PR DESCRIPTION
When a new study is created the user has the option to select a flair for the study. If a flair is not selected the study silently defaults to the users flair on creation. Additionally, if the user has older studies before flairs existed these will all change to follow the current user flair every time they change their profile flair.

Maybe controversial, but to me this seems odd. I'd expect to receive the default "Study Board"  
![image](https://github.com/user-attachments/assets/bd23ceb5-6c11-44c5-9a36-000a866fb3a3)
icon if I don't specify a flair on study creation. Currently, the only way to get the default study board icon is to not have a user flair.

This PR makes it so by default if you don't select a study flair, the study will get the default study board icon. Old studies before flairs existed that have not been specifically assigned a flair will be reverted to the default study board icon instead of following the users current profile flair.