### PR TITLE
second click will close study tour

### DIFF
--- a/ui/analyse/src/plugins/analyse.study.tour.ts
+++ b/ui/analyse/src/plugins/analyse.study.tour.ts
@@ -116,7 +116,7 @@ export function initModule(): StudyTour {
       ],
     });
 
-    tourCtrl.startTour(steps);
+    tourCtrl.toggleTour(steps);
   }
 
   function chapter(setTab: (tab: ChapterTab) => void) {
@@ -192,7 +192,7 @@ export function initModule(): StudyTour {
       },
     ];
 
-    tourCtrl.startTour(steps);
+    tourCtrl.toggleTour(steps);
   }
 }
 
@@ -227,9 +227,12 @@ class TourCtrl {
     );
   }
 
-  startTour(steps: Shepherd.Step.StepOptions[]) {
-    Shepherd.activeTour?.cancel();
-    this.buildTour(steps);
-    this.tour.start();
+  toggleTour(steps: Shepherd.Step.StepOptions[]) {
+    if (Shepherd.activeTour) {
+      Shepherd.activeTour.cancel();
+    } else {
+      this.buildTour(steps);
+      this.tour.start();
+    }
   }
 }


### PR DESCRIPTION
1. go to a study page like [this one](https://lichess.org/study/whCVdUeM)
2. under board, click the last icon, the help "ⓘ"
3. with this PR, clicking it a 2nd time will close it instead of restarting the tour