### PR TITLE
Add winning color if present to JSON game streams

### DIFF
--- a/modules/game/src/main/GamesByUsersStream.scala
+++ b/modules/game/src/main/GamesByUsersStream.scala
@@ -72,6 +72,7 @@ private object GameStream:
               )
               .add("provisional" -> p.provisional))
         )
+        .add("winner" -> g.winnerColor.map(_.name))
         .add("initialFen" -> initialFen)
         .add("clock" -> g.clock.map: clock =>
           Json.obj(


### PR DESCRIPTION
If the game to be JSON:ified has a winner,
a new field "winner" is now added with the color of the winner.

```
{
    ...
    "winner":"white",
    ...
}
```

`/api/stream/games-by-users` - https://lichess.org/api#tag/Games/operation/gamesByUsers
`/api/stream/games/<streamId>` - https://lichess.org/api#tag/Games/operation/gamesByIds

Without this information, one would need to make an additional API lookup by game id to see who won.