### PR TITLE
fix Incomplete regular expression for hostnames Unvalidated Redirects Forwards SSRF

### DIFF
--- a/ui/lib/src/chat/spam.ts
+++ b/ui/lib/src/chat/spam.ts
@@ -27,7 +27,7 @@ const spamRegex = new RegExp(
     '001.rs/',
     'shr.name/',
     'u.to/',
-    '.3-a.net',
+    '\\.3-a\\.net',
     '.ssl443.org',
     '.ns02.us',
     '.myftp.info',


### PR DESCRIPTION
https://github.com/lichess-org/lila/blob/62137a34043da1e869c38eecf75916d1dbdf7f22/ui/lib/src/chat/spam.ts#L30-L30

fix the problem need to escape the dot in the string `.3-a.net` to ensure that it matches only the literal dot character and not any character. This can be done by replacing the dot with `\.`. This change should be made in the array of strings that are used to construct the regular expression.


Sanitizing untrusted URLs is an important technique for preventing attacks such as request forgeries and malicious redirections. Often, this is done by checking that the host of a URL is in a set of allowed hosts. If a regular expression implements such a check, it is easy to accidentally make the check too permissive by not escaping the . meta-characters appropriately. Even if the check is not used in a security-critical context, the incomplete check may still cause undesirable behaviors when it accidentally succeeds.

## POC
The following code checks that a URL redirection will reach the `3-a.net` domain, or one of its subdomains.
```ts
app.get('/some/path', function(req, res) {
    let url = req.param('url'),
        host = urlLib.parse(url).host;
    // BAD: the host of `url` may be controlled by an attacker
    let regex = /^((www|beta).)?3-a.net/;
    if (host.match(regex)) {
        res.redirect(url);
    }
});
```
The check is however easy to bypass because the unescaped `.` allows for any character before `3-a.net`, effectively allowing the redirect to go to an attacker-controlled domain such as `wwwX3-a.net`. Address this vulnerability by escaping `.` appropriately: `let regex = /^((www|beta)\.)?3-a\.net/`.

## References
[Regular Expressions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions)
[SSRF](https://www.owasp.org/index.php/Server_Side_Request_Forgery)
[XSS Unvalidated Redirects and Forwards Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.html)
[CWE-20](https://cwe.mitre.org/data/definitions/20.html)

