### PR TITLE
use lower virtual rating for first game pairing

### DIFF
--- a/modules/core/src/main/user.scala
+++ b/modules/core/src/main/user.scala
@@ -209,7 +209,7 @@ object user:
         perf: PerfKey,
         useCache: Boolean = true
     ): Fu[Option[ByColor[WithPerf]]]
-    def glicko(userId: UserId, perf: PerfKey): Fu[Glicko]
+    def glicko(userId: UserId, perf: PerfKey): Fu[Option[Glicko]]
     def containsDisabled(userIds: Iterable[UserId]): Fu[Boolean]
     def containsEngine(userIds: List[UserId]): Fu[Boolean]
     def usingPerfOf[A, U: UserIdOf](u: U, perfKey: PerfKey)(f: Perf ?=> Fu[A]): Fu[A]

--- a/modules/rating/src/main/Glicko.scala
+++ b/modules/rating/src/main/Glicko.scala
@@ -66,6 +66,10 @@ object Glicko:
 
   val default = new Glicko(1500d, maxDeviation, defaultVolatility)
 
+  // Virtual rating for first pairing to make the expected score 50% without
+  // actually changing the default rating
+  val pairingDefault = new Glicko(1460d, maxDeviation, defaultVolatility)
+
   // managed is for students invited to a class
   val defaultManaged       = new Glicko(800d, 400d, defaultVolatility)
   val defaultManagedPuzzle = new Glicko(800d, 400d, defaultVolatility)

--- a/modules/user/src/main/UserPerfsRepo.scala
+++ b/modules/user/src/main/UserPerfsRepo.scala
@@ -72,13 +72,13 @@ final class UserPerfsRepo(c: Coll)(using Executor) extends lila.core.user.PerfsR
   def setPerf(userId: UserId, pk: PerfKey, perf: Perf): Funit =
     coll.update.one($id(userId), $set(pk.value -> perf), upsert = true).void
 
-  def glicko(userId: UserId, perf: PerfKey): Fu[Glicko] =
+  def glicko(userId: UserId, perf: PerfKey): Fu[Option[Glicko]] =
     coll
       .find($id(userId), $doc(s"$perf.gl" -> true).some)
       .one[Bdoc]
       .dmap:
         _.flatMap(_.child(perf.value))
-          .flatMap(_.getAsOpt[Glicko]("gl")) | lila.rating.Glicko.default
+          .flatMap(_.getAsOpt[Glicko]("gl"))
 
   def addPuzRun(field: String, userId: UserId, score: Int): Funit =
     coll.update


### PR DESCRIPTION
Ideally, new players would score 0.5 on their first game, but it looks
like we pair them too high:

| Time control   | Avg score | Elo |
| ---------------| --------- | --- |
| Ultra bullet   | 0.25      | -96 |
| Bullet         | 0.25      | -96 |
| Blitz          | 0.34      | -59 |
| Rapid          | 0.37      | -47 |
| Classical      | 0.37      | -47 |
| Correspondence | 0.39      | -40 |

Changing the initial rating would change the rating distribution over
time, requiring to lower the rating again and so on.

Instead, use a virtual rating for the first pairing, just like we
already use virtual offsets from a normal distribution.