### PR TITLE
API: add withdraw field /api/tournament/id/results

### DIFF
--- a/modules/tournament/src/main/JsonView.scala
+++ b/modules/tournament/src/main/JsonView.scala
@@ -496,6 +496,7 @@ object JsonView:
         .add("title" -> user.title)
         .add("flair" -> user.flair)
         .add("performance" -> player.performance)
+        .add("withdraw" -> player.withdraw)
         .add("team" -> player.team)
         .add("sheet", sheet.map(sheetJson(streakFire = false, withScores = true)))
 


### PR DESCRIPTION
The withdraw field shows if a participating player is currently withdrawn/paused in an ongoing tournament.

It can already be found via endpoint `/api/tournament/<id>?page=<n>`, which, among other data, serves standings in groups of 10 per page.

This commit adds the withdraw field also to the
`/api/tournament/<id>/results` endpoint, which serves standings as an x-ndjson stream.

The withdraw data is already available at server-side, so the addition of the field should "only" incur the extra cost of the size increase of the json-object for the players which are currently withdrawn/paused.

Example,
Yulia and Diego are playing an arena, and Diego withdraws/pauses.

```
curl -H "accept: application/x-ndjson" "http://localhost:8080/api/tournament/k7zm80gX/results"
```

Before commit:
```json
{"rank":1,"score":2,"rating":2364,"username":"Yulia","title":"WFM","performance":2460}
{"rank":2,"score":0,"rating":1955,"username":"Diego","performance":1863}
```
After commit:
```json
{"rank":1,"score":2,"rating":2364,"username":"Yulia","title":"WFM","performance":2460}
{"rank":2,"score":0,"rating":1955,"username":"Diego","performance":1863,"withdraw":true}
```


The use case I have in mind, is for reducing the amount of user ids to query additional information about.
For the set of members in a team in a team battle,
which are currently not playing a game (i.e waiting for a pairing),
I want to query to find out when they get a new pairing,
and intend to use `/api/users/status` with the user ids of the waiting team members.
But if there are withdrawn members, I wouldn't need to include those user ids in the query.
(The "source" of the user ids of team members already come from the /results endpoint (it includes a "team" field in team battles), so having the withdraw status in same response would be convenient)