### PR TITLE
Prevent duplicate rendering of comments for mainline moves forced as variation

### DIFF
--- a/ui/analyse/src/treeView/columnView.ts
+++ b/ui/analyse/src/treeView/columnView.ts
@@ -42,9 +42,10 @@ function renderChildrenOf(ctx: Ctx, node: Tree.Node, opts: Opts): LooseVNodes | 
   if (conceal === 'hide') return;
   if (opts.isMainline) {
     const isWhite = main.ply % 2 === 1,
-      commentTags = renderMainlineCommentsOf(ctx, main, conceal, true, opts.parentPath + main.id).filter(
-        nonEmpty,
-      );
+    commentTags =
+      !main.forceVariation 
+      ? renderMainlineCommentsOf(ctx, main, conceal, true, opts.parentPath + main.id).filter(nonEmpty) 
+      : [];
     if (!cs[1] && isEmpty(commentTags) && !main.forceVariation)
       return [
         isWhite && moveView.renderIndex(main.ply, false),


### PR DESCRIPTION
📌 **Issue** #17103
There was an issue where comments were being rendered twice for mainline moves. This happened because the logic for rendering comments didn't correctly handle forced variations, leading to duplicate comment displays.

🔧 **Fix**
I modified the logic to ensure that mainline comments are only displayed for non-forced variations, preventing their duplication.

![image](https://github.com/user-attachments/assets/79ef96d3-4114-460b-92f6-dcb150e390cc)


