### PR TITLE
Github action to ensure PRs are editable by maintainers

### DIFF
--- a/.github/workflows/reviewable.yml
+++ b/.github/workflows/reviewable.yml
@@ -22,5 +22,5 @@ jobs:
             echo "❌ Maintainers cannot modify the PR"
             gh pr review ${{ github.event.pull_request.number }} \
               --request-changes \
-              --body "Please allow edits from maintainers on your pull request.\n\nSee how to enable them [here](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests)"
+              --body "Please allow edits from maintainers on your pull request. See how to enable them [here](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests)"
           fi

--- a/.github/workflows/reviewable.yml
+++ b/.github/workflows/reviewable.yml
@@ -11,6 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Ensure maintainers can modify PR
+        if: github.event.pull_request.head.repo.fork
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/reviewable.yml
+++ b/.github/workflows/reviewable.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Ensure maintainers can modify PR
-        if: github.event.pull_request.head.repo.fork
+        if: github.event.pull_request.head.repo.full_name != github.repository
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/reviewable.yml
+++ b/.github/workflows/reviewable.yml
@@ -1,0 +1,25 @@
+name: Reviewable
+
+on: [pull_request_target]
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Ensure maintainers can modify PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          can_modify=$(gh pr view ${{ github.event.pull_request.number }} --json maintainerCanModify --jq '.maintainerCanModify')
+          if [ "$can_modify" = "true" ]; then
+            echo "✅ Maintainers can modify the PR"
+          else
+            echo "❌ Maintainers cannot modify the PR"
+            gh pr review ${{ github.event.pull_request.number }} \
+              --request-changes \
+              --body "Please allow edits from maintainers on your pull request. For more information, visit: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests"
+          fi

--- a/.github/workflows/reviewable.yml
+++ b/.github/workflows/reviewable.yml
@@ -21,5 +21,5 @@ jobs:
             echo "❌ Maintainers cannot modify the PR"
             gh pr review ${{ github.event.pull_request.number }} \
               --request-changes \
-              --body "Please allow edits from maintainers on your pull request. For more information, visit: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests"
+              --body "Please allow edits from maintainers on your pull request.\n\nSee how to enable them [here](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests)"
           fi


### PR DESCRIPTION
Tested on a [test PR on my fork here](https://github.com/fitztrev/lila/pull/8)
![image](https://github.com/user-attachments/assets/99d9e575-e07b-4330-9e6d-417c90d0281d)