### PR TITLE
loosen UblogAutomod.Result db schema for migration

### DIFF
--- a/modules/ublog/src/main/UblogAutomod.scala
+++ b/modules/ublog/src/main/UblogAutomod.scala
@@ -31,7 +31,8 @@ private object UblogAutomod:
   private case class Config(apiKey: Secret, model: String, url: String)
 
   private case class FuzzyResult(
-      classification: String,
+      quality: Option[String],
+      classification: Option[String],
       flagged: Option[JsValue],
       commercial: Option[JsValue],
       offtopic: Option[JsValue],
@@ -107,7 +108,7 @@ final class UblogAutomod(
     val trimmed = msg.slice(msg.lastIndexOf('{'), msg.lastIndexOf('}') + 1)
     Json.parse(trimmed).asOpt[FuzzyResult].flatMap { res =>
       val fixed = Result(
-        classification = res.classification,
+        classification = res.classification.orElse(res.quality).getOrElse("good"),
         evergreen = res.evergreen,
         flagged = fix(res.flagged),
         commercial = fix(res.commercial),

--- a/modules/ublog/src/main/UblogBsonHandlers.scala
+++ b/modules/ublog/src/main/UblogBsonHandlers.scala
@@ -1,5 +1,6 @@
 package lila.ublog
 
+import scala.util.{ Try, Success }
 import play.api.i18n.Lang
 import reactivemongo.api.bson.*
 
@@ -8,21 +9,49 @@ import lila.db.dsl.{ *, given }
 private object UblogBsonHandlers:
 
   import UblogPost.{ LightPost, PreviewPost, Recorded }
+  import UblogAutomod.Result
 
   given BSONHandler[UblogBlog.Id] = tryHandler(
     { case BSONString(v) => UblogBlog.Id(v).toTry(s"Invalid blog id $v") },
     id => BSONString(id.full)
   )
+  given BSONDocumentHandler[Result] = new BSONDocumentHandler[Result]:
+    def writeTry(result: Result) = Success:
+      val quality = result.classification match
+        case "spam"  => 0
+        case "weak"  => 1
+        case "great" => 3
+        case _       => 2
+      BSONDocument(
+        "quality"    -> quality,
+        "flagged"    -> result.flagged,
+        "commercial" -> result.commercial,
+        "evergreen"  -> result.evergreen,
+        "hash"       -> result.hash
+      )
+    def readDocument(doc: BSONDocument) = Try[Result]:
+      val fromQuality = doc.getAsOpt[Int]("quality") match
+        case Some(0) => "spam"
+        case Some(1) => "weak"
+        case Some(3) => "great"
+        case _       => "good"
+      Result(
+        classification = doc.getAsOpt[String]("classification").getOrElse(fromQuality),
+        flagged = doc.getAsOpt[String]("flagged"),
+        commercial = doc.getAsOpt[String]("commercial"),
+        offtopic = doc.getAsOpt[String]("offtopic"),
+        evergreen = doc.getAsOpt[Boolean]("evergreen"),
+        hash = doc.getAsOpt[String]("hash")
+      )
   given BSONDocumentHandler[UblogBlog] = Macros.handler
 
-  given BSONHandler[Lang]                        = langByCodeHandler
-  given BSONDocumentHandler[Recorded]            = Macros.handler
-  given BSONDocumentHandler[UblogImage]          = Macros.handler
-  given BSONDocumentHandler[UblogPost]           = Macros.handler
-  given BSONDocumentHandler[LightPost]           = Macros.handler
-  given BSONDocumentHandler[PreviewPost]         = Macros.handler
-  given BSONDocumentHandler[UblogSimilar]        = Macros.handler
-  given BSONDocumentHandler[UblogAutomod.Result] = Macros.handler
+  given BSONHandler[Lang]                 = langByCodeHandler
+  given BSONDocumentHandler[Recorded]     = Macros.handler
+  given BSONDocumentHandler[UblogImage]   = Macros.handler
+  given BSONDocumentHandler[UblogPost]    = Macros.handler
+  given BSONDocumentHandler[LightPost]    = Macros.handler
+  given BSONDocumentHandler[PreviewPost]  = Macros.handler
+  given BSONDocumentHandler[UblogSimilar] = Macros.handler
 
   val postProjection        = $doc("likers" -> false)
   val lightPostProjection   = $doc("title" -> true)


### PR DESCRIPTION
## Blessed sequence (order matters):
1. deploy this
2. paste the latest [`ublog-system-prompt.txt`](https://github.com/lichess-org/sysadmin/blob/master/prompts/ublog-system-prompt.txt) into settings
3. run the [bin/ublog-automod.mjs](https://github.com/schlawg/lila/blob/blog-migration-prep/bin/ublog-automod.mjs) in this PR to upgrade our blog assessments
4. eventually deploy [blog-discoverability](https://github.com/lichess-org/lila/pull/17690) or something that resembles it
---
- this pr lets lila parse current and future automod documents while preserving legacy behavior

- the prompt and schema were simplified to improve language model performance and ease quality filtering

- all of this code is superseded by the blog-discoverability branch
