### PR TITLE
add toggle for analysis arrows in puzzle board menu

### DIFF
--- a/ui/puzzle/src/autoShape.ts
+++ b/ui/puzzle/src/autoShape.ts
@@ -8,6 +8,7 @@ interface Opts {
   node: Tree.Node;
   nodeList: Tree.Node[];
   showComputer(): boolean;
+  showArrows(): boolean;
   ceval: CevalCtrl;
   nextNodeBest(): Uci | undefined;
   threatMode(): boolean;
@@ -37,7 +38,7 @@ export default function (opts: Opts): DrawShape[] {
   let shapes: DrawShape[] = [];
   if (hovering && hovering.fen === n.fen)
     shapes = shapes.concat(makeAutoShapesFromUci(color, hovering.uci, 'paleBlue'));
-  if (opts.showComputer()) {
+  if (opts.showComputer() && opts.showArrows()) {
     if (n.eval) shapes = shapes.concat(makeAutoShapesFromUci(color, n.eval.best!, 'paleGreen'));
     if (!hovering) {
       let nextBest: Uci | undefined = opts.nextNodeBest();

--- a/ui/puzzle/src/ctrl.ts
+++ b/ui/puzzle/src/ctrl.ts
@@ -21,7 +21,16 @@ import { chessgroundDests, scalachessCharPair } from 'chessops/compat';
 import { CevalCtrl } from 'lib/ceval/ceval';
 import { makeVoiceMove, type VoiceMove } from 'voice';
 import { ctrl as makeKeyboardMove, type KeyboardMove, type KeyboardMoveRootCtrl } from 'keyboardMove';
-import { defined, prop, type Prop, propWithEffect, type Toggle, toggle, requestIdleCallback } from 'lib';
+import {
+  defined,
+  prop,
+  type Prop,
+  propWithEffect,
+  type Toggle,
+  toggle,
+  requestIdleCallback,
+  myUserId,
+} from 'lib';
 import { makeSanAndPlay } from 'chessops/san';
 import { parseFen, makeFen } from 'chessops/fen';
 import { parseSquare, parseUci, makeSquare, makeUci, opposite } from 'chessops/util';
@@ -43,6 +52,7 @@ export default class PuzzleCtrl implements ParentCtrl {
   next: Deferred<PuzzleData | ReplayEnd> = defer<PuzzleData>();
   tree: TreeWrapper;
   ceval: CevalCtrl;
+  showArrows: StoredProp<boolean>;
   autoNext: StoredProp<boolean>;
   rated: StoredProp<boolean>;
   ground: Prop<CgApi> = prop<CgApi | undefined>(undefined) as Prop<CgApi>;
@@ -84,6 +94,7 @@ export default class PuzzleCtrl implements ParentCtrl {
     readonly redraw: Redraw,
     readonly nvui?: NvuiPlugin,
   ) {
+    this.showArrows = storedBooleanProp(`puzzle.show-arrows.${myUserId()}`, true);
     this.rated = storedBooleanPropWithEffect('puzzle.rated', true, this.redraw);
     this.autoNext = storedBooleanProp(
       `puzzle.autoNext${opts.data.streak ? '.streak' : ''}`,

--- a/ui/puzzle/src/view/boardMenu.ts
+++ b/ui/puzzle/src/view/boardMenu.ts
@@ -1,7 +1,7 @@
 import { h } from 'snabbdom';
 import { toggle } from 'lib';
 import { boardMenu as menuDropdown } from 'lib/boardMenu';
-import { boolPrefXhrToggle } from 'lib/controls';
+import { boolPrefXhrToggle, toggle as cmnToggle } from 'lib/controls';
 import type PuzzleCtrl from '../ctrl';
 
 export default function (ctrl: PuzzleCtrl) {
@@ -17,6 +17,15 @@ export default function (ctrl: PuzzleCtrl) {
       menu.blindfold(
         toggle(ctrl.blindfold(), v => ctrl.blindfold(v)),
         true,
+      ),
+      cmnToggle(
+        {
+          name: 'Show arrows in analysis',
+          id: 'showArrows',
+          checked: ctrl.showArrows(),
+          change: ctrl.showArrows,
+        },
+        ctrl.redraw,
       ),
       menu.voiceInput(boolPrefXhrToggle('voice', !!ctrl.voiceMove), true),
       menu.keyboardInput(boolPrefXhrToggle('keyboardMove', !!ctrl.keyboardMove), true),


### PR DESCRIPTION
how could i deny this eloquent entreaty: https://lichess.org/forum/lichess-feedback/best-move-arrow-is-irritating-in-puzzle-evaluation-afterwards

i cannot