### PR TITLE
Keyboard input "clock" to always speak

### DIFF
--- a/ui/round/src/clock/clockCtrl.ts
+++ b/ui/round/src/clock/clockCtrl.ts
@@ -182,7 +182,7 @@ export class ClockController {
         simplePlural(date.getUTCSeconds(), 'second');
       return `${color} ${msg}`;
     });
-    site.sound.say(msgs.join('. '));
+    site.sound.say(msgs.join('. '), false, true);
   };
 }
 


### PR DESCRIPTION
It would speak the clocks but only if Speech was the selected sound effect. This uses `force: true` to always speak the clocks, similar to "who".

https://lichess.org/forum/lichess-feedback/clock-command-not-working