### PR TITLE
always recompute expressions involving assetUrl calls

### DIFF
--- a/modules/oauth/src/main/ui/AuthorizeUi.scala
+++ b/modules/oauth/src/main/ui/AuthorizeUi.scala
@@ -9,7 +9,7 @@ import ScalatagsTemplate.{ *, given }
 final class AuthorizeUi(helpers: Helpers)(lightUserFallback: UserId => LightUser):
   import helpers.{ *, given }
 
-  private val ringsImage = img(
+  private def ringsImage = img(
     cls := "oauth__logo",
     alt := "linked rings icon",
     src := assetUrl("images/icons/linked-rings.png")

--- a/modules/tutor/src/main/ui/TutorBits.scala
+++ b/modules/tutor/src/main/ui/TutorBits.scala
@@ -23,7 +23,7 @@ final class TutorBits(helpers: Helpers)(
           div(cls := "page-menu__content")(mods, body)
         )
 
-  val mascot =
+  def mascot =
     img(
       cls := "mascot",
       src := assetUrl("images/mascot/octopus-shadow.svg")

--- a/modules/web/src/main/helper/AssetFullHelper.scala
+++ b/modules/web/src/main/helper/AssetFullHelper.scala
@@ -46,8 +46,8 @@ trait AssetFullHelper:
           case json          => json.toString
 
   def roundNvuiTag(using ctx: Context) = ctx.blind.option(Esm("round.nvui"))
-  lazy val cashTag: Frag               = iifeModule("javascripts/vendor/cash.min.js")
-  lazy val chessgroundTag: Frag        = script(tpe := "module", src := assetUrl("npm/chessground.min.js"))
+  def cashTag: Frag                    = iifeModule("javascripts/vendor/cash.min.js")
+  def chessgroundTag: Frag             = script(tpe := "module", src := assetUrl("npm/chessground.min.js"))
 
   def basicCsp(using ctx: Context): ContentSecurityPolicy =
     val sockets = socketDomains.map { x => s"wss://$x${(!ctx.req.secure).so(s" ws://$x")}" }

--- a/modules/web/src/main/ui/layout.scala
+++ b/modules/web/src/main/ui/layout.scala
@@ -212,7 +212,7 @@ final class layout(helpers: Helpers, assetHelper: lila.web.ui.AssetFullHelper)(
   private val spaceRegex      = """\s{2,}+""".r
   def spaceless(html: String) = raw(spaceRegex.replaceAllIn(html.replace("\\n", ""), ""))
 
-  val lichessFontFaceCss = spaceless:
+  def lichessFontFaceCss = spaceless:
     s"""<style>@font-face {
         font-family: 'lichess';
         font-display: block;


### PR DESCRIPTION
it's possible we could change chessground, cash, etc in an asset deploy.

getting the right asset without restarting the server is worth the repeated function call overhead (which is infrequent on the MHz scale).