### PR TITLE
directly use pwned k-anonymity api

### DIFF
--- a/conf/base.conf
+++ b/conf/base.conf
@@ -215,7 +215,7 @@ security {
     enabled = false
     url = "http://ip2proxy.lichess.ovh:1929"
   }
-  pwned.url = ""
+  pwned.range_url = "https://api.pwnedpasswords.com/range/"
   hcaptcha = ${hcaptcha}
   lame_name_check = true
   password.bpass.secret = ${user.password.bpass.secret}

--- a/modules/security/src/main/Env.scala
+++ b/modules/security/src/main/Env.scala
@@ -147,7 +147,7 @@ final class Env(
 
   lazy val ipTrust: IpTrust = wire[IpTrust]
 
-  lazy val pwned: Pwned = Pwned(ws, config.pwnedUrl)
+  lazy val pwned: Pwned = Pwned(ws, config.pwnedRangeUrl)
 
   lazy val proxy2faSetting: SettingStore[Strings] @@ Proxy2faSetting = settingStore[Strings](
     "proxy2fa",

--- a/modules/security/src/main/SecurityConfig.scala
+++ b/modules/security/src/main/SecurityConfig.scala
@@ -24,7 +24,7 @@ final private class SecurityConfig(
     val hcaptcha: Hcaptcha.Config,
     @ConfigName("ip2proxy") val ip2Proxy: Ip2Proxy,
     @ConfigName("lame_name_check") val lameNameCheck: LameNameCheck,
-    @ConfigName("pwned.url") val pwnedUrl: String,
+    @ConfigName("pwned.range_url") val pwnedRangeUrl: String,
     @ConfigName("password.bpass.secret") val passwordBPassSecret: Secret
 )
 


### PR DESCRIPTION
reconsidering if we should use the public api directly. unlike some other offered apis, there's essentially no rate limiting for the k-anonymity api.

pros:

* new password leaks immediately reflected
* can retire https://github.com/lichess-org/lila-pwned, for one less service to maintain

cons:

* request latency: 30ms (was a bit surprised, but manta and rubik are in different data centers) -> ~60ms