### PR TITLE
Don't auto draw as we're not sure about opponent has no mating material

### DIFF
--- a/modules/round/src/main/Drawer.scala
+++ b/modules/round/src/main/Drawer.scala
@@ -52,15 +52,12 @@ final private[round] class Drawer(
           Messenger.SystemMessage.Persistent(trans.site.drawOfferAccepted.txt()).some
         )
       case Pov(g, color) if g.playerCanOfferDraw(color) =>
-        if pov.game.position.withColor(color).opponentHasInsufficientMaterial then
-          finisher.other(pov.game, _.Draw, None)
-        else
-          val progress = Progress(g).map(offerDraw(color))
-          messenger.system(g, color.fold(trans.site.whiteOffersDraw, trans.site.blackOffersDraw).txt())
-          for
-            _ <- proxy.save(progress)
-            _ = publishDrawOffer(progress.game)
-          yield List(Event.DrawOffer(by = color.some))
+        val progress = Progress(g).map(offerDraw(color))
+        messenger.system(g, color.fold(trans.site.whiteOffersDraw, trans.site.blackOffersDraw).txt())
+        for
+          _ <- proxy.save(progress)
+          _ = publishDrawOffer(progress.game)
+        yield List(Event.DrawOffer(by = color.some))
       case _ => fuccess(List(Event.ReloadOwner))
 
   def no(pov: Pov)(using proxy: GameProxy): Fu[Events] = pov.game.drawable.so:


### PR DESCRIPTION
We cannot just swap the color and check for `opponentHasInsufficientMaterial` because it's not only depend on pieces on the board, but also whose turn to play. Look at this antichess position: https://lichess.org/analysis/antichess/8/8/3N4/8/1n6/8/8/8_w_-_-_15_44 (from https://github.com/lichess-org/lila/issues/17536) whoever play can win the game so `pov.game.situation.copy(color = color).opponentHasInsufficientMaterial` is true for both sides, even though in real game only White can win.

Fix https://github.com/lichess-org/lila/issues/17536