### PR TITLE
Fix practice mode underboard in the case of stalemates

### DIFF
--- a/ui/analyse/src/study/practice/studyPracticeSuccess.ts
+++ b/ui/analyse/src/study/practice/studyPracticeSuccess.ts
@@ -62,6 +62,7 @@ export default function (root: AnalyseCtrl, goal: Goal, nbMoves: number): boolea
     case 'mate':
       if (node.threefold) return false;
       if (isDrawish(node)) return false;
+      if (root.position(node).unwrap().isStalemate()) return false;
   }
   return null;
 }


### PR DESCRIPTION
In practice mode when the goal is to checkmate the opponent and the onboard position is stalemate, the section under the board doesn't get updated to try again.

For example:

![image](https://github.com/user-attachments/assets/77e43a79-5a76-4c11-b534-c604b3e5d546)
