### PR TITLE
Execute top move from tablebase with Shift+Space

### DIFF
--- a/ui/analyse/src/keyboard.ts
+++ b/ui/analyse/src/keyboard.ts
@@ -112,8 +112,8 @@ export const bind = (ctrl: AnalyseCtrl) => {
   //First explorer move
   kbd.bind('shift+space', () => {
     const move = document
-      .querySelector('.explorer-box:not(.loading) .moves tbody tr')
-      ?.attributes.getNamedItem('data-uci')?.value;
+      .querySelector('.explorer-box:not(.loading) tbody tr[data-uci]')
+      ?.getAttribute('data-uci');
     if (move) ctrl.explorerMove(move);
   });
 


### PR DESCRIPTION
In the analysis board, the Shift+Space shortcut is used to pick the most common opening move when the opening database is visible.

Allow the same shortcut to play the topmost move from the tablebase (which looks like the opening database) in endgames.

It was probably intended that way, but rather than `.moves`, in the tablebase the HTML table is `<table class="tablebase">`, with a slightly different layout than `moves`.

Rather than looking either in `.moves` or in `.tablebase` (which would make for a very long query selector), simply look for whatever UCI move we find in the explorer box.
After all, there are no other `<tr>`s in there which happen to have `data-uci` attributes.
