### PR TITLE
Disable cloud analysis when using an external engine

### DIFF
--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -683,12 +683,14 @@ export default class AnalyseCtrl {
   private onNewCeval = (ev: Tree.ClientEval, path: Tree.Path, isThreat?: boolean): void => {
     this.tree.updateAt(path, (node: Tree.Node) => {
       if (node.fen !== ev.fen && !isThreat) return;
+      const isExternal = this.ceval.engines.active?.tech === 'EXTERNAL';
+
       if (isThreat) {
         const threat = ev as Tree.LocalEval;
         if (!node.threat || isEvalBetter(threat, node.threat)) node.threat = threat;
-      } else if (!node.ceval || isEvalBetter(ev, node.ceval)) node.ceval = ev;
+      } else if ((!node.ceval || isEvalBetter(ev, node.ceval)) && !(isExternal && ev.cloud)) node.ceval = ev;
       else if (!ev.cloud) {
-        if (node.ceval.cloud && this.ceval.isDeeper()) node.ceval = ev;
+        if (node.ceval?.cloud && this.ceval.isDeeper()) node.ceval = ev;
       }
 
       if (path === this.path) {

--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -683,12 +683,12 @@ export default class AnalyseCtrl {
   private onNewCeval = (ev: Tree.ClientEval, path: Tree.Path, isThreat?: boolean): void => {
     this.tree.updateAt(path, (node: Tree.Node) => {
       if (node.fen !== ev.fen && !isThreat) return;
-      const isExternal = this.ceval.engines.active?.tech === 'EXTERNAL';
 
       if (isThreat) {
         const threat = ev as Tree.LocalEval;
         if (!node.threat || isEvalBetter(threat, node.threat)) node.threat = threat;
-      } else if ((!node.ceval || isEvalBetter(ev, node.ceval)) && !(isExternal && ev.cloud)) node.ceval = ev;
+      } else if ((!node.ceval || isEvalBetter(ev, node.ceval)) && !(ev.cloud && this.ceval.engines.external))
+        node.ceval = ev;
       else if (!ev.cloud) {
         if (node.ceval?.cloud && this.ceval.isDeeper()) node.ceval = ev;
       }

--- a/ui/ceval/src/ctrl.ts
+++ b/ui/ceval/src/ctrl.ts
@@ -90,7 +90,12 @@ export default class CevalCtrl {
     if (!this.lastStarted || this.isDeeper() || this.isInfinite || work.threatMode) return;
     const showingNode = this.lastStarted.steps[this.lastStarted.steps.length - 1];
     const byMovetime = 'movetime' in this.search.by && this.search.by.movetime;
-    if (byMovetime && showingNode.ceval?.cloud && ev.millis > 500) {
+    if (
+      byMovetime &&
+      showingNode.ceval?.cloud &&
+      ev.millis > 500 &&
+      this.engines.active?.tech !== 'EXTERNAL'
+    ) {
       const targetNodes = showingNode.ceval.nodes;
       const likelyNodes = Math.round((byMovetime * ev.nodes) / ev.millis);
 

--- a/ui/ceval/src/ctrl.ts
+++ b/ui/ceval/src/ctrl.ts
@@ -90,12 +90,7 @@ export default class CevalCtrl {
     if (!this.lastStarted || this.isDeeper() || this.isInfinite || work.threatMode) return;
     const showingNode = this.lastStarted.steps[this.lastStarted.steps.length - 1];
     const byMovetime = 'movetime' in this.search.by && this.search.by.movetime;
-    if (
-      byMovetime &&
-      showingNode.ceval?.cloud &&
-      ev.millis > 500 &&
-      this.engines.active?.tech !== 'EXTERNAL'
-    ) {
+    if (byMovetime && showingNode.ceval?.cloud && ev.millis > 500 && !this.engines.external) {
       const targetNodes = showingNode.ceval.nodes;
       const likelyNodes = Math.round((byMovetime * ev.nodes) / ev.millis);
 


### PR DESCRIPTION
Closes #11237 

What I did:
- In `AnalyseCtrl`: When the external engine is active, do not store the incoming cloud eval in the node, even if the node has no eval (it seems better to me to display "Calculating..." for a few tenth of a second rather than flash a cloud eval)
- In `CevalCtrl` : Do not stop the external engine when there is already a known cloud eval. This happens when the user has just switched from a local engine to an external engine