### PR TITLE
Show correct max. number of games for multi PGN import

### DIFF
--- a/translation/source/study.xml
+++ b/translation/source/study.xml
@@ -105,7 +105,7 @@
   <string name="automatic">Automatic</string>
   <plurals name="pasteYourPgnTextHereUpToNbGames">
     <item quantity="one">Paste your PGN text here, up to %s game</item>
-    <item quantity="other">Paste your PGN text here (one or multiple games). For each game, a new chapter is created. The study can have up to %s chapters.</item>
+    <item quantity="other">Paste games as PGN text here. For each game, a new chapter is created. The study can have up to %s chapters.</item>
   </plurals>
   <string name="urlOfTheGame">URL of the games, one per line</string>
   <string name="loadAGameFromXOrY">Load games from %1$s or %2$s</string>

--- a/translation/source/study.xml
+++ b/translation/source/study.xml
@@ -105,7 +105,7 @@
   <string name="automatic">Automatic</string>
   <plurals name="pasteYourPgnTextHereUpToNbGames">
     <item quantity="one">Paste your PGN text here, up to %s game</item>
-    <item quantity="other">Paste your PGN text here, up to %s games</item>
+    <item quantity="other">Paste your PGN text here (one or multiple games). For each game, a new chapter is created. The study can have up to %s chapters.</item>
   </plurals>
   <string name="urlOfTheGame">URL of the games, one per line</string>
   <string name="loadAGameFromXOrY">Load games from %1$s or %2$s</string>

--- a/translation/source/study.xml
+++ b/translation/source/study.xml
@@ -103,7 +103,7 @@
   <string name="loadAPositionFromFen">Load a position from FEN</string>
   <string name="loadAGameFromPgn">Load games from PGN</string>
   <string name="automatic">Automatic</string>
-  <plurals name="pasteYourPgnTextHereUpToNbGames">
+  <plurals name="pasteYourPgnTextHereUpToNbGames" comment="It is possible to create multiple chapters in one go. Please try to convey this using a short translation.">
     <item quantity="one">Paste your PGN text here, up to %s game</item>
     <item quantity="other">Paste games as PGN text here. For each game, a new chapter is created. The study can have up to %s chapters.</item>
   </plurals>

--- a/ui/@types/lichess/i18n.d.ts
+++ b/ui/@types/lichess/i18n.d.ts
@@ -4827,7 +4827,7 @@ interface I18n {
     open: string;
     /** Orientation */
     orientation: string;
-    /** Paste your PGN text here, up to %s games */
+    /** Paste your PGN text here (one or multiple games). For each game, a new chapter is created. The study can have up to %s chapters. */
     pasteYourPgnTextHereUpToNbGames: I18nPlural;
     /** %s per page */
     perPage: I18nFormat;

--- a/ui/@types/lichess/i18n.d.ts
+++ b/ui/@types/lichess/i18n.d.ts
@@ -4827,7 +4827,7 @@ interface I18n {
     open: string;
     /** Orientation */
     orientation: string;
-    /** Paste your PGN text here (one or multiple games). For each game, a new chapter is created. The study can have up to %s chapters. */
+    /** Paste games as PGN text here. For each game, a new chapter is created. The study can have up to %s chapters. */
     pasteYourPgnTextHereUpToNbGames: I18nPlural;
     /** %s per page */
     perPage: I18nFormat;

--- a/ui/analyse/src/study/chapterNewForm.ts
+++ b/ui/analyse/src/study/chapterNewForm.ts
@@ -27,7 +27,7 @@ export const fieldValue = (e: Event, id: string) =>
   ((e.target as HTMLElement).querySelector('#chapter-' + id) as HTMLInputElement)?.value;
 
 export class StudyChapterNewForm {
-  readonly multiPgnMax = 32;
+  readonly multiPgnMax = 64;
   variants: Variant[] = [];
   isOpen = toggle(false);
   initial = toggle(false);


### PR DESCRIPTION
### Issue #16921  
In a lichess study, the PGN import functionality allows for 64 games to be imported in one go. However, the import description states 32 as the max. number. 

### Fix
![image](https://github.com/user-attachments/assets/314269e0-7c81-4c55-9f48-23b0a9be9cdd)
