### PR TITLE
Implement specialize ParserImport.game for game.Importer

### DIFF
--- a/modules/game/src/main/Importer.scala
+++ b/modules/game/src/main/Importer.scala
@@ -9,7 +9,7 @@ import play.api.data.Forms.*
 import lila.common.Form.into
 import lila.core.game.{ Game, ImportedGame }
 import lila.game.GameExt.finish
-import lila.tree.{ ImportResult, ParseImport }
+import lila.tree.ParseImport
 
 private val maxPlies = 600
 
@@ -46,15 +46,15 @@ val form = Form:
   )(ImportData.apply)(unapply)
 
 val parseImport: (PgnStr, Option[UserId]) => Either[ErrorStr, ImportedGame] = (pgn, user) =>
-  ParseImport.parseImport(pgn).map { case ImportResult(game, result, replay, initialFen, parsed, _) =>
+  ParseImport.game(pgn).map { case (game, result, initialFen, tags) =>
     val dbGame = lila.core.game
       .newImportedGame(
         chess = game,
         players = ByColor: c =>
-          lila.game.Player.makeImported(c, parsed.tags.names(c), parsed.tags.ratings(c)),
+          lila.game.Player.makeImported(c, tags.names(c), tags.ratings(c)),
         rated = Rated.No,
         source = lila.core.game.Source.Import,
-        pgnImport = PgnImport.make(user = user, date = parsed.tags.anyDate, pgn = pgn).some
+        pgnImport = PgnImport.make(user = user, date = tags.anyDate, pgn = pgn).some
       )
       .sloppy
       .start

--- a/modules/game/src/main/Importer.scala
+++ b/modules/game/src/main/Importer.scala
@@ -9,7 +9,7 @@ import play.api.data.Forms.*
 import lila.common.Form.into
 import lila.core.game.{ Game, ImportedGame }
 import lila.game.GameExt.finish
-import lila.tree.ImportResult
+import lila.tree.{ ImportResult, ParseImport }
 
 private val maxPlies = 600
 
@@ -46,7 +46,7 @@ val form = Form:
   )(ImportData.apply)(unapply)
 
 val parseImport: (PgnStr, Option[UserId]) => Either[ErrorStr, ImportedGame] = (pgn, user) =>
-  lila.tree.parseImport(pgn).map { case ImportResult(game, result, replay, initialFen, parsed, _) =>
+  ParseImport.parseImport(pgn).map { case ImportResult(game, result, replay, initialFen, parsed, _) =>
     val dbGame = lila.core.game
       .newImportedGame(
         chess = game,

--- a/modules/relay/src/main/RelayPush.scala
+++ b/modules/relay/src/main/RelayPush.scala
@@ -4,7 +4,7 @@ import play.api.mvc.RequestHeader
 import chess.format.pgn.{ PgnStr, San, Std, Tags }
 import chess.{ ErrorStr, Replay, Square, TournamentClock }
 import scalalib.actor.AsyncActorSequencers
-import lila.tree.ImportResult
+import lila.tree.{ ImportResult, ParseImport }
 
 import lila.study.{ ChapterPreviewApi, MultiPgn, StudyPgnImport }
 import lila.common.HTTPRequest
@@ -107,7 +107,7 @@ object RelayPush:
 
   // silently consume DGT board king-check move to center at game end
   private[relay] def validate(pgnBody: PgnStr): Either[Failure, ImportResult] =
-    lila.tree
+    ParseImport
       .parseImport(pgnBody)
       .fold(
         err => Failure(Tags.empty, err.value).asLeft,

--- a/modules/relay/src/main/RelayPush.scala
+++ b/modules/relay/src/main/RelayPush.scala
@@ -108,7 +108,7 @@ object RelayPush:
   // silently consume DGT board king-check move to center at game end
   private[relay] def validate(pgnBody: PgnStr): Either[Failure, ImportResult] =
     ParseImport
-      .parseImport(pgnBody)
+      .full(pgnBody)
       .fold(
         err => Failure(Tags.empty, err.value).asLeft,
         result =>

--- a/modules/study/src/main/StudyPgnImport.scala
+++ b/modules/study/src/main/StudyPgnImport.scala
@@ -18,7 +18,7 @@ object StudyPgnImport:
   )
 
   def result(pgn: PgnStr, contributors: List[LightUser]): Either[ErrorStr, Result] =
-    ParseImport.parseImport(pgn).map(result(_, contributors))
+    ParseImport.full(pgn).map(result(_, contributors))
 
   def result(importResult: ImportResult, contributors: List[LightUser]): Result =
     import importResult.{ replay, initialFen, parsed }

--- a/modules/study/src/main/StudyPgnImport.scala
+++ b/modules/study/src/main/StudyPgnImport.scala
@@ -6,7 +6,7 @@ import chess.{ ByColor, Centis, ErrorStr, Node as PgnNode, Outcome, Status, Tour
 
 import lila.core.LightUser
 import lila.tree.Node.{ Comment, Comments, Shapes }
-import lila.tree.{ Branch, Branches, ImportResult, Root, Clock }
+import lila.tree.{ Branch, Branches, ImportResult, ParseImport, Root, Clock }
 
 object StudyPgnImport:
 
@@ -18,7 +18,7 @@ object StudyPgnImport:
   )
 
   def result(pgn: PgnStr, contributors: List[LightUser]): Either[ErrorStr, Result] =
-    lila.tree.parseImport(pgn).map(result(_, contributors))
+    ParseImport.parseImport(pgn).map(result(_, contributors))
 
   def result(importResult: ImportResult, contributors: List[LightUser]): Result =
     import importResult.{ replay, initialFen, parsed }

--- a/modules/study/src/main/StudyPgnImportNew.scala
+++ b/modules/study/src/main/StudyPgnImportNew.scala
@@ -7,7 +7,7 @@ import monocle.syntax.all.*
 
 import lila.core.LightUser
 import lila.tree.Node.{ Comment, Comments }
-import lila.tree.{ ImportResult, Metas, NewBranch, NewRoot, Clock }
+import lila.tree.{ ImportResult, Metas, NewBranch, NewRoot, Clock, ParseImport }
 
 // This code is still unused
 object StudyPgnImportNew:
@@ -22,7 +22,7 @@ object StudyPgnImportNew:
   )
 
   def apply(pgn: PgnStr, contributors: List[LightUser]): Either[ErrorStr, Result] =
-    lila.tree.parseImport(pgn).map { case ImportResult(game, result, replay, initialFen, parsedPgn, _) =>
+    ParseImport.parseImport(pgn).map { case ImportResult(game, result, replay, initialFen, parsedPgn, _) =>
       val annotator = StudyPgnImport.findAnnotator(parsedPgn, contributors)
       StudyPgnImport.parseComments(parsedPgn.initialPosition.comments, annotator) match
         case (shapes, _, _, comments) =>

--- a/modules/study/src/main/StudyPgnImportNew.scala
+++ b/modules/study/src/main/StudyPgnImportNew.scala
@@ -22,7 +22,7 @@ object StudyPgnImportNew:
   )
 
   def apply(pgn: PgnStr, contributors: List[LightUser]): Either[ErrorStr, Result] =
-    ParseImport.parseImport(pgn).map { case ImportResult(game, result, replay, initialFen, parsedPgn, _) =>
+    ParseImport.full(pgn).map { case ImportResult(game, result, replay, initialFen, parsedPgn, _) =>
       val annotator = StudyPgnImport.findAnnotator(parsedPgn, contributors)
       StudyPgnImport.parseComments(parsedPgn.initialPosition.comments, annotator) match
         case (shapes, _, _, comments) =>

--- a/modules/tree/src/main/ParseImport.scala
+++ b/modules/tree/src/main/ParseImport.scala
@@ -20,82 +20,83 @@ case class ImportResult(
     replayError: Option[ErrorStr]
 )
 
-private val maxPlies = 600
+object ParseImport:
+  private val maxPlies = 600
 
-def parseImport(pgn: PgnStr): Either[ErrorStr, ImportResult] =
-  catchOverflow: () =>
-    Parser.full(pgn).map { parsed =>
-      Replay
-        .makeReplay(parsed.toGame, parsed.mainline.take(maxPlies))
-        .pipe { case Replay.Result(replay @ Replay(setup, _, state), replayError) =>
-          val variant    = extractVariant(setup, parsed.tags)
-          val initialFen = parsed.tags.fen.flatMap(Fen.readWithMoveNumber(variant, _)).map(Fen.write)
-          val game       = state.copy(position = replay.state.position.withVariant(variant))
-          val result     = extractResult(game, parsed.tags)
-          ImportResult(game, result, replay.copy(state = game), initialFen, parsed, replayError)
-        }
-    }
+  def parseImport(pgn: PgnStr): Either[ErrorStr, ImportResult] =
+    catchOverflow: () =>
+      Parser.full(pgn).map { parsed =>
+        Replay
+          .makeReplay(parsed.toGame, parsed.mainline.take(maxPlies))
+          .pipe { case Replay.Result(replay @ Replay(setup, _, state), replayError) =>
+            val variant    = extractVariant(setup, parsed.tags)
+            val initialFen = parsed.tags.fen.flatMap(Fen.readWithMoveNumber(variant, _)).map(Fen.write)
+            val game       = state.copy(position = replay.state.position.withVariant(variant))
+            val result     = extractResult(game, parsed.tags)
+            ImportResult(game, result, replay.copy(state = game), initialFen, parsed, replayError)
+          }
+      }
 
-def extractVariant(setup: ChessGame, tags: Tags): Variant =
-  val initBoard    = tags.fen.flatMap(Fen.read).map(_.board)
-  val fromPosition = initBoard.nonEmpty && !tags.fen.exists(_.isInitial)
+  def extractVariant(setup: ChessGame, tags: Tags): Variant =
+    val initBoard    = tags.fen.flatMap(Fen.read).map(_.board)
+    val fromPosition = initBoard.nonEmpty && !tags.fen.exists(_.isInitial)
 
-  tags.variant | {
-    if fromPosition then FromPosition
-    else Standard
-  } match
-    case Chess960 if !isChess960StartPosition(setup.position) => FromPosition
-    case FromPosition if tags.fen.isEmpty                     => Standard
-    case Standard if fromPosition                             => FromPosition
-    case v                                                    => v
+    tags.variant | {
+      if fromPosition then FromPosition
+      else Standard
+    } match
+      case Chess960 if !isChess960StartPosition(setup.position) => FromPosition
+      case FromPosition if tags.fen.isEmpty                     => Standard
+      case Standard if fromPosition                             => FromPosition
+      case v                                                    => v
 
-def extractResult(game: ChessGame, tags: Tags): Option[TagResult] =
-  val status = tags(_.Termination).map(_.toLowerCase) match
-    case Some("normal") =>
-      game.position.status | (if tags.outcome.exists(_.winner.isEmpty) then Status.Draw else Status.Resign)
-    case Some("abandoned")                        => Status.Aborted
-    case Some("time forfeit")                     => Status.Outoftime
-    case Some("rules infraction")                 => Status.Cheat
-    case Some(txt) if txt.contains("won on time") => Status.Outoftime
-    case _                                        => Status.UnknownFinish
+  def extractResult(game: ChessGame, tags: Tags): Option[TagResult] =
+    val status = tags(_.Termination).map(_.toLowerCase) match
+      case Some("normal") =>
+        game.position.status | (if tags.outcome.exists(_.winner.isEmpty) then Status.Draw else Status.Resign)
+      case Some("abandoned")                        => Status.Aborted
+      case Some("time forfeit")                     => Status.Outoftime
+      case Some("rules infraction")                 => Status.Cheat
+      case Some(txt) if txt.contains("won on time") => Status.Outoftime
+      case _                                        => Status.UnknownFinish
 
-  tags.points
-    .map(points => TagResult(status, points))
-    .filter(_.status > Status.Started)
-    .orElse {
-      game.position.status.flatMap: status =>
-        Outcome
-          .guessPointsFromStatusAndPosition(status, game.position.winner)
-          .map(TagResult(status, _))
-    }
+    tags.points
+      .map(points => TagResult(status, points))
+      .filter(_.status > Status.Started)
+      .orElse {
+        game.position.status.flatMap: status =>
+          Outcome
+            .guessPointsFromStatusAndPosition(status, game.position.winner)
+            .map(TagResult(status, _))
+      }
 
-private def isChess960StartPosition(position: Position) =
-  import chess.*
-  val strict =
-    def rankMatches(f: Option[Piece] => Boolean)(rank: Rank) =
-      File.all.forall(file => f(position.board.pieceAt(file, rank)))
-    rankMatches {
-      case Some(Piece(White, King | Queen | Rook | Knight | Bishop)) => true
-      case _                                                         => false
-    }(Rank.First) &&
-    rankMatches {
-      case Some(Piece(White, Pawn)) => true
-      case _                        => false
-    }(Rank.Second) &&
-    List(Rank.Third, Rank.Fourth, Rank.Fifth, Rank.Sixth).forall(rankMatches(_.isEmpty)) &&
-    rankMatches {
-      case Some(Piece(Black, Pawn)) => true
-      case _                        => false
-    }(Rank.Seventh) &&
-    rankMatches {
-      case Some(Piece(Black, King | Queen | Rook | Knight | Bishop)) => true
-      case _                                                         => false
-    }(Rank.Eighth)
+  private def isChess960StartPosition(position: Position) =
+    import chess.*
+    val strict =
+      def rankMatches(f: Option[Piece] => Boolean)(rank: Rank) =
+        File.all.forall(file => f(position.board.pieceAt(file, rank)))
+      rankMatches {
+        case Some(Piece(White, King | Queen | Rook | Knight | Bishop)) => true
+        case _                                                         => false
+      }(Rank.First) &&
+      rankMatches {
+        case Some(Piece(White, Pawn)) => true
+        case _                        => false
+      }(Rank.Second) &&
+      List(Rank.Third, Rank.Fourth, Rank.Fifth, Rank.Sixth).forall(rankMatches(_.isEmpty)) &&
+      rankMatches {
+        case Some(Piece(Black, Pawn)) => true
+        case _                        => false
+      }(Rank.Seventh) &&
+      rankMatches {
+        case Some(Piece(Black, King | Queen | Rook | Knight | Bishop)) => true
+        case _                                                         => false
+      }(Rank.Eighth)
 
-  Chess960.valid(position, strict)
+    Chess960.valid(position, strict)
 
-private def catchOverflow[A](f: () => Either[ErrorStr, A]): Either[ErrorStr, A] =
-  try f()
-  catch
-    case e: RuntimeException if e.getMessage.contains("StackOverflowError") =>
-      ErrorStr("This PGN seems too long or too complex!").asLeft
+  private def catchOverflow[A](f: () => Either[ErrorStr, A]): Either[ErrorStr, A] =
+    try f()
+    catch
+      case e: RuntimeException if e.getMessage.contains("StackOverflowError") =>
+        ErrorStr("This PGN seems too long or too complex!").asLeft

--- a/modules/tree/src/main/ParseImport.scala
+++ b/modules/tree/src/main/ParseImport.scala
@@ -22,7 +22,7 @@ case class ImportResult(
 object ParseImport:
   private val maxPlies = 600
 
-  def parseImport(pgn: PgnStr): Either[ErrorStr, ImportResult] =
+  def full(pgn: PgnStr): Either[ErrorStr, ImportResult] =
     catchOverflow: () =>
       Parser.full(pgn).map { parsed =>
         Replay

--- a/modules/tree/src/main/ParseImport.scala
+++ b/modules/tree/src/main/ParseImport.scala
@@ -38,8 +38,9 @@ object ParseImport:
       }
 
   def extractVariant(setup: ChessGame, tags: Tags): Variant =
-    val initBoard    = tags.fen.flatMap(Fen.read).map(_.board)
-    val fromPosition = initBoard.nonEmpty && !tags.fen.exists(_.isInitial)
+    inline def initBoard = tags.fen.flatMap(Fen.read).map(_.board)
+    @scala.annotation.threadUnsafe
+    lazy val fromPosition = initBoard.nonEmpty && !tags.fen.exists(_.isInitial)
 
     tags.variant | {
       if fromPosition then FromPosition


### PR DESCRIPTION
This pr is basically this commit: [Implement ParseImport.game](https://github.com/lichess-org/lila/commit/c936dfde7c60327c45d74c6a0bdf500572474190) but also refactor the old `parseImport` into small functions reused them between `ParsedImport.game` and `ParsedImport.full`