### PR TITLE
disable spellcheck in notes

### DIFF
--- a/ui/lib/src/chat/note.ts
+++ b/ui/lib/src/chat/note.ts
@@ -28,7 +28,7 @@ export function noteView(ctrl: NoteCtrl, autofocus: boolean): VNode {
   const text = ctrl.text();
   if (text === undefined) return h('div.loading', { hook: { insert: ctrl.fetch } });
   return h('textarea.mchat__note', {
-    attrs: { placeholder: i18n.site.typePrivateNotesHere },
+    attrs: { placeholder: i18n.site.typePrivateNotesHere, spellcheck: 'false' },
     hook: {
       insert(vnode) {
         const el = vnode.elm as HTMLTextAreaElement;


### PR DESCRIPTION
this one seems obvious since "E4" is not a word, but it's a PR in case i'm just unaware of the reason for it