### PR TITLE
allow inline-only modules, use it for oauth button

### DIFF
--- a/modules/oauth/src/main/ui/AuthorizeUi.scala
+++ b/modules/oauth/src/main/ui/AuthorizeUi.scala
@@ -16,7 +16,7 @@ final class AuthorizeUi(helpers: Helpers)(lightUserFallback: UserId => LightUser
   )
 
   private def buttonClass(prompt: AuthorizationRequest.Prompt) =
-    s"button${prompt.isDanger.so(" button-red ok-cancel-confirm text")}"
+    s"button${prompt.isDanger.so(" button-red ok-cancel-confirm text")} disabled"
 
   def apply(prompt: AuthorizationRequest.Prompt, me: User, authorizeUrl: String)(using
       Context
@@ -58,7 +58,7 @@ final class AuthorizeUi(helpers: Helpers)(lightUserFallback: UserId => LightUser
                   )
                 case None =>
                   submitButton(
-                    cls      := List(s"${buttonClass(prompt)} disabled" -> true, "danger" -> isDanger),
+                    cls      := buttonClass(prompt),
                     dataIcon := isDanger.option(Icon.CautionTriangle),
                     disabled := true,
                     id       := "oauth-authorize",

--- a/modules/oauth/src/main/ui/AuthorizeUi.scala
+++ b/modules/oauth/src/main/ui/AuthorizeUi.scala
@@ -25,7 +25,8 @@ final class AuthorizeUi(helpers: Helpers)(lightUserFallback: UserId => LightUser
     val otherUserRequested = prompt.userId.filterNot(me.is(_)).map(lightUserFallback)
     Page("Authorization")
       .css("bits.oauth")
-      .js(Esm("bits.oauth")):
+      .js(Esm("bits.oauth"))
+      .csp(_.withUnsafeInlineScripts):
         main(cls := "oauth box box-pad force-ltr")(
           div(cls := "oauth__top")(
             ringsImage,

--- a/modules/ui/src/main/ContentSecurityPolicy.scala
+++ b/modules/ui/src/main/ContentSecurityPolicy.scala
@@ -15,6 +15,8 @@ case class ContentSecurityPolicy(
 
   def withWebAssembly = copy(scriptSrc = "'unsafe-eval'" :: scriptSrc)
 
+  def withUnsafeInlineScripts = copy(scriptSrc = "'unsafe-inline'" :: scriptSrc)
+
   def withExternalEngine(url: String) = copy(connectSrc = url :: connectSrc)
 
   def withTwitter =

--- a/modules/web/src/main/AssetManifest.scala
+++ b/modules/web/src/main/AssetManifest.scala
@@ -50,18 +50,16 @@ final class AssetManifest(environment: Environment, net: NetConfig)(using ws: St
         case e: Throwable =>
           logger.warn(s"Error reading $pathname")
 
-  private val keyRe = """^(?!common\.)(\S+)\.([A-Z0-9]{8})\.(?:js|css)""".r
-  private def keyOf(path: String): String =
-    path match
-      case keyRe(k, _) => k
-      case _           => path
+  private val jsKeyRe = """^(?!common\.)(\S+)\.([A-Z0-9]{8})\.js""".r
 
   private def closure(
       path: String,
       jsMap: Map[String, SplitAsset],
       visited: Set[String] = Set.empty
   ): List[String] =
-    val k = keyOf(path)
+    val k = path match
+      case jsKeyRe(k, _) => k
+      case _             => path
     jsMap.get(k) match
       case Some(asset) if !visited.contains(k) =>
         asset.imports.flatMap: importName =>

--- a/modules/web/src/main/AssetManifest.scala
+++ b/modules/web/src/main/AssetManifest.scala
@@ -9,8 +9,9 @@ import java.nio.file.Files
 
 import lila.core.config.NetConfig
 
-case class SplitAsset(name: String, imports: List[String], inlineJs: Option[String]):
-  def all = name :: imports
+case class SplitAsset(path: Option[String], imports: List[String], inlineJs: Option[String]):
+  val allModules = path.toList ++ imports
+
 case class AssetMaps(
     js: Map[String, SplitAsset],
     css: Map[String, String],
@@ -29,7 +30,7 @@ final class AssetManifest(environment: Environment, net: NetConfig)(using ws: St
   def css(key: String): String             = maps.css.getOrElse(key, key)
   def hashed(path: String): Option[String] = maps.hashed.get(path)
   def jsAndDeps(keys: List[String]): List[String] = keys.flatMap { key =>
-    maps.js.get(key).so(_.all)
+    maps.js.get(key).so(_.allModules)
   }.distinct
   def inlineJs(key: String): Option[String] = maps.js.get(key).flatMap(_.inlineJs)
   def lastUpdate: Instant                   = maps.modified
@@ -50,21 +51,21 @@ final class AssetManifest(environment: Environment, net: NetConfig)(using ws: St
           logger.warn(s"Error reading $pathname")
 
   private val keyRe = """^(?!common\.)(\S+)\.([A-Z0-9]{8})\.(?:js|css)""".r
-  private def keyOf(fullName: String): String =
-    fullName match
+  private def keyOf(path: String): String =
+    path match
       case keyRe(k, _) => k
-      case _           => fullName
+      case _           => path
 
   private def closure(
-      name: String,
+      path: String,
       jsMap: Map[String, SplitAsset],
       visited: Set[String] = Set.empty
   ): List[String] =
-    val k = keyOf(name)
+    val k = keyOf(path)
     jsMap.get(k) match
       case Some(asset) if !visited.contains(k) =>
         asset.imports.flatMap: importName =>
-          importName :: closure(importName, jsMap, visited + name)
+          importName :: closure(importName, jsMap, visited + path)
       case _ => Nil
 
   // throws an Exception if JsValue is not as expected
@@ -74,22 +75,19 @@ final class AssetManifest(environment: Environment, net: NetConfig)(using ws: St
       .as[JsObject]
       .value
       .map:
-        case (k, JsString(h)) => (k, SplitAsset(s"$k.$h.js", Nil, None))
+        case (k, JsString(h)) => (k, SplitAsset(s"$k.$h.js".some, Nil, None))
         case (k, value) =>
           val path = (value \ "hash")
             .asOpt[String]
             .map(h => s"$k.$h.js")
             .orElse((value \ "path").asOpt[String])
-            .getOrElse(s"$k.js")
           val imports  = (value \ "imports").asOpt[List[String]].getOrElse(Nil)
           val inlineJs = (value \ "inline").asOpt[String]
           (k, SplitAsset(path, imports, inlineJs))
       .toMap
 
-    val js = splits.view.mapValues: asset =>
-      if asset.imports.nonEmpty
-      then asset.copy(imports = closure(asset.name, splits).distinct)
-      else asset
+    val js: Map[String, SplitAsset] = splits.map: (key, asset) =>
+      key -> asset.path.fold(asset)(path => asset.copy(imports = closure(path, splits).distinct))
 
     val css = (manifest \ "css")
       .as[JsObject]
@@ -113,7 +111,7 @@ final class AssetManifest(environment: Environment, net: NetConfig)(using ws: St
       }
       .toMap
 
-    AssetMaps(js.toMap, css, hashed, nowInstant)
+    AssetMaps(js, css, hashed, nowInstant)
 
   private def fetchManifestJson(filename: String) =
     val resource = s"${net.assetBaseUrlInternal}/assets/compiled/$filename"

--- a/modules/web/src/main/ui/layout.scala
+++ b/modules/web/src/main/ui/layout.scala
@@ -163,7 +163,7 @@ final class layout(helpers: Helpers, assetHelper: lila.web.ui.AssetFullHelper)(
   def inlineJs(nonce: Nonce, modules: EsmList = Nil): Frag =
     val code =
       (Esm("site").some :: modules)
-        .flatMap(_.flatMap(m => assetHelper.manifest.inlineJs(m.key).map(js => s"(()=>{${js}})()")))
+        .flatMap(_.flatMap(m => assetHelper.manifest.inlineJs(m.key).map(js => s"(function(){${js}})()")))
         .mkString(";")
     embedJsUnsafe(code)(nonce.some)
 

--- a/ui/.build/src/esbuild.ts
+++ b/ui/.build/src/esbuild.ts
@@ -133,12 +133,11 @@ async function inlineManifest(js: Manifest) {
   for (const pkg of env.building) {
     for (const bundle of pkg.bundle ?? []) {
       if (!bundle.inline) continue;
-
       const inlineSrc = path.join(pkg.root, bundle.inline);
       const moduleName = bundle.module
         ? path.basename(bundle.module, '.ts')
         : path.basename(bundle.inline, '.inline.ts');
-      const packageError = `${errorMark} - Package error ${c.blue(JSON.stringify(bundle))}`;
+      const packageError = `[${c.grey(pkg.name)}] - ${errorMark} - Package error ${c.blue(JSON.stringify(bundle))}`;
 
       if (!(await readable(inlineSrc))) {
         env.log(packageError);

--- a/ui/.build/src/parse.ts
+++ b/ui/.build/src/parse.ts
@@ -100,7 +100,7 @@ async function parsePackage(packageDir: string): Promise<Package> {
             module,
           })),
         );
-      else env.log(`[${c.grey(pkgInfo.name)}] - ${errorMark} - Bundle error ${JSON.stringify(one)}`);
+      else env.log(`[${c.grey(pkgInfo.name)}] - ${errorMark} - Bundle error ${c.blue(JSON.stringify(one))}`);
     }
   }
   if ('sync' in build) {

--- a/ui/.build/src/parse.ts
+++ b/ui/.build/src/parse.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import fg from 'fast-glob';
-import { env } from './env.ts';
+import { env, errorMark, colors as c } from './env.ts';
 
 export type Bundle = { module?: string; inline?: string };
 
@@ -89,16 +89,18 @@ async function parsePackage(packageDir: string): Promise<Package> {
 
   if ('bundle' in build) {
     for (const one of [].concat(build.bundle).map<Bundle>(b => (typeof b === 'string' ? { module: b } : b))) {
-      if (!one.module) continue;
+      const src = one.module ?? one.inline;
+      if (!src) continue;
 
-      if (await readable(path.join(pkgInfo.root, one.module))) pkgInfo.bundle.push(one);
-      else
+      if (await readable(path.join(pkgInfo.root, src))) pkgInfo.bundle.push(one);
+      else if (one.module)
         pkgInfo.bundle.push(
           ...(await globArray(one.module, { cwd: pkgInfo.root, absolute: false })).map(module => ({
             ...one,
             module,
           })),
         );
+      else env.log(`[${c.grey(pkgInfo.name)}] - ${errorMark} - Bundle error ${JSON.stringify(one)}`);
     }
   }
   if ('sync' in build) {

--- a/ui/.build/src/parse.ts
+++ b/ui/.build/src/parse.ts
@@ -95,10 +95,9 @@ async function parsePackage(packageDir: string): Promise<Package> {
       if (await readable(path.join(pkgInfo.root, src))) pkgInfo.bundle.push(one);
       else if (one.module)
         pkgInfo.bundle.push(
-          ...(await globArray(one.module, { cwd: pkgInfo.root, absolute: false })).map(module => ({
-            ...one,
-            module,
-          })),
+          ...(await globArray(one.module, { cwd: pkgInfo.root, absolute: false }))
+            .filter(m => !m.endsWith('.inline.ts')) // no globbed inline sources
+            .map(module => ({ ...one, module })),
         );
       else env.log(`[${c.grey(pkgInfo.name)}] - ${errorMark} - Bundle error ${c.blue(JSON.stringify(one))}`);
     }

--- a/ui/bits/package.json
+++ b/ui/bits/package.json
@@ -44,7 +44,12 @@
     "zxcvbn": "^4.4.2"
   },
   "build": {
-    "bundle": "src/bits.*ts",
+    "bundle": [
+      "src/bits!(*.inline).ts",
+      {
+        "inline": "src/bits.oauth.inline.ts"
+      }
+    ],
     "sync": {
       "node_modules/cropperjs/dist/cropper.min.css": "public/npm",
       "../../node_modules/chessground/dist/chessground.min.js": "public/npm"

--- a/ui/bits/src/bits.oauth.inline.ts
+++ b/ui/bits/src/bits.oauth.inline.ts
@@ -2,13 +2,11 @@
 // as the oauth page can be embedded in very dubious webviews
 
 const el: HTMLElement = document.getElementById('oauth-authorize')!;
-const danger: boolean = el.classList.contains('danger');
 
 setTimeout(
   () => {
     el.removeAttribute('disabled');
-    el.className = 'button';
-    if (danger) el.classList.add('button-red', 'ok-cancel-confirm', 'text');
+    el.classList.remove('disabled');
   },
-  danger ? 5000 : 2000,
+  el.classList.contains('button-red') ? 5000 : 2000,
 );

--- a/ui/bits/src/bits.oauth.inline.ts
+++ b/ui/bits/src/bits.oauth.inline.ts
@@ -4,7 +4,7 @@
 const el: HTMLElement = document.getElementById('oauth-authorize')!;
 
 setTimeout(
-  () => {
+  function () {
     el.removeAttribute('disabled');
     el.classList.remove('disabled');
   },

--- a/ui/site/src/site.inline.ts
+++ b/ui/site/src/site.inline.ts
@@ -3,6 +3,8 @@
 
 if (!window.site) window.site = {} as Site;
 if (!window.site.load)
-  window.site.load = new Promise<void>(resolve =>
-    document.addEventListener('DOMContentLoaded', () => resolve()),
-  );
+  window.site.load = new Promise<void>(function (resolve) {
+    document.addEventListener('DOMContentLoaded', function () {
+      resolve();
+    });
+  });


### PR DESCRIPTION
i have learned that iOS 9 does not like es modules, arrow functions, or anything else that makes javascript tolerable.

- Re-apply 'unsafe-inline' to CSP for the authorize endpoint as it was before we attempted offloading oauth script to a self-contained `bits.oauth.ts` module.
- inline the button-enabling script because iOS 9 does not support es modules either.
