### PR TITLE
Speed up eslint with --cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ RUNNING_PID
 # Docker-compose / docker sbt
 /docker-compose.yml
 /?
+
+# eslint cache
+/.eslintcache

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,9 +2,9 @@ import typescriptEslint from '@typescript-eslint/eslint-plugin';
 import tsParser from '@typescript-eslint/parser';
 
 export default [
+  { ignores: ['*', '!ui/', '!bin/', '**/dist/'] },
   {
     files: ['**/*.ts'],
-    ignores: ['**/dist/**', '**/node_modules/**', '**/public/**'],
     plugins: { '@typescript-eslint': typescriptEslint },
     languageOptions: { parser: tsParser, ecmaVersion: 5, sourceType: 'module' },
     rules: {

--- a/package.json
+++ b/package.json
@@ -41,12 +41,12 @@
     "typescript": "^5.6.2"
   },
   "scripts": {
-    "format": "prettier --write --log-level warn .",
-    "check-format": "prettier --check --log-level warn .",
-    "watch-format": "onchange \"**/*\" -- prettier --write --log-level warn {{changed}}",
+    "format": "prettier --cache --write --log-level warn .",
+    "check-format": "prettier --cache --check --log-level warn .",
+    "watch-format": "onchange \"**/*\" -- prettier --cache --write --log-level warn {{changed}}",
     "add-hooks": "git config --add core.hooksPath bin/git-hooks",
     "remove-hooks": "git config --unset core.hooksPath bin/git-hooks",
-    "lint": "eslint ui",
+    "lint": "eslint --cache",
     "journal": "journalctl --user -fu lila -o cat",
     "metals": "tail -F .metals/metals.log | stdbuf -oL cut -c 21- | rg -v '(notification for request|handleCancellation)'",
     "serverlog": "pnpm journal & pnpm metals",


### PR DESCRIPTION
And also align eslint ignored files with how eslint is automatically run.

This ensures that all contributors run lint on the same set of files. Prior to this change, eslint covers ts files outside ui with its default rules, meaning contributors might commit code with fresh eslint errors that only show up when eslint is run bare, or if an eslint extension is installed in a code editor.

Because this commit adds a global ignore pattern on all folders by default, the bare `eslint` command run no longer takes additional time over `eslint ui`. And the --cache flag means lint will usually be dramatically faster than before.

One-off eslint checks on files in ignored directories can still be performed with: `eslint <path to file>`

Pre-commit run of eslint
```
$ hyperfine -w 3 -N  'node_modules/.bin/eslint ui'
  Time (mean ± σ):      2.405 s ±  0.018 s    [User: 4.728 s, System: 0.316 s]
  Range (min … max):    2.374 s …  2.444 s    10 runs
```

Post-commit run of eslint, without the ui argument. (faster because of the more efficient global ignore patterns)

```
$ hyperfine -w 3 -N  'node_modules/.bin/eslint'
  Time (mean ± σ):      2.203 s ±  0.011 s    [User: 4.338 s, System: 0.296 s]
  Range (min … max):    2.188 s …  2.225 s    10 runs
```

Post-commit example of lint script if repeatedly run. This is much faster, thanks to --cache.

```
$ hyperfine -w 3 -N  'node --run lint'
Benchmark 1: node --run lint
  Time (mean ± σ):     487.3 ms ±   2.4 ms    [User: 606.9 ms, System: 85.5 ms]
  Range (min … max):   483.7 ms … 491.0 ms    10 runs
```

----

I've also added --cache to prettier format scripts. Note that while prettier automatically manages the cache for most tooling updates, it does not clear cache on prettier plugin updates (which we aren't currently using). Nonetheless, to future proof our prettier cache, I'm purposely leaving --cache off the pre-commit hook, which ensures the prettier cache will be often cleared. The cache is still useful when repeatedly running format or when using watch-format.

```
$ hyperfine -w 3 -N  'node --run format'
  Time (mean ± σ):      4.656 s ±  0.066 s    [User: 7.785 s, System: 0.896 s]
  Range (min … max):    4.594 s …  4.808 s    10 runs
```

Post-commit example of prettier under repeated use, now much faster thanks to --cache
```
$ hyperfine -w 3 -N  'node --run format'
  Time (mean ± σ):      1.777 s ±  0.022 s    [User: 1.879 s, System: 0.646 s]
  Range (min … max):    1.751 s …  1.814 s    10 runs
```