### PR TITLE
If the user manually scrolls to the bottom of a chat, enable autoscroll for future messages

### DIFF
--- a/ui/lib/src/chat/discussion.ts
+++ b/ui/lib/src/chat/discussion.ts
@@ -53,7 +53,7 @@ export default function (ctrl: ChatCtrl): Array<VNode | undefined> {
           postpatch: (_, vnode) => {
             const el = vnode.elm as HTMLElement;
 
-            if (el.scrollTop + el.clientHeight > el.scrollHeight - 10) scrollState.pinToBottom = true;
+            if (el.scrollTop + el.clientHeight > el.scrollHeight - 32) scrollState.pinToBottom = true;
             else if (!scrollState.pinToBottom) return;
 
             if (document.visibilityState === 'hidden') el.scrollTop = el.scrollHeight;

--- a/ui/lib/src/chat/discussion.ts
+++ b/ui/lib/src/chat/discussion.ts
@@ -45,6 +45,7 @@ export default function (ctrl: ChatCtrl): Array<VNode | undefined> {
 
             el.addEventListener('scroll', () => {
               if (el.scrollTop < scrollState.lastScrollTop) scrollState.pinToBottom = false;
+              else if (el.scrollTop + el.clientHeight > el.scrollHeight - 10) scrollState.pinToBottom = true;
               scrollState.lastScrollTop = el.scrollTop;
             });
 
@@ -52,9 +53,7 @@ export default function (ctrl: ChatCtrl): Array<VNode | undefined> {
           },
           postpatch: (_, vnode) => {
             const el = vnode.elm as HTMLElement;
-
-            if (el.scrollTop + el.clientHeight > el.scrollHeight - 32) scrollState.pinToBottom = true;
-            else if (!scrollState.pinToBottom) return;
+            if (!scrollState.pinToBottom) return;
 
             if (document.visibilityState === 'hidden') el.scrollTop = el.scrollHeight;
             else if (el.scrollTop + el.clientHeight < el.scrollHeight)


### PR DESCRIPTION
Essentially just undoes e0f9d8e, going back to the original value of 32 @schlawg used in e0f9d8e's parent commit (c3bdbba).

Screen recording showing current behaviour (the tab where I'm moving the scrollbar is for "John1"):

https://github.com/user-attachments/assets/8c6b24d4-90af-4f89-a742-7935778cd96a

