### PR TITLE
Broadcast API search endpoint

### DIFF
--- a/app/controllers/RelayTour.scala
+++ b/app/controllers/RelayTour.scala
@@ -224,6 +224,16 @@ final class RelayTour(env: Env, apiC: => Api, roundC: => RelayRound) extends Lil
         res            <- JsonOk(env.relay.jsonView.top(active, past))
       yield res
 
+  def apiSearch(page: Int, q: String) = Anon:
+    Reasonable(page, Max(20)):
+      q.trim.take(100).some.filter(_.nonEmpty) match
+        case Some(query) =>
+          for
+            tour <- env.relay.pager.search(query, page)
+            res  <- JsonOk(env.relay.jsonView.search(tour))
+          yield res
+        case None => JsonBadRequest("Search query cannot be empty")
+
   def player(tourId: RelayTourId, id: String) = Anon:
     Found(env.relay.api.tourById(tourId)): tour =>
       val decoded = lila.common.String.decodeUriPathSegment(id) | id

--- a/conf/routes
+++ b/conf/routes
@@ -297,6 +297,7 @@ GET   /api/broadcast/round/$roundId<\w{8}>.pgn controllers.RelayRound.apiPgn(rou
 GET   /api/stream/broadcast/round/$roundId<\w{8}>.pgn controllers.RelayRound.stream(roundId: RelayRoundId)
 GET   /api/broadcast                          controllers.RelayTour.apiIndex
 GET   /api/broadcast/top                      controllers.RelayTour.apiTop(page: Int ?= 1)
+GET   /api/broadcast/search                   controllers.RelayTour.apiSearch(page: Int ?= 1, q: String ?= "")
 GET   /api/broadcast/my-rounds                controllers.RelayRound.apiMyRounds
 GET   /$lang<\w\w\w?>/broadcast               controllers.RelayTour.indexLang(lang: Language)
 

--- a/modules/relay/src/main/JsonView.scala
+++ b/modules/relay/src/main/JsonView.scala
@@ -152,6 +152,9 @@ final class JsonView(baseUrl: BaseUrl, markup: RelayMarkup, picfitUrl: PicfitUrl
       "past"     -> paginatorWriteNoNbResults.writes(past.map(tourWithAnyRound(_)))
     )
 
+  def search(tours: Paginator[WithLastRound])(using Config) =
+    paginatorWriteNoNbResults.writes(tours.map(tourWithAnyRound(_)))
+
 object JsonView:
 
   case class Config(html: Boolean)


### PR DESCRIPTION
Add a new API endpoint to search broadcast tournaments that will be used by the mobile app (see https://github.com/lichess-org/mobile/issues/1321).