### PR TITLE
Improve username error message in close account form

### DIFF
--- a/modules/security/src/main/SecurityForm.scala
+++ b/modules/security/src/main/SecurityForm.scala
@@ -27,7 +27,7 @@ final class SecurityForm(
     newPasswordField.verifying(PasswordCheck.sameConstraint(me.username.into(UserStr)))
 
   def myUsernameField(using me: Me) =
-    LilaForm.cleanNonEmptyText.into[UserStr].verifying("Please log into your account first.", _.is(me))
+    LilaForm.cleanNonEmptyText.into[UserStr].verifying("Username doesn't match the currently logged-in account.", _.is(me))
 
   private val anyEmail: Mapping[EmailAddress] =
     LilaForm


### PR DESCRIPTION
One user incorrectly entered their email into the username field in the close account form and the "Please log into your account first" error you currently get in response to that doesn't seem particularly clear.

There probably are better options than my new proposed message but it's the best I was able to come up with on the spot to indicate more clearly that it's about the username while hinting that the logged-in account is relevant and might have to be switched if another account should be closed.