### PR TITLE
Forum mod actions: log to zulip

### DIFF
--- a/modules/core/src/main/irc.scala
+++ b/modules/core/src/main/irc.scala
@@ -27,6 +27,7 @@ trait IrcApi:
       boardName: StudyChapterName
   ): Funit
   def monitorMod(icon: String, text: String, tpe: ModDomain)(using MyId): Funit
+  def publicForumLog(icon: String, text: String)(using MyId): Funit
   def ublogPost(
       user: LightUser,
       id: UblogPostId,

--- a/modules/irc/src/main/IrcApi.scala
+++ b/modules/irc/src/main/IrcApi.scala
@@ -85,6 +85,11 @@ final class IrcApi(
       zulip(_.mod.adminMonitor(tpe), mod.name.value):
         s"${markdown.userLink(mod.name)} :$icon: ${markdown.linkifyPostsAndUsers(text)}"
 
+  def publicForumLog(icon: String, text: String)(using modId: MyId): Funit =
+    lightUser(modId).flatMapz: mod =>
+      zulip(_.mod.commsPublic, "forum-log"):
+        s"${markdown.userLink(mod.name)} :$icon: ${markdown.linkifyPostsAndUsers(text)}"
+
   def ublogPost(
       user: LightUser,
       id: UblogPostId,

--- a/modules/mod/src/main/Modlog.scala
+++ b/modules/mod/src/main/Modlog.scala
@@ -15,6 +15,13 @@ case class Modlog(
   def notable      = action != Modlog.terminateTournament
   def notableZulip = notable && !isLichess
 
+  // only show actions not tied to a specific user
+  def isForum = action match
+    case Modlog.stickyTopic | Modlog.unstickyTopic | Modlog.postAsAnonMod | Modlog.editAsAnonMod |
+        Modlog.openTopic | Modlog.closeTopic =>
+      true
+    case _ => false
+
   def gameId: Option[GameId] = GameId.from:
     details.ifTrue(action == Modlog.cheatDetected).so(_.split(' ').lift(1))
 

--- a/modules/mod/src/main/ModlogApi.scala
+++ b/modules/mod/src/main/ModlogApi.scala
@@ -383,5 +383,8 @@ final class ModlogApi(repo: ModlogRepo, userRepo: UserRepo, ircApi: IrcApi, pres
             else if presetPerms(Permission.CheatHunter) then permissions(MonitoredCheatMod)
             else false
           case _ => false
-        monitorable.so(ircApi.monitorMod(icon = icon, text = text, dom))
+        for
+          _ <- monitorable.so(ircApi.monitorMod(icon = icon, text = text, dom))
+          _ <- m.isForum.so(ircApi.publicForumLog(icon = icon, text = text))
+        yield ()
     }


### PR DESCRIPTION
Actions that are not findable on one's user profile, allowing for better mod coordination.

The zulip mod-log firehose was closed for being too heavy on zulip's server, but considering how few actions are logged, it's worth re-opening it for these forum actions.