### PR TITLE
Adds a new leaderboard feature between a user and their friends

### DIFF
--- a/app/views/user/friendsLeaderboard.scala
+++ b/app/views/user/friendsLeaderboard.scala
@@ -1,0 +1,14 @@
+package views.user
+
+import lila.app.UiEnv.*
+import lila.core.userId.UserId
+
+object friendsLeaderboard:
+
+  private lazy val ui = lila.user.ui.LeaderboardFriends(helpers)
+
+  def apply(
+      leaderboards: lila.rating.UserPerfs.Leaderboards,
+      nbFriends: Set[UserId]
+  )(using Context) =
+    ui.page(leaderboards, nbFriends)

--- a/build.sbt
+++ b/build.sbt
@@ -117,7 +117,7 @@ lazy val i18n = module("i18n",
     I18n.serialize(
       sourceDir = new File("translation/source"),
       destDir = new File("translation/dest"),
-      dbs = "site arena emails learn activity coordinates study class contact appeal patron coach broadcast streamer tfa settings preferences team perfStat search tourname faq lag swiss puzzle puzzleTheme challenge storm ublog insight keyboardMove timeago oauthScope dgt voiceCommands onboarding features nvui".split(' ').toList,
+      dbs = "site arena emails learn activity coordinates study class contact appeal patron leaderboard coach broadcast streamer tfa settings preferences team perfStat search tourname faq lag swiss puzzle puzzleTheme challenge storm ublog insight keyboardMove timeago oauthScope dgt voiceCommands onboarding features nvui".split(' ').toList,
       outputDir = (Compile / resourceManaged).value
     )
   }.taskValue

--- a/conf/routes
+++ b/conf/routes
@@ -35,7 +35,7 @@ GET   /tv/channels                     controllers.Main.movedPermanently(to = "/
 GET   /tv/:chanKey                     controllers.Tv.onChannel(chanKey)
 GET   /tv/:chanKey/frame               controllers.Tv.frame(chanKey)
 GET   /tv/:chanKey/feed                controllers.Tv.feed(chanKey)
-GET   /tv/$gameId<\w{8}>/:color/sides controllers.Tv.sides(gameId: GameId, color: Color)
+GET   /tv/$gameId<\w{8}>/:color/sides  controllers.Tv.sides(gameId: GameId, color: Color)
 GET   /games                           controllers.Tv.games
 GET   /games/:chanKey                  controllers.Tv.gamesChannel(chanKey)
 GET   /games/:chanKey/replacement/$gameId<\w{8}> controllers.Tv.gameChannelReplacement(chanKey, gameId: GameId, exclude: List[GameId])
@@ -53,8 +53,10 @@ POST  /api/rel/unblock/:userId         controllers.Relation.unblock(userId: User
 # lichobile BC
 POST  /rel/unfollow/:user              controllers.Relation.unfollowBc(user: UserStr)
 POST  /rel/follow/:user                controllers.Relation.followBc(user: UserStr)
+
 # end lichobile BC
 GET   /@/:username/following           controllers.Relation.following(username: UserStr, page: Int ?= 1)
+GET   /@/:username/following/leaderboard controllers.User.friendsLeaderboard(username: UserStr, page: Int ?= 1)
 GET   /@/:username/followers           controllers.Relation.followers(username: UserStr, page: Int ?= 1)
 GET   /rel/blocks                      controllers.Relation.blocks(page: Int ?= 1)
 

--- a/modules/coreI18n/src/main/key.scala
+++ b/modules/coreI18n/src/main/key.scala
@@ -2868,3 +2868,12 @@ object I18nKey:
     val `turnOffVoiceRecognition`: I18nKey = "voiceCommands:turnOffVoiceRecognition"
     val `showPuzzleSolution`: I18nKey = "voiceCommands:showPuzzleSolution"
 
+  object leaderboard:
+    val `friendsLeaderboardTitle`: I18nKey = "leaderboard:friendsLeaderboardTitle"
+    val `friendsLeaderboardDescription`: I18nKey = "leaderboard:friendsLeaderboardDescription"
+    val `noFriendsToCompare`: I18nKey = "leaderboard:noFriendsToCompare"
+    val `noFriendsInfo1`: I18nKey = "leaderboard:noFriendsInfo1"
+    val `noFriendsInfo2`: I18nKey = "leaderboard:noFriendsInfo2"
+    val `explorePopularPlayers`: I18nKey = "leaderboard:explorePopularPlayers"
+    val `howYouCompareAgainstFriends`: I18nKey = "leaderboard:howYouCompareAgainstFriends"
+    val `seeLeaderboardWithFriends`: I18nKey = "leaderboard:seeLeaderboardWithFriends"

--- a/modules/coreI18n/src/main/modules.scala
+++ b/modules/coreI18n/src/main/modules.scala
@@ -4,6 +4,6 @@ enum I18nModule:
   case site, arena, emails, learn, activity, coordinates, study, `class`, contact, appeal, patron, coach,
     broadcast, streamer, tfa, settings, preferences, team, perfStat, search, tourname, faq, lag, swiss,
     puzzle, puzzleTheme, challenge, storm, ublog, insight, keyboardMove, timeago, oauthScope, dgt,
-    voiceCommands, onboarding, features, nvui
+    voiceCommands, onboarding, features, nvui, leaderboard
 object I18nModule:
   type Selector = I18nModule.type => I18nModule

--- a/modules/relation/src/main/ui/RelationUi.scala
+++ b/modules/relation/src/main/ui/RelationUi.scala
@@ -115,6 +115,13 @@ final class RelationUi(helpers: Helpers):
           h1(
             a(href := routes.User.show(u.username), dataIcon := Icon.LessThan, cls := "text"),
             trans.site.friends()
+          ),
+          div(cls := "box__top__actions")(
+            a(
+              href     := s"/@/${u.username}/following/leaderboard",
+              cls      := "button button-empty",
+              dataIcon := Icon.Trophy
+            )(trans.leaderboard.seeLeaderboardWithFriends.txt())
           )
         ),
         pagTable(pag, routes.Relation.following(u.username))

--- a/modules/user/src/main/ui/LeaderboardFriends.scala
+++ b/modules/user/src/main/ui/LeaderboardFriends.scala
@@ -1,0 +1,76 @@
+package lila.user
+package ui
+
+import lila.core.user.LightPerf
+import lila.core.userId.UserId
+import lila.ui.*
+
+import ScalatagsTemplate.{ *, given }
+
+final class LeaderboardFriends(helpers: Helpers):
+  import helpers.{ *, given }
+
+  def page(
+      leaderboards: lila.rating.UserPerfs.Leaderboards,
+      nbFriends: Set[UserId]
+  )(using ctx: Context) =
+    Page(trans.site.leaderboard.txt())
+      .css(if nbFriends.size < 1 then "user.nofriends" else "user.list")
+      .flag(_.fullScreen)
+      .graph(
+        title = trans.leaderboard.friendsLeaderboardTitle.txt(),
+        url = s"$netBaseUrl${routes.User.list.url}",
+        description = trans.leaderboard.friendsLeaderboardDescription.txt()
+      ):
+        main(cls := "page-menu full-screen-force")(
+          if nbFriends.size < 1 then
+            div(cls := "community page-menu__content box box-pad full-height")(
+              div(cls := "community__empty")(
+                h2(trans.leaderboard.noFriendsToCompare.txt()),
+                p(
+                  trans.leaderboard.noFriendsInfo1.txt(),
+                  br,
+                  trans.leaderboard.noFriendsInfo2.txt()
+                ),
+                div(cls := "actions")(
+                  a(
+                    cls  := "button button-fat",
+                    href := routes.User.list
+                  )(trans.leaderboard.explorePopularPlayers.txt())
+                )
+              )
+            )
+          else
+            div(cls := "community page-menu__content box box-pad")(
+              div(cls := "community__leaders")(
+                h2(trans.leaderboard.howYouCompareAgainstFriends.pluralSame(nbFriends.size - 1)),
+                div(cls := "leaderboards")(
+                  userTopPerf(leaderboards.bullet, PerfKey.bullet),
+                  userTopPerf(leaderboards.blitz, PerfKey.blitz),
+                  userTopPerf(leaderboards.rapid, PerfKey.rapid),
+                  userTopPerf(leaderboards.classical, PerfKey.classical),
+                  userTopPerf(leaderboards.ultraBullet, PerfKey.ultraBullet),
+                  userTopPerf(leaderboards.crazyhouse, PerfKey.crazyhouse),
+                  userTopPerf(leaderboards.chess960, PerfKey.chess960),
+                  userTopPerf(leaderboards.antichess, PerfKey.antichess),
+                  userTopPerf(leaderboards.atomic, PerfKey.atomic),
+                  userTopPerf(leaderboards.threeCheck, PerfKey.threeCheck),
+                  userTopPerf(leaderboards.kingOfTheHill, PerfKey.kingOfTheHill),
+                  userTopPerf(leaderboards.horde, PerfKey.horde),
+                  userTopPerf(leaderboards.racingKings, PerfKey.racingKings)
+                )
+              )
+            )
+        )
+
+  private def userTopPerf(users: List[LightPerf], pk: PerfKey)(using ctx: Context) =
+    st.section(cls := "user-top")(
+      h2(cls := "text", dataIcon := pk.perfIcon)(
+        a(href := routes.User.topNb(200, pk))(pk.perfTrans)
+      ),
+      ol(users.map: l =>
+        li(
+          lightUserLink(l.user),
+          ctx.pref.showRatings.option(l.rating)
+        ))
+    )

--- a/translation/dest/leaderboard/en-US.xml
+++ b/translation/dest/leaderboard/en-US.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="friendsLeaderboardTitle">Friends Leaderboard</string>
+    <string name="friendsLeaderboardDescription">Leaderboard of your friends on Lichess</string>
+    <string name="noFriendsToCompare">You don\'t have any friends to compare to yet</string>
+    <string name="noFriendsInfo1">To see comparative rankings with your friends, you need to follow other users on Lichess.</string>
+    <string name="noFriendsInfo2">Visit player profiles and click the follow button to add them to your leaderboard.</string>
+    <string name="explorePopularPlayers">Explore popular players</string>
+    <plurals name="howYouCompareAgainstFriends">
+        <item quantity="one">See how you compare against your only friend</item>
+        <item quantity="other">See how you compare against your %s friends</item>
+    </plurals>
+    <string name="seeLeaderboardWithFriends">See Leaderboard with Friends</string>
+</resources>

--- a/translation/dest/leaderboard/es-ES.xml
+++ b/translation/dest/leaderboard/es-ES.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="friendsLeaderboardTitle">Clasificación de amigos</string>
+    <string name="friendsLeaderboardDescription">Clasificación de tus amigos en Lichess</string>
+    <string name="noFriendsToCompare">Aún no tienes amigos para comparar</string>
+    <string name="noFriendsInfo1">Para ver clasificaciones comparativas con tus amigos, necesitas seguir a otros usuarios en Lichess.</string>
+    <string name="noFriendsInfo2">Visita perfiles de jugadores y haz clic en el botón seguir para añadirlos a tu clasificación.</string>
+    <string name="explorePopularPlayers">Explorar jugadores populares</string>
+    <plurals name="howYouCompareAgainstFriends">
+        <item quantity="one">Mira cómo te comparas con tu único amigo</item>
+        <item quantity="other">Mira cómo te comparas con tus %s amigos</item>
+    </plurals>
+    <string name="seeLeaderboardWithFriends">Ver clasificación con amigos</string>
+</resources>

--- a/translation/dest/leaderboard/fr-FR.xml
+++ b/translation/dest/leaderboard/fr-FR.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="friendsLeaderboardTitle">Classement des amis</string>
+    <string name="friendsLeaderboardDescription">Classement de vos amis sur Lichess</string>
+    <string name="noFriendsToCompare">Vous n\'avez pas encore d\'amis à comparer</string>
+    <string name="noFriendsInfo1">Pour voir des classements comparatifs avec vos amis, vous devez suivre d\'autres utilisateurs sur Lichess.</string>
+    <string name="noFriendsInfo2">Visitez les profils des joueurs et cliquez sur le bouton suivre pour les ajouter à votre classement.</string>
+    <string name="explorePopularPlayers">Explorer les joueurs populaires</string>
+    <plurals name="howYouCompareAgainstFriends">
+        <item quantity="one">Voyez comment vous vous comparez à votre seul ami</item>
+        <item quantity="other">Voyez comment vous vous comparez à vos %s amis</item>
+    </plurals>
+    <string name="seeLeaderboardWithFriends">Voir le classement avec les amis</string>
+</resources>

--- a/translation/dest/leaderboard/pt-BR.xml
+++ b/translation/dest/leaderboard/pt-BR.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="friendsLeaderboardTitle">Classificação de Amigos</string>
+    <string name="friendsLeaderboardDescription">Classificação dos seus amigos no Lichess</string>
+    <string name="noFriendsToCompare">Você ainda não tem amigos para comparar</string>
+    <string name="noFriendsInfo1">Para ver classificações comparativas com seus amigos, você precisa seguir outros usuários no Lichess.</string>
+    <string name="noFriendsInfo2">Visite perfis de jogadores e clique no botão seguir para adicioná-los à sua classificação.</string>
+    <string name="explorePopularPlayers">Explorar jogadores populares</string>
+   <plurals name="howYouCompareAgainstFriends">
+        <item quantity="one">Veja como você se compara com seu único amigo</item>
+        <item quantity="other">Veja como você se compara com seus %s amigos</item>
+    </plurals>
+    <string name="seeLeaderboardWithFriends">Ver Classificação com Amigos</string>
+</resources>

--- a/translation/dest/leaderboard/pt-PT.xml
+++ b/translation/dest/leaderboard/pt-PT.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="friendsLeaderboardTitle">Classificação de Amigos</string>
+    <string name="friendsLeaderboardDescription">Classificação dos seus amigos no Lichess</string>
+    <string name="noFriendsToCompare">Você ainda não tem amigos para comparar</string>
+    <string name="noFriendsInfo1">Para ver classificações comparativas com os seus amigos, você precisa seguir outros usuários no Lichess.</string>
+    <string name="noFriendsInfo2">Visite perfis de jogadores e clique no botão seguir para adicioná-los à sua classificação.</string>
+    <string name="explorePopularPlayers">Explorar jogadores populares</string>
+   <plurals name="howYouCompareAgainstFriends">
+        <item quantity="one">Veja como você se compara com o seu único amigo</item>
+        <item quantity="other">Veja como você se compara com os seus %s amigos</item>
+    </plurals>
+    <string name="seeLeaderboardWithFriends">Ver Classificação com Amigos</string>
+</resources>

--- a/translation/source/leaderboard.xml
+++ b/translation/source/leaderboard.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="friendsLeaderboardTitle">Friends Leaderboard</string>
+    <string name="friendsLeaderboardDescription">Leaderboard of your friends on Lichess</string>
+    <string name="noFriendsToCompare">You don't have any friends to compare to yet</string>
+    <string name="noFriendsInfo1">To see comparative rankings with your friends, you need to follow other users on Lichess.</string>
+    <string name="noFriendsInfo2">Visit player profiles and click the follow button to add them to your leaderboard.</string>
+    <string name="explorePopularPlayers">Explore popular players</string>
+    <plurals name="howYouCompareAgainstFriends">
+        <item quantity="one">See how you compare against your only friend</item>
+        <item quantity="other">See how you compare against your %s friends</item>
+    </plurals>
+    <string name="seeLeaderboardWithFriends">See Leaderboard with Friends</string>
+</resources>

--- a/ui/@types/lichess/i18n.d.ts
+++ b/ui/@types/lichess/i18n.d.ts
@@ -5634,4 +5634,22 @@ interface I18n {
     /** Watch the video tutorial */
     watchTheVideoTutorial: string;
   };
+  leaderboard: {
+    /** Friends Leaderboard */
+    friendsLeaderboardTitle: string;
+    /** Leaderboard of your friends on Lichess */
+    friendsLeaderboardDescription: string;
+    /** You don't have any friends to compare to yet */
+    noFriendsToCompare: string;
+    /** To see comparative rankings with your friends, you need to follow other users on Lichess. */
+    noFriendsInfo1: string;
+    /** Visit player profiles and click the follow button to add them to your leaderboard. */
+    noFriendsInfo2: string;
+    /** Explore popular players */
+    explorePopularPlayers: string;
+    /** See how you compare against your friends */
+    howYouCompareAgainstFriends: I18nPlural;
+    /** See Leaderboard with Friends */
+    seeLeaderboardWithFriends: string;
+  };
 }

--- a/ui/user/css/_nofriends.scss
+++ b/ui/user/css/_nofriends.scss
@@ -1,0 +1,47 @@
+.page-menu.full-screen-force {
+  position: relative;
+  min-height: calc(100vh - 150px);
+
+  .community__empty {
+    position: absolute;
+    left: 50%;
+    top: 55%;
+    transform: translate(-50%, -45%);
+    width: 90%;
+    max-width: 600px;
+    text-align: center;
+
+    h2 {
+      font-size: 2em;
+      font-weight: bold;
+      margin-bottom: 2.5rem;
+      color: $c-font;
+      line-height: 1.3;
+    }
+
+    p {
+      margin: 0 auto 3rem;
+      max-width: 550px;
+      font-size: 1.1em;
+      line-height: 1.6;
+      opacity: 0.9;
+    }
+
+    .actions {
+      margin-top: 3rem;
+
+      .button {
+        font-size: 1.2em;
+        text-transform: uppercase;
+        padding: 1em 2em;
+        font-weight: bold;
+        display: inline-block;
+
+        &:hover {
+          background: lighten($c-lead, 5%);
+          color: #fff;
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds a new leaderboard feature that allows users to compare their ratings
against their friends across different game variants.

This implementation includes:
- Privacy controls to ensure users can only view their own friends' rankings,
- Support for singular/plural translations (e.g., "your only friend" vs "your X friends"),
- Multilingual support (EN, PT, ES, FR, BR),
- UI integration with existing following/friends system,
- New route (/@/:username/following/leaderboard)

This is the new button in the friends page:

![image](https://github.com/user-attachments/assets/04caf880-987e-43cf-a2ee-10c6848b59e7)

This is the friends leaderboard for a user with at least one friend:

![image](https://github.com/user-attachments/assets/d186044a-dace-435a-9424-1a9063584468)

This is the friends leaderboard for a user with no friends:

![image](https://github.com/user-attachments/assets/baaa357f-81b7-40f1-93b9-70fd0f127977)

Co-authored-by: Francisco Guerreiro <francisco.franca.guerreiro@tecnico.ulisboa.pt>
@franciscofguerreiro