### PR TITLE
Relax tourney join rate limit

### DIFF
--- a/modules/web/src/main/Limiters.scala
+++ b/modules/web/src/main/Limiters.scala
@@ -128,7 +128,7 @@ final class Limiters(using Executor, lila.core.config.RateLimit):
 
   val ublog = RateLimit[UserId](credits = 5 * 3, duration = 24.hour, key = "ublog.create.user")
 
-  val tourJoin = RateLimit[UserId](credits = 30, duration = 10.minutes, key = "tournament.user.join")
+  val tourJoin = RateLimit[UserId](credits = 30, duration = 2.minutes, key = "tournament.user.join")
 
   val tourCreate = RateLimit[UserId](credits = 240, duration = 1.day, key = "tournament.user")
 


### PR DESCRIPTION
As a bot developer, I am feeling that the 10-minute cooldown period for rate limit is too long for the tourney-join endpoint.

Some users want to [schedule several bot tourneys out a few weeks](https://discord.com/channels/1339265423861878876/1339265423861878879/1346931723958751304) into the future.

It's cumbersome to register a bot for all of these tourneys, so I created a [small script](https://github.com/greg-finley/lichess-tourney-joiner).

Currently we need to repeatedly wait a long time to join all tourneys:
![image](https://github.com/user-attachments/assets/19552c2b-d39c-4811-bd31-8c7254349f6b)

Here is [the commit originally adding the tourney join rate limit](https://github.com/lichess-org/lila/commit/328e01e5872aa6e6624fd55851c68259a09edd64) in case it's helpful context.

Discord threads of interest:
* https://discord.com/channels/1339265423861878876/1339265423861878879/1347262480635662389
* Lichess help: https://discord.com/channels/280713822073913354/1347263516272234606