### PR TITLE
add --test/-t option to typecheck tests

### DIFF
--- a/ui/.build/readme
+++ b/ui/.build/readme
@@ -13,6 +13,7 @@ Options:
   -p, --prod          build minified assets (prod builds)
   -n, --no-install    don't run pnpm install
   -d, --debug         build assets with site.debug = true
+  -t, --test          typecheck sources in ./tests/**. warning - this enables skipLibCheck for dependencies
   -l, --log=<url>     monkey patch console log functions in javascript manifest to POST log messages to
                       <url> or localhost:8666 (default). if used with --watch, the ui/build process
                       will listen for http on 8666 and display received json as 'web' in build logs

--- a/ui/.build/src/main.ts
+++ b/ui/.build/src/main.ts
@@ -19,6 +19,7 @@ const args: Record<string, string> = {
   '--watch': 'w',
   '--prod': 'p',
   '--debug': 'd',
+  '--test': 't',
   '--clean-exit': '',
   '--clean': 'c',
   '--update': '',
@@ -67,6 +68,7 @@ export async function main(): Promise<void> {
   env.clean = argv.some(x => x.startsWith('--clean')) || oneDashArgs.includes('c');
   env.install = !argv.includes('--no-install') && !oneDashArgs.includes('n');
   env.rgb = argv.includes('--rgb');
+  env.test = argv.includes('--test') || oneDashArgs.includes('t');
 
   if (argv.length === 1 && (argv[0] === '--help' || argv[0] === '-h')) {
     console.log(fs.readFileSync(path.resolve(env.buildDir, 'readme'), 'utf8'));
@@ -135,6 +137,7 @@ class Env {
   install = true;
   sync = true;
   i18n = true;
+  test = false;
   exitCode: Map<Builder, number | false> = new Map();
   startTime: number | undefined = Date.now();
   logTime = true;

--- a/ui/common/src/device.ts
+++ b/ui/common/src/device.ts
@@ -5,7 +5,7 @@ import { bind } from './snabbdom';
 const longPressDuration = 610;
 
 export function bindMobileTapHold(el: HTMLElement, f: (e: Event) => unknown, redraw?: () => void): void {
-  let longPressCountdown: number;
+  let longPressCountdown: Timeout;
 
   el.addEventListener('touchstart', e => {
     longPressCountdown = setTimeout(() => {

--- a/ui/common/src/gridHacks.ts
+++ b/ui/common/src/gridHacks.ts
@@ -2,7 +2,7 @@ import { bindChessgroundResize } from './resize';
 import { throttle } from './timing';
 
 export const runner = (hacks: () => void, throttleMs = 100): void => {
-  let timeout: number | undefined;
+  let timeout: Timeout | undefined;
 
   const runHacks = throttle(throttleMs, () =>
     requestAnimationFrame(() => {

--- a/ui/common/src/timing.ts
+++ b/ui/common/src/timing.ts
@@ -171,7 +171,7 @@ export function debounce<T extends (...args: any) => void>(
 
 export function browserTaskQueueMonitor(interval = 1000): { wasSuspended: boolean; reset: () => void } {
   let lastTime: number;
-  let timeout: number;
+  let timeout: Timeout;
   let suspended = false;
 
   start();


### PR DESCRIPTION
this compiles (and watches if -w) sources in tests directory. to make it work with vitest, i had to enable skipLibCheck so it's only appropriate to use this on dev machines.

as i said in discord, i could also set up a separate watch to run tests when sources change, but my arm would need to be twisted as i don't want to encourage testing. the less bugs i know about, the better.