### PR TITLE
Fix nvui regex to prevent undefined on invalid input

### DIFF
--- a/ui/nvui/src/command.ts
+++ b/ui/nvui/src/command.ts
@@ -5,7 +5,7 @@ export const commands = {
   piece: {
     help: 'p: Read locations of a piece type. Example: p N, p k.',
     apply(c: string, pieces: Pieces, style: Style): string | undefined {
-      return tryC(c, /^p ([p|n|b|r|q|k])$/i, p => renderPieceKeys(pieces, p, style));
+      return tryC(c, /^p ([pnbrqk])$/i, p => renderPieceKeys(pieces, p, style));
     },
   },
   scan: {

--- a/ui/nvui/tests/command.test.ts
+++ b/ui/nvui/tests/command.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from 'vitest';
+import { commands } from '../src/command';
+import { Pieces } from 'chessground/types';
+
+const pieces: Pieces = new Map();
+pieces.set('a1', {
+  role: 'king',
+  color: 'white',
+});
+pieces.set('a2', {
+  role: 'queen',
+  color: 'white',
+});
+pieces.set('b1', {
+  role: 'knight',
+  color: 'white',
+});
+pieces.set('b2', {
+  role: 'knight',
+  color: 'white',
+});
+
+test('piece command', () => {
+  expect(commands.piece.apply('p N', pieces, 'san')).toBe('white knight: b1, b2');
+  expect(commands.piece.apply('p N', pieces, 'nato')).toBe('white knight: bravo 1, bravo 2');
+  expect(commands.piece.apply('p b', pieces, 'san')).toBe('black bishop: none');
+
+  expect(commands.piece.apply('p X', pieces, 'san')).toBeUndefined();
+  expect(commands.piece.apply('p |', pieces, 'san')).toBeUndefined();
+});
+
+test('scan command', () => {
+  expect(commands.scan.apply('s a', pieces, 'san')).toBe('a1 white king, a2 white queen');
+  expect(commands.scan.apply('s 1', pieces, 'san')).toBe('a1 white king, b1 white knight');
+
+  expect(commands.scan.apply('s x', pieces, 'san')).toBeUndefined();
+  expect(commands.scan.apply('s 9', pieces, 'san')).toBeUndefined();
+});


### PR DESCRIPTION
| before | after |
| - | - |
| ![image](https://github.com/user-attachments/assets/4964e26a-7154-4642-9a98-35b2573d83c5) | ![image](https://github.com/user-attachments/assets/22916463-6734-4004-b0e9-e525085d0699) |



