### PR TITLE
restrict evalcache put to stockfish 16 or better

### DIFF
--- a/ui/ceval/src/ctrl.ts
+++ b/ui/ceval/src/ctrl.ts
@@ -209,7 +209,10 @@ export default class CevalCtrl {
   }
 
   get isCacheable(): boolean {
-    return this.engines.active?.tech === 'NNUE';
+    //>=sf16 or fsf14+nnue
+    return (
+      this.engines.active?.tech === 'NNUE' && this.engines.active.requires.includes('dynamicImportFromWorker')
+    );
   }
 
   get showingCloud(): boolean {


### PR DESCRIPTION
Stockfish has [standardised its eval](https://stockfishchess.org/blog/2022/stockfish-15-1/#new-evaluation) output since sf15.1. This change aims to prevent users of sf14 from continuing to contribute to evalcache. The benefit is consistency of evaluation from users with sf16 onwards.