### PR TITLE
Remove 'null' from lobby when the user is not logged in

### DIFF
--- a/ui/lobby/src/lobby.inline.ts
+++ b/ui/lobby/src/lobby.inline.ts
@@ -14,7 +14,7 @@ function layout() {
   cols = newCols;
   document
     .querySelector<HTMLElement>(cols > 2 ? '.lobby__side' : '.lobby')
-    ?.append(document.querySelector('.lobby__timeline')!);
+    ?.append(document.querySelector('.lobby__timeline') ?? '');
 }
 
 layout();


### PR DESCRIPTION
The inline javascript is trying to append an element that only exists when the user is logged in, resulting in viewing "null" instead when they are not logged in. Moreover, when the window size changes, a series of nulls are rendered.

Before
![Before](https://github.com/user-attachments/assets/92426385-19c2-48fd-99f8-41b9880294b2)

After
![After](https://github.com/user-attachments/assets/1756ff20-acc5-4823-b195-ddda614d1898)
