### PR TITLE
Use toLowerCase on the orientation color to handle it correctly when adding a chapter

### DIFF
--- a/modules/study/src/main/ChapterMaker.scala
+++ b/modules/study/src/main/ChapterMaker.scala
@@ -218,7 +218,7 @@ private[study] object ChapterMaker:
     case Fixed(color: Color) extends Orientation(color.name, color.some)
     case Auto                extends Orientation("automatic", none)
   object Orientation:
-    def apply(str: String) = Color.fromName(str).fold[Orientation](Auto)(Fixed.apply)
+    def apply(str: String) = Color.fromName(str.toLowerCase()).fold[Orientation](Auto)(Fixed.apply)
 
   case class Data(
       name: StudyChapterName,


### PR DESCRIPTION
Fixes #16262 

The problem was that when the data was handled, the orientation was set to either "White" or "Black". But the Orientation object needed it in lowercase to correctly get the Color from it.

It is working great now, but let me know if I missed something ! 