### PR TITLE
Show puzzle hint when square is 0

### DIFF
--- a/ui/puzzle/src/autoShape.ts
+++ b/ui/puzzle/src/autoShape.ts
@@ -72,7 +72,7 @@ export default function (opts: Opts): DrawShape[] {
     } else shapes = shapes.concat(makeAutoShapesFromUci(opposite(color), n.threat.pvs[0].moves[0], 'red'));
   }
   const feedback = feedbackAnnotation(n);
-  const hint = opts.hint && { orig: makeSquare(opts.hint), brush: 'green' };
+  const hint = opts.hint !== undefined ? { orig: makeSquare(opts.hint), brush: 'green' } : undefined;
   return [
     ...shapes,
     ...annotationShapes(n),


### PR DESCRIPTION
Fix:
https://github.com/lichess-org/lila/issues/16710

I managed to recreate the bug with the example from the issue.

If hint square is 0 => opts.hint === 0, the expression:
hint = opts.hint && { orig: makeSquare(opts.hint), brush: 'green' }
will evaluate to 0 and not proceed into the makeSquare function. The resulting hint will be 0 instead of the object { orig: makeSquare(0), brush: 'green' }

Before:

https://github.com/user-attachments/assets/ac7621cc-e3db-4a4b-a42c-e0b5a0ca598a


With the fix its working ok:

https://github.com/user-attachments/assets/c1083a91-7a16-401f-80de-c6e6e8c5fecc


