### PR TITLE
add --tscExternal to benchmark old vs new

### DIFF
--- a/ui/.build/src/main.ts
+++ b/ui/.build/src/main.ts
@@ -24,6 +24,7 @@ const args: Record<string, string> = {
   '--clean': 'c',
   '--update': '',
   '--no-install': 'n',
+  '--tsc-external': 'x',
   '--log': 'l',
 };
 
@@ -69,6 +70,7 @@ export async function main(): Promise<void> {
   env.install = !argv.includes('--no-install') && !oneDashArgs.includes('n');
   env.rgb = argv.includes('--rgb');
   env.test = argv.includes('--test') || oneDashArgs.includes('t');
+  env.tscExternal = argv.includes('--tsc-external') || oneDashArgs.includes('x');
 
   if (argv.length === 1 && (argv[0] === '--help' || argv[0] === '-h')) {
     console.log(fs.readFileSync(path.resolve(env.buildDir, 'readme'), 'utf8'));
@@ -138,6 +140,8 @@ class Env {
   sync = true;
   i18n = true;
   test = false;
+  tscExternal = false;
+
   exitCode: Map<Builder, number | false> = new Map();
   startTime: number | undefined = Date.now();
   logTime = true;

--- a/ui/.build/src/tsc.ts
+++ b/ui/.build/src/tsc.ts
@@ -5,17 +5,20 @@ import { Worker } from 'node:worker_threads';
 import { env, colors as c, errorMark } from './main.ts';
 import { globArray, folderSize } from './parse.ts';
 import type { WorkerData, Message } from './tscWorker.ts';
+import { tscExternal, stopTscExternal } from './tscExternal.ts';
 import ts from 'typescript';
 
 const workers: Worker[] = [];
 
 export async function stopTsc(): Promise<void> {
+  if (env.tscExternal) return stopTscExternal();
   await Promise.allSettled(workers.map(w => w.terminate()));
   workers.length = 0;
 }
 
 export async function tsc(): Promise<void> {
   if (!env.tsc) return;
+  if (env.tscExternal) return tscExternal();
   await Promise.allSettled([
     fs.promises.mkdir(path.join(env.buildTempDir, 'noCheck')),
     fs.promises.mkdir(path.join(env.buildTempDir, 'noEmit')),

--- a/ui/.build/src/tscExternal.ts
+++ b/ui/.build/src/tscExternal.ts
@@ -1,0 +1,89 @@
+import * as fs from 'node:fs';
+import * as cps from 'node:child_process';
+import * as path from 'node:path';
+import { env, colors as c, errorMark, warnMark, lines } from './main.ts';
+import { globArray } from './parse.ts';
+
+let tscPs: cps.ChildProcessWithoutNullStreams | undefined;
+
+export function stopTscExternal(): void {
+  tscPs?.kill();
+  tscPs = undefined;
+}
+
+export async function tscExternal(): Promise<void> {
+  return new Promise((resolve, reject) =>
+    (async () => {
+      if (!env.tsc) return resolve();
+
+      const cfg: any = { files: [] };
+      const cfgPath = path.join(env.buildTempDir, 'build.tsconfig.json');
+
+      cfg.references = (await globArray('*/tsconfig*.json', { cwd: env.uiDir }))
+        .sort((a, b) => a.localeCompare(b))
+        .filter(x => env.building.some(mod => x.startsWith(`${mod.root}/`)))
+        .map(x => ({ path: x }));
+
+      // verify that tsconfig references are correct
+      for (const tsconfig of cfg.references) {
+        if (!tsconfig?.path) continue;
+        if (!fs.existsSync(tsconfig.path)) env.exit(`${errorMark} - Missing: '${c.cyan(tsconfig.path)}'`);
+        const ref = JSON.parse(await fs.promises.readFile(tsconfig.path, 'utf8'));
+        const module = path.basename(path.dirname(tsconfig.path));
+        for (const dep of env.deps.get(module) ?? []) {
+          if (!ref.references?.some((x: any) => x.path.endsWith(path.join(dep, 'tsconfig.json'))))
+            env.warn(
+              `${warnMark} - Module ${c.grey(module)} depends on ${c.grey(dep)} with no reference in '${c.cyan(
+                module + '/tsconfig.json',
+              )}'`,
+              'tsc',
+            );
+        }
+      }
+
+      await fs.promises.writeFile(cfgPath, JSON.stringify(cfg));
+      const thisPs = (tscPs = cps.spawn('.build/node_modules/.bin/tsc', [
+        '-b',
+        cfgPath,
+        ...(env.watch ? ['-w', '--preserveWatchOutput'] : ['--incremental']),
+      ]));
+
+      env.log(`Compiling typescript`, { ctx: 'tsc' });
+
+      thisPs.stdout?.on('data', (buf: Buffer) => {
+        const txts = lines(buf.toString('utf8'));
+        for (const txt of txts) {
+          if (txt.includes('Found 0 errors')) {
+            resolve();
+            env.done(0, 'tsc');
+          } else {
+            tscLog(txt);
+          }
+        }
+      });
+      thisPs.stderr?.on('data', txt => env.log(txt, { ctx: 'tsc', error: true }));
+      thisPs.addListener('close', code => {
+        thisPs.removeAllListeners();
+        if (code !== null) env.done(code, 'tsc');
+        if (code === 0) resolve();
+        else reject();
+      });
+    })(),
+  );
+}
+
+function tscLog(text: string): void {
+  if (text.includes('File change detected') || text.includes('Starting compilation')) return; // redundant
+  text = text.replace(/\d?\d:\d\d:\d\d (PM|AM) - /, '');
+  if (text.match(/: error TS\d\d\d\d/)) text = fixTscError(text);
+  if (text.match(/Found (\d+) errors?/)) {
+    if (env.watch) env.done(1, 'tsc');
+  } else env.log(text, { ctx: 'tsc' });
+}
+
+const fixTscError = (text: string) =>
+  // format location for vscode embedded terminal ctrl click
+  text
+    .replace(/^[./]*/, `${errorMark} - '\x1b[36m`)
+    .replace(/\.ts\((\d+),(\d+)\):/, ".ts:$1:$2\x1b[0m' -")
+    .replace(/error (TS\d{4})/, '$1');

--- a/ui/lobby/tsconfig.json
+++ b/ui/lobby/tsconfig.json
@@ -1,5 +1,9 @@
 {
   "extends": "../tsconfig.base.json",
   "compilerOptions": { "noEmit": true, "isolatedDeclarations": false },
-  "references": [{ "path": "../common/tsconfig.json" }, { "path": "../dasher/tsconfig.json" }]
+  "references": [
+    { "path": "../common/tsconfig.json" },
+    { "path": "../dasher/tsconfig.json" },
+    { "path": "../game/tsconfig.json" }
+  ]
 }

--- a/ui/tsconfig.base.json
+++ b/ui/tsconfig.base.json
@@ -1,5 +1,6 @@
 {
   "exclude": ["${configDir}/tests", "${configDir}/dist"],
+  "include": ["${configDir}/src"],
   "compilerOptions": {
     "outDir": "${configDir}/dist",
     "rootDir": "${configDir}/src",


### PR DESCRIPTION
this branch benchmarks two versions of ui/build.

there is a new option `-x`/`--tscExternal` for timing the old style (invoke tsc in a spawned process) vs the current style (emit/check typescript in parallel with node workers).

```
ui/build -cx # this is the old way
ui/build -c # this is the newer way
```

anyone who can run a few rounds, i would appreciate metrics from a variety of machines to decide the best path forward. so far i have surprising results for arm vs intel.
