### PR TITLE
fix(board-menu): allow text wrapping in option menu

### DIFF
--- a/ui/common/css/component/_board-menu.scss
+++ b/ui/common/css/component/_board-menu.scss
@@ -44,7 +44,6 @@
     label {
       flex: 4 1 auto;
       cursor: pointer;
-      white-space: nowrap;
     }
 
     .switch + label {


### PR DESCRIPTION
some langauges have long translations for the options menu, causing it to overlap with the board and text wrapping was disabled 

closes #17202

**before:** 

![image](https://github.com/user-attachments/assets/e71738fe-8770-449c-80a5-4f4a7732ddb1)


**now:**


![image](https://github.com/user-attachments/assets/19ef744a-487d-4ace-9766-4cb87ce1d8a4)

