### PR TITLE
Don't give draw claims as explanations for imported games

### DIFF
--- a/ui/game/src/game.ts
+++ b/ui/game/src/game.ts
@@ -46,7 +46,7 @@ export const moretimeable = (data: GameData): boolean =>
     (!!data.correspondence &&
       data.correspondence[data.opponent.color] < data.correspondence.increment - 3600));
 
-const imported = (data: GameData): boolean => data.game.source === 'import';
+export const imported = (data: GameData): boolean => data.game.source === 'import';
 
 export const replayable = (data: GameData): boolean =>
   imported(data) || finished(data) || (aborted(data) && bothPlayersHavePlayed(data));

--- a/ui/game/src/view/status.ts
+++ b/ui/game/src/view/status.ts
@@ -1,4 +1,5 @@
 import type { Ctrl } from '../interfaces';
+import { imported } from '../game';
 
 export function bishopOnColor(expandedFen: string, offset: 0 | 1): boolean {
   if (expandedFen.length !== 64) throw new Error('Expanded FEN expected to be 64 characters');
@@ -73,6 +74,7 @@ export default function status(ctrl: Ctrl): string {
       if (insufficientMaterial(d.game.variant.key, d.game.fen))
         return `${i18n.site.insufficientMaterial} • ${i18n.site.draw}`;
       if (d.game.drawOffers?.some(turn => turn >= d.game.turns)) return i18n.site.drawByMutualAgreement;
+      if (imported(d)) return i18n.site.draw;
       return `${i18n.site.drawClaimed} • ${i18n.site.insufficientMaterial}`;
     }
     case 'outoftime':


### PR DESCRIPTION
Note: this PR applies a fix for games whose `Source` is 'imported'. I'm not sure if a `Source` val of 'local' can also refer to games played off lichess; if so, they should be included in this PR too.

--------------------------------------

For Masters DB games, if the players agreed to a draw by mutual agreement, the game is incorrectly labelled as a draw claim by insufficient material. E.g.:

![image](https://github.com/user-attachments/assets/e1a176e5-2cf5-46b6-a92b-996b104706df)

This is due to #17114, where I incorrectly assumed control flows reaching this point in the code could only be draws by insufficient material claims. However, imported games in the Masters DB aren't obliged to provide specific draw info, so they can also reach this point.