### PR TITLE
client build script improvements

### DIFF
--- a/ui/.build/package.json
+++ b/ui/.build/package.json
@@ -14,11 +14,13 @@
     "sass-embedded-win32-x64": "1.83.3"
   },
   "dependencies": {
-    "@types/node": "22.10.6",
+    "@types/micromatch": "^4.0.9",
+    "@types/node": "22.12.0",
     "@types/tinycolor2": "1.4.6",
     "esbuild": "0.24.2",
     "fast-glob": "3.3.3",
     "fast-xml-parser": "4.5.1",
+    "micromatch": "4.0.8",
     "tinycolor2": "1.6.0",
     "typescript": "5.7.3"
   },

--- a/ui/.build/package.json
+++ b/ui/.build/package.json
@@ -14,12 +14,14 @@
     "sass-embedded-win32-x64": "1.83.3"
   },
   "dependencies": {
+    "@types/fs-ext": "^2.0.3",
     "@types/micromatch": "^4.0.9",
     "@types/node": "22.12.0",
     "@types/tinycolor2": "1.4.6",
     "esbuild": "0.24.2",
     "fast-glob": "3.3.3",
     "fast-xml-parser": "4.5.1",
+    "fs-ext": "^2.1.1",
     "micromatch": "4.0.8",
     "tinycolor2": "1.6.0",
     "typescript": "5.7.3"

--- a/ui/.build/pnpm-lock.yaml
+++ b/ui/.build/pnpm-lock.yaml
@@ -8,9 +8,12 @@ importers:
 
   .:
     dependencies:
+      '@types/micromatch':
+        specifier: ^4.0.9
+        version: 4.0.9
       '@types/node':
-        specifier: 22.10.6
-        version: 22.10.6
+        specifier: 22.12.0
+        version: 22.12.0
       '@types/tinycolor2':
         specifier: 1.4.6
         version: 1.4.6
@@ -23,6 +26,9 @@ importers:
       fast-xml-parser:
         specifier: 4.5.1
         version: 4.5.1
+      micromatch:
+        specifier: 4.0.8
+        version: 4.0.8
       tinycolor2:
         specifier: 1.6.0
         version: 1.6.0
@@ -213,8 +219,14 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@types/node@22.10.6':
-    resolution: {integrity: sha512-qNiuwC4ZDAUNcY47xgaSuS92cjf8JbSUoaKS77bmLG1rU7MlATVSiw/IlrjtIyyskXBZ8KkNfjK/P5na7rgXbQ==}
+  '@types/braces@3.0.5':
+    resolution: {integrity: sha512-SQFof9H+LXeWNz8wDe7oN5zu7ket0qwMu5vZubW4GCJ8Kkeh6nBWUz87+KTz/G3Kqsrp0j/W253XJb3KMEeg3w==}
+
+  '@types/micromatch@4.0.9':
+    resolution: {integrity: sha512-7V+8ncr22h4UoYRLnLXSpTxjQrNUXtWHGeMPRJt1nULXI57G9bIcpyrHlmrQ7QK24EyyuXvYcSSWAM8GA9nqCg==}
+
+  '@types/node@22.12.0':
+    resolution: {integrity: sha512-Fll2FZ1riMjNmlmJOdAyY5pUbkftXslB5DgEzlIuNaiWhXd00FhWxVC/r4yV/4wBb9JfImTu+jiSvXTkJ7F/gA==}
 
   '@types/tinycolor2@1.4.6':
     resolution: {integrity: sha512-iEN8J0BoMnsWBqjVbWH/c0G0Hh7O21lpR2/+PrvAVgWdzL7eexIFm4JN/Wn10PTcmNdtS6U67r499mlWMXOxNw==}
@@ -424,7 +436,13 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.17.1
 
-  '@types/node@22.10.6':
+  '@types/braces@3.0.5': {}
+
+  '@types/micromatch@4.0.9':
+    dependencies:
+      '@types/braces': 3.0.5
+
+  '@types/node@22.12.0':
     dependencies:
       undici-types: 6.20.0
 

--- a/ui/.build/pnpm-lock.yaml
+++ b/ui/.build/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@types/fs-ext':
+        specifier: ^2.0.3
+        version: 2.0.3
       '@types/micromatch':
         specifier: ^4.0.9
         version: 4.0.9
@@ -26,6 +29,9 @@ importers:
       fast-xml-parser:
         specifier: 4.5.1
         version: 4.5.1
+      fs-ext:
+        specifier: ^2.1.1
+        version: 2.1.1
       micromatch:
         specifier: 4.0.8
         version: 4.0.8
@@ -222,6 +228,9 @@ packages:
   '@types/braces@3.0.5':
     resolution: {integrity: sha512-SQFof9H+LXeWNz8wDe7oN5zu7ket0qwMu5vZubW4GCJ8Kkeh6nBWUz87+KTz/G3Kqsrp0j/W253XJb3KMEeg3w==}
 
+  '@types/fs-ext@2.0.3':
+    resolution: {integrity: sha512-0j2F+laosJF2NTd2DVheQ5GvXo8ln9L175VwLPfbsppE33iYC+6gn6XlOQS0pGvZm2yrQ32/LRZh0As/7rCs2Q==}
+
   '@types/micromatch@4.0.9':
     resolution: {integrity: sha512-7V+8ncr22h4UoYRLnLXSpTxjQrNUXtWHGeMPRJt1nULXI57G9bIcpyrHlmrQ7QK24EyyuXvYcSSWAM8GA9nqCg==}
 
@@ -255,6 +264,10 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
+  fs-ext@2.1.1:
+    resolution: {integrity: sha512-/TrISPOFhCkbgIRWK9lzscRzwPCu0PqtCcvMc9jsHKBgZGoqA0VzhspVht5Zu8lxaXjIYIBWILHpRotYkCCcQA==}
+    engines: {node: '>= 8.0.0'}
+
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -278,6 +291,9 @@ packages:
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
+
+  nan@2.22.0:
+    resolution: {integrity: sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw==}
 
   picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
@@ -438,6 +454,10 @@ snapshots:
 
   '@types/braces@3.0.5': {}
 
+  '@types/fs-ext@2.0.3':
+    dependencies:
+      '@types/node': 22.12.0
+
   '@types/micromatch@4.0.9':
     dependencies:
       '@types/braces': 3.0.5
@@ -500,6 +520,10 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
+  fs-ext@2.1.1:
+    dependencies:
+      nan: 2.22.0
+
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -518,6 +542,8 @@ snapshots:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.1
+
+  nan@2.22.0: {}
 
   picomatch@2.3.1: {}
 

--- a/ui/.build/src/build.ts
+++ b/ui/.build/src/build.ts
@@ -1,110 +1,72 @@
 import fs from 'node:fs';
-import cps from 'node:child_process';
-import ps from 'node:process';
-import path from 'node:path';
-import { parsePackages, globArray } from './parse.ts';
-import { tsc, stopTscWatch } from './tsc.ts';
+import { execSync } from 'node:child_process';
+import { chdir } from 'node:process';
+import { parsePackages } from './parse.ts';
+import { task, stopTask } from './task.ts';
+import { tsc, stopTsc } from './tsc.ts';
 import { sass, stopSass } from './sass.ts';
-import { esbuild, stopEsbuildWatch } from './esbuild.ts';
-import { sync, stopSync } from './sync.ts';
+import { esbuild, stopEsbuild } from './esbuild.ts';
+import { sync } from './sync.ts';
 import { hash } from './hash.ts';
 import { stopManifest } from './manifest.ts';
 import { env, errorMark, c } from './env.ts';
-import { i18n, stopI18nWatch } from './i18n.ts';
+import { i18n } from './i18n.ts';
 import { unique } from './algo.ts';
 import { clean } from './clean.ts';
 
 export async function build(pkgs: string[]): Promise<void> {
-  if (env.install) cps.execSync('pnpm install', { cwd: env.rootDir, stdio: 'inherit' });
+  chdir(env.rootDir);
+
+  if (env.install) execSync('pnpm install', { stdio: 'inherit' });
+
   if (!pkgs.length) env.log(`Parsing packages in '${c.cyan(env.uiDir)}'`);
 
-  ps.chdir(env.uiDir);
-  await parsePackages();
+  await Promise.allSettled([parsePackages(), fs.promises.mkdir(env.buildTempDir)]);
 
   pkgs
     .filter(x => !env.packages.has(x))
     .forEach(x => env.exit(`${errorMark} - unknown package '${c.magenta(x)}'`));
 
-  env.building =
-    pkgs.length === 0 ? [...env.packages.values()] : unique(pkgs.flatMap(p => env.transitiveDeps(p)));
+  env.building = pkgs.length === 0 ? [...env.packages.values()] : unique(pkgs.flatMap(p => env.deps(p)));
 
   if (pkgs.length) env.log(`Building ${c.grey(env.building.map(x => x.name).join(', '))}`);
 
-  await Promise.allSettled([
-    fs.promises.mkdir(env.jsOutDir),
-    fs.promises.mkdir(env.cssOutDir),
-    fs.promises.mkdir(env.hashOutDir),
-    fs.promises.mkdir(env.themeGenDir),
-    fs.promises.mkdir(env.buildTempDir),
-  ]);
-
-  await Promise.all([sass(), sync().then(hash), i18n()]);
-  await Promise.all([tsc(), esbuild(), monitor(pkgs)]);
+  await Promise.all([i18n(), sync().then(hash), sass(), tsc(), esbuild()]);
+  await monitor(pkgs);
 }
 
-export async function stopBuildWatch(): Promise<void> {
-  for (const w of watchers) w.close();
-  watchers.length = 0;
-  clearTimeout(tscTimeout);
-  clearTimeout(packageTimeout);
-  tscTimeout = packageTimeout = undefined;
+function stopBuild(): Promise<any> {
+  stopTask();
   stopSass();
-  stopSync();
-  stopI18nWatch();
-  stopManifest();
-  await Promise.allSettled([stopTscWatch(), stopEsbuildWatch()]);
+  stopManifest(true);
+  return Promise.allSettled([stopTsc(), stopEsbuild()]);
 }
 
-const watchers: fs.FSWatcher[] = [];
-
-let packageTimeout: NodeJS.Timeout | undefined;
-let tscTimeout: NodeJS.Timeout | undefined;
-
-async function monitor(pkgs: string[]): Promise<void> {
+function monitor(pkgs: string[]) {
   if (!env.watch) return;
-  const [typePkgs, typings] = await Promise.all([
-    globArray('*/package.json', { cwd: env.typesDir }),
-    globArray('*/*.d.ts', { cwd: env.typesDir }),
-  ]);
-  const tscChange = async () => {
-    if (packageTimeout) return;
-    stopManifest();
-    await Promise.allSettled([stopTscWatch(), stopEsbuildWatch()]);
-    clearTimeout(tscTimeout);
-    tscTimeout = setTimeout(() => {
-      if (packageTimeout) return;
-      tsc().then(esbuild);
-    }, 2000);
-  };
-  const packageChange = async () => {
-    if (env.watch && env.install) {
-      clearTimeout(tscTimeout);
-      clearTimeout(packageTimeout);
-      await stopBuildWatch();
-      packageTimeout = setTimeout(() => clean().then(() => build(pkgs)), 2000);
-      return;
-    }
-    env.warn('Exiting due to package.json change');
-    ps.exit(0);
-  };
-
-  watchers.push(await watchModified(path.join(env.rootDir, 'package.json'), packageChange));
-  for (const p of typePkgs) watchers.push(await watchModified(p, packageChange));
-  for (const t of typings) watchers.push(await watchModified(t, tscChange));
-  for (const pkg of env.building) {
-    watchers.push(await watchModified(path.join(pkg.root, 'package.json'), packageChange));
-    watchers.push(await watchModified(path.join(pkg.root, 'tsconfig.json'), tscChange));
-  }
-}
-
-async function watchModified(pathname: string, onChange: () => void): Promise<fs.FSWatcher> {
-  let stat = await fs.promises.stat(pathname);
-
-  return fs.watch(pathname, async () => {
-    const newStat = await fs.promises.stat(pathname);
-    if (stat.mtimeMs === newStat.mtimeMs) return;
-
-    stat = newStat;
-    onChange();
+  return task({
+    key: 'monitor',
+    glob: [
+      { cwd: env.rootDir, path: 'package.json' },
+      { cwd: env.typesDir, path: '*/package.json' },
+      { cwd: env.uiDir, path: '*/package.json' },
+      { cwd: env.typesDir, path: '*/*.d.ts' },
+      { cwd: env.uiDir, path: '*/tsconfig.json' },
+    ],
+    debounce: 1000,
+    monitorOnly: true,
+    execute: async files => {
+      if (files.some(x => x.endsWith('package.json'))) {
+        if (!env.install) env.exit('Exiting due to package.json change');
+        await stopBuild();
+        if (env.clean) await clean();
+        build(pkgs);
+      } else if (files.some(x => x.endsWith('.d.ts') || x.endsWith('tsconfig.json'))) {
+        stopManifest();
+        await Promise.allSettled([stopTsc(), stopEsbuild()]);
+        tsc();
+        esbuild();
+      }
+    },
   });
 }

--- a/ui/.build/src/console.ts
+++ b/ui/.build/src/console.ts
@@ -25,9 +25,7 @@ export async function startConsole() {
         if (val.length <= 1) val = val[0] ?? '';
         else if (val.every(x => typeof x === 'string')) val = val.join(' ');
 
-        env.log(`${mark}${c.grey(typeof val === 'string' ? val : JSON.stringify(val, undefined, 2))}`, {
-          ctx: 'web',
-        });
+        env.log(`${mark}${c.grey(typeof val === 'string' ? val : JSON.stringify(val, undefined, 2))}`, 'web');
         res
           .writeHead(200, { 'Access-Control-Allow-Origin': '*', 'Access-Control-Allow-Methods': 'POST' })
           .end();

--- a/ui/.build/src/env.ts
+++ b/ui/.build/src/env.ts
@@ -1,83 +1,70 @@
-import path from 'node:path';
+import p from 'node:path';
 import type { Package } from './parse.ts';
-import { unique, isEquivalent } from './algo.ts';
-import { type Manifest, updateManifest } from './manifest.ts';
+import { unique, isEquivalent, trimLines } from './algo.ts';
+import { updateManifest } from './manifest.ts';
+import { taskOk } from './task.ts';
 
-// state, logging, and exit code logic
-
-type Builder = 'sass' | 'tsc' | 'esbuild';
+// state, logging, status
 
 export const env = new (class {
-  readonly rootDir = path.resolve(path.dirname(new URL(import.meta.url).pathname), '../../..');
-  readonly uiDir = path.join(this.rootDir, 'ui');
-  readonly outDir = path.join(this.rootDir, 'public');
-  readonly cssOutDir = path.join(this.outDir, 'css');
-  readonly jsOutDir = path.join(this.outDir, 'compiled');
-  readonly hashOutDir = path.join(this.outDir, 'hashed');
-  readonly themeDir = path.join(this.uiDir, 'common', 'css', 'theme');
-  readonly themeGenDir = path.join(this.themeDir, 'gen');
-  readonly buildDir = path.join(this.uiDir, '.build');
-  readonly cssTempDir = path.join(this.buildDir, 'build', 'css');
-  readonly buildSrcDir = path.join(this.uiDir, '.build', 'src');
-  readonly buildTempDir = path.join(this.buildDir, 'build');
-  readonly typesDir = path.join(this.uiDir, '@types');
-  readonly i18nSrcDir = path.join(this.rootDir, 'translation', 'source');
-  readonly i18nDestDir = path.join(this.rootDir, 'translation', 'dest');
-  readonly i18nJsDir = path.join(this.rootDir, 'translation', 'js');
+  readonly rootDir = p.resolve(p.dirname(new URL(import.meta.url).pathname), '../../..');
+  readonly uiDir = p.join(this.rootDir, 'ui');
+  readonly outDir = p.join(this.rootDir, 'public');
+  readonly cssOutDir = p.join(this.outDir, 'css');
+  readonly jsOutDir = p.join(this.outDir, 'compiled');
+  readonly hashOutDir = p.join(this.outDir, 'hashed');
+  readonly themeDir = p.join(this.uiDir, 'common', 'css', 'theme');
+  readonly themeGenDir = p.join(this.themeDir, 'gen');
+  readonly buildDir = p.join(this.uiDir, '.build');
+  readonly cssTempDir = p.join(this.buildDir, 'build', 'css');
+  readonly buildSrcDir = p.join(this.uiDir, '.build', 'src');
+  readonly buildTempDir = p.join(this.buildDir, 'build');
+  readonly typesDir = p.join(this.uiDir, '@types');
+  readonly i18nSrcDir = p.join(this.rootDir, 'translation', 'source');
+  readonly i18nDestDir = p.join(this.rootDir, 'translation', 'dest');
+  readonly i18nJsDir = p.join(this.rootDir, 'translation', 'js');
 
   watch = false;
   clean = false;
   prod = false;
   debug = false;
-  remoteLog: string | boolean = false;
   rgb = false;
-  install = true;
-  sync = true;
-  i18n = true;
   test = false;
-  exitCode: Map<Builder, number | false> = new Map();
-  startTime: number | undefined = Date.now();
+  install = true;
   logTime = true;
   logCtx = true;
   logColor = true;
+  remoteLog: string | boolean = false;
+  startTime: number | undefined = Date.now();
 
   packages: Map<string, Package> = new Map();
   workspaceDeps: Map<string, string[]> = new Map();
   building: Package[] = [];
-  manifest: { js: Manifest; i18n: Manifest; css: Manifest; hashed: Manifest; dirty: boolean } = {
-    i18n: {},
-    js: {},
-    css: {},
-    hashed: {},
-    dirty: false,
-  };
 
-  get sass(): boolean {
-    return this.exitCode.get('sass') !== false;
-  }
+  private status: { [key in Context]?: number | false } = {};
 
-  get tsc(): boolean {
-    return this.exitCode.get('tsc') !== false;
-  }
-
-  get esbuild(): boolean {
-    return this.exitCode.get('esbuild') !== false;
-  }
-
-  get manifestOk(): boolean {
+  get manifest(): boolean {
     return (
       isEquivalent(this.building, [...this.packages.values()]) &&
-      this.sync &&
-      this.i18n &&
-      (['tsc', 'esbuild', 'sass'] as const).every(x => this.exitCode.get(x) === 0)
+      (['tsc', 'esbuild', 'sass', 'i18n'] as const).map(b => this.status[b]).every(x => x === 0)
     );
   }
 
   get manifestFile(): string {
-    return path.join(this.jsOutDir, `manifest.${this.prod ? 'prod' : 'dev'}.json`);
+    return p.join(this.jsOutDir, `manifest.${this.prod ? 'prod' : 'dev'}.json`);
   }
 
-  transitiveDeps(pkgName: string): Package[] {
+  *tasks<T extends 'sync' | 'hash' | 'bundle'>(
+    t: T,
+  ): Generator<[Package, Package[T] extends Array<infer U> ? U : never]> {
+    for (const pkg of this.building) {
+      for (const item of pkg[t] as (Package[T] extends (infer U)[] ? U : never)[]) {
+        yield [pkg, item];
+      }
+    }
+  }
+
+  deps(pkgName: string): Package[] {
     const depList = (dep: string): string[] => [
       ...(this.workspaceDeps.get(dep) ?? []).flatMap(d => depList(d)),
       dep,
@@ -85,25 +72,8 @@ export const env = new (class {
     return unique(depList(pkgName).map(name => this.packages.get(name)));
   }
 
-  warn(d: any, ctx = 'build'): void {
-    this.log(d, { ctx: ctx, warn: true });
-  }
-
-  error(d: any, ctx = 'build'): void {
-    this.log(d, { ctx: ctx, error: true });
-  }
-
-  exit(d: any, ctx = 'build'): void {
-    this.log(d, { ctx: ctx, error: true });
-    process.exit(1);
-  }
-
-  good(ctx = 'build'): void {
-    this.log(c.good('No errors') + this.watch ? ` - ${c.grey('Watching')}...` : '', { ctx: ctx });
-  }
-
-  log(d: any, { ctx = 'build', error = false, warn = false }: any = {}): void {
-    let text: string =
+  log(d: any, ctx = 'build'): void {
+    const text: string =
       !d || typeof d === 'string' || d instanceof Buffer
         ? String(d)
         : Array.isArray(d)
@@ -114,42 +84,41 @@ export const env = new (class {
       (this.logTime ? prettyTime() : '') + (ctx && this.logCtx ? `[${escape(ctx, colorForCtx(ctx))}]` : '')
     ).trim();
 
-    lines(this.logColor ? text : stripColorEscapes(text)).forEach(line =>
-      console.log(
-        `${prefix ? prefix + ' - ' : ''}${escape(line, error ? codes.error : warn ? codes.warn : undefined)}`,
-      ),
-    );
+    for (const line of trimLines(this.logColor ? text : stripColorEscapes(text)))
+      console.log(`${prefix ? prefix + ' - ' : ''}${line}`);
   }
 
-  done(code: number, ctx: Builder): void {
-    this.exitCode.set(ctx, code);
-    const err = [...this.exitCode.values()].find(x => x);
-    const allDone = this.exitCode.size === 3;
-    if (ctx !== 'tsc' || code === 0)
+  exit(d?: any, ctx = 'build'): void {
+    if (d) this.log(d, ctx);
+    process.exit(1);
+  }
+
+  begin(ctx: Context, enable?: boolean): boolean {
+    if (enable === false) this.status[ctx] = false;
+    else if (enable === true || this.status[ctx] !== false) this.status[ctx] = undefined;
+    return this.status[ctx] !== false;
+  }
+
+  done(ctx: Context, code: number = 0): void {
+    if (code !== this.status[ctx] && ['tsc', 'esbuild', 'sass', 'i18n'].includes(ctx)) {
       this.log(
         `${code === 0 ? 'Done' : c.red('Failed')}` + (this.watch ? ` - ${c.grey('Watching')}...` : ''),
-        { ctx },
+        ctx,
       );
-    if (allDone) {
-      if (this.startTime && !err) this.log(`Done in ${c.green((Date.now() - this.startTime) / 1000 + '')}s`);
-      this.startTime = undefined; // it's pointless to time subsequent builds, they are too fast
     }
-    if (!this.watch && err) process.exitCode = err;
-    if (!err) updateManifest();
+    this.status[ctx] = code;
+    if (this.manifest && taskOk()) {
+      if (this.startTime) this.log(`Done in ${c.green((Date.now() - this.startTime) / 1000 + '')}s`);
+      this.startTime = undefined;
+      updateManifest();
+    }
+    if (!this.watch && code) process.exit(code);
   }
 })();
 
-export const lines = (s: string): string[] => s.split(/[\n\r\f]+/).filter(x => x.trim());
+export type Context = 'sass' | 'tsc' | 'esbuild' | 'sync' | 'hash' | 'i18n' | 'web';
 
-const escape = (text: string, code?: string): string =>
-  env.logColor && code ? `\x1b[${code}m${stripColorEscapes(text)}\x1b[0m` : text;
-
-const colorLines = (text: string, code: string) =>
-  lines(text)
-    .map(t => escape(t, code))
-    .join('\n');
-
-const codes: Record<string, string> = {
+const codes = {
   black: '30',
   red: '31',
   green: '32',
@@ -157,38 +126,58 @@ const codes: Record<string, string> = {
   blue: '34',
   magenta: '35',
   cyan: '36',
+  white: '37',
   grey: '90',
   error: '31',
   warn: '33',
+  greenBold: '32;1',
+  yellowBold: '33;1',
+  blueBold: '34;1',
+  magentaBold: '35;1',
+  cyanBold: '36;1',
+  greyBold: '90;1',
 };
 
-export const c: Record<string, (text: string) => string> = {
-  red: (text: string): string => colorLines(text, codes.red),
-  green: (text: string): string => colorLines(text, codes.green),
-  yellow: (text: string): string => colorLines(text, codes.yellow),
-  blue: (text: string): string => colorLines(text, codes.blue),
-  magenta: (text: string): string => colorLines(text, codes.magenta),
-  cyan: (text: string): string => colorLines(text, codes.cyan),
-  grey: (text: string): string => colorLines(text, codes.grey),
-  black: (text: string): string => colorLines(text, codes.black),
-  error: (text: string): string => colorLines(text, codes.error),
-  warn: (text: string): string => colorLines(text, codes.warn),
-  good: (text: string): string => colorLines(text, codes.green + ';1'),
-  cyanBold: (text: string): string => colorLines(text, codes.cyan + ';1'),
-};
+function colorForCtx(ctx: string) {
+  return (
+    {
+      build: codes.green,
+      sass: codes.magenta,
+      tsc: codes.yellow,
+      esbuild: codes.blueBold,
+      sync: codes.cyan,
+      hash: codes.blue,
+      i18n: codes.cyanBold,
+      manifest: codes.white,
+      web: codes.magentaBold,
+    }[ctx] ?? codes.grey
+  );
+}
+
+function escape(text: string, code?: string) {
+  return env.logColor && code ? `\x1b[${code}m${stripColorEscapes(text)}\x1b[0m` : text;
+}
+
+function colorLines(text: string, code: string) {
+  return trimLines(text)
+    .map(t => escape(t, code))
+    .join('\n');
+}
+
+export const c: Record<keyof typeof codes, (text: string) => string> = Object.keys(codes).reduce(
+  (acc, key) => {
+    acc[key as keyof typeof codes] = (text: string) => colorLines(text, codes[key as keyof typeof codes]);
+    return acc;
+  },
+  {} as Record<keyof typeof codes, (text: string) => string>,
+);
 
 export const errorMark: string = c.red('✘ ') + c.error('[ERROR]');
 export const warnMark: string = c.yellow('⚠ ') + c.warn('[WARNING]');
 
-const colorForCtx = (ctx: string): string =>
-  ({
-    build: codes.green,
-    sass: codes.magenta,
-    tsc: codes.yellow,
-    esbuild: codes.blue,
-  })[ctx] ?? codes.grey;
-
-const pad2 = (n: number) => (n < 10 ? `0${n}` : `${n}`);
+function pad2(n: number) {
+  return n < 10 ? `0${n}` : `${n}`;
+}
 
 function stripColorEscapes(text: string) {
   return text.replace(/\x1b\[[0-9;]*m/, '');

--- a/ui/.build/src/esbuild.ts
+++ b/ui/.build/src/esbuild.ts
@@ -1,27 +1,17 @@
-import path from 'node:path';
+import p from 'node:path';
 import es from 'esbuild';
 import fs from 'node:fs';
-import { env, errorMark, c } from './env.ts';
+import { env, errorMark, warnMark, c } from './env.ts';
 import { type Manifest, updateManifest } from './manifest.ts';
-import { trimAndConsolidateWhitespace, readable } from './parse.ts';
+import { task, stopTask } from './task.ts';
+import { reduceWhitespace } from './algo.ts';
 
-const esbuildCtx: es.BuildContext[] = [];
-const inlineWatch: fs.FSWatcher[] = [];
-let inlineTimer: NodeJS.Timeout;
+let esbuildCtx: es.BuildContext | undefined;
 
-export async function esbuild(): Promise<void> {
-  if (!env.esbuild) return;
-  env.exitCode.delete('esbuild');
+export async function esbuild(): Promise<any> {
+  if (!env.begin('esbuild')) return;
 
-  const entryPoints = [];
-  for (const pkg of env.building) {
-    for (const { module } of pkg.bundle) {
-      if (module) entryPoints.push(path.join(pkg.root, module));
-    }
-  }
-  entryPoints.sort();
-  const ctx = await es.context({
-    entryPoints,
+  const options: es.BuildOptions = {
     bundle: true,
     metafile: true,
     treeShaking: true,
@@ -35,42 +25,141 @@ export async function esbuild(): Promise<void> {
     entryNames: '[name].[hash]',
     chunkNames: 'common.[hash]',
     plugins,
+  };
+
+  await fs.promises.mkdir(env.jsOutDir).catch(() => {});
+  return Promise.all([
+    inlineTask(),
+    task({
+      key: 'bundle',
+      ctx: 'esbuild',
+      debounce: 300,
+      noEnvStatus: true,
+      globListOnly: true,
+      glob: env.building.flatMap(pkg =>
+        pkg.bundle
+          .map(bundle => bundle.module)
+          .filter((module): module is string => Boolean(module))
+          .map(path => ({ cwd: pkg.root, path })),
+      ),
+      execute: async entryPoints => {
+        await esbuildCtx?.dispose();
+        entryPoints.sort();
+        esbuildCtx = await es.context({ ...options, entryPoints });
+        if (env.watch) esbuildCtx.watch();
+        else {
+          await esbuildCtx.rebuild();
+          await esbuildCtx.dispose();
+        }
+      },
+    }),
+  ]);
+}
+
+export async function stopEsbuild(): Promise<void> {
+  stopTask(['bundle', 'inline']);
+  await esbuildCtx?.dispose();
+  esbuildCtx = undefined;
+}
+
+function inlineTask() {
+  const js: Manifest = {};
+  const inlineToModule: Record<string, string> = {};
+  for (const [pkg, bundle] of env.tasks('bundle'))
+    if (bundle.inline)
+      inlineToModule[p.join(pkg.root, bundle.inline)] = bundle.module
+        ? p.basename(bundle.module, '.ts')
+        : p.basename(bundle.inline, '.inline.ts');
+  return task({
+    key: 'inline',
+    ctx: 'esbuild',
+    debounce: 300,
+    noEnvStatus: true,
+    glob: env.building.flatMap(pkg =>
+      pkg.bundle
+        .map(b => b.inline)
+        .filter((i): i is string => Boolean(i))
+        .map(i => ({ cwd: pkg.root, path: i })),
+    ),
+    execute: (_, inlines) =>
+      Promise.all(
+        inlines.map(async inlineSrc => {
+          const moduleName = inlineToModule[inlineSrc];
+          try {
+            const res = await es.transform(await fs.promises.readFile(inlineSrc), {
+              minify: true,
+              loader: 'ts',
+            });
+            esbuildLog(res.warnings);
+            js[moduleName] ??= {};
+            js[moduleName].inline = res.code;
+          } catch (e) {
+            if (e && typeof e === 'object' && 'errors' in e)
+              esbuildLog((e as es.TransformFailure).errors, true);
+            throw '';
+          }
+        }),
+      ).then(() => updateManifest({ js, merge: true })),
   });
-  if (env.watch) {
-    ctx.watch();
-    esbuildCtx.push(ctx);
-  } else {
-    await ctx.rebuild();
-    await ctx.dispose();
+}
+
+function bundleManifest(meta: es.Metafile = { inputs: {}, outputs: {} }) {
+  const js: Manifest = {};
+  for (const [filename, info] of Object.entries(meta.outputs)) {
+    const out = splitPath(filename);
+    if (!out) continue;
+    if (out.name === 'common') {
+      out.name = `common.${out.hash}`;
+      js[out.name] = {};
+    } else js[out.name] = { hash: out.hash };
+    const imports: string[] = [];
+    for (const imp of info.imports) {
+      if (imp.kind === 'import-statement') {
+        const path = splitPath(imp.path);
+        if (path) imports.push(`${path.name}.${path.hash}.js`);
+      }
+    }
+    js[out.name].imports = imports;
+  }
+  updateManifest({ js, merge: true });
+}
+
+function esbuildLog(msgs: es.Message[], error = false): void {
+  for (const msg of msgs) {
+    const file = msg.location?.file.replace(/^[./]*/, '') ?? '<unknown>';
+    const line = msg.location?.line
+      ? `:${msg.location.line}`
+      : '' + (msg.location?.column ? `:${msg.location.column}` : '');
+    const srcText = msg.location?.lineText;
+    env.log(`${error ? errorMark : warnMark} - '${c.cyan(file + line)}' - ${msg.text}`, 'esbuild');
+    if (srcText) env.log('  ' + c.magenta(srcText), 'esbuild');
   }
 }
 
-export async function stopEsbuildWatch(): Promise<void> {
-  const proof = Promise.allSettled(esbuildCtx.map(x => x.dispose()));
-  for (const w of inlineWatch) w.close();
-  inlineWatch.length = 0;
-  esbuildCtx.length = 0;
-  await proof;
+function splitPath(path: string) {
+  const match = path.match(/\/public\/compiled\/(.*)\.([A-Z0-9]+)\.js$/);
+  return match ? { name: match[1], hash: match[2] } : undefined;
 }
+
+// our html minifier will only process characters between the first two backticks encountered
+// so:
+//   $html`     <div>    ${    x ?      `<- 2nd backtick   ${y}${z}` : ''    }     </div>`
+//
+// minifies (partially) to:
+//   `<div> ${ x ? `<- 2nd backtick   ${y}${z}` : ''    }     </div>`
+//
+// nested template literals in interpolations are unchanged and still work, but they
+// won't be minified. this is fine, we don't need an ast parser as it's pretty rare
 
 const plugins = [
   {
-    // our html minifier will only process characters between the first two backticks encountered
-    // so:
-    //   $html`     <div>    ${    x ?      `<- 2nd backtick   ${y}${z}` : ''    }     </div>`
-    //
-    // minifies (partially) to:
-    //   `<div> ${ x ? `<- 2nd backtick   ${y}${z}` : ''    }     </div>`
-    //
-    // nested template literals in interpolations are unchanged and still work, but they
-    // won't be minified. this is fine, we don't need an ast parser as it's pretty rare
     name: '$html',
     setup(build: es.PluginBuild) {
       build.onLoad({ filter: /\.ts$/ }, async (args: es.OnLoadArgs) => ({
         loader: 'ts',
         contents: (await fs.promises.readFile(args.path, 'utf8')).replace(
           /\$html`([^`]*)`/g,
-          (_, s) => `\`${trimAndConsolidateWhitespace(s)}\``,
+          (_, s) => `\`${reduceWhitespace(s)}\``,
         ),
       }));
     },
@@ -81,98 +170,10 @@ const plugins = [
       build.onEnd(async (result: es.BuildResult) => {
         esbuildLog(result.errors, true);
         esbuildLog(result.warnings);
-        env.done(result.errors.length, 'esbuild');
-        if (result.errors.length === 0) jsManifest(result.metafile!);
+        env.begin('esbuild');
+        env.done('esbuild', result.errors.length);
+        if (result.errors.length === 0) bundleManifest(result.metafile!);
       });
     },
   },
 ];
-
-function esbuildLog(msgs: es.Message[], error = false): void {
-  for (const msg of msgs) {
-    const file = msg.location?.file.replace(/^[./]*/, '') ?? '<unknown>';
-    const line = msg.location?.line
-      ? `:${msg.location.line}`
-      : '' + (msg.location?.column ? `:${msg.location.column}` : '');
-    const srcText = msg.location?.lineText;
-    env.log(`${error ? errorMark : c.warn('WARNING')} - '${c.cyan(file + line)}' - ${msg.text}`, {
-      ctx: 'esbuild',
-    });
-    if (srcText) env.log('  ' + c.magenta(srcText), { ctx: 'esbuild' });
-  }
-}
-
-async function jsManifest(meta: es.Metafile = { inputs: {}, outputs: {} }) {
-  for (const w of inlineWatch) w.close();
-  inlineWatch.length = 0;
-  clearTimeout(inlineTimer);
-
-  const newJsManifest: Manifest = {};
-  for (const [filename, info] of Object.entries(meta.outputs)) {
-    const out = splitPath(filename);
-    if (!out) continue;
-    if (out.name === 'common') {
-      out.name = `common.${out.hash}`;
-      newJsManifest[out.name] = {};
-    } else newJsManifest[out.name] = { hash: out.hash };
-    const imports: string[] = [];
-    for (const imp of info.imports) {
-      if (imp.kind === 'import-statement') {
-        const path = splitPath(imp.path);
-        if (path) imports.push(`${path.name}.${path.hash}.js`);
-      }
-    }
-    newJsManifest[out.name].imports = imports;
-  }
-  await inlineManifest(newJsManifest);
-}
-
-async function inlineManifest(js: Manifest) {
-  const makeWatchers = env.watch && inlineWatch.length === 0;
-  let success = true;
-  for (const pkg of env.building) {
-    for (const bundle of pkg.bundle ?? []) {
-      if (!bundle.inline) continue;
-      const inlineSrc = path.join(pkg.root, bundle.inline);
-      const moduleName = bundle.module
-        ? path.basename(bundle.module, '.ts')
-        : path.basename(bundle.inline, '.inline.ts');
-      const packageError = `[${c.grey(pkg.name)}] - ${errorMark} - Package error ${c.blue(JSON.stringify(bundle))}`;
-
-      if (!(await readable(inlineSrc))) {
-        env.log(packageError);
-        for (const w of inlineWatch) w.close();
-        inlineWatch.length = 0;
-        if (!env.watch) env.exit('Failed'); // all inline sources must exist
-      }
-
-      try {
-        const res = await es.transform(await fs.promises.readFile(inlineSrc), {
-          minify: true,
-          loader: 'ts',
-        });
-        esbuildLog(res.warnings);
-        js[moduleName] ??= {};
-        js[moduleName].inline = res.code;
-      } catch (e) {
-        if (e && typeof e === 'object' && 'errors' in e) esbuildLog((e as es.TransformFailure).errors, true);
-        else env.log(`${packageError} - ${JSON.stringify(e)}`);
-        if (env.watch) success = false;
-        else env.exit('Failed');
-      }
-      if (makeWatchers)
-        inlineWatch.push(
-          fs.watch(inlineSrc, () => {
-            clearTimeout(inlineTimer);
-            inlineTimer = setTimeout(() => inlineManifest(js), 200);
-          }),
-        );
-    }
-  }
-  if (success) updateManifest({ js });
-}
-
-function splitPath(path: string) {
-  const match = path.match(/\/public\/compiled\/(.*)\.([A-Z0-9]+)\.js$/);
-  return match ? { name: match[1], hash: match[2] } : undefined;
-}

--- a/ui/.build/src/hash.ts
+++ b/ui/.build/src/hash.ts
@@ -1,72 +1,79 @@
 import fs from 'node:fs';
-import path from 'node:path';
+import p from 'node:path';
 import crypto from 'node:crypto';
-import { globArray } from './parse.ts';
-import { updateManifest } from './manifest.ts';
-import { env } from './env.ts';
+import { task } from './task.ts';
+import { type Manifest, updateManifest } from './manifest.ts';
+import { env, c } from './env.ts';
+import type { Package } from './parse.ts';
+import { isEquivalent } from './algo.ts';
 
 export async function hash(): Promise<void> {
-  const newHashLinks = new Map<string, number>();
-  const alreadyHashed = new Map<string, string>();
-  const hashed = (
-    await Promise.all(
-      env.building.flatMap(pkg =>
-        pkg.hash.map(async hash =>
-          (await globArray(hash.glob, { cwd: env.outDir })).map(path => ({
-            path,
-            update: hash.update,
-            root: pkg.root,
-          })),
-        ),
-      ),
-    )
-  ).flat();
+  if (!env.begin('hash')) return;
+  const hashed: Manifest = {};
+  const pathOnly: { glob: string[] } = { glob: [] };
+  const hashRuns: { glob: string | string[]; update?: string; pkg?: Package }[] = [];
 
-  const sourceStats = await Promise.all(hashed.map(hash => fs.promises.stat(hash.path)));
+  for (const [pkg, { glob, update, ...rest }] of env.tasks('hash')) {
+    update ? hashRuns.push({ glob, update, pkg, ...rest }) : pathOnly.glob.push(glob);
+    env.log(`${c.grey(pkg.name)} '${c.cyan(glob)}' -> '${c.cyan('public/hashed')}'`, 'hash');
+  }
+  if (pathOnly.glob.length) hashRuns.push(pathOnly);
 
-  for (const [i, stat] of sourceStats.entries()) {
-    const name = hashed[i].path.slice(env.outDir.length + 1);
-    if (stat.mtimeMs === env.manifest.hashed[name]?.mtime)
-      alreadyHashed.set(name, env.manifest.hashed[name].hash!);
-    else newHashLinks.set(name, stat.mtimeMs);
-  }
-  await Promise.allSettled([...alreadyHashed].map(([name, hash]) => link(name, hash)));
-
-  for await (const { name, hash } of [...newHashLinks.keys()].map(hashLink)) {
-    env.manifest.hashed[name] = Object.defineProperty({ hash }, 'mtime', { value: newHashLinks.get(name) });
-  }
-  if (newHashLinks.size === 0 && alreadyHashed.size === Object.keys(env.manifest.hashed).length) return;
-
-  for (const key of Object.keys(env.manifest.hashed)) {
-    if (!hashed.some(x => x.path.endsWith(key))) delete env.manifest.hashed[key];
-  }
-
-  const updates: Map<string, { root: string; mapping: Record<string, string> }> = new Map();
-  for (const { root, path, update } of hashed) {
-    if (!update) continue;
-    const updateFile = updates.get(update) ?? { root, mapping: {} };
-    const from = path.slice(env.outDir.length + 1);
-    updateFile.mapping[from] = asHashed(from, env.manifest.hashed[from].hash!);
-    updates.set(update, updateFile);
-  }
-  for await (const { name, hash } of [...updates].map(([n, r]) => update(n, r.root, r.mapping))) {
-    env.manifest.hashed[name] = { hash };
-  }
-  updateManifest({ dirty: true });
+  await fs.promises.mkdir(env.hashOutDir).catch(() => {});
+  await Promise.all(
+    hashRuns.map(({ glob, update, pkg }) =>
+      task({
+        ctx: 'hash',
+        debounce: 300,
+        root: env.rootDir,
+        glob: Array<string>()
+          .concat(glob)
+          .map(path => ({ cwd: env.rootDir, path })),
+        execute: async (files, fullList) => {
+          const shouldLog = !isEquivalent(files, fullList);
+          await Promise.all(
+            files.map(async src => {
+              const { name, hash } = await hashLink(p.relative(env.outDir, src));
+              hashed[name] = { hash };
+              if (shouldLog)
+                env.log(
+                  `'${c.cyan(src)}' -> '${c.cyan(p.join('public', 'hashed', asHashed(name, hash)))}'`,
+                  'hash',
+                );
+            }),
+          );
+          if (update && pkg?.root) {
+            const updates: Record<string, string> = {};
+            for (const src of fullList.map(f => p.relative(env.outDir, f))) {
+              updates[src] = asHashed(src, hashed[src].hash!);
+            }
+            const { name, hash } = await replaceHash(p.relative(pkg.root, update), pkg.root, updates);
+            hashed[name] = { hash };
+            if (shouldLog)
+              env.log(
+                `${c.grey(pkg.name)} '${c.cyan(name)}' -> '${c.cyan(p.join('public', 'hashed', asHashed(name, hash)))}'`,
+                'hash',
+              );
+          }
+          updateManifest({ hashed, merge: true });
+        },
+      }),
+    ),
+  );
 }
 
-async function update(name: string, root: string, files: Record<string, string>) {
+async function replaceHash(name: string, root: string, files: Record<string, string>) {
   const result = Object.entries(files).reduce(
     (data, [from, to]) => data.replaceAll(from, to),
-    await fs.promises.readFile(path.join(root, name), 'utf8'),
+    await fs.promises.readFile(p.join(root, name), 'utf8'),
   );
   const hash = crypto.createHash('sha256').update(result).digest('hex').slice(0, 8);
-  await fs.promises.writeFile(path.join(env.hashOutDir, asHashed(name, hash)), result);
+  await fs.promises.writeFile(p.join(env.hashOutDir, asHashed(name, hash)), result);
   return { name, hash };
 }
 
 async function hashLink(name: string) {
-  const src = path.join(env.outDir, name);
+  const src = p.join(env.outDir, name);
   const hash = crypto
     .createHash('sha256')
     .update(await fs.promises.readFile(src))
@@ -77,8 +84,8 @@ async function hashLink(name: string) {
 }
 
 async function link(name: string, hash: string) {
-  const link = path.join(env.hashOutDir, asHashed(name, hash));
-  return fs.promises.symlink(path.join('..', name), link).catch(() => {});
+  const link = p.join(env.hashOutDir, asHashed(name, hash));
+  return fs.promises.symlink(p.join('..', name), link).catch(() => {});
 }
 
 function asHashed(path: string, hash: string) {

--- a/ui/.build/src/main.ts
+++ b/ui/.build/src/main.ts
@@ -4,7 +4,7 @@ import { flockSync, constants } from 'fs-ext';
 import { deepClean } from './clean.ts';
 import { build } from './build.ts';
 import { startConsole } from './console.ts';
-import { env, c, errorMark } from './env.ts';
+import { env, errorMark } from './env.ts';
 
 // main entry point
 

--- a/ui/.build/src/main.ts
+++ b/ui/.build/src/main.ts
@@ -1,8 +1,10 @@
 import ps from 'node:process';
+import fs from 'node:fs';
+import { flockSync, constants } from 'fs-ext';
 import { deepClean } from './clean.ts';
 import { build } from './build.ts';
 import { startConsole } from './console.ts';
-import { env } from './env.ts';
+import { env, c, errorMark } from './env.ts';
 
 // main entry point
 
@@ -108,7 +110,17 @@ env.test = argv.includes('--test') || oneDashArgs.includes('t');
 if (argv.includes('--help') || oneDashArgs.includes('h')) {
   console.log(usage);
   ps.exit(0);
-} else if (env.clean) {
+}
+
+try {
+  const fd = fs.openSync(env.buildDir, 'r');
+  ps.on('exit', () => fs.closeSync(fd));
+  flockSync(fd, constants.LOCK_EX | constants.LOCK_NB);
+} catch {
+  env.exit(`${errorMark} - Another instance is already running`);
+}
+
+if (env.clean) {
   await deepClean();
   if (argv.includes('--clean-exit')) ps.exit(0);
 }

--- a/ui/.build/src/manifest.ts
+++ b/ui/.build/src/manifest.ts
@@ -1,36 +1,59 @@
 import cps from 'node:child_process';
-import path from 'node:path';
+import p from 'node:path';
 import fs from 'node:fs';
 import crypto from 'node:crypto';
 import { env, c, warnMark } from './env.ts';
-import { allSources as allCssSources } from './sass.ts';
 import { jsLogger } from './console.ts';
-import { shallowSort, isEquivalent } from './algo.ts';
+import { glob } from './parse.ts';
+import { taskOk } from './task.ts';
+import { shallowSort, isEquivalent, isContained } from './algo.ts';
 
-type SplitAsset = { hash?: string; path?: string; imports?: string[]; inline?: string; mtime?: number };
-export type Manifest = { [key: string]: SplitAsset };
-
+const manifest: { js: Manifest; i18n: Manifest; css: Manifest; hashed: Manifest; dirty: boolean } = {
+  i18n: {},
+  js: {},
+  css: {},
+  hashed: {},
+  dirty: false,
+};
 let writeTimer: NodeJS.Timeout;
 
-export function stopManifest(): void {
+type SplitAsset = { hash?: string; path?: string; imports?: string[]; inline?: string };
+
+export type Manifest = { [key: string]: SplitAsset };
+export type ManifestUpdate = Partial<typeof manifest> & { merge?: boolean };
+
+export function stopManifest(clear = false): void {
   clearTimeout(writeTimer);
+  if (clear) {
+    manifest.i18n = manifest.js = manifest.css = manifest.hashed = {};
+    manifest.dirty = false;
+  }
 }
 
-export function updateManifest(update: Partial<typeof env.manifest> = {}): void {
-  if (update?.dirty) env.manifest.dirty = true;
-  for (const key of Object.keys(update ?? {}) as (keyof typeof env.manifest)[]) {
-    if (key === 'dirty' || isEquivalent(env.manifest[key], update?.[key])) continue;
-    env.manifest[key] = shallowSort({ ...env.manifest[key], ...update?.[key] });
-    env.manifest.dirty = true;
+export function updateManifest(update: ManifestUpdate = {}): void {
+  if (update.dirty) manifest.dirty = true;
+
+  for (const key of Object.keys(update) as (keyof ManifestUpdate)[]) {
+    if (key === 'dirty' || key === 'merge') continue;
+    else if (update.merge && !isContained(manifest[key], update[key]))
+      for (const [k, v] of Object.entries(structuredClone(update[key]!))) {
+        manifest[key][k] = shallowSort({ ...manifest[key][k], ...v });
+      }
+    else if (!update.merge && !isEquivalent(manifest[key], update[key]))
+      manifest[key] = structuredClone(update[key])!;
+    else continue;
+
+    manifest[key] = shallowSort(manifest[key]);
+    manifest.dirty = true;
   }
-  if (!env.manifest.dirty) return;
-  clearTimeout(writeTimer);
-  writeTimer = setTimeout(writeManifest, 500);
+  if (manifest.dirty) {
+    clearTimeout(writeTimer);
+    writeTimer = setTimeout(writeManifest, 500);
+  }
 }
 
 async function writeManifest() {
-  if (!env.manifestOk || !(await isComplete())) return;
-
+  if (!(env.manifest && taskOk() && (await isComplete()))) return;
   const commitMessage = cps
     .execSync('git log -1 --pretty=%s', { encoding: 'utf-8' })
     .trim()
@@ -47,59 +70,57 @@ async function writeManifest() {
   if (env.remoteLog) clientJs.push(jsLogger());
 
   const pairLine = ([name, info]: [string, SplitAsset]) => `'${name.replaceAll("'", "\\'")}':'${info.hash}'`;
-  const jsLines = Object.entries(env.manifest.js)
+  const jsLines = Object.entries(manifest.js)
     .filter(([name, _]) => !/common\.[A-Z0-9]{8}/.test(name))
     .map(pairLine)
     .join(',');
-  const cssLines = Object.entries(env.manifest.css).map(pairLine).join(',');
-  const hashedLines = Object.entries(env.manifest.hashed).map(pairLine).join(',');
+  const cssLines = Object.entries(manifest.css).map(pairLine).join(',');
+  const hashedLines = Object.entries(manifest.hashed).map(pairLine).join(',');
 
   clientJs.push(`window.site.manifest={\ncss:{${cssLines}},\njs:{${jsLines}},\nhashed:{${hashedLines}}\n};`);
 
   const hashable = clientJs.join('\n');
   const hash = crypto.createHash('sha256').update(hashable).digest('hex').slice(0, 8);
-  // add the date after hashing
+
   const clientManifest =
     hashable +
     `\nwindow.site.info.date='${
       new Date(new Date().toUTCString()).toISOString().split('.')[0] + '+00:00'
     }';\n`;
-  const serverManifest = {
-    js: { manifest: { hash }, ...env.manifest.js, ...env.manifest.i18n },
-    css: { ...env.manifest.css },
-    hashed: { ...env.manifest.hashed },
-  };
-
+  const serverManifest = JSON.stringify(
+    {
+      js: { manifest: { hash }, ...manifest.js, ...manifest.i18n },
+      css: { ...manifest.css },
+      hashed: { ...manifest.hashed },
+    },
+    null,
+    env.prod ? undefined : 2,
+  );
   await Promise.all([
-    fs.promises.writeFile(path.join(env.jsOutDir, `manifest.${hash}.js`), clientManifest),
-    fs.promises.writeFile(
-      path.join(env.jsOutDir, `manifest.${env.prod ? 'prod' : 'dev'}.json`),
-      JSON.stringify(serverManifest, null, env.prod ? undefined : 2),
-    ),
+    fs.promises.writeFile(p.join(env.jsOutDir, `manifest.${hash}.js`), clientManifest),
+    fs.promises.writeFile(p.join(env.jsOutDir, `manifest.${env.prod ? 'prod' : 'dev'}.json`), serverManifest),
   ]);
-  env.manifest.dirty = false;
+  manifest.dirty = false;
+  const serverHash = crypto.createHash('sha256').update(serverManifest).digest('hex').slice(0, 8);
+  env.log(`Client '${c.cyan(`public/compiled/manifest.${hash}.js`)}'`, 'manifest');
   env.log(
-    `Manifest '${c.cyan(`public/compiled/manifest.${env.prod ? 'prod' : 'dev'}.json`)}' -> '${c.cyan(
-      `public/compiled/manifest.${hash}.js`,
-    )}'`,
+    `Server '${c.cyan(`public/compiled/manifest.${env.prod ? 'prod' : 'dev'}.json`)}' hash ${c.grey(serverHash)}`,
+    'manifest',
   );
 }
 
 async function isComplete() {
-  for (const bundle of [...env.packages.values()].map(x => x.bundle ?? []).flat()) {
-    if (!bundle.module) continue;
-    const name = path.basename(bundle.module, '.ts');
-    if (!env.manifest.js[name]) {
-      env.log(`${warnMark} - No manifest without building '${c.cyan(name + '.ts')}'`);
-      return false;
+  if (env.building.length < env.packages.size) return false;
+
+  for (const pkg of env.building) {
+    const globs = pkg.bundle.map(b => b.module).filter((x): x is string => Boolean(x));
+    for (const file of await glob(globs, { cwd: pkg.root })) {
+      const name = p.basename(file, '.ts');
+      if (!manifest.js[name]) {
+        env.log(`${warnMark} - No entry for '${c.cyan(name + '.ts')}'`, 'manifest');
+        return false;
+      }
     }
   }
-  for (const css of await allCssSources()) {
-    const name = path.basename(css, '.scss');
-    if (!env.manifest.css[name]) {
-      env.log(`${warnMark} - No manifest without building '${c.cyan(name + '.scss')}'`);
-      return false;
-    }
-  }
-  return Object.keys(env.manifest.i18n).length > 0;
+  return Object.keys(manifest.i18n).length > 0;
 }

--- a/ui/.build/src/manifest.ts
+++ b/ui/.build/src/manifest.ts
@@ -53,7 +53,7 @@ export function updateManifest(update: ManifestUpdate = {}): void {
 }
 
 async function writeManifest() {
-  if (!(env.manifest && taskOk() && (await isComplete()))) return;
+  if (!(env.manifest && taskOk())) return;
   const commitMessage = cps
     .execSync('git log -1 --pretty=%s', { encoding: 'utf-8' })
     .trim()
@@ -107,20 +107,4 @@ async function writeManifest() {
     `Server '${c.cyan(`public/compiled/manifest.${env.prod ? 'prod' : 'dev'}.json`)}' hash ${c.grey(serverHash)}`,
     'manifest',
   );
-}
-
-async function isComplete() {
-  if (env.building.length < env.packages.size) return false;
-
-  for (const pkg of env.building) {
-    const globs = pkg.bundle.map(b => b.module).filter((x): x is string => Boolean(x));
-    for (const file of await glob(globs, { cwd: pkg.root })) {
-      const name = p.basename(file, '.ts');
-      if (!manifest.js[name]) {
-        env.log(`${warnMark} - No entry for '${c.cyan(name + '.ts')}'`, 'manifest');
-        return false;
-      }
-    }
-  }
-  return Object.keys(manifest.i18n).length > 0;
 }

--- a/ui/.build/src/manifest.ts
+++ b/ui/.build/src/manifest.ts
@@ -2,9 +2,8 @@ import cps from 'node:child_process';
 import p from 'node:path';
 import fs from 'node:fs';
 import crypto from 'node:crypto';
-import { env, c, warnMark } from './env.ts';
+import { env, c } from './env.ts';
 import { jsLogger } from './console.ts';
-import { glob } from './parse.ts';
 import { taskOk } from './task.ts';
 import { shallowSort, isEquivalent, isContained } from './algo.ts';
 

--- a/ui/.build/src/parse.ts
+++ b/ui/.build/src/parse.ts
@@ -1,27 +1,34 @@
 import fs from 'node:fs';
-import path from 'node:path';
+import p from 'node:path';
 import fg from 'fast-glob';
-import { env, errorMark, c } from './env.ts';
-
-export type Bundle = { module?: string; inline?: string };
+import { env } from './env.ts';
 
 export interface Package {
-  root: string; // absolute path to package.json parentdir (package root)
+  root: string; // absolute path to package.json parentdir
   name: string; // dirname of package root
-  pkg: any; // the entire package.json object
-  bundle: { module?: string; inline?: string }[]; // TODO doc
-  hash: { glob: string; update?: string }[]; // TODO doc
+  pkg: any; // package.json object
+  bundle: Bundle[]; // esbuild bundling
+  hash: Hash[]; // files to symlink hash
   sync: Sync[]; // pre-bundle filesystem copies from package json
 }
 
-export interface Sync {
-  src: string; // src must be a file or a glob expression, use <dir>/** to sync entire directories
-  dest: string; // TODO doc
-  pkg: Package;
+interface Bundle {
+  module?: string; // file glob for esm modules (esbuild entry points)
+  inline?: string; // inject this script into response html
+}
+
+interface Hash {
+  glob: string; // glob for assets
+  update?: string; // file to update with hashed filenames
+}
+
+interface Sync {
+  src: string; // file glob expression, use <dir>/** to sync entire directories
+  dest: string; // directory to copy into
 }
 
 export async function parsePackages(): Promise<void> {
-  for (const dir of (await globArray('[^@.]*/package.json')).map(pkg => path.dirname(pkg))) {
+  for (const dir of (await glob('ui/[^@.]*/package.json')).map(pkg => p.dirname(pkg))) {
     const pkgInfo = await parsePackage(dir);
     env.packages.set(pkgInfo.name, pkgInfo);
   }
@@ -35,18 +42,14 @@ export async function parsePackages(): Promise<void> {
   }
 }
 
-export async function globArray(glob: string, opts: fg.Options = {}): Promise<string[]> {
-  const files: string[] = [];
-  for await (const f of fg.stream(glob, { cwd: env.uiDir, absolute: true, onlyFiles: true, ...opts })) {
-    files.push(f.toString('utf8'));
-  }
-  return files;
-}
-
-export async function globArrays(globs: string[] | undefined, opts: fg.Options = {}): Promise<string[]> {
-  if (!globs) return [];
-  const globResults = await Promise.all(globs.map(g => globArray(g, opts)));
-  return [...new Set<string>(globResults.flat())];
+export async function glob(glob: string[] | string | undefined, opts: fg.Options = {}): Promise<string[]> {
+  if (!glob) return [];
+  const results = await Promise.all(
+    Array()
+      .concat(glob)
+      .map(async g => fg.glob(g, { cwd: env.rootDir, absolute: true, ...opts })),
+  );
+  return [...new Set(results.flat())];
 }
 
 export async function folderSize(folder: string): Promise<number> {
@@ -55,7 +58,7 @@ export async function folderSize(folder: string): Promise<number> {
 
     const sizes = await Promise.all(
       entries.map(async entry => {
-        const fullPath = path.join(dir, entry.name);
+        const fullPath = p.join(dir, entry.name);
         if (entry.isDirectory()) return getSize(fullPath);
         if (entry.isFile()) return (await fs.promises.stat(fullPath)).size;
         return 0;
@@ -73,11 +76,33 @@ export async function readable(file: string): Promise<boolean> {
     .catch(() => false);
 }
 
-async function parsePackage(packageDir: string): Promise<Package> {
+export async function subfolders(folder: string, depth = 1): Promise<string[]> {
+  const folders: string[] = [];
+  if (depth > 0)
+    await Promise.all(
+      (await fs.promises.readdir(folder).catch(() => [])).map(f =>
+        fs.promises.stat(p.join(folder, f)).then(s => s.isDirectory() && folders.push(p.join(folder, f))),
+      ),
+    );
+  return folders;
+}
+
+export function isFolder(file: string): Promise<boolean> {
+  return fs.promises
+    .stat(file)
+    .then(s => s.isDirectory())
+    .catch(() => false);
+}
+
+export function isGlob(path: string): boolean {
+  return /[*?!{}[\]()]/.test(path);
+}
+
+async function parsePackage(root: string): Promise<Package> {
   const pkgInfo: Package = {
-    pkg: JSON.parse(await fs.promises.readFile(path.join(packageDir, 'package.json'), 'utf8')),
-    name: path.basename(packageDir),
-    root: packageDir,
+    pkg: JSON.parse(await fs.promises.readFile(p.join(root, 'package.json'), 'utf8')),
+    name: p.basename(root),
+    root,
     bundle: [],
     sync: [],
     hash: [],
@@ -85,34 +110,23 @@ async function parsePackage(packageDir: string): Promise<Package> {
   if (!('build' in pkgInfo.pkg)) return pkgInfo;
   const build = pkgInfo.pkg.build;
 
+  // 'hash' and 'sync' paths beginning with '/' are repo relative, otherwise they are package relative
+  const normalize = (file: string) => (file[0] === '/' ? file.slice(1) : p.join('ui', pkgInfo.name, file));
+  const normalizeObject = <T extends Record<string, any>>(o: T) =>
+    Object.fromEntries(Object.entries(o).map(([k, v]) => [k, typeof v === 'string' ? normalize(v) : v]));
+
   if ('hash' in build)
-    pkgInfo.hash = [].concat(build.hash).map(glob => (typeof glob === 'string' ? { glob } : glob));
+    pkgInfo.hash = []
+      .concat(build.hash)
+      .map(g => (typeof g === 'string' ? { glob: normalize(g) } : normalizeObject(g))) as Hash[];
 
-  if ('bundle' in build) {
-    for (const one of [].concat(build.bundle).map<Bundle>(b => (typeof b === 'string' ? { module: b } : b))) {
-      const src = one.module ?? one.inline;
-      if (!src) continue;
-
-      if (await readable(path.join(pkgInfo.root, src))) pkgInfo.bundle.push(one);
-      else if (one.module)
-        pkgInfo.bundle.push(
-          ...(await globArray(one.module, { cwd: pkgInfo.root, absolute: false }))
-            .filter(m => !m.endsWith('.inline.ts')) // no globbed inline sources
-            .map(module => ({ ...one, module })),
-        );
-      else env.log(`[${c.grey(pkgInfo.name)}] - ${errorMark} - Bundle error ${c.blue(JSON.stringify(one))}`);
-    }
-  }
-  if ('sync' in build) {
+  if ('sync' in build)
     pkgInfo.sync = Object.entries<string>(build.sync).map(x => ({
-      src: x[0],
-      dest: x[1],
-      pkg: pkgInfo,
+      src: normalize(x[0]),
+      dest: normalize(x[1]),
     }));
-  }
-  return pkgInfo;
-}
 
-export function trimAndConsolidateWhitespace(text: string): string {
-  return text.trim().replace(/\s+/g, ' ');
+  if ('bundle' in build)
+    pkgInfo.bundle = [].concat(build.bundle).map(b => (typeof b === 'string' ? { module: b } : b));
+  return pkgInfo;
 }

--- a/ui/.build/src/sass.ts
+++ b/ui/.build/src/sass.ts
@@ -1,245 +1,166 @@
 import cps from 'node:child_process';
 import fs from 'node:fs';
 import ps from 'node:process';
-import path from 'node:path';
+import p from 'node:path';
 import crypto from 'node:crypto';
 import clr from 'tinycolor2';
-import { env, c, lines, errorMark } from './env.ts';
-import { globArray, readable } from './parse.ts';
+import { env, c, errorMark } from './env.ts';
+import { readable, glob } from './parse.ts';
+import { task } from './task.ts';
 import { updateManifest } from './manifest.ts';
-import { clamp } from './algo.ts';
+import { clamp, isEquivalent, trimLines } from './algo.ts';
 
+const importMap = new Map<string, Set<string>>();
 const colorMixMap = new Map<string, { c1: string; c2?: string; op: string; val: number }>();
 const themeColorMap = new Map<string, Map<string, clr.Instance>>();
-const importMap = new Map<string, Set<string>>();
-const processed = new Set<string>();
+
 let sassPs: cps.ChildProcessWithoutNullStreams | undefined;
-let watcher: SassWatch | undefined;
-let awaitingFullBuild: boolean | undefined = undefined;
 
 export function stopSass(): void {
   sassPs?.removeAllListeners();
   sassPs?.kill();
   sassPs = undefined;
-  watcher?.destroy();
-  watcher = undefined;
   importMap.clear();
-  processed.clear();
   colorMixMap.clear();
   themeColorMap.clear();
 }
 
 export async function sass(): Promise<void> {
-  if (!env.sass) return;
-  env.exitCode.delete('sass');
+  if (!env.begin('sass')) return;
 
-  await fs.promises.mkdir(path.join(env.buildTempDir, 'css')).catch(() => {});
+  await Promise.allSettled([
+    fs.promises.mkdir(env.cssOutDir),
+    fs.promises.mkdir(env.themeGenDir),
+    fs.promises.mkdir(p.join(env.buildTempDir, 'css')),
+  ]);
 
-  awaitingFullBuild ??= env.watch && env.building.length === env.packages.size;
+  let remaining: Set<string>;
 
-  const sources = await allSources();
-  await Promise.allSettled([parseThemeColorDefs(), ...sources.map(src => parseScss(src))]);
-  await buildColorMixes().then(buildColorWrap);
+  return task({
+    ctx: 'sass',
+    glob: { cwd: env.uiDir, path: '*/css/**/*.scss' },
+    debounce: 300,
+    root: env.rootDir,
+    execute: async (modified, fullList) => {
+      const concreteAll = new Set(fullList.filter(isConcrete));
+      const partialTouched = modified.filter(isPartial);
+      const transitiveTouched = partialTouched.flatMap(p => [...importersOf(p)]);
+      const concreteTouched = [...new Set([...transitiveTouched, ...modified])].filter(isConcrete);
 
-  if (env.watch) watcher = new SassWatch();
+      remaining = remaining
+        ? new Set([...remaining, ...concreteTouched].filter(x => concreteAll.has(x)))
+        : concreteAll;
 
-  compile(sources, env.building.length !== env.packages.size);
-
-  if (!sources.length) env.done(0, 'sass');
-}
-
-export async function allSources(): Promise<string[]> {
-  return (await globArray('./*/css/**/[^_]*.scss', { absolute: false })).filter(x => !x.includes('/gen/'));
-}
-
-async function unbuiltSources(): Promise<string[]> {
-  return Promise.all(
-    (await allSources()).filter(
-      src => !readable(path.join(env.cssTempDir, `${path.basename(src, '.scss')}.css`)),
-    ),
-  );
-}
-
-class SassWatch {
-  dependencies = new Set<string>();
-  touched = new Set<string>();
-  timeout: NodeJS.Timeout | undefined;
-  watchers: fs.FSWatcher[] = [];
-  watchDirs = new Set<string>();
-  constructor() {
-    this.watch();
-  }
-
-  async watch() {
-    if (!env.watch) return;
-    const watchDirs = new Set<string>([...importMap.keys()].map(path.dirname));
-    (await allSources()).forEach(s => watchDirs.add(path.dirname(s)));
-    if (this.watchDirs.size === watchDirs.size || [...watchDirs].every(d => this.watchDirs.has(d))) return;
-    if (this.watchDirs.size) env.log('Rebuilding watchers...', { ctx: 'sass' });
-    for (const x of this.watchers) x.close();
-    this.watchers.length = 0;
-    this.watchDirs = watchDirs;
-    for (const dir of this.watchDirs) {
-      const fsWatcher = fs.watch(dir);
-      fsWatcher.on('change', (event: string, srcFile: string) => this.onChange(dir, event, srcFile));
-      fsWatcher.on('error', (err: Error) => env.error(err, 'sass'));
-      this.watchers.push(fsWatcher);
-    }
-  }
-
-  destroy() {
-    this.clear();
-    for (const x of this.watchers) x.close();
-    this.watchers.length = 0;
-  }
-
-  clear() {
-    clearTimeout(this.timeout);
-    this.timeout = undefined;
-    this.dependencies.clear();
-    this.touched.clear();
-  }
-
-  add(files: string[]): boolean {
-    clearTimeout(this.timeout);
-    this.timeout = setTimeout(() => this.fire(), 200);
-    if (files.every(f => this.touched.has(f))) return false;
-    files.forEach(src => {
-      this.touched.add(src);
-      if (!/[^_].*\.scss/.test(path.basename(src))) {
-        this.dependencies.add(src);
-      } else importersOf(src).forEach(dest => this.dependencies.add(dest));
-    });
-    return true;
-  }
-
-  onChange(dir: string, event: string, srcFile: string) {
-    if (event === 'change') {
-      if (this.add([path.join(dir, srcFile)])) env.log(`File '${c.cyanBold(srcFile)}' changed`);
-    } else if (event === 'rename') {
-      globArray('*.scss', { cwd: dir, absolute: false }).then(files => {
-        if (this.add(files.map(f => path.join(dir, f)))) {
-          env.log(`Cross your fingers - directory '${c.cyanBold(dir)}' changed`, { ctx: 'sass' });
-        }
-      });
-    }
-  }
-
-  async fire() {
-    const sources = [...this.dependencies].filter(src => /\/[^_][^/]+\.scss$/.test(src));
-    const touched = [...this.touched];
-    this.clear();
-    this.watch(); // experimental
-    let rebuildColors = false;
-
-    for (const src of touched) {
-      processed.delete(src);
-      if (src.includes('common/css/theme/_')) {
-        rebuildColors = true;
+      if (modified.some(src => src.startsWith('ui/common/css/theme/_'))) {
         await parseThemeColorDefs();
       }
-    }
-    const oldMixSet = new Set([...colorMixMap.keys()]);
-    for (const src of touched) await parseScss(src);
-    const newMixSet = new Set([...colorMixMap.keys()]);
-    if ([...newMixSet].some(mix => !oldMixSet.has(mix))) rebuildColors = true;
-    if (rebuildColors) {
-      buildColorMixes()
-        .then(buildColorWrap)
-        .then(() => compile(sources));
-    } else compile(sources);
-  }
+
+      const oldMixes = Object.fromEntries(colorMixMap);
+
+      const processed = new Set<string>();
+      await Promise.all(concreteTouched.map(src => parseScss(src, processed)));
+
+      if (!isEquivalent(oldMixes, Object.fromEntries(colorMixMap))) {
+        await buildColorMixes();
+        await buildColorWrap();
+      }
+
+      remaining = new Set(await compile([...remaining], remaining.size < concreteAll.size));
+
+      if (!remaining.size)
+        updateManifest({
+          css: Object.fromEntries(
+            await Promise.all((await glob(p.join(env.cssTempDir, '*.css'))).map(hashMoveCss)),
+          ),
+          merge: true,
+        });
+    },
+  });
 }
 
-// compile an array of concrete scss files to ui/.build/dist/css/*.css (css temp dir prior to hashMove)
-function compile(sources: string[], logAll = true) {
-  if (!sources.length) return sources.length;
+// compile an array of concrete scss files, return any that error
+function compile(sources: string[], logAll = true): Promise<string[]> {
+  return new Promise(async resolve => {
+    if (!sources.length) return resolve([]);
 
-  const sassExec =
-    process.env.SASS_PATH ||
-    fs.realpathSync(
-      path.join(env.buildDir, 'node_modules', `sass-embedded-${ps.platform}-${ps.arch}`, 'dart-sass', 'sass'),
+    const sassExec =
+      process.env.SASS_PATH ||
+      (await fs.promises.realpath(
+        p.join(env.buildDir, 'node_modules', `sass-embedded-${ps.platform}-${ps.arch}`, 'dart-sass', 'sass'),
+      ));
+
+    if (!fs.existsSync(sassExec)) {
+      env.exit(`Sass executable not found '${c.cyan(sassExec)}'`, 'sass');
+    }
+    if (logAll) sources.forEach(src => env.log(`Building '${c.cyan(src)}'`, 'sass'));
+    else env.log('Building', 'sass');
+
+    const sassArgs = ['--no-error-css', '--stop-on-error', '--no-color', '--quiet', '--quiet-deps'];
+    sassPs?.removeAllListeners();
+    sassPs = cps.spawn(
+      sassExec,
+      sassArgs.concat(
+        env.prod ? ['--style=compressed', '--no-source-map'] : ['--embed-sources'],
+        sources.map(
+          (src: string) => `${src}:${p.join(env.cssTempDir, p.basename(src).replace(/(.*)scss$/, '$1css'))}`,
+        ),
+      ),
     );
 
-  if (!fs.existsSync(sassExec)) {
-    env.error(`Sass executable not found '${c.cyan(sassExec)}'`, 'sass');
-    env.done(1, 'sass');
-  }
-  if (logAll) sources.forEach(src => env.log(`Building '${c.cyan(src)}'`, { ctx: 'sass' }));
-  else env.log('Building', { ctx: 'sass' });
-
-  const sassArgs = ['--no-error-css', '--stop-on-error', '--no-color', '--quiet', '--quiet-deps'];
-  sassPs?.removeAllListeners();
-  sassPs = cps.spawn(
-    sassExec,
-    sassArgs.concat(
-      env.prod ? ['--style=compressed', '--no-source-map'] : ['--embed-sources'],
-      sources.map(
-        (src: string) =>
-          `${src}:${path.join(env.cssTempDir, path.basename(src).replace(/(.*)scss$/, '$1css'))}`,
-      ),
-    ),
-  );
-
-  sassPs.stderr?.on('data', (buf: Buffer) => sassError(buf.toString('utf8')));
-  sassPs.stdout?.on('data', (buf: Buffer) => {
-    const txts = lines(buf.toString('utf8'));
-    for (const txt of txts) env.log(c.red(txt), { ctx: 'sass' });
+    sassPs.stderr?.on('data', (buf: Buffer) => sassError(buf.toString('utf8')));
+    sassPs.stdout?.on('data', (buf: Buffer) => sassError(buf.toString('utf8')));
+    sassPs.on('close', async (code: number) => {
+      if (code === 0) resolve([]);
+      else
+        failed(sources)
+          .then(resolve)
+          .catch(() => resolve(sources));
+    });
   });
-  sassPs.on('close', async (code: number) => {
-    if (code !== 0) return env.done(code, 'sass');
-    if (awaitingFullBuild && compile(await unbuiltSources()) > 0) return;
-    awaitingFullBuild = false; // now we are ready to make manifests
-    cssManifest();
-    env.done(0, 'sass');
-  });
-  return sources.length;
 }
 
 // recursively parse scss file and its imports to build dependency and color maps
-async function parseScss(src: string) {
-  if (path.dirname(src).endsWith('/gen')) return;
+async function parseScss(src: string, processed: Set<string>) {
+  if (p.dirname(src).endsWith('/gen')) return;
   if (processed.has(src)) return;
   processed.add(src);
-  try {
-    const text = await fs.promises.readFile(src, 'utf8');
-    for (const match of text.matchAll(/\$m-([-_a-z0-9]+)/g)) {
-      const [str, mix] = [match[1], parseColor(match[1])];
-      if (!mix) {
-        env.log(`${errorMark} - invalid color mix: '${c.magenta(str)}' in '${c.cyan(src)}'`, {
-          ctx: 'sass',
-        });
-        continue;
-      }
-      colorMixMap.set(str, mix);
+
+  const text = await fs.promises.readFile(src, 'utf8');
+
+  for (const match of text.matchAll(/\$m-([-_a-z0-9]+)/g)) {
+    const [str, mix] = [match[1], parseColor(match[1])];
+    if (!mix) {
+      env.log(`${errorMark} Invalid color mix: '${c.magenta(str)}' in '${c.cyan(src)}'`, 'sass');
+      continue;
     }
-    for (const match of text.matchAll(/^@(?:import|use)\s+['"](.*)['"]/gm)) {
-      if (match.length !== 2) continue;
+    colorMixMap.set(str, mix);
+  }
 
-      const absDep = (await readable(path.resolve(path.dirname(src), match[1]) + '.scss'))
-        ? path.resolve(path.dirname(src), match[1] + '.scss')
-        : path.resolve(path.dirname(src), resolvePartial(match[1]));
+  for (const match of text.matchAll(/^@(?:import|use)\s+['"](.*)['"]/gm)) {
+    if (match.length !== 2) continue;
 
-      if (!absDep.startsWith(env.uiDir) || /node_modules.*\.css/.test(absDep)) continue;
+    const absDep = (await readable(p.resolve(p.dirname(src), match[1]) + '.scss'))
+      ? p.resolve(p.dirname(src), match[1] + '.scss')
+      : p.resolve(p.dirname(src), resolvePartial(match[1]));
 
-      const dep = absDep.slice(env.uiDir.length + 1);
-      if (!importMap.get(dep)?.add(src)) importMap.set(dep, new Set<string>([src]));
-      await parseScss(dep);
-    }
-  } catch (e) {
-    env.log(`${errorMark} failed to read ${src} - ${JSON.stringify(e, undefined, 2)}`);
+    if (/node_modules.*\.css/.test(absDep)) continue;
+    else if (!absDep.startsWith(env.uiDir)) throw `Bad import '${match[1]}`;
+
+    const dep = p.relative(env.rootDir, absDep);
+    if (!importMap.get(dep)?.add(src)) importMap.set(dep, new Set<string>([src]));
+    await parseScss(dep, processed);
   }
 }
 
 // collect mixable scss color definitions from theme files
 async function parseThemeColorDefs() {
-  const themeFiles = await globArray('./common/css/theme/_*.scss', { absolute: false });
+  const themeFiles = await glob('ui/common/css/theme/_*.scss', { absolute: false });
   const themes: string[] = ['dark'];
   const capturedColors = new Map<string, string>();
   for (const themeFile of themeFiles ?? []) {
     const theme = /_([^/]+)\.scss/.exec(themeFile)?.[1];
     if (!theme) {
-      env.log(`${errorMark} - invalid theme filename '${c.cyan(themeFile)}'`, { ctx: 'sass' });
+      env.log(`${errorMark} Invalid theme filename '${c.cyan(themeFile)}'`, 'sass');
       continue;
     }
     const text = fs.readFileSync(themeFile, 'utf8');
@@ -274,7 +195,7 @@ async function parseThemeColorDefs() {
 
 // given color definitions and mix instructions, build mixed color css variables in themed scss mixins
 async function buildColorMixes() {
-  const out = fs.createWriteStream(path.join(env.themeGenDir, '_mix.scss'));
+  const out = fs.createWriteStream(p.join(env.themeGenDir, '_mix.scss'));
   for (const theme of themeColorMap.keys()) {
     const colorMap = themeColorMap.get(theme)!;
     out.write(`@mixin ${theme}-mix {\n`);
@@ -295,7 +216,7 @@ async function buildColorMixes() {
         }
       })();
       if (mixed) colors.push(`  --m-${colorMix}: ${env.rgb ? mixed.toRgbString() : mixed.toHslString()};`);
-      else env.log(`${errorMark} - invalid mix op: '${c.magenta(colorMix)}'`, { ctx: 'sass' });
+      else env.log(`${errorMark} Invalid mix op: '${c.magenta(colorMix)}'`, 'sass');
     }
     out.write(colors.sort().join('\n') + '\n}\n\n');
   }
@@ -307,7 +228,7 @@ async function buildColorWrap() {
   const cssVars = new Set<string>();
   for (const color of colorMixMap.keys()) cssVars.add(`m-${color}`);
 
-  for (const file of await globArray(path.join(env.themeDir, '_*.scss'))) {
+  for (const file of await glob(p.join(env.themeDir, '_*.scss'))) {
     for (const line of (await fs.promises.readFile(file, 'utf8')).split('\n')) {
       if (line.indexOf('--') === -1) continue;
       const commentIndex = line.indexOf('//');
@@ -322,8 +243,8 @@ async function buildColorWrap() {
       .map(variable => `$${variable}: var(--${variable});`)
       .join('\n') + '\n';
 
-  const wrapFile = path.join(env.themeDir, 'gen', '_wrap.scss');
-  await fs.promises.mkdir(path.dirname(wrapFile), { recursive: true });
+  const wrapFile = p.join(env.themeDir, 'gen', '_wrap.scss');
+  await fs.promises.mkdir(p.dirname(wrapFile), { recursive: true });
   if (await readable(wrapFile)) {
     if ((await fs.promises.readFile(wrapFile, 'utf8')) === scssWrap) return; // don't touch wrap if no changes
   }
@@ -345,18 +266,23 @@ function parseColor(colorMix: string) {
     : undefined;
 }
 
-function resolvePartial(partial: string): string {
-  const nameBegin = partial.lastIndexOf(path.sep) + 1;
-  return `${partial.slice(0, nameBegin)}_${partial.slice(nameBegin)}.scss`;
+async function failed(attempted: string[]): Promise<string[]> {
+  return Promise.all(
+    attempted.filter(src => !readable(p.join(env.cssTempDir, `${p.basename(src, '.scss')}.css`))),
+  );
 }
 
-function sassError(error: string) {
-  for (const err of lines(error)) {
-    if (err.startsWith('Error:')) {
-      env.log(c.grey('-'.repeat(75)), { ctx: 'sass' });
-      env.log(`${errorMark} - ${err.slice(7)}`, { ctx: 'sass' });
-    } else env.log(err, { ctx: 'sass' });
-  }
+function isConcrete(src: string) {
+  return !p.basename(src).startsWith('_');
+}
+
+function isPartial(src: string) {
+  return p.basename(src).startsWith('_');
+}
+
+function resolvePartial(partial: string): string {
+  const nameBegin = partial.lastIndexOf(p.sep) + 1;
+  return `${partial.slice(0, nameBegin)}_${partial.slice(nameBegin)}.scss`;
 }
 
 function importersOf(srcFile: string, bset = new Set<string>()): Set<string> {
@@ -366,18 +292,22 @@ function importersOf(srcFile: string, bset = new Set<string>()): Set<string> {
   return bset;
 }
 
-export async function cssManifest(): Promise<void> {
-  const files = await globArray(path.join(env.cssTempDir, '*.css'));
-  updateManifest({ css: Object.fromEntries(await Promise.all(files.map(hashMoveCss))) });
-}
-
 async function hashMoveCss(src: string) {
   const content = await fs.promises.readFile(src, 'utf-8');
   const hash = crypto.createHash('sha256').update(content).digest('hex').slice(0, 8);
-  const basename = path.basename(src, '.css');
+  const basename = p.basename(src, '.css');
   await Promise.allSettled([
-    env.prod ? undefined : fs.promises.rename(`${src}.map`, path.join(env.cssOutDir, `${basename}.css.map`)),
-    fs.promises.rename(src, path.join(env.cssOutDir, `${basename}.${hash}.css`)),
+    env.prod ? undefined : fs.promises.rename(`${src}.map`, p.join(env.cssOutDir, `${basename}.css.map`)),
+    fs.promises.rename(src, p.join(env.cssOutDir, `${basename}.${hash}.css`)),
   ]);
-  return [path.basename(src, '.css'), { hash }];
+  return [p.basename(src, '.css'), { hash }];
+}
+
+function sassError(error: string) {
+  for (const err of trimLines(error)) {
+    if (err.startsWith('Error:')) {
+      env.log(c.grey('-'.repeat(75)), 'sass');
+      env.log(`${errorMark} - ${err.slice(7)}`, 'sass');
+    } else env.log(err, 'sass');
+  }
 }

--- a/ui/.build/src/sass.ts
+++ b/ui/.build/src/sass.ts
@@ -79,53 +79,41 @@ export async function sass(): Promise<void> {
 }
 
 // compile an array of concrete scss files, return any that error
-function compile(sources: string[], logAll = true): Promise<string[]> {
-  return new Promise(resolve =>
-    (async () => {
-      if (!sources.length) return resolve([]);
+async function compile(sources: string[], logAll = true): Promise<string[]> {
+  const sassBin =
+    process.env.SASS_PATH ??
+    (await fs.promises.realpath(
+      p.join(env.buildDir, 'node_modules', `sass-embedded-${ps.platform}-${ps.arch}`, 'dart-sass', 'sass'),
+    ));
+  if (!(await readable(sassBin))) env.exit(`Sass executable not found '${c.cyan(sassBin)}'`, 'sass');
 
-      const sassExec =
-        process.env.SASS_PATH ||
-        (await fs.promises.realpath(
-          p.join(
-            env.buildDir,
-            'node_modules',
-            `sass-embedded-${ps.platform}-${ps.arch}`,
-            'dart-sass',
-            'sass',
-          ),
-        ));
+  return new Promise(resolve => {
+    if (!sources.length) return resolve([]);
+    if (logAll) sources.forEach(src => env.log(`Building '${c.cyan(src)}'`, 'sass'));
+    else env.log('Building', 'sass');
 
-      if (!fs.existsSync(sassExec)) {
-        env.exit(`Sass executable not found '${c.cyan(sassExec)}'`, 'sass');
-      }
-      if (logAll) sources.forEach(src => env.log(`Building '${c.cyan(src)}'`, 'sass'));
-      else env.log('Building', 'sass');
-
-      const sassArgs = ['--no-error-css', '--stop-on-error', '--no-color', '--quiet', '--quiet-deps'];
-      sassPs?.removeAllListeners();
-      sassPs = cps.spawn(
-        sassExec,
-        sassArgs.concat(
-          env.prod ? ['--style=compressed', '--no-source-map'] : ['--embed-sources'],
-          sources.map(
-            (src: string) =>
-              `${src}:${p.join(env.cssTempDir, p.basename(src).replace(/(.*)scss$/, '$1css'))}`,
-          ),
+    const sassArgs = ['--no-error-css', '--stop-on-error', '--no-color', '--quiet', '--quiet-deps'];
+    sassPs?.removeAllListeners();
+    sassPs = cps.spawn(
+      sassBin,
+      sassArgs.concat(
+        env.prod ? ['--style=compressed', '--no-source-map'] : ['--embed-sources'],
+        sources.map(
+          (src: string) => `${src}:${p.join(env.cssTempDir, p.basename(src).replace(/(.*)scss$/, '$1css'))}`,
         ),
-      );
+      ),
+    );
 
-      sassPs.stderr?.on('data', (buf: Buffer) => sassError(buf.toString('utf8')));
-      sassPs.stdout?.on('data', (buf: Buffer) => sassError(buf.toString('utf8')));
-      sassPs.on('close', async (code: number) => {
-        if (code === 0) resolve([]);
-        else
-          failed(sources)
-            .then(resolve)
-            .catch(() => resolve(sources));
-      });
-    })(),
-  );
+    sassPs.stderr?.on('data', (buf: Buffer) => sassError(buf.toString('utf8')));
+    sassPs.stdout?.on('data', (buf: Buffer) => sassError(buf.toString('utf8')));
+    sassPs.on('close', async (code: number) => {
+      if (code === 0) resolve([]);
+      else
+        failed(sources)
+          .then(resolve)
+          .catch(() => resolve(sources));
+    });
+  });
 }
 
 // recursively parse scss file and its imports to build dependency and color maps

--- a/ui/.build/src/sync.ts
+++ b/ui/.build/src/sync.ts
@@ -1,104 +1,57 @@
 import fs from 'node:fs';
-import path from 'node:path';
-import { type Sync, globArray, globArrays } from './parse.ts';
-import { hash } from './hash.ts';
-import { env, errorMark, c } from './env.ts';
-import { quantize } from './algo.ts';
+import p from 'node:path';
+import { task } from './task.ts';
+import { env, c } from './env.ts';
+import { isGlob, isFolder } from './parse.ts';
+import { quantize, isEquivalent } from './algo.ts';
 
-const syncWatch: fs.FSWatcher[] = [];
-let watchTimeout: NodeJS.Timeout | undefined;
-
-export function stopSync(): void {
-  clearTimeout(watchTimeout);
-  for (const watcher of syncWatch) watcher.close();
-  syncWatch.length = 0;
-}
-
-export async function sync(): Promise<void> {
-  if (!env.sync) return;
-  const watched = new Map<string, Sync[]>();
-  const updated = new Set<string>();
-
-  for (const pkg of env.building) {
-    for (const sync of pkg.sync) {
-      for (const src of await syncGlob(sync)) {
-        if (env.watch) watched.set(src, [...(watched.get(src) ?? []), sync]);
-      }
-    }
-    if (!env.watch) continue;
-    const sources = await globArrays(
-      pkg.hash.map(x => x.glob),
-      { cwd: env.outDir },
-    );
-
-    for (const src of sources.filter(isUnmanagedAsset)) {
-      if (!watched.has(path.dirname(src))) watched.set(path.dirname(src), []);
-    }
-  }
-  if (env.watch)
-    for (const dir of watched.keys()) {
-      const watcher = fs.watch(dir);
-
-      watcher.on('change', () => {
-        updated.add(dir);
-        clearTimeout(watchTimeout);
-        watchTimeout = setTimeout(() => {
-          Promise.all([...updated].flatMap(d => (watched.get(d) ?? []).map(x => syncGlob(x)))).then(hash);
-          updated.clear();
-        }, 2000);
+export async function sync(): Promise<any> {
+  if (!env.begin('sync')) return;
+  return Promise.all(
+    [...env.tasks('sync')].map(async ([pkg, sync]) => {
+      const root = await syncRoot(env.rootDir, sync.src);
+      await task({
+        glob: { path: sync.src, cwd: env.rootDir },
+        ctx: 'sync',
+        debounce: 300,
+        execute: (files, fullList) => {
+          const logEvery = !isEquivalent(files, fullList);
+          if (!logEvery)
+            env.log(`${c.grey(pkg.name)} '${c.cyan(sync.src)}' -> '${c.cyan(sync.dest)}'`, 'sync');
+          return Promise.all(
+            files.map(async f => {
+              if ((await syncOne(f, p.join(env.rootDir, sync.dest, f.slice(root.length)))) && logEvery)
+                env.log(
+                  `${c.grey(pkg.name)} '${c.cyan(f.slice(root.length))}' -> '${c.cyan(sync.dest)}'`,
+                  'sync',
+                );
+            }),
+          );
+        },
       });
-      watcher.on('error', (err: Error) => env.error(err));
-      syncWatch.push(watcher);
-    }
+    }),
+  );
 }
 
-export function isUnmanagedAsset(absfile: string): boolean {
-  if (!absfile.startsWith(env.outDir)) return false;
-  const name = absfile.slice(env.outDir.length + 1);
-  if (['compiled/', 'hashed/', 'css/'].some(dir => name.startsWith(dir))) return false;
-  return true;
-}
-
-async function syncGlob(cp: Sync): Promise<Set<string>> {
-  const watchDirs = new Set<string>();
-  const dest = path.join(env.rootDir, cp.dest) + path.sep;
-
-  const globIndex = cp.src.search(/[*?!{}[\]()]|\*\*|\[[^[\]]*\]/);
-  const globRoot =
-    globIndex > 0 && cp.src[globIndex - 1] === path.sep
-      ? cp.src.slice(0, globIndex - 1)
-      : path.dirname(cp.src.slice(0, globIndex));
-
-  const srcs = await globArray(cp.src, { cwd: cp.pkg.root, absolute: false });
-
-  watchDirs.add(path.join(cp.pkg.root, globRoot));
-  env.log(`[${c.grey(cp.pkg.name)}] - Sync '${c.cyan(cp.src)}' to '${c.cyan(cp.dest)}'`);
-  const fileCopies = [];
-
-  for (const src of srcs) {
-    const srcPath = path.join(cp.pkg.root, src);
-    watchDirs.add(path.dirname(srcPath));
-    const destPath = path.join(dest, src.slice(globRoot.length));
-    fileCopies.push(syncOne(srcPath, destPath, cp.pkg.name));
+async function syncOne(absSrc: string, absDest: string): Promise<boolean> {
+  const [src, dest] = (
+    await Promise.allSettled([
+      fs.promises.stat(absSrc),
+      fs.promises.stat(absDest),
+      fs.promises.mkdir(p.dirname(absDest), { recursive: true }),
+    ])
+  ).map(x => (x.status === 'fulfilled' ? (x.value as fs.Stats) : undefined));
+  if (src && (!dest || quantize(src.mtimeMs, 300) !== quantize(dest.mtimeMs, 300))) {
+    await fs.promises.copyFile(absSrc, absDest);
+    await fs.promises.utimes(absDest, src.atime, src.mtime);
+    return true;
   }
-  await Promise.allSettled(fileCopies);
-  return watchDirs;
+  return false;
 }
 
-async function syncOne(absSrc: string, absDest: string, pkgName: string) {
-  try {
-    const [src, dest] = (
-      await Promise.allSettled([
-        fs.promises.stat(absSrc),
-        fs.promises.stat(absDest),
-        fs.promises.mkdir(path.dirname(absDest), { recursive: true }),
-      ])
-    ).map(x => (x.status === 'fulfilled' ? (x.value as fs.Stats) : undefined));
-    if (src && (!dest || quantize(src.mtimeMs, 2000) !== quantize(dest.mtimeMs, 2000))) {
-      await fs.promises.copyFile(absSrc, absDest);
-      fs.utimes(absDest, src.atime, src.mtime, () => {});
-    }
-  } catch (_) {
-    env.log(`[${c.grey(pkgName)}] - ${errorMark} - failed sync '${c.cyan(absSrc)}' to '${c.cyan(absDest)}'`);
-  }
+async function syncRoot(cwd: string, path: string): Promise<string> {
+  if (!(isGlob(path) || (await isFolder(p.join(cwd, path))))) return p.join(cwd, p.dirname(path));
+  const [head, ...tail] = path.split(p.sep);
+  if (isGlob(head)) return cwd;
+  return syncRoot(p.join(cwd, head), tail.join(p.sep));
 }

--- a/ui/.build/src/task.ts
+++ b/ui/.build/src/task.ts
@@ -1,0 +1,194 @@
+import fg from 'fast-glob';
+import mm from 'micromatch';
+import fs from 'node:fs';
+import p from 'node:path';
+import { glob, isFolder, subfolders } from './parse.ts';
+import { randomToken } from './algo.ts';
+import { type Context, env, c, errorMark } from './env.ts';
+
+const fsWatches = new Map<AbsPath, FSWatch>();
+const tasks = new Map<TaskKey, Task>();
+const fileTimes = new Map<AbsPath, number>();
+
+type Path = string;
+type AbsPath = string;
+type CwdPath = { cwd: AbsPath; path: Path };
+type Debounce = { time: number; timeout?: NodeJS.Timeout; rename: boolean; files: Set<AbsPath> };
+type TaskKey = string;
+type FSWatch = { watcher: fs.FSWatcher; cwd: AbsPath; keys: Set<TaskKey> };
+type Task = Omit<TaskOpts, 'glob' | 'debounce'> & {
+  glob: CwdPath[];
+  key: TaskKey;
+  debounce: Debounce;
+  fileTimes: Map<AbsPath, number>;
+  status: 'ok' | 'error' | undefined;
+};
+type TaskOpts = {
+  glob: CwdPath | CwdPath[];
+  execute: (touched: AbsPath[], fullList: AbsPath[]) => Promise<any>;
+  key?: TaskKey; // optional key for replace & cancel
+  ctx?: Context; // optional context for logging
+  pkg?: string; // optional package for logging
+  debounce?: number; // optional number in ms
+  root?: AbsPath; // optional relative root for file lists, otherwise all paths are absolute
+  globListOnly?: boolean; // default false - ignore file mods, only execute when glob list changes
+  monitorOnly?: boolean; // default false - do not execute on initial traverse, only on future changes
+  noEnvStatus?: boolean; // default false - don't inform env.done of task status
+};
+
+export async function task(o: TaskOpts): Promise<void> {
+  const { monitorOnly: noInitial, debounce, key: inKey } = o;
+  const glob = Array<CwdPath>().concat(o.glob ?? []);
+  if (glob.length === 0) return;
+  if (inKey) stopTask(inKey);
+  const newWatch: Task = {
+    ...o,
+    glob,
+    key: inKey ?? randomToken(),
+    status: noInitial ? 'ok' : undefined,
+    debounce: { time: debounce ?? 0, rename: !noInitial, files: new Set<AbsPath>() },
+    fileTimes: noInitial ? await globTimes(glob) : new Map(),
+  };
+  tasks.set(newWatch.key, newWatch);
+  if (env.watch) newWatch.glob.forEach(g => watchGlob(g, newWatch.key));
+  if (!noInitial) return execute(newWatch);
+}
+
+export function stopTask(keys?: TaskKey | TaskKey[]) {
+  const stopKeys = Array<TaskKey>().concat(keys ?? [...tasks.keys()]);
+  for (const key of stopKeys) {
+    clearTimeout(tasks.get(key)?.debounce.timeout);
+    tasks.delete(key);
+    for (const [folder, fw] of fsWatches) {
+      if (fw.keys.delete(key) && fw.keys.size === 0) {
+        fw.watcher.close();
+        fsWatches.delete(folder);
+      }
+    }
+  }
+}
+
+export function taskOk(ctx?: Context): boolean {
+  const all = [...tasks.values()].filter(w => (ctx ? w.ctx === ctx : true));
+  return all.filter(w => !w.monitorOnly).length > 0 && all.every(w => w.status === 'ok');
+}
+
+export async function watchGlob({ cwd, path: globPath }: CwdPath, key: TaskKey): Promise<any> {
+  if (!(await isFolder(cwd))) return;
+  const [head, ...tail] = globPath.split(p.sep);
+  const path = tail.join(p.sep);
+
+  if (head.includes('**')) {
+    await subfolders(cwd, 10).then(folders => folders.forEach(f => addFsWatch(f, key)));
+  } else if (/[*?!{}[\]()]/.test(head) && path) {
+    await subfolders(cwd, 1).then(folders =>
+      Promise.all(
+        folders.filter(f => mm.isMatch(p.basename(f), head)).map(f => watchGlob({ cwd: f, path }, key)),
+      ),
+    );
+  } else if (path) {
+    return watchGlob({ cwd: p.join(cwd, head), path }, key);
+  }
+  addFsWatch(cwd, key);
+}
+
+async function onFsChange(fsw: FSWatch, event: string, filename: string | null) {
+  const fullpath = p.join(fsw.cwd, filename ?? '');
+
+  if (event === 'change') fileTimes.set(fullpath, await cachedFileTime(fullpath, true));
+  for (const watch of [...fsw.keys].map(k => tasks.get(k)!)) {
+    const fullglobs = watch.glob.map(({ cwd, path }) => p.join(cwd, path));
+    if (!mm.isMatch(fullpath, fullglobs)) {
+      if (event === 'change') continue;
+      try {
+        if (!(await fs.promises.stat(fullpath)).isDirectory()) continue;
+      } catch {
+        fsWatches.get(fullpath)?.watcher.close();
+        fsWatches.delete(fullpath);
+        continue;
+      }
+      addFsWatch(fullpath, watch.key);
+      if (!(await glob(fullglobs, { cwd: undefined, absolute: true })).some(x => x.includes(fullpath)))
+        continue;
+    }
+    if (event === 'rename') watch.debounce.rename = true;
+    if (event === 'change') watch.debounce.files.add(fullpath);
+    clearTimeout(watch.debounce.timeout);
+    watch.debounce.timeout = setTimeout(() => execute(watch), watch.debounce.time);
+  }
+}
+
+async function execute(watch: Task): Promise<void> {
+  const relative = (files: AbsPath[]) => (watch.root ? files.map(f => p.relative(watch.root!, f)) : files);
+  const debounced = Object.freeze([...watch.debounce.files]);
+  const modified: AbsPath[] = [];
+  watch.debounce.files.clear();
+
+  if (watch.debounce.rename) {
+    watch.debounce.rename = false;
+    const files = await globTimes(watch.glob);
+    const keys = [...files.keys()];
+    if (
+      watch.globListOnly &&
+      (watch.fileTimes.size !== files.size || !keys.every(f => watch.fileTimes.has(f)))
+    ) {
+      modified.push(...keys);
+    } else if (!watch.globListOnly) {
+      for (const [fullpath, time] of [...files]) {
+        if (watch.fileTimes.get(fullpath) !== time) modified.push(fullpath);
+      }
+    }
+    watch.fileTimes = files;
+  } else if (!watch.globListOnly) {
+    await Promise.all(
+      debounced.map(async file => {
+        const fileTime = await cachedFileTime(file);
+        if (watch.fileTimes.get(file) === fileTime) return;
+        watch.fileTimes.set(file, fileTime);
+        modified.push(file);
+      }),
+    );
+  }
+  if (!modified.length) return;
+
+  if (watch.ctx) env.begin(watch.ctx);
+  watch.status = undefined;
+  try {
+    await watch.execute(relative(modified), relative([...watch.fileTimes.keys()]));
+    watch.status = 'ok';
+    if (watch.ctx && !watch.noEnvStatus && taskOk(watch.ctx)) env.done(watch.ctx);
+  } catch (e) {
+    watch.status = 'error';
+    const message = e instanceof Error ? (e.stack ?? e.message) : String(e);
+    if (!env.watch) env.exit(`${errorMark} ${message}`, watch.ctx);
+    else if (e)
+      env.log(`${errorMark} ${watch.pkg ? `[${c.grey(watch.pkg)}] ` : ''}- ${c.grey(message)}`, watch.ctx);
+    if (watch.ctx && !watch.noEnvStatus) env.done(watch.ctx, -1);
+  }
+}
+
+function addFsWatch(root: AbsPath, key: TaskKey) {
+  if (fsWatches.has(root)) {
+    fsWatches.get(root)?.keys.add(key);
+    return;
+  }
+  const fsWatch = { watcher: fs.watch(root), cwd: root, keys: new Set([key]) };
+  fsWatch.watcher.on('change', (event, f) => onFsChange(fsWatch, event, String(f)));
+  fsWatches.set(root, fsWatch);
+}
+
+async function cachedFileTime(file: AbsPath, update = false): Promise<number> {
+  if (fileTimes.has(file) && !update) return fileTimes.get(file)!;
+  const stat = (await fs.promises.stat(file)).mtimeMs;
+  fileTimes.set(file, stat);
+  return stat;
+}
+
+async function globTimes(paths: CwdPath[]): Promise<Map<AbsPath, number>> {
+  const globs = paths.map(({ path, cwd }) => fg.glob(path, { cwd, absolute: true }));
+  return new Map(
+    await Promise.all(
+      (await Promise.all(globs)).flat().map(async f => [f, await cachedFileTime(f)] as [string, number]),
+    ),
+  );
+}

--- a/ui/.build/src/tsc.ts
+++ b/ui/.build/src/tsc.ts
@@ -1,25 +1,25 @@
 import fs from 'node:fs';
 import os from 'node:os';
-import path from 'node:path';
+import p from 'node:path';
 import ts from 'typescript';
+import fg from 'fast-glob';
 import { Worker } from 'node:worker_threads';
 import { env, c, errorMark } from './env.ts';
-import { globArray, folderSize, readable } from './parse.ts';
+import { folderSize, readable } from './parse.ts';
 import { clamp } from './algo.ts';
-import type { WorkerData, Message } from './tscWorker.ts';
+import type { WorkerData, Message, ErrorMessage } from './tscWorker.ts';
 
 const workers: Worker[] = [];
+const spamGuard = new Map<string, number>(); // dedup tsc errors
 
 export async function tsc(): Promise<void> {
-  if (!env.tsc) return;
-  env.exitCode.delete('tsc');
-
+  if (!env.begin('tsc')) return;
   await Promise.allSettled([
-    fs.promises.mkdir(path.join(env.buildTempDir, 'noCheck')),
-    fs.promises.mkdir(path.join(env.buildTempDir, 'noEmit')),
+    fs.promises.mkdir(p.join(env.buildTempDir, 'noCheck')),
+    fs.promises.mkdir(p.join(env.buildTempDir, 'noEmit')),
   ]);
 
-  const buildPaths = (await globArray('*/tsconfig*.json', { cwd: env.uiDir }))
+  const buildPaths = (await fg.glob('*/tsconfig*.json', { cwd: env.uiDir, absolute: true }))
     .sort((a, b) => a.localeCompare(b)) // repeatable build order
     .filter(x => env.building.some(pkg => x.startsWith(`${pkg.root}/`)));
 
@@ -39,19 +39,19 @@ export async function tsc(): Promise<void> {
       )
       .push(cfg);
 
-  tscLog(`Typing ${c.grey('noCheck')} (${workBuckets.noCheck.length} workers)`);
+  tscLog(`Typing ${c.grey('--noCheck')} (${workBuckets.noCheck.length} workers)`);
   await assignWork(workBuckets.noCheck, 'noCheck');
 
-  tscLog(`Typechecking ${c.grey('noEmit')} (${workBuckets.noEmit.length} workers)`);
+  tscLog(`Checking ${c.grey('--noEmit')} (${workBuckets.noEmit.length} workers)`);
   await assignWork(workBuckets.noEmit, 'noEmit');
 }
 
-export async function stopTscWatch(): Promise<void> {
+export async function stopTsc(): Promise<void> {
   await Promise.allSettled(workers.map(w => w.terminate()));
   workers.length = 0;
 }
 
-function assignWork(buckets: SplitConfig[][], key: 'noCheck' | 'noEmit') {
+function assignWork(buckets: SplitConfig[][], key: 'noCheck' | 'noEmit'): Promise<void> {
   let resolve: (() => void) | undefined = undefined;
   const status: ('ok' | 'busy' | 'error')[] = [];
   const ok = new Promise<void>(res => (resolve = res));
@@ -62,11 +62,11 @@ function assignWork(buckets: SplitConfig[][], key: 'noCheck' | 'noEmit') {
 
     status[msg.index] = msg.type;
 
-    if (msg.type === 'error') return tscError(msg);
+    if (msg.type === 'error') return tscError(msg.data);
     if (status.some(s => s !== 'ok')) return;
 
     resolve?.();
-    if (key === 'noEmit' && env.exitCode.get('tsc') !== 0) env.done(0, 'tsc'); // TODO - no more exitCode
+    if (key === 'noEmit') env.done('tsc');
   };
 
   for (const bucket of buckets) {
@@ -76,7 +76,7 @@ function assignWork(buckets: SplitConfig[][], key: 'noCheck' | 'noEmit') {
       index: status.length,
     };
     status.push('busy');
-    const worker = new Worker(path.resolve(env.buildSrcDir, 'tscWorker.ts'), { workerData });
+    const worker = new Worker(p.resolve(env.buildSrcDir, 'tscWorker.ts'), { workerData });
     workers.push(worker);
     worker.on('message', onMessage);
     worker.on('error', onError);
@@ -97,14 +97,14 @@ interface SplitConfig {
 }
 
 async function splitConfig(cfgPath: string): Promise<SplitConfig[]> {
-  const root = path.dirname(cfgPath);
-  const pkgName = path.basename(root);
+  const root = p.dirname(cfgPath);
+  const pkgName = p.basename(root);
   const { config, error } = ts.readConfigFile(cfgPath, ts.sys.readFile);
   const io: Promise<any>[] = [];
 
   if (error) throw new Error(`'${cfgPath}': ${error.messageText}`);
 
-  const co: any = ts.parseJsonConfigFileContent(config, ts.sys, path.dirname(cfgPath)).options;
+  const co: any = ts.parseJsonConfigFileContent(config, ts.sys, p.dirname(cfgPath)).options;
 
   if (co.moduleResolution) co.moduleResolution = ts.ModuleResolutionKind[co.moduleResolution];
   if (co.module) co.module = ts.ModuleKind[co.module];
@@ -114,32 +114,26 @@ async function splitConfig(cfgPath: string): Promise<SplitConfig[]> {
   co.incremental = true;
 
   config.compilerOptions = co;
-  config.size = await folderSize(path.join(root, 'src'));
-  config.include = config.include?.map((glob: string) =>
-    path.resolve(root, glob.replace('${configDir}', '.')),
-  );
+  config.size = await folderSize(p.join(root, 'src'));
+  config.include = config.include?.map((glob: string) => p.resolve(root, glob.replace('${configDir}', '.')));
   config.include ??= [co.rootDir ? `${co.rootDir}/**/*` : `${root}/src/**/*`];
   config.exclude = config.exclude
     ?.filter((glob: string) => !env.test || !glob.includes('tests'))
-    .map((glob: string) => path.resolve(root, glob.replace('${configDir}', '.')));
+    .map((glob: string) => p.resolve(root, glob.replace('${configDir}', '.')));
   config.extends = undefined;
   config.references = env.workspaceDeps
     .get(pkgName)
-    ?.map(ref => ({ path: path.join(env.buildTempDir, 'noCheck', `${ref}.tsconfig.json`) }));
+    ?.map(ref => ({ path: p.join(env.buildTempDir, 'noCheck', `${ref}.tsconfig.json`) }));
 
   const noEmitData = structuredClone(config);
-  const noEmit = path.join(env.buildTempDir, 'noEmit', `${pkgName}.tsconfig.json`);
+  const noEmit = p.join(env.buildTempDir, 'noEmit', `${pkgName}.tsconfig.json`);
   noEmitData.compilerOptions.noEmit = true;
-  noEmitData.compilerOptions.tsBuildInfoFile = path.join(
-    env.buildTempDir,
-    'noEmit',
-    `${pkgName}.tsbuildinfo`,
-  );
-  if (env.test && (await readable(path.join(root, 'tests')))) {
-    noEmitData.include.push(path.join(root, 'tests'));
+  noEmitData.compilerOptions.tsBuildInfoFile = p.join(env.buildTempDir, 'noEmit', `${pkgName}.tsbuildinfo`);
+  if (env.test && (await readable(p.join(root, 'tests')))) {
+    noEmitData.include.push(p.join(root, 'tests'));
     noEmitData.compilerOptions.rootDir = root;
     noEmitData.compilerOptions.skipLibCheck = true;
-    noEmitData.size += await folderSize(path.join(root, 'tests'));
+    noEmitData.size += await folderSize(p.join(root, 'tests'));
   }
   io.push(fs.promises.writeFile(noEmit, JSON.stringify(noEmitData, undefined, 2)));
 
@@ -147,10 +141,10 @@ async function splitConfig(cfgPath: string): Promise<SplitConfig[]> {
 
   if (!co.noEmit) {
     const noCheckData = structuredClone(config);
-    const noCheck = path.join(env.buildTempDir, 'noCheck', `${pkgName}.tsconfig.json`);
+    const noCheck = p.join(env.buildTempDir, 'noCheck', `${pkgName}.tsconfig.json`);
     noCheckData.compilerOptions.noCheck = true;
     noCheckData.compilerOptions.emitDeclarationOnly = true;
-    noCheckData.compilerOptions.tsBuildInfoFile = path.join(
+    noCheckData.compilerOptions.tsBuildInfoFile = p.join(
       env.buildTempDir,
       'noCheck',
       `${pkgName}.tsbuildinfo`,
@@ -163,19 +157,22 @@ async function splitConfig(cfgPath: string): Promise<SplitConfig[]> {
 }
 
 function tscLog(msg: string): void {
-  env.log(msg, { ctx: 'tsc' });
+  env.log(msg, 'tsc');
 }
 
-function tscError(msg: Message): void {
-  const { code, text, file, line, col } = msg.data;
-  const prelude = `${errorMark} ts${code} `;
-  const message = `${ts.flattenDiagnosticMessageText(text, '\n', 0)}`;
-  let location = '';
-  if (file) {
-    location = `${c.grey('in')} '${c.cyan(path.relative(env.uiDir, file))}`;
-    if (line !== undefined) location += c.grey(`:${line + 1}:${col + 1}`);
-    location += `' - `;
+function tscError({ code, text, file, line, col }: ErrorMessage['data']): void {
+  const key = `${code}:${text}:${file}`;
+  if (performance.now() > (spamGuard.get(key) ?? -Infinity)) {
+    const prelude = `${errorMark} ts${code} `;
+    const message = `${ts.flattenDiagnosticMessageText(text, '\n', 0)}`;
+    let location = '';
+    if (file) {
+      location = `${c.grey('in')} '${c.cyan(p.relative(env.uiDir, file))}`;
+      if (line !== undefined) location += c.grey(`:${line + 1}:${col + 1}`);
+      location += `' - `;
+    }
+    tscLog(`${prelude}${location}${message}`);
   }
-  tscLog(`${prelude}${location}${message}`);
-  if (!env.exitCode.get('tsc')) env.done(1, 'tsc'); // TODO - no more exitCode
+  spamGuard.set(key, performance.now() + 1000);
+  env.done('tsc', code);
 }

--- a/ui/.build/tsconfig.json
+++ b/ui/.build/tsconfig.json
@@ -10,10 +10,10 @@
     "strict": true,
     "esModuleInterop": true,
     "isolatedModules": true,
-    "moduleResolution": "Node",
-    "module": "ES2022",
-    "target": "ES2022",
-    "lib": ["ES2022"],
+    "moduleResolution": "node",
+    "module": "es2022",
+    "target": "es2023",
+    "lib": ["es2023"],
     "types": ["node"]
   }
 }

--- a/ui/README.md
+++ b/ui/README.md
@@ -1,24 +1,35 @@
-# Getting Started
+# Building the client
 
-Client assets are built with the [/ui/build](./build) script.
+Use the [/ui/build](./build) script.
 
 ```bash
 ui/build --help
 ```
 
-You can usually start up `ui/build -wc` and leave it running. This performs a clean build and continuously rebuilds source files when changes are detected. Keep an eye on stdout for build errors. On success, reload the browser page for the results.
+You can start up `ui/build -w` in watch mode to continuously rebuild when changes are detected. Keep an eye on stdout for build errors. On success, reload the browser page for the results.
 
-# UI packages
+# About packages
 
-A package.json file describes the hierarchy of source files, dependencies, and build steps for each folder in the /ui pnpm monorepo.
+Our client source code is arranged as a pnpm monorepo workspace described by [/pnpm-workspace.yaml](../pnpm-workspace.yaml). A separate package.json file describes source files, dependencies, and build steps for each ui package.
 
-We must tell tsc how to resolve static workspace imports from external sources back to declaration (\*.d.ts) files in the imported package's dist folder. When a single declaration barrel describes all package types, we use the "types" property as shown in this example from [/ui/voice/package.json](./voice/package.json):
+One workspace package (such as /ui/analyse) may depend on another (such as /ui/common) using a "dependencies" property keyed by the package name with "workspace:\*" as the version. That tells [pnpm](https://pnpm.io) and our build script that the dependency should be resolved by [/pnpm-workspace.yaml](../pnpm-workspace.yaml) (spoiler - it's in ui/common).
+
+```json
+  "dependencies": {
+    "common": "workspace:*"
+  }
+```
+
+We do not use devDependencies because no package artifacts are published to npm. There is no useful distinction between dependencies and devDependencies when we're always building assets for the lila server.
+
+## tsc import resolution
+tsc type checking uses package.json properties to resolve static import declarations in external sources to the correct declaration (\*.d.ts) files in the imported package. When a single declaration barrel describes all package types, we use the "types" property as shown in this example from [/ui/voice/package.json](./voice/package.json):
 
 ```json
   "types": "dist/voice.d.ts",
 ```
 
-When more granular access to a package is needed, we use the "typesVersion" property to expose selective imports within the dist folder to tsc along with an optional "typings" property to identify any main barrel within that "typesVersion" mapping.
+When more granular access to the imported package is needed, we use the "typesVersion" property to expose selective imports within the dist folder along with an optional "typings" property to identify a main barrel within the "typesVersion" mapping.
 
 ```json
   "typings": "common",
@@ -31,16 +42,17 @@ When more granular access to a package is needed, we use the "typesVersion" prop
   },
 ```
 
-The [esbuild bundler](https://esbuild.github.io/getting-started/#your-first-bundle) works in tandem with tsc on typescript sources but resolves imports differently. It reads an "exports" object to resolve static workspace imports from other packages directly to the imported package's typescript source files.
+## esbuild import resolution
+The [esbuild bundler](https://esbuild.github.io/getting-started/#your-first-bundle) does things a bit differently. It uses an "exports" object to resolve static workspace imports from other packages directly to the imported package's typescript source files. Declaration (*.d.ts) files are not used.
 
-For example, imports of common package code from a dependent package like this example from [/ui/opening/src/opening.ts](./opening/src/opening.ts):
+In this example from [/ui/opening/src/opening.ts](./opening/src/opening.ts):
 
 ```typescript
 import { initMiniBoards } from 'common/miniBoard';
 import { requestIdleCallback } from 'common';
 ```
 
-Are mapped back to common/src by this snippet from [/ui/common/package.json](./common/package.json):
+The above 'common' and 'common/miniBoard' import declarations are mapped to the correct typescript sources by this snippet from [/ui/common/package.json](./common/package.json):
 
 ```json
   "exports": {
@@ -53,107 +65,88 @@ Are mapped back to common/src by this snippet from [/ui/common/package.json](./c
 
 While esbuild may bundle imported code directly into the entry point module, it may also split imported code into "common" chunk modules that are shared and imported by other workspace modules. This chunked approach is called code splitting and reduces the overall footprint of asset transfers over the wire and within the browser cache.
 
-Because the client is a monorepo consisting of many packages, it is necessary to express dependencies on another workspace package with a "dependencies" object property keyed by the package name with "workspace:\*" as the value. That tells [pnpm](https://pnpm.io) and ui/build that the dependency is a workspace package folder located directly within /ui.
+## "build" property (top-level in package.json)
 
-```json
-  "dependencies": {
-    "common": "workspace:*",
-    "some-npm-package": "^1.0.0",
-    "local-override-of-an-npm-package": "link:../local-override-of-an-npm-package"
-  },
-```
+We define a custom "build" property object to describe how [/ui/build](./build) generates assets for the website.
 
-We do not classify devDependencies because these workspace packages are not built and published to npm for others to use without building. There is no useful distinction between dependencies and devDependencies when we're always building static assets directly for lila.
+Properties within build come in three flavors - "bundle", "sync", and "hash". Each of these can have one or more entries containing pathnames or globs. For bundles, pathnames are resolved relative to the package folder. For sync and hash objects, paths that start with `/` are resolved relative to the git repo root. Otherwise, they are resolved relative to the package.
 
-## Build & Bundle
+## "bundle" property
+The "bundle" property tells esbuild which javascript modules should be created as named entry points. Most correspond to a server controller and scala module found in [/app](../app) and [/modules](../modules) respectively. These usually generate the html DOM on which the javascript operates.
 
-We define a custom, top-level "build" object to describe how [/ui/build](./build) generates assets for the website.
+Path elements within bundle may specify a glob pattern to match multiple module sources and bundle each into named javascript entry points.
+
+This excerpt from [/ui/analyse/package.json](./analyse/package.json) matches analyse.ts, analyse.nvui.ts, analyse.study.ts, analyse.study.topic.form.ts, and analyse.study.tour.ts from various places in the folder hierarchy within analyse/src:
 
 ```json
   "build": {
-```
-
-Understanding the mechanisms expressed by properties of the "build" object will help you create / edit packages and define how dependencies are managed.
-
-The "bundle" property tells esbuild which javascript modules should be created as named entry points. Most correspond to a server controller and scala module found in [/app](../app) and [/modules](../modules) respectively. These usually generate the html DOM on which the javascript operates.
-
-Path elements inside the "bundle" property are resolved relative to the folder where the package.json resides. A path may specify a glob pattern to match multiple module sources and bundle each into named javascript entry points.
-
-This example from [/ui/analyse/package.json](./analyse/package.json) matches analyse.ts, analyse.nvui.ts, analyse.study.ts, analyse.study.topic.form.ts, and analyse.study.tour.ts from various places in the folder hierarchy within analyse/src:
-
-```json
     "bundle": "src/**/analyse.*ts",
+    ...
+  }
 ```
 
-All bundled output is transpiled to esm modules in the /public/compiled folder. Filenames are composed with the module source basename, followed by an 8 char content hash, and ending with .js.
+Bundle outputs are produced by esbuild as javascript esm modules in the /public/compiled folder. Filenames are composed with the module source basename, followed by an 8 char content hash, and ending with .js.
 
-Multiple bundles specs may be given in an array, elements of which may be globs like above or bare paths as shown in this [/ui/site/package.json](./site/package.json) example:
+Bundles may also be described by objects containing a "module" path and an "inline" path. The "module" path serves the same purpose as a bare string - naming the source module for an entry point. The "inline" path identifies a special typescript source from which ui/build will emit javascript statements into a manifest.\*.json entry for the server.
+
+When that parent module is requested by a browser, the lila server injects those inline statements into a \<script> tag following the assembled DOM within the \<body> element. This allows blocking setup code to manipulate the DOM based on viewport calculations before rendering to avoid FOUC. This should be rare and globs are not supported here. [/ui/site/package.json](./site/package.json) shows an example:
 
 ```json
     "bundle": [
-      "src/site.lpvEmbed.ts",
-      "src/site.puzzleEmbed.ts",
-      "src/site.tvEmbed.ts",
-```
-
-A bundle may also be described with an object containing a "module" path and an "inline" path. The "module" value serves the same purpose as in the direct path examples above - naming the source module for an entry point. But the "inline" value identifies a secondary ts source from which ui/build will emit javascript statements into a manifest.\*.json entry for the parent module.
-
-When that parent module is requested by a browser, the lila server injects its inline statements into a \<script> tag following the assembled DOM within the \<body> element. This allows blocking setup code to manipulate the DOM based on viewport calculations before rendering. This should be done sparingly and globs are not supported here. The final object in [/ui/site/package.json](./site/package.json)'s bundle array shows a valid example:
-
-```json
+      "src/site.*Embed.ts",
       {
         "module": "src/site.ts",
         "inline": "src/site.inline.ts"
       }
+    ],
 ```
 
-## Sync
+Globs are not allowed for either path when using the "inline" property.
 
-The sync object describes filesystem copies performed by ui/build from the package folder to elsewhere in the lila repo. Sync property keys identify source assets and are resolved relative to the package folder. Sync property values locate the destination folder relative to repo root. You'll typically want to copy from the package folder to somewhere in /public which is why key and value paths are resolved with different roots. In watch mode, ui/build will copy assets to the destination folder whenever they change.
+## "sync" property
 
-A typical usage for sync is to copy elements from node_modules (an npm package dependency) to the /public/npm folder when an external package needs to be loaded dynamically, usually because it is too large to bundle. This example from [/ui/ceval/package.json](./ceval/package.json) copies stockfish wasms to /public/npm:
+The sync object describes filesystem copies performed by ui/build. Sync object properties map source asset globs (keys) to destination folders (values). In watch mode, ui/build will copy assets to the destination folder whenever they change.
+
+One usage for sync is to copy elements from node_modules (an npm package dependency) to the /public/npm folder where they can be fetched and imported dynamically, often because they are too large to bundle. This example from [/ui/ceval/package.json](./ceval/package.json) copies stockfish wasms to /public/npm:
 
 ```json
     "sync": {
-      "node_modules/*stockfish*/*.{js,wasm}": "public/npm"
+      "node_modules/*stockfish*/*.{js,wasm}": "/public/npm"
     },
 ```
 
-Sync is helpful when you must link a local version of an npm package using [pnpm link](https://github.com/lichess-org/lila/wiki/Lichess-UI-Development#customizing-linked-pnpm-modules) or a "link:..." version specifier in package.json. Isolating issues involving chessground, pgn-viewer, or third party dependencies will often require this. During `ui/build -w` watch, the sync element ensures that changes to locally linked packages are propagated through the build system to their destinations within the /public folder so they are visible on browser reloads.
+Sync watch is helpful when you must link a [local version of an npm package](https://github.com/lichess-org/lila/wiki/Lichess-UI-Development#customizing-linked-pnpm-modules). Issues involving chessground, pgn-viewer, or third party dependencies often require this. The sync element ensures that changes to locally linked packages are propagated through the build system to their destinations within the /public folder so they are visible on browser reloads.
 
-## Hash
+## "hash" property
 
-Web asset distribution involves the caching of URLs, and hashes provide a repeatable way to compute URLs as a function of a file's content. Our Content Delivery Network (CDN) takes advantage of URL/key uniqueness to store and deliver static assets via caching edge servers located around the world. Once the first request for a new URL triggers an initial response from the lichess server, subsequent delivery of that asset version to IPs in that region do not involve lichess. The CDN persists cache entries for up to a year, so responses from static URLs are effectively frozen in place barring manual intervention.
+Why hash? Web asset distribution involves frequent caching, and hashes provide a repeatable way to compute URLs as a function of a file's content. ui/build writes the hashes used to cache asset URLs to a manifest.\*.json file. The server uses this manifest to link content-hashed URLs for unique asset versions in every response. Between the client and server, our Content Delivery Network (CDN) caches static assets via edge servers located around the world. Once the first request for a unique URL triggers an initial response from the lichess server, subsequent requests for that same URL from that region do not involve the lichess data center. The CDN edge servers persist cache entries for up to a year, so responses for the same URL are frozen in time without manual intervention.
 
-ui/build calculates and writes all hashes used to determine asset URLs to a manifest.\*.json file. This file is used by the lila server to tell browsers what they need. Javascript and css assets built from lichess sources are hashed automatically, but the "build" / "hash" section within package.json describes assets that must be hashed separately. These include images, fonts, and packages of js & css from the npmjs repository that we don't compile but must be exposed through our content distribution strategy.
+ui/build automatically hashes compiled and bundled sources such as typescript and scss. For unmanaged assets, like images, fonts, and dynamically loaded npm repo files, you must use "build" / "hash" object entries.
 
-"build" / "hash" may contain a single entry or an array of entries. an entry may be a bare string glob or filename relative to /public. It may also be an object with a "glob" property (relative to /public) and an optional "update" filename property relative to /ui/\<package>. More on this below.
+Hash object entries identify files for which a symlink named with their content hash is created within /public/hashed. The symlink points back to the original file (somewhere in /public), ensuring that when the file's content changes on the filesystem, its corresponding symlink gets a new name. Asset URLs use the symlink rather than the base filename, allowing optimal CDN caching and distribution.
 
-ui/build computes a sha256 checksum of each matched asset's content and creates a symlink named with a hash from that checksum within /public/hashed. The symlink points back to the original file (somewhere in /public). When an asset's content changes on the filesystem, its corresponding symlink will get a new name. This changes the object's URL and forces our CDN to create a fresh cache entry that will propagate through their edge server caches in distribution. Once again, lila is kept informed by ui/build through entries it writes to manifest.\*.json.
+"build" / "hash" may contain a single entry or an array of entries. Entries may be bare string globs:
 
 ```json
     "hash": [
-      "lifat/background/montage*.webp",
-      "npm/*",
-      "javascripts/**",
-      "piece-css/*"
+      "/public/lifat/background/montage*.webp",
+      "/public/npm/*",
+      "/public/javascripts/**",
+      "/public/piece-css/*"
     ]
 ```
-
-Note that matched assets are hashed during manifest creation AFTER "sync" operations have completed for all packages. In the ceval/package.json example we saw where stockfish wasms are synced to /public/npm. Here in site/package.json, those synced stockfish wasms are subsequently matched by the npm/* glob and symlinked in /public/hashed for efficient distribution. 
-
-"build" / "hash" entires that provide a filename for the "update" property will first process the "glob" property, creating symlinks in /public/hashed (same as before). Afterwards, the "update" file is transformed with all occurrence of globbed sources replaced by their hashed symlinks. The updated file is then itself content-hashed, written to /public/hashed, and remapped from its original path in manifest.json. This is useful when an asset references other files by name and those references must be updated to reflect the hashed URLs. For example: [/ui/common/css/theme/font-face.css](./common/css/theme/font-face.css) is transformed via this hash entry from [/ui/common/package.json](./common/package.json):
+They may also be `{ "glob": "<pattern>", "update": "<package-relative-path>" }` objects. When these are processed, symlinks for globbed files are created in /public/hashed. Then all occurrence of those globbed filenames are replaced with their hashed symlinks within the "update" file's contents. The updated contents are also content-hashed and written to /public/hashed. This is useful when an asset references other files by name and those references must be updated to reflect the hashed URLs. For example: [/ui/common/css/theme/font-face.css](./common/css/theme/font-face.css) is transformed via this hash entry from [/ui/common/package.json](./common/package.json):
 
 ```json
     "hash": [
       {
-        "glob": "font/*.woff2",
+        "glob": "/public/font/*.woff2",
         "update": "css/theme/font-face.css"
       }
     ]
 ```
 
-And that's about it for package.json. The nodejs sources for ui/build script are in the [/ui/.build](./.build) folder. Have a glance if something goes wrong or you have questions beyond the scope of this readme.
+Note that "update" files must be package relative. And that's about it for package.json. The nodejs sources for ui/build script are in the [/ui/.build](./.build) folder.
 
 # Testing
 

--- a/ui/analyse/package.json
+++ b/ui/analyse/package.json
@@ -31,8 +31,8 @@
   "build": {
     "bundle": "src/**/analyse.*ts",
     "sync": {
-      "node_modules/@yaireo/tagify/dist/tagify.min.js": "public/npm",
-      "node_modules/sortablejs/modular/sortable.esm.js": "public/npm"
+      "node_modules/@yaireo/tagify/dist/tagify.min.js": "/public/npm",
+      "node_modules/sortablejs/modular/sortable.esm.js": "/public/npm"
     }
   }
 }

--- a/ui/bits/package.json
+++ b/ui/bits/package.json
@@ -51,8 +51,8 @@
       }
     ],
     "sync": {
-      "node_modules/cropperjs/dist/cropper.min.css": "public/npm",
-      "../../node_modules/chessground/dist/chessground.min.js": "public/npm"
+      "node_modules/cropperjs/dist/cropper.min.css": "/public/npm",
+      "/node_modules/chessground/dist/chessground.min.js": "/public/npm"
     }
   }
 }

--- a/ui/ceval/package.json
+++ b/ui/ceval/package.json
@@ -29,7 +29,7 @@
   },
   "build": {
     "sync": {
-      "node_modules/*stockfish*/*.{js,wasm}": "public/npm"
+      "node_modules/*stockfish*/*.{js,wasm}": "/public/npm"
     }
   }
 }

--- a/ui/common/package.json
+++ b/ui/common/package.json
@@ -25,7 +25,7 @@
   },
   "build": {
     "hash": {
-      "glob": "font/*.woff2",
+      "glob": "/public/font/*.woff2",
       "update": "css/theme/font-face.css"
     }
   }

--- a/ui/common/src/algo.ts
+++ b/ui/common/src/algo.ts
@@ -31,7 +31,7 @@ export function deepFreeze<T>(obj: T): T {
   return Object.freeze(obj);
 }
 
-// recursive comparison of enumerable primitives. complex properties get reference equality only
+// comparison of enumerable primitives. complex properties get reference equality only
 export function isEquivalent(a: any, b: any): boolean {
   if (a === b) return true;
   if (typeof a !== typeof b) return false;
@@ -41,10 +41,20 @@ export function isEquivalent(a: any, b: any): boolean {
   if (typeof a !== 'object') return false;
   const [aKeys, bKeys] = [Object.keys(a), Object.keys(b)];
   if (aKeys.length !== bKeys.length) return false;
-  for (const key of aKeys) {
-    if (!bKeys.includes(key) || !isEquivalent(a[key], b[key])) return false;
+  return aKeys.every(key => bKeys.includes(key) && isEquivalent(a[key], b[key]));
+}
+
+// true if a merge of sub into o would result in no change to o (structural containment)
+export function isContained(o: any, sub: any): boolean {
+  if (o === sub || sub === undefined) return true;
+  if (typeof o !== typeof sub) return false;
+  if (Array.isArray(o)) {
+    return Array.isArray(sub) && o.length === sub.length && o.every((x, i) => isEquivalent(x, sub[i]));
   }
-  return true;
+  if (typeof o !== 'object') return false;
+  const [aKeys, subKeys] = [Object.keys(o), Object.keys(sub)];
+  if (aKeys.length < subKeys.length) return false;
+  return subKeys.every(key => aKeys.includes(key) && isContained(o[key], sub[key]));
 }
 
 export function zip<T, U>(arr1: T[], arr2: U[]): [T, U][] {
@@ -72,4 +82,12 @@ export function shallowSort(obj: { [key: string]: any }): { [key: string]: any }
   const sorted: { [key: string]: any } = {};
   for (const key of Object.keys(obj).sort()) sorted[key] = obj[key];
   return sorted;
+}
+
+export function reduceWhitespace(text: string): string {
+  return text.trim().replace(/\s+/g, ' ');
+}
+
+export function trimLines(s: string): string[] {
+  return s.split(/[\n\r\f]+/).filter(x => x.trim());
 }

--- a/ui/common/tests/algo.test.ts
+++ b/ui/common/tests/algo.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, test } from 'vitest';
-import { trimAndConsolidateWhitespace } from '../src/parse';
+import { reduceWhitespace } from '../src/algo';
 
 describe('minify', () => {
   test('string', () => {
-    expect(trimAndConsolidateWhitespace('a       b')).toBe('a b');
-    expect(trimAndConsolidateWhitespace('tab\ttab')).toBe('tab tab');
+    expect(reduceWhitespace('a       b')).toBe('a b');
+    expect(reduceWhitespace('tab\ttab')).toBe('tab tab');
   });
   test('html', () => {
     const html = `
@@ -17,7 +17,7 @@ describe('minify', () => {
       </body>
       </html>
     `;
-    const minified = trimAndConsolidateWhitespace(html);
+    const minified = reduceWhitespace(html);
     expect(minified).toBe('<html> <head> <title>Test</title> </head> <body> <h1>Test</h1> </body> </html>');
   });
 });

--- a/ui/site/package.json
+++ b/ui/site/package.json
@@ -16,22 +16,20 @@
   },
   "build": {
     "bundle": [
-      "src/site.lpvEmbed.ts",
-      "src/site.puzzleEmbed.ts",
-      "src/site.tvEmbed.ts",
+      "src/site.*Embed.ts",
       {
         "module": "src/site.ts",
         "inline": "src/site.inline.ts"
       }
     ],
     "sync": {
-      "node_modules/dialog-polyfill/dist/dialog-polyfill.esm.js": "public/npm"
+      "node_modules/dialog-polyfill/dist/dialog-polyfill.esm.js": "/public/npm"
     },
     "hash": [
-      "lifat/background/montage*.webp",
-      "npm/*",
-      "javascripts/**",
-      "piece-css/*"
+      "/public/lifat/background/montage*.webp",
+      "/public/npm/*",
+      "/public/javascripts/**",
+      "/public/piece-css/*"
     ]
   }
 }

--- a/ui/voice/package.json
+++ b/ui/voice/package.json
@@ -24,10 +24,10 @@
       "src/move/voice.move.ts"
     ],
     "sync": {
-      "grammar/**": "public/compiled/grammar"
+      "grammar/**": "/public/compiled/grammar"
     },
     "hash": [
-      "compiled/grammar/*"
+      "/public/compiled/grammar/*"
     ]
   }
 }


### PR DESCRIPTION
- actually fail build when sync or hash steps error
- recover and log exceptions rather than crash
- improve logging (no more duplicate errors from tsc on common imports)
- MOAR colorz
- standardize path conventions in package.json build objects and logs - /rooted paths are repo relative otherwise package relative
- ditch the various haphazard watch logics in favor of a common task harness
- handle directory changes on watched globs (previously, the list of files being watched were frozen when the glob was first run)
- many watch related bugfixes