### PR TITLE
Write performance field in LeaderboardApi.Entry

### DIFF
--- a/modules/tournament/src/main/BSONHandlers.scala
+++ b/modules/tournament/src/main/BSONHandlers.scala
@@ -201,6 +201,7 @@ object BSONHandlers:
         "s"   -> o.score,
         "r"   -> o.rank,
         "w"   -> o.rankRatio,
+        "e"   -> o.performance,
         "f"   -> o.freq.map(_.id),
         "p"   -> o.speed.map(_.id),
         "v"   -> o.perf.id,


### PR DESCRIPTION
I noticed that the `"performance"` json field had the `null` value in the json response when I tried the `/api/user/<user>/tournament/played` endpoint.
Adding it to the BSON writer for `LeaderboardApi.Entry` gives the field a value.

Relates: 6906069

Note,
I assume there will always be a value for performance if at least 1 game has been played... At least there were in the 3 test arenas I tried.
If not, the field should be added in `ApiJsonView` as a `Json.obj(...).add("performance" -> e.entry.performance)` in order for it to be omitted instead of included with `null`.