### PR TITLE
require recommended ublog posts to share at least 4 common likers

### DIFF
--- a/bin/mongodb/ublog-similar-full.js
+++ b/bin/mongodb/ublog-similar-full.js
@@ -5,7 +5,7 @@
  * Should run only once, then be replaced with
  * ublog-graph-incremental.js
  */
-const nbSimilar = 6;
+const nbSimilar = 20;
 console.log('Full recompute');
 const all = db.ublog_post.find({ live: true, 'likers.1': { $exists: true } }, { likers: 1 }).toArray();
 console.log(`${all.length} posts to go.`);
@@ -28,8 +28,11 @@ all.forEach(p => {
       if (id != p._id) similar.set(id, (similar.get(id) || 0) + 1);
     });
   });
-  const top3 = Array.from(similar)
+  const sorted = Array.from(similar)
     .sort((a, b) => b[1] - a[1])
     .slice(0, nbSimilar);
-  db.ublog_post.updateOne({ _id: p._id }, { $set: { similar: top3.map(([id, _]) => id) } });
+  db.ublog_post.updateOne(
+    { _id: p._id },
+    { $set: { similar: sorted.map(([id, count]) => ({ id, count })) } },
+  );
 });

--- a/bin/mongodb/ublog-similar-full.js
+++ b/bin/mongodb/ublog-similar-full.js
@@ -14,16 +14,24 @@ db.ublog_post.updateMany({}, { $set: { similar: [] } });
 
 print('Full recompute');
 
-const all = db.ublog_post.aggregate([
-  { $match: { live: true, 'likers.1': { $exists: true } } },
-  {
-    $lookup: {
-      let: { id: '$blog' }, pipeline: [
-        { $match: { $expr: { $and: [{ $eq: ['$_id', '$$id'] }, { $gte: ['$tier', minTier] }] } } },
-        { $project: { _id: 1 } }
-      ], from: 'ublog_blog', as: 'blog'
-    }
-  }, { $unwind: '$blog' }, { $project: { likers: 1 } }]).toArray();
+const all = db.ublog_post
+  .aggregate([
+    { $match: { live: true, 'likers.1': { $exists: true } } },
+    {
+      $lookup: {
+        let: { id: '$blog' },
+        pipeline: [
+          { $match: { $expr: { $and: [{ $eq: ['$_id', '$$id'] }, { $gte: ['$tier', minTier] }] } } },
+          { $project: { _id: 1 } },
+        ],
+        from: 'ublog_blog',
+        as: 'blog',
+      },
+    },
+    { $unwind: '$blog' },
+    { $project: { likers: 1 } },
+  ])
+  .toArray();
 print(`${all.length} listed posts to go.`);
 
 print(`Computing likers...`);

--- a/bin/mongodb/ublog-similar-incremental.js
+++ b/bin/mongodb/ublog-similar-incremental.js
@@ -4,7 +4,7 @@
  *
  * Should run periodically, e.g. every 1 hour.
  */
-const nbSimilar = 6;
+const nbSimilar = 20;
 const since = new Date(Date.now() - 1000 * 60 * 60 * 24 * 15);
 const updatable = db.ublog_post.find({ live: true, 'updated.at': { $gt: since } }, { likers: 1 }).toArray();
 console.log(`${updatable.length} posts were updated since ${since}`);
@@ -30,8 +30,11 @@ updatable.forEach(p => {
       if (id != p._id) similar.set(id, (similar.get(id) || 0) + 1);
     });
   });
-  const top3 = Array.from(similar)
+  const sorted = Array.from(similar)
     .sort((a, b) => b[1] - a[1])
     .slice(0, nbSimilar);
-  db.ublog_post.updateOne({ _id: p._id }, { $set: { similar: top3.map(([id, _]) => id) } });
+  db.ublog_post.updateOne(
+    { _id: p._id },
+    { $set: { similar: sorted.map(([id, count]) => ({ id, count })) } },
+  );
 });

--- a/modules/ublog/src/main/UblogApi.scala
+++ b/modules/ublog/src/main/UblogApi.scala
@@ -129,8 +129,8 @@ final class UblogApi(
         .sort($doc("lived.at" -> -1))
         .cursor[UblogPost.PreviewPost](ReadPref.sec)
         .list(3)
-      similarIds = post.similar.filterNot(sameAuthor.map(_.id).contains)
-      similar <- postPreviews(post.similar)
+      similarIds = post.similar.filterNot(s => s.count < 4 && sameAuthor.map(_.id).contains(s.id))
+      similar <- postPreviews(post.similar.map(_.id))
       mix = (similar ++ sameAuthor).filter(_.isLichess || kid.no)
     yield scala.util.Random.shuffle(mix).take(6)
 

--- a/modules/ublog/src/main/UblogBsonHandlers.scala
+++ b/modules/ublog/src/main/UblogBsonHandlers.scala
@@ -15,12 +15,13 @@ private object UblogBsonHandlers:
   )
   given BSONDocumentHandler[UblogBlog] = Macros.handler
 
-  given BSONHandler[Lang]                = langByCodeHandler
-  given BSONDocumentHandler[Recorded]    = Macros.handler
-  given BSONDocumentHandler[UblogImage]  = Macros.handler
-  given BSONDocumentHandler[UblogPost]   = Macros.handler
-  given BSONDocumentHandler[LightPost]   = Macros.handler
-  given BSONDocumentHandler[PreviewPost] = Macros.handler
+  given BSONHandler[Lang]                 = langByCodeHandler
+  given BSONDocumentHandler[Recorded]     = Macros.handler
+  given BSONDocumentHandler[UblogImage]   = Macros.handler
+  given BSONDocumentHandler[UblogPost]    = Macros.handler
+  given BSONDocumentHandler[LightPost]    = Macros.handler
+  given BSONDocumentHandler[PreviewPost]  = Macros.handler
+  given BSONDocumentHandler[UblogSimilar] = Macros.handler
 
   val postProjection      = $doc("likers" -> false)
   val lightPostProjection = $doc("title" -> true)

--- a/modules/ublog/src/main/UblogPost.scala
+++ b/modules/ublog/src/main/UblogPost.scala
@@ -24,7 +24,7 @@ case class UblogPost(
     lived: Option[UblogPost.Recorded],
     likes: UblogPost.Likes,
     views: UblogPost.Views,
-    similar: List[UblogPostId],
+    similar: List[UblogSimilar],
     rankAdjustDays: Option[Int],
     pinned: Option[Boolean]
 ) extends UblogPost.BasePost
@@ -40,6 +40,8 @@ case class UblogPost(
   def canView(using Option[Me]) = live || allows.draft
 
 case class UblogImage(id: ImageId, alt: Option[String] = None, credit: Option[String] = None)
+
+case class UblogSimilar(id: UblogPostId, count: Int)
 
 object UblogPost:
 

--- a/modules/ublog/src/main/UblogRank.scala
+++ b/modules/ublog/src/main/UblogRank.scala
@@ -41,7 +41,7 @@ object UblogRank:
       BEST    -> "Best"
     )
     object tierDays:
-      val LOW  = -7
+      val LOW  = -4
       val HIGH = 5
       val BEST = 7
       val map  = Map(Tier.LOW -> LOW, Tier.HIGH -> HIGH, Tier.BEST -> BEST)


### PR DESCRIPTION
- don't recommended posts with less than 4 common likers
- we could filter these in bin/mongodb/*.js scripts but with < 50k posts total, let's err on the side of storing more data in ublog_post.similar rather than less
- boost default (LOW) blog tier for a fighting chance at the lower half of community listing page.

## requires `mongosh bin/mongodb/ublog-similar-full.js`
lila can expect a few mongo exceptions while that's running