### PR TITLE
Add delay to victory, defeat sounds

### DIFF
--- a/ui/round/src/ctrl.ts
+++ b/ui/round/src/ctrl.ts
@@ -562,7 +562,10 @@ export default class RoundController implements MoveRootCtrl {
     }
     if (!d.player.spectator && d.game.turns > 1) {
       const key = o.winner ? (d.player.color === o.winner ? 'victory' : 'defeat') : 'draw';
-      site.sound.play(key);
+      // Delay 'victory'& 'defeat' sounds to avoid overlapping with 'checkmate' sound
+      setTimeout(() => {
+        site.sound.play(key);
+      }, 600);
       if (
         key != 'victory' &&
         d.game.turns > 6 &&


### PR DESCRIPTION
Fixes bug possibly introduced in [#16220](https://github.com/lichess-org/lila/pull/16220)
Also noted in issue [#7209](https://github.com/lichess-org/lila/issues/7209) where checkmate and victory play at the same time.

Allow `checkmate` sound to finish playing by adding a delay to the `victory`, `defeat`, `draw` sounds.
I tested this locally with the Robot & Standard sounds, and I think it works.