### PR TITLE
Show sticky posts first on user blog (not only on profile recent posts)

### DIFF
--- a/modules/ublog/src/main/UblogApi.scala
+++ b/modules/ublog/src/main/UblogApi.scala
@@ -79,7 +79,7 @@ final class UblogApi(
   def latestPosts(blogId: UblogBlog.Id, nb: Int): Fu[List[UblogPost.PreviewPost]] =
     colls.post
       .find($doc("blog" -> blogId, "live" -> true), previewPostProjection.some)
-      .sort($doc("sticky" -> -1, "lived.at" -> -1))
+      .sort(userLiveSort)
       .cursor[UblogPost.PreviewPost](ReadPref.sec)
       .list(nb)
 

--- a/modules/ublog/src/main/UblogBsonHandlers.scala
+++ b/modules/ublog/src/main/UblogBsonHandlers.scala
@@ -34,3 +34,5 @@ private object UblogBsonHandlers:
       "topics"  -> true,
       "sticky"  -> true
     )
+
+  val userLiveSort = $doc("sticky" -> -1, "lived.at" -> -1)

--- a/modules/ublog/src/main/UblogPaginator.scala
+++ b/modules/ublog/src/main/UblogPaginator.scala
@@ -29,7 +29,7 @@ final class UblogPaginator(
         collection = colls.post,
         selector = $doc("blog" -> blog, "live" -> live),
         projection = previewPostProjection.some,
-        sort = if live then $doc("sticky" -> -1, "lived.at" -> -1) else $doc("created.at" -> -1),
+        sort = if live then userLiveSort else $doc("created.at" -> -1),
         _.sec
       ),
       currentPage = page,

--- a/modules/ublog/src/main/UblogPaginator.scala
+++ b/modules/ublog/src/main/UblogPaginator.scala
@@ -29,7 +29,7 @@ final class UblogPaginator(
         collection = colls.post,
         selector = $doc("blog" -> blog, "live" -> live),
         projection = previewPostProjection.some,
-        sort = if live then $doc("lived.at" -> -1) else $doc("created.at" -> -1),
+        sort = if live then $doc("sticky" -> -1, "lived.at" -> -1) else $doc("created.at" -> -1),
         _.sec
       ),
       currentPage = page,

--- a/modules/ublog/src/main/ui/UblogUi.scala
+++ b/modules/ublog/src/main/ui/UblogUi.scala
@@ -97,7 +97,7 @@ final class UblogUi(helpers: Helpers, atomUi: AtomUi)(picfitUrl: lila.core.misc.
             standardFlash,
             if posts.nbResults > 0 then
               div(cls := "ublog-index__posts ublog-post-cards infinite-scroll")(
-                posts.currentPageResults.map(p => card(p, showSticky = ~p.sticky)),
+                posts.currentPageResults.map(card(_)),
                 pagerNext(posts, np => s"${routes.Ublog.index(user.username, np).url}")
               )
             else

--- a/modules/ublog/src/main/ui/UblogUi.scala
+++ b/modules/ublog/src/main/ui/UblogUi.scala
@@ -100,7 +100,7 @@ final class UblogUi(helpers: Helpers, atomUi: AtomUi)(picfitUrl: lila.core.misc.
             standardFlash,
             if posts.nbResults > 0 then
               div(cls := "ublog-index__posts ublog-post-cards infinite-scroll")(
-                posts.currentPageResults.map(card(_)),
+                posts.currentPageResults.map(p => card(p, showSticky = ~p.sticky)),
                 pagerNext(posts, np => s"${routes.Ublog.index(user.username, np).url}")
               )
             else

--- a/translation/source/ublog.xml
+++ b/translation/source/ublog.xml
@@ -22,7 +22,7 @@
   <string name="publishOnYourBlog">Publish on your blog</string>
   <string name="publishHelp">If checked, the post will be listed on your blog. If not, it will be private, in your draft posts</string>
   <string name="stickyPost" comment="Label for the toggle that can make this blog post sticky.">Sticky post</string>
-  <string name="stickyPostHelp">If checked, this post will be listed first in your profile recent posts.</string>
+  <string name="stickyPostHelp">If checked, this post will be listed first in your profile recent posts and on your blog.</string>
   <plurals name="publishedNbBlogPosts">
     <item quantity="one">Published a blog post</item>
     <item quantity="other">Published %s blog posts</item>

--- a/ui/@types/lichess/i18n.d.ts
+++ b/ui/@types/lichess/i18n.d.ts
@@ -5457,7 +5457,7 @@ interface I18n {
     selectPostTopics: string;
     /** Sticky post */
     stickyPost: string;
-    /** If checked, this post will be listed first in your profile recent posts. */
+    /** If checked, this post will be listed first in your profile recent posts and on your blog. */
     stickyPostHelp: string;
     /** This is a draft */
     thisIsADraft: string;


### PR DESCRIPTION
It would make sense to keep the same order between profile recent posts and user blog.

![image](https://github.com/user-attachments/assets/e418b4e8-f386-496a-b868-f1d9abf23c3b)

![image](https://github.com/user-attachments/assets/130d16ed-c22a-4a79-9c9a-75c05221c726)

This way, even the lichess blog could use sticky posts if needed

![image](https://github.com/user-attachments/assets/f1513431-50d4-450b-93db-219f016872f9)
