### PR TITLE
Keyboard remapper to offer a fallback for non latin keyboard users

### DIFF
--- a/ui/lib/src/keyboardRemapper.ts
+++ b/ui/lib/src/keyboardRemapper.ts
@@ -61,14 +61,14 @@ const alphabet: string[] = Array.from(
 
 function qwertyMapLowerCaseLetters(): Mapping[] {
   return alphabet.map(
-    (letter: string) => <Mapping>{ key: letter, code: 'Key' + letter.toLocaleUpperCase(), shiftKey: false },
+    (letter: string) => <Mapping>{ key: letter, code: 'Key' + letter.toUpperCase(), shiftKey: false },
   );
 }
 
 function qwertyMapUpperCaseLetters(): Mapping[] {
   return alphabet.map(
     (letter: string) =>
-      <Mapping>{ key: letter.toUpperCase(), code: 'Key' + letter.toLocaleUpperCase(), shiftKey: true },
+      <Mapping>{ key: letter.toUpperCase(), code: 'Key' + letter.toUpperCase(), shiftKey: true },
   );
 }
 
@@ -79,6 +79,6 @@ const digits: string[] = Array.from(
 
 function qwertyMapDigits(): Mapping[] {
   return digits.map(
-    (letter: string) => <Mapping>{ key: letter, code: 'Digit' + letter.toLocaleUpperCase(), shiftKey: false },
+    (letter: string) => <Mapping>{ key: letter, code: 'Digit' + letter.toUpperCase(), shiftKey: false },
   );
 }

--- a/ui/lib/src/keyboardRemapper.ts
+++ b/ui/lib/src/keyboardRemapper.ts
@@ -1,0 +1,84 @@
+export type KeyboardMapping = 'NONE' | 'QWERTY';
+
+interface Mapping {
+  key: string;
+  code: string;
+  shiftKey: boolean;
+}
+
+export class KeyboardRemapper {
+  mapping: KeyboardMapping = 'NONE';
+
+  constructor(mapping?: KeyboardMapping) {
+    if (mapping !== undefined) this.mapping = mapping;
+  }
+
+  map(e: KeyboardEvent): { mapped: boolean; key: string } {
+    let mappingFound: Mapping | undefined = undefined;
+    if (this.mapping === 'QWERTY') {
+      mappingFound = qwertyMappings.find(item => item.code === e.code && item.shiftKey === e.shiftKey);
+    }
+    if (mappingFound != undefined) return { mapped: true, key: mappingFound.key };
+    else return { mapped: false, key: e.key };
+  }
+}
+
+const qwertyMappings: Mapping[] = [
+  ...qwertyMapUpperCaseLetters(),
+  ...qwertyMapLowerCaseLetters(),
+  ...qwertyMapDigits(),
+  {
+    key: '?',
+    code: 'Slash',
+    shiftKey: true,
+  },
+  {
+    key: '=',
+    code: 'Equal',
+    shiftKey: false,
+  },
+  {
+    key: '-',
+    code: 'Minus',
+    shiftKey: false,
+  },
+  {
+    key: '+',
+    code: 'Equal',
+    shiftKey: true,
+  },
+  {
+    key: '#',
+    code: 'Digit3 ',
+    shiftKey: true,
+  },
+];
+
+const alphabet: string[] = Array.from(
+  { length: 26 },
+  (_, i) => String.fromCharCode(97 + i), // 'a' is char code 97
+);
+
+function qwertyMapLowerCaseLetters(): Mapping[] {
+  return alphabet.map(
+    (letter: string) => <Mapping>{ key: letter, code: 'Key' + letter.toLocaleUpperCase(), shiftKey: false },
+  );
+}
+
+function qwertyMapUpperCaseLetters(): Mapping[] {
+  return alphabet.map(
+    (letter: string) =>
+      <Mapping>{ key: letter.toUpperCase(), code: 'Key' + letter.toLocaleUpperCase(), shiftKey: true },
+  );
+}
+
+const digits: string[] = Array.from(
+  { length: 10 },
+  (_, i) => String.fromCharCode(48 + i), // '0' is char code 48
+);
+
+function qwertyMapDigits(): Mapping[] {
+  return digits.map(
+    (letter: string) => <Mapping>{ key: letter, code: 'Digit' + letter.toLocaleUpperCase(), shiftKey: false },
+  );
+}

--- a/ui/lib/src/keyboardRemapper.ts
+++ b/ui/lib/src/keyboardRemapper.ts
@@ -23,10 +23,33 @@ export class KeyboardRemapper {
   }
 }
 
+const alphabet: string[] = Array.from(
+  { length: 26 },
+  (_, i) => String.fromCharCode(97 + i), // 'a' is char code 97
+);
+
+const digits: string[] = Array.from(
+  { length: 10 },
+  (_, i) => String.fromCharCode(48 + i), // '0' is char code 48
+);
+
+const qwertyMapLowerCaseLetters: Mapping[] = alphabet.map(
+  (letter: string) => <Mapping>{ key: letter, code: 'Key' + letter.toUpperCase(), shiftKey: false },
+);
+
+const qwertyMapUpperCaseLetters: Mapping[] = alphabet.map(
+  (letter: string) =>
+    <Mapping>{ key: letter.toUpperCase(), code: 'Key' + letter.toUpperCase(), shiftKey: true },
+);
+
+const qwertyMapDigits: Mapping[] = digits.map(
+  (letter: string) => <Mapping>{ key: letter, code: 'Digit' + letter.toUpperCase(), shiftKey: false },
+);
+
 const qwertyMappings: Mapping[] = [
-  ...qwertyMapUpperCaseLetters(),
-  ...qwertyMapLowerCaseLetters(),
-  ...qwertyMapDigits(),
+  ...qwertyMapUpperCaseLetters,
+  ...qwertyMapLowerCaseLetters,
+  ...qwertyMapDigits,
   {
     key: '?',
     code: 'Slash',
@@ -53,32 +76,3 @@ const qwertyMappings: Mapping[] = [
     shiftKey: true,
   },
 ];
-
-const alphabet: string[] = Array.from(
-  { length: 26 },
-  (_, i) => String.fromCharCode(97 + i), // 'a' is char code 97
-);
-
-function qwertyMapLowerCaseLetters(): Mapping[] {
-  return alphabet.map(
-    (letter: string) => <Mapping>{ key: letter, code: 'Key' + letter.toUpperCase(), shiftKey: false },
-  );
-}
-
-function qwertyMapUpperCaseLetters(): Mapping[] {
-  return alphabet.map(
-    (letter: string) =>
-      <Mapping>{ key: letter.toUpperCase(), code: 'Key' + letter.toUpperCase(), shiftKey: true },
-  );
-}
-
-const digits: string[] = Array.from(
-  { length: 10 },
-  (_, i) => String.fromCharCode(48 + i), // '0' is char code 48
-);
-
-function qwertyMapDigits(): Mapping[] {
-  return digits.map(
-    (letter: string) => <Mapping>{ key: letter, code: 'Digit' + letter.toUpperCase(), shiftKey: false },
-  );
-}

--- a/ui/site/src/mousetrap.ts
+++ b/ui/site/src/mousetrap.ts
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import { KeyboardRemapper } from 'lib/keyboardRemapper';
+
 type Action = 'keypress' | 'keydown' | 'keyup';
 
 type Callback = (e: KeyboardEvent) => void;
@@ -31,6 +33,8 @@ interface Binding {
   modifiers: string[];
   action: Action;
 }
+
+const qwertyRemapper = new KeyboardRemapper('QWERTY');
 
 const MAP: Record<string, string> = {
   8: 'backspace',
@@ -209,10 +213,11 @@ export default class Mousetrap {
   };
 
   private getMatches = (e: KeyboardEvent): Binding[] => {
+    const { mapped: mapped, key: mappedKey } = qwertyRemapper.map(e);
     const key = keyFromEvent(e);
     const action = e.type;
     const modifiers = action === 'keyup' && isModifier(key) ? [key] : eventModifiers(e);
-    return (this.bindings[key] || []).filter(
+    return (this.bindings[key] || (mapped && this.bindings[mappedKey]) || []).filter(
       binding =>
         action === binding.action &&
         // Chrome will not fire a keypress if meta or control is down,


### PR DESCRIPTION
fixes #16925 

The idea is initially for the nvui interface, but the solution seems to fit mousetrap as a fallback if no binding is found.

Point of reflection/discussion: the fallback is systematic. Is there any case we would not want it ? (then we would add a preference)

Demo [here](https://youtu.be/fn3FEpXYV8E)

The demo may not be compelling unless you consider that hybrid keyboards have the qwerty chars printed on them.
