### PR TITLE
Fix blindmode command menu in broadcasts

### DIFF
--- a/modules/relay/src/main/ui/RelayUi.scala
+++ b/modules/relay/src/main/ui/RelayUi.scala
@@ -29,6 +29,7 @@ final class RelayUi(helpers: Helpers)(
     Page(rt.fullName)
       .css("analyse.relay")
       .i18n(_.study, _.broadcast)
+      .i18nOpt(ctx.blind, _.keyboardMove)
       .js(analyseNvuiTag)
       .js(pageModule(rt, data, chatOption, socketVersion))
       .zoom


### PR DESCRIPTION
Fixes #16855

```
Uncaught TypeError: Cannot read properties of undefined (reading 'readOutClocks')
    at boardCommands (command.ts:36:29)
```