### PR TITLE
fix: DOM text reinterpreted as HTML

### DIFF
--- a/ui/site/src/powertip.ts
+++ b/ui/site/src/powertip.ts
@@ -57,7 +57,7 @@ const imagePowertip = (el: HTMLElement) =>
       preRender: (el: HTMLElement) => {
         const w = el.dataset.width ? ` width="${el.dataset.width}"` : '';
         const h = el.dataset.height ? ` height="${el.dataset.height}"` : '';
-        document.querySelector('#image-powertip')!.innerHTML = `<img src="${el.dataset.src}"${w}${h}>`;
+        document.querySelector('#image-powertip')!.innerHTML = `<img src="${he.escape(el.dataset.src)}"${w}${h}>`;
       },
       popupId: 'image-powertip',
       placement: 's',


### PR DESCRIPTION
## Ticket 🎟️ #17242

To fix the problem, we need to ensure that the value of `el.dataset.src` is properly sanitized or escaped before being inserted into the HTML string. The best way to do this is to use a library that provides functions for escaping HTML characters. One such library is `he` (HTML entities), which can be used to escape the value of `el.dataset.src`.

1. Install the `he` library if it is not already installed.
2. Import the `he` library in the file.
3. Use the `he.escape` function to escape the value of `el.dataset.src` before inserting it into the HTML string.