### PR TITLE
mark ublog_post.similar as optional

### DIFF
--- a/modules/ublog/src/main/UblogApi.scala
+++ b/modules/ublog/src/main/UblogApi.scala
@@ -129,8 +129,10 @@ final class UblogApi(
         .sort($doc("lived.at" -> -1))
         .cursor[UblogPost.PreviewPost](ReadPref.sec)
         .list(3)
-      similarIds = post.similar.filterNot(s => s.count < 4 && sameAuthor.map(_.id).contains(s.id))
-      similar <- postPreviews(post.similar.map(_.id))
+      similar <- post.similar
+        .map(_.filterNot(s => s.count < 4 && sameAuthor.exists(_.id == s.id)).map(_.id))
+        .collect { case ids if ids.nonEmpty => postPreviews(ids) }
+        .getOrElse(fuccess(Nil))
       mix = (similar ++ sameAuthor).filter(_.isLichess || kid.no)
     yield scala.util.Random.shuffle(mix).take(6)
 

--- a/modules/ublog/src/main/UblogForm.scala
+++ b/modules/ublog/src/main/UblogForm.scala
@@ -86,7 +86,7 @@ object UblogForm:
         lived = none,
         likes = UblogPost.Likes(1),
         views = UblogPost.Views(0),
-        similar = Nil,
+        similar = none,
         rankAdjustDays = none,
         pinned = none
       )

--- a/modules/ublog/src/main/UblogPost.scala
+++ b/modules/ublog/src/main/UblogPost.scala
@@ -24,7 +24,7 @@ case class UblogPost(
     lived: Option[UblogPost.Recorded],
     likes: UblogPost.Likes,
     views: UblogPost.Views,
-    similar: List[UblogSimilar],
+    similar: Option[List[UblogSimilar]],
     rankAdjustDays: Option[Int],
     pinned: Option[Boolean]
 ) extends UblogPost.BasePost


### PR DESCRIPTION
it does complicate the lookup a smidge, but it might become useful to distinguish between the cases where similarity check has not even run (None) and cases where the check has run but found nothing (Nil).

mostly this change reduces exception spew in logs when a requested blog doesn't satisfy `{ $match: { live: true, 'likers.1': { $exists: true } } }` and does not get a similar field.
