### PR TITLE
Announce all pieces by color

### DIFF
--- a/translation/source/nvui.xml
+++ b/translation/source/nvui.xml
@@ -23,7 +23,7 @@
   <string name="moveToPieceByType">Move to squares using piece names. For example: repeated k will move to every square where there is a knight. Use uppercase to invert order.</string>
   <string name="moveToRank">Move to rank 1 to 8.</string>
   <string name="moveToFile">Move to file a to h.</string>
-  <string name="announcePieceLocations">Announce locations of pieces. Example: p capital N for white knights, p lowercase k for black king.</string>
+  <string name="announcePieceLocations">Announce locations of pieces. Example: p capital N for white knights, p lowercase k for black king, p capital A for all white pieces.</string>
   <string name="announcePiecesOnRankOrFile">Announce pieces on a rank or a file. Example: s a, s 1.</string>
   <string name="goToBoard">Go to the board. Default square is e-4. You can specify a square: board a-1 or b a-1 will take you to square a-1.</string>
   <string name="movePiece">To move a piece, use standard algebraic notation.</string>

--- a/ui/@types/lichess/i18n.d.ts
+++ b/ui/@types/lichess/i18n.d.ts
@@ -1747,7 +1747,7 @@ interface I18n {
     announceLastMove: string;
     /** Announce piece captured in last move. */
     announceLastMoveCapture: string;
-    /** Announce locations of pieces. Example: p capital N for white knights, p lowercase k for black king. */
+    /** Announce locations of pieces. Example: p capital N for white knights, p lowercase k for black king, p capital A for all white pieces. */
     announcePieceLocations: string;
     /** Announce pieces on a rank or a file. Example: s a, s 1. */
     announcePiecesOnRankOrFile: string;

--- a/ui/lib/src/nvui/chess.ts
+++ b/ui/lib/src/nvui/chess.ts
@@ -122,26 +122,27 @@ export const renderSan = (san: San | undefined, uci: Uci | undefined, style: Mov
             )
             .join(' ');
 
+const renderPiecesByColor = (pieces: Pieces, style: MoveStyle, color: Color): string => {
+  return ROLES.slice()
+    .reverse()
+    .reduce<{ role: Role; keys: Key[] }[]>(
+      (lists, role) =>
+        lists.concat({
+          role,
+          keys: keysWithPiece(pieces, role, color),
+        }),
+      [],
+    )
+    .filter(l => l.keys.length)
+    .map(l => `${transRole(l.role)}: ${l.keys.map(k => renderKey(k, style)).join(', ')}`)
+    .join(', ');
+};
+
 export const renderPieces = (pieces: Pieces, style: MoveStyle): VNode =>
   h(
     'div.pieces',
     COLORS.map(color =>
-      h(`div.${color}-pieces`, [
-        h('h3', i18n.site[color]),
-        ROLES.slice()
-          .reverse()
-          .reduce<{ role: Role; keys: Key[] }[]>(
-            (lists, role) =>
-              lists.concat({
-                role,
-                keys: keysWithPiece(pieces, role, color),
-              }),
-            [],
-          )
-          .filter(l => l.keys.length)
-          .map(l => `${transRole(l.role)}: ${l.keys.map(k => renderKey(k, style)).join(', ')}`)
-          .join(', '),
-      ]),
+      h(`div.${color}-pieces`, [h('h3', i18n.site[color]), renderPiecesByColor(pieces, style, color)]),
     ),
   );
 
@@ -161,6 +162,7 @@ const keysWithPiece = (pieces: Pieces, role?: Role, color?: Color): Key[] =>
 
 export function renderPieceKeys(pieces: Pieces, p: string, style: MoveStyle): string {
   const color: Color = p === p.toUpperCase() ? 'white' : 'black';
+  if (p.toLowerCase() == 'a') return renderPiecesByColor(pieces, style, color);
   const role = charToRole(p)!;
   const keys = keysWithPiece(pieces, role, color);
   let pieceStr = transPieceStr(role, color, i18n);

--- a/ui/lib/src/nvui/command.ts
+++ b/ui/lib/src/nvui/command.ts
@@ -15,7 +15,7 @@ export const commands: () => Commands = memoize(() => ({
   piece: {
     help: i18n.nvui.announcePieceLocations,
     apply(c: string, pieces: Pieces, style: MoveStyle): string | undefined {
-      return tryC(c, /^\/?p ([pnbrqk])$/i, p => renderPieceKeys(pieces, p, style));
+      return tryC(c, /^\/?p ([apnbrqk])$/i, p => renderPieceKeys(pieces, p, style));
     },
   },
   scan: {


### PR DESCRIPTION
fixes #17658 

A pseudo piece A (like all) is added to p command

p a will announce where black pieces are
the same way
p n announces where black knight is
