### PR TITLE
Do not highlight notes

### DIFF
--- a/ui/lib/css/chat/_chat.scss
+++ b/ui/lib/css/chat/_chat.scss
@@ -26,9 +26,6 @@
       line-height: 1.7em;
       outline: none;
       resize: none;
-      &:focus {
-        border-color: $c-primary;
-      }
     }
   }
 


### PR DESCRIPTION
Relates to  #17251
Clicking on notes to cover/hide the chatroom creates a disturbing highlight. 