### PR TITLE
Add puzzle rating deviation to json response

### DIFF
--- a/modules/puzzle/src/main/JsonView.scala
+++ b/modules/puzzle/src/main/JsonView.scala
@@ -209,6 +209,7 @@ object JsonView:
   private def puzzleJsonBase(puzzle: Puzzle): JsObject = Json.obj(
     "id"       -> puzzle.id,
     "rating"   -> puzzle.glicko.intRating,
+    "rd"       -> puzzle.glicko.intDeviation,
     "plays"    -> puzzle.plays,
     "solution" -> puzzle.line.tail.map(_.uci),
     "themes"   -> simplifyThemes(puzzle.themes)


### PR DESCRIPTION
This exposes a puzzle's rating deviation in the api. It was previously absent, but is present in the puzzle database and in player perf json responses.

I used 'rd' to mimic player rating deviation in other contexts (e.g., https://github.com/lichess-org/lila/blob/9a7c405c2a5608264395c3d9497fdbed2a349eb5/modules/user/src/main/JsonView.scala#L87).

If this is approved, I will add the information to the api schema (I don't think I can do that simultaneously, right?).