### PR TITLE
Puzzle report: make sure to report the correct puzzle id

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "serverlog": "pnpm journal & pnpm metals",
     "piece-css": "pnpx tsx bin/gen/piece-css.ts",
     "trans-dump": "pnpx tsx bin/trans-dump.ts",
+    "test": "cd ui/ && pnpm test",
     "multilog": "pnpm serverlog & ui/build -w"
   }
 }

--- a/ui/puzzle/src/ctrl.ts
+++ b/ui/puzzle/src/ctrl.ts
@@ -81,7 +81,7 @@ export default class PuzzleCtrl implements ParentCtrl {
   voteDisabled?: boolean;
   isDaily: boolean;
   blindfolded = false;
-  private readonly report: Report;
+  private report: Report;
 
   constructor(
     readonly opts: PuzzleOpts,
@@ -140,7 +140,7 @@ export default class PuzzleCtrl implements ParentCtrl {
 
     this.keyboardHelp = propWithEffect(location.hash === '#keyboard', this.redraw);
     keyboard(this);
-    this.report = new Report(this.data.puzzle.id);
+    this.report = new Report();
 
     // If the page loads while being hidden (like when changing settings),
     // chessground is not displayed, and the first move is not fully applied.
@@ -230,6 +230,7 @@ export default class PuzzleCtrl implements ParentCtrl {
     this.isDaily = location.href.endsWith('/daily');
     this.hintHasBeenShown(false);
     this.canViewSolution(false);
+    this.report = new Report();
 
     this.setPath(site.blindMode ? initialPath : treePath.init(initialPath));
     setTimeout(

--- a/ui/puzzle/src/report.ts
+++ b/ui/puzzle/src/report.ts
@@ -13,9 +13,9 @@ export default class Report {
   tsHideReportDialog: StoredProp<number>;
 
   // bump when logic is changed, to distinguish cached clients from new ones
-  private version = 1;
+  private version = 2;
 
-  constructor(readonly id: PuzzleId) {
+  constructor() {
     this.tsHideReportDialog = storedIntProp('puzzle.report.hide.ts', 0);
   }
 
@@ -53,13 +53,13 @@ export default class Report {
       ) {
         // in all case, we do not want to show the dialog more than once
         this.reported = true;
-        const reason = `v${this.version}: after move ${node.ply}. ${node.san}, at depth ${ev.depth}, multiple solutions, pvs ${ev.pvs.map(pv => `${pv.moves[0]}: ${pv.cp}`).join(', ')}`;
-        this.reportDialog(reason);
+        const reason = `(v${this.version}) after move ${node.ply}. ${node.san}, at depth ${ev.depth}, multiple solutions, pvs ${ev.pvs.map(pv => `${pv.moves[0]}: ${pv.cp}`).join(', ')}`;
+        this.reportDialog(ctrl.data.puzzle.id, reason);
       }
     }
   }
 
-  private reportDialog = (reason: string) => {
+  private reportDialog = (puzzleId: PuzzleId, reason: string) => {
     const switchButton =
       `<div class="switch switch-report-puzzle" title="temporarily disable reporting puzzles">` +
       `<input id="puzzle-toggle-report" class="cmn-toggle cmn-toggle--subtle" type="checkbox">` +
@@ -95,7 +95,7 @@ export default class Report {
         dlg.close();
       });
       $('.apply', dlg.view).on('click', () => {
-        xhr.report(this.id, reason);
+        xhr.report(puzzleId, reason);
         dlg.close();
       });
       dlg.showModal();


### PR DESCRIPTION
The id of the puzzle was not updated when you switch to another puzzle, so the id would only match with the analysis if it's the first puzzle loaded on the page