### PR TITLE
Add replacement for Norwegian 'å' character

### DIFF
--- a/modules/core/src/main/fide.scala
+++ b/modules/core/src/main/fide.scala
@@ -40,6 +40,7 @@ object diacritics:
   private val replacements = List(
     "ö" -> "oe",
     "ø" -> "o",
+    "å" -> "aa",
     "ä" -> "ae",
     "ü" -> "ue",
     "ß" -> "ss"


### PR DESCRIPTION
I haven't hit a scenario yet with this character, but I guess it doesn't hurt to have the replacement ready for when it happens.