### PR TITLE
Reduce default ublog tier for many users lichess-org/lila#17239

### DIFF
--- a/modules/ublog/src/main/UblogRank.scala
+++ b/modules/ublog/src/main/UblogRank.scala
@@ -23,7 +23,7 @@ object UblogRank:
 
     def default(user: UserWithPerfs) =
       if user.marks.troll then Tier.HIDDEN
-      else if user.hasTitle || user.perfs.standard.glicko.establishedIntRating.exists(_ > IntRating(2200))
+      else if user.hasTitle || user.perfs.standard.glicko.establishedIntRating.exists(_ > IntRating(2400))
       then Tier.NORMAL
       else Tier.LOW
 


### PR DESCRIPTION
There is discussion on that issue.  This is my first suggestion, reducing the default ublog tier for most players.

If instead we prefer the default tier should solely be based upon title, perhaps only titles FM/WFM and stronger should be considered for normal tier (given our position with USCF at the moment).