### PR TITLE
Revert PR #17362

### DIFF
--- a/ui/analyse/src/study/chapterNewForm.ts
+++ b/ui/analyse/src/study/chapterNewForm.ts
@@ -16,7 +16,6 @@ import type { StudyChapters } from './studyChapters';
 import type { LichessEditor } from 'editor';
 import { pubsub } from 'lib/pubsub';
 import { lichessRules } from 'chessops/compat';
-import pgnImport from '@/pgnImport';
 
 export const modeChoices = [
   ['normal', i18n.study.normalAnalysis],
@@ -90,18 +89,11 @@ export class StudyChapterNewForm {
     const study = this.root.study!;
     const dd = { ...d, sticky: study.vm.mode.sticky, initial: this.initial() };
     if (!dd.pgn) this.send('addChapter', dd);
-    else {
-      try {
-        pgnImport(dd.pgn);
-      } catch (error) {
-        alert('Error parsing PGN: ' + (error as any).message);
-        return;
-      }
+    else
       importPgn(study.data.id, dd).catch(e => {
         if (e.message === 'Too many requests') alert('Limit of 1000 pgn imports every 24 hours');
         throw e;
       });
-    }
     this.isOpen(false);
     this.setChaptersTab();
   };


### PR DESCRIPTION
[User saying](https://lichess.org/forum/lichess-feedback/error-parsing-pgn-err_kings) that they used to be able to import pgns without kings before. I can reproduce that old behaviour and surprisingly even move replay works. They can't add more moves through the UI but they can go through whatever pseudo-legal moves they include in the PGN.

chessops cares about the bad setup but scalachess doesn't. In light of better error messaging work done recently by Thanh I am reverting #17362