### PR TITLE
Move the list button to a less used area of the lobby chart

### DIFF
--- a/ui/lobby/css/app/_app.scss
+++ b/ui/lobby/css/app/_app.scss
@@ -62,6 +62,11 @@
     }
   }
 
+  .toggle-padding-left {
+    @extend .toggle;
+    padding-left: 90%;
+  }
+
   .gamesFiltered {
     color: $c-accent;
 

--- a/ui/lobby/src/view/realTime/chart.ts
+++ b/ui/lobby/src/view/realTime/chart.ts
@@ -106,7 +106,7 @@ function renderYAxis() {
 }
 
 export function toggle(ctrl: LobbyController) {
-  return h('i.toggle', {
+  return h('i.toggle-padding-left', {
     key: 'set-mode-list',
     attrs: { title: i18n.site.list, 'data-icon': licon.List },
     hook: bind('mousedown', _ => ctrl.setMode('list'), ctrl.redraw),


### PR DESCRIPTION
For me, the lobby chart looks like this:

![image](https://github.com/user-attachments/assets/dc8aa6ea-fcd1-4a4e-9588-aee03add3978)

This tends to make it a bit difficult to click the "list" button, since there's a good chance it'll be somewhat covered with player challenges. However, the area near the setting button is likely to be empty, due to the long time control.