### PR TITLE
Don't hide any notation when a phone's orientation changes to horizontal and back to vertical

### DIFF
--- a/ui/round/src/round.ts
+++ b/ui/round/src/round.ts
@@ -30,7 +30,10 @@ async function app(opts: RoundOpts): Promise<RoundController> {
 
   let vnode = patch(el, blueprint);
 
-  window.addEventListener('resize', redraw); // col1 / col2+ transition
+  window.addEventListener('resize', () => {
+    redraw(); // col1 / col2+ transition
+    ctrl.autoScroll();
+  });
 
   if (ctrl.isPlaying()) menuHover();
 

--- a/ui/round/src/view/replay.ts
+++ b/ui/round/src/view/replay.ts
@@ -210,6 +210,7 @@ export function render(ctrl: RoundController): LooseVNode {
               }
             });
             ctrl.autoScroll = () => autoScroll(el, ctrl);
+            window.addEventListener('resize', () => ctrl.autoScroll());
             if (ctrl.ply > 2) {
               ctrl.autoScroll();
               if (isCol1()) ctrl.autoScroll();

--- a/ui/round/src/view/replay.ts
+++ b/ui/round/src/view/replay.ts
@@ -210,7 +210,6 @@ export function render(ctrl: RoundController): LooseVNode {
               }
             });
             ctrl.autoScroll = () => autoScroll(el, ctrl);
-            window.addEventListener('resize', ctrl.autoScroll);
             if (ctrl.ply > 2) {
               ctrl.autoScroll();
               if (isCol1()) ctrl.autoScroll();

--- a/ui/round/src/view/replay.ts
+++ b/ui/round/src/view/replay.ts
@@ -210,7 +210,7 @@ export function render(ctrl: RoundController): LooseVNode {
               }
             });
             ctrl.autoScroll = () => autoScroll(el, ctrl);
-            window.addEventListener('resize', () => ctrl.autoScroll());
+            window.addEventListener('resize', ctrl.autoScroll);
             if (ctrl.ply > 2) {
               ctrl.autoScroll();
               if (isCol1()) ctrl.autoScroll();


### PR DESCRIPTION
To reproduce this minor bug:

- Go on a phone and play a game to at least 5 moves. Do not refresh the page at any point.
- Briefly change the phone's orientation to horizontal, and then back to vertical.
- The last one or two ply should be obscured from the notation.