### PR TITLE
Make the first friend row a different colour from the background.

### DIFF
--- a/modules/relation/src/main/ui/RelationUi.scala
+++ b/modules/relation/src/main/ui/RelationUi.scala
@@ -166,7 +166,7 @@ final class RelationUi(helpers: Helpers):
         main(cls := "box page-small")(body)
 
   private def pagTable(pager: Paginator[Related[UserWithPerfs]], call: Call)(using ctx: Context) =
-    table(cls := "slist slist-pad")(
+    table(cls := "slist slist-pad slist-invert")(
       if pager.nbResults > 0
       then
         tbody(cls := "infinite-scroll")(


### PR DESCRIPTION
Just aims to make it more immediately obvious that the first row is a row in the table.

Before:
![image](https://github.com/user-attachments/assets/fab8c58b-7a4e-4a67-a92b-12ff96482633)

After:
![image](https://github.com/user-attachments/assets/2a5e620c-1815-4f13-8696-e2e91e746e47)