### PR TITLE
remove useless manifest bifurcation and unused attribute

### DIFF
--- a/app/views/base/embed.scala
+++ b/app/views/base/embed.scala
@@ -41,7 +41,6 @@ object embed:
     page.ui.dataTheme        := ctx.bg,
     page.ui.dataPieceSet     := ctx.pieceSet.name,
     page.ui.dataBoard        := ctx.boardClass,
-    page.ui.dataDev,
     page.ui.dataSocketDomains,
     style := page.boardStyle(zoomable = false)
   )

--- a/app/views/base/page.scala
+++ b/app/views/base/page.scala
@@ -111,7 +111,6 @@ object page:
               "zen-auto"             -> (zenable && pref.isZenAuto)
             )
           },
-          dataDev,
           dataVapid := (ctx.isAuth && env.security.lilaCookie.isRememberMe(ctx.req))
             .option(env.push.vapidPublicKey),
           dataUser     := ctx.userId,

--- a/conf/base.conf
+++ b/conf/base.conf
@@ -18,7 +18,6 @@ net {
   asset.domain = ${net.domain}
   asset.base_url = "http://"${net.asset.domain}
   asset.base_url_internal = ${net.asset.base_url}
-  asset.minified = false
   base_url = "http://"${net.domain}
   email = ""
   crawlable = false

--- a/modules/core/src/main/config.scala
+++ b/modules/core/src/main/config.scala
@@ -56,7 +56,6 @@ object config:
       assetDomain: AssetDomain,
       assetBaseUrl: AssetBaseUrl,
       assetBaseUrlInternal: AssetBaseUrlInternal,
-      minifiedAssets: Boolean,
       stageBanner: Boolean,
       siteName: String,
       socketDomains: List[String],

--- a/modules/web/src/main/AssetManifest.scala
+++ b/modules/web/src/main/AssetManifest.scala
@@ -20,11 +20,10 @@ case class AssetMaps(
     modified: Instant
 )
 
-final class AssetManifest(net: NetConfig, getFile: GetRelativeFile)(using Executor):
+final class AssetManifest(getFile: GetRelativeFile)(using Executor):
   private var maps: AssetMaps = AssetMaps(Map.empty, Map.empty, Map.empty, java.time.Instant.MIN)
 
-  private val filename = s"manifest.${if net.minifiedAssets then "prod" else "dev"}.json"
-  private val logger   = lila.log("assetManifest")
+  private val logger = lila.log("assetManifest")
 
   def css(key: String): String             = maps.css.getOrElse(key, key)
   def hashed(path: String): Option[String] = maps.hashed.get(path)
@@ -35,7 +34,7 @@ final class AssetManifest(net: NetConfig, getFile: GetRelativeFile)(using Execut
   def lastUpdate: Instant                   = maps.modified
 
   def update(): Unit =
-    val pathname = getFile.exec(s"public/compiled/$filename").toPath
+    val pathname = getFile.exec(s"public/compiled/manifest.json").toPath
     try
       val current = Files.getLastModifiedTime(pathname).toInstant
       if current.isAfter(maps.modified)

--- a/modules/web/src/main/WebConfig.scala
+++ b/modules/web/src/main/WebConfig.scala
@@ -55,7 +55,6 @@ object WebConfig:
     assetDomain = c.get[AssetDomain]("net.asset.domain"),
     assetBaseUrl = c.get[AssetBaseUrl]("net.asset.base_url"),
     assetBaseUrlInternal = c.get[AssetBaseUrlInternal]("net.asset.base_url_internal"),
-    minifiedAssets = c.get[Boolean]("net.asset.minified"),
     stageBanner = c.get[Boolean]("net.stage.banner"),
     siteName = c.get[String]("net.site.name"),
     socketDomains = c.get[List[String]]("net.socket.domains"),

--- a/modules/web/src/main/helper/AssetFullHelper.scala
+++ b/modules/web/src/main/helper/AssetFullHelper.scala
@@ -51,8 +51,7 @@ trait AssetFullHelper:
     val sockets = socketDomains.map { x => s"wss://$x${(!ctx.req.secure).so(s" ws://$x")}" }
     // include both ws and wss when insecure because requests may come through a secure proxy
     val localDev =
-      (!netConfig.minifiedAssets).so("http://localhost:8666")
-        :: (!ctx.req.secure).so(List("http://127.0.0.1:3000"))
+      (!ctx.req.secure).so(List("http://127.0.0.1:3000", "http://localhost:8666"))
     lila.web.ContentSecurityPolicy.page(
       netConfig.assetDomain,
       netConfig.assetDomain.value :: sockets ::: analyseEndpoints.explorer :: analyseEndpoints.tablebase :: localDev

--- a/modules/web/src/main/ui/layout.scala
+++ b/modules/web/src/main/ui/layout.scala
@@ -205,7 +205,6 @@ final class layout(helpers: Helpers, assetHelper: lila.web.ui.AssetFullHelper)(
   val dataPieceSet3d    = attr("data-piece-set3d")
   val dataAssetUrl      = attr("data-asset-url")      := netConfig.assetBaseUrl.value
   val dataAssetVersion  = attr("data-asset-version")
-  val dataDev           = attr("data-dev")            := (!netConfig.minifiedAssets).option("true")
 
   val spinnerMask = raw:
     """<svg width="0" height="0"><mask id="mask"><path fill="#fff" stroke="#fff" stroke-linejoin="round" d="M38.956.5c-3.53.418-6.452.902-9.286 2.984C5.534 1.786-.692 18.533.68 29.364 3.493 50.214 31.918 55.785 41.329 41.7c-7.444 7.696-19.276 8.752-28.323 3.084C3.959 39.116-.506 27.392 4.683 17.567 9.873 7.742 18.996 4.535 29.03 6.405c2.43-1.418 5.225-3.22 7.655-3.187l-1.694 4.86 12.752 21.37c-.439 5.654-5.459 6.112-5.459 6.112-.574-1.47-1.634-2.942-4.842-6.036-3.207-3.094-17.465-10.177-15.788-16.207-2.001 6.967 10.311 14.152 14.04 17.663 3.73 3.51 5.426 6.04 5.795 6.756 0 0 9.392-2.504 7.838-8.927L37.4 7.171z"/></mask></svg>"""

--- a/ui/.build/src/env.ts
+++ b/ui/.build/src/env.ts
@@ -52,10 +52,6 @@ export const env = new (class {
     );
   }
 
-  get manifestFile(): string {
-    return join(this.jsOutDir, `manifest.${this.prod ? 'prod' : 'dev'}.json`);
-  }
-
   *tasks<T extends 'sync' | 'hash' | 'bundle'>(
     t: T,
   ): Generator<[Package, Package[T] extends Array<infer U> ? U : never]> {

--- a/ui/.build/src/manifest.ts
+++ b/ui/.build/src/manifest.ts
@@ -96,12 +96,12 @@ async function writeManifest() {
   );
   await Promise.all([
     fs.promises.writeFile(join(env.jsOutDir, `manifest.${hash}.js`), clientManifest),
-    fs.promises.writeFile(join(env.jsOutDir, `manifest.${env.prod ? 'prod' : 'dev'}.json`), serverManifest),
+    fs.promises.writeFile(join(env.jsOutDir, `manifest.json`), serverManifest),
   ]);
   manifest.dirty = false;
   const serverHash = crypto.createHash('sha256').update(serverManifest).digest('hex').slice(0, 8);
   env.log(
-    `'${c.cyan(`public/compiled/manifest.${hash}.js`)}', '${c.cyan(`public/compiled/manifest.${env.prod ? 'prod' : 'dev'}.json`)}' ${c.grey(serverHash)}`,
+    `'${c.cyan(`public/compiled/manifest.${hash}.js`)}', '${c.cyan(`public/compiled/manifest.json`)}' ${c.grey(serverHash)}`,
     'manifest',
   );
 }


### PR DESCRIPTION
always use `manifest.json` (no more `manifest.prod.json` or `manifest.dev.json`). server doesn't need netConfig.minifiedAssets.

also remove the data-dev attribute because i couldn't find it used anywhere.

if the client ever needs to know whether assets are minified, we could in future compile something into window.site.info to that effect (rather than tying to the server)