### PR TITLE
always show liveboard

### DIFF
--- a/ui/analyse/src/study/relay/relayCtrl.ts
+++ b/ui/analyse/src/study/relay/relayCtrl.ts
@@ -75,7 +75,7 @@ export default class RelayCtrl {
       );
     const pinnedName = this.isPinnedStreamOngoing() && data.pinned?.name;
     if (pinnedName) this.streams.push(['ps', pinnedName]);
-    this.chatCtrl.isDisabled = () => this.tourShow() || !this.data.sync?.ongoing;
+    this.chatCtrl.isDisabled = () => this.tourShow();
     this.chatCtrl.setChapterId(chapterSelect.get());
     this.baseRedraw.add(() => this.chatCtrl.redraw?.());
     pubsub.on('socket.in.crowd', d => {


### PR DESCRIPTION
which means users will not see chat toggle in the broadcast game view. it also means we will show the "live state" of completed rounds, which could be weird. at any rate we cannot guarantee it's accurate because there's no relayPath at that point.