### PR TITLE
Remove cats-parse VersionScheme.Always

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -42,11 +42,6 @@ Compile / sourceDirectory                  := baseDirectory.value / "app"
 Compile / scalaSource                      := baseDirectory.value / "app"
 Universal / sourceDirectory                := baseDirectory.value / "dist"
 
-// cats-parse v1.0.0 is the same as v0.3.1, so this is safe
-ThisBuild / libraryDependencySchemes ++= Seq(
-  "org.typelevel" %% "cats-parse" % VersionScheme.Always
-)
-
 // format: off
 libraryDependencies ++= akka.bundle ++ playWs.bundle ++ macwire.bundle ++ scalalib.bundle ++ chess.bundle ++ Seq(
   play.json, play.logback, compression, hasher,


### PR DESCRIPTION
We used to depend on scala-uri which depends on an old version of
cats-parse. But it seems we don't depend on it any more, so this is
not necessary any more.