### PR TITLE
Leave “Public Account” disabled by default, and remove requirements that don't happen.

### DIFF
--- a/modules/title/src/main/ui/TitleUi.scala
+++ b/modules/title/src/main/ui/TitleUi.scala
@@ -152,7 +152,7 @@ Today's date is [current date]""")
           form("public"),
           frag("Public account"),
           help = frag(
-            "Makes your FIDE ID public in your profile. Required for coaching."
+            "Makes your real name and FIDE ID public in your profile. Required for coaching."
           ).some,
           half = true
         ),

--- a/modules/title/src/main/ui/TitleUi.scala
+++ b/modules/title/src/main/ui/TitleUi.scala
@@ -149,12 +149,10 @@ Today's date is [current date]""")
       ),
       form3.split(
         form3.checkbox(
-          if form("public").value.isDefined || form.hasErrors
-          then form("public")
-          else form("public").copy(value = "true".some),
+          form("public"),
           frag("Public account"),
           help = frag(
-            "Makes your real name public. Required for coaching, streaming, and prize tournaments."
+            "Makes your FIDE ID public in your profile. Required for coaching."
           ).some,
           half = true
         ),


### PR DESCRIPTION
Avoid confusion with players with titles.