### PR TITLE
Prevent overwrite of .mchat__tab border radius in voice tab

### DIFF
--- a/ui/chat/css/_palantir.scss
+++ b/ui/chat/css/_palantir.scss
@@ -19,7 +19,6 @@
 .palantir {
   flex: 0 1 auto;
   animation: palantir-glowing 1.5s ease-in-out infinite;
-  border-radius: 0 3px 0 0;
 
   &-slot {
     animation: none;


### PR DESCRIPTION
Fixes #16340