### PR TITLE
Add title attr to token scope toggle when disabled

### DIFF
--- a/modules/oauth/src/main/ui/TokenUi.scala
+++ b/modules/oauth/src/main/ui/TokenUi.scala
@@ -125,7 +125,8 @@ final class TokenUi(helpers: Helpers)(
                           s"${form("scopes").name}[]",
                           value = scope.key,
                           checked = !disabled && form.data.valuesIterator.contains(scope.key),
-                          disabled = disabled
+                          disabled = disabled,
+                          title = disabled.option(ot.alreadyHavePlayedGames.txt())
                         )
                       ),
                       label(`for` := id, st.title := disabled.option(ot.alreadyHavePlayedGames.txt()))(

--- a/modules/ui/src/main/helper/Form3.scala
+++ b/modules/ui/src/main/helper/Form3.scala
@@ -94,7 +94,8 @@ final class Form3(formHelper: FormHelper & I18nHelper, flairApi: FlairApi):
       fieldName: String,
       checked: Boolean,
       disabled: Boolean = false,
-      value: Value = "true"
+      value: Value = "true",
+      title: Option[String] = None
   ) =
     frag(
       st.input(
@@ -106,7 +107,10 @@ final class Form3(formHelper: FormHelper & I18nHelper, flairApi: FlairApi):
         checked.option(st.checked),
         disabled.option(st.disabled)
       ),
-      label(`for` := fieldId)
+      label(
+        `for` := fieldId,
+        title.map(st.title := _)
+      )
     )
 
   def nativeCheckbox[Value: Show](


### PR DESCRIPTION
On page https://lichess.org/account/oauth/token/create

There was hover text over the label for `bot:play`/`board:play` but not the toggle button itself.