### PR TITLE
use outerWidth/outerHeight for powertip hover hitbox

### DIFF
--- a/ui/common/css/component/_friend-box.scss
+++ b/ui/common/css/component/_friend-box.scss
@@ -71,7 +71,7 @@
 
       &.tv {
         flex: 0 0 auto;
-        padding: 0 5px 0 0;
+        padding: 0 5px;
       }
 
       &.friend-study {

--- a/ui/site/src/powertip.ts
+++ b/ui/site/src/powertip.ts
@@ -698,9 +698,9 @@ function isMouseOver(element: Cash) {
   const elementPosition = element.offset()!;
   return (
     session.currentX >= elementPosition.left &&
-    session.currentX <= elementPosition.left + element.width() &&
+    session.currentX <= elementPosition.left + element.outerWidth() &&
     session.currentY >= elementPosition.top &&
-    session.currentY <= elementPosition.top + element.height()
+    session.currentY <= elementPosition.top + element.outerHeight()
   );
 }
 


### PR DESCRIPTION
this is a more direct fix for https://github.com/lichess-org/lila/issues/4272 than https://github.com/lichess-org/lila/commit/de56429ea50c65442f660350565352296658e15a. but due to the increased surface area, it is for review.

worst case unintended impact would be an overly sticky hover on some element that has huge border/padding. but i doubt that will happen.