### PR TITLE
voice move confirm tweaks

### DIFF
--- a/ui/chess/src/moveRootCtrl.ts
+++ b/ui/chess/src/moveRootCtrl.ts
@@ -1,5 +1,5 @@
 export interface MoveRootCtrl {
-  pluginMove: (orig: Key, dest: Key, prom: Role | undefined) => void;
+  pluginMove: (orig: Key, dest: Key, prom: Role | undefined, preConfirmed?: boolean /* = false */) => void;
   redraw: () => void;
   flipNow: () => void;
   offerDraw?: (v: boolean, immediately?: boolean) => void;
@@ -12,6 +12,7 @@ export interface MoveRootCtrl {
   blindfold?: (v?: boolean) => boolean;
   speakClock?: () => void;
   goBerserk?: () => void;
+  shouldConfirmMove?: () => boolean;
 }
 
 export interface MoveUpdate {

--- a/ui/chess/src/moveRootCtrl.ts
+++ b/ui/chess/src/moveRootCtrl.ts
@@ -12,7 +12,7 @@ export interface MoveRootCtrl {
   blindfold?: (v?: boolean) => boolean;
   speakClock?: () => void;
   goBerserk?: () => void;
-  shouldConfirmMove?: () => boolean;
+  confirmMoveToggle?: () => boolean;
 }
 
 export interface MoveUpdate {

--- a/ui/round/src/ctrl.ts
+++ b/ui/round/src/ctrl.ts
@@ -334,16 +334,13 @@ export default class RoundController implements MoveRootCtrl {
     this.keyboardMove?.update({ fen, canMove: this.canMove() });
   };
 
-  shouldConfirmMove = (): boolean =>
-    (this.data.pref.submitMove && this.confirmMoveToggle()) || this.confirmMoveToggle();
-
   sendMove = (orig: Key, dest: Key, prom: Role | undefined, meta: MoveMetadata): void => {
     const move: SocketMove = { u: orig + dest };
     if (prom) move.u += prom === 'knight' ? 'n' : prom[0];
     if (blur.get()) move.b = 1;
     this.resign(false);
 
-    if (!meta.preConfirmed && this.shouldConfirmMove() && !meta.premove) {
+    if (!meta.preConfirmed && this.confirmMoveToggle() && !meta.premove) {
       if (site.sound.speech()) {
         const spoken = `${speakable(sanOf(readFen(this.stepAt(this.ply).fen), move.u))}. confirm?`;
         site.sound.say(spoken, false, true);
@@ -359,7 +356,7 @@ export default class RoundController implements MoveRootCtrl {
     const drop: SocketDrop = { role, pos: key };
     if (blur.get()) drop.b = 1;
     this.resign(false);
-    if (this.shouldConfirmMove() && !isPredrop) {
+    if (this.confirmMoveToggle() && !isPredrop) {
       this.toSubmit = drop;
       this.redraw();
     } else {

--- a/ui/round/src/interfaces.ts
+++ b/ui/round/src/interfaces.ts
@@ -7,6 +7,7 @@ import type { ChatCtrl, ChatPlugin } from 'chat';
 import * as Prefs from 'common/prefs';
 import type { EnhanceOpts } from 'common/richText';
 import type { RoundSocket } from './socket';
+import type { MoveMetadata as CgMoveMetadata } from 'chessground/types';
 
 export { type RoundSocket } from './socket';
 export { type CorresClockData } from './corresClock/corresClockCtrl';
@@ -196,8 +197,8 @@ export interface Pref {
   resizeHandle: Prefs.ShowResizeHandle;
 }
 
-export interface MoveMetadata {
-  premove?: boolean;
+export interface MoveMetadata extends CgMoveMetadata {
+  preConfirmed?: boolean;
   justDropped?: Role;
   justCaptured?: Piece;
 }

--- a/ui/round/src/view/boardMenu.ts
+++ b/ui/round/src/view/boardMenu.ts
@@ -19,7 +19,9 @@ export default function (ctrl: RoundController): LooseVNode {
         ),
         menu.voiceInput(boolPrefXhrToggle('voice', !!ctrl.voiceMove), !spectator),
         menu.keyboardInput(boolPrefXhrToggle('keyboardMove', !!ctrl.keyboardMove), !spectator),
-        !spectator && d.pref.submitMove ? menu.confirmMove(ctrl.confirmMoveToggle) : undefined,
+        !spectator && (d.pref.submitMove || ctrl.voiceMove)
+          ? menu.confirmMove(ctrl.confirmMoveToggle)
+          : undefined,
       ]),
       h('section.board-menu__links', [
         h(

--- a/ui/voice/src/move/voice.move.ts
+++ b/ui/voice/src/move/voice.move.ts
@@ -297,9 +297,9 @@ export function initModule({
     // trim choices to clarity window
     options = options.filter(([, m]) => m.cost - lowestCost <= clarityThreshold);
 
-    if (!timer() && options.length === 1 && options[0][1].cost < 0.3) {
+    if (!timer() && options.length === 1 && (options[0][1].cost < 0.3 || root.shouldConfirmMove?.())) {
       console.info('chooseMoves', `chose '${options[0][0]}' cost=${options[0][1].cost}`);
-      submit(options[0][0]);
+      submit(options[0][0], false);
       return true;
     }
     return ambiguate(options);
@@ -321,7 +321,7 @@ export function initModule({
     if (preferred && timer()) {
       choiceTimeout = setTimeout(
         () => {
-          submit(options[0][0]);
+          submit(options[0][0], false);
           choiceTimeout = undefined;
           voice.mic.setRecognizer('default');
         },
@@ -349,7 +349,7 @@ export function initModule({
     buildSquares();
   }
 
-  function submit(uci: Uci) {
+  function submit(uci: Uci, preConfirmed = true) {
     clearMoveProgress();
     if (uci.length < 3) {
       const dests = [...new Set(ucis.filter(x => x.length === 4 && x.startsWith(uci)))];
@@ -362,7 +362,7 @@ export function initModule({
     const role = promo(uci);
     cg.cancelMove();
     if (role) promote(cg, dest(uci), role);
-    root.pluginMove(src(uci), dest(uci), role);
+    root.pluginMove(src(uci), dest(uci), role, preConfirmed);
     return true;
   }
 

--- a/ui/voice/src/move/voice.move.ts
+++ b/ui/voice/src/move/voice.move.ts
@@ -297,7 +297,7 @@ export function initModule({
     // trim choices to clarity window
     options = options.filter(([, m]) => m.cost - lowestCost <= clarityThreshold);
 
-    if (!timer() && options.length === 1 && (options[0][1].cost < 0.3 || root.shouldConfirmMove?.())) {
+    if (!timer() && options.length === 1 && (options[0][1].cost < 0.3 || root.confirmMoveToggle?.())) {
       console.info('chooseMoves', `chose '${options[0][0]}' cost=${options[0][1].cost}`);
       submit(options[0][0], false);
       return true;


### PR DESCRIPTION
- always add move confirm to board menu when voice is enabled
- smooth overlap between arrows / colors / numbers voice confirm and standard move confirm.