### PR TITLE
patch Worker to use hash linked wasm wrapper js

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "onchange": "^7.1.0",
     "prettier": "^3.5.2",
     "snabbdom": "3.5.1",
-    "typescript": "^5.7.3",
+    "typescript": "^5.8.2",
     "vitest": "^3.0.7"
   },
   "//": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,10 +16,10 @@ importers:
         version: 0.0.201
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.25.0
-        version: 8.25.0(@typescript-eslint/parser@8.25.0(eslint@9.21.0)(typescript@5.7.3))(eslint@9.21.0)(typescript@5.7.3)
+        version: 8.25.0(@typescript-eslint/parser@8.25.0(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(typescript@5.8.2)
       '@typescript-eslint/parser':
         specifier: ^8.25.0
-        version: 8.25.0(eslint@9.21.0)(typescript@5.7.3)
+        version: 8.25.0(eslint@9.21.0)(typescript@5.8.2)
       ab:
         specifier: github:lichess-org/ab-stub
         version: https://codeload.github.com/lichess-org/ab-stub/tar.gz/94236bf34dbc9c05daf50f4c9842d859b9142be0
@@ -48,8 +48,8 @@ importers:
         specifier: 3.5.1
         version: 3.5.1
       typescript:
-        specifier: ^5.7.3
-        version: 5.7.3
+        specifier: ^5.8.2
+        version: 5.8.2
       vitest:
         specifier: ^3.0.7
         version: 3.0.7(@types/node@22.13.5)(jsdom@26.0.0)(yaml@2.7.0)
@@ -2321,8 +2321,8 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
-  typescript@5.7.3:
-    resolution: {integrity: sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==}
+  typescript@5.8.2:
+    resolution: {integrity: sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -2833,32 +2833,32 @@ snapshots:
 
   '@types/zxcvbn@4.4.5': {}
 
-  '@typescript-eslint/eslint-plugin@8.25.0(@typescript-eslint/parser@8.25.0(eslint@9.21.0)(typescript@5.7.3))(eslint@9.21.0)(typescript@5.7.3)':
+  '@typescript-eslint/eslint-plugin@8.25.0(@typescript-eslint/parser@8.25.0(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(typescript@5.8.2)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.25.0(eslint@9.21.0)(typescript@5.7.3)
+      '@typescript-eslint/parser': 8.25.0(eslint@9.21.0)(typescript@5.8.2)
       '@typescript-eslint/scope-manager': 8.25.0
-      '@typescript-eslint/type-utils': 8.25.0(eslint@9.21.0)(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.25.0(eslint@9.21.0)(typescript@5.7.3)
+      '@typescript-eslint/type-utils': 8.25.0(eslint@9.21.0)(typescript@5.8.2)
+      '@typescript-eslint/utils': 8.25.0(eslint@9.21.0)(typescript@5.8.2)
       '@typescript-eslint/visitor-keys': 8.25.0
       eslint: 9.21.0
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
-      ts-api-utils: 2.0.1(typescript@5.7.3)
-      typescript: 5.7.3
+      ts-api-utils: 2.0.1(typescript@5.8.2)
+      typescript: 5.8.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.25.0(eslint@9.21.0)(typescript@5.7.3)':
+  '@typescript-eslint/parser@8.25.0(eslint@9.21.0)(typescript@5.8.2)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.25.0
       '@typescript-eslint/types': 8.25.0
-      '@typescript-eslint/typescript-estree': 8.25.0(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 8.25.0(typescript@5.8.2)
       '@typescript-eslint/visitor-keys': 8.25.0
       debug: 4.4.0
       eslint: 9.21.0
-      typescript: 5.7.3
+      typescript: 5.8.2
     transitivePeerDependencies:
       - supports-color
 
@@ -2867,20 +2867,20 @@ snapshots:
       '@typescript-eslint/types': 8.25.0
       '@typescript-eslint/visitor-keys': 8.25.0
 
-  '@typescript-eslint/type-utils@8.25.0(eslint@9.21.0)(typescript@5.7.3)':
+  '@typescript-eslint/type-utils@8.25.0(eslint@9.21.0)(typescript@5.8.2)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 8.25.0(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.25.0(eslint@9.21.0)(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 8.25.0(typescript@5.8.2)
+      '@typescript-eslint/utils': 8.25.0(eslint@9.21.0)(typescript@5.8.2)
       debug: 4.4.0
       eslint: 9.21.0
-      ts-api-utils: 2.0.1(typescript@5.7.3)
-      typescript: 5.7.3
+      ts-api-utils: 2.0.1(typescript@5.8.2)
+      typescript: 5.8.2
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/types@8.25.0': {}
 
-  '@typescript-eslint/typescript-estree@8.25.0(typescript@5.7.3)':
+  '@typescript-eslint/typescript-estree@8.25.0(typescript@5.8.2)':
     dependencies:
       '@typescript-eslint/types': 8.25.0
       '@typescript-eslint/visitor-keys': 8.25.0
@@ -2889,19 +2889,19 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.5
       semver: 7.7.1
-      ts-api-utils: 2.0.1(typescript@5.7.3)
-      typescript: 5.7.3
+      ts-api-utils: 2.0.1(typescript@5.8.2)
+      typescript: 5.8.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.25.0(eslint@9.21.0)(typescript@5.7.3)':
+  '@typescript-eslint/utils@8.25.0(eslint@9.21.0)(typescript@5.8.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.1(eslint@9.21.0)
       '@typescript-eslint/scope-manager': 8.25.0
       '@typescript-eslint/types': 8.25.0
-      '@typescript-eslint/typescript-estree': 8.25.0(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 8.25.0(typescript@5.8.2)
       eslint: 9.21.0
-      typescript: 5.7.3
+      typescript: 5.8.2
     transitivePeerDependencies:
       - supports-color
 
@@ -4028,15 +4028,15 @@ snapshots:
 
   tree-kill@1.2.2: {}
 
-  ts-api-utils@2.0.1(typescript@5.7.3):
+  ts-api-utils@2.0.1(typescript@5.8.2):
     dependencies:
-      typescript: 5.7.3
+      typescript: 5.8.2
 
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
 
-  typescript@5.7.3: {}
+  typescript@5.8.2: {}
 
   undate@0.3.0: {}
 

--- a/ui/.build/package.json
+++ b/ui/.build/package.json
@@ -22,7 +22,7 @@
     "fast-xml-parser": "4.5.3",
     "micromatch": "4.0.8",
     "tinycolor2": "1.6.0",
-    "typescript": "5.7.3"
+    "typescript": "5.8.2"
   },
   "scripts": {
     "dev": "node --experimental-strip-types --no-warnings src/main.ts $@"

--- a/ui/.build/pnpm-lock.yaml
+++ b/ui/.build/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: 1.6.0
         version: 1.6.0
       typescript:
-        specifier: 5.7.3
-        version: 5.7.3
+        specifier: 5.8.2
+        version: 5.8.2
     optionalDependencies:
       sass-embedded-darwin-arm64:
         specifier: 1.85.0
@@ -339,8 +339,8 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
-  typescript@5.7.3:
-    resolution: {integrity: sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==}
+  typescript@5.8.2:
+    resolution: {integrity: sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -555,6 +555,6 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
-  typescript@5.7.3: {}
+  typescript@5.8.2: {}
 
   undici-types@6.20.0: {}

--- a/ui/.build/tsconfig.json
+++ b/ui/.build/tsconfig.json
@@ -10,6 +10,7 @@
     "strict": true,
     "esModuleInterop": true,
     "isolatedModules": true,
+    "erasableSyntaxOnly": true,
     "moduleResolution": "node",
     "module": "es2022",
     "target": "es2023",

--- a/ui/@types/lichess/index.d.ts
+++ b/ui/@types/lichess/index.d.ts
@@ -26,6 +26,7 @@ interface Site {
     jsModule(name: string): string;
     loadIife(path: string, opts?: AssetUrlOpts): Promise<void>;
     loadEsm<T>(key: string, opts?: EsmModuleOpts): Promise<T>;
+    patchWorkerConstructor(): void;
   };
   unload: { expected: boolean };
   redirect(o: RedirectTo, beep?: boolean): void;

--- a/ui/ceval/package.json
+++ b/ui/ceval/package.json
@@ -30,6 +30,7 @@
   "build": {
     "sync": {
       "node_modules/*stockfish*/*.{js,wasm}": "/public/npm"
-    }
+    },
+    "hash": "/public/npm/lila-stockfish-web/*"
   }
 }

--- a/ui/ceval/src/engines/engines.ts
+++ b/ui/ceval/src/engines/engines.ts
@@ -47,7 +47,6 @@ export class Engines {
         variants: [key],
         cloudEval: true,
         assets: {
-          version: 'sfw009',
           root: 'npm/lila-stockfish-web',
           nnue: [`${variantMap(key)}-${nnue}.nnue`],
           js: 'fsf14.js',
@@ -75,7 +74,6 @@ export class Engines {
           minMem: 1536,
           cloudEval: true,
           assets: {
-            version: 'sfw009',
             root: 'npm/lila-stockfish-web',
             js: 'sf16-7.js',
           },
@@ -92,7 +90,6 @@ export class Engines {
           minMem: 2560,
           cloudEval: true,
           assets: {
-            version: 'sfw009',
             root: 'npm/lila-stockfish-web',
             js: 'sf17-79.js',
           },
@@ -127,7 +124,6 @@ export class Engines {
           requires: ['sharedMem', 'simd', 'dynamicImportFromWorker'],
           variants: variants.map(v => v[0]),
           assets: {
-            version: 'sfw009',
             root: 'npm/lila-stockfish-web',
             js: 'fsf14.js',
           },

--- a/ui/ceval/src/engines/stockfishWebEngine.ts
+++ b/ui/ceval/src/engines/stockfishWebEngine.ts
@@ -33,12 +33,13 @@ export class StockfishWebEngine implements CevalEngine {
   }
 
   async boot(): Promise<void> {
-    const [pathVersion, root, js] = [this.info.assets.version, this.info.assets.root, this.info.assets.js];
-    const makeModule = await import(site.asset.url(`${root}/${js}`, { pathVersion, documentOrigin: true }));
+    site.asset.patchWorkerConstructor();
+    const [root, js] = [this.info.assets.root, this.info.assets.js];
+    const makeModule = await import(site.asset.url(`${root}/${js}`, { documentOrigin: true }));
     const module: StockfishWeb = await makeModule.default({
       wasmMemory: sharedWasmMemory(this.info.minMem!),
       onError: (msg: string) => Promise.reject(new Error(msg)),
-      locateFile: (file: string) => site.asset.url(`${root}/${file}`, { pathVersion }),
+      locateFile: (file: string) => site.asset.url(`${root}/${file}`),
     });
     if (this.info.tech === 'NNUE') {
       if (this.info.variants?.length === 1) {

--- a/ui/site/src/asset.ts
+++ b/ui/site/src/asset.ts
@@ -79,3 +79,28 @@ export const loadEsmPage = async (name: string) => {
 export function embedChessground() {
   return import(url('npm/chessground.min.js'));
 }
+
+let isWorkerPatched = false;
+
+export function patchWorkerConstructor() {
+  // this might be the cleanest way to bootstrap emscripted wasm as es6 with a different link.
+  // libpthread.js:allocateUnusedWorker is hardwired to import the bare module script
+  // filename relative to import.meta.url, but we need it hashed for auto-versioning
+  if (isWorkerPatched) return;
+  isWorkerPatched = true;
+
+  window.Worker = class extends window.Worker {
+    constructor(urlOrStr: string | URL, opts?: WorkerOptions) {
+      const url = new URL(urlOrStr.toString());
+      const file = url.pathname.split('/').pop();
+      if (file?.endsWith('.js') && (url.host === location.host || url.origin === baseUrl())) {
+        const key = Object.keys(site.manifest.hashed).find(k => k.endsWith(file));
+        if (key) {
+          super(new URL(`assets/${asHashed(key, site.manifest.hashed[key])}`, url.origin), opts);
+          return;
+        }
+      }
+      super(urlOrStr, opts);
+    }
+  };
+}


### PR DESCRIPTION
to customize the url for emscripten generated pthreads, monkey patching the web Worker constructor is cleaner than the alternatives.