### PR TITLE
In the lobby, vertically align `Mode` with `Rating` and `Time`.

### DIFF
--- a/ui/lobby/src/view/realTime/list.ts
+++ b/ui/lobby/src/view/realTime/list.ts
@@ -90,7 +90,7 @@ export const render = (ctrl: LobbyController, allHooks: Hook[]) => {
           },
           [h('i.is'), i18n.site.time],
         ),
-        h('th', i18n.site.mode),
+        h('th', [h('i.is'), i18n.site.mode]),
       ]),
     ),
     h(


### PR DESCRIPTION
The `Mode` header is slightly lower than the other two headers:

![image](https://github.com/user-attachments/assets/09b27da2-6fd6-4fe2-a3ef-394be64bf3d6)

Using the `is` style fixes the issue since it extends `%data-icon`, which has a `vertical-align` property set to `middle`.