### PR TITLE
Add empty alt text to feed icons

### DIFF
--- a/modules/feed/src/main/FeedUi.scala
+++ b/modules/feed/src/main/FeedUi.scala
@@ -181,5 +181,6 @@ final class FeedUi(helpers: Helpers, atomUi: AtomUi)(
   private def marker(flair: Option[Flair] = none, customClass: Option[String] = none) =
     img(
       src := flairSrc(flair.getOrElse(Flair("symbols.white-star"))),
-      cls := customClass.getOrElse(s"daily-feed__update__marker ${flair.nonEmpty.so(" nobg")}")
+      cls := customClass.getOrElse(s"daily-feed__update__marker ${flair.nonEmpty.so(" nobg")}"),
+      alt := ""
     )


### PR DESCRIPTION
This will affect the feed icons on main page and /feed. The alt text should be empty because the icons are decorative and the icons do not provide any information not already given in the text of each feed update.