### PR TITLE
Fix nav flicker that happens on window resize

### DIFF
--- a/ui/common/css/header/_topnav-hidden.scss
+++ b/ui/common/css/header/_topnav-hidden.scss
@@ -116,7 +116,6 @@
     @include if-rtl {
       transform: translateX(calc(100% + 10px));
     }
-    transition: transform 200ms;
 
     padding-bottom: 1.2rem;
     overflow-y: auto;
@@ -180,6 +179,10 @@
         opacity: 1;
         transition: opacity 125ms ease-in-out 125ms;
       }
+    }
+
+    .opened ~ & {
+      transition: transform 200ms;
     }
   }
 

--- a/ui/site/src/topBar.ts
+++ b/ui/site/src/topBar.ts
@@ -26,8 +26,13 @@ export default function () {
 
   $('#tn-tg').on('change', e => {
     const menuOpen = (e.target as HTMLInputElement).checked;
-    if (menuOpen) document.body.addEventListener('touchmove', blockBodyScroll, { passive: false });
-    else document.body.removeEventListener('touchmove', blockBodyScroll);
+    if (menuOpen) {
+      document.body.addEventListener('touchmove', blockBodyScroll, { passive: false });
+      $(e.target).addClass('opened');
+    } else {
+      document.body.removeEventListener('touchmove', blockBodyScroll);
+      setTimeout(() => $(e.target).removeClass('opened'), 200);
+    }
     document.body.classList.toggle('masked', menuOpen);
   });
 


### PR DESCRIPTION
Fixes the navigation hamburger menu flicker that happens on window resize. The issue is `transition: transform 200ms;` always being applied when the layout changes. Changed to add the transition selectively when the menu is opened/closed.

The approach in this PR keeps all transitions as is. The new `opened` class cannot be simply `toggled` as we need to wait long enough for the transition to finish (for the close transition), hence the `setTimeout` call on menu close. I felt this was the most straightforward approach that maintains compatibility as listening to when a `transitioned` event completes seems to be browser specific.

Solves the problem seen here:

https://github.com/user-attachments/assets/d006125a-fa27-4f6a-a71a-61bbd13c60dd


