### PR TITLE
Prompting your preferred game format when challenged

### DIFF
--- a/app/controllers/Challenge.scala
+++ b/app/controllers/Challenge.scala
@@ -21,7 +21,6 @@ final class Challenge(env: Env) extends LilaController(env):
       .bindFromRequest()
       .fold(
         err => {
-          lila.log("challengePref").error(err.toString)
           Redirect(routes.Pref.form("privacy")).flashFailure(err.toString)
         },
         data =>

--- a/app/controllers/Challenge.scala
+++ b/app/controllers/Challenge.scala
@@ -20,11 +20,13 @@ final class Challenge(env: Env) extends LilaController(env):
     challengePref
       .bindFromRequest()
       .fold(
-        err => 
-          Redirect(routes.Pref.form("privacy")).flashFailure(err.toString),
+        err => {
+          lila.log("challengePref").error(err.toString)
+          Redirect(routes.Pref.form("privacy")).flashFailure(err.toString)
+        },
         data =>
           challengePrefApi
-            .upsertChallengePref(data, me.username.toString())
+            .upsert(data, me.username.toString())
             .inject(Redirect(routes.Pref.form("privacy")).flashSuccess)
       )
   }

--- a/app/mashup/UserInfo.scala
+++ b/app/mashup/UserInfo.scala
@@ -28,7 +28,7 @@ case class UserInfo(
     isStreamer: Boolean,
     isCoach: Boolean,
     insightVisible: Boolean,
-    challengePref: Option[ChallengePref],
+    challengePref: Option[ChallengePref]
 ):
   export trophies.ranks
   export nbs.crosstable
@@ -120,7 +120,7 @@ object UserInfo:
         streamerApi.isActualStreamer(user).mon(_.user.segment("streamer")),
         coachApi.isListedCoach(user).mon(_.user.segment("coach")),
         (user.count.rated >= 10).so(insightShare.grant(user)(using ctx.me)),
-        challengePrefApi.find(user.username.toString).mon(_.user.segment("challengePref")),
-      ).mapN(UserInfo(nbs, _, _, _, _, _, _, _, _, _, _, _, _,_, _))
+        challengePrefApi.find(user.username.toString).mon(_.user.segment("challengePref"))
+      ).mapN(UserInfo(nbs, _, _, _, _, _, _, _, _, _, _, _, _, _, _))
 
     def preloadTeams(info: UserInfo) = teamCache.lightCache.preloadMany(info.teamIds)

--- a/app/views/ui.scala
+++ b/app/views/ui.scala
@@ -83,7 +83,8 @@ val storm = lila.storm.ui.StormUi(helpers)
 
 val racer = lila.racer.ui.RacerUi(helpers)
 
-val challenge = lila.challenge.ui.ChallengeUi(helpers)
+val challenge     = lila.challenge.ui.ChallengeUi(helpers)
+val challengePref = lila.challenge.ui.ChallengePrefUi(helpers)(account.ui.AccountPage, env.mode)
 
 val dev = lila.web.ui.DevUi(helpers)(mod.ui.menu)
 

--- a/app/views/user/show/header.scala
+++ b/app/views/user/show/header.scala
@@ -6,6 +6,7 @@ import lila.app.mashup.UserInfo
 import lila.user.Plan.sinceDate
 import lila.user.PlayTime.*
 import lila.user.Profile.*
+import lila.challenge.ChallengePref
 
 object header:
 
@@ -128,7 +129,8 @@ object header:
                     u.light,
                     relation = social.relation,
                     followable = social.followable,
-                    blocked = social.blocked
+                    blocked = social.blocked,
+                    ChallengePref.getUrlAttr(info.challengePref)
                   )
                 ),
               a(

--- a/app/views/user/show/header.scala
+++ b/app/views/user/show/header.scala
@@ -130,7 +130,7 @@ object header:
                     relation = social.relation,
                     followable = social.followable,
                     blocked = social.blocked,
-                    ChallengePref.asEncodedUrlLAttr(info.challengePref)
+                    ChallengePref.asEncodedUrlAttr(info.challengePref)
                   )
                 ),
               a(

--- a/app/views/user/show/header.scala
+++ b/app/views/user/show/header.scala
@@ -130,7 +130,7 @@ object header:
                     relation = social.relation,
                     followable = social.followable,
                     blocked = social.blocked,
-                    ChallengePref.getUrlAttr(info.challengePref)
+                    ChallengePref.asEncodedUrlLAttr(info.challengePref)
                   )
                 ),
               a(

--- a/conf/routes
+++ b/conf/routes
@@ -499,6 +499,8 @@ POST  /challenge/$id<\w{8}>/cancel     controllers.Challenge.cancel(id: Challeng
 POST  /challenge/$id<\w{8}>/to-friend  controllers.Challenge.toFriend(id: ChallengeId)
 POST  /challenge/rematch-of/$id<\w{8}> controllers.Challenge.offerRematchForGame(id: GameId)
 POST  /challenge/update-preference     controllers.Challenge.updatePreference
+GET   /challenge/delete-preference     controllers.Challenge.deletePreference
+GET   /challenge/preference            controllers.Challenge.showPreference
 
 # Notify
 GET  /notify                           controllers.Notify.recent(page: Int ?= 1)

--- a/conf/routes
+++ b/conf/routes
@@ -498,6 +498,7 @@ POST  /challenge/$id<\w{8}>/decline    controllers.Challenge.decline(id: Challen
 POST  /challenge/$id<\w{8}>/cancel     controllers.Challenge.cancel(id: ChallengeId)
 POST  /challenge/$id<\w{8}>/to-friend  controllers.Challenge.toFriend(id: ChallengeId)
 POST  /challenge/rematch-of/$id<\w{8}> controllers.Challenge.offerRematchForGame(id: GameId)
+POST  /challenge/update-preference     controllers.Challenge.updatePreference
 
 # Notify
 GET  /notify                           controllers.Notify.recent(page: Int ?= 1)

--- a/modules/challenge/src/main/ChallengePref.scala
+++ b/modules/challenge/src/main/ChallengePref.scala
@@ -11,13 +11,18 @@ import play.api.libs.json.JsValue
 import reactivemongo.api.bson.*
 
 case class ChallengePref(
+    gameType: String,
     variant: String,
     timeMode: String,
     gameMode: String,
     time: Int,
     increment: Int,
     days: Int,
-    fen: String
+    fen: String,
+    color: String,
+    ratingMin: Int,
+    ratingMax: Int,
+    aiLevel: Int,
 )
 
 object ChallengePref:
@@ -32,8 +37,8 @@ object ChallengePref:
       "fen"       -> o.fen
     )
 
-  def unapply(o: ChallengePref): Option[(String, String, String, Int, Int, Int, String)] = Some(
-    (o.variant, o.timeMode, o.gameMode, o.time, o.increment, o.days, o.fen)
+  def unapply(o: ChallengePref): Option[(String, String, String, String, Int, Int, Int, String, String, Int, Int, Int)] = Some(
+    (o.gameType, o.variant, o.timeMode, o.gameMode, o.time, o.increment, o.days, o.fen, o.color, o.ratingMin, o.ratingMax, o.aiLevel)
   )
 
   def asEncodedUrlAttr(pref: Option[ChallengePref]): String =
@@ -46,13 +51,18 @@ object ChallengePref:
 
 val challengePref = Form(
   mapping(
+    "gameType"  -> text,
     "variant"   -> text,
     "timeMode"  -> text,
     "gameMode"  -> text,
     "time"      -> number,
     "increment" -> number,
     "days"      -> number,
-    "fen"       -> text
+    "fen"       -> text,
+    "color"     -> text,
+    "ratingMin" -> number,
+    "ratingMax" -> number,
+    "aiLevel" -> number,
   )(ChallengePref.apply)(ChallengePref.unapply)
 )
 

--- a/modules/challenge/src/main/ChallengePref.scala
+++ b/modules/challenge/src/main/ChallengePref.scala
@@ -60,5 +60,5 @@ val challengePref = Form(
 )
 
 given BSONDocumentReader[ChallengePref] = Macros.reader
-
+given BSONDocumentWriter[ChallengePref] = Macros.writer
 

--- a/modules/challenge/src/main/ChallengePref.scala
+++ b/modules/challenge/src/main/ChallengePref.scala
@@ -1,0 +1,47 @@
+package lila.challenge
+
+import play.api.data.*
+import play.api.data.Forms.*
+
+import java.net.URLEncoder
+import play.api.libs.json.Json
+import play.api.libs.json.Writes
+import play.api.libs.json.JsValue
+
+case class ChallengePref(
+    variant: String,
+    timeMode: String,
+    gameMode: String,
+    time: Int,
+    increment: Int,
+    days: Int,
+    fen: String
+)
+
+object ChallengePref:
+  implicit val challengePrefWrites: Writes[ChallengePref] = new Writes[ChallengePref]:
+    def writes(o: ChallengePref): JsValue = Json.obj(
+      "variant"   -> o.variant,
+      "timeMode"  -> o.timeMode,
+      "gameMode"  -> o.gameMode,
+      "time"      -> o.time,
+      "increment" -> o.increment,
+      "days"      -> o.days,
+      "fen"       -> o.fen
+    )
+
+  def unapply(o: ChallengePref): Option[(String, String, String, Int, Int, Int, String)] = Some(
+    (o.variant, o.timeMode, o.gameMode, o.time, o.increment, o.days, o.fen)
+  )
+
+val challengePref = Form(
+  mapping(
+    "variant"   -> text,
+    "timeMode"   -> text,
+    "gameMode"  -> text,
+    "time"      -> number,
+    "increment" -> number,
+    "days"      -> number,
+    "fen"       -> text
+  )(ChallengePref.apply)(ChallengePref.unapply)
+)

--- a/modules/challenge/src/main/ChallengePref.scala
+++ b/modules/challenge/src/main/ChallengePref.scala
@@ -22,7 +22,7 @@ case class ChallengePref(
     color: String,
     ratingMin: Int,
     ratingMax: Int,
-    aiLevel: Int,
+    aiLevel: Int
 )
 
 object ChallengePref:
@@ -37,8 +37,23 @@ object ChallengePref:
       "fen"       -> o.fen
     )
 
-  def unapply(o: ChallengePref): Option[(String, String, String, String, Int, Int, Int, String, String, Int, Int, Int)] = Some(
-    (o.gameType, o.variant, o.timeMode, o.gameMode, o.time, o.increment, o.days, o.fen, o.color, o.ratingMin, o.ratingMax, o.aiLevel)
+  def unapply(
+      o: ChallengePref
+  ): Option[(String, String, String, String, Int, Int, Int, String, String, Int, Int, Int)] = Some(
+    (
+      o.gameType,
+      o.variant,
+      o.timeMode,
+      o.gameMode,
+      o.time,
+      o.increment,
+      o.days,
+      o.fen,
+      o.color,
+      o.ratingMin,
+      o.ratingMax,
+      o.aiLevel
+    )
   )
 
   def asEncodedUrlAttr(pref: Option[ChallengePref]): String =
@@ -62,7 +77,7 @@ val challengePref = Form(
     "color"     -> text,
     "ratingMin" -> number,
     "ratingMax" -> number,
-    "aiLevel" -> number,
+    "aiLevel"   -> number
   )(ChallengePref.apply)(ChallengePref.unapply)
 )
 

--- a/modules/challenge/src/main/ChallengePref.scala
+++ b/modules/challenge/src/main/ChallengePref.scala
@@ -36,12 +36,12 @@ object ChallengePref:
     (o.variant, o.timeMode, o.gameMode, o.time, o.increment, o.days, o.fen)
   )
 
-  def getUrlAttr(pref: Option[ChallengePref]): String =
+  def asEncodedUrlLAttr(pref: Option[ChallengePref]): String =
     pref match {
       case Some(obj) => {
         val jsonString = Json.stringify(Json.toJson(obj))
         val encoded    = URLEncoder.encode(jsonString, "UTF-8")
-        s"&preset=${encoded}"
+        s"&challenge-pref=${encoded}"
       }
       case None => ""
     }

--- a/modules/challenge/src/main/ChallengePref.scala
+++ b/modules/challenge/src/main/ChallengePref.scala
@@ -8,6 +8,8 @@ import play.api.libs.json.Json
 import play.api.libs.json.Writes
 import play.api.libs.json.JsValue
 
+import reactivemongo.api.bson.*
+
 case class ChallengePref(
     variant: String,
     timeMode: String,
@@ -34,6 +36,17 @@ object ChallengePref:
     (o.variant, o.timeMode, o.gameMode, o.time, o.increment, o.days, o.fen)
   )
 
+  def getUrlAttr(pref: Option[ChallengePref]): String =
+    pref match {
+      case Some(obj) => {
+        val jsonString = Json.stringify(Json.toJson(obj))
+        val encoded    = URLEncoder.encode(jsonString, "UTF-8")
+        s"&preset=${encoded}"
+      }
+      case None => ""
+    }
+
+
 val challengePref = Form(
   mapping(
     "variant"   -> text,
@@ -45,3 +58,7 @@ val challengePref = Form(
     "fen"       -> text
   )(ChallengePref.apply)(ChallengePref.unapply)
 )
+
+given BSONDocumentReader[ChallengePref] = Macros.reader
+
+

--- a/modules/challenge/src/main/ChallengePref.scala
+++ b/modules/challenge/src/main/ChallengePref.scala
@@ -36,21 +36,18 @@ object ChallengePref:
     (o.variant, o.timeMode, o.gameMode, o.time, o.increment, o.days, o.fen)
   )
 
-  def asEncodedUrlLAttr(pref: Option[ChallengePref]): String =
-    pref match {
-      case Some(obj) => {
+  def asEncodedUrlAttr(pref: Option[ChallengePref]): String =
+    pref match
+      case Some(obj) =>
         val jsonString = Json.stringify(Json.toJson(obj))
         val encoded    = URLEncoder.encode(jsonString, "UTF-8")
         s"&challenge-pref=${encoded}"
-      }
       case None => ""
-    }
-
 
 val challengePref = Form(
   mapping(
     "variant"   -> text,
-    "timeMode"   -> text,
+    "timeMode"  -> text,
     "gameMode"  -> text,
     "time"      -> number,
     "increment" -> number,
@@ -61,4 +58,3 @@ val challengePref = Form(
 
 given BSONDocumentReader[ChallengePref] = Macros.reader
 given BSONDocumentWriter[ChallengePref] = Macros.writer
-

--- a/modules/challenge/src/main/ChallengePrefApi.scala
+++ b/modules/challenge/src/main/ChallengePrefApi.scala
@@ -1,0 +1,27 @@
+package lila.challenge
+
+import reactivemongo.api.bson.*
+import lila.db.dsl.{ *, given }
+
+final class ChallengePrefApi(
+    colls: ChallengeColls
+)(using Executor):
+
+  private val coll = colls.challengePref
+
+  def upsertChallengePref(o: ChallengePref, userName: String)(using me: Me): Funit =
+    coll.update
+      .one(
+        $id(userName),
+        $doc(
+          "variant"   -> o.variant,
+          "timeMode"  -> o.timeMode,
+          "gameMode"  -> o.gameMode,
+          "time"      -> o.time,
+          "increment" -> o.increment,
+          "days"      -> o.days,
+          "fen"       -> o.fen
+        ),
+        upsert = true
+      )
+      .void

--- a/modules/challenge/src/main/ChallengePrefApi.scala
+++ b/modules/challenge/src/main/ChallengePrefApi.scala
@@ -13,15 +13,7 @@ final class ChallengePrefApi(
     coll.update
       .one(
         $id(userName),
-        $doc(
-          "variant"   -> o.variant,
-          "timeMode"  -> o.timeMode,
-          "gameMode"  -> o.gameMode,
-          "time"      -> o.time,
-          "increment" -> o.increment,
-          "days"      -> o.days,
-          "fen"       -> o.fen
-        ),
+        o,
         upsert = true
       )
       .void

--- a/modules/challenge/src/main/ChallengePrefApi.scala
+++ b/modules/challenge/src/main/ChallengePrefApi.scala
@@ -18,5 +18,8 @@ final class ChallengePrefApi(
       )
       .void
 
-  def find(userName: String): Fu[Option[ChallengePref]] = 
+  def find(userName: String): Fu[Option[ChallengePref]] =
     coll.find($id(userName)).one[ChallengePref]
+
+  def remove(userName: String): Funit =
+    coll.delete.one($id(userName)).void

--- a/modules/challenge/src/main/ChallengePrefApi.scala
+++ b/modules/challenge/src/main/ChallengePrefApi.scala
@@ -9,7 +9,7 @@ final class ChallengePrefApi(
 
   private val coll = colls.challengePref
 
-  def upsertChallengePref(o: ChallengePref, userName: String)(using me: Me): Funit =
+  def upsert(o: ChallengePref, userName: String): Funit =
     coll.update
       .one(
         $id(userName),
@@ -25,3 +25,6 @@ final class ChallengePrefApi(
         upsert = true
       )
       .void
+
+  def find(userName: String): Fu[Option[ChallengePref]] = 
+    coll.find($id(userName)).one[ChallengePref]

--- a/modules/challenge/src/main/Env.scala
+++ b/modules/challenge/src/main/Env.scala
@@ -63,6 +63,8 @@ final class Env(
 
   lazy val bulk = wire[ChallengeBulkApi]
 
+  lazy val challengePrefApi = wire[ChallengePrefApi]
+
   lazy val msg = wire[ChallengeMsg]
 
   lazy val keepAliveStream = wire[ChallengeKeepAliveStream]
@@ -79,5 +81,6 @@ final class Env(
     case lila.core.round.DeleteUnplayed(gameId) => api.removeByGameId(gameId)
 
 private class ChallengeColls(db: lila.db.Db):
-  val challenge = db(CollName("challenge"))
-  val bulk      = db(CollName("challenge_bulk"))
+  val challenge     = db(CollName("challenge"))
+  val bulk          = db(CollName("challenge_bulk"))
+  val challengePref = db(CollName("challenge_pref"))

--- a/modules/challenge/src/main/ui/ChallengePrefUI.scala
+++ b/modules/challenge/src/main/ui/ChallengePrefUI.scala
@@ -14,7 +14,8 @@ final class ChallengePrefUi(helpers: Helpers)(
   def show(challengePref: Option[ChallengePref], username: String)(using ctx: Context) =
     AccountPage("Challenge", "challenge"):
       val challengePrefAttr = ChallengePref.asEncodedUrlAttr(challengePref)
-      val challengeLink     = s"${routes.Lobby.home}?edit=true${challengePrefAttr}#friend"
+      val challengePrefEdit = s"${routes.Lobby.home}?edit=true${challengePrefAttr}#friend"
+      val challengeLink     = s"${routes.Lobby.home}?user=${username.toString}${challengePrefAttr}#friend"
 
       div(cls := "box box-pad")(
         div(cls := "box__top")(
@@ -23,22 +24,30 @@ final class ChallengePrefUi(helpers: Helpers)(
         standardFlash.map(div(cls := "box__pad")(_)),
         div(cls := "box__pad")(
           p(
+            "Setting your preferred challenge will set the 'Challenge to a game' dialog when friends challenge you."
+          ),
+          p(
             challengePref match
               case Some(_) => "You have set your preferred challenge."
               case None    => "You have NOT set your preferred challenge."
-          )
-        ),
-        div(cls := "box__pad")(
-          p(
-            "You can ",
-            a(href := challengeLink)("create or edit"),
-            " you preferred challenge by pretending you challenge yourself (click on a king to validate). "
           ),
-          p("It will be shown to the players who challenge you to a game."),
           p(
-            "You can ",
-            a(href := routes.Challenge.deletePreference)("remove it"),
-            " when you want. "
+            challengePref match
+              case Some(_) =>
+                p(
+                  "You can ",
+                  a(href := challengePrefEdit)("edit it"),
+                  " or ",
+                  a(href := routes.Challenge.deletePreference)("remove it"),
+                  ". You can also share this ",
+                  a(href := challengeLink)("link"),
+                  " to challenge you."
+                )
+              case None =>
+                p(
+                  "You can ",
+                  a(href := challengePrefEdit)("create it")
+                )
           )
         )
       )

--- a/modules/challenge/src/main/ui/ChallengePrefUI.scala
+++ b/modules/challenge/src/main/ui/ChallengePrefUI.scala
@@ -14,7 +14,7 @@ final class ChallengePrefUi(helpers: Helpers)(
   def show(challengePref: Option[ChallengePref], username: String)(using ctx: Context) =
     AccountPage("Challenge", "challenge"):
       val challengePrefAttr = ChallengePref.asEncodedUrlAttr(challengePref)
-      val challengeLink     = s"${routes.Lobby.home}?user=${username}${challengePrefAttr}#friend"
+      val challengeLink     = s"${routes.Lobby.home}?edit=true${challengePrefAttr}#friend"
 
       div(cls := "box box-pad")(
         div(cls := "box__top")(

--- a/modules/challenge/src/main/ui/ChallengePrefUI.scala
+++ b/modules/challenge/src/main/ui/ChallengePrefUI.scala
@@ -1,0 +1,44 @@
+package lila.challenge
+package ui
+
+import lila.ui.*
+
+import ScalatagsTemplate.{ *, given }
+
+final class ChallengePrefUi(helpers: Helpers)(
+    AccountPage: (String, String) => Context ?=> Page,
+    mode: play.api.Mode
+):
+  import helpers.{ *, given }
+
+  def show(challengePref: Option[ChallengePref], username: String)(using ctx: Context) =
+    AccountPage("Challenge", "challenge"):
+      val challengePrefAttr = ChallengePref.asEncodedUrlAttr(challengePref)
+      val challengeLink     = s"${routes.Lobby.home}?user=${username}${challengePrefAttr}#friend"
+
+      div(cls := "box box-pad")(
+        div(cls := "box__top")(
+          h1(RawFrag("Challenge"))
+        ),
+        standardFlash.map(div(cls := "box__pad")(_)),
+        div(cls := "box__pad")(
+          p(
+            challengePref match
+              case Some(_) => "You have set your preferred challenge."
+              case None    => "You have NOT set your preferred challenge."
+          )
+        ),
+        div(cls := "box__pad")(
+          p(
+            "You can ",
+            a(href := challengeLink)("create or edit"),
+            " you preferred challenge by pretending you challenge yourself (click on a king to validate). "
+          ),
+          p("It will be shown to the players who challenge you to a game."),
+          p(
+            "You can ",
+            a(href := routes.Challenge.deletePreference)("remove it"),
+            " when you want. "
+          )
+        )
+      )

--- a/modules/pref/src/main/ui/AccountUi.scala
+++ b/modules/pref/src/main/ui/AccountUi.scala
@@ -85,6 +85,9 @@ final class AccountUi(helpers: Helpers):
             a(activeCls(categ.slug), href := routes.Pref.form(categ.slug))(
               categName(categ)
             ),
+          a(activeCls("challenge"), href := routes.Challenge.showPreference)(
+            RawFrag("Challenge")
+          ),
           a(activeCls("notification"), href := routes.Pref.form("notification"))(
             trans.site.notifications()
           ),

--- a/modules/relation/src/main/ui/RelationUi.scala
+++ b/modules/relation/src/main/ui/RelationUi.scala
@@ -47,14 +47,15 @@ final class RelationUi(helpers: Helpers):
       user: lila.core.LightUser,
       relation: Option[Relation],
       followable: Boolean,
-      blocked: Boolean
+      blocked: Boolean,
+      challengePrefAttr: String = ""
   )(using ctx: Context) =
     val blocks = relation.contains(Relation.Block)
     div(cls := "relation-actions")(
       (ctx.isnt(user) && !blocked && !blocks).option(
         a(
           cls      := "text",
-          href     := s"${routes.Lobby.home}?user=${user.name}#friend",
+          href     := s"${routes.Lobby.home}?user=${user.name}${challengePrefAttr}#friend",
           dataIcon := Icon.Swords
         )(trans.challenge.challengeToPlay.txt())
       ),

--- a/ui/lobby/src/ctrl.ts
+++ b/ui/lobby/src/ctrl.ts
@@ -77,7 +77,7 @@ export default class LobbyController {
       const forceOptions: ForceSetupOptions = {};
       const urlParams = new URLSearchParams(location.search);
       const friendUser = urlParams.get('user') ?? undefined;
-      const friendOptionsEncoded = urlParams.get('preset') ?? undefined;
+      const friendOptionsEncoded = urlParams.get('challenge-pref') ?? undefined;
       const friendOptions = !!friendOptionsEncoded
         ? (JSON.parse(decodeURIComponent(friendOptionsEncoded)) as FriendSetupOptions)
         : undefined;

--- a/ui/lobby/src/ctrl.ts
+++ b/ui/lobby/src/ctrl.ts
@@ -115,7 +115,7 @@ export default class LobbyController {
           this.setupCtrl.openModalWithchallengePrefOptions(
             locationHash as Exclude<GameType, 'local'>,
             challengePrefOptions,
-            friendUser
+            friendUser,
           );
         else this.setupCtrl.openModal(locationHash as Exclude<GameType, 'local'>, forceOptions, friendUser);
         redraw();

--- a/ui/lobby/src/ctrl.ts
+++ b/ui/lobby/src/ctrl.ts
@@ -17,7 +17,7 @@ import type {
   PoolMember,
   GameType,
   ForceSetupOptions,
-  FriendSetupOptions,
+  challengePrefSetupOptions,
   LobbyMe,
 } from './interfaces';
 import LobbySocket from './socket';
@@ -77,9 +77,9 @@ export default class LobbyController {
       const forceOptions: ForceSetupOptions = {};
       const urlParams = new URLSearchParams(location.search);
       const friendUser = urlParams.get('user') ?? undefined;
-      const friendOptionsEncoded = urlParams.get('challenge-pref') ?? undefined;
-      const friendOptions = !!friendOptionsEncoded
-        ? (JSON.parse(decodeURIComponent(friendOptionsEncoded)) as FriendSetupOptions)
+      const challengePrefOptionsEncoded = urlParams.get('challenge-pref') ?? undefined;
+      const challengePrefOptions = !!challengePrefOptionsEncoded
+        ? (JSON.parse(decodeURIComponent(challengePrefOptionsEncoded)) as challengePrefSetupOptions)
         : undefined;
       const minutesPerSide = urlParams.get('minutesPerSide');
       const increment = urlParams.get('increment');
@@ -110,10 +110,10 @@ export default class LobbyController {
       }
 
       pubsub.after('dialog.polyfill').then(() => {
-        if (friendUser && friendOptions)
-          this.setupCtrl.openModalWithFriendOptions(
+        if (friendUser && challengePrefOptions)
+          this.setupCtrl.openModalWithchallengePrefOptions(
             locationHash as Exclude<GameType, 'local'>,
-            friendOptions,
+            challengePrefOptions,
             friendUser,
           );
         else this.setupCtrl.openModal(locationHash as Exclude<GameType, 'local'>, forceOptions, friendUser);

--- a/ui/lobby/src/ctrl.ts
+++ b/ui/lobby/src/ctrl.ts
@@ -17,6 +17,7 @@ import type {
   PoolMember,
   GameType,
   ForceSetupOptions,
+  FriendSetupOptions,
   LobbyMe,
 } from './interfaces';
 import LobbySocket from './socket';
@@ -76,6 +77,10 @@ export default class LobbyController {
       const forceOptions: ForceSetupOptions = {};
       const urlParams = new URLSearchParams(location.search);
       const friendUser = urlParams.get('user') ?? undefined;
+      const friendOptionsEncoded = urlParams.get('preset') ?? undefined;
+      const friendOptions = !!friendOptionsEncoded
+        ? (JSON.parse(decodeURIComponent(friendOptionsEncoded)) as FriendSetupOptions)
+        : undefined;
       const minutesPerSide = urlParams.get('minutesPerSide');
       const increment = urlParams.get('increment');
       const variant = urlParams.get('variant');
@@ -105,7 +110,13 @@ export default class LobbyController {
       }
 
       pubsub.after('dialog.polyfill').then(() => {
-        this.setupCtrl.openModal(locationHash as Exclude<GameType, 'local'>, forceOptions, friendUser);
+        if (friendUser && friendOptions)
+          this.setupCtrl.openModalWithFriendOptions(
+            locationHash as Exclude<GameType, 'local'>,
+            friendOptions,
+            friendUser,
+          );
+        else this.setupCtrl.openModal(locationHash as Exclude<GameType, 'local'>, forceOptions, friendUser);
         redraw();
       });
       history.replaceState(null, '', '/');

--- a/ui/lobby/src/ctrl.ts
+++ b/ui/lobby/src/ctrl.ts
@@ -77,6 +77,7 @@ export default class LobbyController {
       const forceOptions: ForceSetupOptions = {};
       const urlParams = new URLSearchParams(location.search);
       const friendUser = urlParams.get('user') ?? undefined;
+      this.setupCtrl.isEditingPreference = (urlParams.get('edit') ?? undefined) === undefined ? false : true;
       const challengePrefOptionsEncoded = urlParams.get('challenge-pref') ?? undefined;
       const challengePrefOptions = !!challengePrefOptionsEncoded
         ? (JSON.parse(decodeURIComponent(challengePrefOptionsEncoded)) as challengePrefSetupOptions)
@@ -110,11 +111,11 @@ export default class LobbyController {
       }
 
       pubsub.after('dialog.polyfill').then(() => {
-        if (friendUser && challengePrefOptions)
+        if (challengePrefOptions)
           this.setupCtrl.openModalWithchallengePrefOptions(
             locationHash as Exclude<GameType, 'local'>,
             challengePrefOptions,
-            friendUser,
+            friendUser
           );
         else this.setupCtrl.openModal(locationHash as Exclude<GameType, 'local'>, forceOptions, friendUser);
         redraw();

--- a/ui/lobby/src/interfaces.ts
+++ b/ui/lobby/src/interfaces.ts
@@ -142,6 +142,7 @@ export interface ForceSetupOptions {
 }
 
 export interface challengePrefSetupOptions {
+  gameType: GameType;
   variant: VariantKey;
   timeMode: TimeMode;
   gameMode: GameMode;
@@ -150,4 +151,7 @@ export interface challengePrefSetupOptions {
   days: number;
   fen: string;
   color: Color;
+  ratingMin: number;
+  ratingMax: number;
+  aiLevel: number;
 }

--- a/ui/lobby/src/interfaces.ts
+++ b/ui/lobby/src/interfaces.ts
@@ -145,8 +145,9 @@ export interface FriendSetupOptions {
   variant: VariantKey;
   timeMode: TimeMode;
   gameMode: GameMode;
-  time?: number;
-  increment?: number;
-  days?: number;
-  fen?: string;
+  time: number;
+  increment: number;
+  days: number;
+  fen: string;
+  color: Color;
 }

--- a/ui/lobby/src/interfaces.ts
+++ b/ui/lobby/src/interfaces.ts
@@ -140,3 +140,13 @@ export interface ForceSetupOptions {
   time?: number;
   increment?: number;
 }
+
+export interface FriendSetupOptions {
+  variant: VariantKey;
+  timeMode: TimeMode;
+  gameMode: GameMode;
+  time?: number;
+  increment?: number;
+  days?: number;
+  fen?: string;
+}

--- a/ui/lobby/src/interfaces.ts
+++ b/ui/lobby/src/interfaces.ts
@@ -141,7 +141,7 @@ export interface ForceSetupOptions {
   increment?: number;
 }
 
-export interface FriendSetupOptions {
+export interface challengePrefSetupOptions {
   variant: VariantKey;
   timeMode: TimeMode;
   gameMode: GameMode;

--- a/ui/lobby/src/setupCtrl.ts
+++ b/ui/lobby/src/setupCtrl.ts
@@ -224,9 +224,9 @@ export default class SetupController {
     );
     this.daysV = this.propWithApply(sliderInitVal(friendOptions?.days || 1, daysVToDays, this.maxDaysV)!);
     this.gameMode = this.propWithApply(friendOptions.gameMode);
-    this.ratingMin = this.propWithApply(0);
-    this.ratingMax = this.propWithApply(0);
-    this.aiLevel = this.propWithApply(0);
+    this.ratingMin = this.propWithApply(1);
+    this.ratingMax = this.propWithApply(-300);
+    this.aiLevel = this.propWithApply(+300);
   };
 
   closeModal?: () => void; // managed by view/setup/modal.ts

--- a/ui/lobby/src/setupCtrl.ts
+++ b/ui/lobby/src/setupCtrl.ts
@@ -43,6 +43,7 @@ export default class SetupController {
   friendUser = '';
   loading = false;
   blindModeColor: Prop<Color | 'random'>;
+  isEditingPreference = false;
 
   // Store props
   variant: Prop<VariantKey>;
@@ -212,7 +213,7 @@ export default class SetupController {
   openModalWithchallengePrefOptions = (
     gameType: Exclude<GameType, 'local'>,
     challengePrefOptions: challengePrefSetupOptions,
-    friendUser: string,
+    friendUser?: string,
   ) => {
     this.openModal(gameType, undefined, friendUser, false);
     this.variant = propWithEffect(challengePrefOptions.variant, this.onDropdownChange);
@@ -346,9 +347,9 @@ export default class SetupController {
     this.root.redraw();
 
     let urlPath =
-      this.root.me?.username === this.friendUser ? '/challenge/update-preference' : `/setup/${this.gameType}`;
+      this.isEditingPreference ? '/challenge/update-preference' : `/setup/${this.gameType}`;
     let formData =
-      this.root.me?.username === this.friendUser
+      this.isEditingPreference
         ? this.challengePrefSetupOptionsToFormData(color)
         : this.propsToFormData(color);
     if (this.gameType === 'hook') urlPath += `/${site.sri}`;

--- a/ui/lobby/src/setupCtrl.ts
+++ b/ui/lobby/src/setupCtrl.ts
@@ -217,12 +217,12 @@ export default class SetupController {
     this.openModal(gameType, undefined, friendUser, false);
     this.variant = propWithEffect(friendOptions.variant, this.onDropdownChange);
     this.fen = this.propWithApply(friendOptions?.fen || '');
-    this.timeMode = propWithEffect(friendOptions?.timeMode || 0, this.onDropdownChange);
+    this.timeMode = propWithEffect(friendOptions?.timeMode || '', this.onDropdownChange);
     this.timeV = this.propWithApply(sliderInitVal(friendOptions?.time || 0, timeVToTime, this.maxTimeV)!);
     this.incrementV = this.propWithApply(
       sliderInitVal(friendOptions?.increment || 0, incrementVToIncrement, this.maxIncrementV)!,
     );
-    this.daysV = this.propWithApply(sliderInitVal(friendOptions?.days || 0, daysVToDays, this.maxDaysV)!);
+    this.daysV = this.propWithApply(sliderInitVal(friendOptions?.days || 1, daysVToDays, this.maxDaysV)!);
     this.gameMode = this.propWithApply(friendOptions.gameMode);
     this.ratingMin = this.propWithApply(0);
     this.ratingMax = this.propWithApply(0);

--- a/ui/lobby/src/setupCtrl.ts
+++ b/ui/lobby/src/setupCtrl.ts
@@ -308,6 +308,18 @@ export default class SetupController {
       color,
     });
 
+  friendSetupOptionsToFormData = (color: Color | 'random'): FormData =>
+    xhr.form({
+      variant: this.variant(),
+      fen: this.fen(),
+      timeMode: this.timeMode(),
+      time: this.time(),
+      increment: this.increment(),
+      days: this.days(),
+      gameMode: this.gameMode(),
+      color: color,
+    });
+
   validFen = (): boolean => this.variant() !== 'fromPosition' || (!this.fenError && !!this.fen());
   validTime = (): boolean => this.timeMode() !== 'realTime' || this.time() > 0 || this.increment() > 0;
   validAiTime = (): boolean =>
@@ -329,14 +341,19 @@ export default class SetupController {
     this.loading = true;
     this.root.redraw();
 
-    let urlPath = `/setup/${this.gameType}`;
+    let urlPath =
+      this.root.me?.username === this.friendUser ? '/challenge/update-preference' : `/setup/${this.gameType}`;
+    let formData =
+      this.root.me?.username === this.friendUser
+        ? this.friendSetupOptionsToFormData(color)
+        : this.propsToFormData(color);
     if (this.gameType === 'hook') urlPath += `/${site.sri}`;
     const urlParams = { user: this.friendUser || undefined };
     let response;
     try {
       response = await xhr.textRaw(xhr.url(urlPath, urlParams), {
         method: 'post',
-        body: this.propsToFormData(color),
+        body: formData,
       });
     } catch (_) {
       this.loading = false;

--- a/ui/lobby/src/setupCtrl.ts
+++ b/ui/lobby/src/setupCtrl.ts
@@ -224,9 +224,9 @@ export default class SetupController {
     );
     this.daysV = this.propWithApply(sliderInitVal(challengePrefOptions?.days || 1, daysVToDays, this.maxDaysV)!);
     this.gameMode = this.propWithApply(challengePrefOptions.gameMode);
-    this.ratingMin = this.propWithApply(1);
-    this.ratingMax = this.propWithApply(-300);
-    this.aiLevel = this.propWithApply(+300);
+    this.ratingMin = this.propWithApply(-300);
+    this.ratingMax = this.propWithApply(300);
+    this.aiLevel = this.propWithApply(1);
   };
 
   closeModal?: () => void; // managed by view/setup/modal.ts
@@ -310,6 +310,7 @@ export default class SetupController {
 
   challengePrefSetupOptionsToFormData = (color: Color | 'random'): FormData =>
     xhr.form({
+      gameType: this.gameType,
       variant: this.variant(),
       fen: this.fen(),
       timeMode: this.timeMode(),
@@ -318,6 +319,9 @@ export default class SetupController {
       days: this.days(),
       gameMode: this.gameMode(),
       color: color,
+      aiLevel: this.aiLevel(),
+      ratingMin: this.ratingMin(),
+      ratingMax : this.ratingMax(),
     });
 
   validFen = (): boolean => this.variant() !== 'fromPosition' || (!this.fenError && !!this.fen());

--- a/ui/lobby/src/setupCtrl.ts
+++ b/ui/lobby/src/setupCtrl.ts
@@ -8,6 +8,7 @@ import { INITIAL_FEN } from 'chessops/fen';
 import type LobbyController from './ctrl';
 import type {
   ForceSetupOptions,
+  FriendSetupOptions,
   GameMode,
   GameType,
   InputValue,
@@ -58,6 +59,9 @@ export default class SetupController {
   timeV: Prop<InputValue>;
   incrementV: Prop<InputValue>;
   daysV: Prop<InputValue>;
+  readonly maxTimeV = 100;
+  readonly maxIncrementV = 100;
+  readonly maxDaysV = 20;
 
   time: () => RealValue = () => timeVToTime(this.timeV());
   increment: () => RealValue = () => incrementVToIncrement(this.incrementV());
@@ -97,11 +101,17 @@ export default class SetupController {
     this.variant = propWithEffect(forceOptions?.variant || storeProps.variant, this.onDropdownChange);
     this.fen = this.propWithApply(forceOptions?.fen || storeProps.fen);
     this.timeMode = propWithEffect(forceOptions?.timeMode || storeProps.timeMode, this.onDropdownChange);
-    this.timeV = this.propWithApply(sliderInitVal(forceOptions?.time || storeProps.time, timeVToTime, 100)!);
-    this.incrementV = this.propWithApply(
-      sliderInitVal(forceOptions?.increment || storeProps.increment, incrementVToIncrement, 100)!,
+    this.timeV = this.propWithApply(
+      sliderInitVal(forceOptions?.time || storeProps.time, timeVToTime, this.maxTimeV)!,
     );
-    this.daysV = this.propWithApply(sliderInitVal(storeProps.days, daysVToDays, 20)!);
+    this.incrementV = this.propWithApply(
+      sliderInitVal(
+        forceOptions?.increment || storeProps.increment,
+        incrementVToIncrement,
+        this.maxIncrementV,
+      )!,
+    );
+    this.daysV = this.propWithApply(sliderInitVal(storeProps.days, daysVToDays, this.maxDaysV)!);
     this.gameMode = this.propWithApply(storeProps.gameMode);
     this.ratingMin = this.propWithApply(storeProps.ratingMin);
     this.ratingMax = this.propWithApply(storeProps.ratingMax);
@@ -188,6 +198,7 @@ export default class SetupController {
     gameType: Exclude<GameType, 'local'>,
     forceOptions?: ForceSetupOptions,
     friendUser?: string,
+    loadProps = true,
   ) => {
     this.root.leavePool();
     this.gameType = gameType;
@@ -195,7 +206,27 @@ export default class SetupController {
     this.fenError = false;
     this.lastValidFen = '';
     this.friendUser = friendUser || '';
-    this.loadPropsFromStore(forceOptions);
+    if (loadProps) this.loadPropsFromStore(forceOptions);
+  };
+
+  openModalWithFriendOptions = (
+    gameType: Exclude<GameType, 'local'>,
+    friendOptions: FriendSetupOptions,
+    friendUser: string,
+  ) => {
+    this.openModal(gameType, undefined, friendUser, false);
+    this.variant = propWithEffect(friendOptions.variant, this.onDropdownChange);
+    this.fen = this.propWithApply(friendOptions?.fen || '');
+    this.timeMode = propWithEffect(friendOptions?.timeMode || 0, this.onDropdownChange);
+    this.timeV = this.propWithApply(sliderInitVal(friendOptions?.time || 0, timeVToTime, this.maxTimeV)!);
+    this.incrementV = this.propWithApply(
+      sliderInitVal(friendOptions?.increment || 0, incrementVToIncrement, this.maxIncrementV)!,
+    );
+    this.daysV = this.propWithApply(sliderInitVal(friendOptions?.days || 0, daysVToDays, this.maxDaysV)!);
+    this.gameMode = this.propWithApply(friendOptions.gameMode);
+    this.ratingMin = this.propWithApply(0);
+    this.ratingMax = this.propWithApply(0);
+    this.aiLevel = this.propWithApply(0);
   };
 
   closeModal?: () => void; // managed by view/setup/modal.ts

--- a/ui/lobby/src/setupCtrl.ts
+++ b/ui/lobby/src/setupCtrl.ts
@@ -8,7 +8,7 @@ import { INITIAL_FEN } from 'chessops/fen';
 import type LobbyController from './ctrl';
 import type {
   ForceSetupOptions,
-  FriendSetupOptions,
+  challengePrefSetupOptions,
   GameMode,
   GameType,
   InputValue,
@@ -209,21 +209,21 @@ export default class SetupController {
     if (loadProps) this.loadPropsFromStore(forceOptions);
   };
 
-  openModalWithFriendOptions = (
+  openModalWithchallengePrefOptions = (
     gameType: Exclude<GameType, 'local'>,
-    friendOptions: FriendSetupOptions,
+    challengePrefOptions: challengePrefSetupOptions,
     friendUser: string,
   ) => {
     this.openModal(gameType, undefined, friendUser, false);
-    this.variant = propWithEffect(friendOptions.variant, this.onDropdownChange);
-    this.fen = this.propWithApply(friendOptions?.fen || '');
-    this.timeMode = propWithEffect(friendOptions?.timeMode || '', this.onDropdownChange);
-    this.timeV = this.propWithApply(sliderInitVal(friendOptions?.time || 0, timeVToTime, this.maxTimeV)!);
+    this.variant = propWithEffect(challengePrefOptions.variant, this.onDropdownChange);
+    this.fen = this.propWithApply(challengePrefOptions?.fen || '');
+    this.timeMode = propWithEffect(challengePrefOptions?.timeMode || '', this.onDropdownChange);
+    this.timeV = this.propWithApply(sliderInitVal(challengePrefOptions?.time || 0, timeVToTime, this.maxTimeV)!);
     this.incrementV = this.propWithApply(
-      sliderInitVal(friendOptions?.increment || 0, incrementVToIncrement, this.maxIncrementV)!,
+      sliderInitVal(challengePrefOptions?.increment || 0, incrementVToIncrement, this.maxIncrementV)!,
     );
-    this.daysV = this.propWithApply(sliderInitVal(friendOptions?.days || 1, daysVToDays, this.maxDaysV)!);
-    this.gameMode = this.propWithApply(friendOptions.gameMode);
+    this.daysV = this.propWithApply(sliderInitVal(challengePrefOptions?.days || 1, daysVToDays, this.maxDaysV)!);
+    this.gameMode = this.propWithApply(challengePrefOptions.gameMode);
     this.ratingMin = this.propWithApply(1);
     this.ratingMax = this.propWithApply(-300);
     this.aiLevel = this.propWithApply(+300);
@@ -308,7 +308,7 @@ export default class SetupController {
       color,
     });
 
-  friendSetupOptionsToFormData = (color: Color | 'random'): FormData =>
+  challengePrefSetupOptionsToFormData = (color: Color | 'random'): FormData =>
     xhr.form({
       variant: this.variant(),
       fen: this.fen(),
@@ -345,7 +345,7 @@ export default class SetupController {
       this.root.me?.username === this.friendUser ? '/challenge/update-preference' : `/setup/${this.gameType}`;
     let formData =
       this.root.me?.username === this.friendUser
-        ? this.friendSetupOptionsToFormData(color)
+        ? this.challengePrefSetupOptionsToFormData(color)
         : this.propsToFormData(color);
     if (this.gameType === 'hook') urlPath += `/${site.sri}`;
     const urlParams = { user: this.friendUser || undefined };

--- a/ui/lobby/src/setupCtrl.ts
+++ b/ui/lobby/src/setupCtrl.ts
@@ -219,11 +219,15 @@ export default class SetupController {
     this.variant = propWithEffect(challengePrefOptions.variant, this.onDropdownChange);
     this.fen = this.propWithApply(challengePrefOptions?.fen || '');
     this.timeMode = propWithEffect(challengePrefOptions?.timeMode || '', this.onDropdownChange);
-    this.timeV = this.propWithApply(sliderInitVal(challengePrefOptions?.time || 0, timeVToTime, this.maxTimeV)!);
+    this.timeV = this.propWithApply(
+      sliderInitVal(challengePrefOptions?.time || 0, timeVToTime, this.maxTimeV)!,
+    );
     this.incrementV = this.propWithApply(
       sliderInitVal(challengePrefOptions?.increment || 0, incrementVToIncrement, this.maxIncrementV)!,
     );
-    this.daysV = this.propWithApply(sliderInitVal(challengePrefOptions?.days || 1, daysVToDays, this.maxDaysV)!);
+    this.daysV = this.propWithApply(
+      sliderInitVal(challengePrefOptions?.days || 1, daysVToDays, this.maxDaysV)!,
+    );
     this.gameMode = this.propWithApply(challengePrefOptions.gameMode);
     this.ratingMin = this.propWithApply(-300);
     this.ratingMax = this.propWithApply(300);
@@ -322,7 +326,7 @@ export default class SetupController {
       color: color,
       aiLevel: this.aiLevel(),
       ratingMin: this.ratingMin(),
-      ratingMax : this.ratingMax(),
+      ratingMax: this.ratingMax(),
     });
 
   validFen = (): boolean => this.variant() !== 'fromPosition' || (!this.fenError && !!this.fen());
@@ -346,12 +350,10 @@ export default class SetupController {
     this.loading = true;
     this.root.redraw();
 
-    let urlPath =
-      this.isEditingPreference ? '/challenge/update-preference' : `/setup/${this.gameType}`;
-    let formData =
-      this.isEditingPreference
-        ? this.challengePrefSetupOptionsToFormData(color)
-        : this.propsToFormData(color);
+    let urlPath = this.isEditingPreference ? '/challenge/update-preference' : `/setup/${this.gameType}`;
+    let formData = this.isEditingPreference
+      ? this.challengePrefSetupOptionsToFormData(color)
+      : this.propsToFormData(color);
     if (this.gameType === 'hook') urlPath += `/${site.sri}`;
     const urlParams = { user: this.friendUser || undefined };
     let response;

--- a/ui/lobby/src/view/setup/components/isEditingMessage.ts
+++ b/ui/lobby/src/view/setup/components/isEditingMessage.ts
@@ -1,0 +1,13 @@
+import type { MaybeVNode } from 'common/snabbdom';
+import { h } from 'snabbdom';
+import type LobbyController from '../../../ctrl';
+
+export const isEditingMessage = (ctrl: LobbyController): MaybeVNode => {
+
+  if (site.blindMode || !ctrl.setupCtrl.isEditingPreference) return null;
+
+  return h(
+      'div.is-editing',
+      "You are editing a challenge preference. Click on a king to confirm. Close the dialog to cancel"
+    );
+  }

--- a/ui/lobby/src/view/setup/components/isEditingMessage.ts
+++ b/ui/lobby/src/view/setup/components/isEditingMessage.ts
@@ -3,11 +3,10 @@ import { h } from 'snabbdom';
 import type LobbyController from '../../../ctrl';
 
 export const isEditingMessage = (ctrl: LobbyController): MaybeVNode => {
-
   if (site.blindMode || !ctrl.setupCtrl.isEditingPreference) return null;
 
   return h(
-      'div.is-editing',
-      "You are editing a challenge preference. Click on a king to confirm. Close the dialog to cancel"
-    );
-  }
+    'div.is-editing',
+    'You are editing a challenge preference. Click on a king to confirm. Close the dialog to cancel',
+  );
+};

--- a/ui/lobby/src/view/setup/modal.ts
+++ b/ui/lobby/src/view/setup/modal.ts
@@ -11,6 +11,7 @@ import { createButtons } from './components/colorButtons';
 import { ratingView } from './components/ratingView';
 import { fenInput } from './components/fenInput';
 import { levelButtons } from './components/levelButtons';
+import { isEditingMessage } from './components/isEditingMessage';
 
 export default function setupModal(ctrl: LobbyController): MaybeVNode {
   const { setupCtrl } = ctrl;
@@ -19,12 +20,13 @@ export default function setupModal(ctrl: LobbyController): MaybeVNode {
     class: 'game-setup',
     css: [{ hashed: 'lobby.setup' }],
     onClose: () => {
+      if (ctrl.setupCtrl.isEditingPreference) window.location.replace('/challenge/preference') 
       setupCtrl.closeModal = undefined;
       setupCtrl.gameType = null;
       setupCtrl.root.redraw();
     },
     modal: true,
-    vnodes: [...views[setupCtrl.gameType](ctrl), ratingView(ctrl)],
+    vnodes: [...views[setupCtrl.gameType](ctrl), isEditingMessage(ctrl), ratingView(ctrl)],
     onInsert: dlg => {
       setupCtrl.closeModal = dlg.close;
       dlg.show();
@@ -44,12 +46,7 @@ const views = {
     ]),
   ],
   friend: (ctrl: LobbyController): MaybeVNodes => [
-    h(
-      'h2',
-      ctrl.setupCtrl.root.me?.username === ctrl.setupCtrl.friendUser
-        ? 'Your preferred challenge'
-        : i18n.site.playWithAFriend,
-    ),
+    h('h2', i18n.site.playWithAFriend),
     h('div.setup-content', [
       ctrl.setupCtrl.friendUser ? userLink({ name: ctrl.setupCtrl.friendUser, line: false }) : null,
       variantPicker(ctrl),

--- a/ui/lobby/src/view/setup/modal.ts
+++ b/ui/lobby/src/view/setup/modal.ts
@@ -44,7 +44,12 @@ const views = {
     ]),
   ],
   friend: (ctrl: LobbyController): MaybeVNodes => [
-    h('h2', i18n.site.playWithAFriend),
+    h(
+      'h2',
+      ctrl.setupCtrl.root.me?.username === ctrl.setupCtrl.friendUser
+        ? 'Your preferred challenge'
+        : i18n.site.playWithAFriend,
+    ),
     h('div.setup-content', [
       ctrl.setupCtrl.friendUser ? userLink({ name: ctrl.setupCtrl.friendUser, line: false }) : null,
       variantPicker(ctrl),

--- a/ui/lobby/src/view/setup/modal.ts
+++ b/ui/lobby/src/view/setup/modal.ts
@@ -20,7 +20,7 @@ export default function setupModal(ctrl: LobbyController): MaybeVNode {
     class: 'game-setup',
     css: [{ hashed: 'lobby.setup' }],
     onClose: () => {
-      if (ctrl.setupCtrl.isEditingPreference) window.location.replace('/challenge/preference') 
+      if (ctrl.setupCtrl.isEditingPreference) window.location.replace('/challenge/preference');
       setupCtrl.closeModal = undefined;
       setupCtrl.gameType = null;
       setupCtrl.root.redraw();


### PR DESCRIPTION
A new tab in preferences allows user A to create/edit one challenge preference using the existing challenge dialog.

When user B accesses the profile of user A, the 'challenge to a game link' is overridden to carry user A preference.
(In this case, user B stored preferences are not changed)

User A can also copy and paste his challenge link for share it.


Benefits: the challenge link carries only one attribute (challenge-pref) for everything. It may supersedes the forcedOptions where attributes are added one at a time. Obviously, the user cannot write the URL manually but needs to use the challenge preference page.



Ideas for the future:

- Shortening the url when it is shared (for ex: /challenge/:key would redirect to /?user=xx&challenge-pref=xxxx#friend)
- Save more than one preference to enable/disable them (this is why I create a new collection in DB)
- Generate links to share for other situations; ai, challenge a user
- Allow the dialog to propose more than one type of challenge
- Enforce the preference(s) server side so that the challenge is refused if not the preference