### PR TITLE
Fix clean stage builds

### DIFF
--- a/app/controllers/User.scala
+++ b/app/controllers/User.scala
@@ -347,7 +347,7 @@ final class User(
       me: Me
   ): Fu[Result] =
     env.report.api.inquiries
-      .ofModId(me.id)
+      .ofModId(me)
       .zip(env.user.api.withPerfsAndEmails(username).orFail(s"No such user $username"))
       .flatMap { case (inquiry, WithPerfsAndEmails(user, emails)) =>
         import views.mod.{ user as ui }


### PR DESCRIPTION
Resolves error

```
Found:    (me : lila.app.Me)
Required: ?{ id: ? }
Note that implicit extension methods cannot be applied because they are ambiguous;
both given instance given_UserIdOf_Me in object Me and given instance given_Conversion_Me_User in object Me provide an extension method `id` on (me : lila.app.Me)
```

Which I can reproduce when running:

```
sbt clean && ./lila.sh stage
```

Related https://github.com/lichess-org/lila/pull/15878