### PR TITLE
Have Git ignore `dump.rdb`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ ui/*/npm-debug.log
 ui/*/tsconfig.tsbuildinfo
 hs_*.log
 dependency-graph.png
+dump.rdb
 
 RUNNING_PID
 .DS_Store


### PR DESCRIPTION
For me, this file is created whenever I stop redis-server.