### PR TITLE
wallpaiper over preview option in WYSIWYG editor regarding isssue #16256

### DIFF
--- a/ui/bits/css/_markdown-editor.scss
+++ b/ui/bits/css/_markdown-editor.scss
@@ -51,6 +51,9 @@
     }
     &-md-tab-container {
       background: none;
+      /* preview is not accurate to what lichess shows */
+      display: none;
+      width: 0;
     }
     &-tabs {
       @extend %flex-center;
@@ -60,6 +63,8 @@
         height: 2em;
         line-height: 2em;
         margin: 0 0 -1px 0;
+        /* preview is not accurate to what lichess shows */
+        display: none;
       }
     }
     &-popup {


### PR DESCRIPTION
![issue](https://github.com/lichess-org/lila/issues/16256)

before:
![image](https://github.com/user-attachments/assets/3b53d486-9e56-4f44-8f7c-b018be9ab99b)

It shows the inaccurate "preview" pane. Only that preview pane does not give an accurate preview and does not
add anything the  WYSIWYG pane does not address.
 
![image](https://github.com/user-attachments/assets/ca872aef-307b-40a2-b6d8-b51c3c2e855b)


It does not show what your blog post will be rendered as and can cause confusion see the issue this closes. It is a quick and dirty solution to remove a pointless tab pane that only causes confusion and has no point.

A more involved fix would involve getting the preview and result to line up. But I am just an intern or something.

