### PR TITLE
Update _layout.scss

### DIFF
--- a/ui/lobby/css/_layout.scss
+++ b/ui/lobby/css/_layout.scss
@@ -48,7 +48,7 @@
       'about  about   about';
 
     &__start {
-      margin: 2em 0 0 0;
+      margin: 0.4em 0 0 0;
       flex-flow: column;
       align-items: stretch;
       justify-content: center;


### PR DESCRIPTION
The home page counters always overlap into spotlight, this kind of fixes it. It's better to just remove the margin in my opinion but ok.