### PR TITLE
Made right side panel unselectable during gameplay

### DIFF
--- a/ui/round/css/_moves.scss
+++ b/ui/round/css/_moves.scss
@@ -40,7 +40,6 @@ $buttons-height: 2.5rem;
   #{$moves-tag},
   .message {
     flex: 0 0 7.4rem;
-    user-select: none;
   }
 
   @import 'moves-col1';

--- a/ui/round/css/_moves.scss
+++ b/ui/round/css/_moves.scss
@@ -40,6 +40,7 @@ $buttons-height: 2.5rem;
   #{$moves-tag},
   .message {
     flex: 0 0 7.4rem;
+    user-select: none;
   }
 
   @import 'moves-col1';

--- a/ui/round/css/_user.scss
+++ b/ui/round/css/_user.scss
@@ -80,4 +80,9 @@
       align-self: flex-start;
     }
   }
+
+  &.ruser-bottom.user-link.online,
+  &.user-link.online.ruser-top {
+    user-select: none;
+  }
 }

--- a/ui/round/css/_user.scss
+++ b/ui/round/css/_user.scss
@@ -1,6 +1,7 @@
 .ruser {
   @extend %zen;
 
+  user-select: none;
   display: flex;
   justify-content: start;
   align-items: center;
@@ -79,10 +80,5 @@
     &-bottom {
       align-self: flex-start;
     }
-  }
-
-  &.ruser-bottom.user-link.online,
-  &.user-link.online.ruser-top {
-    user-select: none;
   }
 }


### PR DESCRIPTION
Issue: Username and text messages were selectable during gameplay.

Solution: Implemented `user-select: none;` in `_user.scss` and `_moves.scss`.


Fixes #17000 


Before:

![image](https://github.com/user-attachments/assets/a146b324-9f33-476b-8b3f-9e06383221e6)

After:

<img width="1032" alt="Screenshot 2025-02-22 at 3 49 44 PM" src="https://github.com/user-attachments/assets/08c436bf-56c9-4ed9-8858-07647c84769c" />
