### PR TITLE
Do not check for pawns being present again.

### DIFF
--- a/ui/lib/src/game/view/status.ts
+++ b/ui/lib/src/game/view/status.ts
@@ -36,7 +36,7 @@ export function insufficientMaterial(variant: VariantKey, fullFen: FEN): boolean
   if (/^[KkNn]{3}$/.test(pieces)) return true;
   if (/b/i.test(pieces)) {
     const expandedFen = expandFen(fullFen);
-    return (!bishopOnColor(expandedFen, 0) || !bishopOnColor(expandedFen, 1)) && !/[pPnN]/.test(pieces);
+    return (!bishopOnColor(expandedFen, 0) || !bishopOnColor(expandedFen, 1)) && !/[nN]/.test(pieces);
   }
   return false;
 }


### PR DESCRIPTION
Checking for pawns being present seems to be unnecessary, due to `if (/[prq]/i.test(pieces)) return false;` a few lines before.