### PR TITLE
Display the 'c' keyboard shortcut under the 'other' to focus chat for rounds

### DIFF
--- a/app/controllers/Round.scala
+++ b/app/controllers/Round.scala
@@ -316,4 +316,4 @@ final class Round(
   }
 
   def help = Open:
-    Ok.snip(lila.web.ui.help.round)
+    Ok.snip(lila.web.ui.help.round(ctx.kid.no))

--- a/modules/web/src/main/ui/help.scala
+++ b/modules/web/src/main/ui/help.scala
@@ -36,7 +36,7 @@ object help:
     .map: letter =>
       frag(s"${letter.capitalize} = ", phonetic(letter), ". ")
 
-  def round(using Translate) =
+  def round(hasChat: Boolean)(using Translate) =
     frag(
       h2(trans.site.keyboardShortcuts()),
       table(
@@ -45,6 +45,9 @@ object help:
           header(trans.site.other()),
           flip,
           zen,
+          hasChat.option(
+            row(kbd("c"), trans.site.focusChat())
+          ),
           helpDialog
         )
       )


### PR DESCRIPTION
Bugfix for https://github.com/lichess-org/lila/issues/16255

Display the 'c' shortcuts when playing rounds in the 'Other' section

<img width="296" alt="Screenshot 2024-10-21 at 08 50 09" src="https://github.com/user-attachments/assets/38fcc0f1-1285-47ab-97e2-938022fd57cf">
