### PR TITLE
Return bots and account age conditions in tournament API

### DIFF
--- a/modules/tournament/src/main/JsonView.scala
+++ b/modules/tournament/src/main/JsonView.scala
@@ -140,6 +140,8 @@ final class JsonView(
           .add[Condition.RatingCondition]("minRating", tour.conditions.minRating)
           .add[Condition.RatingCondition]("maxRating", tour.conditions.maxRating)
           .add("minRatedGames", tour.conditions.nbRatedGame)
+          .add("botsAllowed", tour.conditions.bots.exists(_.allowed))
+          .add("minAccountAgeInDays", tour.conditions.accountAge.map(_.days))
           .add("onlyTitled", tour.conditions.titled.isDefined)
           .add("teamMember", tour.conditions.teamMember.map(_.teamId))
           .add("allowList", withAllowList.so(tour.conditions.allowList).map(_.userIds))


### PR DESCRIPTION
Among other things, this is useful when updating the tournament, since entry conditions need to be set to the desired value when sending an update API call or they reset to their default value.