### PR TITLE
add punctuation to move to help screen reader

### DIFF
--- a/ui/lib/src/nvui/chess.ts
+++ b/ui/lib/src/nvui/chess.ts
@@ -483,7 +483,7 @@ export function renderMainline(nodes: Tree.Node[], currentPath: Tree.Path, style
     if (!node.san || !node.uci) return;
     path += node.id;
     const content: VNodeChildren = [
-      node.ply & 1 ? plyToTurn(node.ply) + ' ' : null,
+      node.ply & 1 ? plyToTurn(node.ply) + '. ' : null,
       renderSan(node.san, node.uci, style),
     ];
     res.push(h('move', { attrs: { p: path }, class: { active: path === currentPath } }, content));


### PR DESCRIPTION
addendum to #17416

I did not realise there were 2 different functions printing the moves.

Also competing for the smallest change in Lila's history.