### PR TITLE
dont symlink anything

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -81,7 +81,6 @@ def asset_profile(ssh, *,
         "files": ASSETS_FILES,
         "workflow_url": ASSETS_BUILD_URL,
         "artifact_name": "lila-assets",
-        "symlinks": [],
         "post": post,
         "stage": stage,
         "user": user
@@ -91,15 +90,13 @@ def server_profile(ssh, *,
                    deploy_dir="/home/lichess-deploy",
                    post="systemctl restart lichess",
                    stage=False,
-                   user="lichess",
-                   symlinks=["lib", "bin"]):
+                   user="lichess"):
     return {
         "ssh": ssh,
         "deploy_dir": deploy_dir,
         "files": SERVER_FILES,
         "workflow_url": SERVER_BUILD_URL,
         "artifact_name": "lila-server",
-        "symlinks": symlinks,
         "post": post,
         "stage": stage,
         "user": user,
@@ -111,7 +108,7 @@ PROFILES = {
     "snafu-assets": asset_profile("root@snafu.lichess.ovh", post=curl_cli("change asset version", url="https://lichess.dev/run/cli"), stage=True),
     "snafu-server": server_profile("root@snafu.lichess.ovh", post="systemctl restart lichess-stage", stage=True),
     "testy-assets": asset_profile("root@snafu.lichess.ovh", deploy_dir="/home/testy/deploy", post=curl_cli("change asset version", url="https://testy.lichess.dev/run/cli", token_file="/home/testy/.testy-cli"), stage=True, user="testy"),
-    "testy-server": server_profile("root@snafu.lichess.ovh", deploy_dir="/home/testy/deploy", post="systemctl restart testy", stage=True, user="testy", symlinks=None),
+    "testy-server": server_profile("root@snafu.lichess.ovh", deploy_dir="/home/testy/deploy", post="systemctl restart testy", stage=True, user="testy"),
     "manta-server": server_profile("root@manta.lichess.ovh", deploy_dir="/home/lichess/deploy"),
     "manta-assets": asset_profile("root@manta.lichess.ovh", deploy_dir="/home/lichess/deploy"),
 }
@@ -297,21 +294,22 @@ def deploy_script(profile, session, run, url):
             f"git -C {deploy_dir} lfs pull",
             "echo \\# Copying assets ...",
             f"rsync -a {artifact_unzipped}/d/public {deploy_dir}/",
-            f"rm -rf {artifact_unzipped}",
         ]
-    elif not profile.get("symlinks"):
-        commands += podman_deploy_bins(deploy_dir, f"{artifact_unzipped}/d")
     else:
         commands += [
-            f'echo "{artifact_unzipped}/d/{symlink} -> {deploy_dir}/{symlink}";ln -f --no-target-directory -s {artifact_unzipped}/d/{symlink} {deploy_dir}/{symlink}'
-            for symlink in profile["symlinks"]
-        ] + [f"chmod -f +x {deploy_dir}/bin/lila || true"]
+            f"rsync -a {artifact_unzipped}/d/bin/ {deploy_dir}/bin/",
+            f"rm -rf {deploy_dir}/lib~",
+            f"mv {deploy_dir}/lib {deploy_dir}/lib~",
+            f"mv {artifact_unzipped}/d/lib {deploy_dir}/",
+            f"chmod -f +x {deploy_dir}/bin/lila || true",
+        ]
 
     return commands + [
         f"chown -R {user_group} {deploy_dir}",
         f"echo \"SSH: {profile['ssh']}\"",
         f"echo {shlex.quote('Running: ' + profile['post'])}" if profile["stage"] else f"/bin/bash -c {shlex.quote(deploy_prompt)}",
         profile["post"],
+        f"rm -rf {artifact_unzipped}",
         "echo",
         f"echo \\# Done.",
     ]
@@ -338,18 +336,6 @@ def deploy(profile, repo, commit, github_api_token, dry_run):
     print(f"Deploying {url} to {profile['ssh']}...")
     return tmux(profile["ssh"], deploy_script(profile, session, run, url), dry_run=dry_run)
 
-
-def podman_deploy_bins(deploy_dir, artifact_dir):
-    # podman deploys cannot escape a volume mapping via symlink.
-    # but the powerful technology 'mv' can deploy bin and lib in place
-    return [
-            f"rm -rf {deploy_dir}/bin~ {deploy_dir}/lib~",
-            f"mv -f {deploy_dir}/bin {deploy_dir}/bin~",
-            f"mv -f {deploy_dir}/lib {deploy_dir}/lib~",
-            f"mv -f {artifact_dir}/bin {deploy_dir}/bin",
-            f"mv -f {artifact_dir}/lib {deploy_dir}/lib",
-            f"chmod -f +x {deploy_dir}/bin/lila || true",
-        ]
 
 def main():
     # Parse command line arguments.


### PR DESCRIPTION
make all deployments isolated to {deploy_dir}. this unifies testy, stage, and prod flows. it makes deploys safe for containers using isolated volume maps. any benefits we may have got from symlinking bin & lib are redundant with the version history available in github.