### PR TITLE
one tablesort to rule them all

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,9 +103,6 @@ importers:
       sortablejs:
         specifier: ^1.15.6
         version: 1.15.6
-      tablesort:
-        specifier: ^5.5.0
-        version: 5.5.0
 
   ui/bits:
     dependencies:
@@ -172,9 +169,6 @@ importers:
       shepherd.js:
         specifier: ^11.2.0
         version: 11.2.0
-      tablesort:
-        specifier: ^5.3.0
-        version: 5.3.0
       zxcvbn:
         specifier: ^4.4.2
         version: 4.4.2
@@ -319,8 +313,8 @@ importers:
         specifier: ^0.10.0
         version: 0.10.0
       tablesort:
-        specifier: ^5.3.0
-        version: 5.3.0
+        specifier: 5.5.0
+        version: 5.5.0
 
   ui/lobby:
     dependencies:
@@ -393,9 +387,6 @@ importers:
       prop-types:
         specifier: ^15.8.1
         version: 15.8.1
-      tablesort:
-        specifier: ^5.3.0
-        version: 5.3.0
 
   ui/msg:
     dependencies:
@@ -516,9 +507,6 @@ importers:
       lichess-pgn-viewer:
         specifier: ^2.4.0
         version: 2.4.0
-      tablesort:
-        specifier: ^5.3.0
-        version: 5.3.0
 
   ui/storm:
     dependencies:
@@ -2158,9 +2146,6 @@ packages:
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
-
-  tablesort@5.3.0:
-    resolution: {integrity: sha512-WkfcZBHsp47gVH9CBHG0ZXopriG01IA87arGrchvIe868d4RiXVvoYPS1zMq9IdW05kBs5iGsqxTABqLyWonbg==}
 
   tablesort@5.5.0:
     resolution: {integrity: sha512-/yi34JHVmfuzwtK+6O/rhxbIimNp+eAZGXlVz8pWTyoJggAs8lDf76bsbjeGpE2sbvsNmIR9u8a0KfUj0YGGvw==}
@@ -3962,8 +3947,6 @@ snapshots:
 
   symbol-tree@3.2.4:
     optional: true
-
-  tablesort@5.3.0: {}
 
   tablesort@5.5.0: {}
 

--- a/ui/analyse/package.json
+++ b/ui/analyse/package.json
@@ -19,8 +19,7 @@
     "lib": "workspace:*",
     "prop-types": "^15.8.1",
     "shepherd.js": "^11.2.0",
-    "sortablejs": "^1.15.6",
-    "tablesort": "^5.5.0"
+    "sortablejs": "^1.15.6"
   },
   "build": {
     "bundle": "src/**/analyse.*ts",

--- a/ui/analyse/src/study/relay/relayPlayers.ts
+++ b/ui/analyse/src/study/relay/relayPlayers.ts
@@ -13,8 +13,7 @@ import type {
   StudyPlayer,
   StudyPlayerFromServer,
 } from '../interfaces';
-import tablesort from 'tablesort';
-import extendTablesortNumber from 'lib/tablesortNumber';
+import { sortTable, extendTablesortNumber } from 'lib/tablesort';
 import { defined } from 'lib';
 import { type Attrs, type Hooks, init as initSnabbdom, attributesModule, type VNodeData } from 'snabbdom';
 import { convertPlayerFromServer } from '../studyChapters';
@@ -394,7 +393,7 @@ const ratingDiff = (p: RelayPlayer | RelayPlayerGame) => {
 const tableAugment = (el: HTMLTableElement) => {
   extendTablesortNumber();
   $(el).each(function (this: HTMLElement) {
-    tablesort(this, {
+    sortTable(this, {
       descending: true,
     });
   });

--- a/ui/bits/package.json
+++ b/ui/bits/package.json
@@ -37,7 +37,6 @@
     "prop-types": "^15.8.1",
     "qrcode": "^1.5.4",
     "shepherd.js": "^11.2.0",
-    "tablesort": "^5.3.0",
     "zxcvbn": "^4.4.2"
   },
   "build": {

--- a/ui/bits/src/bits.clas.ts
+++ b/ui/bits/src/bits.clas.ts
@@ -1,5 +1,4 @@
-import tablesort from 'tablesort';
-import extendTablesortNumber from 'lib/tablesortNumber';
+import { sortTable, extendTablesortNumber } from 'lib/tablesort';
 import * as xhr from 'lib/xhr';
 import { Textcomplete } from '@textcomplete/core';
 import { TextareaEditor } from '@textcomplete/textarea';
@@ -8,7 +7,7 @@ import type { UserCompleteResult } from 'lib/userComplete';
 
 site.load.then(() => {
   $('table.sortable').each(function (this: HTMLElement) {
-    tablesort(this, {
+    sortTable(this, {
       descending: true,
     });
   });

--- a/ui/bits/src/bits.cms.ts
+++ b/ui/bits/src/bits.cms.ts
@@ -1,7 +1,7 @@
 import * as xhr from 'lib/xhr';
 import { throttle } from 'lib/async';
 import { currentTheme } from 'lib/device';
-import tablesort from 'tablesort';
+import { sortTable } from 'lib/tablesort';
 import { storedJsonProp } from 'lib/storage';
 import { Editor, type EditorType } from '@toast-ui/editor';
 
@@ -11,7 +11,7 @@ site.load.then(() => {
   });
   $('.flash').addClass('fade');
   $('table.cms__pages').each(function (this: HTMLTableElement) {
-    tablesort(this, { descending: true });
+    sortTable(this, { descending: true });
   });
   $('.cms__pages__search').on('input', function (this: HTMLInputElement) {
     const query = this.value.toLowerCase().trim();

--- a/ui/lib/package.json
+++ b/ui/lib/package.json
@@ -28,7 +28,7 @@
     "stockfish-nnue.wasm": "1.0.0-1946a675.smolnet",
     "stockfish.js": "^10.0.2",
     "stockfish.wasm": "^0.10.0",
-    "tablesort": "^5.3.0"
+    "tablesort": "5.5.0"
   },
   "build": {
     "sync": {

--- a/ui/lib/src/tablesort.ts
+++ b/ui/lib/src/tablesort.ts
@@ -1,6 +1,10 @@
 import tablesort from 'tablesort';
 
-export default function extendTablesortNumber(): void {
+export function sortTable(el: HTMLElement, options: { descending: boolean }): void {
+  tablesort(el, options);
+}
+
+export function extendTablesortNumber(): void {
   tablesort.extend(
     'number',
     (item: string) => item.match(/^[-+]?(\d)*-?([,\.]){0,1}-?(\d)+([E,e][\-+][\d]+)?%?$/),

--- a/ui/lib/src/tablesortNumber.ts
+++ b/ui/lib/src/tablesortNumber.ts
@@ -4,18 +4,11 @@ export default function extendTablesortNumber(): void {
   tablesort.extend(
     'number',
     (item: string) => item.match(/^[-+]?(\d)*-?([,\.]){0,1}-?(\d)+([E,e][\-+][\d]+)?%?$/),
-    (a: string, b: string) => compareNumber(cleanNumber(b), cleanNumber(a)),
+    (a: string, b: string) => validNum(b) - validNum(a),
   );
 }
 
-const cleanNumber = (i: string) => i.replace(/[^\-?0-9.]/g, '');
-
-const compareNumber = (a: any, b: any) => {
-  a = parseFloat(a);
-  b = parseFloat(b);
-
-  a = isNaN(a) ? 0 : a;
-  b = isNaN(b) ? 0 : b;
-
-  return a - b;
+const validNum = (i: string): number => {
+  const num = parseFloat(i.replace(/[^\-?0-9.]/g, ''));
+  return isNaN(num) ? 0 : num;
 };

--- a/ui/mod/package.json
+++ b/ui/mod/package.json
@@ -12,8 +12,7 @@
     "apexcharts": "^3.54.1",
     "lib": "workspace:*",
     "debounce-promise": "^3.1.2",
-    "prop-types": "^15.8.1",
-    "tablesort": "^5.3.0"
+    "prop-types": "^15.8.1"
   },
   "build": {
     "bundle": "src/mod.*ts"

--- a/ui/mod/src/mod.games.ts
+++ b/ui/mod/src/mod.games.ts
@@ -1,5 +1,4 @@
-import extendTablesortNumber from 'lib/tablesortNumber';
-import tablesort from 'tablesort';
+import { sortTable, extendTablesortNumber } from 'lib/tablesort';
 import { debounce } from 'lib/async';
 import { formToXhr } from 'lib/xhr';
 import { checkBoxAll, expandCheckboxZone, shiftClickCheckboxRange } from './checkBoxes';
@@ -26,7 +25,7 @@ const setupFilter = () => {
 const setupTable = () => {
   const table = document.querySelector('table.game-list') as HTMLTableElement;
   extendTablesortNumber();
-  tablesort(table, { descending: true });
+  sortTable(table, { descending: true });
 
   expandCheckboxZone(table, 'td:first-child', shiftClickCheckboxRange(table));
   checkBoxAll(table);

--- a/ui/mod/src/mod.search.ts
+++ b/ui/mod/src/mod.search.ts
@@ -1,6 +1,5 @@
 import { text as xhrText } from 'lib/xhr';
-import extendTablesortNumber from 'lib/tablesortNumber';
-import tablesort from 'tablesort';
+import { sortTable, extendTablesortNumber } from 'lib/tablesort';
 import { checkBoxAll, expandCheckboxZone, selector, shiftClickCheckboxRange } from './checkBoxes';
 import { confirm } from 'lib/dialogs';
 
@@ -17,7 +16,7 @@ site.load.then(() => {
   $('.mod-user-table').each(function (this: HTMLTableElement) {
     const table = this;
     extendTablesortNumber();
-    tablesort(table, { descending: true });
+    sortTable(table, { descending: true });
     expandCheckboxZone(table, 'td:last-child', shiftClickCheckboxRange(table));
     checkBoxAll(table);
     const select = table.querySelector('thead select');

--- a/ui/mod/src/mod.user.ts
+++ b/ui/mod/src/mod.user.ts
@@ -1,8 +1,7 @@
 import { formToXhr, text as xhrText } from 'lib/xhr';
 import { debounce } from 'lib/async';
 import * as licon from 'lib/licon';
-import extendTablesortNumber from 'lib/tablesortNumber';
-import tablesort from 'tablesort';
+import { sortTable, extendTablesortNumber } from 'lib/tablesort';
 import { expandCheckboxZone, shiftClickCheckboxRange, selector } from './checkBoxes';
 import { spinnerHtml } from 'lib/controls';
 import { confirm } from 'lib/dialogs';
@@ -124,7 +123,7 @@ site.load.then(() => {
       $(el).height($(el).height());
     });
     makeReady('.mz-section--others table', (table: HTMLTableElement) => {
-      tablesort(table, { descending: true });
+      sortTable(table, { descending: true });
       if (table) {
         expandCheckboxZone(table, 'td:last-child', shiftClickCheckboxRange(table));
         const select = table.querySelector('thead select');
@@ -186,7 +185,7 @@ site.load.then(() => {
     makeReady(
       '.mz-section--identification .slist--sort',
       el => {
-        tablesort(el, { descending: true });
+        sortTable(el, { descending: true });
       },
       'ready-sort',
     );

--- a/ui/site/package.json
+++ b/ui/site/package.json
@@ -8,8 +8,7 @@
   "dependencies": {
     "lib": "workspace:*",
     "dialog-polyfill": "0.5.6",
-    "lichess-pgn-viewer": "^2.4.0",
-    "tablesort": "^5.3.0"
+    "lichess-pgn-viewer": "^2.4.0"
   },
   "build": {
     "bundle": [


### PR DESCRIPTION
Closes https://github.com/lichess-org/lila/issues/17259

The reason for the error is that `ui/analyse` was using `tablesort@5.5.0` and `ui/lib/tablesortNumber` was using `tablesort@5.3.0`. The extension was being applied, but it was being applied to a different module that was using 5.3.0 while the actual sorting was being done with 5.5.0.

To avoid these hassles in the future, I've put one tablesort helper function in ui/lib and that is the only place where tablesort is defined in any package.json