### PR TITLE
fix(socket) Unvalidated dynamic method call

### DIFF
--- a/ui/lib/src/socket.ts
+++ b/ui/lib/src/socket.ts
@@ -302,7 +302,10 @@ class WsSocket {
       default:
         // return true in a receive handler to prevent pubsub and events
         if (!(this.settings.receive && this.settings.receive(m.t, m.d))) {
-          const sentAsEvent = this.settings.events[m.t] && this.settings.events[m.t](m.d || null, m);
+          const sentAsEvent =
+            this.settings.events.hasOwnProperty(m.t) &&
+            typeof this.settings.events[m.t] === 'function' &&
+            this.settings.events[m.t](m.d || null, m);
           if (!sentAsEvent) pubsub.emit(('socket.in.' + m.t) as PubsubEvent, m.d, m);
         }
     }


### PR DESCRIPTION
https://github.com/lichess-org/lila/blob/b663df5430b65a3b9bc1788b9dfd933c2ef0ebd3/ui/lib/src/socket.ts#L305-L305


Fix the issue need to validate the dynamic method lookup `this.settings.events[m.t]` before invoking it. Specifically:
1. Check if `m.t` is a valid key in `this.settings.events` using `hasOwnProperty`.
2. Ensure that the value of `this.settings.events[m.t]` is a function before invoking it.

This fix ensures that only valid and callable methods are invoked, preventing runtime exceptions and mitigating the risk of malicious input.


---


<!--StartFragment-->
JavaScript makes it easy to look up object properties dynamically at runtime. In particular, methods can be looked up by name and then called. However, if the method name is user-controlled, an attacker could choose a name that makes the application invoke an unexpected method, which may cause a runtime exception. If this exception is not handled, it could be used to mount a denial-of-service attack.Show paths |   |  
-- | -- | --



#### References
[Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map).
[Object.prototype](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/prototype).







