### PR TITLE
Allow the user to delete a whole variation while at any move on it.

### DIFF
--- a/translation/source/site.xml
+++ b/translation/source/site.xml
@@ -70,6 +70,7 @@
   <string name="promoteVariation">Promote variation</string>
   <string name="makeMainLine">Make mainline</string>
   <string name="deleteFromHere">Delete from here</string>
+  <string name="deleteVariation">Delete variation</string>
   <string name="collapseVariations">Collapse variations</string>
   <string name="expandVariations">Expand variations</string>
   <string name="forceVariation">Force variation</string>

--- a/ui/@types/lichess/i18n.d.ts
+++ b/ui/@types/lichess/i18n.d.ts
@@ -3057,6 +3057,8 @@ interface I18n {
     deleteFromHere: string;
     /** Delete this imported game? */
     deleteThisImportedGame: string;
+    /** Delete variation */
+    deleteVariation: string;
     /** Depth %s */
     depthX: I18nFormat;
     /** Private description */

--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -629,6 +629,11 @@ export default class AnalyseCtrl {
     this.redraw();
   }
 
+  async deleteVariation(path: Tree.Path): Promise<void> {
+    const variationStart = this.tree.variationStart(path);
+    if (variationStart) await this.deleteNode(variationStart);
+  }
+
   promote(path: Tree.Path, toMainline: boolean): void {
     this.tree.promoteAt(path, toMainline);
     this.jump(path);

--- a/ui/analyse/src/treeView/contextMenu.ts
+++ b/ui/analyse/src/treeView/contextMenu.ts
@@ -78,6 +78,10 @@ function view(opts: Opts, coords: Coords): VNode {
 
       !onMainline && action(licon.Checkmark, i18n.site.makeMainLine, () => ctrl.promote(opts.path, true)),
 
+      !onMainline &&
+        opts.path !== ctrl.tree.variationStart(opts.path) &&
+        action(licon.Trash, i18n.site.deleteVariation, () => ctrl.deleteVariation(opts.path)),
+
       action(licon.Trash, i18n.site.deleteFromHere, () => ctrl.deleteNode(opts.path)),
 
       action(licon.PlusButton, i18n.site.expandVariations, () => ctrl.setAllCollapsed(opts.path, false)),

--- a/ui/lib/src/tree/tree.ts
+++ b/ui/lib/src/tree/tree.ts
@@ -26,6 +26,7 @@ export interface TreeWrapper {
   lastMainlineNode(path: Tree.Path): Tree.Node;
   pathExists(path: Tree.Path): boolean;
   deleteNodeAt(path: Tree.Path): void;
+  variationStart(path: Tree.Path): Tree.Path | undefined;
   setCollapsedAt(path: Tree.Path, collapsed: boolean): MaybeNode;
   setCollapsedRecursive(path: Tree.Path, collapsed: boolean): void;
   promoteAt(path: Tree.Path, toMainline: boolean): void;
@@ -146,6 +147,17 @@ export function build(root: Tree.Node): TreeWrapper {
     ops.removeChild(parentNode(path), treePath.last(path));
   }
 
+  function variationStart(path: Tree.Path): Tree.Path | undefined {
+    const nodes = getNodeList(path);
+    for (let i = nodes.length - 2; i >= 0; i--) {
+      const node = nodes[i + 1];
+      const parent = nodes[i];
+      if (parent.children[0].id !== node.id || node.forceVariation)
+        return treePath.fromNodeList(nodes.slice(0, i + 2));
+    }
+    return undefined;
+  }
+
   function promoteAt(path: Tree.Path, toMainline: boolean): void {
     const nodes = getNodeList(path);
     for (let i = nodes.length - 2; i >= 0; i--) {
@@ -236,6 +248,7 @@ export function build(root: Tree.Node): TreeWrapper {
     lastMainlineNode: (path: Tree.Path): Tree.Node => lastMainlineNodeFrom(root, path),
     pathExists,
     deleteNodeAt,
+    variationStart,
     promoteAt,
     forceVariationAt(path: Tree.Path, force: boolean) {
       return updateAt(path, function (node) {


### PR DESCRIPTION
Currently to delete a whole variation you have to go to the first move of it and click `Delete from here`.

Reusing the trash icon isn't completely ideal, but not sure what other icon might work.