### PR TITLE
Permalog: always convert reason to string before escaping to html

### DIFF
--- a/ui/common/src/permalog.ts
+++ b/ui/common/src/permalog.ts
@@ -100,7 +100,7 @@ function makeLog(): LichessLog {
     log(`${terseHref()} - ${e.reason}`);
     if (site.debug)
       domDialog({
-        htmlText: escapeHtml(e.reason),
+        htmlText: escapeHtml(e.reason.toString()),
         class: 'debug',
         show: true,
       });


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/PromiseRejectionEvent/reason

`reason read-only property is any JavaScript value or Object which provides the reason passed into Promise.reject()`

fix https://github.com/lichess-org/lila/issues/16295