### PR TITLE
tweak: Increase the number of possible puzzle racers to 20 in puzzle racer

### DIFF
--- a/modules/racer/src/main/RacerRace.scala
+++ b/modules/racer/src/main/RacerRace.scala
@@ -49,7 +49,7 @@ case class RacerRace(
 object RacerRace:
 
   val duration   = 90
-  val maxPlayers = 10
+  val maxPlayers = 20
 
   opaque type Id = String
   object Id extends OpaqueString[Id]

--- a/ui/racer/src/ctrl.ts
+++ b/ui/racer/src/ctrl.ts
@@ -115,7 +115,8 @@ export default class RacerCtrl implements PuzCtrl {
 
   isPlayer = () => !this.vm.alreadyStarted && this.data.players.some(p => p.name === this.data.player.name);
 
-  raceFull = () => this.data.players.length >= 10;
+  // Must be changed with val maxPlayers in RacerRace.scala
+  raceFull = () => this.data.players.length >= 20;
 
   status = (): RaceStatus => (this.run.clock.started() ? (this.run.clock.flag() ? 'post' : 'racing') : 'pre');
 


### PR DESCRIPTION
# Change the possible number of puzzle racers to 20 from 10.

A request on the lichess discord. 