### PR TITLE
fix: reset page number when pagination is changed in brodcast

### DIFF
--- a/ui/analyse/src/study/multiBoard.ts
+++ b/ui/analyse/src/study/multiBoard.ts
@@ -57,6 +57,7 @@ export class MultiBoardCtrl {
 
   setMaxPerPage = (nb: string) => {
     this.maxPerPageStorage.set(nb);
+    this.page = 1;
     this.redraw();
   };
 


### PR DESCRIPTION
closes #17399 

resets the page number when pagination is changed