### PR TITLE
Do not have the client engine use the server eval

### DIFF
--- a/ui/ceval/src/view/main.ts
+++ b/ui/ceval/src/view/main.ts
@@ -82,7 +82,7 @@ function localInfo(ctrl: ParentCtrl, ev?: Tree.ClientEval | false): EvalInfo {
 }
 
 function threatButton(ctrl: ParentCtrl): VNode | null {
-  if (ctrl.getCeval().download || (ctrl.disableThreatMode && ctrl.disableThreatMode())) return null;
+  if (ctrl.getCeval().download || ctrl.disableThreatMode?.()) return null;
   return h('button.show-threat', {
     class: { active: ctrl.threatMode(), hidden: !!ctrl.getNode().check },
     attrs: { 'data-icon': licon.Target, title: i18n.site.showThreat + ' (x)' },
@@ -116,25 +116,7 @@ function engineName(ctrl: CevalCtrl): VNode[] {
     : [];
 }
 
-const serverNodes = 4e6;
-
-export function getBestEval(evs: NodeEvals): EvalScore | undefined {
-  const serverEv = evs.server,
-    localEv = evs.client;
-
-  if (!serverEv) return localEv;
-  if (!localEv) return serverEv;
-
-  // Prefer localEv if it exceeds fishnet node limit or finds a better mate.
-  if (
-    localEv.nodes > serverNodes ||
-    (typeof localEv.mate !== 'undefined' &&
-      (typeof serverEv.mate === 'undefined' || Math.abs(localEv.mate) < Math.abs(serverEv.mate)))
-  )
-    return localEv;
-
-  return serverEv;
-}
+export const getBestEval = (evs: NodeEvals): EvalScore | undefined => evs.client || evs.server;
 
 export function renderGauge(ctrl: ParentCtrl): VNode | undefined {
   if (ctrl.ongoing || !ctrl.showEvalGauge()) return;


### PR DESCRIPTION
This PR is intended to only affect the evaluation shown by the running engine, and temporarily the evals given to moves in the notation (until refreshing). I could be wrong though.

For why we might want to consider this:

- Open a game you've played in the analysis board, and request a computer analysis.
- Once it's done, toggle on the SF 16 engine, and set the number of lines to at least 2.
- For many moves, you should see the main bold evaluation stay where it is for a few seconds, and then suddenly switch to the evaluation of the top line.

The reason for this is that the SF 17 server analysis is used for the main bold eval, until the client engine reaches 4 million nodes. But for the user this feels confusing; especially if they're using SF 16 on their end, the abrupt change in evaluation can be large.

This isn't as much of a problem when the number of lines is just 1, since in that case no evaluation is displayed for the line. However, it's still not fully candid, since initially the main evaluation in bold won't necessarily correspond with the current line given.