### PR TITLE
always close Dialog instance when closing modal

### DIFF
--- a/ui/lobby/src/setupCtrl.ts
+++ b/ui/lobby/src/setupCtrl.ts
@@ -197,10 +197,7 @@ export default class SetupController {
     this.loadPropsFromStore(forceOptions);
   };
 
-  closeModal = () => {
-    this.gameType = null;
-    this.root.redraw();
-  };
+  closeModal?: () => void; // managed by view/setup/modal.ts
 
   validateFen = debounce(() => {
     const fen = this.fen();
@@ -292,7 +289,7 @@ export default class SetupController {
     const poolMember = this.hookToPoolMember(color);
     if (poolMember) {
       this.root.enterPool(poolMember);
-      this.closeModal();
+      this.closeModal?.();
       return;
     }
 
@@ -330,13 +327,13 @@ export default class SetupController {
       if (response.status === 403) {
         // 403 FORBIDDEN closes this modal because challenges to the recipient
         // will not be accepted.  see friend() in controllers/Setup.scala
-        this.closeModal();
+        this.closeModal?.();
       }
     } else if (redirected) {
       location.href = url;
     } else {
       this.loading = false;
-      this.closeModal();
+      this.closeModal?.();
     }
   };
 }

--- a/ui/lobby/src/view/setup/modal.ts
+++ b/ui/lobby/src/view/setup/modal.ts
@@ -18,9 +18,17 @@ export default function setupModal(ctrl: LobbyController): MaybeVNode {
   return snabDialog({
     class: 'game-setup',
     css: [{ hashed: 'lobby.setup' }],
-    onClose: setupCtrl.closeModal,
+    onClose: () => {
+      setupCtrl.closeModal = undefined;
+      setupCtrl.gameType = null;
+      setupCtrl.root.redraw();
+    },
     modal: true,
     vnodes: [...views[setupCtrl.gameType](ctrl), ratingView(ctrl)],
+    onInsert: dlg => {
+      setupCtrl.closeModal = dlg.close;
+      dlg.show();
+    },
   });
 }
 


### PR DESCRIPTION
common/dialog has basic snab integration, but we still need to inform the Dialog instance when a dialog is closed for proper cleanup