### PR TITLE
fix: sound slider not working on safari

### DIFF
--- a/ui/common/src/device.ts
+++ b/ui/common/src/device.ts
@@ -66,6 +66,12 @@ export const isAndroid = (): boolean => /Android/.test(navigator.userAgent);
 
 export const isSafari = (): boolean => /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
 
+export const getSafariMajorVersion = (): number | undefined => {
+  if (!isSafari()) return undefined;
+  const match = /Version\/(\d*)/.exec(navigator.userAgent);
+  return match && match.length > 1 ? parseInt(match[1]) : undefined;
+};
+
 export const isIOS = (constraint?: { below?: number; atLeast?: number }): boolean => {
   let answer = ios();
   if (!constraint || !answer) return answer;

--- a/ui/common/src/device.ts
+++ b/ui/common/src/device.ts
@@ -67,9 +67,9 @@ export const isAndroid = (): boolean => /Android/.test(navigator.userAgent);
 export const isSafari = (): boolean => /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
 
 export const getSafariMajorVersion = (): number | undefined => {
-  if (!isSafari()) return undefined;
-  const match = /Version\/(\d*)/.exec(navigator.userAgent);
-  return match && match.length > 1 ? parseInt(match[1]) : undefined;
+  const regex = /^((?!chrome|android).)*Version\/(\d+).*Safari/i;
+  const result = regex.exec(navigator.userAgent);
+  return result ? parseInt(result[2]) : undefined;
 };
 
 export const isIOS = (constraint?: { below?: number; atLeast?: number }): boolean => {

--- a/ui/dasher/src/dasher.ts
+++ b/ui/dasher/src/dasher.ts
@@ -2,6 +2,7 @@ import type { Redraw } from 'common/snabbdom';
 import { DasherCtrl } from './ctrl';
 import { json as xhrJson } from 'common/xhr';
 import { spinnerVdom, spinnerHtml } from 'common/spinner';
+import { getSafariMajorVersion } from 'common/device';
 import { init as initSnabbdom, type VNode, classModule, attributesModule, h } from 'snabbdom';
 
 const patch = initSnabbdom([classModule, attributesModule]);
@@ -22,6 +23,14 @@ export default async function initModule(): Promise<DasherCtrl> {
       vnode || element,
       h('div#dasher_app.dropdown', ctrl?.render() ?? h('div.initiating', spinnerVdom())),
     );
+
+    const safari = getSafariMajorVersion();
+    if (safari && safari < 18) {
+      const el = document?.querySelector("#dasher_app .sound input[type='range']");
+      if (el) {
+        (el as HTMLElement).style.appearance = 'slider-vertical';
+      }
+    }
   };
 
   redraw();


### PR DESCRIPTION
fixes #16384 

The issue was filed for mobile, but I was able to reproduce on Mac and believe that the sound slider is currently non-functional on Safari <17.4:

- https://webkit.org/blog/15190/implementing-vertical-form-controls/
- https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_writing_modes/Vertical_controls#creating_vertical_range_sliders_in_older_browsers

This is kind of hacky but as long as Lila is still committed to supporting Safari 11.1+ it seems like the least intrusive solution.

Tested that it continues to work without the original deprecation logs in Chrome and now works on Safari 16.