### PR TITLE
Replace link with span on practice success if autoNext is enabled

### DIFF
--- a/ui/analyse/src/study/practice/studyPracticeView.ts
+++ b/ui/analyse/src/study/practice/studyPracticeView.ts
@@ -59,9 +59,7 @@ export function underboard(ctrl: StudyCtrl): MaybeVNodes {
   switch (p.success()) {
     case true:
       if (p.autoNext()) {
-        return [
-          h('span.feedback.win', 'Success!'),
-        ];
+        return [h('span.feedback.win', 'Success!')];
       } else {
         return [
           h(

--- a/ui/analyse/src/study/practice/studyPracticeView.ts
+++ b/ui/analyse/src/study/practice/studyPracticeView.ts
@@ -58,15 +58,21 @@ export function underboard(ctrl: StudyCtrl): MaybeVNodes {
   else if (!ctrl.data.chapter.practice) return [descView(ctrl, true)];
   switch (p.success()) {
     case true:
-      return [
-        h(
-          'a.feedback.win',
-          ctrl.nextChapter()
-            ? { hook: bind('click', ctrl.goToNextChapter) }
-            : { attrs: { href: '/practice' } },
-          [h('span', 'Success!'), ctrl.nextChapter() ? 'Go to next exercise' : 'Back to practice menu'],
-        ),
-      ];
+      if (p.autoNext()) {
+        return [
+          h('span.feedback.win', 'Success!'),
+        ];
+      } else {
+        return [
+          h(
+            'a.feedback.win',
+            ctrl.nextChapter()
+              ? { hook: bind('click', ctrl.goToNextChapter) }
+              : { attrs: { href: '/practice' } },
+            [h('span', 'Success!'), ctrl.nextChapter() ? 'Go to next exercise' : 'Back to practice menu'],
+          ),
+        ];
+      }
     case false:
       return [
         h('a.feedback.fail', { hook: bind('click', p.reset, ctrl.redraw) }, [


### PR DESCRIPTION
This PR aims to fix the issue https://github.com/lichess-org/lila/issues/16948.

The reported bug is caused by the `studyPracticeCrtl.onVictory()` method calling the `goToNextChapter` method with a 1 second timeout, allowing a 1 second window for the user to click the "Success" button and manually triggering the `goToNextChapter` method again. This resulted in two chapters being marked as completed at the same time.

![2025-03-01T17:42:08,683355496+01:00](https://github.com/user-attachments/assets/0827b6fb-24e4-4fc6-a140-4676fe0034a6)

The fix simply replaces the "Success" button with a non-clickable `span` if the user has the "Load next exercise immediately" option checked to avoid the issue.
