### PR TITLE
import api rather than window.lichess

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,6 +131,12 @@ importers:
         specifier: workspace:*
         version: link:../tree
 
+  ui/api:
+    dependencies:
+      common:
+        specifier: workspace:*
+        version: link:../common
+
   ui/bits:
     dependencies:
       '@fnando/sparkline':
@@ -166,6 +172,9 @@ importers:
       '@yaireo/tagify':
         specifier: 4.17.9
         version: 4.17.9(prop-types@15.8.1)
+      api:
+        specifier: workspace:*
+        version: link:../api
       canvas-confetti:
         specifier: ^1.9.3
         version: 1.9.3
@@ -277,6 +286,9 @@ importers:
 
   ui/chat:
     dependencies:
+      api:
+        specifier: workspace:*
+        version: link:../api
       common:
         specifier: workspace:*
         version: link:../common
@@ -591,6 +603,9 @@ importers:
 
   ui/site:
     dependencies:
+      api:
+        specifier: workspace:*
+        version: link:../api
       chat:
         specifier: workspace:*
         version: link:../chat

--- a/ui/@types/lichess/index.d.ts
+++ b/ui/@types/lichess/index.d.ts
@@ -155,29 +155,8 @@ interface Events {
   off(key: string, cb: (...args: any[]) => void): void;
 }
 
-interface Api {
-  initializeDom: (root?: HTMLElement) => void;
-  events: Events;
-  socket: {
-    subscribeToMoveLatency: () => void;
-    events: Events;
-  };
-  onlineFriends: {
-    request: () => void;
-    events: Events;
-  };
-  chat: {
-    post: (text: string) => void;
-  };
-  overrides: {
-    [key: string]: (...args: any[]) => unknown;
-  };
-  analysis?: any;
-}
-
 interface Window {
   site: Site;
-  lichess: Api;
   fipr: Fipr;
   i18n: I18n;
   $as<T>(cash: Cash): T;

--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -195,7 +195,7 @@ export default class AnalyseCtrl {
     });
     pubsub.on('board.change', redraw);
     this.persistence?.merge();
-    window.lichess.analysis = api(this);
+    (window as any).lichess.analysis = api(this);
   }
 
   initialize(data: AnalyseData, merge: boolean): void {

--- a/ui/api/package.json
+++ b/ui/api/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "api",
+  "version": "2.0.0",
+  "private": true,
+  "description": "lichess.org browser extension API",
+  "author": "Thibault Duplessis",
+  "license": "AGPL-3.0-or-later",
+  "typings": "api",
+  "typesVersions": {
+    "*": {
+      "*": [
+        "dist/*"
+      ]
+    }
+  },
+  "exports": {
+    ".": "./src/api.ts",
+    "./*": "./src/*.ts"
+  },
+  "dependencies": {
+    "common": "workspace:*"
+  }
+}

--- a/ui/api/src/api.ts
+++ b/ui/api/src/api.ts
@@ -1,4 +1,4 @@
-import type { Pubsub, PubsubCallback, PubsubEvent } from 'common/pubsub';
+import { type PubsubCallback, type PubsubEvent, pubsub, initializeDom } from 'common/pubsub';
 
 // #TODO document these somewhere
 const publicEvents = ['ply', 'analysis.change', 'chat.resize', 'analysis.closeAll'];
@@ -6,8 +6,29 @@ const socketEvents = ['lag', 'close'];
 const socketInEvents = ['mlat', 'fen', 'notifications', 'endData'];
 const friendsEvents = ['playing', 'stopped_playing', 'onlines', 'enters', 'leaves'];
 
-export const api = (pubsub: Pubsub): Api => ({
-  initializeDom: (root?: HTMLElement) => pubsub.emit('content-loaded', root),
+export interface Api {
+  initializeDom: (root?: HTMLElement) => void;
+  events: Events;
+  socket: {
+    subscribeToMoveLatency: () => void;
+    events: Events;
+  };
+  onlineFriends: {
+    request: () => void;
+    events: Events;
+  };
+  chat: {
+    post: (text: string) => void;
+  };
+  overrides: {
+    [key: string]: (...args: any[]) => unknown;
+  };
+  analysis?: any;
+}
+
+// this object is available to extensions as window.lichess
+export const api: Api = ((window as any).lichess = {
+  initializeDom,
   events: {
     on(name: PubsubEvent, cb: PubsubCallback): void {
       if (!publicEvents.includes(name)) throw 'This event is not part of the public API';

--- a/ui/api/tsconfig.json
+++ b/ui/api/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tsconfig.base.json"
+}

--- a/ui/bits/package.json
+++ b/ui/bits/package.json
@@ -27,6 +27,7 @@
     "@types/yaireo__tagify": "4.27.0",
     "@types/zxcvbn": "^4.4.5",
     "@yaireo/tagify": "4.17.9",
+    "api": "workspace:*",
     "canvas-confetti": "^1.9.3",
     "chat": "workspace:*",
     "chess": "workspace:*",

--- a/ui/bits/src/bits.challengePage.ts
+++ b/ui/bits/src/bits.challengePage.ts
@@ -2,6 +2,7 @@ import * as xhr from 'common/xhr';
 import { wsConnect, wsSend } from 'common/socket';
 import { userComplete } from 'common/userComplete';
 import { isTouchDevice, isIos } from 'common/device';
+import { initializeDom } from 'common/pubsub';
 
 interface ChallengeOpts {
   xhrUrl: string;
@@ -19,7 +20,7 @@ export function initModule(opts: ChallengeOpts): void {
         xhr.text(opts.xhrUrl).then(html => {
           $(selector).replaceWith($(html).find(selector));
           init();
-          window.lichess.initializeDom($(selector)[0]);
+          initializeDom($(selector)[0]);
         });
       },
     },

--- a/ui/bits/src/bits.infiniteScroll.ts
+++ b/ui/bits/src/bits.infiniteScroll.ts
@@ -1,5 +1,6 @@
 import * as xhr from 'common/xhr';
 import { spinnerHtml } from 'common/spinner';
+import { initializeDom } from 'common/pubsub';
 
 export function initModule(selector: string = '.infinite-scroll'): void {
   $(selector).each(function (this: HTMLElement) {
@@ -36,7 +37,7 @@ function register(el: HTMLElement, selector: string, backoff = 500) {
           nav.remove();
           $(el).append(($(html).is(selector) ? $(html) : $(html).find(selector)).html());
           dedupEntries(el);
-          window.lichess.initializeDom(el);
+          initializeDom(el);
           setTimeout(() => register(el, selector, backoff * 1.05), backoff); // recursion with backoff
         },
         e => {

--- a/ui/bits/src/bits.user.ts
+++ b/ui/bits/src/bits.user.ts
@@ -1,6 +1,7 @@
 import * as xhr from 'common/xhr';
 import { makeLinkPopups } from 'common/linkPopup';
 import { alert } from 'common/dialog';
+import { initializeDom } from 'common/pubsub';
 
 export function initModule(): void {
   makeLinkPopups($('.social_links'));
@@ -47,7 +48,7 @@ export function initModule(): void {
       browseTo = (path: string) =>
         xhr.text(path).then(html => {
           $content.html(html);
-          window.lichess.initializeDom($content[0]);
+          initializeDom($content[0]);
           history.replaceState({}, '', path);
           site.asset.loadEsm('bits.infiniteScroll');
         });

--- a/ui/chat/package.json
+++ b/ui/chat/package.json
@@ -10,6 +10,7 @@
     ".": "./src/chat.ts"
   },
   "dependencies": {
+    "api": "workspace:*",
     "common": "workspace:*",
     "palantir": "workspace:*"
   }

--- a/ui/chat/src/ctrl.ts
+++ b/ui/chat/src/ctrl.ts
@@ -18,6 +18,7 @@ import { prop } from 'common';
 import { storage, type LichessStorage } from 'common/storage';
 import { pubsub, type PubsubEvent, type PubsubCallback } from 'common/pubsub';
 import { alert } from 'common/dialog';
+import { api } from 'api';
 
 export default class ChatCtrl {
   data: ChatData;
@@ -102,7 +103,7 @@ export default class ChatCtrl {
       alert('Max length: 140 chars. ' + text.length + ' chars used.');
       return false;
     }
-    window.lichess.chat.post(text);
+    api.chat.post(text);
     return true;
   };
 

--- a/ui/chat/src/moderation.ts
+++ b/ui/chat/src/moderation.ts
@@ -6,7 +6,7 @@ import type { ModerationCtrl, ModerationOpts, ModerationData, ModerationReason }
 import { numberFormat } from 'common/number';
 import { userModInfo, flag, timeout } from './xhr';
 import type ChatCtrl from './ctrl';
-import { pubsub } from 'common/pubsub';
+import { pubsub, initializeDom } from 'common/pubsub';
 import { confirm } from 'common/dialog';
 
 export function moderationCtrl(opts: ModerationOpts): ModerationCtrl {
@@ -158,7 +158,7 @@ export function moderationView(ctrl?: ModerationCtrl): VNode[] | undefined {
             {
               hook: {
                 insert() {
-                  window.lichess.initializeDom();
+                  initializeDom();
                 },
               },
             },

--- a/ui/common/src/pubsub.ts
+++ b/ui/common/src/pubsub.ts
@@ -99,6 +99,10 @@ export class Pubsub {
 
 export const pubsub: Pubsub = new Pubsub();
 
+export function initializeDom(root?: HTMLElement): void {
+  pubsub.emit('content-loaded', root);
+}
+
 interface OneTimeHandler {
   promise: Promise<void>;
   resolve?: () => void;

--- a/ui/lobby/src/lobby.ts
+++ b/ui/lobby/src/lobby.ts
@@ -2,7 +2,7 @@ import * as xhr from 'common/xhr';
 import main from './main';
 import type { LobbyOpts } from './interfaces';
 import { wsConnect, wsPingInterval } from 'common/socket';
-import { pubsub } from 'common/pubsub';
+import { pubsub, initializeDom } from 'common/pubsub';
 
 export function initModule(opts: LobbyOpts) {
   opts.appElement = document.querySelector('.lobby__app') as HTMLElement;
@@ -35,12 +35,12 @@ export function initModule(opts: LobbyOpts) {
       reload_timeline() {
         xhr.text('/timeline').then(html => {
           $('.timeline').html(html);
-          window.lichess.initializeDom();
+          initializeDom();
         });
       },
       featured(o: { html: string }) {
         $('.lobby__tv').html(o.html);
-        window.lichess.initializeDom();
+        initializeDom();
       },
       redirect(e: RedirectTo) {
         lobbyCtrl.setRedirecting();

--- a/ui/mod/src/mod.user.ts
+++ b/ui/mod/src/mod.user.ts
@@ -6,6 +6,7 @@ import tablesort from 'tablesort';
 import { expandCheckboxZone, shiftClickCheckboxRange, selector } from './checkBoxes';
 import { spinnerHtml } from 'common/spinner';
 import { confirm } from 'common/dialog';
+import { initializeDom } from 'common/pubsub';
 
 site.load.then(() => {
   const $toggle = $('.mod-zone-toggle'),
@@ -63,7 +64,7 @@ site.load.then(() => {
   const getLocationHash = (a: HTMLAnchorElement) => a.href.replace(/.+(#\w+)$/, '$1');
 
   function userMod($inZone: Cash) {
-    window.lichess.initializeDom($inZone[0]);
+    initializeDom($inZone[0]);
 
     const makeReady = (selector: string, f: (el: HTMLElement, i: number) => void, cls = 'ready') => {
       $inZone.find(selector + `:not(.${cls})`).each(function (this: HTMLElement, i: number) {

--- a/ui/notify/src/view.ts
+++ b/ui/notify/src/view.ts
@@ -3,6 +3,7 @@ import { h, type VNode } from 'snabbdom';
 import * as licon from 'common/licon';
 import { spinnerVdom as spinner } from 'common/spinner';
 import makeRenderers from './renderers';
+import { initializeDom } from 'common/pubsub';
 
 const renderers = makeRenderers();
 
@@ -73,7 +74,7 @@ function clickHook(f: () => void) {
   };
 }
 
-const contentLoaded = (vnode: VNode) => window.lichess.initializeDom(vnode.elm as HTMLElement);
+const contentLoaded = (vnode: VNode) => initializeDom(vnode.elm as HTMLElement);
 
 function recentNotifications(d: NotifyData, scrolling: boolean): VNode {
   return h(

--- a/ui/round/src/round.ts
+++ b/ui/round/src/round.ts
@@ -11,7 +11,7 @@ import { wsConnect, wsDestroy } from 'common/socket';
 import { storage } from 'common/storage';
 import { setClockWidget } from 'common/clock';
 import { makeChat } from 'chat';
-import { pubsub } from 'common/pubsub';
+import { pubsub, initializeDom } from 'common/pubsub';
 import { myUserId } from 'common';
 import { alert } from 'common/dialog';
 
@@ -76,7 +76,7 @@ async function boot(
           $meta.length && $('.game__meta').replaceWith($meta);
           $('.crosstable').replaceWith($html.find('.crosstable'));
           startTournamentClock();
-          window.lichess.initializeDom();
+          initializeDom();
         });
       },
       tourStanding(s: TourPlayer[]) {

--- a/ui/simul/src/simul.home.ts
+++ b/ui/simul/src/simul.home.ts
@@ -1,5 +1,5 @@
 import { wsConnect } from 'common/socket';
-import { pubsub } from 'common/pubsub';
+import { pubsub, initializeDom } from 'common/pubsub';
 
 site.load.then(() => {
   wsConnect(`/socket/v5`, false, { params: { flag: 'simul' } });
@@ -7,6 +7,6 @@ site.load.then(() => {
     const rsp = await fetch('/simul/reload');
     const html = await rsp.text();
     $('.simul-list__content').html(html);
-    window.lichess.initializeDom();
+    initializeDom();
   });
 });

--- a/ui/site/package.json
+++ b/ui/site/package.json
@@ -6,6 +6,7 @@
   "author": "Thibault Duplessis",
   "license": "AGPL-3.0-or-later",
   "dependencies": {
+    "api": "workspace:*",
     "chat": "workspace:*",
     "chess": "workspace:*",
     "common": "workspace:*",

--- a/ui/site/src/announce.ts
+++ b/ui/site/src/announce.ts
@@ -1,4 +1,5 @@
 import { escapeHtml } from 'common';
+import { initializeDom } from 'common/pubsub';
 
 let timeout: Timeout | undefined;
 
@@ -24,7 +25,7 @@ const announce = (d: LichessAnnouncement) => {
     const millis = d.date ? new Date(d.date).getTime() - Date.now() : 5000;
     if (millis > 0) timeout = setTimeout(kill, millis);
     else kill();
-    if (d.date) window.lichess.initializeDom();
+    if (d.date) initializeDom();
   }
 };
 

--- a/ui/site/src/friends.ts
+++ b/ui/site/src/friends.ts
@@ -1,5 +1,6 @@
 import { notNull } from 'common/common';
 import * as licon from 'common/licon';
+import { api as lichess } from 'api';
 
 type TitleName = string;
 
@@ -17,7 +18,7 @@ export default class OnlineFriends {
   users: Map<string, Friend>;
 
   constructor(readonly el: HTMLElement) {
-    const api = window.lichess.onlineFriends;
+    const api = lichess.onlineFriends;
     this.titleEl = this.el.querySelector('.friend_box_title') as HTMLElement;
     this.titleEl.addEventListener('click', () => {
       this.el.querySelector('.content_wrap')?.classList.toggle('none');

--- a/ui/site/src/powertip.ts
+++ b/ui/site/src/powertip.ts
@@ -2,6 +2,7 @@ import * as licon from 'common/licon';
 import { text as xhrText } from 'common/xhr';
 import { requestIdleCallback, $as } from 'common';
 import { spinnerHtml } from 'common/spinner';
+import { initializeDom } from 'common/pubsub';
 
 // Thanks Steven Benner! - adapted from https://github.com/stevenbenner/jquery-powertip
 
@@ -13,7 +14,7 @@ const onPowertipPreRender = (id: string, preload?: (url: string) => void) => (el
   xhrText(url + '/mini').then(html => {
     const el = document.getElementById(id) as HTMLElement;
     el.innerHTML = html;
-    window.lichess.initializeDom(el);
+    initializeDom(el);
   });
 };
 

--- a/ui/site/src/site.ts
+++ b/ui/site/src/site.ts
@@ -7,14 +7,13 @@ import { unload, redirect, reload } from './reload';
 import announce from './announce';
 import { displayLocale } from 'common/i18n';
 import sound from './sound';
-import { api } from './api';
-import { pubsub } from 'common/pubsub';
 
 const site = window.site;
 // site.load is initialized in site.inline.ts (body script)
 // site.manifest is fetched
 // site.info, site.debug are populated by ui/build
-// site.quietMode, site.analysis are set elsewhere
+// site.quietMode is set elsewhere
+// window.lichess is initialized in ui/api/src/api.ts
 site.sri = randomToken();
 site.displayLocale = displayLocale;
 site.blindMode = document.body.classList.contains('blind-mode');
@@ -27,6 +26,3 @@ site.reload = reload;
 site.announce = announce;
 site.sound = sound;
 site.load.then(boot);
-
-// public API
-window.lichess = api(pubsub);


### PR DESCRIPTION
i moved initializeDom to pubsub so there are less imports of the new api package. this should help us if api needs to depend on other packages (besides common) down the road.

remember - those pubsub strings are typed, so the 'content-loaded' string itself is as good as a function name