### PR TITLE
Enable newlines in profile bio and don't shorten text

### DIFF
--- a/app/views/user/show/header.scala
+++ b/app/views/user/show/header.scala
@@ -191,7 +191,7 @@ object header:
                     profile.nonEmptyRealName.map: name =>
                       strong(cls := "name")(name),
                     profile.nonEmptyBio.map: bio =>
-                      p(cls := "bio")(richText(shorten(bio, 400), nl2br = false))
+                      p(cls := "bio")(richText(bio, nl2br = true))
                   )
                 ),
                 div(cls := "stats")(


### PR DESCRIPTION
Resolves #16275

Enables newlines (as well as custom spacing) in a user's profile bio. By not calling `shorten`, all sequences of whitespace chars won't be replaced with single spaces. For the part about shortening the text if its length is over 400, the text the user enters can already never be over 400 chars, due to this line in UserForm.scala: 
`"bio"        -> optional(cleanNoSymbolsAndNonEmptyText(maxLength = 400)),`