### PR TITLE
Set the default opening explorer color to the player's played color

### DIFF
--- a/ui/analyse/src/explorer/explorerConfig.ts
+++ b/ui/analyse/src/explorer/explorerConfig.ts
@@ -83,7 +83,7 @@ export class ExplorerConfigCtrl {
         value: storedStringProp('analyse.explorer.player.name', this.myName || ''),
         previous: storedJsonProp<string[]>('explorer.player.name.previous', () => []),
       },
-      color: prevData?.color || prop('white'),
+      color: prevData?.color || prop(root.bottomColor()),
       byDb() {
         return this.byDbData[this.db()] || this.byDbData.lichess;
       },


### PR DESCRIPTION
Resolves #16531 

When reviewing a game and using the opening explorer with the Player book. Now, by default, it will set the color to the player's color in the game. This will avoid having white by default and having the player change it each time. Of course the user can then change the color back if wanted. I simply used the bottom color since it will always be the player's color in a review. Let me know if I am missing a side effect, I don't have much knowledge on the opening books. 