### PR TITLE
send user context in puzzle streak json

### DIFF
--- a/app/controllers/Puzzle.scala
+++ b/app/controllers/Puzzle.scala
@@ -128,9 +128,8 @@ final class Puzzle(env: Env, apiC: => Api) extends LilaController(env):
       views.puzzle.ui.show(puzzle, json, prefJson, PuzzleSettings.default, langPath)
     .map(_.noCache.enforceCrossSiteIsolation)
 
-  private def streakJsonAndPuzzle(using Translate) =
-    given Option[Me] = none
-    given Perf       = lila.rating.Perf.default
+  private def streakJsonAndPuzzle(using Context) =
+    given Perf = lila.rating.Perf.default
     env.puzzle.streak.apply.flatMapz { case PuzzleStreak(ids, puzzle) =>
       env.puzzle.jsonView(puzzle = puzzle, PuzzleAngle.mix.some, none).map { puzzleJson =>
         (puzzleJson ++ Json.obj("streak" -> ids), puzzle).some


### PR DESCRIPTION
Closes #17178 

The client stores streak info in local storage under the key [`puzzle.streak.${data.user?.id || 'anon'`](https://github.com/lichess-org/lila/blob/47f5ab28e6bef70f06dbc4fadabe9bbec0795f48/ui/puzzle/src/streak.ts#L23). Since user ctx is never sent by the server, it is always set to anon and all users on that machine whether they are logged in or not use that same anon streak session.