### PR TITLE
Let the team know that the last push was at least an hour ago.

### DIFF
--- a/modules/relay/src/main/RelayCard.scala
+++ b/modules/relay/src/main/RelayCard.scala
@@ -18,4 +18,7 @@ case class RelayCard(
       .orElse:
         round.shouldHaveStarted1Hour.option:
           List(if round.sync.hasUpstream then "Upstream has not started" else "Nothing pushed yet")
+      .orElse:
+        round.pushShouldHaveFinished.option:
+          List("Last pushed have some time")
       .orZero

--- a/modules/relay/src/main/RelayRound.scala
+++ b/modules/relay/src/main/RelayRound.scala
@@ -57,6 +57,10 @@ case class RelayRound(
 
   def shouldHaveStarted1Hour = !hasStarted && startsAtTime.exists(_.isBefore(nowInstant.minusHours(1)))
 
+  def pushShouldHaveFinished = hasStarted && !isFinished && sync.isPush && sync.log.updatedAt.exists(
+    _.isBefore(nowInstant.minusHours(1))
+  )
+
   def shouldGiveUp =
     !hasStarted && startsAtTime.match
       case Some(at) => at.isBefore(nowInstant.minusHours(3))


### PR DESCRIPTION
Exactly as happens in an upstream broadcast
There are rounds where the organizers never complete any boards.
Making it permanently "ongoing".