### PR TITLE
License puzzle themes in COPYING.md

### DIFF
--- a/COPYING.md
+++ b/COPYING.md
@@ -71,7 +71,7 @@ public/sounds/sfx | [Enigmahack](https://github.com/Enigmahack) | AGPLv3+
 public/sounds/lisp | [EdinburghCollective](http://lichess.org/@/EdinburghCollective) | [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/)
 SVG in ui/learn/src/apple.ts | [Sensa](https://www.svgrepo.com/svg/434273/star) | [CC0 1.0](https://creativecommons.org/publicdomain/zero/1.0/deed.en)
 public/flair/img/symbols.neovim-mark.webp | Jason Long | [CC BY 3.0](https://creativecommons.org/licenses/by/3.0/) (Modified by converting to webp and resizing)
-
+translation/source/puzzleTheme.xml | the lila authors and contributors | [CC0 1.0](https://creativecommons.org/publicdomain/zero/1.0/)
 ## Exceptions (non-free)
 
 <!-- prettier-ignore -->


### PR DESCRIPTION
Explicitly licensing the list of puzzle themes XML file for use as a dataset: https://huggingface.co/datasets/Lichess/puzzle-themes