### PR TITLE
added margin between flag and country title on the powertip

### DIFF
--- a/ui/common/css/component/_power-tip.scss
+++ b/ui/common/css/component/_power-tip.scss
@@ -46,14 +46,11 @@
       &__flag {
         @extend %flex-center;
         margin-inline-start: 0.5ch;
+        gap: 0.5ch;
         flex: 1 1 auto;
         overflow: hidden;
         font-size: 0.9em;
         color: $c-font-dim;
-
-        .flag {
-          margin-inline-end: 0.4em;
-        }
       }
       signal {
         flex: 0 0 auto;

--- a/ui/common/css/component/_power-tip.scss
+++ b/ui/common/css/component/_power-tip.scss
@@ -50,6 +50,10 @@
         overflow: hidden;
         font-size: 0.9em;
         color: $c-font-dim;
+
+        .flag {
+          margin-inline-end: 0.4em;
+        }
       }
       signal {
         flex: 0 0 auto;


### PR DESCRIPTION
Based on this issue:
https://github.com/lichess-org/lila/issues/16675

I added margin on the powertip:
Before:
![image](https://github.com/user-attachments/assets/2b230214-7c6d-415c-8f92-447fbd1531c4)
After:
![image](https://github.com/user-attachments/assets/723268ef-7ef6-41a9-aacf-d9fdaa476564)
