### PR TITLE
fix: align link in move comment

### DIFF
--- a/ui/tree/css/_tree.scss
+++ b/ui/tree/css/_tree.scss
@@ -74,10 +74,6 @@
     color: $c-primary;
   }
 
-  comment a {
-    vertical-align: middle;
-  }
-
   comment.truncated {
     cursor: pointer;
   }

--- a/ui/tree/css/_tree.scss
+++ b/ui/tree/css/_tree.scss
@@ -75,7 +75,7 @@
   }
 
   comment a {
-    vertical-align: top;
+    vertical-align: middle;
   }
 
   comment.truncated {


### PR DESCRIPTION
before:
![Screenshot from 2024-12-15 14-10-50](https://github.com/user-attachments/assets/77e8871b-24f4-4c6c-9d46-25de42b405a6)
After:
![image_2024-12-15_141411033](https://github.com/user-attachments/assets/0e665b7a-67a5-4bee-9864-2f1b2ef1ba88)
