### PR TITLE
Enable sass parser in ui/build to parse indirect color assignments

### DIFF
--- a/ui/common/css/theme/_default.scss
+++ b/ui/common/css/theme/_default.scss
@@ -30,7 +30,7 @@ $c-shade: hsl(0, 0%, 30%);
 $c-inaccuracy: hsl(202, 78%, 62%);
 $c-mistake: hsl(41, 100%, 45%);
 $c-blunder: hsl(0, 69%, 60%);
-$c-good: $c-secondary;
+$c-good: hsl(88, 62%, 37%);
 $c-brilliant: hsl(129, 71%, 45%);
 $c-interesting: hsl(307, 80%, 70%);
 $c-paper: hsl(60, 56%, 91%);


### PR DESCRIPTION
The sass build for colors currently only works for direct assignments, but doesn't work correctly when being assigned to another variables and causes the assignee to be #000 instead.

Should fix #16559.