### PR TITLE
use td for table cell + do not use buggy data-sort-reverse

### DIFF
--- a/ui/analyse/css/study/relay/_tour.scss
+++ b/ui/analyse/css/study/relay/_tour.scss
@@ -381,6 +381,9 @@ $hover-bg: $m-primary_bg--mix-30;
         font-weight: bold;
       }
     }
+    td.player-name {
+      text-align: start;
+    }
     .rp {
       margin-inline-start: 1ch;
     }

--- a/ui/analyse/src/study/relay/relayPlayers.ts
+++ b/ui/analyse/src/study/relay/relayPlayers.ts
@@ -224,7 +224,7 @@ const renderPlayers = (ctrl: RelayPlayers, players: RelayPlayer[]): VNode => {
       h(
         'thead',
         h('tr', [
-          h('th', { attrs: { 'data-sort-reverse': true } }, i18n.site.player),
+          h('th', defaultSort, i18n.site.player),
           withRating ? h('th', !withScores && defaultSort, 'Elo') : undefined,
           withScores ? h('th', defaultSort, i18n.broadcast.score) : h('th', i18n.site.games),
         ]),
@@ -234,7 +234,7 @@ const renderPlayers = (ctrl: RelayPlayers, players: RelayPlayer[]): VNode => {
         players.map(player =>
           h('tr', [
             h(
-              'th',
+              'td.player-name',
               { attrs: { 'data-sort': player.name || '' } },
               h('a', playerLinkConfig(ctrl, player, true), [
                 playerFed(player.fed),

--- a/ui/analyse/src/study/relay/relayPlayers.ts
+++ b/ui/analyse/src/study/relay/relayPlayers.ts
@@ -224,7 +224,7 @@ const renderPlayers = (ctrl: RelayPlayers, players: RelayPlayer[]): VNode => {
       h(
         'thead',
         h('tr', [
-          h('th', defaultSort, i18n.site.player),
+          h('th', i18n.site.player),
           withRating ? h('th', !withScores && defaultSort, 'Elo') : undefined,
           withScores ? h('th', defaultSort, i18n.broadcast.score) : h('th', i18n.site.games),
         ]),


### PR DESCRIPTION
Fix for #17389

- Use td for player name cell (th is semantically incorrect, I think it was chosen for the text alignment)
- Do not use data-sort-reverse (it fails to update aria-sort and sort icon)


On this screenshot, you see that the sort icon (triangle) is correct
![image](https://github.com/user-attachments/assets/23684dcb-a819-4012-994b-4cb86ca10254)

More importantly, the aria-sort is correct
![image](https://github.com/user-attachments/assets/ec6dafc3-56fe-472d-8197-d91fca5baf20)



Although, this fixes the issue of having a sorted list with a correct aria-sort ... I did not manage to have the names sorted in ascending order when name header is clicked for the first time 
I think that is the issue @julien4215 was trying to solve using data-sort-reverse



EDIT:
After a chat with julien on discord, I understand the initial situation better
I think he is going to fix the issue in tablesort

