### PR TITLE
Fix #16759: chart rating history clipping to always include the latest rating val

### DIFF
--- a/ui/chart/src/chart.ratingHistory.ts
+++ b/ui/chart/src/chart.ratingHistory.ts
@@ -324,6 +324,10 @@ function smoothDates(data: TsAndRating[], step: number, begin: number) {
   const reversed = data.slice().reverse();
   const allDates: number[] = [];
   for (let i = begin; i <= end; i += oneStep) allDates.push(i);
+  // Ensure latest rating is always included (regardless of step or begin)
+  if (allDates[allDates.length - 1] < end) {
+    allDates.push(end);
+  }
   const result: Point[] = [];
   for (let j = 0; j < allDates.length; j++) {
     const match = reversed.find(x => x.ts <= allDates[j]);


### PR DESCRIPTION
-  See for the full desc Issue #16759
- Works as expected for scroll/slider in both directions
- Fixes `SmoothDates()`
- Always includes the latest player rating into allDates, when bin size/end date clips, prevents duplication.

<img width="1059" alt="Screenshot 2025-03-20 at 17 25 28" src="https://github.com/user-attachments/assets/dfba5c8c-86e8-414a-b735-80e3eb335871" />
<img width="1072" alt="Screenshot 2025-03-20 at 17 25 13" src="https://github.com/user-attachments/assets/24314d42-2942-48e3-9f7c-5143fa3e24b0" />
