### PR TITLE
Prevent pool buttons from overflowing

### DIFF
--- a/ui/lobby/css/_defs.scss
+++ b/ui/lobby/css/_defs.scss
@@ -24,7 +24,6 @@
   }
 
   @include mq-at-least-col3 {
-    height: 600px;
-    max-height: calc(100vh - #{$site-header-outer-height} - #{$block-gap});
+    min-height: 600px;
   }
 }

--- a/ui/lobby/css/_layout.scss
+++ b/ui/lobby/css/_layout.scss
@@ -75,7 +75,7 @@
   @include mq-at-least-col4 {
     ---cols: 4; // ui/lobby/src/main.ts
     grid-template-columns: repeat(4, 1fr);
-    grid-template-rows: fit-content(0) min-content 1fr repeat(3, fit-content(0));
+    grid-template-rows: auto min-content 1fr repeat(3, fit-content(0));
     grid-template-areas:
       'side   app     app     table'
       'tv     blog    blog    puzzle'

--- a/ui/lobby/css/app/_pool.scss
+++ b/ui/lobby/css/app/_pool.scss
@@ -8,7 +8,6 @@
   padding-top: 9px;
   background-color: transparent !important;
   box-shadow: none;
-  overflow: visible !important; // for button shadows
 
   @include fluid-size('font-size', 14px, 25px);
 

--- a/ui/lobby/css/app/_pool.scss
+++ b/ui/lobby/css/app/_pool.scss
@@ -8,6 +8,7 @@
   padding-top: 9px;
   background-color: transparent !important;
   box-shadow: none;
+  overflow: visible !important; // for button shadows
 
   @include fluid-size('font-size', 14px, 25px);
 


### PR DESCRIPTION
Removes a line that was added in ede45dd. From what I can tell it only affects sizing, and not button shadows.

Before and after for this PR:

https://github.com/user-attachments/assets/77506400-488e-4106-bbea-c18ac48a2781

https://github.com/user-attachments/assets/57bcefe1-096f-4e98-ba34-726484b35344

(other buttons become smaller to compensate, preventing an overflow that would obscure blog cards)