### PR TITLE
Username error fixed

### DIFF
--- a/modules/security/src/main/SecurityForm.scala
+++ b/modules/security/src/main/SecurityForm.scala
@@ -72,7 +72,7 @@ final class SecurityForm(
         ),
         Constraints.pattern(
           regex = lila.user.nameRules.newUsernameLetters,
-          error = "usernameCharsInvalid"
+          error = "usernamePatternInvalid"
         )
       )
       .into[UserName]

--- a/translation/source/site.xml
+++ b/translation/source/site.xml
@@ -810,6 +810,7 @@
   <string name="usernamePrefixInvalid">The username must start with a letter.</string>
   <string name="usernameSuffixInvalid">The username must end with a letter or a number.</string>
   <string name="usernameCharsInvalid">The username must only contain letters, numbers, underscores, and hyphens. Consecutive underscores and hyphens are not allowed.</string>
+  <string name="usernamePatternInvalid">The username must follow the pattern of letters and numbers, separated by at most one underscore or hyphen.</string>
   <string name="usernameUnacceptable">This username is not acceptable.</string>
   <string name="playChessInStyle">Play chess in style</string>
   <string name="chessBasics">Chess basics</string>


### PR DESCRIPTION
When we used to enter any other unallowed syntax in the username other than the double underscore, two error messages was displayed. 


![Screenshot (112)](https://github.com/user-attachments/assets/c4406dfa-f496-4c10-8f16-55da554120fa)
