### PR TITLE
fix(ui): prevent puzzle tools sidebar from shrinking (closes #17225)

### DIFF
--- a/ui/puzzle/css/_tools.scss
+++ b/ui/puzzle/css/_tools.scss
@@ -3,6 +3,8 @@
 
   background: $c-bg-box;
 
+  min-height: 70vh;
+
   .ceval-wrap {
     flex: 0 0 38px;
   }


### PR DESCRIPTION
## Issue #17225 

### Exact URL of where the bug happened
https://lichess.org/training

### Before
![image](https://github.com/user-attachments/assets/19951a40-6f45-4016-94db-69ad10acc3d3)

### After
![image](https://github.com/user-attachments/assets/12d85865-3690-48b3-bf7d-ce6267cc949f)

Initially, when the board is resized, the right sidebar also shrank, causing the menu bar to overflow. Since the left sidebar does not shrink with the board, I added `min-height: 70vh` to the right sidebar (matching the left sidebar). This ensures it won’t collapse too much and remains user-friendly.

Closes #17225 
