### PR TITLE
ublogs IRC: Send separately by topic

### DIFF
--- a/modules/core/src/main/irc.scala
+++ b/modules/core/src/main/irc.scala
@@ -33,5 +33,5 @@ trait IrcApi:
       slug: String,
       title: String,
       intro: String,
-      topicTier: String
+      topic: String
   ): Funit

--- a/modules/core/src/main/irc.scala
+++ b/modules/core/src/main/irc.scala
@@ -27,4 +27,11 @@ trait IrcApi:
       boardName: StudyChapterName
   ): Funit
   def monitorMod(icon: String, text: String, tpe: ModDomain)(using MyId): Funit
-  def ublogPost(user: LightUser, id: UblogPostId, slug: String, title: String, intro: String): Funit
+  def ublogPost(
+      user: LightUser,
+      id: UblogPostId,
+      slug: String,
+      title: String,
+      intro: String,
+      topicTier: String
+  ): Funit

--- a/modules/irc/src/main/IrcApi.scala
+++ b/modules/irc/src/main/IrcApi.scala
@@ -90,9 +90,10 @@ final class IrcApi(
       id: UblogPostId,
       slug: String,
       title: String,
-      intro: String
+      intro: String,
+      topicTier: String
   ): Funit =
-    zulip(_.blog, "non-tiered new posts"):
+    zulip(_.blog, topicTier):
       val link = markdown.lichessLink(s"/@/${user.name}/blog/$slug/$id", title)
       s":note: $link $intro - by ${markdown.userLink(user)}"
 

--- a/modules/irc/src/main/IrcApi.scala
+++ b/modules/irc/src/main/IrcApi.scala
@@ -91,9 +91,9 @@ final class IrcApi(
       slug: String,
       title: String,
       intro: String,
-      topicTier: String
+      topic: String
   ): Funit =
-    zulip(_.blog, topicTier):
+    zulip(_.blog, topic):
       val link = markdown.lichessLink(s"/@/${user.name}/blog/$slug/$id", title)
       s":note: $link $intro - by ${markdown.userLink(user)}"
 

--- a/modules/ublog/src/main/UblogApi.scala
+++ b/modules/ublog/src/main/UblogApi.scala
@@ -50,7 +50,7 @@ final class UblogApi(
           tl.Propagate(tl.UblogPost(author.id, post.id, post.slug, post.title))
             .toFollowersOf(post.created.by)
         shutupApi.publicText(author.id, post.allText, PublicSource.Ublog(post.id))
-        if blog.modTier.isEmpty then sendPostToZulipMaybe(author, post)
+        sendPostToZulip(author, post, blog.modTier)
 
   def getUserBlogOption(user: User, insertMissing: Boolean = false): Fu[Option[UblogBlog]] =
     getBlog(UblogBlog.Id.User(user.id))
@@ -147,15 +147,21 @@ final class UblogApi(
 
     def deleteImage(post: UblogPost): Funit = picfitApi.deleteByRel(rel(post))
 
-  private def sendPostToZulipMaybe(user: User, post: UblogPost): Funit =
-    (post.markdown.value.sizeIs > 1000).so:
-      irc.ublogPost(
-        user.light,
-        id = post.id,
-        slug = post.slug,
-        title = post.title,
-        intro = post.intro
-      )
+  private def sendPostToZulip(user: User, post: UblogPost, modTier: Option[UblogRank.Tier]): Funit =
+    val topic = modTier match
+      case UblogRank.Tier.HIGH    => "high tier new posts"
+      case UblogRank.Tier.NORMAL  => "normal tier new posts"
+      case UblogRank.Tier.LOW     => "low tier new posts"
+      case UblogRank.Tier.VISIBLE => "unlisted tier new posts"
+      case _                      => "non-tiered new posts"
+    irc.ublogPost(
+      user.light,
+      id = post.id,
+      slug = post.slug,
+      title = post.title,
+      intro = post.intro,
+      topicTier = topic
+    )
 
   def liveLightsByIds(ids: List[UblogPostId]): Fu[List[UblogPost.LightPost]] =
     colls.post

--- a/modules/ublog/src/main/UblogApi.scala
+++ b/modules/ublog/src/main/UblogApi.scala
@@ -148,20 +148,14 @@ final class UblogApi(
     def deleteImage(post: UblogPost): Funit = picfitApi.deleteByRel(rel(post))
 
   private def sendPostToZulip(user: User, post: UblogPost, modTier: Option[UblogRank.Tier]): Funit =
-    val topic = modTier match
-      case UblogRank.Tier.BEST    => "best tier new posts"
-      case UblogRank.Tier.HIGH    => "high tier new posts"
-      case UblogRank.Tier.NORMAL  => "normal tier new posts"
-      case UblogRank.Tier.LOW     => "low tier new posts"
-      case UblogRank.Tier.VISIBLE => "unlisted tier new posts"
-      case _                      => "non-tiered new posts"
+    val tierName = modTier.fold("non-tiered")(t => s"${UblogRank.Tier.name(t).toLowerCase} tier")
     irc.ublogPost(
       user.light,
       id = post.id,
       slug = post.slug,
       title = post.title,
       intro = post.intro,
-      topicTier = topic
+      topic = s"$tierName new posts"
     )
 
   def liveLightsByIds(ids: List[UblogPostId]): Fu[List[UblogPost.LightPost]] =

--- a/modules/ublog/src/main/UblogApi.scala
+++ b/modules/ublog/src/main/UblogApi.scala
@@ -149,6 +149,7 @@ final class UblogApi(
 
   private def sendPostToZulip(user: User, post: UblogPost, modTier: Option[UblogRank.Tier]): Funit =
     val topic = modTier match
+      case UblogRank.Tier.BEST    => "best tier new posts"
       case UblogRank.Tier.HIGH    => "high tier new posts"
       case UblogRank.Tier.NORMAL  => "normal tier new posts"
       case UblogRank.Tier.LOW     => "low tier new posts"


### PR DESCRIPTION
1. Remove the limiter: Often times blogs that need to be checked don't reach the team without going to /blog
2. Divide Tiers by Topic
    - If the blog is High tier I can have some observations that I won't have in another tier
    - Unlisted blog may have a second chance to be listed again