### PR TITLE
Make adding `target="_blank"` to all Markdown links

### DIFF
--- a/modules/common/src/main/MarkdownRender.scala
+++ b/modules/common/src/main/MarkdownRender.scala
@@ -174,6 +174,7 @@ object MarkdownRender:
               html
                 .srcPos(node.getChars())
                 .attr("href", url)
+                .attr("target", "_blank")
                 .attr("rel", rel)
                 .withAttr(resolvedLink)
                 .tag("a")
@@ -295,6 +296,7 @@ object MarkdownRender:
   private val lilaLinkAttributeProvider = new AttributeProvider:
     override def setAttributes(node: Node, part: AttributablePart, attributes: MutableAttributes) =
       if (node.isInstanceOf[Link] || node.isInstanceOf[AutoLink]) && part == AttributablePart.LINK then
+        attributes.replaceValue("target", "_blank")
         attributes.replaceValue("rel", rel)
         attributes.replaceValue("href", RawHtml.removeUrlTrackingParameters(attributes.getValue("href")))
 

--- a/modules/common/src/test/MarkdownTest.scala
+++ b/modules/common/src/test/MarkdownTest.scala
@@ -14,16 +14,20 @@ class MarkdownTest extends munit.FunSuite:
     val md = Markdown("https://example.com")
     assertEquals(
       render(md),
-      Html("""<p><a href="https://example.com" target="_blank" rel="nofollow noopener noreferrer">https://example.com</a></p>
-""")
+      Html(
+        """<p><a href="https://example.com" target="_blank" rel="nofollow noopener noreferrer">https://example.com</a></p>
+"""
+      )
     )
   }
   test("markdown links remove tracking tags") {
     val md = Markdown("[Example](https://example.com?utm_campaign=spy&utm_source=evil)")
     assertEquals(
       render(md),
-      Html("""<p><a href="https://example.com" target="_blank" rel="nofollow noopener noreferrer">Example</a></p>
-""")
+      Html(
+        """<p><a href="https://example.com" target="_blank" rel="nofollow noopener noreferrer">Example</a></p>
+"""
+      )
     )
   }
   val domain     = NetDomain("http://l.org")
@@ -76,8 +80,10 @@ class MarkdownTest extends munit.FunSuite:
   test("markdown image whitelist block") {
     assertEquals(
       render(Markdown("![image](https://evil.com/image.png)")),
-      Html("""<p><a href="https://evil.com/image.png" target="_blank" rel="nofollow noopener noreferrer">image</a></p>
-""")
+      Html(
+        """<p><a href="https://evil.com/image.png" target="_blank" rel="nofollow noopener noreferrer">image</a></p>
+"""
+      )
     )
   }
   test("markdown chapter embed auto link") {

--- a/modules/common/src/test/MarkdownTest.scala
+++ b/modules/common/src/test/MarkdownTest.scala
@@ -14,7 +14,7 @@ class MarkdownTest extends munit.FunSuite:
     val md = Markdown("https://example.com")
     assertEquals(
       render(md),
-      Html("""<p><a href="https://example.com" rel="nofollow noopener noreferrer">https://example.com</a></p>
+      Html("""<p><a href="https://example.com" target="_blank" rel="nofollow noopener noreferrer">https://example.com</a></p>
 """)
     )
   }
@@ -22,7 +22,7 @@ class MarkdownTest extends munit.FunSuite:
     val md = Markdown("[Example](https://example.com?utm_campaign=spy&utm_source=evil)")
     assertEquals(
       render(md),
-      Html("""<p><a href="https://example.com" rel="nofollow noopener noreferrer">Example</a></p>
+      Html("""<p><a href="https://example.com" target="_blank" rel="nofollow noopener noreferrer">Example</a></p>
 """)
     )
   }
@@ -76,7 +76,7 @@ class MarkdownTest extends munit.FunSuite:
   test("markdown image whitelist block") {
     assertEquals(
       render(Markdown("![image](https://evil.com/image.png)")),
-      Html("""<p><a href="https://evil.com/image.png" rel="nofollow noopener noreferrer">image</a></p>
+      Html("""<p><a href="https://evil.com/image.png" target="_blank" rel="nofollow noopener noreferrer">image</a></p>
 """)
     )
   }


### PR DESCRIPTION
Resolves #15290, but also adds in other places
Therefore, making sure you don't leave the site completely when you click on a link