### PR TITLE
More accurate help message when pasting pgn in study

### DIFF
--- a/translation/source/study.xml
+++ b/translation/source/study.xml
@@ -105,7 +105,7 @@
   <string name="automatic">Automatic</string>
   <plurals name="pasteYourPgnTextHereUpToNbGames">
     <item quantity="one">Paste your PGN text here, up to %s game</item>
-    <item quantity="other">Paste your PGN text here, up to %s games</item>
+    <item quantity="other">Paste your PGN text here. Each game is a new chapter. The study can have up to %s chapters</item>
   </plurals>
   <string name="urlOfTheGame">URL of the games, one per line</string>
   <string name="loadAGameFromXOrY">Load games from %1$s or %2$s</string>

--- a/ui/@types/lichess/i18n.d.ts
+++ b/ui/@types/lichess/i18n.d.ts
@@ -4827,7 +4827,7 @@ interface I18n {
     open: string;
     /** Orientation */
     orientation: string;
-    /** Paste your PGN text here, up to %s games */
+    /** Paste your PGN text here. Each game is a new chapter. The study can have up to %s chapters */
     pasteYourPgnTextHereUpToNbGames: I18nPlural;
     /** %s per page */
     perPage: I18nFormat;

--- a/ui/analyse/src/study/chapterNewForm.ts
+++ b/ui/analyse/src/study/chapterNewForm.ts
@@ -27,7 +27,7 @@ export const fieldValue = (e: Event, id: string) =>
   ((e.target as HTMLElement).querySelector('#chapter-' + id) as HTMLInputElement)?.value;
 
 export class StudyChapterNewForm {
-  readonly multiPgnMax = 32;
+  readonly multiPgnMax = 64;
   variants: Variant[] = [];
   isOpen = toggle(false);
   initial = toggle(false);


### PR DESCRIPTION
When you paste a pgn with multiple games in a study, the max number is limited by the maximum 64 chapters in a study.

So I suggest we change the message: 

`Paste your PGN text here. Each game is a new chapter. The study can have up to %s chapters`