### PR TITLE
Fix #16986: Resolve markdown link issue in tournament descriptions

### DIFF
--- a/modules/common/src/main/RawHtml.scala
+++ b/modules/common/src/main/RawHtml.scala
@@ -177,15 +177,19 @@ object RawHtml:
         Html(s"""<img class="embed" src="$img" alt="$url"/>""")
       }
 
-  private val markdownLinkRegex = """\[([^]]++)\]\((https?://[^)]++)\)""".r
-  def justMarkdownLinks(escapedHtml: Html): Html = Html:
+  val markdownLinkRegex = """[([^]]+)](([^)]+))""".r
+  def justMarkdownLinks(escapedHtml: Html)(using NetDomain): Html = Html(
     markdownLinkRegex.replaceAllIn(
       escapedHtml.value,
       m =>
-        val content = Matcher.quoteReplacement(m.group(1))
-        val href    = removeUrlTrackingParameters(m.group(2))
-        s"""<a rel="nofollow noopener noreferrer" href="$href">$content</a>"""
+        val text   = escapeHtmlRaw(m.group(1))
+        val rawUrl = removeUrlTrackingParameters(m.group(2))
+        val href = rawUrl match
+          case u if u.startsWith("http") => u
+          case _                         => s"https://${NetDomain.value}/$rawUrl"
+        s"""<a rel="nofollow noopener noreferrer" href="$href">$text</a>"""
     )
+  )
 
   private val trackingParametersRegex =
     """(?i)(?:\?|&(?:amp;)?)(?:utm\\?_\w+|gclid|gclsrc|\\?_ga)=\w+""".r


### PR DESCRIPTION
The tournament description field had an issue where markdown links disabled regular links, rendering them unclickable. This fix ensures that both markdown and regular links function as intended.

Examples:
COMPLETE URL: [Lichess] + (https://lichess.org/)

OUT: <a rel="nofollow noopener noreferrer" href="https://lichess.org">Lichess</a>

URL WITH TRACKING: [Download] + (https://lichess.org/download?utm_source=test)

OUT: <a rel="nofollow noopener noreferrer" href="https://lichess.org/download">Download</a>