### PR TITLE
Broadcast group/round/game navigation for nvui

### DIFF
--- a/ui/analyse/src/plugins/analyse.nvui.ts
+++ b/ui/analyse/src/plugins/analyse.nvui.ts
@@ -588,6 +588,7 @@ function studyDetails(ctrl: AnalyseController): MaybeVNode {
   const relayGroups = study?.relay?.data.group;
   const relayRounds = study?.relay?.data.rounds;
   const tour = study?.relay?.data.tour;
+  const hash = window.location.hash;
   return (
     study &&
     h('div.study-details', [
@@ -602,7 +603,7 @@ function studyDetails(ctrl: AnalyseController): MaybeVNode {
             h(
               'select',
               {
-                attrs: { id: 'group-select' },
+                attrs: { autofocus: hash === '#group-select' ? true : false },
                 hook: bind('change', (e: InputEvent) => {
                   const target = e.target as HTMLSelectElement;
                   const selectedOption = target.options[target.selectedIndex];
@@ -611,7 +612,11 @@ function studyDetails(ctrl: AnalyseController): MaybeVNode {
                 }),
               },
               relayGroups.tours.map(t =>
-                h('option', { attrs: { selected: t.id == tour?.id, url: `/broadcast/-/${t.id}` } }, t.name),
+                h(
+                  'option',
+                  { attrs: { selected: t.id == tour?.id, url: `/broadcast/-/${t.id}#group-select` } },
+                  t.name,
+                ),
               ),
             ),
           ]),
@@ -625,6 +630,7 @@ function studyDetails(ctrl: AnalyseController): MaybeVNode {
             h(
               'select',
               {
+                attrs: { autofocus: hash === '#round-select' ? true : false },
                 hook: bind('change', (e: InputEvent) => {
                   const target = e.target as HTMLSelectElement;
                   const selectedOption = target.options[target.selectedIndex];
@@ -638,7 +644,7 @@ function studyDetails(ctrl: AnalyseController): MaybeVNode {
                   {
                     attrs: {
                       selected: r.id == study.data.id,
-                      url: `/broadcast/${tour.slug}/${r.slug}/${r.id}`,
+                      url: `/broadcast/${tour.slug}/${r.slug}/${r.id}#round-select`,
                     },
                   },
                   r.name,

--- a/ui/analyse/src/plugins/analyse.nvui.ts
+++ b/ui/analyse/src/plugins/analyse.nvui.ts
@@ -595,79 +595,86 @@ function studyDetails(ctrl: AnalyseController): MaybeVNode {
       h('span', `Title: ${study.data.name}. By: ${study.data.ownerId}`),
       h('br'),
       relayGroups &&
-        h('div.relay-groups', [
-          h('label', { attrs: { for: 'group-select' } }, 'Current group:'),
-          h(
-            'select',
-            {
-              attrs: { id: 'group-select' },
-              hook: bind('change', (e: InputEvent) => {
-                const target = e.target as HTMLSelectElement;
-                const selectedOption = target.options[target.selectedIndex];
-                const url = selectedOption.getAttribute('url');
-                if (url) window.location.href = url;
-              }),
-            },
-            relayGroups.tours.map(t =>
-              h('option', { attrs: { selected: t.id == tour?.id, url: `/broadcast/-/${t.id}` } }, t.name),
+        h(
+          'div.relay-groups',
+          h('label', [
+            'Current group:',
+            h(
+              'select',
+              {
+                attrs: { id: 'group-select' },
+                hook: bind('change', (e: InputEvent) => {
+                  const target = e.target as HTMLSelectElement;
+                  const selectedOption = target.options[target.selectedIndex];
+                  const url = selectedOption.getAttribute('url');
+                  if (url) window.location.href = url;
+                }),
+              },
+              relayGroups.tours.map(t =>
+                h('option', { attrs: { selected: t.id == tour?.id, url: `/broadcast/-/${t.id}` } }, t.name),
+              ),
             ),
-          ),
-        ]),
+          ]),
+        ),
       tour &&
         relayRounds &&
-        h('div.relay-rounds', [
-          h('label', { attrs: { for: 'round-select' } }, 'Current round:'),
+        h(
+          'div.relay-rounds',
+          h('label', [
+            'Current round:',
+            h(
+              'select',
+              {
+                hook: bind('change', (e: InputEvent) => {
+                  const target = e.target as HTMLSelectElement;
+                  const selectedOption = target.options[target.selectedIndex];
+                  const url = selectedOption.getAttribute('url');
+                  if (url) window.location.href = url;
+                }),
+              },
+              relayRounds.map(r =>
+                h(
+                  'option',
+                  {
+                    attrs: {
+                      selected: r.id == study.data.id,
+                      url: `/broadcast/${tour.slug}/${r.slug}/${r.id}`,
+                    },
+                  },
+                  r.name,
+                ),
+              ),
+            ),
+          ]),
+        ),
+      h('div.chapters', [
+        h('label', [
+          'Current chapter:',
           h(
             'select',
             {
-              attrs: { id: 'round-select' },
+              attrs: { id: 'chapter-select' },
               hook: bind('change', (e: InputEvent) => {
                 const target = e.target as HTMLSelectElement;
                 const selectedOption = target.options[target.selectedIndex];
-                const url = selectedOption.getAttribute('url');
-                if (url) window.location.href = url;
+                const chapterId = selectedOption.getAttribute('chapterId');
+                study.setChapter(chapterId!);
               }),
             },
-            relayRounds.map(r =>
+            study.chapters.list.all().map((ch, i) =>
               h(
                 'option',
                 {
                   attrs: {
-                    selected: r.id == study.data.id,
-                    url: `/broadcast/${tour.slug}/${r.slug}/${r.id}`,
+                    selected: ch.id === study.currentChapter().id,
+                    chapterId: ch.id,
                   },
                 },
-                r.name,
+                `${i + 1}. ${ch.name}`,
               ),
             ),
           ),
         ]),
-      h('div.chapters', [
-        h('label', { attrs: { for: 'chapter-select' } }, 'Current chapter:'),
-        h(
-          'select',
-          {
-            attrs: { id: 'chapter-select' },
-            hook: bind('change', (e: InputEvent) => {
-              const target = e.target as HTMLSelectElement;
-              const selectedOption = target.options[target.selectedIndex];
-              const chapterId = selectedOption.getAttribute('chapterId');
-              study.setChapter(chapterId!);
-            }),
-          },
-          study.chapters.list.all().map((ch, i) =>
-            h(
-              'option',
-              {
-                attrs: {
-                  selected: ch.id === study.currentChapter().id,
-                  chapterId: ch.id,
-                },
-              },
-              `${i + 1}. ${ch.name}`,
-            ),
-          ),
-        ),
         study.members.canContribute()
           ? h('div.buttons', [
               h(

--- a/ui/analyse/src/plugins/analyse.nvui.ts
+++ b/ui/analyse/src/plugins/analyse.nvui.ts
@@ -142,7 +142,7 @@ export function initModule(ctrl: AnalyseController): NvuiPlugin {
               h('label', [
                 'Command input',
                 h('input.move.mousetrap', {
-                  attrs: { name: 'move', type: 'text', autocomplete: 'off', autofocus: true },
+                  attrs: { name: 'move', type: 'text', autocomplete: 'off' },
                 }),
               ]),
             ],

--- a/ui/analyse/src/plugins/analyse.nvui.ts
+++ b/ui/analyse/src/plugins/analyse.nvui.ts
@@ -595,47 +595,59 @@ function studyDetails(ctrl: AnalyseController): MaybeVNode {
       h('span', `Title: ${study.data.name}. By: ${study.data.ownerId}`),
       h('br'),
       relayGroups &&
-        h(
-          'select',
-          {
-            hook: bind('change', (e: InputEvent) => {
-              const target = e.target as HTMLSelectElement;
-              const selectedOption = target.options[target.selectedIndex];
-              const url = selectedOption.getAttribute('url');
-              if (url) window.location.href = url;
-            }),
-          },
-          relayGroups.tours.map(t =>
-            h('option', { attrs: { selected: t.id == tour?.id, url: `/broadcast/-/${t.id}` } }, t.name),
-          ),
-        ),
-      tour &&
-        relayRounds &&
-        h(
-          'select',
-          {
-            hook: bind('change', (e: InputEvent) => {
-              const target = e.target as HTMLSelectElement;
-              const selectedOption = target.options[target.selectedIndex];
-              const url = selectedOption.getAttribute('url');
-              if (url) window.location.href = url;
-            }),
-          },
-          relayRounds.map(r =>
-            h(
-              'option',
-              {
-                attrs: { selected: r.id == study.data.id, url: `/broadcast/${tour.slug}/${r.slug}/${r.id}` },
-              },
-              r.name,
+        h('div.relay-groups', [
+          h('label', { attrs: { for: 'group-select' } }, 'Current group:'),
+          h(
+            'select',
+            {
+              attrs: { id: 'group-select' },
+              hook: bind('change', (e: InputEvent) => {
+                const target = e.target as HTMLSelectElement;
+                const selectedOption = target.options[target.selectedIndex];
+                const url = selectedOption.getAttribute('url');
+                if (url) window.location.href = url;
+              }),
+            },
+            relayGroups.tours.map(t =>
+              h('option', { attrs: { selected: t.id == tour?.id, url: `/broadcast/-/${t.id}` } }, t.name),
             ),
           ),
-        ),
-      h('label.chapters', [
-        h('h2', 'Current chapter:'),
+        ]),
+      tour &&
+        relayRounds &&
+        h('div.relay-rounds', [
+          h('label', { attrs: { for: 'round-select' } }, 'Current round:'),
+          h(
+            'select',
+            {
+              attrs: { id: 'round-select' },
+              hook: bind('change', (e: InputEvent) => {
+                const target = e.target as HTMLSelectElement;
+                const selectedOption = target.options[target.selectedIndex];
+                const url = selectedOption.getAttribute('url');
+                if (url) window.location.href = url;
+              }),
+            },
+            relayRounds.map(r =>
+              h(
+                'option',
+                {
+                  attrs: {
+                    selected: r.id == study.data.id,
+                    url: `/broadcast/${tour.slug}/${r.slug}/${r.id}`,
+                  },
+                },
+                r.name,
+              ),
+            ),
+          ),
+        ]),
+      h('div.chapters', [
+        h('label', { attrs: { for: 'chapter-select' } }, 'Current chapter:'),
         h(
           'select',
           {
+            attrs: { id: 'chapter-select' },
             hook: bind('change', (e: InputEvent) => {
               const target = e.target as HTMLSelectElement;
               const selectedOption = target.options[target.selectedIndex];

--- a/ui/analyse/src/plugins/analyse.nvui.ts
+++ b/ui/analyse/src/plugins/analyse.nvui.ts
@@ -603,7 +603,7 @@ function studyDetails(ctrl: AnalyseController): MaybeVNode {
             h(
               'select',
               {
-                attrs: { autofocus: hash === '#group-select' ? true : false },
+                attrs: { autofocus: hash === '#group-select' },
                 hook: bind('change', (e: InputEvent) => {
                   const target = e.target as HTMLSelectElement;
                   const selectedOption = target.options[target.selectedIndex];
@@ -630,7 +630,7 @@ function studyDetails(ctrl: AnalyseController): MaybeVNode {
             h(
               'select',
               {
-                attrs: { autofocus: hash === '#round-select' ? true : false },
+                attrs: { autofocus: hash === '#round-select' },
                 hook: bind('change', (e: InputEvent) => {
                   const target = e.target as HTMLSelectElement;
                   const selectedOption = target.options[target.selectedIndex];

--- a/ui/analyse/src/plugins/analyse.nvui.ts
+++ b/ui/analyse/src/plugins/analyse.nvui.ts
@@ -586,6 +586,8 @@ const onInsertHandler = (callback: () => void, el: HTMLElement) => {
 function studyDetails(ctrl: AnalyseController): MaybeVNode {
   const study = ctrl.study;
   const relayGroups = study?.relay?.data.group;
+  const relayRounds = study?.relay?.data.rounds;
+  const tour = study?.relay?.data.tour;
   return (
     study &&
     h('div.study-details', [
@@ -593,10 +595,42 @@ function studyDetails(ctrl: AnalyseController): MaybeVNode {
       h('span', `Title: ${study.data.name}. By: ${study.data.ownerId}`),
       h('br'),
       relayGroups &&
-        h('div.relayGroups', [
-          h('h2', 'Relay groups'),
-          ...relayGroups.tours.map(tour => h('a', { attrs: { href: `/broadcast/-/${tour.id}` } }, tour.name)),
-        ]),
+        h(
+          'select',
+          {
+            hook: bind('change', (e: InputEvent) => {
+              const target = e.target as HTMLSelectElement;
+              const selectedOption = target.options[target.selectedIndex];
+              const url = selectedOption.getAttribute('url');
+              if (url) window.location.href = url;
+            }),
+          },
+          relayGroups.tours.map(t =>
+            h('option', { attrs: { selected: t.id == tour?.id, url: `/broadcast/-/${t.id}` } }, t.name),
+          ),
+        ),
+      tour &&
+        relayRounds &&
+        h(
+          'select',
+          {
+            hook: bind('change', (e: InputEvent) => {
+              const target = e.target as HTMLSelectElement;
+              const selectedOption = target.options[target.selectedIndex];
+              const url = selectedOption.getAttribute('url');
+              if (url) window.location.href = url;
+            }),
+          },
+          relayRounds.map(r =>
+            h(
+              'option',
+              {
+                attrs: { selected: r.id == study.data.id, url: `/broadcast/${tour.slug}/${r.slug}/${r.id}` },
+              },
+              r.name,
+            ),
+          ),
+        ),
       h('label.chapters', [
         h('h2', 'Current chapter:'),
         h(

--- a/ui/analyse/src/plugins/analyse.nvui.ts
+++ b/ui/analyse/src/plugins/analyse.nvui.ts
@@ -583,6 +583,13 @@ const onInsertHandler = (callback: () => void, el: HTMLElement) => {
   el.addEventListener('keydown', ev => ev.key === 'Enter' && callback());
 };
 
+const redirectToSelectedHook = bind('change', (e: InputEvent) => {
+  const target = e.target as HTMLSelectElement;
+  const selectedOption = target.options[target.selectedIndex];
+  const url = selectedOption.getAttribute('url');
+  if (url) window.location.href = url;
+});
+
 function studyDetails(ctrl: AnalyseController): MaybeVNode {
   const study = ctrl.study;
   const relayGroups = study?.relay?.data.group;
@@ -604,12 +611,7 @@ function studyDetails(ctrl: AnalyseController): MaybeVNode {
               'select',
               {
                 attrs: { autofocus: hash === '#group-select' },
-                hook: bind('change', (e: InputEvent) => {
-                  const target = e.target as HTMLSelectElement;
-                  const selectedOption = target.options[target.selectedIndex];
-                  const url = selectedOption.getAttribute('url');
-                  if (url) window.location.href = url;
-                }),
+                hook: redirectToSelectedHook,
               },
               relayGroups.tours.map(t =>
                 h(
@@ -631,12 +633,7 @@ function studyDetails(ctrl: AnalyseController): MaybeVNode {
               'select',
               {
                 attrs: { autofocus: hash === '#round-select' },
-                hook: bind('change', (e: InputEvent) => {
-                  const target = e.target as HTMLSelectElement;
-                  const selectedOption = target.options[target.selectedIndex];
-                  const url = selectedOption.getAttribute('url');
-                  if (url) window.location.href = url;
-                }),
+                hook: redirectToSelectedHook,
               },
               relayRounds.map(r =>
                 h(


### PR DESCRIPTION
addresses part of #17234   

I made some videos to illustrate the same scenario [visual ](https://youtu.be/e20_2XPwTeQ)vs [non visual](https://youtu.be/lp7tdM2p-UQ)

In this video, the screen reader keeps reading from the start of the page ... I added an autofocus on the selection that triggers the new page. I think it make the experience better


