### PR TITLE
add Contact broadcast team in contact page

### DIFF
--- a/modules/web/src/main/ui/contact.scala
+++ b/modules/web/src/main/ui/contact.scala
@@ -316,16 +316,16 @@ object contact:
             ),
             Leaf(
               "contact-broadcast",
-              "Contact the Broadcast Team",
+              "Broadcast a tournament on Lichess",
               frag(
                 p(
-                  "If you want to make your broadcasts official on Lichess, ",
-                  "or have any questions about them."
+                  "If you want to officially broadcast a tournament on Lichess, ",
+                  "or have any questions about our broadcasts:"
                 ),
                 p(
-                  "Please contact ",
+                  "Please contact our Broadcast Team at ",
                   contactEmailLink("broadcast@lichess.org"),
-                  " or ",
+                  " or on ",
                   a(href := "https://discord.gg/Syx9CbN8Jv")("our discord"),
                   "."
                 )

--- a/modules/web/src/main/ui/contact.scala
+++ b/modules/web/src/main/ui/contact.scala
@@ -315,6 +315,23 @@ object contact:
               )
             ),
             Leaf(
+              "contact-broadcast",
+              "Contact the Broadcast Team",
+              frag(
+                p(
+                  "If you want to make your broadcasts official on Lichess, ",
+                  "or have any questions about them."
+                ),
+                p(
+                  "Please contact ",
+                  contactEmailLink("broadcast@lichess.org"),
+                  " or ",
+                  a(href := "https://discord.gg/Syx9CbN8Jv")("our discord"),
+                  "."
+                )
+              )
+            ),
+            Leaf(
               "contact-other",
               noneOfTheAbove(),
               frag(


### PR DESCRIPTION
Make it easier for organizers to find the official Broadcast Team contact

Currently it is still a little hidden.

![Screenshot 2024-11-05 07 06 29](https://github.com/user-attachments/assets/03fde263-76ef-42f5-bbf4-35596e22b772)
