### PR TITLE
prevent zombie forms on picture submission

### DIFF
--- a/modules/streamer/src/main/StreamerApi.scala
+++ b/modules/streamer/src/main/StreamerApi.scala
@@ -161,7 +161,7 @@ final class StreamerApi(
     picfitApi
       .uploadFile(s"streamer:${s.id}", picture, userId = by.id)
       .flatMap { pic =>
-        coll.update.one($id(s.id), $set("picture" -> pic.id, "approval.requested" -> true)).void
+        coll.update.one($id(s.id), $set("picture" -> pic.id)).void
       }
 
   // unapprove after 6 weeks if you never streamed (was originally 1 week)

--- a/modules/streamer/src/main/StreamerForm.scala
+++ b/modules/streamer/src/main/StreamerForm.scala
@@ -89,7 +89,7 @@ object StreamerForm:
             requested = m.requested,
             ignored = m.ignored,
             chatEnabled = m.chat,
-            reason = m.reason,
+            reason = if m.granted then none else (~m.reason).some,
             lastGrantedAt = m.granted.option(nowInstant).orElse(streamer.approval.lastGrantedAt)
           )
         else // data in UserData.approval must be ignored here

--- a/modules/streamer/src/main/ui/StreamerEdit.scala
+++ b/modules/streamer/src/main/ui/StreamerEdit.scala
@@ -46,7 +46,8 @@ final class StreamerEdit(helpers: Helpers, bits: StreamerBits):
             div(cls := "box-pad") {
               val granted   = s.streamer.approval.granted
               val requested = s.streamer.approval.requested
-              val (clas, icon) = (granted, requested, wasListed) match
+              val declined  = s.streamer.approval.reason.nonEmpty
+              val (clas, icon) = (granted, requested, declined) match
                 case (true, true, _)       => ("status is-green", Icon.Search)
                 case (true, false, _)      => ("status is-green", Icon.Checkmark)
                 case (false, true, _)      => ("status is-gold", Icon.CautionTriangle)
@@ -70,7 +71,7 @@ final class StreamerEdit(helpers: Helpers, bits: StreamerBits):
                             )
                         )
                       else if requested then trs.pendingReview()
-                      else if wasListed then
+                      else if declined then
                         frag(
                           "Your previous application was declined. ",
                           s.streamer.approval.reason


### PR DESCRIPTION
- remove "requested" -> true from picture apply, that was a relic which caused our zombie problem
- stop using wasListed to distinguish between declines and 
- when the form was last touched by a mod, approval.reason.isDefined is always true
- use reason.isDefined rather than wasListed to better determine the appropriate status display. this can result in confusing status text on the edit form if someone is both a mod and a streamer but at least behavior will still be correct
