### PR TITLE
fix duplicate chats when switching variants in broadcasts

### DIFF
--- a/ui/analyse/src/study/relay/relayChat.ts
+++ b/ui/analyse/src/study/relay/relayChat.ts
@@ -17,6 +17,7 @@ export function relayChatView({ ctrl, relay }: RelayViewContext): VNode | undefi
   if (ctrl.isEmbed || !ctrl.opts.chat) return undefined;
   return h('section.mchat.mchat-optional', {
     hook: onInsert(() => {
+      ctrl.opts.chat.instance?.destroy();
       ctrl.opts.chat.instance = makeChat({
         ...ctrl.opts.chat,
         plugin: relay.chatCtrl,

--- a/ui/lib/src/chat/ctrl.ts
+++ b/ui/lib/src/chat/ctrl.ts
@@ -180,7 +180,7 @@ export default class ChatCtrl {
   };
 
   destroy = (): void => {
-    if (!this.opts.persistent) this.subs.forEach(([eventName, callback]) => pubsub.off(eventName, callback));
+    this.subs.forEach(([eventName, callback]) => pubsub.off(eventName, callback));
   };
 
   setTab = (tab: Tab = this.getTab()): Tab => {


### PR DESCRIPTION
only respect the `opts.persistent` flag when node removal originates from snab.
borrowed manual destroy() pattern from the rest of analyse to fix the dup chat issue.