### PR TITLE
add --no-corepack argument

### DIFF
--- a/ui/.build/src/main.ts
+++ b/ui/.build/src/main.ts
@@ -17,6 +17,7 @@ const args: Record<string, string> = {
   '--no-color': '',
   '--no-time': '',
   '--no-context': '',
+  '--no-corepack': '',
   '--help': 'h',
   '--watch': 'w',
   '--prod': 'p',
@@ -46,6 +47,7 @@ Options:
   --no-color          don't use color in logs
   --no-time           don't log the time
   --no-context        don't log the context
+  --no-corepack       don't use corepack to install pnpm (protect or restricted system node installs)
 
 Exclusive Options:    (any of these will disable other functions)
   --clean-exit        clean all build artifacts and exit

--- a/ui/build
+++ b/ui/build
@@ -13,7 +13,11 @@ fi
 
 cd "$(dirname "${BASH_SOURCE:-$0}")/.build"
 
-corepack enable
+if [[ " $* " != *" --no-corepack "* ]]; then
+  if ! corepack enable >/dev/null 2>&1; then
+    echo "Corepack not available. Try a userland node such as nvm."
+  fi
+fi
 
 pnpm install --silent --ignore-workspace
 


### PR DESCRIPTION
if using a system node, we may lack permission to enable it