### PR TITLE
always request webp from picfit

### DIFF
--- a/modules/memo/src/main/Picfit.scala
+++ b/modules/memo/src/main/Picfit.scala
@@ -172,7 +172,7 @@ final class PicfitUrl(config: PicfitConfig)(using Executor) extends lila.core.mi
       height: Int
   ) =
     // parameters must be given in alphabetical order for the signature to work (!)
-    val queryString = s"h=$height&op=$operation&path=$id&w=$width"
+    val queryString = s"fmt=webp&h=$height&op=$operation&path=$id&w=$width"
     s"${config.endpointGet}/display?${signQueryString(queryString)}"
 
   private object signQueryString:

--- a/ui/bits/src/bits.cropDialog.ts
+++ b/ui/bits/src/bits.cropDialog.ts
@@ -93,7 +93,7 @@ export async function initModule(o?: CropOpts): Promise<void> {
       maxWidth: opts.max?.pixels,
       maxHeight: opts.max?.pixels,
     });
-    const imgOutputFormat = isPng(opts.source) ? 'png' : 'jpeg';
+    const imgOutputFormat = isJpeg(opts.source) ? 'jpeg' : 'png';
     const tryQuality = (quality = 1) => {
       canvas.toBlob(
         blob => {
@@ -156,8 +156,8 @@ export async function initModule(o?: CropOpts): Promise<void> {
   }
 }
 
-const isPng = (source?: Blob | string) => {
-  if (source instanceof Blob) return source.type == 'image/png';
-  if (typeof source == 'string') return source.endsWith('.png');
+const isJpeg = (source?: Blob | string) => {
+  if (source instanceof Blob) return source.type == 'image/jpeg';
+  if (typeof source == 'string') return /\.jpe?g$/i.test(source);
   return false;
 };


### PR DESCRIPTION
Afaict we already use webp without fallback for a couple of things (flairs, backgrounds). We could also ask picfit to deliver all images as webp. Thoughts?

cc @kraktus, cc @schlawg 