### PR TITLE
Fix & ignore all NewTree tests

### DIFF
--- a/modules/study/src/main/StudyPgnImport.scala
+++ b/modules/study/src/main/StudyPgnImport.scala
@@ -170,7 +170,7 @@ object StudyPgnImport:
         logger.warn(s"study PgnImport.makeNode StackOverflowError")
         None
 
-  private def guessNewClockState(prev: Clock, ply: Ply, tc: Option[TournamentClock], emt: Centis): Clock =
+  private[study] def guessNewClockState(prev: Clock, ply: Ply, tc: Option[TournamentClock], emt: Centis): Clock =
     Clock(prev.centis - emt + ~tc.map(_.incrementAtPly(ply)), trust = false.some)
 
   /*

--- a/modules/study/src/main/StudyPgnImport.scala
+++ b/modules/study/src/main/StudyPgnImport.scala
@@ -170,7 +170,12 @@ object StudyPgnImport:
         logger.warn(s"study PgnImport.makeNode StackOverflowError")
         None
 
-  private[study] def guessNewClockState(prev: Clock, ply: Ply, tc: Option[TournamentClock], emt: Centis): Clock =
+  private[study] def guessNewClockState(
+      prev: Clock,
+      ply: Ply,
+      tc: Option[TournamentClock],
+      emt: Centis
+  ): Clock =
     Clock(prev.centis - emt + ~tc.map(_.incrementAtPly(ply)), trust = false.some)
 
   /*

--- a/modules/study/src/main/StudyPgnImportNew.scala
+++ b/modules/study/src/main/StudyPgnImportNew.scala
@@ -10,9 +10,7 @@ import lila.core.LightUser
 import lila.tree.Node.{ Comment, Comments }
 import lila.tree.{ ImportResult, Metas, NewBranch, NewRoot, NewTree, Clock }
 
-/** This code is still unused, and is now out of sync with the StudyPgnImport it's supposed to replace. Some
-  * features are missing that are present in StudyPgnImport, such as the ability to replay clock states.
-  */
+// This code is still unused
 object StudyPgnImportNew:
 
   import StudyPgnImport.Context
@@ -93,33 +91,40 @@ object StudyPgnImportNew:
     data
       .san(context.currentGame.situation)
       .map(moveOrDrop =>
-        val game   = moveOrDrop.applyGame(context.currentGame)
-        val uci    = moveOrDrop.toUci
-        val id     = UciCharPair(uci)
-        val sanStr = moveOrDrop.toSanStr
-        val newBranch = StudyPgnImport.parseComments(data.metas.comments, annotator) match
-          case (shapes, clock, emt, comments) =>
-            NewBranch(
-              id = id,
-              move = Uci.WithSan(uci, sanStr),
-              comp = false,
-              forceVariation = false,
-              Metas(
-                ply = game.ply,
-                fen = Fen.write(game),
-                check = game.situation.check,
-                dests = None,
-                drops = None,
-                eval = None,
-                shapes = shapes,
-                comments = comments,
-                gamebook = None,
-                glyphs = data.metas.glyphs,
-                opening = None,
-                clock = ???, // TODO it's in StudyPgnImport, but not here
-                crazyData = game.situation.board.crazyData
-              )
+        val game                           = moveOrDrop.applyGame(context.currentGame)
+        val uci                            = moveOrDrop.toUci
+        val id                             = UciCharPair(uci)
+        val sanStr                         = moveOrDrop.toSanStr
+        val (shapes, clock, emt, comments) = StudyPgnImport.parseComments(data.metas.comments, annotator)
+        val mover                          = !game.ply.turn
+        val computedClock: Option[Clock] = clock
+          .map(Clock(_, trust = true.some))
+          .orElse:
+            (context.clocks(mover), emt)
+              .mapN(StudyPgnImport.guessNewClockState(_, game.ply, context.timeControl, _))
+          .filter(_.positive)
+        val newBranch =
+          NewBranch(
+            id = id,
+            move = Uci.WithSan(uci, sanStr),
+            comp = false,
+            forceVariation = false,
+            Metas(
+              ply = game.ply,
+              fen = Fen.write(game),
+              check = game.situation.check,
+              dests = None,
+              drops = None,
+              eval = None,
+              shapes = shapes,
+              comments = comments,
+              gamebook = None,
+              glyphs = data.metas.glyphs,
+              opening = None,
+              clock = computedClock,
+              crazyData = game.situation.board.crazyData
             )
+          )
 
         (Context(game, context.clocks, context.timeControl), newBranch.some)
       )

--- a/modules/study/src/test/BsonHandlersTest.scala
+++ b/modules/study/src/test/BsonHandlersTest.scala
@@ -30,20 +30,20 @@ class BsonHandlersTest extends munit.FunSuite:
       val y = treeBson.reads(treeBson.writes(w, x))
       assertEquals(y, x.withoutClockTrust)
 
-  test("NewTree writes.reads == identity"):
+  test("NewTree writes.reads == identity".ignore):
     PgnFixtures.all.foreach: pgn =>
       val x = StudyPgnImportNew(pgn, Nil).toOption.get.root
       val y = newTreeBson.reads(newTreeBson.writes(w, x))
       assertEquals(x.withoutClockTrust, y)
 
-  test("NewTree.reads.Tree.writes == identity"):
+  test("NewTree.reads.Tree.writes == identity".ignore):
     PgnFixtures.all.foreach: pgn =>
       val x    = StudyPgnImport.result(pgn, Nil).toOption.get.root
       val bdoc = treeBson.writes(w, x)
       val y    = newTreeBson.reads(bdoc)
       assertEquals(x.toNewRoot.cleanup.withoutClockTrust, y.cleanup)
 
-  test("Tree.reads.NewTree.writes == identity"):
+  test("Tree.reads.NewTree.writes == identity".ignore):
     PgnFixtures.all.foreach: pgn =>
       val x    = StudyPgnImportNew(pgn, Nil).toOption.get.root
       val bdoc = newTreeBson.writes(w, x)

--- a/modules/study/src/test/JsonTest.scala
+++ b/modules/study/src/test/JsonTest.scala
@@ -10,53 +10,54 @@ import lila.study.Helpers.*
 import lila.tree.{ NewRoot, Node, Root }
 
 import BSONHandlers.given
+import play.api.libs.json.Json
 
 class JsonTest extends munit.FunSuite:
 
   val user = LightUser(UserId("nt9"), UserName("nt9"), None, None, false)
 
-  // test("Json writes"):
-  //   PgnFixtures.roundTrip
-  //     .zip(JsonFixtures.all)
-  //     .foreach: (pgn, expected) =>
-  //       val result   = StudyPgnImport.result(pgn, List(user)).toOption.get
-  //       val imported = result.root.cleanCommentIds
-  //       val json     = writeTree(imported, result.variant)
-  //       assertEquals(json, expected)
-  //
-  // test("NewTree Json writes"):
-  //   PgnFixtures.roundTrip
-  //     .zip(JsonFixtures.all)
-  //     .foreach: (pgn, expected) =>
-  //       val result   = StudyPgnImportNew(pgn, List(user)).toOption.get
-  //       val imported = result.root.cleanup
-  //       val json     = writeTree(imported, result.variant)
-  //       assertEquals(Json.parse(json), Json.parse(expected))
+  test("Json writes"):
+    PgnFixtures.roundTrip
+      .zip(JsonFixtures.all)
+      .foreach: (pgn, expected) =>
+        val result   = StudyPgnImport.result(pgn, List(user)).toOption.get
+        val imported = result.root.cleanCommentIds
+        val json     = writeTree(imported, result.variant)
+        assertEquals(json, expected)
+
+  test("NewTree Json writes"):
+    PgnFixtures.roundTrip
+      .zip(JsonFixtures.all)
+      .foreach: (pgn, expected) =>
+        val result   = StudyPgnImportNew(pgn, List(user)).toOption.get
+        val imported = result.root.cleanup
+        val json     = writeTree(imported, result.variant)
+        assertEquals(Json.parse(json), Json.parse(expected))
 
   given Conversion[Bdoc, Reader] = Reader(_)
   val treeBson                   = summon[BSON[Root]]
   val newTreeBson                = summon[BSON[NewRoot]]
   val w                          = new Writer
 
-  // test("Json writes with BSONHandlers"):
-  //   PgnFixtures.roundTrip
-  //     .zip(JsonFixtures.all)
-  //     .foreach: (pgn, expected) =>
-  //       val result    = StudyPgnImport.result(pgn, List(user)).toOption.get
-  //       val imported  = result.root.cleanCommentIds
-  //       val afterBson = treeBson.reads(treeBson.writes(w, imported))
-  //       val json      = writeTree(afterBson, result.variant)
-  //       assertEquals(json, expected)
-  //
-  // test("NewTree Json writes with BSONHandlers"):
-  //   PgnFixtures.roundTrip
-  //     .zip(JsonFixtures.all)
-  //     .foreach: (pgn, expected) =>
-  //       val result    = StudyPgnImportNew(pgn, List(user)).toOption.get
-  //       val imported  = result.root
-  //       val afterBson = newTreeBson.reads(newTreeBson.writes(w, imported))
-  //       val json      = writeTree(afterBson.cleanup, result.variant)
-  //       assertEquals(Json.parse(json), Json.parse(expected))
+  test("Json writes with BSONHandlers"):
+    PgnFixtures.roundTrip
+      .zip(JsonFixtures.all)
+      .foreach: (pgn, expected) =>
+        val result    = StudyPgnImport.result(pgn, List(user)).toOption.get
+        val imported  = result.root.cleanCommentIds
+        val afterBson = treeBson.reads(treeBson.writes(w, imported))
+        val json      = writeTree(afterBson, result.variant)
+        assertEquals(json, expected)
+
+  test("NewTree Json writes with BSONHandlers"):
+    PgnFixtures.roundTrip
+      .zip(JsonFixtures.all)
+      .foreach: (pgn, expected) =>
+        val result    = StudyPgnImportNew(pgn, List(user)).toOption.get
+        val imported  = result.root
+        val afterBson = newTreeBson.reads(newTreeBson.writes(w, imported))
+        val json      = writeTree(afterBson.cleanup, result.variant)
+        assertEquals(Json.parse(json), Json.parse(expected))
 
   extension (root: Root)
     def cleanCommentIds: Root =

--- a/modules/study/src/test/JsonTest.scala
+++ b/modules/study/src/test/JsonTest.scala
@@ -25,7 +25,7 @@ class JsonTest extends munit.FunSuite:
         val json     = writeTree(imported, result.variant)
         assertEquals(json, expected)
 
-  test("NewTree Json writes"):
+  test("NewTree Json writes".ignore):
     PgnFixtures.roundTrip
       .zip(JsonFixtures.all)
       .foreach: (pgn, expected) =>
@@ -49,7 +49,7 @@ class JsonTest extends munit.FunSuite:
         val json      = writeTree(afterBson, result.variant)
         assertEquals(json, expected)
 
-  test("NewTree Json writes with BSONHandlers"):
+  test("NewTree Json writes with BSONHandlers".ignore):
     PgnFixtures.roundTrip
       .zip(JsonFixtures.all)
       .foreach: (pgn, expected) =>

--- a/modules/study/src/test/NewTreeCheck.scala
+++ b/modules/study/src/test/NewTreeCheck.scala
@@ -38,32 +38,33 @@ class NewTreeCheck extends munit.ScalaCheckSuite:
       val root = x.toRoot
       val bdoc = treeBson.writes(w, root)
       val y    = treeBson.reads(bdoc)
-      assertEquals(y, root)
+      assertEquals(y, root.withoutClockTrust)
 
   test("NewTree.writes.Tree.reads == identity"):
     forAll: (x: NewRoot) =>
       val bdoc = newTreeBson.writes(w, x)
       val y    = treeBson.reads(bdoc).toNewRoot
-      assertEquals(y, x)
+      assertEquals(y, x.withoutClockTrust)
 
   test("Tree.writes.NewTree.reads == identity"):
     forAll: (x: NewRoot) =>
       val bdoc = treeBson.writes(w, x.toRoot)
       val y    = newTreeBson.reads(bdoc)
-      assertEquals(y, x)
+      assertEquals(y, x.withoutClockTrust)
 
   test("NewTree.writes.NewTree.reads == identity"):
     forAll: (x: NewRoot) =>
       val bdoc = newTreeBson.writes(w, x)
       val y    = newTreeBson.reads(bdoc)
-      assertEquals(y, x)
+      assertEquals(y, x.withoutClockTrust)
 
   test("Tree.writes.Tree.reads == identity"):
     forAll: (x: NewRoot) =>
       val root = x.toRoot
       val bdoc = treeBson.writes(w, root)
       val y    = treeBson.reads(bdoc)
-      assertEquals(y, root)
+      assertEquals(y, root.withoutClockTrust)
+
   test("Root conversion check"):
     forAll: (root: NewRoot) =>
       val oldRoot = root.toRoot

--- a/modules/study/src/test/PgnRoundTripTest.scala
+++ b/modules/study/src/test/PgnRoundTripTest.scala
@@ -19,40 +19,40 @@ class PgnRoundTripTest extends munit.FunSuite:
 
   val user = LightUser(UserId("lichess"), UserName("Annotator"), None, None, false)
 
-  // test("roundtrip"):
-  //   PgnFixtures.roundTrip
-  //     .foreach: pgn =>
-  //       val imported = StudyPgnImport.result(pgn, List(user)).toOption.get
-  //       val dumped   = rootToPgn(imported.root)
-  //       assertEquals(dumped.value.cleanTags, pgn.cleanTags)
+  test("roundtrip"):
+    PgnFixtures.roundTrip
+      .foreach: pgn =>
+        val imported = StudyPgnImport.result(pgn, List(user)).toOption.get
+        val dumped   = rootToPgn(imported.root)
+        assertEquals(dumped.value.cleanTags, pgn.cleanTags)
 
-  // test("NewTree roundtrip"):
-  //   PgnFixtures.roundTrip
-  //     .foreach: pgn =>
-  //       val imported = StudyPgnImportNew(pgn, List(user)).toOption.get
-  //       val dumped   = rootToPgn(imported.root)
-  //       assertEquals(dumped.value.cleanTags, pgn.cleanTags)
+  test("NewTree roundtrip"):
+    PgnFixtures.roundTrip
+      .foreach: pgn =>
+        val imported = StudyPgnImportNew(pgn, List(user)).toOption.get
+        val dumped   = rootToPgn(imported.root)
+        assertEquals(dumped.value.cleanTags, pgn.cleanTags)
 
   given Conversion[Bdoc, Reader] = Reader(_)
   val treeBson                   = summon[BSON[Root]]
   val newTreeBson                = summon[BSON[NewRoot]]
   val w                          = new Writer
 
-  // test("roundtrip with BSONHandlers"):
-  //   PgnFixtures.roundTrip
-  //     .foreach: pgn =>
-  //       val imported  = StudyPgnImport.result(pgn, List(user)).toOption.get
-  //       val afterBson = treeBson.reads(treeBson.writes(w, imported.root))
-  //       val dumped    = rootToPgn(afterBson)
-  //       assertEquals(dumped.value.cleanTags, pgn.cleanTags)
-  //
-  // test("NewTree roundtrip with BSONHandlers"):
-  //   PgnFixtures.roundTrip
-  //     .foreach: pgn =>
-  //       val imported  = StudyPgnImportNew(pgn, List(user)).toOption.get
-  //       val afterBson = newTreeBson.reads(newTreeBson.writes(w, imported.root))
-  //       val dumped    = rootToPgn(afterBson)
-  //       assertEquals(dumped.value.cleanTags, pgn.cleanTags)
+  test("roundtrip with BSONHandlers"):
+    PgnFixtures.roundTrip
+      .foreach: pgn =>
+        val imported  = StudyPgnImport.result(pgn, List(user)).toOption.get
+        val afterBson = treeBson.reads(treeBson.writes(w, imported.root))
+        val dumped    = rootToPgn(afterBson)
+        assertEquals(dumped.value.cleanTags, pgn.cleanTags)
+
+  test("NewTree roundtrip with BSONHandlers"):
+    PgnFixtures.roundTrip
+      .foreach: pgn =>
+        val imported  = StudyPgnImportNew(pgn, List(user)).toOption.get
+        val afterBson = newTreeBson.reads(newTreeBson.writes(w, imported.root))
+        val dumped    = rootToPgn(afterBson)
+        assertEquals(dumped.value.cleanTags, pgn.cleanTags)
 
   extension (pgn: String)
     def cleanTags: String =

--- a/modules/study/src/test/PgnRoundTripTest.scala
+++ b/modules/study/src/test/PgnRoundTripTest.scala
@@ -26,7 +26,7 @@ class PgnRoundTripTest extends munit.FunSuite:
         val dumped   = rootToPgn(imported.root)
         assertEquals(dumped.value.cleanTags, pgn.cleanTags)
 
-  test("NewTree roundtrip"):
+  test("NewTree roundtrip".ignore):
     PgnFixtures.roundTrip
       .foreach: pgn =>
         val imported = StudyPgnImportNew(pgn, List(user)).toOption.get
@@ -46,7 +46,7 @@ class PgnRoundTripTest extends munit.FunSuite:
         val dumped    = rootToPgn(afterBson)
         assertEquals(dumped.value.cleanTags, pgn.cleanTags)
 
-  test("NewTree roundtrip with BSONHandlers"):
+  test("NewTree roundtrip with BSONHandlers".ignore):
     PgnFixtures.roundTrip
       .foreach: pgn =>
         val imported  = StudyPgnImportNew(pgn, List(user)).toOption.get

--- a/modules/study/src/test/newTreeTest.scala
+++ b/modules/study/src/test/newTreeTest.scala
@@ -3,6 +3,7 @@ import chess.format.pgn.PgnStr
 
 import scala.language.implicitConversions
 
+@munit.IgnoreSuite
 class NewTreeTest extends munit.FunSuite:
 
   import Helpers.*

--- a/modules/study/src/test/newTreeTest.scala
+++ b/modules/study/src/test/newTreeTest.scala
@@ -10,18 +10,18 @@ class NewTreeTest extends munit.FunSuite:
   given Conversion[String, PgnStr] = PgnStr(_)
   given Conversion[PgnStr, String] = _.value
 
-  // test("tree <-> newTree conversion"):
-  //   PgnFixtures.all.foreach: pgn =>
-  //     val x       = StudyPgnImport.result(pgn, Nil).toOption.get
-  //     val newRoot = x.root.toNewRoot
-  //     assertEquals(newRoot.toRoot, x.root)
+  test("tree <-> newTree conversion"):
+    PgnFixtures.all.foreach: pgn =>
+      val x       = StudyPgnImport.result(pgn, Nil).toOption.get
+      val newRoot = x.root.toNewRoot
+      assertEquals(newRoot.toRoot, x.root)
 
-  // test("PgnImport works"):
-  //   PgnFixtures.all.foreach: pgn =>
-  //     val x = StudyPgnImport.result(pgn, Nil).toOption.get
-  //     val y = StudyPgnImportNew(pgn, Nil).toOption.get
-  //     assertEquals(y.end, x.ending)
-  //     assertEquals(y.variant, x.variant)
-  //     assertEquals(y.tags, x.tags)
-  //     val oldRoot = x.root.toNewRoot.cleanup
-  //     assertEquals(y.root.cleanup, oldRoot)
+  test("PgnImport works"):
+    PgnFixtures.all.foreach: pgn =>
+      val x = StudyPgnImport.result(pgn, Nil).toOption.get
+      val y = StudyPgnImportNew(pgn, Nil).toOption.get
+      assertEquals(y.end, x.ending)
+      assertEquals(y.variant, x.variant)
+      assertEquals(y.tags, x.tags)
+      val oldRoot = x.root.toNewRoot.cleanup
+      assertEquals(y.root.cleanup, oldRoot)


### PR DESCRIPTION
This PR adapts some changes related to `Tree` and `PgnImport` to `NewTree`/`PgnImportNew`.

So this fixes all the NewTree tests but also ignores them so it'll not affect CI.
