### PR TITLE
Translate board menu in puzzle and game

### DIFF
--- a/modules/coreI18n/src/main/key.scala
+++ b/modules/coreI18n/src/main/key.scala
@@ -1133,9 +1133,7 @@ object I18nKey:
     val `notifyWeb`: I18nKey = "preferences:notifyWeb"
     val `notifyDevice`: I18nKey = "preferences:notifyDevice"
     val `bellNotificationSound`: I18nKey = "preferences:bellNotificationSound"
-    val `blindFold`: I18nKey = "preferences:blindFold"
-    val `voiceInput`: I18nKey = "preferences:voiceInput"
-    val `keyboardInput`: I18nKey = "preferences:keyboardInput"
+    val `blindfold`: I18nKey = "preferences:blindfold"
 
   object puzzle:
     val `puzzles`: I18nKey = "puzzle:puzzles"

--- a/modules/coreI18n/src/main/key.scala
+++ b/modules/coreI18n/src/main/key.scala
@@ -202,7 +202,6 @@ object I18nKey:
     val `timezone`: I18nKey = "broadcast:timezone"
     val `fideRatingCategory`: I18nKey = "broadcast:fideRatingCategory"
     val `optionalDetails`: I18nKey = "broadcast:optionalDetails"
-    val `upcomingBroadcasts`: I18nKey = "broadcast:upcomingBroadcasts"
     val `pastBroadcasts`: I18nKey = "broadcast:pastBroadcasts"
     val `allBroadcastsByMonth`: I18nKey = "broadcast:allBroadcastsByMonth"
     val `nbBroadcasts`: I18nKey = "broadcast:nbBroadcasts"
@@ -1134,6 +1133,9 @@ object I18nKey:
     val `notifyWeb`: I18nKey = "preferences:notifyWeb"
     val `notifyDevice`: I18nKey = "preferences:notifyDevice"
     val `bellNotificationSound`: I18nKey = "preferences:bellNotificationSound"
+    val `blindFold`: I18nKey = "preferences:blindFold"
+    val `voiceInput`: I18nKey = "preferences:voiceInput"
+    val `keyboardInput`: I18nKey = "preferences:keyboardInput"
 
   object puzzle:
     val `puzzles`: I18nKey = "puzzle:puzzles"

--- a/translation/source/preferences.xml
+++ b/translation/source/preferences.xml
@@ -67,4 +67,7 @@
   <string name="notifyWeb">Browser</string>
   <string name="notifyDevice">Device</string>
   <string name="bellNotificationSound">Bell notification sound</string>
+  <string name="blindFold" comment="As in Blindfold chess">Blindfold</string>
+  <string name="voiceInput">Voice input</string>
+  <string name="keyboardInput">Keyboard input</string>
 </resources>

--- a/translation/source/preferences.xml
+++ b/translation/source/preferences.xml
@@ -67,7 +67,5 @@
   <string name="notifyWeb">Browser</string>
   <string name="notifyDevice">Device</string>
   <string name="bellNotificationSound">Bell notification sound</string>
-  <string name="blindFold" comment="As in Blindfold chess">Blindfold</string>
-  <string name="voiceInput">Voice input</string>
-  <string name="keyboardInput">Keyboard input</string>
+  <string name="blindfold" comment="As in Blindfold chess">Blindfold</string>
 </resources>

--- a/ui/@types/lichess/i18n.d.ts
+++ b/ui/@types/lichess/i18n.d.ts
@@ -2066,7 +2066,7 @@ interface I18n {
     /** Bell notification sound */
     bellNotificationSound: string;
     /** Blindfold */
-    blindFold: string;
+    blindfold: string;
     /** Board coordinates (A-H, 1-8) */
     boardCoordinates: string;
     /** Board highlights (last move and check) */
@@ -2123,8 +2123,6 @@ interface I18n {
     inputMovesWithTheKeyboard: string;
     /** Input moves with your voice */
     inputMovesWithVoice: string;
-    /** Keyboard input */
-    keyboardInput: string;
     /** Material difference */
     materialDifference: string;
     /** Move confirmation */
@@ -2191,8 +2189,6 @@ interface I18n {
     takebacksWithOpponentApproval: string;
     /** Tenths of seconds */
     tenthsOfSeconds: string;
-    /** Voice input */
-    voiceInput: string;
     /** When premoving */
     whenPremoving: string;
     /** When time remaining < 10 seconds */

--- a/ui/@types/lichess/i18n.d.ts
+++ b/ui/@types/lichess/i18n.d.ts
@@ -2065,6 +2065,8 @@ interface I18n {
   preferences: {
     /** Bell notification sound */
     bellNotificationSound: string;
+    /** Blindfold */
+    blindFold: string;
     /** Board coordinates (A-H, 1-8) */
     boardCoordinates: string;
     /** Board highlights (last move and check) */
@@ -2121,6 +2123,8 @@ interface I18n {
     inputMovesWithTheKeyboard: string;
     /** Input moves with your voice */
     inputMovesWithVoice: string;
+    /** Keyboard input */
+    keyboardInput: string;
     /** Material difference */
     materialDifference: string;
     /** Move confirmation */
@@ -2187,6 +2191,8 @@ interface I18n {
     takebacksWithOpponentApproval: string;
     /** Tenths of seconds */
     tenthsOfSeconds: string;
+    /** Voice input */
+    voiceInput: string;
     /** When premoving */
     whenPremoving: string;
     /** When time remaining < 10 seconds */

--- a/ui/common/src/boardMenu.ts
+++ b/ui/common/src/boardMenu.ts
@@ -53,7 +53,7 @@ export class BoardMenu {
 
   voiceInput = (toggle: Toggle, enabled = true): VNode =>
     this.cmnToggle({
-      name: i18n.preferences.voiceInput,
+      name: i18n.preferences.inputMovesWithVoice,
       id: 'voice',
       checked: toggle(),
       change: toggle,
@@ -63,7 +63,7 @@ export class BoardMenu {
 
   keyboardInput = (toggle: Toggle, enabled = true): VNode =>
     this.cmnToggle({
-      name: i18n.preferences.keyboardInput,
+      name: i18n.preferences.inputMovesWithTheKeyboard,
       id: 'keyboard',
       checked: toggle(),
       change: toggle,
@@ -73,7 +73,7 @@ export class BoardMenu {
 
   blindfold = (toggle: Toggle, enabled = true): VNode =>
     this.cmnToggle({
-      name: i18n.preferences.blindFold,
+      name: i18n.preferences.blindfold,
       id: 'blindfold',
       checked: toggle(),
       change: toggle,

--- a/ui/common/src/boardMenu.ts
+++ b/ui/common/src/boardMenu.ts
@@ -44,7 +44,7 @@ export class BoardMenu {
 
   zenMode = (enabled = true): VNode =>
     this.cmnToggle({
-      name: 'Zen mode',
+      name: i18n.preferences.zenMode,
       id: 'zen',
       checked: $('body').hasClass('zen'),
       change: () => pubsub.emit('zen'),
@@ -53,7 +53,7 @@ export class BoardMenu {
 
   voiceInput = (toggle: Toggle, enabled = true): VNode =>
     this.cmnToggle({
-      name: 'Voice input',
+      name: i18n.preferences.voiceInput,
       id: 'voice',
       checked: toggle(),
       change: toggle,
@@ -63,7 +63,7 @@ export class BoardMenu {
 
   keyboardInput = (toggle: Toggle, enabled = true): VNode =>
     this.cmnToggle({
-      name: 'Keyboard input',
+      name: i18n.preferences.keyboardInput,
       id: 'keyboard',
       checked: toggle(),
       change: toggle,
@@ -73,7 +73,7 @@ export class BoardMenu {
 
   blindfold = (toggle: Toggle, enabled = true): VNode =>
     this.cmnToggle({
-      name: 'Blindfold',
+      name: i18n.preferences.blindFold,
       id: 'blindfold',
       checked: toggle(),
       change: toggle,

--- a/ui/puzzle/src/view/boardMenu.ts
+++ b/ui/puzzle/src/view/boardMenu.ts
@@ -20,7 +20,7 @@ export default function (ctrl: PuzzleCtrl) {
       h(
         'a',
         { attrs: { target: '_blank', href: '/account/preferences/display' } },
-        'Game display preferences',
+        i18n.preferences.display,
       ),
     ]),
   ]);

--- a/ui/puzzle/src/view/boardMenu.ts
+++ b/ui/puzzle/src/view/boardMenu.ts
@@ -17,11 +17,7 @@ export default function (ctrl: PuzzleCtrl) {
       menu.keyboardInput(boolPrefXhrToggle('keyboardMove', !!ctrl.keyboardMove), true),
     ]),
     h('section.board-menu__links', [
-      h(
-        'a',
-        { attrs: { target: '_blank', href: '/account/preferences/display' } },
-        i18n.preferences.display,
-      ),
+      h('a', { attrs: { target: '_blank', href: '/account/preferences/display' } }, i18n.preferences.display),
     ]),
   ]);
 }

--- a/ui/round/src/view/boardMenu.ts
+++ b/ui/round/src/view/boardMenu.ts
@@ -27,12 +27,12 @@ export default function (ctrl: RoundController): LooseVNode {
         h(
           'a',
           { attrs: { target: '_blank', href: '/account/preferences/display' } },
-          'Game display preferences',
+          i18n.preferences.display,
         ),
         h(
           'a',
           { attrs: { target: '_blank', href: '/account/preferences/game-behavior ' } },
-          'Game behavior preferences',
+          i18n.preferences.gameBehavior,
         ),
       ]),
     ];


### PR DESCRIPTION
Note that I have used 2 translations from preferences (which are the titles of the preference pages)

'Game display preferences' becomes 'Display' (i18n.preferences.display)
'Game behavior preferences' becomes 'Game behavior' (i18n.preferences.gameBehavior)

If you prefer, I can add 2 specific keys


Puzzle board menu:
![lichess-puzzle-boardmenu-en](https://github.com/user-attachments/assets/169852e8-1945-49dc-bcac-5e8100aea7ea)
![lichess-puzzle-boardmenu-fr](https://github.com/user-attachments/assets/12bf1d6f-f7f9-4e44-bdf1-d30d963b96a5)


Game board menu:

![lichess-game-boardmenu-en](https://github.com/user-attachments/assets/cfe92055-5c25-4966-bdb2-093540e4c426)
![lichess-game-boardmenu-fr](https://github.com/user-attachments/assets/8f571bd5-d480-4fa3-a30a-4daacd18fc83)
