### PR TITLE
Avoid listing BBB twice

### DIFF
--- a/modules/tournament/src/main/Spotlight.scala
+++ b/modules/tournament/src/main/Spotlight.scala
@@ -23,14 +23,11 @@ object Spotlight:
       case None       => (tour.isTeamRelated.so(Schedule.Freq.Weekly.importance), -tour.secondsToStart.value)
 
   def select(tours: List[Tournament], max: Int)(using me: Option[UserWithPerfs]): List[Tournament] =
-    me.foldUse(select(tours))(selectForMe(tours)).distinct.topN(max)
+    me.foldUse(select(tours))(tours.filter(selectForMe).distinct).topN(max)
 
   private def select(tours: List[Tournament]): List[Tournament] =
     tours.filter: tour =>
       tour.spotlight.forall(manually(tour, _))
-
-  private def selectForMe(tours: List[Tournament])(using UserWithPerfs): List[Tournament] =
-    tours.filter(selectForMe)
 
   private def selectForMe(tour: Tournament)(using UserWithPerfs): Boolean =
     !tour.isFinished &&

--- a/modules/tournament/src/main/Spotlight.scala
+++ b/modules/tournament/src/main/Spotlight.scala
@@ -23,7 +23,7 @@ object Spotlight:
       case None       => (tour.isTeamRelated.so(Schedule.Freq.Weekly.importance), -tour.secondsToStart.value)
 
   def select(tours: List[Tournament], max: Int)(using me: Option[UserWithPerfs]): List[Tournament] =
-    me.foldUse(select(tours))(selectForMe(tours)).topN(max)
+    me.foldUse(select(tours))(selectForMe(tours)).distinct.topN(max)
 
   private def select(tours: List[Tournament]): List[Tournament] =
     tours.filter: tour =>


### PR DESCRIPTION
In case a tournament has been featured,
and a Lichess user is member in a team which is participating in the tournament, the tournament can show twice.
This commit removes duplicates.

![bbb](https://github.com/user-attachments/assets/afeb8f8c-3b61-4c95-8078-c6bdf3f16a0f)
