### PR TITLE
properly encode vapid keys

### DIFF
--- a/modules/push/src/main/Env.scala
+++ b/modules/push/src/main/Env.scala
@@ -32,7 +32,7 @@ final class Env(
 
   private val config = appConfig.get[PushConfig]("push")(AutoConfig.loader)
 
-  def vapidPublicKey = config.web.vapidPublicKey
+  lazy val vapidPublicKey = config.web.vapidPublicKey.replace("/", "_").replace("+", "-").replace("=", "")
 
   private val deviceApi  = DeviceApi(db(config.deviceColl))
   val webSubscriptionApi = WebSubscriptionApi(db(config.subscriptionColl))


### PR DESCRIPTION
applicationServerKey argument to PushManager.subscribe must be Base64URL encoded (a few character substitutions and minus padding)

I have absolutely no idea why all three major browsers just started complaining about this now because the server code doesn't seem to have changed, but here we are.