### PR TITLE
Change tournament table style on smaller screens

### DIFF
--- a/ui/lobby/css/_box.scss
+++ b/ui/lobby/css/_box.scss
@@ -48,6 +48,9 @@
       padding: 0.5em 0.4em;
       border-top: $border;
       max-width: 21ch;
+      @media (max-width: at-most($x-small)) {
+        max-width: 18ch;
+      }
 
       &.name a {
         font-weight: bold;
@@ -88,6 +91,13 @@
       background: $m-bg--fade-40;
     }
     overflow: hidden;
+    @media (max-width: at-most($x-small)) {
+      max-width: 23ch;
+      margin: auto;
+    }
+    @media (max-width: at-most($xx-small)) {
+      max-width: 16ch;
+    }
   }
   .progress__bar {
     border-radius: 2em;


### PR DESCRIPTION
There are two issues in that table:
1. It causes the page to overflow ( #16719)
2. The progress bar overflows

This commit should fix both

Before and after:

![image](https://github.com/user-attachments/assets/36de10a5-a3f8-4833-bc4a-121e675a321e)

![image](https://github.com/user-attachments/assets/28161c83-135a-4a8a-993b-b4eb8369b453)
