### PR TITLE
common/socket tweak

### DIFF
--- a/ui/@types/lichess/index.d.ts
+++ b/ui/@types/lichess/index.d.ts
@@ -36,7 +36,6 @@ interface Site {
   blindMode: boolean;
   load: Promise<void>; // DOMContentLoaded promise
   quantity(n: number): 'zero' | 'one' | 'two' | 'few' | 'many' | 'other';
-  socket: SocketI;
   quietMode?: boolean;
   analysis?: any; // expose the analysis ctrl
   // file://./../../.build/src/manifest.ts
@@ -115,15 +114,6 @@ interface SoundI {
   sayOrPlay(name: string, text: string): void;
   preloadBoardSounds(): void;
   url(name: string): string;
-}
-
-interface SocketI {
-  averageLag: number;
-  pingInterval(): number;
-  getVersion(): number | false;
-  send: SocketSend;
-  sign(s: string): void;
-  destroy(): void;
 }
 
 interface LichessSpeech {

--- a/ui/analyse/src/analyse.ts
+++ b/ui/analyse/src/analyse.ts
@@ -1,7 +1,7 @@
 import { patch } from './view/util';
 import makeBoot from './boot';
 import makeStart from './start';
-import StrongSocket from 'common/socket';
+import { wsConnect } from 'common/socket';
 
 export { patch };
 
@@ -16,9 +16,8 @@ export function initModule({ mode, cfg }: { mode: 'userAnalysis' | 'replay'; cfg
 
 function userAnalysis(cfg: any) {
   cfg.$side = $('.analyse__side').clone();
-  site.socket = new StrongSocket(cfg.socketUrl || '/analysis/socket/v5', cfg.socketVersion, {
+  cfg.socketSend = wsConnect(cfg.socketUrl || '/analysis/socket/v5', cfg.socketVersion, {
     receive: (t: string, d: any) => analyse.socketReceive(t, d),
-  });
-  cfg.socketSend = site.socket.send;
+  }).send;
   const analyse = start(cfg);
 }

--- a/ui/analyse/src/boot.ts
+++ b/ui/analyse/src/boot.ts
@@ -1,20 +1,20 @@
 import type { AnalyseApi, AnalyseOpts } from './interfaces';
-import StrongSocket from 'common/socket';
+import { wsConnect } from 'common/socket';
+import { AnalyseSocketSend } from './socket';
 
 export default function (start: (opts: AnalyseOpts) => AnalyseApi) {
   return function (cfg: AnalyseOpts) {
     const socketUrl = `/watch/${cfg.data.game.id}/${cfg.data.player.color}/v6`;
-    site.socket = new StrongSocket(socketUrl, cfg.data.player.version, {
+    cfg.$side = $('.analyse__side').clone();
+    cfg.$underboard = $('.analyse__underboard').clone();
+    cfg.socketSend = wsConnect(socketUrl, cfg.data.player.version, {
       params: {
         userTv: cfg.data.userTv && cfg.data.userTv.id,
       },
       receive(t: string, d: any) {
         analyse.socketReceive(t, d);
       },
-    });
-    cfg.$side = $('.analyse__side').clone();
-    cfg.$underboard = $('.analyse__underboard').clone();
-    cfg.socketSend = site.socket.send;
+    }).send as AnalyseSocketSend;
     const analyse = start(cfg);
   };
 }

--- a/ui/analyse/src/plugins/analyse.study.ts
+++ b/ui/analyse/src/plugins/analyse.study.ts
@@ -2,7 +2,7 @@ import { patch } from '../view/util';
 import makeBoot from '../boot';
 import makeStart from '../start';
 import * as studyDeps from '../study/studyDeps';
-import StrongSocket from 'common/socket';
+import { wsConnect } from 'common/socket';
 
 export { patch };
 
@@ -10,10 +10,9 @@ export const start = makeStart(patch, studyDeps);
 export const boot = makeBoot(start);
 
 export function initModule(cfg: any) {
-  site.socket = new StrongSocket(cfg.socketUrl || '/analysis/socket/v5', cfg.socketVersion, {
+  cfg.socketSend = wsConnect(cfg.socketUrl || '/analysis/socket/v5', cfg.socketVersion, {
     receive: (t: string, d: any) => analyse.socketReceive(t, d),
     ...(cfg.embed ? { params: { flag: 'embed' } } : {}),
-  });
-  cfg.socketSend = site.socket.send;
+  }).send;
   const analyse = start(cfg);
 }

--- a/ui/bits/src/bits.challengePage.ts
+++ b/ui/bits/src/bits.challengePage.ts
@@ -1,5 +1,5 @@
 import * as xhr from 'common/xhr';
-import StrongSocket from 'common/socket';
+import { wsConnect, wsSend } from 'common/socket';
 import { userComplete } from 'common/userComplete';
 import { isTouchDevice, isIos } from 'common/device';
 
@@ -13,7 +13,7 @@ export function initModule(opts: ChallengeOpts): void {
   const selector = '.challenge-page';
   let accepting: boolean;
 
-  site.socket = new StrongSocket(`/challenge/${opts.data.challenge.id}/socket/v5`, opts.data.socketVersion, {
+  wsConnect(`/challenge/${opts.data.challenge.id}/socket/v5`, opts.data.socketVersion, {
     events: {
       reload() {
         xhr.text(opts.xhrUrl).then(html => {
@@ -90,7 +90,7 @@ export function initModule(opts: ChallengeOpts): void {
 
   function pingNow() {
     if (document.getElementById('ping-challenge')) {
-      site.socket.send('ping');
+      wsSend('ping');
       setTimeout(pingNow, 9000);
     }
   }

--- a/ui/bits/src/bits.team.ts
+++ b/ui/bits/src/bits.team.ts
@@ -1,6 +1,6 @@
 import * as xhr from 'common/xhr';
 import flairPickerLoader from './flairPicker';
-import StrongSocket from 'common/socket';
+import { wsConnect } from 'common/socket';
 import { makeChat } from 'chat';
 import { prompt } from 'common/dialog';
 
@@ -11,7 +11,7 @@ interface TeamOpts {
 }
 
 export function initModule(opts: TeamOpts): void {
-  site.socket = new StrongSocket('/team/' + opts.id, opts.socketVersion);
+  wsConnect('/team/' + opts.id, opts.socketVersion);
 
   if (opts.chat) makeChat(opts.chat);
 

--- a/ui/chart/src/chart.lag.ts
+++ b/ui/chart/src/chart.lag.ts
@@ -10,6 +10,7 @@ import {
 import dataLabels from 'chartjs-plugin-datalabels';
 import { fontColor, fontFamily, resizePolyfill } from './common';
 import { pubsub } from 'common/pubsub';
+import { wsSend, wsAverageLag } from 'common/socket';
 
 declare module 'chart.js' {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -30,7 +31,7 @@ const v = {
 };
 
 export async function initModule(): Promise<void> {
-  pubsub.after('socket.hasConnected').then(() => site.socket.send('moveLat', true));
+  pubsub.after('socket.hasConnected').then(() => wsSend('moveLat', true));
   $('.meter canvas').each(function (this: HTMLCanvasElement, index) {
     const colors = ['#55bf3b', '#dddf0d', '#df5353'];
     const dataset: ChartDataset<'doughnut'>[] = [
@@ -110,7 +111,7 @@ export async function initModule(): Promise<void> {
       });
     else {
       setInterval(function () {
-        v.network = Math.round(site.socket.averageLag);
+        v.network = Math.round(wsAverageLag());
         if (v.network <= 0) return;
         chart.options.plugins!.needle!.value = Math.min(750, v.network);
         chart.options.plugins!.title!.text = makeTitle(index, v.network);

--- a/ui/common/src/miniBoard.ts
+++ b/ui/common/src/miniBoard.ts
@@ -4,6 +4,7 @@ import { lichessClockIsRunning, setClockWidget } from './clock';
 import { uciToMove } from 'chessground/util';
 import { Chessground as makeChessground } from 'chessground';
 import { pubsub } from './pubsub';
+import { wsSend } from './socket';
 
 export const initMiniBoard = (node: HTMLElement): void => {
   const [fen, orientation, lm] = node.getAttribute('data-state')!.split(',');
@@ -74,8 +75,7 @@ export const initMiniGame = (node: Element, withCg?: typeof makeChessground): st
 export const initMiniGames = (parent?: HTMLElement): void => {
   const nodes = Array.from((parent || document).getElementsByClassName('mini-game--init')),
     ids = nodes.map(x => initMiniGame(x)).filter(id => id);
-  if (ids.length)
-    pubsub.after('socket.hasConnected').then(() => site.socket.send('startWatching', ids.join(' ')));
+  if (ids.length) pubsub.after('socket.hasConnected').then(() => wsSend('startWatching', ids.join(' ')));
 };
 
 export const updateMiniGame = (node: HTMLElement, data: MiniGameUpdateData): void => {

--- a/ui/lobby/src/ctrl.ts
+++ b/ui/lobby/src/ctrl.ts
@@ -24,6 +24,7 @@ import Filter from './filter';
 import SetupController from './setupCtrl';
 import { storage, type LichessStorage } from 'common/storage';
 import { pubsub } from 'common/pubsub';
+import { wsPingInterval } from 'common/socket';
 
 export default class LobbyController {
   data: LobbyData;
@@ -153,7 +154,7 @@ export default class LobbyController {
       if (!nb && nb !== 0) return;
       timeouts.forEach(clearTimeout);
       timeouts = [];
-      const interv = Math.abs(site.socket.pingInterval() / nbSteps);
+      const interv = Math.abs(wsPingInterval() / nbSteps);
       const prev = previous || nb;
       previous = nb;
       for (let i = 0; i < nbSteps; i++)

--- a/ui/puz/src/sign.ts
+++ b/ui/puz/src/sign.ts
@@ -1,8 +1,9 @@
 import { pubsub } from 'common/pubsub';
+import { wsSend } from 'common/socket';
 
 export default function (serverKey: string): Promise<string> {
   const otp = randomAscii(64);
-  site.socket.send('sk1', `${serverKey}!${otp}`);
+  wsSend('sk1', `${serverKey}!${otp}`);
   return new Promise(solve => pubsub.on('socket.in.sk1', encrypted => solve(xor(encrypted, otp))));
 }
 

--- a/ui/racer/src/ctrl.ts
+++ b/ui/racer/src/ctrl.ts
@@ -24,7 +24,7 @@ import type {
 } from './interfaces';
 import { storedBooleanProp } from 'common/storage';
 import { PromotionCtrl } from 'chess/promotion';
-import StrongSocket from 'common/socket';
+import { wsConnect, wsSend } from 'common/socket';
 import { pubsub } from 'common/pubsub';
 
 export default class RacerCtrl implements PuzCtrl {
@@ -79,7 +79,7 @@ export default class RacerCtrl implements PuzCtrl {
     );
     this.promotion = new PromotionCtrl(this.withGround, this.setGround, this.redraw);
     this.serverUpdate(opts.data);
-    site.socket = new StrongSocket(`/racer/${this.race.id}`, false, {
+    wsConnect(`/racer/${this.race.id}`, false, {
       events: {
         racerState: (data: UpdatableData) => {
           this.serverUpdate(data);
@@ -87,8 +87,7 @@ export default class RacerCtrl implements PuzCtrl {
           this.redrawSlow();
         },
       },
-    });
-    site.socket.sign(this.sign);
+    }).sign(this.sign);
     pubsub.on('zen', () => {
       const zen = $('body').toggleClass('zen').hasClass('zen');
       window.dispatchEvent(new Event('resize'));
@@ -257,7 +256,7 @@ export default class RacerCtrl implements PuzCtrl {
     this.redraw();
   };
 
-  private socketSend = (tpe: string, data?: any) => site.socket.send(tpe, data, { sign: this.sign });
+  private socketSend = (tpe: string, data?: any) => wsSend(tpe, data, { sign: this.sign });
 
   private setZen = throttlePromiseDelay(
     () => 1000,

--- a/ui/round/src/ctrl.ts
+++ b/ui/round/src/ctrl.ts
@@ -50,6 +50,7 @@ import { storage, once, type LichessBooleanStorage } from 'common/storage';
 import { pubsub } from 'common/pubsub';
 import { readFen, almostSanOf, speakable } from 'chess/sanWriter';
 import { plyToTurn } from 'chess';
+import { wsDestroy } from 'common/socket';
 
 interface GoneBerserk {
   white?: boolean;
@@ -893,7 +894,7 @@ export default class RoundController implements MoveRootCtrl {
       setTimeout(() => {
         if ($('#KeyboardO,#show_btn,#shadowHostId').length) {
           alert('Play enhancement extensions are no longer allowed!');
-          site.socket.destroy();
+          wsDestroy();
           this.setRedirecting();
           location.href = '/page/play-extensions';
         }

--- a/ui/round/src/round.ts
+++ b/ui/round/src/round.ts
@@ -7,7 +7,7 @@ import { text as xhrText } from 'common/xhr';
 import type MoveOn from './moveOn';
 import type { TourPlayer } from 'game';
 import { tourStandingCtrl, type TourStandingCtrl } from './tourStanding';
-import StrongSocket from 'common/socket';
+import { wsConnect, wsDestroy } from 'common/socket';
 import { storage } from 'common/storage';
 import { setClockWidget } from 'common/clock';
 import { makeChat } from 'chat';
@@ -52,7 +52,7 @@ async function boot(
   const socketUrl = opts.data.player.spectator
     ? `/watch/${data.game.id}/${data.player.color}/v6`
     : `/play/${data.game.id}${data.player.id}/v6`;
-  site.socket = new StrongSocket(socketUrl, data.player.version, {
+  opts.socketSend = wsConnect(socketUrl, data.player.version, {
     params: { userTv: data.userTv && data.userTv.id },
     receive(t: string, d: any) {
       round.socketReceive(t, d);
@@ -87,8 +87,7 @@ async function boot(
         }
       },
     },
-  });
-  opts.socketSend = site.socket.send;
+  }).send;
 
   const startTournamentClock = () => {
     if (data.tournament)
@@ -141,7 +140,7 @@ async function boot(
 
   if (!data.player.spectator && location.hostname != (document as any)['Location'.toLowerCase()].hostname) {
     alert(`Games cannot be played through a web proxy. Please use ${location.hostname} instead.`);
-    site.socket.destroy();
+    wsDestroy();
   }
   return ctrl;
 }

--- a/ui/round/src/socket.ts
+++ b/ui/round/src/socket.ts
@@ -5,6 +5,7 @@ import type RoundController from './ctrl';
 import { defined } from 'common';
 import { domDialog } from 'common/dialog';
 import { pubsub } from 'common/pubsub';
+import { wsSign, wsVersion } from 'common/socket';
 
 export interface RoundSocket {
   send: SocketSend;
@@ -47,7 +48,7 @@ function backoff(delay: number, factor: number, callback: Callback): Callback {
 }
 
 export function make(send: SocketSend, ctrl: RoundController): RoundSocket {
-  site.socket.sign(ctrl.sign);
+  wsSign(ctrl.sign);
 
   const reload = (o?: Incoming, isRetry?: boolean) => {
     // avoid reload if possible!
@@ -56,7 +57,7 @@ export function make(send: SocketSend, ctrl: RoundController): RoundSocket {
       handlers[o.t]!(o.d);
     } else
       xhrReload(ctrl).then(data => {
-        const version = site.socket.getVersion();
+        const version = wsVersion();
         if (version !== false && version > data.player.version) {
           // race condition! try to reload again
           if (isRetry) site.reload();

--- a/ui/simul/src/simul.home.ts
+++ b/ui/simul/src/simul.home.ts
@@ -1,8 +1,8 @@
-import StrongSocket from 'common/socket';
+import { wsConnect } from 'common/socket';
 import { pubsub } from 'common/pubsub';
 
 site.load.then(() => {
-  site.socket = new StrongSocket(`/socket/v5`, false, { params: { flag: 'simul' } });
+  wsConnect(`/socket/v5`, false, { params: { flag: 'simul' } });
   pubsub.on('socket.in.reload', async () => {
     const rsp = await fetch('/simul/reload');
     const html = await rsp.text();

--- a/ui/simul/src/simul.ts
+++ b/ui/simul/src/simul.ts
@@ -1,7 +1,7 @@
 import { init, VNode, classModule, attributesModule } from 'snabbdom';
 import type { SimulOpts } from './interfaces';
 import SimulCtrl from './ctrl';
-import StrongSocket from 'common/socket';
+import { wsConnect } from 'common/socket';
 
 const patch = init([classModule, attributesModule]);
 
@@ -10,10 +10,9 @@ import view from './view/main';
 export function initModule(opts: SimulOpts) {
   const element = document.querySelector('main.simul') as HTMLElement;
 
-  site.socket = new StrongSocket(`/simul/${opts.data.id}/socket/v4`, opts.socketVersion, {
+  opts.socketSend = wsConnect(`/simul/${opts.data.id}/socket/v4`, opts.socketVersion, {
     receive: (t: string, d: any) => ctrl.socket.receive(t, d),
-  });
-  opts.socketSend = site.socket.send;
+  }).send;
   opts.element = element;
   opts.$side = $('.simul__side').clone();
 

--- a/ui/site/src/boot.ts
+++ b/ui/site/src/boot.ts
@@ -6,7 +6,6 @@ import announce from './announce';
 import OnlineFriends from './friends';
 import powertip from './powertip';
 import serviceWorker from './serviceWorker';
-import StrongSocket from 'common/socket';
 import { watchers } from 'common/watchers';
 import { isIos } from 'common/device';
 import { scrollToInnerSelector, requestIdleCallback } from 'common';
@@ -55,9 +54,6 @@ export function boot() {
 
     toggleBoxInit();
 
-    setTimeout(() => {
-      if (!site.socket) site.socket = new StrongSocket('/socket/v5', false);
-    }, 300); // TODO fix this
     window.addEventListener('resize', dispatchChessgroundResize);
 
     if (setBlind && !site.blindMode) setTimeout(() => $('#blind-mode button').trigger('click'), 1500);

--- a/ui/site/src/reload.ts
+++ b/ui/site/src/reload.ts
@@ -1,4 +1,5 @@
 import { promiseTimeout } from 'common/promise';
+import { wsDestroy } from 'common/socket';
 
 let redirectInProgress: false | string = false;
 
@@ -40,7 +41,7 @@ export const reload = (err?: any) => {
   if (err) console.warn(err);
   if (redirectInProgress) return;
   unload.expected = true;
-  site.socket.destroy();
+  wsDestroy();
   if (location.hash) location.reload();
   else location.assign(location.href);
 };

--- a/ui/site/src/site.ts
+++ b/ui/site/src/site.ts
@@ -11,10 +11,10 @@ import { api } from './api';
 import { pubsub } from 'common/pubsub';
 
 const site = window.site;
-// site.load is initialized in layout.scala embedded script tags
+// site.load is initialized in site.inline.ts (body script)
 // site.manifest is fetched
 // site.info, site.debug are populated by ui/build
-// site.socket, site.quietMode, site.analysis are set elsewhere
+// site.quietMode, site.analysis are set elsewhere
 site.sri = randomToken();
 site.displayLocale = displayLocale;
 site.blindMode = document.body.classList.contains('blind-mode');

--- a/ui/site/src/topBar.ts
+++ b/ui/site/src/topBar.ts
@@ -3,6 +3,7 @@ import { memoize } from 'common';
 import { spinnerHtml } from 'common/spinner';
 import { clamp } from 'common/algo';
 import { pubsub } from 'common/pubsub';
+import { wsSend } from 'common/socket';
 
 export default function () {
   const top = document.getElementById('top')!;
@@ -114,7 +115,7 @@ export default function () {
             if (!isVisible(selector)) $toggle.trigger('click');
           },
           setNotified() {
-            site.socket.send('notified');
+            wsSend('notified');
           },
           pulse() {
             $toggle.addClass('pulse');

--- a/ui/swiss/src/swiss.ts
+++ b/ui/swiss/src/swiss.ts
@@ -1,7 +1,7 @@
 import { init, VNode, classModule, attributesModule } from 'snabbdom';
 import type { SwissOpts } from './interfaces';
 import SwissCtrl from './ctrl';
-import StrongSocket from 'common/socket';
+import { wsConnect } from 'common/socket';
 
 const patch = init([classModule, attributesModule]);
 
@@ -10,11 +10,10 @@ import view from './view/main';
 export function initModule(opts: SwissOpts) {
   const element = document.querySelector('main.swiss') as HTMLElement;
 
-  site.socket = new StrongSocket('/swiss/' + opts.data.id, opts.data.socketVersion || 0, {
-    receive: (t: string, d: any) => ctrl.socket.receive(t, d),
-  });
   opts.classes = element.getAttribute('class');
-  opts.socketSend = site.socket.send;
+  opts.socketSend = wsConnect('/swiss/' + opts.data.id, opts.data.socketVersion || 0, {
+    receive: (t: string, d: any) => ctrl.socket.receive(t, d),
+  }).send;
   opts.element = element;
   opts.$side = $('.swiss__side').clone();
 

--- a/ui/tournament/src/tournament.schedule.ts
+++ b/ui/tournament/src/tournament.schedule.ts
@@ -2,7 +2,7 @@ import view from './view/scheduleView';
 
 import { init, type VNode, classModule, attributesModule } from 'snabbdom';
 import type { Tournament } from './interfaces';
-import StrongSocket from 'common/socket';
+import { wsConnect } from 'common/socket';
 import { pubsub } from 'common/pubsub';
 
 const patch = init([classModule, attributesModule]);
@@ -19,7 +19,7 @@ export interface Ctrl {
 }
 
 export function initModule(opts: { data: Data }) {
-  site.socket = new StrongSocket('/socket/v5', false, { params: { flag: 'tournament' } });
+  wsConnect('/socket/v5', false, { params: { flag: 'tournament' } });
 
   const element = document.querySelector('.tour-chart') as HTMLElement;
 

--- a/ui/tournament/src/tournament.ts
+++ b/ui/tournament/src/tournament.ts
@@ -1,6 +1,6 @@
 import { init, classModule, attributesModule } from 'snabbdom';
 import type { TournamentOpts } from './interfaces';
-import StrongSocket from 'common/socket';
+import { wsConnect } from 'common/socket';
 
 const patch = init([classModule, attributesModule]);
 
@@ -9,10 +9,9 @@ import view from './view/main';
 
 export function initModule(opts: TournamentOpts) {
   document.body.dataset.tournamentId = opts.data.id;
-  site.socket = new StrongSocket(`/tournament/${opts.data.id}/socket/v5`, opts.data.socketVersion, {
+  opts.socketSend = wsConnect(`/tournament/${opts.data.id}/socket/v5`, opts.data.socketVersion, {
     receive: (t: string, d: any) => ctrl.socket.receive(t, d),
-  });
-  opts.socketSend = site.socket.send;
+  }).send;
   opts.element = document.querySelector('main.tour') as HTMLElement;
   opts.classes = opts.element.getAttribute('class');
   opts.$side = $('.tour__side').clone();


### PR DESCRIPTION
tame a bit of strange that has crept into StrongSocket over the years.

i just made some export functions and a local var for the class singleton, but we can do it another way if you prefer. we could export siteSocket directly or make a thin object wrapper with the same functions, but in a single import. lmk

i did not look into why we always store off a reference to socket.send. i assume it's for wrapping/patching somewhere so i left it alone