### PR TITLE
dont create identical javascripts

### DIFF
--- a/modules/web/src/main/AssetManifest.scala
+++ b/modules/web/src/main/AssetManifest.scala
@@ -76,10 +76,14 @@ final class AssetManifest(environment: Environment, net: NetConfig)(using ws: St
       .map:
         case (k, JsString(h)) => (k, SplitAsset(s"$k.$h.js", Nil, None))
         case (k, value) =>
-          val name     = (value \ "hash").asOpt[String].fold(s"$k.js")(h => s"$k.$h.js")
+          val path = (value \ "hash")
+            .asOpt[String]
+            .map(h => s"$k.$h.js")
+            .orElse((value \ "path").asOpt[String])
+            .getOrElse(s"$k.js")
           val imports  = (value \ "imports").asOpt[List[String]].getOrElse(Nil)
           val inlineJs = (value \ "inline").asOpt[String]
-          (k, SplitAsset(name, imports, inlineJs))
+          (k, SplitAsset(path, imports, inlineJs))
       .toMap
 
     val js = splits.view.mapValues: asset =>

--- a/ui/.build/src/manifest.ts
+++ b/ui/.build/src/manifest.ts
@@ -7,7 +7,7 @@ import { allSources as allCssSources } from './sass.ts';
 import { jsLogger } from './console.ts';
 import { shallowSort, isEquivalent } from './algo.ts';
 
-type SplitAsset = { hash?: string; imports?: string[]; inline?: string; mtime?: number };
+type SplitAsset = { hash?: string; path?: string; imports?: string[]; inline?: string; mtime?: number };
 export type Manifest = { [key: string]: SplitAsset };
 
 export const current: { js: Manifest; i18n: Manifest; css: Manifest; hashed: Manifest; dirty: boolean } = {


### PR DESCRIPTION
trim translation/js & public/compiled/i18n from 41MB to 28MB by mapping empty category/locale pairings to `<category>.en-GB.<hash>.js` in manifest.