### PR TITLE
fix: threefold repetition message not preserved in non-standard games

### DIFF
--- a/modules/game/src/main/GameRepo.scala
+++ b/modules/game/src/main/GameRepo.scala
@@ -368,7 +368,6 @@ final class GameRepo(c: Coll)(using Executor) extends lila.core.game.GameRepo(c)
   private def holdAlertField(color: Color) = s"p${color.fold(0, 1)}.${PF.holdAlert}"
 
   private val finishUnsets = $doc(
-    F.positionHashes               -> true,
     F.playingUids                  -> true,
     F.unmovedRooks                 -> true,
     ("p0." + PF.isOfferingDraw)    -> true,


### PR DESCRIPTION
fixes #17117

The described bug occurs in all non-standard games because the existence of threefold repetition is [recognized using](https://github.com/lichess-org/scalachess/blob/master/core/src/main/scala/History.scala#L29) the `positionHashes` attribute, but `positionHashes` is unset when a game finishes. It does not occur in standard games because those use the new [HuffmanPgn](https://github.com/lichess-org/lila/blob/981b81d33af3e16d0750e77bef747e3e28ee3cf3/modules/game/src/main/BSONHandlers.scala#L244), which implicitly encode position hashes, instead of oldPgn.

If storing positionHashes is too costly, happy to work on an alternative solution as maintainers see fit, e.g. we could explicitly add threefold repetition as a field in `game5`.

Tested by inducing threefold repetition in a from position game.