### PR TITLE
tweak deprecation flag during build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,11 +11,11 @@ lazy val root = Project("lila", file("."))
   .dependsOn(api)
   .aggregate(api)
   .settings(buildSettings)
-  .settings(scalacOptions ++= Seq("-unchecked", "-deprecation"))
 
 organization         := "org.lichess"
 Compile / run / fork := true
 javaOptions ++= Seq("-Xms64m", "-Xmx512m", "-Dlogger.file=conf/logger.dev.xml")
+ThisBuild / scalacOptions ++= Seq("-unchecked", "-deprecation")
 ThisBuild / usePipelining := false
 // shorter prod classpath
 scriptClasspath             := Seq("*")


### PR DESCRIPTION
Changing to this format shows the individual deprecation details in my local build as well as in the github action logs.

| before | after |
| - | - |
| ![image](https://github.com/user-attachments/assets/7440b7ba-56e5-4ed6-a039-ffe144d9a947) | ![image](https://github.com/user-attachments/assets/34bd70b7-7387-4f1e-b919-003c403e5cd3)