### PR TITLE
fix Prototype-polluting function mod.activity() code Injection

### DIFF
--- a/ui/mod/src/mod.activity.ts
+++ b/ui/mod/src/mod.activity.ts
@@ -100,7 +100,8 @@ function queues(data: any) {
 
 function merge(base: any, extend: any): void {
   for (const key in extend) {
-    if (isObject(base[key]) && isObject(extend[key])) merge(base[key], extend[key]);
+    if (!extend.hasOwnProperty(key) || key === '__proto__' || key === 'constructor') continue;
+    if (base.hasOwnProperty(key) && isObject(base[key]) && isObject(extend[key])) merge(base[key], extend[key]);
     else base[key] = extend[key];
   }
   return base;

--- a/ui/mod/src/mod.activity.ts
+++ b/ui/mod/src/mod.activity.ts
@@ -101,7 +101,8 @@ function queues(data: any) {
 function merge(base: any, extend: any): void {
   for (const key in extend) {
     if (!extend.hasOwnProperty(key) || key === '__proto__' || key === 'constructor') continue;
-    if (base.hasOwnProperty(key) && isObject(base[key]) && isObject(extend[key])) merge(base[key], extend[key]);
+    if (base.hasOwnProperty(key) && isObject(base[key]) && isObject(extend[key]))
+      merge(base[key], extend[key]);
     else base[key] = extend[key];
   }
   return base;


### PR DESCRIPTION
https://github.com/lichess-org/lila/blob/0d7709f95a01bb9e270bceb43fa92d8f7b1deb78/ui/mod/src/mod.activity.ts#L104-L104

fix for problem, we need to ensure that the `merge` function does not allow prototype pollution. This can be achieved by:
1. Blocking the properties `__proto__` and `constructor` from being merged.
2. Ensuring that only own properties of the destination object are merged recursively.

We will modify the `merge` function to include these checks. Specifically, we will:
- Add a check to skip the properties `__proto__` and `constructor`.
- Ensure that the property being merged is an own property of the destination object.

Most JavaScript objects inherit the properties of the built-in `Object.prototype` object. Prototype pollution is a type of vulnerability in which an attacker is able to modify `Object.prototype`. Since most objects inherit from the compromised `Object.prototype`, the attacker can use this to tamper with the application logic, and often escalate to remote code execution or cross-site scripting.

One way to cause prototype pollution is through use of an unsafe merge or extend function to recursively copy properties from one object to another, or through the use of a deep assignment function to assign to an unverified chain of property names. Such a function has the potential to modify any object reachable from the destination object, and the built-in `Object.prototype` is usually reachable through the special properties `__proto__` and `constructor.prototype`.


## POC
This function recursively copies properties from `src` to `dst`:
```js
function merge(dst, src) {
    for (let key in src) {
        if (!src.hasOwnProperty(key)) continue;
        if (isObject(dst[key])) {
            merge(dst[key], src[key]);
        } else {
            dst[key] = src[key];
        }
    }
}
```
However, if src is the `object {"__proto__": {"isAdmin": true}}`, it will inject the property `isAdmin: true` in `Object.prototype`. The issue can be fixed by ensuring that only own properties of the destination object are merged recursively:
```js
function merge(dst, src) {
    for (let key in src) {
        if (!src.hasOwnProperty(key)) continue;
        if (dst.hasOwnProperty(key) && isObject(dst[key])) {
            merge(dst[key], src[key]);
        } else {
            dst[key] = src[key];
        }
    }
}
```
Alternatively, block the `__proto__` and `constructor` properties:
```js
function merge(dst, src) {
    for (let key in src) {
        if (!src.hasOwnProperty(key)) continue;
        if (key === "__proto__" || key === "constructor") continue;
        if (isObject(dst[key])) {
            merge(dst[key], src[key]);
        } else {
            dst[key] = src[key];
        }
    }
}
```
## References
[lodash](https://hackerone.com/reports/380873), [jQuery](https://hackerone.com/reports/454365), [extend](https://hackerone.com/reports/381185), [just-extend](https://hackerone.com/reports/430291), [merge.recursive](https://hackerone.com/reports/381194)
[CWE-78](https://cwe.mitre.org/data/definitions/78.html)
[CWE-79](https://cwe.mitre.org/data/definitions/79.html)
[CWE-94](https://cwe.mitre.org/data/definitions/94.html)
[CWE-400](https://cwe.mitre.org/data/definitions/400.html)
[CWE-471](https://cwe.mitre.org/data/definitions/471.html)
[CWE-915](https://cwe.mitre.org/data/definitions/915.html)

