### PR TITLE
Fix withCookies warning

### DIFF
--- a/app/controllers/Challenge.scala
+++ b/app/controllers/Challenge.scala
@@ -153,7 +153,7 @@ final class Challenge(env: Env) extends LilaController(env):
         }
       }
       .map { cookieOption =>
-        cookieOption.foldLeft(res)(_ withCookies _)
+        cookieOption.foldLeft(res)(_.withCookies(_))
       }
 
   def decline(id: ChallengeId) = AuthBody { ctx ?=> _ ?=>


### PR DESCRIPTION
```
[warn] 156 |        cookieOption.foldLeft(res)(_ withCookies _)
[warn]     |                                     ^^^^^^^^^^^
[warn]     |Alphanumeric method withCookies is not declared infix; it should not be used as infix operator.
[warn]     |Instead, use method syntax .withCookies(...) or backticked identifier `withCookies`.
[warn]     |The latter can be rewritten automatically under -rewrite -source 3.4-migration.
[warn] one warning found
```