### PR TITLE
new feature: half blindfolded puzzles like in listudy

### DIFF
--- a/modules/coreI18n/src/main/key.scala
+++ b/modules/coreI18n/src/main/key.scala
@@ -1143,6 +1143,7 @@ object I18nKey:
     val `notifyDevice`: I18nKey = "preferences:notifyDevice"
     val `bellNotificationSound`: I18nKey = "preferences:bellNotificationSound"
     val `blindfold`: I18nKey = "preferences:blindfold"
+    val `halfBlindfold`: I18nKey = "preferences:halfBlindfold"
 
   object puzzle:
     val `puzzles`: I18nKey = "puzzle:puzzles"

--- a/translation/source/preferences.xml
+++ b/translation/source/preferences.xml
@@ -69,4 +69,5 @@
   <string name="notifyDevice">Device</string>
   <string name="bellNotificationSound">Bell notification sound</string>
   <string name="blindfold" comment="As in Blindfold chess">Blindfold</string>
+  <string name="halfBlindfold">Half Blindfold</string>
 </resources>

--- a/ui/.build/src/task.ts
+++ b/ui/.build/src/task.ts
@@ -107,10 +107,7 @@ async function execute(t: Task): Promise<void> {
       }),
     );
   }
-  if (modified.length === 0) {
-    t.status = 'ok';
-    return;
-  }
+  if (modified.length === 0) return;
 
   if (t.ctx) env.begin(t.ctx);
   t.status = undefined;

--- a/ui/.build/src/task.ts
+++ b/ui/.build/src/task.ts
@@ -107,7 +107,11 @@ async function execute(t: Task): Promise<void> {
       }),
     );
   }
-  if (modified.length === 0) return;
+  if (modified.length === 0)
+  {
+    t.status = "ok";
+    return;
+  }
 
   if (t.ctx) env.begin(t.ctx);
   t.status = undefined;

--- a/ui/.build/src/task.ts
+++ b/ui/.build/src/task.ts
@@ -107,9 +107,8 @@ async function execute(t: Task): Promise<void> {
       }),
     );
   }
-  if (modified.length === 0)
-  {
-    t.status = "ok";
+  if (modified.length === 0) {
+    t.status = 'ok';
     return;
   }
 

--- a/ui/common/src/boardMenu.ts
+++ b/ui/common/src/boardMenu.ts
@@ -80,14 +80,14 @@ export class BoardMenu {
       disabled: !enabled,
     });
 
-    halfBlindfold = (toggle: Toggle, enabled = true): VNode =>
-      this.cmnToggle({
-        name: i18n.preferences.halfBlindfold,
-        id: 'halfBlindfold',
-        checked: toggle(),
-        change: toggle,
-        disabled: !enabled,
-      });
+  halfBlindfold = (toggle: Toggle, enabled = true): VNode =>
+    this.cmnToggle({
+      name: i18n.preferences.halfBlindfold,
+      id: 'halfBlindfold',
+      checked: toggle(),
+      change: toggle,
+      disabled: !enabled,
+    });
 
   confirmMove = (toggle: Toggle, enabled = true): VNode =>
     this.cmnToggle({

--- a/ui/common/src/boardMenu.ts
+++ b/ui/common/src/boardMenu.ts
@@ -80,6 +80,15 @@ export class BoardMenu {
       disabled: !enabled,
     });
 
+    halfBlindfold = (toggle: Toggle, enabled = true): VNode =>
+      this.cmnToggle({
+        name: i18n.preferences.halfBlindfold,
+        id: 'halfBlindfold',
+        checked: toggle(),
+        change: toggle,
+        disabled: !enabled,
+      });
+
   confirmMove = (toggle: Toggle, enabled = true): VNode =>
     this.cmnToggle({
       name: 'Confirm move',

--- a/ui/puzzle/src/ctrl.ts
+++ b/ui/puzzle/src/ctrl.ts
@@ -167,7 +167,7 @@ export default class PuzzleCtrl implements ParentCtrl {
     this.path = path;
     this.nodeList = this.tree.getNodeList(path);
     this.node = treeOps.last(this.nodeList)!;
-    if (!this.halfBlindfold() || (path.length < this.visiblePath.length))
+    if (!this.halfBlindfold() || (path.length < this.visiblePath.length) || this.mode == "view")
     {
       this.visibleNode = this.node;
     }
@@ -436,12 +436,12 @@ export default class PuzzleCtrl implements ParentCtrl {
       }
     } else if (progress === 'win') {
       if (this.streak) this.sound.good();
+      this.visibleNode = this.node;
+      this.withGround(this.showGround);
       this.lastFeedback = 'win';
       if (this.mode != 'view') {
         const sent = this.mode === 'play' ? this.sendResult(true) : Promise.resolve();
         this.mode = 'view';
-        this.visibleNode = this.node;
-        this.withGround(this.showGround);
         sent.then(_ => (this.autoNext() ? this.nextPuzzle() : this.startCeval()));
       }
     } else if (progress) {
@@ -645,6 +645,8 @@ export default class PuzzleCtrl implements ParentCtrl {
 
     this.autoScrollRequested = true;
     this.voteDisabled = true;
+    this.visibleNode = this.node;
+    this.withGround(this.showGround)
     this.redraw();
     this.startCeval();
     setTimeout(() => {

--- a/ui/puzzle/src/ctrl.ts
+++ b/ui/puzzle/src/ctrl.ts
@@ -58,7 +58,7 @@ export default class PuzzleCtrl implements ParentCtrl {
   cgConfig?: CgConfig;
   path: Tree.Path;
   node: Tree.Node;
-  visibleNode : Tree.Node;
+  visibleNode: Tree.Node;
   nodeList: Tree.Node[];
   mainline: Tree.Node[];
   initialPath: Tree.Path;
@@ -167,12 +167,9 @@ export default class PuzzleCtrl implements ParentCtrl {
     this.path = path;
     this.nodeList = this.tree.getNodeList(path);
     this.node = treeOps.last(this.nodeList)!;
-    if (!this.halfBlindfold() || (path.length < this.visiblePath.length) || this.mode == "view")
-    {
+    if (!this.halfBlindfold() || path.length < this.visiblePath.length || this.mode == 'view') {
       this.visibleNode = this.node;
-    }
-    else
-    {
+    } else {
       const visibleNodeList = this.tree.getNodeList(this.visiblePath);
       const visibleNode = treeOps.last(visibleNodeList)!;
       this.visibleNode = visibleNode;
@@ -225,9 +222,11 @@ export default class PuzzleCtrl implements ParentCtrl {
   initiate = (fromData: PuzzleData): void => {
     this.data = fromData;
     this.tree = treeBuild(pgnToTree(this.data.game.pgn.split(' ')));
-    const initialNodeList = treeOps.mainlineNodeList(this.tree.root)
+    const initialNodeList = treeOps.mainlineNodeList(this.tree.root);
     const initialPath = treePath.fromNodeList(initialNodeList);
-    const visiblePath = treePath.fromNodeList(initialNodeList.slice(0, initialNodeList.length - Math.min(initialNodeList.length, 4)));
+    const visiblePath = treePath.fromNodeList(
+      initialNodeList.slice(0, initialNodeList.length - Math.min(initialNodeList.length, 4)),
+    );
     this.mode = 'play';
     this.next = defer();
     this.round = undefined;
@@ -280,7 +279,7 @@ export default class PuzzleCtrl implements ParentCtrl {
     const dests = chessgroundDests(this.position());
     const nextNode = this.node.children[0];
     const canMove = this.mode === 'view' || (color === this.pov && (!nextNode || nextNode.puzzle === 'fail'));
-    const showDests = (!this.blindfold() && !this.halfBlindfold());
+    const showDests = !this.blindfold() && !this.halfBlindfold();
     const movable = canMove
       ? {
           color: dests.size > 0 ? color : undefined,
@@ -291,7 +290,7 @@ export default class PuzzleCtrl implements ParentCtrl {
       : {
           color: undefined,
           dests: new Map(),
-          showDests : showDests
+          showDests: showDests,
         };
     const config = {
       fen: this.visibleNode.fen,
@@ -603,7 +602,7 @@ export default class PuzzleCtrl implements ParentCtrl {
   };
 
   userJump = (path: Tree.Path): void => {
-    // if (this.halfBlindfolded && path.length > this.visiblePath.length) return; 
+    // if (this.halfBlindfolded && path.length > this.visiblePath.length) return;
     if (this.tree.nodeAtPath(path)?.puzzle === 'fail' && this.mode != 'view') return;
     this.withGround(g => g.selectSquare(null));
     this.jump(path);
@@ -646,7 +645,7 @@ export default class PuzzleCtrl implements ParentCtrl {
     this.autoScrollRequested = true;
     this.voteDisabled = true;
     this.visibleNode = this.node;
-    this.withGround(this.showGround)
+    this.withGround(this.showGround);
     this.redraw();
     this.startCeval();
     setTimeout(() => {
@@ -703,10 +702,10 @@ export default class PuzzleCtrl implements ParentCtrl {
   halfBlindfold = (v?: boolean): boolean => {
     if (v !== undefined && v !== this.halfBlindfolded) {
       this.halfBlindfolded = v;
-      this.withGround(this.showGround)
+      this.withGround(this.showGround);
       this.redraw();
       //we reset the path in case it's longer than visible path
-      this.jump(this.path)
+      this.jump(this.path);
     }
     return this.halfBlindfolded;
   };

--- a/ui/puzzle/src/interfaces.ts
+++ b/ui/puzzle/src/interfaces.ts
@@ -49,6 +49,7 @@ export interface PuzzlePrefs {
     duration: number;
   };
   blindfold: boolean;
+  halfBlindfold: boolean;
   keyboardMove: boolean;
   voiceMove: boolean;
 }

--- a/ui/puzzle/src/view/boardMenu.ts
+++ b/ui/puzzle/src/view/boardMenu.ts
@@ -18,6 +18,10 @@ export default function (ctrl: PuzzleCtrl) {
         toggle(ctrl.blindfold(), v => ctrl.blindfold(v)),
         true,
       ),
+      menu.halfBlindfold(
+        toggle(ctrl.halfBlindfold(), v => ctrl.halfBlindfold(v)),
+        true,
+      ),
       menu.voiceInput(boolPrefXhrToggle('voice', !!ctrl.voiceMove), true),
       menu.keyboardInput(boolPrefXhrToggle('keyboardMove', !!ctrl.keyboardMove), true),
     ]),

--- a/ui/puzzle/src/view/chessground.ts
+++ b/ui/puzzle/src/view/chessground.ts
@@ -30,11 +30,12 @@ export function makeConfig(ctrl: PuzzleCtrl): CgConfig {
       free: false,
       color: opts.movable!.color,
       dests: opts.movable!.dests,
-      showDests: ctrl.pref.destination && !ctrl.blindfold(),
+      showDests: ctrl.pref.destination && (!ctrl.blindfold() && !ctrl.halfBlindfold()),
       rookCastle: ctrl.pref.rookCastle,
+      shadowMove: ctrl.halfBlindfold(),
     },
     draggable: {
-      enabled: ctrl.pref.moveEvent > 0,
+      enabled: ctrl.pref.moveEvent > 0 && !ctrl.halfBlindfold(),
       showGhost: ctrl.pref.highlight,
     },
     selectable: {

--- a/ui/puzzle/src/view/chessground.ts
+++ b/ui/puzzle/src/view/chessground.ts
@@ -30,7 +30,7 @@ export function makeConfig(ctrl: PuzzleCtrl): CgConfig {
       free: false,
       color: opts.movable!.color,
       dests: opts.movable!.dests,
-      showDests: ctrl.pref.destination && (!ctrl.blindfold() && !ctrl.halfBlindfold()),
+      showDests: ctrl.pref.destination && !ctrl.blindfold() && !ctrl.halfBlindfold(),
       rookCastle: ctrl.pref.rookCastle,
       shadowMove: ctrl.halfBlindfold(),
     },

--- a/ui/puzzle/src/view/tree.ts
+++ b/ui/puzzle/src/view/tree.ts
@@ -92,7 +92,7 @@ function renderMainlineMoveOf(ctx: Ctx, node: Tree.Node, opts: RenderOpts): VNod
     active: path === ctx.ctrl.path,
     current: path === ctx.ctrl.initialPath,
     hist: node.ply < ctx.ctrl.initialNode.ply,
-    lastvisible: (path === ctx.ctrl.visiblePath) && ctx.ctrl.halfBlindfolded
+    lastvisible: path === ctx.ctrl.visiblePath && ctx.ctrl.halfBlindfolded,
   };
   if (node.puzzle) classes[node.puzzle] = true;
   return h('move', { attrs: { p: path }, class: classes }, renderMove(node));

--- a/ui/puzzle/src/view/tree.ts
+++ b/ui/puzzle/src/view/tree.ts
@@ -92,6 +92,7 @@ function renderMainlineMoveOf(ctx: Ctx, node: Tree.Node, opts: RenderOpts): VNod
     active: path === ctx.ctrl.path,
     current: path === ctx.ctrl.initialPath,
     hist: node.ply < ctx.ctrl.initialNode.ply,
+    lastvisible: (path === ctx.ctrl.visiblePath) && ctx.ctrl.halfBlindfolded
   };
   if (node.puzzle) classes[node.puzzle] = true;
   return h('move', { attrs: { p: path }, class: classes }, renderMove(node));

--- a/ui/tree/css/_tree.scss
+++ b/ui/tree/css/_tree.scss
@@ -130,6 +130,10 @@
     border: 1px solid $c-accent;
   }
 
+  move.lastvisible {
+    border: 1px solid $c-inaccuracy;
+  }
+
   move.active {
     font-weight: bold;
     background: $m-primary_bg--mix-25;


### PR DESCRIPTION
Hello,

Status is red because it needs a PR from chessground to compile, please see at the end of the description

I implemented a first version of "half blinded" puzzles. Basically it's what is available here : [https://listudy.org/en/blind-tactics/549](https://listudy.org/en/blind-tactics/549) for example. It's related to this issue : #17122 

The idea is that instead of having the full blindfold chessboard you can see the state 4 half move before the last one. And you have to play the last moves in you head and solve the puzzle wihtout seeing pieces moving. I think it's really interesting and I wanted to have that in lichess, so here is how it works.

First, you can enable "half blinfold" in the options, and the last visible move will be in blue. You can click on any node but the ones after the blue ones won't be displayed : 

![gif1](https://github.com/user-attachments/assets/9b60c80c-eb3d-4842-835e-d345643444d3)

In this problem, the pawn f6 has been moved to f5 in a  #"hidden" move, so tring to move f6 doesn't work : 

![gif3](https://github.com/user-attachments/assets/0d90e597-3f8e-481d-b459-21baaace5a90)

But we can move f5 to f4 even if it's hidden. This can seems a bit weird but it's like that on listudy and I find it's a good way to do:

![gif4](https://github.com/user-attachments/assets/3af21b22-61a4-4e7d-b628-01c317caa299)

when we solve the problem the final position is displayed (and all node can be displayed in view mode)

![gif5](https://github.com/user-attachments/assets/9a020ba4-312b-4955-adb1-048404118515)

We can also see hint and the solution as for a normal problem :

![gif6](https://github.com/user-attachments/assets/01693c05-d260-4549-ae28-9f3a185e9ada)

This required to modify a bit chessground, so I made a pull request here that implement "shadow move" which is basically executing a move without touching to the pieces (blindfoled mode is implemented by hiding the pieces with css but they are actually moved). The PR is at : https://github.com/lichess-org/chessground/pull/323

I think the build will fail without the modification in chessground because I added a config field.

Now I think this doesn't work well for mobile because the nodes aren't displayed, but I will work on it if you are planning to accept the feature. This PR allow to test it on a computer. I also plan to make the number of hidden move editable in config.
