### PR TITLE
Show player signal in game

### DIFF
--- a/modules/api/src/main/RoundApi.scala
+++ b/modules/api/src/main/RoundApi.scala
@@ -65,6 +65,7 @@ final private[api] class RoundApi(
         .compose(withBookmark(bookmarked))
         .compose(withForecastCount(forecast.map(_.steps.size)))
         .compose(withOpponentSignal(pov))
+        .compose(withPlayerSignal(pov))
     )(json)
   }.mon(_.round.api.player)
 
@@ -205,6 +206,9 @@ final private[api] class RoundApi(
     if pov.game.speed <= chess.Speed.Bullet then
       json.add("opponentSignal", pov.opponent.userId.flatMap(userLag.getLagRating))
     else json
+
+  private def withPlayerSignal(pov: Pov)(json: JsObject) =
+    json.add("playerSignal", pov.player.userId.flatMap(userLag.getLagRating))
 
   private def withPuzzleOpening(
       opening: Option[Either[PuzzleOpening.FamilyWithCount, PuzzleOpening.WithCount]]

--- a/ui/round/src/interfaces.ts
+++ b/ui/round/src/interfaces.ts
@@ -53,6 +53,7 @@ export interface RoundData extends GameData {
   possibleDrops?: string;
   forecastCount?: number;
   opponentSignal?: number;
+  playerSignal?: number;
   crazyhouse?: Tree.NodeCrazy;
   correspondence?: CorresClockData;
   tv?: Tv;

--- a/ui/round/src/view/user.ts
+++ b/ui/round/src/view/user.ts
@@ -10,7 +10,7 @@ export function userHtml(ctrl: RoundController, player: Player, position: Positi
     user = player.user,
     perf = (user?.perfs || {})[d.game.perf],
     rating = player.rating || perf?.rating,
-    signal = user?.id === d.opponent.user?.id ? d.opponentSignal : undefined;
+    signal = user?.id === d.opponent.user?.id ? d.opponentSignal : d.playerSignal;
 
   if (user) {
     const connecting = !player.onGame && ctrl.firstSeconds && user.online;


### PR DESCRIPTION
![Screenshot 2025-03-11 23 01 25](https://github.com/user-attachments/assets/fca9df4f-a1a4-4e5c-8539-317199dc5404)

Showing the player's signal would be interesting as a way to show that your ping is unstable.
Relying on the dasher or "reconnecting..." notice in the corner of the site is not very good.
The opponent's signal continues to only show in bullet