### PR TITLE
provide loadEsm for embeds

### DIFF
--- a/app/controllers/Analyse.scala
+++ b/app/controllers/Analyse.scala
@@ -105,7 +105,12 @@ final class Analyse(
               case AcceptsPgn() => Ok(pgn)
               case _ =>
                 Ok.snip:
-                  views.analyse.embed.lpv(pgn, color.some, getPgn = true)
+                  views.analyse.embed.lpv(
+                    pgn,
+                    getPgn = true,
+                    title = "Lichess PGN viewer",
+                    "orientation" -> color.name
+                  )
           case _ =>
             render:
               case AcceptsPgn() => NotFound("*")

--- a/app/views/analyse.scala
+++ b/app/views/analyse.scala
@@ -1,6 +1,7 @@
 package views.analyse
 
 import chess.format.pgn.PgnStr
+import play.api.libs.json.Json
 
 import lila.app.UiEnv.{ *, given }
 import lila.round.RoundGame.secondsSinceCreation
@@ -70,14 +71,25 @@ object replay:
 
 object embed:
 
-  def lpv(pgn: PgnStr, orientation: Option[Color], getPgn: Boolean)(using ctx: EmbedContext) =
+  def lpv(pgn: PgnStr, getPgn: Boolean, title: String, args: (String, Json.JsValueWrapper)*)(using
+      ctx: EmbedContext
+  ) =
+    val opts = Seq[(String, Json.JsValueWrapper)](
+      "menu" -> Json.obj("getPgn" -> Json.obj("enabled" -> getPgn)),
+      "i18n" -> Json.obj(
+        "flipTheBoard"         -> trans.site.flipBoard.txt(),
+        "analysisBoard"        -> trans.site.analysis.txt(),
+        "practiceWithComputer" -> trans.site.practiceWithComputer.txt(),
+        "getPgn"               -> trans.study.copyChapterPgn.txt(),
+        "download"             -> trans.site.download.txt()
+      )
+    ) ++ args
     views.base.embed.minimal(
-      title = "Lichess PGN viewer",
+      title = title,
       cssKeys = List("bits.lpv.embed"),
-      modules = Esm("site.lpvEmbed")
+      modules = esmInitObj("site.lpvEmbed", opts*)
     )(
-      div(cls := "is2d")(div(pgn)),
-      ui.embed.lpvJs(orientation, getPgn)(ctx.nonce.some)
+      div(cls := "is2d")(div(pgn))
     )
 
   def notFound(using EmbedContext) =

--- a/app/views/base/embed.scala
+++ b/app/views/base/embed.scala
@@ -26,7 +26,9 @@ object embed:
         ),
         st.body(
           bodyModifiers,
-          body
+          body,
+          page.ui.inlineJs(ctx.nonce),
+          page.ui.modulesInit(modules, ctx.nonce.some)
         )
       )
     )

--- a/app/views/study.scala
+++ b/app/views/study.scala
@@ -114,17 +114,15 @@ object embed:
   def apply(s: lila.study.Study, chapterId: StudyChapterId, pgn: PgnStr)(using ctx: EmbedContext) =
     val canGetPgn  = s.settings.shareable == lila.study.Settings.UserSelection.Everyone
     val isGamebook = pgn.value.contains("""[ChapterMode "gamebook"]""")
-    views.base.embed.minimal(
+    views.analyse.embed.lpv(
+      pgn,
+      canGetPgn,
       title = s.name.value,
-      cssKeys = List("bits.lpv.embed"),
-      modules = Esm("site.lpvEmbed")
-    )(
-      div(cls := "is2d")(div(pgn)),
-      views.analyse.ui.embed.lpvJs(
-        views.analyse.ui.embed.lpvConfig(orientation = none, getPgn = canGetPgn) ++
-          isGamebook.so:
-            Json.obj("gamebook" -> Json.obj("url" -> routes.Study.chapter(s.id, chapterId).url))
-      )(ctx.nonce.some)
+      isGamebook
+        .option[(String, Json.JsValueWrapper)](
+          "gamebook" -> Json.obj("url" -> routes.Study.chapter(s.id, chapterId).url)
+        )
+        .toSeq*
     )
 
   def notFound(using EmbedContext) =

--- a/modules/analyse/src/main/ui/AnalyseUi.scala
+++ b/modules/analyse/src/main/ui/AnalyseUi.scala
@@ -137,27 +137,3 @@ final class AnalyseUi(helpers: Helpers)(endpoints: AnalyseEndpoints):
 
     def analyseModule(mode: String, json: JsObject) =
       PageModule("analyse", Json.obj("mode" -> mode, "cfg" -> json))
-
-  object embed:
-
-    def lpvJs(orientation: Option[Color], getPgn: Boolean)(using Translate): WithNonce[Frag] =
-      lpvJs(lpvConfig(orientation, getPgn))
-
-    def lpvJs(lpvConfig: JsObject)(using Translate): WithNonce[Frag] =
-      embedJsUnsafe(s"""document.addEventListener("DOMContentLoaded",function(){LpvEmbed(${safeJsonValue(
-          lpvConfig + ("i18n" -> Json.obj(
-            "flipTheBoard"         -> trans.site.flipBoard.txt(),
-            "analysisBoard"        -> trans.site.analysis.txt(),
-            "practiceWithComputer" -> trans.site.practiceWithComputer.txt(),
-            "getPgn"               -> trans.study.copyChapterPgn.txt(),
-            "download"             -> trans.site.download.txt()
-          ))
-        )})})""")
-
-    def lpvConfig(orientation: Option[Color], getPgn: Boolean) = Json
-      .obj(
-        "menu" -> Json.obj(
-          "getPgn" -> Json.obj("enabled" -> getPgn)
-        )
-      )
-      .add("orientation", orientation.map(_.name))

--- a/ui/site/src/site.lpvEmbed.ts
+++ b/ui/site/src/site.lpvEmbed.ts
@@ -8,7 +8,7 @@ interface OptsWithI18n extends Opts {
   };
 }
 
-(window as any).LpvEmbed = function (opts: Partial<OptsWithI18n>) {
+export function initModule(opts: Partial<OptsWithI18n>) {
   const elem = document.body.firstChild!.firstChild as HTMLElement;
   const lpv = Lpv(elem, {
     initialPly: parseInt(location.hash.slice(1)) || undefined,
@@ -36,4 +36,4 @@ interface OptsWithI18n extends Opts {
       `<a href="${opts.gamebook.url}" target="_blank" class="button button-no-upper lpv__gamebook">${text}</a>`,
     );
   }
-};
+}


### PR DESCRIPTION
- add structured argument passing to embedded contexts via lite loadEsm implementation in client manifest.js
- deleted more than i created. but i don't fully grasp the modules/ui/views/app separation logic. i'm sure you'll want to fix
