### PR TITLE
Increase the max number of study chapters to 256.

### DIFF
--- a/modules/study/src/main/Study.scala
+++ b/modules/study/src/main/Study.scala
@@ -89,7 +89,7 @@ case class Study(
 
 object Study:
 
-  val maxChapters = Max(64)
+  val maxChapters = Max(256)
 
   val previewNbMembers  = 4
   val previewNbChapters = 4

--- a/ui/analyse/src/study/studyChapters.ts
+++ b/ui/analyse/src/study/studyChapters.ts
@@ -69,7 +69,7 @@ export default class StudyChaptersCtrl {
 
   sort = (ids: string[]) => this.send('sortChapters', ids);
   toggleNewForm = () => {
-    if (this.newForm.isOpen() || this.list.size() < 64) this.newForm.toggle();
+    if (this.newForm.isOpen() || this.list.size() < 256) this.newForm.toggle();
     else alert('You have reached the limit of 64 chapters per study. Please create a new study.');
   };
   loadFromServer = (chapters: ChapterPreviewFromServer[]) =>


### PR DESCRIPTION
Addresses #7042

For studies I use for chess lessons and personal analysis, I tend to require multiple due to the 64 limit. I tested a limit of even up to 1024 and didn't find an issue with performance on my local laptop. This PR just proposes increasing to 256 for now and seeing how it goes. Maybe on phones it's a different story?