### PR TITLE
rename looseH -> hl, allow number vnodes, and eliminate spreads

### DIFF
--- a/ui/analyse/src/explorer/explorerView.ts
+++ b/ui/analyse/src/explorer/explorerView.ts
@@ -2,7 +2,7 @@ import type { VNode } from 'snabbdom';
 import * as licon from 'lib/licon';
 import { numberFormat } from 'lib/i18n';
 import perfIcons from 'lib/game/perfIcons';
-import { bind, dataIcon, type MaybeVNode, type LooseVNodes, looseH as h } from 'lib/snabbdom';
+import { bind, dataIcon, type MaybeVNode, type LooseVNodes, hl } from 'lib/snabbdom';
 import { view as renderConfig } from './explorerConfig';
 import { moveArrowAttributes, ucfirst } from './explorerUtil';
 import type AnalyseCtrl from '../ctrl';
@@ -22,13 +22,13 @@ function resultBar(move: OpeningMoveStats): VNode {
   const sum = move.white + move.draws + move.black;
   const section = (key: 'white' | 'black' | 'draws') => {
     const percent = (move[key] * 100) / sum;
-    return h(
+    return hl(
       'span.' + key,
       { attrs: { style: 'width: ' + Math.round((move[key] * 1000) / sum) / 10 + '%' } },
       percent > 12 ? Math.round(percent) + (percent > 20 ? '%' : '') : '',
     );
   };
-  return h('div.bar', ['white', 'draws', 'black'].map(section));
+  return hl('div.bar', ['white', 'draws', 'black'].map(section));
 }
 
 function showMoveTable(ctrl: AnalyseCtrl, data: OpeningData): VNode | null {
@@ -48,28 +48,28 @@ function showMoveTable(ctrl: AnalyseCtrl, data: OpeningData): VNode | null {
         ]
       : data.moves;
 
-  return h('table.moves', [
-    h('thead', [
-      h('tr', [
-        h('th', i18n.site.move),
-        h('th', { attrs: { colspan: 2 } }, i18n.site.games),
-        h('th', i18n.site.whiteDrawBlack),
+  return hl('table.moves', [
+    hl('thead', [
+      hl('tr', [
+        hl('th', i18n.site.move),
+        hl('th', { attrs: { colspan: 2 } }, i18n.site.games),
+        hl('th', i18n.site.whiteDrawBlack),
       ]),
     ]),
-    h(
+    hl(
       'tbody',
       moveArrowAttributes(ctrl, { fen: data.fen, onClick: (_, uci) => uci && ctrl.explorerMove(uci) }),
       movesWithCurrent.map(move => {
         const total = move.white + move.draws + move.black;
-        return h(`tr${move.uci ? '' : '.sum'}`, { key: move.uci, attrs: { 'data-uci': move.uci } }, [
-          h(
+        return hl(`tr${move.uci ? '' : '.sum'}`, { key: move.uci, attrs: { 'data-uci': move.uci } }, [
+          hl(
             'td',
             { attrs: { title: move.opening ? `${move.opening.eco}: ${move.opening.name}` : '' } },
             move.san,
           ),
-          h('td', ((total / sumTotal) * 100).toFixed(0) + '%'),
-          h('td', numberFormat(total)),
-          h('td', { attrs: { title: moveStatsTooltip(ctrl, move) } }, resultBar(move)),
+          hl('td', ((total / sumTotal) * 100).toFixed(0) + '%'),
+          hl('td', numberFormat(total)),
+          hl('td', { attrs: { title: moveStatsTooltip(ctrl, move) } }, resultBar(move)),
         ]);
       }),
     ),
@@ -95,18 +95,18 @@ function moveStatsTooltip(ctrl: AnalyseCtrl, move: OpeningMoveStats): string {
 
 const showResult = (winner?: Color): VNode =>
   winner === 'white'
-    ? h('result.white', '1-0')
+    ? hl('result.white', '1-0')
     : winner === 'black'
-      ? h('result.black', '0-1')
-      : h('result.draws', '½-½');
+      ? hl('result.black', '0-1')
+      : hl('result.draws', '½-½');
 
 function showGameTable(ctrl: AnalyseCtrl, fen: FEN, title: string, games: OpeningGame[]): VNode | null {
   if (!ctrl.explorer.withGames || !games.length) return null;
   const openedId = ctrl.explorer.gameMenu(),
     isMasters = ctrl.explorer.db() === 'masters';
-  return h('table.games', [
-    h('thead', [h('tr', [h('th.title', { attrs: { colspan: isMasters ? 4 : 5 } }, title)])]),
-    h(
+  return hl('table.games', [
+    hl('thead', [hl('tr', [hl('th.title', { attrs: { colspan: isMasters ? 4 : 5 } }, title)])]),
+    hl(
       'tbody',
       moveArrowAttributes(ctrl, {
         fen,
@@ -123,23 +123,23 @@ function showGameTable(ctrl: AnalyseCtrl, fen: FEN, title: string, games: Openin
       games.map(game => {
         return openedId === game.id
           ? gameActions(ctrl, game)
-          : h('tr', { key: game.id, attrs: { 'data-id': game.id, 'data-uci': game.uci || '' } }, [
+          : hl('tr', { key: game.id, attrs: { 'data-id': game.id, 'data-uci': game.uci || '' } }, [
               ctrl.explorer.opts.showRatings &&
-                h(
+                hl(
                   'td',
-                  [game.white, game.black].map(p => h('span', '' + p.rating)),
+                  [game.white, game.black].map(p => hl('span', '' + p.rating)),
                 ),
-              h(
+              hl(
                 'td',
-                [game.white, game.black].map(p => h('span', p.name)),
+                [game.white, game.black].map(p => hl('span', p.name)),
               ),
-              h('td', showResult(game.winner)),
-              h('td', game.month || game.year),
+              hl('td', showResult(game.winner)),
+              hl('td', game.month || game.year),
               !isMasters &&
-                h(
+                hl(
                   'td',
                   game.speed &&
-                    h('i', { attrs: { title: ucfirst(game.speed), ...dataIcon(perfIcons[game.speed]) } }),
+                    hl('i', { attrs: { title: ucfirst(game.speed), ...dataIcon(perfIcons[game.speed]) } }),
                 ),
             ]);
       }),
@@ -161,31 +161,31 @@ function gameActions(ctrl: AnalyseCtrl, game: OpeningGame): VNode {
     ctrl.explorer.gameMenu(null);
     ctrl.redraw();
   };
-  return h('tr', { key: game.id + '-m' }, [
-    h('td.game_menu', { attrs: { colspan: ctrl.explorer.db() === 'masters' ? 4 : 5 } }, [
-      h(
+  return hl('tr', { key: game.id + '-m' }, [
+    hl('td.game_menu', { attrs: { colspan: ctrl.explorer.db() === 'masters' ? 4 : 5 } }, [
+      hl(
         'div.game_title',
         `${game.white.name} - ${game.black.name}, ${showResult(game.winner).text}, ${game.year}`,
       ),
-      h('div.menu', [
-        h(
+      hl('div.menu', [
+        hl(
           'a.text',
           { attrs: dataIcon(licon.Eye), hook: bind('click', _ => openGame(ctrl, game.id)) },
           'View',
         ),
         ctrl.study &&
-          h(
+          hl(
             'a.text',
             { attrs: dataIcon(licon.BubbleSpeech), hook: bind('click', _ => send(false), ctrl.redraw) },
             'Cite',
           ),
         ctrl.study &&
-          h(
+          hl(
             'a.text',
             { attrs: dataIcon(licon.PlusButton), hook: bind('click', _ => send(true), ctrl.redraw) },
             'Insert',
           ),
-        h(
+        hl(
           'a.text',
           { attrs: dataIcon(licon.X), hook: bind('click', _ => ctrl.explorer.gameMenu(null), ctrl.redraw) },
           'Close',
@@ -196,42 +196,42 @@ function gameActions(ctrl: AnalyseCtrl, game: OpeningGame): VNode {
 }
 
 const closeButton = (ctrl: AnalyseCtrl): VNode =>
-  h(
+  hl(
     'button.button.button-empty.text',
     { attrs: dataIcon(licon.X), hook: bind('click', ctrl.toggleExplorer, ctrl.redraw) },
     i18n.site.close,
   );
 
 const showEmpty = (ctrl: AnalyseCtrl, data?: OpeningData): VNode =>
-  h('div.data.empty', [
+  hl('div.data.empty', [
     explorerTitle(ctrl.explorer),
     openingTitle(ctrl, data),
-    h('div.message', [
-      h(
+    hl('div.message', [
+      hl(
         'strong',
         ctrl.explorer.root.node.ply >= MAX_DEPTH ? i18n.site.maxDepthReached : i18n.site.noGameFound,
       ),
-      data?.queuePosition
-        ? h('p.explanation', `Indexing ${data.queuePosition} other players first ...`)
+      !!data?.queuePosition
+        ? hl('p.explanation', `Indexing ${data.queuePosition} other players first ...`)
         : !ctrl.explorer.config.fullHouse() &&
-          h('p.explanation', i18n.site.maybeIncludeMoreGamesFromThePreferencesMenu),
+          hl('p.explanation', i18n.site.maybeIncludeMoreGamesFromThePreferencesMenu),
     ]),
   ]);
 
 const showGameEnd = (ctrl: AnalyseCtrl, title: string): VNode =>
-  h('div.data.empty', [
-    h('div.title', i18n.site.gameOver),
-    h('div.message', [h('i', { attrs: dataIcon(licon.InfoCircle) }), h('h3', title), closeButton(ctrl)]),
+  hl('div.data.empty', [
+    hl('div.title', i18n.site.gameOver),
+    hl('div.message', [hl('i', { attrs: dataIcon(licon.InfoCircle) }), hl('h3', title), closeButton(ctrl)]),
   ]);
 
 const openingTitle = (ctrl: AnalyseCtrl, data?: OpeningData) => {
   const opening = data?.opening;
   const title = opening ? `${opening.eco} ${opening.name}` : '';
-  return h(
+  return hl(
     'div.title',
     { attrs: opening ? { title } : {} },
     opening
-      ? [h('a', { attrs: { href: `/opening/${opening.name}`, target: '_blank' } }, title)]
+      ? [hl('a', { attrs: { href: `/opening/${opening.name}`, target: '_blank' } }, title)]
       : [showTitle(ctrl.data.game.variant)],
   );
 };
@@ -248,7 +248,7 @@ function show(ctrl: AnalyseCtrl): MaybeVNode {
       recentTable = showGameTable(ctrl, data.fen, i18n.site.recentGames, data.recentGames || []),
       topTable = showGameTable(ctrl, data.fen, i18n.site.topGames, data.topGames || []);
     if (moveTable || recentTable || topTable)
-      lastShow = h('div.data', [
+      lastShow = hl('div.data', [
         explorerTitle(ctrl.explorer),
         data?.opening && openingTitle(ctrl, data),
         moveTable,
@@ -266,17 +266,17 @@ function show(ctrl: AnalyseCtrl): MaybeVNode {
         data.moves.filter(m => m.category === category),
       );
     if (data.moves.length)
-      lastShow = h('div.data', [
-        ...row('loss', i18n.site.winning),
-        ...row('unknown', i18n.site.unknown),
-        ...row('syzygy-loss', i18n.site.winOr50MovesByPriorMistake, i18n.site.unknownDueToRounding),
-        ...row('maybe-loss', 'Win or 50 moves'),
-        ...row('blessed-loss', i18n.site.winPreventedBy50MoveRule),
-        ...row('draw', i18n.site.drawn),
-        ...row('cursed-win', i18n.site.lossSavedBy50MoveRule),
-        ...row('maybe-win', 'Loss or 50 moves'),
-        ...row('syzygy-win', i18n.site.lossOr50MovesByPriorMistake, i18n.site.unknownDueToRounding),
-        ...row('win', i18n.site.losing),
+      lastShow = hl('div.data', [
+        row('loss', i18n.site.winning),
+        row('unknown', i18n.site.unknown),
+        row('syzygy-loss', i18n.site.winOr50MovesByPriorMistake, i18n.site.unknownDueToRounding),
+        row('maybe-loss', 'Win or 50 moves'),
+        row('blessed-loss', i18n.site.winPreventedBy50MoveRule),
+        row('draw', i18n.site.drawn),
+        row('cursed-win', i18n.site.lossSavedBy50MoveRule),
+        row('maybe-win', 'Loss or 50 moves'),
+        row('syzygy-win', i18n.site.lossOr50MovesByPriorMistake, i18n.site.unknownDueToRounding),
+        row('win', i18n.site.losing),
       ]);
     else if (data.checkmate) lastShow = showGameEnd(ctrl, i18n.site.checkmate);
     else if (data.stalemate) lastShow = showGameEnd(ctrl, i18n.site.stalemate);
@@ -289,7 +289,7 @@ function show(ctrl: AnalyseCtrl): MaybeVNode {
 const explorerTitle = (explorer: ExplorerCtrl) => {
   const db = explorer.db();
   const otherLink = (name: string, title: string) =>
-    h(
+    hl(
       'button.button-link',
       {
         key: name,
@@ -299,7 +299,7 @@ const explorerTitle = (explorer: ExplorerCtrl) => {
       name,
     );
   const playerLink = () =>
-    h(
+    hl(
       'button.button-link.player',
       {
         key: 'player',
@@ -318,7 +318,7 @@ const explorerTitle = (explorer: ExplorerCtrl) => {
       i18n.site.player,
     );
   const active = (nodes: LooseVNodes, title: string) =>
-    h(
+    hl(
       'span.active.text.' + db,
       {
         attrs: { title, ...dataIcon(licon.Book) },
@@ -331,22 +331,22 @@ const explorerTitle = (explorer: ExplorerCtrl) => {
     lichessDbExplanation = i18n.site.lichessDbExplanation;
   const data = explorer.current();
   const queuePosition = data && isOpening(data) && data.queuePosition;
-  return h('div.explorer-title', [
+  return hl('div.explorer-title', [
     db === 'masters'
-      ? active([h('strong', 'Masters'), ' database'], masterDbExplanation)
+      ? active([hl('strong', 'Masters'), ' database'], masterDbExplanation)
       : explorer.config.allDbs.includes('masters') && otherLink('Masters', masterDbExplanation),
     db === 'lichess'
-      ? active([h('strong', 'Lichess'), ' database'], lichessDbExplanation)
+      ? active([hl('strong', 'Lichess'), ' database'], lichessDbExplanation)
       : otherLink('Lichess', lichessDbExplanation),
     db === 'player'
       ? playerName
         ? active(
             [
-              h(`strong${playerName.length > 14 ? '.long' : ''}`, playerName),
+              hl(`strong${playerName.length > 14 ? '.long' : ''}`, playerName),
               ` ${i18n.site[explorer.config.data.color() === 'white' ? 'asWhite' : 'asBlack']}`,
               explorer.isIndexing() &&
                 !explorer.config.data.open() &&
-                h('i.ddloader', {
+                hl('i.ddloader', {
                   attrs: {
                     title: queuePosition
                       ? `Indexing ${queuePosition} other players first ...`
@@ -356,7 +356,7 @@ const explorerTitle = (explorer: ExplorerCtrl) => {
             ],
             i18n.site.switchSides,
           )
-        : active([h('strong', 'Player'), ' database'], '')
+        : active([hl('strong', 'Player'), ' database'], '')
       : playerLink(),
   ]);
 };
@@ -367,15 +367,15 @@ function showTitle(variant: Variant) {
 }
 
 function showConfig(ctrl: AnalyseCtrl): VNode {
-  return h('div.config', [explorerTitle(ctrl.explorer), ...renderConfig(ctrl.explorer.config)]);
+  return hl('div.config', [explorerTitle(ctrl.explorer), renderConfig(ctrl.explorer.config)]);
 }
 
 function showFailing(ctrl: AnalyseCtrl) {
-  return h('div.data.empty', [
-    h('div.title', showTitle(ctrl.data.game.variant)),
-    h('div.failing.message', [
-      h('h3', 'Oops, sorry!'),
-      h('p.explanation', ctrl.explorer.failing()?.toString()),
+  return hl('div.data.empty', [
+    hl('div.title', showTitle(ctrl.data.game.variant)),
+    hl('div.failing.message', [
+      hl('h3', 'Oops, sorry!'),
+      hl('p.explanation', ctrl.explorer.failing()?.toString()),
       closeButton(ctrl),
     ]),
   ]);
@@ -391,7 +391,7 @@ export default function (ctrl: AnalyseCtrl): VNode | undefined {
     configOpened = config.data.open(),
     loading = !configOpened && (explorer.loading() || (!data && !explorer.failing())),
     content = configOpened ? showConfig(ctrl) : explorer.failing() ? showFailing(ctrl) : show(ctrl);
-  return h(
+  return hl(
     `section.explorer-box.sub-box${configOpened ? '.explorer__config' : ''}`,
     {
       class: { loading, reduced: !configOpened && (!!explorer.failing() || explorer.movesAway() > 2) },
@@ -405,9 +405,9 @@ export default function (ctrl: AnalyseCtrl): VNode | undefined {
       },
     },
     [
-      h('div.overlay'),
+      hl('div.overlay'),
       content,
-      h('button.fbt.toconf', {
+      hl('button.fbt.toconf', {
         attrs: {
           'aria-label': configOpened ? 'Close configuration' : 'Open configuration',
           ...dataIcon(configOpened ? licon.X : licon.Gear),

--- a/ui/analyse/src/fork.ts
+++ b/ui/analyse/src/fork.ts
@@ -69,7 +69,7 @@ export function make(ctrl: AnalyseCtrl): ForkCtrl {
     },
     proceed(it) {
       if (displayed()) {
-        it = defined(it) ? it : hovering ? hovering : selected;
+        it = it ?? hovering ?? selected;
 
         const childNode = ctrl.node.children[it];
         if (defined(childNode)) {

--- a/ui/analyse/src/study/chapterNewForm.ts
+++ b/ui/analyse/src/study/chapterNewForm.ts
@@ -3,7 +3,7 @@ import { defined, prop, type Prop, toggle } from 'lib';
 import { type Dialog, snabDialog } from 'lib/view/dialog';
 import { alert } from 'lib/view/dialogs';
 import * as licon from 'lib/licon';
-import { bind, bindSubmit, onInsert, looseH as h, dataIcon, type VNode } from 'lib/snabbdom';
+import { bind, bindSubmit, onInsert, hl, dataIcon, type VNode } from 'lib/snabbdom';
 import { storedProp } from 'lib/storage';
 import { json as xhrJson, text as xhrText } from 'lib/xhr';
 import type AnalyseCtrl from '../ctrl';
@@ -115,7 +115,7 @@ export function view(ctrl: StudyChapterNewForm): VNode {
   const study = ctrl.root.study!;
   const activeTab = ctrl.tab();
   const makeTab = (key: ChapterTab, name: string, title: string) =>
-    h(
+    hl(
       'span.' + key,
       {
         class: { active: activeTab === key },
@@ -158,11 +158,11 @@ export function view(ctrl: StudyChapterNewForm): VNode {
     },
     vnodes: [
       activeTab !== 'edit' &&
-        h('h2', [
+        hl('h2', [
           i18n.study.newChapter,
-          h('i.help', { attrs: { 'data-icon': licon.InfoCircle }, hook: bind('click', ctrl.startTour) }),
+          hl('i.help', { attrs: { 'data-icon': licon.InfoCircle }, hook: bind('click', ctrl.startTour) }),
         ]),
-      h(
+      hl(
         'form.form3',
         {
           hook: bindSubmit(
@@ -181,9 +181,9 @@ export function view(ctrl: StudyChapterNewForm): VNode {
           ),
         },
         [
-          h('div.form-group', [
-            h('label.form-label', { attrs: { for: 'chapter-name' } }, i18n.site.name),
-            h('input#chapter-name.form-control', {
+          hl('div.form-group', [
+            hl('label.form-label', { attrs: { for: 'chapter-name' } }, i18n.site.name),
+            hl('input#chapter-name.form-control', {
               attrs: { minlength: 2, maxlength: 80 },
               hook: onInsert<HTMLInputElement>(el => {
                 if (!el.value) {
@@ -197,7 +197,7 @@ export function view(ctrl: StudyChapterNewForm): VNode {
               }),
             }),
           ]),
-          h('div.tabs-horiz', { attrs: { role: 'tablist' } }, [
+          hl('div.tabs-horiz', { attrs: { role: 'tablist' } }, [
             makeTab('init', i18n.study.empty, i18n.study.startFromInitialPosition),
             makeTab('edit', i18n.study.editor, i18n.study.startFromCustomPosition),
             makeTab('game', 'URL', i18n.study.loadAGameByUrl),
@@ -205,7 +205,7 @@ export function view(ctrl: StudyChapterNewForm): VNode {
             makeTab('pgn', 'PGN', i18n.study.loadAGameFromPgn),
           ]),
           activeTab === 'edit' &&
-            h(
+            hl(
               'div.board-editor-wrap',
               {
                 hook: {
@@ -232,13 +232,13 @@ export function view(ctrl: StudyChapterNewForm): VNode {
               [spinner()],
             ),
           activeTab === 'game' &&
-            h('div.form-group', [
-              h(
+            hl('div.form-group', [
+              hl(
                 'label.form-label',
                 { attrs: { for: 'chapter-game' } },
                 i18n.study.loadAGameFromXOrY('lichess.org', 'chessgames.com'),
               ),
-              h('textarea#chapter-game.form-control', {
+              hl('textarea#chapter-game.form-control', {
                 attrs: { placeholder: i18n.study.urlOfTheGame },
                 hook: onInsert((el: HTMLTextAreaElement) => {
                   el.addEventListener('change', () => el.reportValidity());
@@ -261,8 +261,8 @@ export function view(ctrl: StudyChapterNewForm): VNode {
               }),
             ]),
           activeTab === 'fen' &&
-            h('div.form-group', [
-              h('input#chapter-fen.form-control', {
+            hl('div.form-group', [
+              hl('input#chapter-fen.form-control', {
                 attrs: {
                   value: ctrl.root.node.fen,
                   placeholder: i18n.study.loadAPositionFromFen,
@@ -278,22 +278,22 @@ export function view(ctrl: StudyChapterNewForm): VNode {
                   });
                 }),
               }),
-              h(
+              hl(
                 'a.preview-in-editor',
                 {
                   hook: bind('click', () => ctrl.tab('edit'), ctrl.root.redraw),
                 },
-                [h('i.text', { attrs: dataIcon(licon.Eye) }), i18n.study.editor],
+                [hl('i.text', { attrs: dataIcon(licon.Eye) }), i18n.study.editor],
               ),
             ]),
           activeTab === 'pgn' &&
-            h('div.form-group', [
-              h('textarea#chapter-pgn.form-control', {
+            hl('div.form-group', [
+              hl('textarea#chapter-pgn.form-control', {
                 attrs: {
                   placeholder: i18n.study.pasteYourPgnTextHereUpToNbGames(ctrl.multiPgnMax),
                 },
               }),
-              h(
+              hl(
                 'button.button.button-empty.import-from__chapter',
                 {
                   attrs: { type: 'button' },
@@ -312,7 +312,7 @@ export function view(ctrl: StudyChapterNewForm): VNode {
                 i18n.study.importFromChapterX(study.currentChapter().name),
               ),
               window.FileReader &&
-                h('input#chapter-pgn-file.form-control', {
+                hl('input#chapter-pgn-file.form-control', {
                   attrs: { type: 'file', accept: '.pgn' },
                   hook: bind('change', e => {
                     const file = (e.target as HTMLInputElement).files![0];
@@ -326,10 +326,10 @@ export function view(ctrl: StudyChapterNewForm): VNode {
                   }),
                 }),
             ]),
-          h('div.form-split', [
-            h('div.form-group.form-half', [
-              h('label.form-label', { attrs: { for: 'chapter-variant' } }, i18n.site.variant),
-              h(
+          hl('div.form-split', [
+            hl('div.form-group.form-half', [
+              hl('label.form-label', { attrs: { for: 'chapter-variant' } }, i18n.site.variant),
+              hl(
                 'select#chapter-variant.form-control',
                 {
                   attrs: { disabled: gameOrPgn },
@@ -338,13 +338,13 @@ export function view(ctrl: StudyChapterNewForm): VNode {
                   }),
                 },
                 gameOrPgn
-                  ? [h('option', { attrs: { value: 'standard' } }, i18n.study.automatic)]
+                  ? [hl('option', { attrs: { value: 'standard' } }, i18n.study.automatic)]
                   : ctrl.variants.map(v => option(v.key, currentChapter.setup.variant.key, v.name)),
               ),
             ]),
-            h('div.form-group.form-half', [
-              h('label.form-label', { attrs: { for: 'chapter-orientation' } }, i18n.study.orientation),
-              h(
+            hl('div.form-group.form-half', [
+              hl('label.form-label', { attrs: { for: 'chapter-orientation' } }, i18n.study.orientation),
+              hl(
                 'select#chapter-orientation.form-control',
                 {
                   hook: bind('change', e => {
@@ -360,16 +360,16 @@ export function view(ctrl: StudyChapterNewForm): VNode {
               ),
             ]),
           ]),
-          h('div.form-group' + (ctrl.isBroadcast ? '.none' : ''), [
-            h('label.form-label', { attrs: { for: 'chapter-mode' } }, i18n.study.analysisMode),
-            h(
+          hl('div.form-group' + (ctrl.isBroadcast ? '.none' : ''), [
+            hl('label.form-label', { attrs: { for: 'chapter-mode' } }, i18n.study.analysisMode),
+            hl(
               'select#chapter-mode.form-control',
               modeChoices.map(c => option(c[0], mode, c[1])),
             ),
           ]),
-          h(
+          hl(
             'div.form-actions.single',
-            h('button.button', { attrs: { type: 'submit' } }, i18n.study.createChapter),
+            hl('button.button', { attrs: { type: 'submit' } }, i18n.study.createChapter),
           ),
         ],
       ),

--- a/ui/analyse/src/study/description.ts
+++ b/ui/analyse/src/study/description.ts
@@ -1,5 +1,5 @@
 import * as licon from 'lib/licon';
-import { type VNode, bind, onInsert, looseH as h } from 'lib/snabbdom';
+import { type VNode, bind, onInsert, hl } from 'lib/snabbdom';
 import { richHTML } from 'lib/richText';
 import type StudyCtrl from './studyCtrl';
 import { confirm } from 'lib/view/dialogs';
@@ -34,17 +34,17 @@ export function view(study: StudyCtrl, chapter: boolean): VNode | undefined {
   if (desc.edit) return edit(desc, chapter ? study.data.chapter.id : study.data.id, chapter);
   const isEmpty = desc.text === '-';
   if (!desc.text || (isEmpty && !contrib)) return;
-  return h(`div.study-desc${chapter ? '.chapter-desc' : ''}${isEmpty ? '.empty' : ''}`, [
+  return hl(`div.study-desc${chapter ? '.chapter-desc' : ''}${isEmpty ? '.empty' : ''}`, [
     contrib &&
       !isEmpty &&
-      h('div.contrib', [
-        h('span', descTitle(chapter)),
+      hl('div.contrib', [
+        hl('span', descTitle(chapter)),
         !isEmpty &&
-          h('a', {
+          hl('a', {
             attrs: { 'data-icon': licon.Pencil, title: 'Edit' },
             hook: bind('click', () => (desc.edit = true), desc.redraw),
           }),
-        h('a', {
+        hl('a', {
           attrs: { 'data-icon': licon.Trash, title: 'Delete' },
           hook: bind('click', async () => {
             if (await confirm('Delete permanent description?')) desc.save('');
@@ -52,23 +52,27 @@ export function view(study: StudyCtrl, chapter: boolean): VNode | undefined {
         }),
       ]),
     isEmpty
-      ? h('a.text.button', { hook: bind('click', () => (desc.edit = true), desc.redraw) }, descTitle(chapter))
-      : h('div.text', { hook: richHTML(desc.text) }),
+      ? hl(
+          'a.text.button',
+          { hook: bind('click', () => (desc.edit = true), desc.redraw) },
+          descTitle(chapter),
+        )
+      : hl('div.text', { hook: richHTML(desc.text) }),
   ]);
 }
 
 const edit = (ctrl: DescriptionCtrl, id: string, chapter: boolean): VNode =>
-  h('div.study-desc-form', [
-    h('div.title', [
+  hl('div.study-desc-form', [
+    hl('div.title', [
       descTitle(chapter),
-      h('button.button.button-empty.button-green', {
+      hl('button.button.button-empty.button-green', {
         attrs: { 'data-icon': licon.Checkmark, title: 'Save and close' },
         hook: bind('click', () => (ctrl.edit = false), ctrl.redraw),
       }),
     ]),
-    h('form.form3', [
-      h('div.form-group', [
-        h('textarea#form-control.desc-text.' + id, {
+    hl('form.form3', [
+      hl('div.form-group', [
+        hl('textarea#form-control.desc-text.' + id, {
           hook: onInsert<HTMLInputElement>(el => {
             el.value = ctrl.text === '-' ? '' : ctrl.text || '';
             el.oninput = () => ctrl.save(el.value.trim());

--- a/ui/analyse/src/study/gamebook/gamebookButtons.ts
+++ b/ui/analyse/src/study/gamebook/gamebookButtons.ts
@@ -1,5 +1,5 @@
 import * as licon from 'lib/licon';
-import { bind, dataIcon, type VNode, looseH as h } from 'lib/snabbdom';
+import { bind, dataIcon, type VNode, hl } from 'lib/snabbdom';
 import type AnalyseCtrl from '../../ctrl';
 import type StudyCtrl from '../studyCtrl';
 
@@ -10,9 +10,9 @@ export function playButtons(root: AnalyseCtrl): VNode | undefined {
   const state = ctrl.state,
     fb = state.feedback,
     myTurn = fb === 'play';
-  return h('div.gamebook-buttons', [
+  return hl('div.gamebook-buttons', [
     root.path &&
-      h(
+      hl(
         'button.fbt.text.back',
         {
           attrs: { 'data-icon': licon.LessThan, type: 'button' },
@@ -21,7 +21,7 @@ export function playButtons(root: AnalyseCtrl): VNode | undefined {
         i18n.study.back,
       ),
     myTurn &&
-      h(
+      hl(
         'button.fbt.text.solution',
         {
           attrs: { 'data-icon': licon.PlayTriangle, type: 'button' },
@@ -37,7 +37,7 @@ export function overrideButton(study: StudyCtrl): VNode | undefined {
   if (study.data.chapter.gamebook) {
     const o = study.vm.gamebookOverride;
     if (study.members.canContribute())
-      return h(
+      return hl(
         'button.fbt.text.preview',
         {
           class: { active: o === 'play' },
@@ -54,7 +54,7 @@ export function overrideButton(study: StudyCtrl): VNode | undefined {
       const isAnalyse = o === 'analyse',
         ctrl = study.gamebookPlay;
       if (isAnalyse || (ctrl && ctrl.state.feedback === 'end'))
-        return h(
+        return hl(
           'a.fbt.text.preview',
           {
             class: { active: isAnalyse },

--- a/ui/analyse/src/study/gamebook/gamebookPlayView.ts
+++ b/ui/analyse/src/study/gamebook/gamebookPlayView.ts
@@ -1,16 +1,16 @@
 import GamebookPlayCtrl, { type State } from './gamebookPlayCtrl';
 import * as licon from 'lib/licon';
-import { type VNode, iconTag, bind, dataIcon, looseH as h } from 'lib/snabbdom';
+import { type VNode, iconTag, bind, dataIcon, hl } from 'lib/snabbdom';
 import { richHTML } from 'lib/richText';
 
 export function render(ctrl: GamebookPlayCtrl): VNode {
   const state = ctrl.state;
-  return h('div.gamebook', { hook: { insert: _ => site.asset.loadCssPath('analyse.gamebook.play') } }, [
+  return hl('div.gamebook', { hook: { insert: _ => site.asset.loadCssPath('analyse.gamebook.play') } }, [
     (state.comment || state.feedback === 'play' || state.feedback === 'end') &&
-      h('div.comment', { class: { hinted: state.showHint } }, [
+      hl('div.comment', { class: { hinted: state.showHint } }, [
         state.comment
-          ? h('div.content', { hook: richHTML(state.comment) })
-          : h(
+          ? hl('div.content', { hook: richHTML(state.comment) })
+          : hl(
               'div.content',
               state.feedback === 'play'
                 ? i18n.study.whatWouldYouPlay
@@ -18,9 +18,9 @@ export function render(ctrl: GamebookPlayCtrl): VNode {
             ),
         hintZone(ctrl),
       ]),
-    h('div.floor', [
+    hl('div.floor', [
       renderFeedback(ctrl, state),
-      h('img.mascot', {
+      hl('img.mascot', {
         attrs: { width: 120, height: 120, src: site.asset.url('images/mascot/octopus.svg') },
       }),
     ]),
@@ -30,8 +30,8 @@ export function render(ctrl: GamebookPlayCtrl): VNode {
 function hintZone(ctrl: GamebookPlayCtrl) {
   const state = ctrl.state,
     buttonData = () => ({ attrs: { type: 'button' }, hook: bind('click', ctrl.hint, ctrl.redraw) });
-  if (state.showHint) return h('button', buttonData(), [h('div.hint', { hook: richHTML(state.hint!) })]);
-  if (state.hint) return h('button.hint', buttonData(), i18n.site.getAHint);
+  if (state.showHint) return hl('button', buttonData(), [hl('div.hint', { hook: richHTML(state.hint!) })]);
+  if (state.hint) return hl('button.hint', buttonData(), i18n.site.getAHint);
   return undefined;
 }
 
@@ -39,27 +39,30 @@ function renderFeedback(ctrl: GamebookPlayCtrl, state: State) {
   const fb = state.feedback,
     color = ctrl.root.turnColor();
   if (fb === 'bad')
-    return h(
+    return hl(
       'button.feedback.act.bad' + (state.comment ? '.com' : ''),
       { attrs: { type: 'button' }, hook: bind('click', ctrl.retry) },
-      [iconTag(licon.Reload), h('span', i18n.site.retry)],
+      [iconTag(licon.Reload), hl('span', i18n.site.retry)],
     );
   if (fb === 'good' && state.comment)
-    return h('button.feedback.act.good.com', { attrs: { type: 'button' }, hook: bind('click', ctrl.next) }, [
-      h('span.text', { attrs: dataIcon(licon.PlayTriangle) }, i18n.study.next),
-      h('kbd', '<space>'),
+    return hl('button.feedback.act.good.com', { attrs: { type: 'button' }, hook: bind('click', ctrl.next) }, [
+      hl('span.text', { attrs: dataIcon(licon.PlayTriangle) }, i18n.study.next),
+      hl('kbd', '<space>'),
     ]);
   if (fb === 'end') return renderEnd(ctrl);
-  return h(
+  return hl(
     'div.feedback.info.' + fb + (state.init ? '.init' : ''),
-    h(
+    hl(
       'div',
       fb === 'play'
         ? [
-            h('div.no-square', h('piece.king.' + color)),
-            h('div.instruction', [
-              h('strong', i18n.site.yourTurn),
-              h('em', i18n.puzzle[color === 'white' ? 'findTheBestMoveForWhite' : 'findTheBestMoveForBlack']),
+            hl('div.no-square', hl('piece.king.' + color)),
+            hl('div.instruction', [
+              hl('strong', i18n.site.yourTurn),
+              hl(
+                'em',
+                i18n.puzzle[color === 'white' ? 'findTheBestMoveForWhite' : 'findTheBestMoveForBlack'],
+              ),
             ]),
           ]
         : i18n.study.goodMove,
@@ -69,9 +72,9 @@ function renderFeedback(ctrl: GamebookPlayCtrl, state: State) {
 
 function renderEnd(ctrl: GamebookPlayCtrl) {
   const study = ctrl.root.study!;
-  return h('div.feedback.end', [
+  return hl('div.feedback.end', [
     study.nextChapter() &&
-      h(
+      hl(
         'button.next.text',
         {
           attrs: { 'data-icon': licon.PlayTriangle, type: 'button' },
@@ -79,7 +82,7 @@ function renderEnd(ctrl: GamebookPlayCtrl) {
         },
         i18n.study.nextChapter,
       ),
-    h(
+    hl(
       'button.retry',
       {
         attrs: { 'data-icon': licon.Reload, type: 'button' },
@@ -87,7 +90,7 @@ function renderEnd(ctrl: GamebookPlayCtrl) {
       },
       i18n.study.playAgain,
     ),
-    h(
+    hl(
       'button.analyse',
       {
         attrs: { 'data-icon': licon.Microscope, type: 'button' },

--- a/ui/analyse/src/study/multiCloudEval.ts
+++ b/ui/analyse/src/study/multiCloudEval.ts
@@ -2,7 +2,7 @@ import { type Prop, defined } from 'lib';
 import type { EvalHitMulti } from '../interfaces';
 import { storedBooleanPropWithEffect } from 'lib/storage';
 import { povChances } from 'lib/ceval/winningChances';
-import { type VNode, bind, looseH as h } from 'lib/snabbdom';
+import { type VNode, bind, hl } from 'lib/snabbdom';
 import type { StudyChapters } from './studyChapters';
 import { debounce } from 'lib/async';
 import type { ServerNodeMsg } from './interfaces';
@@ -94,7 +94,7 @@ export class MultiCloudEval {
 }
 
 export const renderEvalToggle = (ctrl: MultiCloudEval): VNode =>
-  h('input', {
+  hl('input', {
     attrs: { type: 'checkbox', checked: ctrl.showEval() },
     hook: bind('change', e => ctrl.showEval((e.target as HTMLInputElement).checked)),
   });

--- a/ui/analyse/src/study/playerBars.ts
+++ b/ui/analyse/src/study/playerBars.ts
@@ -1,5 +1,5 @@
 import type { VNode } from 'snabbdom';
-import { looseH as h } from 'lib/snabbdom';
+import { hl } from 'lib/snabbdom';
 import renderClocks from '../view/clocks';
 import type AnalyseCtrl from '../ctrl';
 import { renderMaterialDiffs } from '../view/components';
@@ -67,22 +67,22 @@ function renderPlayer(
     rating = showRatings && player?.rating,
     result = showResult && resultOf(tags, color === 'white'),
     top = ctrl.bottomColor() !== color;
-  return h(`div.study__player.study__player-${top ? 'top' : 'bot'}`, { class: { ticking } }, [
-    h('div.left', [
-      result && h(`${resultTag(result)}.result`, result),
-      h('span.info', [
-        team ? h('span.team', team) : undefined,
+  return hl(`div.study__player.study__player-${top ? 'top' : 'bot'}`, { class: { ticking } }, [
+    hl('div.left', [
+      result && hl(`${resultTag(result)}.result`, result),
+      hl('span.info', [
+        team ? hl('span.team', team) : undefined,
         playerFed(player?.fed),
         player && userTitle(player),
         player &&
           (relayPlayers
-            ? h(`a.name.relay-player-${color}`, relayPlayers.playerLinkConfig(player), player.name)
-            : h(
+            ? hl(`a.name.relay-player-${color}`, relayPlayers.playerLinkConfig(player), player.name)
+            : hl(
                 fideId ? 'a.name' : 'span.name',
                 { attrs: fidePageLinkAttrs(player, ctrl.isEmbed) },
                 player.name,
               )),
-        rating && h('span.elo', `${rating}`),
+        rating && hl('span.elo', `${rating}`),
       ]),
     ]),
     materialDiffs[top ? 0 : 1],
@@ -92,7 +92,7 @@ function renderPlayer(
 
 export const playerFed = (fed?: Federation): VNode | undefined =>
   fed &&
-  h('img.mini-game__flag', {
+  hl('img.mini-game__flag', {
     attrs: {
       src: site.asset.url(`images/fide-fed-webp/${fed.id}.webp`),
       title: `Federation: ${fed.name}`,

--- a/ui/analyse/src/study/relay/liveboardPlugin.ts
+++ b/ui/analyse/src/study/relay/liveboardPlugin.ts
@@ -1,4 +1,4 @@
-import { looseH as h, VNode } from 'lib/snabbdom';
+import { hl, VNode } from 'lib/snabbdom';
 import { getChessground, initMiniBoardWith } from 'lib/view/miniBoard';
 import { fenColor, uciToMove } from 'lib/game/chess';
 import { type ChatPlugin } from 'lib/chat/interfaces';
@@ -58,7 +58,7 @@ export class LiveboardPlugin implements ChatPlugin {
     this.board.orientation = this.ctrl.bottomColor();
     this.animate = true;
 
-    return h('div.chat-liveboard', {
+    return hl('div.chat-liveboard', {
       hook: {
         insert: (vn: VNode) => initMiniBoardWith(vn.elm as HTMLElement, this.board!),
         update: (_, vn: VNode) => {

--- a/ui/analyse/src/study/relay/relayManagerView.ts
+++ b/ui/analyse/src/study/relay/relayManagerView.ts
@@ -1,5 +1,5 @@
 import * as licon from 'lib/licon';
-import { looseH as h, bind, onInsert, dataIcon, type MaybeVNode } from 'lib/snabbdom';
+import { hl, bind, onInsert, dataIcon, type MaybeVNode } from 'lib/snabbdom';
 import type { LogEvent } from './interfaces';
 import type RelayCtrl from './relayCtrl';
 import { memoize } from 'lib';
@@ -10,28 +10,27 @@ export default function (ctrl: RelayCtrl, study: StudyCtrl): MaybeVNode {
   const contributor = study.members.canContribute(),
     sync = ctrl.data.sync;
   return contributor || study.data.admin
-    ? h('div.relay-admin__container', [
-        contributor
-          ? h('div.relay-admin', { hook: onInsert(_ => site.asset.loadCssPath('analyse.relay-admin')) }, [
-              h('h2', [
-                h('span.text', { attrs: dataIcon(licon.RadioTower) }, 'Broadcast manager'),
-                h('a', {
-                  attrs: { href: `/broadcast/round/${study.data.id}/edit`, 'data-icon': licon.Gear },
-                }),
-              ]),
-              sync?.url || sync?.ids || sync?.urls || sync?.users
-                ? (sync.ongoing ? stateOn : stateOff)(ctrl)
-                : statePush(),
-              renderLog(ctrl),
-            ])
-          : undefined,
-        contributor || study.data.admin ? studyViewSide(study, false) : undefined,
+    ? hl('div.relay-admin__container', [
+        contributor &&
+          hl('div.relay-admin', { hook: onInsert(_ => site.asset.loadCssPath('analyse.relay-admin')) }, [
+            hl('h2', [
+              hl('span.text', { attrs: dataIcon(licon.RadioTower) }, 'Broadcast manager'),
+              hl('a', {
+                attrs: { href: `/broadcast/round/${study.data.id}/edit`, 'data-icon': licon.Gear },
+              }),
+            ]),
+            sync?.url || sync?.ids || sync?.urls || sync?.users
+              ? (sync.ongoing ? stateOn : stateOff)(ctrl)
+              : statePush(),
+            renderLog(ctrl),
+          ]),
+        (contributor || study.data.admin) && studyViewSide(study, false),
       ])
     : undefined;
 }
 
 const logSuccess = (e: LogEvent) =>
-  e.moves ? [h('strong', '' + e.moves), ` new move${e.moves > 1 ? 's' : ''}`] : ['Nothing new'];
+  e.moves ? [hl('strong', '' + e.moves), ` new move${e.moves > 1 ? 's' : ''}`] : ['Nothing new'];
 
 function renderLog(ctrl: RelayCtrl) {
   const url = ctrl.data.sync?.url;
@@ -40,59 +39,55 @@ function renderLog(ctrl: RelayCtrl) {
     .reverse()
     .map(e => {
       const err =
-        e.error && h('a', url ? { attrs: { href: url, target: '_blank', rel: 'nofollow' } } : {}, e.error);
-      return h(
+        e.error && hl('a', url ? { attrs: { href: url, target: '_blank', rel: 'nofollow' } } : {}, e.error);
+      return hl(
         'div' + (err ? '.err' : ''),
         { key: e.at, attrs: dataIcon(err ? licon.CautionCircle : licon.Checkmark) },
-        [h('div', [...(err ? [err] : logSuccess(e)), h('time', dateFormatter()(new Date(e.at)))])],
+        [hl('div', [err ? [err] : logSuccess(e), hl('time', dateFormatter()(new Date(e.at)))])],
       );
     });
-  if (ctrl.loading()) logLines.unshift(h('div.load', [h('i.ddloader'), 'Polling source...']));
-  return h('div.log', logLines);
+  if (ctrl.loading()) logLines.unshift(hl('div.load', [hl('i.ddloader'), 'Polling source...']));
+  return hl('div.log', logLines);
 }
 
 function stateOn(ctrl: RelayCtrl) {
   const sync = ctrl.data.sync;
-  return h(
+  return hl(
     'div.state.on.clickable',
     { hook: bind('click', _ => ctrl.setSync(false)), attrs: dataIcon(licon.ChasingArrows) },
     [
-      h('div', [
+      hl('div', [
         'Connected ',
-        ...(sync
-          ? [
-              sync.delay ? `with ${sync.delay}s delay ` : null,
-              ...(sync.url
-                ? ['to source', h('br'), sync.url.replace(/https?:\/\//, '')]
-                : sync.ids
-                  ? ['to', h('br'), sync.ids.length, ' game(s)']
-                  : sync.users
-                    ? [
-                        'to',
-                        h('br'),
-                        sync.users.length > 4 ? `${sync.users.length} users` : sync.users.join(' '),
-                      ]
-                    : sync.urls
-                      ? ['to', h('br'), sync.urls.length, ' sources']
-                      : []),
-              sync.filter ? ` (round ${sync.filter})` : null,
-              sync.slices ? ` (slice ${sync.slices})` : null,
-            ]
-          : []),
+        sync && [
+          !!sync.delay && `with ${sync.delay}s delay `,
+          sync.url
+            ? ['to source', hl('br'), sync.url.replace(/https?:\/\//, '')]
+            : sync.ids
+              ? ['to', hl('br'), sync.ids.length, ' game(s)']
+              : sync.users
+                ? [
+                    'to',
+                    hl('br'),
+                    sync.users.length > 4 ? `${sync.users.length} users` : sync.users.join(' '),
+                  ]
+                : sync.urls && ['to', hl('br'), sync.urls.length, ' sources'],
+          !!sync.filter && ` (round ${sync.filter})`,
+          !!sync.slices && ` (slice ${sync.slices})`,
+        ],
       ]),
     ],
   );
 }
 
 const stateOff = (ctrl: RelayCtrl) =>
-  h(
+  hl(
     'div.state.off.clickable',
     { hook: bind('click', _ => ctrl.setSync(true)), attrs: dataIcon(licon.PlayTriangle) },
-    [h('div.fat', 'Click to connect')],
+    [hl('div.fat', 'Click to connect')],
   );
 
 const statePush = () =>
-  h('div.state.push', { attrs: dataIcon(licon.UploadCloud) }, ['Listening to Broadcaster App']);
+  hl('div.state.push', { attrs: dataIcon(licon.UploadCloud) }, ['Listening to Broadcaster App']);
 
 const dateFormatter = memoize(
   () =>

--- a/ui/analyse/src/study/relay/relayPlayers.ts
+++ b/ui/analyse/src/study/relay/relayPlayers.ts
@@ -1,4 +1,4 @@
-import { type Redraw, type VNode, bind, dataIcon, looseH as h, onInsert } from 'lib/snabbdom';
+import { type VNode, bind, dataIcon, hl, onInsert } from 'lib/snabbdom';
 import { json as xhrJson } from 'lib/xhr';
 import * as licon from 'lib/licon';
 import { spinnerVdom as spinner } from 'lib/view/controls';
@@ -133,63 +133,57 @@ const playerView = (ctrl: RelayPlayers, show: PlayerToShow, tour: RelayTour): VN
   const tc = tour.info.fideTc || 'standard';
   const age: number | undefined = p?.fide?.year && year - p.fide.year;
   const fidePageData = p && { attrs: fidePageLinkAttrs(p, ctrl.isEmbed) };
-  return h(
+  return hl(
     'div.relay-tour__player',
     {
       class: { loading: !show.player },
     },
     p
       ? [
-          h(`a.relay-tour__player__name`, fidePageData, [userTitle(p), p.name]),
+          hl(`a.relay-tour__player__name`, fidePageData, [userTitle(p), p.name]),
           p.team
-            ? h('div.relay-tour__player__team.text', { attrs: dataIcon(licon.Group) }, p.team)
+            ? hl('div.relay-tour__player__team.text', { attrs: dataIcon(licon.Group) }, p.team)
             : undefined,
-          h('div.relay-tour__player__cards', [
-            ...(p.fide?.ratings
-              ? ratingCategs.map(([key, name]) =>
-                  h(`div.relay-tour__player__card${key === tc ? '.active' : ''}`, [
-                    h('em', name),
-                    h('span', [p.fide?.ratings[key] || '-']),
-                  ]),
-                )
-              : []),
-            age
-              ? h('div.relay-tour__player__card', [h('em', i18n.broadcast.ageThisYear), h('span', [age])])
-              : undefined,
-            p.fed
-              ? h('div.relay-tour__player__card', [
-                  h('em', i18n.broadcast.federation),
-                  h('a.relay-tour__player__fed', { attrs: { href: `/fide/federation/${p.fed.name}` } }, [
-                    h('img.mini-game__flag', {
-                      attrs: { src: site.asset.url(`images/fide-fed-webp/${p.fed.id}.webp`) },
-                    }),
-                    p.fed.name,
-                  ]),
-                ])
-              : undefined,
-            p.fideId
-              ? h('div.relay-tour__player__card', [
-                  h('em', 'FIDE ID'),
-                  h('a', fidePageData, p.fideId.toString()),
-                ])
-              : undefined,
-            p.score
-              ? h('div.relay-tour__player__card', [
-                  h('em', i18n.broadcast.score),
-                  h('span', [p.score, ' / ', p.played]),
-                ])
-              : undefined,
-            p.performance
-              ? h('div.relay-tour__player__card', [
-                  h('em', i18n.site.performance),
-                  h('span', [p.performance, p.games.length < 4 ? '?' : '']),
-                ])
-              : undefined,
-            p.ratingDiff &&
-              h('div.relay-tour__player__card', [h('em', i18n.broadcast.ratingDiff), ratingDiff(p)]),
+          hl('div.relay-tour__player__cards', [
+            p.fide?.ratings &&
+              ratingCategs.map(([key, name]) =>
+                hl(`div.relay-tour__player__card${key === tc ? '.active' : ''}`, [
+                  hl('em', name),
+                  hl('span', [p.fide?.ratings[key] || '-']),
+                ]),
+              ),
+            !!age &&
+              hl('div.relay-tour__player__card', [hl('em', i18n.broadcast.ageThisYear), hl('span', [age])]),
+            p.fed &&
+              hl('div.relay-tour__player__card', [
+                hl('em', i18n.broadcast.federation),
+                hl('a.relay-tour__player__fed', { attrs: { href: `/fide/federation/${p.fed.name}` } }, [
+                  hl('img.mini-game__flag', {
+                    attrs: { src: site.asset.url(`images/fide-fed-webp/${p.fed.id}.webp`) },
+                  }),
+                  p.fed.name,
+                ]),
+              ]),
+            !!p.fideId &&
+              hl('div.relay-tour__player__card', [
+                hl('em', 'FIDE ID'),
+                hl('a', fidePageData, p.fideId.toString()),
+              ]),
+            p.score !== undefined &&
+              hl('div.relay-tour__player__card', [
+                hl('em', i18n.broadcast.score),
+                hl('span', [p.score, ' / ', p.played]),
+              ]),
+            !!p.performance &&
+              hl('div.relay-tour__player__card', [
+                hl('em', i18n.site.performance),
+                hl('span', [p.performance, p.games.length < 4 ? '?' : '']),
+              ]),
+            p.ratingDiff !== undefined &&
+              hl('div.relay-tour__player__card', [hl('em', i18n.broadcast.ratingDiff), ratingDiff(p)]),
           ]),
-          h('table.relay-tour__player__games.slist.slist-pad', [
-            h('thead', h('tr', h('td', { attrs: { colspan: 69 } }, i18n.broadcast.gamesThisTournament))),
+          hl('table.relay-tour__player__games.slist.slist-pad', [
+            hl('thead', hl('tr', hl('td', { attrs: { colspan: 69 } }, i18n.broadcast.gamesThisTournament))),
             renderPlayerGames(ctrl, p, true),
           ]),
         ]
@@ -198,7 +192,7 @@ const playerView = (ctrl: RelayPlayers, show: PlayerToShow, tour: RelayTour): VN
 };
 
 const playersList = (ctrl: RelayPlayers): VNode =>
-  h(
+  hl(
     'div.relay-tour__players',
     {
       class: { loading: ctrl.loading, nodata: !ctrl.players },
@@ -211,50 +205,48 @@ const playersList = (ctrl: RelayPlayers): VNode =>
 
 const renderPlayers = (ctrl: RelayPlayers, players: RelayPlayer[]): VNode => {
   const withRating = !!players.find(p => p.rating);
-  const withScores = !!players.find(p => p.score);
+  const withScores = !!players.find(p => p.score !== undefined);
   const defaultSort = { attrs: { 'data-sort-default': 1 } };
   const sortByBoth = (x?: number, y?: number) => ({
     attrs: { 'data-sort': (x || 0) * 100000 + (y || 0) },
   });
-  return h(
+  return hl(
     'table.relay-tour__players.slist.slist-invert.slist-pad',
     {
       hook: onInsert(tableAugment),
     },
     [
-      h(
+      hl(
         'thead',
-        h('tr', [
-          h('th', i18n.site.player),
-          withRating ? h('th', !withScores && defaultSort, 'Elo') : undefined,
-          withScores ? h('th', defaultSort, i18n.broadcast.score) : undefined,
-          h('th', i18n.site.games),
+        hl('tr', [
+          hl('th', i18n.site.player),
+          withRating && hl('th', !withScores && defaultSort, 'Elo'),
+          withScores && hl('th', defaultSort, i18n.broadcast.score),
+          hl('th', i18n.site.games),
         ]),
       ),
-      h(
+      hl(
         'tbody',
         players.map(player =>
-          h('tr', [
-            h(
+          hl('tr', [
+            hl(
               'td.player-name',
               { attrs: { 'data-sort': player.name || '' } },
-              h('a', playerLinkConfig(ctrl, player, true), [
+              hl('a', playerLinkConfig(ctrl, player, true), [
                 playerFed(player.fed),
                 userTitle(player),
                 player.name,
               ]),
             ),
-            withRating
-              ? h(
-                  'td',
-                  sortByBoth(player.rating, (player.score || 0) * 10),
-                  player.rating ? [`${player.rating}`, ratingDiff(player)] : undefined,
-                )
-              : undefined,
-            withScores
-              ? h('td', sortByBoth((player.score || 0) * 10, player.rating), `${player.score ?? 0}`)
-              : undefined,
-            h('td', sortByBoth(player.played, player.rating), `${player.played}`),
+            withRating &&
+              hl(
+                'td',
+                sortByBoth(player.rating, (player.score || 0) * 10),
+                !!player.rating && [`${player.rating}`, ratingDiff(player)],
+              ),
+            withScores &&
+              hl('td', sortByBoth((player.score || 0) * 10, player.rating), `${player.score ?? 0}`),
+            hl('td', sortByBoth(player.played, player.rating), `${player.played ?? 0}`),
           ]),
         ),
       ),
@@ -284,7 +276,7 @@ export const playerLinkHook = (ctrl: RelayPlayers, player: RelayPlayer, withTip:
                 ctrl.loadPlayerWithGames(id).then((p: RelayPlayerWithGames) => {
                   const vdom = renderPlayerTipWithGames(ctrl, p);
                   tipEl.innerHTML = '';
-                  patch(tipEl, h(`div#${playerTipId}`, vdom));
+                  patch(tipEl, hl(`div#${playerTipId}`, vdom));
                   $.powerTip.reposition(el);
                 });
               },
@@ -313,26 +305,23 @@ export const fidePageLinkAttrs = (p: StudyPlayer, blank?: boolean): Attrs | unde
 const isRelayPlayer = (p: StudyPlayer | RelayPlayer): p is RelayPlayer => 'score' in p;
 
 const renderPlayerTipHead = (ctrl: RelayPlayers, p: StudyPlayer | RelayPlayer): VNode =>
-  h('div.tpp__player', [
-    h(`a.tpp__player__name`, playerLinkConfig(ctrl, p, false), [userTitle(p), p.name]),
-    p.team ? h('div.tpp__player__team', p.team) : undefined,
-    h('div.tpp__player__info', [
-      h('div', [
-        playerFed(p.fed),
-        ...(p.rating ? [`${p.rating}`, isRelayPlayer(p) ? ratingDiff(p) : undefined] : []),
-      ]),
-      isRelayPlayer(p) && p.score !== undefined ? h('div', `${p.score}`) : undefined,
+  hl('div.tpp__player', [
+    hl(`a.tpp__player__name`, playerLinkConfig(ctrl, p, false), [userTitle(p), p.name]),
+    p.team && hl('div.tpp__player__team', p.team),
+    hl('div.tpp__player__info', [
+      hl('div', [playerFed(p.fed), !!p.rating && [`${p.rating}`, isRelayPlayer(p) && ratingDiff(p)]]),
+      isRelayPlayer(p) && p.score !== undefined && hl('div', `${p.score}`),
     ]),
   ]);
 
 const renderPlayerTipWithGames = (ctrl: RelayPlayers, p: RelayPlayerWithGames): VNode =>
-  h('div.tpp', [
+  hl('div.tpp', [
     renderPlayerTipHead(ctrl, p),
-    h('div.tpp__games', h('table', renderPlayerGames(ctrl, p, false))),
+    hl('div.tpp__games', hl('table', renderPlayerGames(ctrl, p, false))),
   ]);
 
 const renderPlayerGames = (ctrl: RelayPlayers, p: RelayPlayerWithGames, withTips: boolean): VNode =>
-  h(
+  hl(
     'tbody',
     p.games.map((game, i) => {
       const op = game.opponent;
@@ -344,8 +333,8 @@ const renderPlayerGames = (ctrl: RelayPlayers, p: RelayPlayerWithGames, withTips
           ? formatPointsStr(points)
           : `${formatPointsStr(points)} (${customPoints})`;
       const pointsVnode = (points: PointsStr, customPoints: number | undefined): VNode =>
-        h(points === '1' ? 'good' : points === '0' ? 'bad' : 'span', formatPoints(points, customPoints));
-      return h(
+        hl(points === '1' ? 'good' : points === '0' ? 'bad' : 'span', formatPoints(points, customPoints));
+      return hl(
         'tr',
         {
           hook: bind('click', e => {
@@ -356,10 +345,10 @@ const renderPlayerGames = (ctrl: RelayPlayers, p: RelayPlayerWithGames, withTips
           }),
         },
         [
-          h('td', `${i + 1}`),
-          h(
+          hl('td', `${i + 1}`),
+          hl(
             'td',
-            h(
+            hl(
               'a',
               {
                 hook: withTips ? playerLinkHook(ctrl, op, true) : {},
@@ -368,10 +357,10 @@ const renderPlayerGames = (ctrl: RelayPlayers, p: RelayPlayerWithGames, withTips
               [playerFed(op.fed), userTitle(op), op.name],
             ),
           ),
-          h('td', op.rating?.toString()),
-          h('td.is.color-icon.' + game.color),
-          h('td.tpp__games__status', points !== undefined ? pointsVnode(points, customPoints) : '*'),
-          h('td', defined(game.ratingDiff) ? ratingDiff(game) : undefined),
+          hl('td', op.rating?.toString()),
+          hl('td.is.color-icon.' + game.color),
+          hl('td.tpp__games__status', points !== undefined ? pointsVnode(points, customPoints) : '*'),
+          hl('td', defined(game.ratingDiff) ? ratingDiff(game) : undefined),
         ],
       );
     }),
@@ -382,10 +371,10 @@ const ratingDiff = (p: RelayPlayer | RelayPlayerGame) => {
   return !defined(rd)
     ? undefined
     : rd > 0
-      ? h('good.rp', '+' + rd)
+      ? hl('good.rp', '+' + rd)
       : rd < 0
-        ? h('bad.rp', '−' + -rd)
-        : h('span.rp--same', ' ==');
+        ? hl('bad.rp', '−' + -rd)
+        : hl('span.rp--same', ' ==');
 };
 
 const tableAugment = (el: HTMLTableElement) => {

--- a/ui/analyse/src/study/relay/relayStats.ts
+++ b/ui/analyse/src/study/relay/relayStats.ts
@@ -1,4 +1,3 @@
-import type { Redraw } from 'lib/snabbdom';
 import { spinnerVdom as spinner } from 'lib/view/controls';
 import type { RelayRound } from './interfaces';
 import { json as xhrJson } from 'lib/xhr';

--- a/ui/analyse/src/study/relay/relayTeams.ts
+++ b/ui/analyse/src/study/relay/relayTeams.ts
@@ -1,4 +1,4 @@
-import { type MaybeVNodes, type Redraw, type VNode, onInsert, looseH as h } from 'lib/snabbdom';
+import { type MaybeVNodes, type VNode, onInsert, hl } from 'lib/snabbdom';
 import { json as xhrJson } from 'lib/xhr';
 import type { RoundId } from './interfaces';
 import type { ChapterId, ChapterPreview, StudyPlayer, ChapterSelect, StatusStr } from '../interfaces';
@@ -48,7 +48,7 @@ export default class RelayTeams {
 }
 
 export const teamsView = (ctrl: RelayTeams, chapters: StudyChapters, players: RelayPlayers) =>
-  h(
+  hl(
     'div.relay-tour__team-table',
     {
       class: { loading: ctrl.loading, nodata: !ctrl.teams },
@@ -73,17 +73,17 @@ const renderTeams = (
 ): MaybeVNodes =>
   teams.table.map(row => {
     const firstTeam = row.teams[0];
-    return h('div.relay-tour__team-match', [
-      h('div.relay-tour__team-match__teams', [
-        h('strong.relay-tour__team-match__team', row.teams[0].name),
-        h('span.relay-tour__team-match__team__points', [
-          h('points', firstTeam.points.toString()),
-          h('vs', 'vs'),
-          h('points', row.teams[1].points.toString()),
+    return hl('div.relay-tour__team-match', [
+      hl('div.relay-tour__team-match__teams', [
+        hl('strong.relay-tour__team-match__team', row.teams[0].name),
+        hl('span.relay-tour__team-match__team__points', [
+          hl('points', firstTeam.points.toString()),
+          hl('vs', 'vs'),
+          hl('points', row.teams[1].points.toString()),
         ]),
-        h('strong.relay-tour__team', row.teams[1].name),
+        hl('strong.relay-tour__team', row.teams[1].name),
       ]),
-      h(
+      hl(
         'div.relay-tour__team-match__games',
         row.games.map(game => {
           const chap = chapters.get(game.id);
@@ -93,7 +93,7 @@ const renderTeams = (
             game.pov === 'white' ? [players.white, players.black] : [players.black, players.white];
           return (
             chap &&
-            h('a.relay-tour__team-match__game', { attrs: gameLinkAttrs(roundPath, chap) }, [
+            hl('a.relay-tour__team-match__game', { attrs: gameLinkAttrs(roundPath, chap) }, [
               playerView(playersCtrl, sortedPlayers[0]),
               statusView(chap, game.pov, chapters, cloudEval),
               playerView(playersCtrl, sortedPlayers[1]),
@@ -105,17 +105,17 @@ const renderTeams = (
   });
 
 const playerView = (players: RelayPlayers, p: StudyPlayer) =>
-  h('span.relay-tour__team-match__game__player', [
-    h('span.mini-game__user', players.playerLinkConfig(p), [
+  hl('span.relay-tour__team-match__game__player', [
+    hl('span.mini-game__user', players.playerLinkConfig(p), [
       playerFed(p.fed),
-      h('span.name', [userTitle(p), p.name]),
+      hl('span.name', [userTitle(p), p.name]),
     ]),
-    p.rating && h('rating', `${p.rating}`),
+    !!p.rating && hl('rating', `${p.rating}`),
   ]);
 
 const statusView = (g: ChapterPreview, pov: Color, chapters: StudyChapters, cloudEval?: MultiCloudEval) => {
   const status = pov === 'white' ? g.status : (g.status?.split('').reverse().join('') as StatusStr);
-  return h(
+  return hl(
     'span.relay-tour__team-match__game__status',
     status && status !== '*' ? status : cloudEval ? evalGauge(g, pov, chapters, cloudEval) : '*',
   );
@@ -127,14 +127,14 @@ const evalGauge = (
   chapters: StudyChapters,
   cloudEval: MultiCloudEval,
 ): VNode =>
-  h(
+  hl(
     `span.eval-gauge-horiz.pov-${pov}`,
     {
       attrs: { 'data-id': game.id },
       hook: onInsert(cloudEval.observe),
     },
     [
-      h(`span.eval-gauge-horiz__black`, {
+      hl(`span.eval-gauge-horiz__black`, {
         hook: {
           postpatch(old, vnode) {
             const prevNodeCloud = old.data?.cloud;
@@ -153,6 +153,6 @@ const evalGauge = (
           },
         },
       }),
-      h('tick.zero'),
+      hl('tick.zero'),
     ],
   );

--- a/ui/analyse/src/study/relay/relayTourView.ts
+++ b/ui/analyse/src/study/relay/relayTourView.ts
@@ -1,7 +1,7 @@
 import type AnalyseCtrl from '../../ctrl';
 import RelayCtrl, { type RelayTab } from './relayCtrl';
 import * as licon from 'lib/licon';
-import { bind, dataIcon, onInsert, looseH as h, type LooseVNode } from 'lib/snabbdom';
+import { bind, dataIcon, onInsert, hl, type LooseVNode } from 'lib/snabbdom';
 import type { VNode } from 'snabbdom';
 import { innerHTML, richHTML } from 'lib/richText';
 import type { RelayData, RelayGroup, RelayRound, RelayTourDates, RelayTourInfo } from './interfaces';
@@ -38,7 +38,7 @@ export function renderRelayTour(ctx: RelayViewContext): VNode | undefined {
             ? players(ctx)
             : overview(ctx);
 
-  return h('div.box.relay-tour', content);
+  return hl('div.box.relay-tour', content);
 }
 
 export const tourSide = (ctx: RelayViewContext, kid: LooseVNode) => {
@@ -46,7 +46,7 @@ export const tourSide = (ctx: RelayViewContext, kid: LooseVNode) => {
   const empty = study.chapters.list.looksNew();
   const resizeId =
     !isTouchDevice() && displayColumns() > (ctx.hasRelayTour ? 1 : 2) && `relayTour/${relay.data.tour.id}`;
-  return h(
+  return hl(
     'aside.relay-tour__side',
     {
       hook: {
@@ -54,17 +54,17 @@ export const tourSide = (ctx: RelayViewContext, kid: LooseVNode) => {
       },
     },
     [
-      ...(empty
+      empty
         ? [startCountdown(relay)]
         : [
-            h('div.relay-tour__side__header', [
-              h(
+            hl('div.relay-tour__side__header', [
+              hl(
                 'button.relay-tour__side__name',
                 { hook: bind('mousedown', relay.tourShow.toggle, relay.redraw) },
                 relay.roundName(),
               ),
               !ctrl.isEmbed &&
-                h('button.streamer-show.data-count', {
+                hl('button.streamer-show.data-count', {
                   attrs: {
                     'data-icon': licon.Mic,
                     'data-count': relay.streams.length,
@@ -77,14 +77,14 @@ export const tourSide = (ctx: RelayViewContext, kid: LooseVNode) => {
                   },
                   hook: bind('click', relay.showStreamerMenu.toggle, relay.redraw),
                 }),
-              h('button.relay-tour__side__search', {
+              hl('button.relay-tour__side__search', {
                 attrs: { 'data-icon': licon.Search },
                 hook: bind('click', study.search.open.toggle),
               }),
             ]),
-          ]),
+          ],
       !ctrl.isEmbed && relay.showStreamerMenu() && renderStreamerMenu(relay),
-      !empty ? gamesList(study, relay) : h('div.vertical-spacer'),
+      !empty ? gamesList(study, relay) : hl('div.vertical-spacer'),
       !empty &&
         resizeId &&
         verticalResizeSeparator({
@@ -101,7 +101,7 @@ export const tourSide = (ctx: RelayViewContext, kid: LooseVNode) => {
           min: () => 0,
           max: () => window.innerHeight,
           initialMaxHeight: window.innerHeight / 3,
-          kid: h('div.chat__members', { hook: onInsert(el => watchers(el, false)) }),
+          kid: hl('div.chat__members', { hook: onInsert(el => watchers(el, false)) }),
         }),
       kid,
     ],
@@ -111,21 +111,18 @@ export const tourSide = (ctx: RelayViewContext, kid: LooseVNode) => {
 const startCountdown = (relay: RelayCtrl) => {
   const round = relay.currentRound(),
     startsAt = defined(round.startsAt) && new Date(round.startsAt),
-    date = startsAt && h('time', commonDateFormat(startsAt));
-  return h('div.relay-tour__side__empty', { attrs: dataIcon(licon.RadioTower) }, [
-    h('strong', round.name),
-    ...(startsAt
+    date = startsAt && hl('time', commonDateFormat(startsAt));
+  return hl('div.relay-tour__side__empty', { attrs: dataIcon(licon.RadioTower) }, [
+    hl('strong', round.name),
+    startsAt
       ? startsAt.getTime() < Date.now() + 1000 * 10 * 60 // in the last 10 minutes, only say it's soon.
         ? [i18n.broadcast.startVerySoon, date]
-        : [h('strong', timeago(startsAt)), date]
-      : [i18n.broadcast.notYetStarted]),
+        : [hl('strong', timeago(startsAt)), date]
+      : [i18n.broadcast.notYetStarted],
   ]);
 };
 
-const players = (ctx: RelayViewContext) => [
-  ...header(ctx),
-  playersView(ctx.relay.players, ctx.relay.data.tour),
-];
+const players = (ctx: RelayViewContext) => [header(ctx), playersView(ctx.relay.players, ctx.relay.data.tour)];
 
 export const showInfo = (i: RelayTourInfo, dates?: RelayTourDates) => {
   const contents = [
@@ -141,16 +138,16 @@ export const showInfo = (i: RelayTourInfo, dates?: RelayTourDates) => {
       ([key, value, icon, textAlternative, linkName]) =>
         key &&
         value &&
-        h('div.relay-tour__info__' + key, [
-          icon && h('img', { attrs: { src: site.asset.flairSrc(icon), alt: textAlternative! } }),
+        hl('div.relay-tour__info__' + key, [
+          icon && hl('img', { attrs: { src: site.asset.flairSrc(icon), alt: textAlternative! } }),
           linkName
-            ? h('a', { attrs: { href: value, target: '_blank', rel: 'nofollow noreferrer' } }, linkName)
+            ? hl('a', { attrs: { href: value, target: '_blank', rel: 'nofollow noreferrer' } }, linkName)
             : value,
         ]),
     )
     .filter(defined);
 
-  return contents.length ? h('div.relay-tour__info', contents) : undefined;
+  return contents.length ? hl('div.relay-tour__info', contents) : undefined;
 };
 
 const dateFormat = memoize(() =>
@@ -170,37 +167,36 @@ const showDates = (dates: RelayTourDates) => {
 
 const showSource = (data: RelayData) =>
   data.lcc
-    ? h('div.relay-tour__source', [
+    ? hl('div.relay-tour__source', [
         'PGN source: ',
-        h('a', { attrs: { href: 'https://www.livechesscloud.com' } }, 'LiveChessCloud'),
+        hl('a', { attrs: { href: 'https://www.livechesscloud.com' } }, 'LiveChessCloud'),
       ])
     : undefined;
 
 const overview = (ctx: RelayViewContext) => {
   const tour = ctx.relay.data.tour;
   return [
-    ...header(ctx),
+    header(ctx),
     showInfo(tour.info, tour.dates),
-    tour.description
-      ? h('div.relay-tour__markup', {
-          hook: innerHTML(tour.description, () => tour.description!),
-        })
-      : undefined,
-    ...(ctx.ctrl.isEmbed ? [] : [showSource(ctx.relay.data), share(ctx)]),
+    tour.description &&
+      hl('div.relay-tour__markup', {
+        hook: innerHTML(tour.description, () => tour.description!),
+      }),
+    ctx.ctrl.isEmbed || [showSource(ctx.relay.data), share(ctx)],
   ];
 };
 
 const share = (ctx: RelayViewContext) => {
   const iframe = (path: string) =>
     `<iframe src="${baseUrl()}/embed${path}" style="width: 100%; aspect-ratio: 4/3;" frameborder="0"></iframe>`;
-  const iframeHelp = h(
+  const iframeHelp = hl(
     'div.form-help',
     i18n.broadcast.iframeHelp.asArray(
-      h('a', { attrs: { href: '/developers#broadcast' } }, i18n.broadcast.webmastersPage),
+      hl('a', { attrs: { href: '/developers#broadcast' } }, i18n.broadcast.webmastersPage),
     ),
   );
   const roundName = ctx.relay.roundName();
-  return h(
+  return hl(
     'div.relay-tour__share',
     [
       [ctx.relay.data.tour.name, ctx.relay.tourPath()],
@@ -208,10 +204,10 @@ const share = (ctx: RelayViewContext) => {
       [
         `${roundName} PGN`,
         `${ctx.relay.roundPath()}.pgn`,
-        h(
+        hl(
           'div.form-help',
           i18n.broadcast.pgnSourceHelp.asArray(
-            h(
+            hl(
               'a',
               { attrs: { href: '/api#tag/Broadcasts/operation/broadcastStreamRoundPgn' } },
               'streaming API',
@@ -222,8 +218,8 @@ const share = (ctx: RelayViewContext) => {
       [i18n.broadcast.embedThisBroadcast, iframe(ctx.relay.tourPath()), iframeHelp],
       [i18n.broadcast.embedThisRound(roundName), iframe(ctx.relay.roundPath()), iframeHelp],
     ].map(([text, path, help]: [string, string, VNode]) =>
-      h('div.form-group', [
-        h('label.form-label', text),
+      hl('div.form-group', [
+        hl('label.form-label', text),
         copyMeInput(path.startsWith('/') ? `${baseUrl()}${path}` : path),
         help,
       ]),
@@ -234,32 +230,30 @@ const share = (ctx: RelayViewContext) => {
 const groupSelect = (ctx: RelayViewContext, group: RelayGroup) => {
   const toggle = ctx.relay.groupSelectShow;
   const clickHook = { hook: bind('click', toggle.toggle, ctx.relay.redraw) };
-  return h(
+  return hl(
     'div.mselect.relay-tour__mselect.relay-tour__group-select',
     {
       class: { mselect__active: toggle() },
     },
     [
-      h(
+      hl(
         'label.mselect__label',
         clickHook,
         group.tours.find(t => t.id === ctx.relay.data.tour.id)?.name || ctx.relay.data.tour.name,
       ),
-      ...(toggle()
-        ? [
-            h('label.fullscreen-mask', clickHook),
-            h(
-              'nav.mselect__list',
-              group.tours.map(tour =>
-                h(
-                  `a.mselect__item${tour.id === ctx.relay.data.tour.id ? '.current' : ''}`,
-                  { attrs: { href: ctx.study.embeddablePath(`/broadcast/-/${tour.id}`) } },
-                  tour.name,
-                ),
-              ),
+      toggle() && [
+        hl('label.fullscreen-mask', clickHook),
+        hl(
+          'nav.mselect__list',
+          group.tours.map(tour =>
+            hl(
+              `a.mselect__item${tour.id === ctx.relay.data.tour.id ? '.current' : ''}`,
+              { attrs: { href: ctx.study.embeddablePath(`/broadcast/-/${tour.id}`) } },
+              tour.name,
             ),
-          ]
-        : []),
+          ),
+        ),
+      ],
     ],
   );
 };
@@ -269,100 +263,92 @@ const roundSelect = (relay: RelayCtrl, study: StudyCtrl) => {
   const clickHook = { hook: bind('click', toggle.toggle, relay.redraw) };
   const round = relay.currentRound();
   const icon = roundStateIcon(round, true);
-  return h(
+  return hl(
     'div.mselect.relay-tour__mselect.relay-tour__round-select',
     {
       class: { mselect__active: toggle() },
     },
     [
-      h('label.mselect__label.relay-tour__round-select__label', clickHook, [
-        h('span.relay-tour__round-select__name', round.name),
-        h(
-          'span.relay-tour__round-select__status',
-          icon || [round.startsAt ? timeago(round.startsAt) : undefined],
-        ),
+      hl('label.mselect__label.relay-tour__round-select__label', clickHook, [
+        hl('span.relay-tour__round-select__name', round.name),
+        hl('span.relay-tour__round-select__status', icon || (!!round.startsAt && timeago(round.startsAt))),
       ]),
-      ...(toggle()
-        ? [
-            h('label.fullscreen-mask', clickHook),
-            h(
-              'div.relay-tour__round-select__list.mselect__list',
+      toggle() && [
+        hl('label.fullscreen-mask', clickHook),
+        hl(
+          'div.relay-tour__round-select__list.mselect__list',
+          {
+            hook: onInsert(el => {
+              const goTo = el.querySelector('.ongoing-round') ?? el.querySelector('.current-round');
+              goTo
+                ?.closest('.relay-tour__round-select')
+                ?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+            }),
+          },
+          hl(
+            'table',
+            hl(
+              'tbody',
               {
-                hook: onInsert(el => {
-                  const goTo = el.querySelector('.ongoing-round') ?? el.querySelector('.current-round');
-                  goTo
-                    ?.closest('.relay-tour__round-select')
-                    ?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+                hook: bind('click', e => {
+                  const target = e.target as HTMLElement;
+                  if (target.tagName !== 'A') site.redirect($(target).parents('tr').find('a').attr('href')!);
                 }),
               },
-              h(
-                'table',
-                h(
-                  'tbody',
+              relay.data.rounds.map((round, i) =>
+                hl(
+                  'tr.mselect__item',
                   {
-                    hook: bind('click', e => {
-                      const target = e.target as HTMLElement;
-                      if (target.tagName !== 'A')
-                        site.redirect($(target).parents('tr').find('a').attr('href')!);
-                    }),
+                    class: {
+                      ['current-round']: round.id === study.data.id,
+                      ['ongoing-round']: !!round.ongoing,
+                    },
                   },
-                  relay.data.rounds.map((round, i) =>
-                    h(
-                      'tr.mselect__item',
-                      {
-                        class: {
-                          ['current-round']: round.id === study.data.id,
-                          ['ongoing-round']: !!round.ongoing,
-                        },
-                      },
-                      [
-                        h(
-                          'td.name',
-                          h(
-                            'a',
-                            { attrs: { href: study.embeddablePath(relay.roundUrlWithHash(round)) } },
-                            round.name,
-                          ),
-                        ),
-                        h(
-                          'td.time',
-                          round.startsAt
-                            ? commonDateFormat(new Date(round.startsAt))
-                            : round.startsAfterPrevious
-                              ? i18n.broadcast.startsAfter(
-                                  relay.data.rounds[i - 1]?.name || 'the previous round',
-                                )
-                              : '',
-                        ),
-                        h(
-                          'td.status',
-                          roundStateIcon(round, false) ||
-                            (round.startsAt ? timeago(round.startsAt) : undefined),
-                        ),
-                      ],
+                  [
+                    hl(
+                      'td.name',
+                      hl(
+                        'a',
+                        { attrs: { href: study.embeddablePath(relay.roundUrlWithHash(round)) } },
+                        round.name,
+                      ),
                     ),
-                  ),
+                    hl(
+                      'td.time',
+                      !!round.startsAt
+                        ? commonDateFormat(new Date(round.startsAt))
+                        : round.startsAfterPrevious &&
+                            i18n.broadcast.startsAfter(
+                              relay.data.rounds[i - 1]?.name || 'the previous round',
+                            ),
+                    ),
+                    hl(
+                      'td.status',
+                      roundStateIcon(round, false) || (!!round.startsAt && timeago(round.startsAt)),
+                    ),
+                  ],
                 ),
               ),
             ),
-          ]
-        : []),
+          ),
+        ),
+      ],
     ],
   );
 };
 
 const games = (ctx: RelayViewContext) => [
-  ...header(ctx),
+  header(ctx),
   ctx.study.chapters.list.looksNew()
-    ? h(
+    ? hl(
         'div.relay-tour__note',
-        h('div', [
-          h('div', i18n.broadcast.noBoardsYet),
+        hl('div', [
+          hl('div', i18n.broadcast.noBoardsYet),
           ctx.study.members.myMember() &&
-            h(
+            hl(
               'small',
               i18n.broadcast.boardsCanBeLoaded.asArray(
-                h('a', { attrs: { href: '/broadcast/app' } }, 'Broadcaster App'),
+                hl('a', { attrs: { href: '/broadcast/app' } }, 'Broadcaster App'),
               ),
             ),
         ]),
@@ -372,11 +358,11 @@ const games = (ctx: RelayViewContext) => [
 ];
 
 const teams = (ctx: RelayViewContext) => [
-  ...header(ctx),
+  header(ctx),
   ctx.relay.teams && teamsView(ctx.relay.teams, ctx.study.chapters.list, ctx.relay.players),
 ];
 
-const stats = (ctx: RelayViewContext) => [...header(ctx), statsView(ctx.relay.stats)];
+const stats = (ctx: RelayViewContext) => [header(ctx), statsView(ctx.relay.stats)];
 
 const header = (ctx: RelayViewContext) => {
   const { ctrl, relay } = ctx;
@@ -385,34 +371,34 @@ const header = (ctx: RelayViewContext) => {
     studyD = ctrl.study?.data.description;
 
   return [
-    h('div.relay-tour__header', [
-      h('div.relay-tour__header__content', [
-        h('h1', group?.name || d.tour.name),
-        h('div.relay-tour__header__selectors', [
+    hl('div.relay-tour__header', [
+      hl('div.relay-tour__header__content', [
+        hl('h1', group?.name || d.tour.name),
+        hl('div.relay-tour__header__selectors', [
           group && groupSelect(ctx, group),
           roundSelect(relay, ctx.study),
         ]),
       ]),
       broadcastImageOrStream(ctx),
     ]),
-    studyD && h('div.relay-tour__note.pinned', h('div', [h('div', { hook: richHTML(studyD, false) })])),
+    studyD && hl('div.relay-tour__note.pinned', hl('div', [hl('div', { hook: richHTML(studyD, false) })])),
     d.tour.communityOwner &&
-      h(
+      hl(
         'div.relay-tour__note',
-        h('div', [
-          h('div', i18n.broadcast.communityBroadcast),
-          h('small', i18n.broadcast.createdAndManagedBy.asArray(userLink(d.tour.communityOwner))),
+        hl('div', [
+          hl('div', i18n.broadcast.communityBroadcast),
+          hl('small', i18n.broadcast.createdAndManagedBy.asArray(userLink(d.tour.communityOwner))),
         ]),
       ),
     d.note &&
-      h(
+      hl(
         'div.relay-tour__note',
-        h('div', [
-          h('div', { hook: richHTML(d.note, false) }),
-          h('small', 'This note is visible to contributors only.'),
+        hl('div', [
+          hl('div', { hook: richHTML(d.note, false) }),
+          hl('small', 'This note is visible to contributors only.'),
         ]),
       ),
-    h('div.relay-tour__nav', [makeTabs(ctrl), ...subscribe(relay, ctrl)]),
+    hl('div.relay-tour__nav', [makeTabs(ctrl), subscribe(relay, ctrl)]),
   ];
 };
 
@@ -443,7 +429,7 @@ const makeTabs = (ctrl: AnalyseCtrl) => {
   if (!relay) return undefined;
 
   const makeTab = (key: RelayTab, name: string) =>
-    h(
+    hl(
       `span.relay-tour__tabs--${key}`,
       {
         class: { active: relay.tab() === key },
@@ -452,34 +438,33 @@ const makeTabs = (ctrl: AnalyseCtrl) => {
       },
       name,
     );
-  return h('nav.relay-tour__tabs', { attrs: { role: 'tablist' } }, [
+  return hl('nav.relay-tour__tabs', { attrs: { role: 'tablist' } }, [
     makeTab('overview', i18n.broadcast.overview),
     makeTab('boards', i18n.broadcast.boards),
     makeTab('players', i18n.site.players),
     relay.teams && makeTab('teams', i18n.broadcast.teams),
-    study.members.myMember() && relay.data.tour.tier
+    study.members.myMember() && !!relay.data.tour.tier
       ? makeTab('stats', i18n.site.stats)
-      : ctrl.isEmbed
-        ? h(
-            'a.relay-tour__tabs--open.text',
-            {
-              attrs: { href: relay.tourPath(), target: '_blank', 'data-icon': licon.Expand },
-            },
-            i18n.broadcast.openLichess,
-          )
-        : undefined,
+      : ctrl.isEmbed &&
+        hl(
+          'a.relay-tour__tabs--open.text',
+          {
+            attrs: { href: relay.tourPath(), target: '_blank', 'data-icon': licon.Expand },
+          },
+          i18n.broadcast.openLichess,
+        ),
   ]);
 };
 
 const roundStateIcon = (round: RelayRound, titleAsText: boolean) =>
   round.ongoing
-    ? h(
+    ? hl(
         'span.round-state.ongoing',
         { attrs: { ...dataIcon(licon.DiscBig), title: !titleAsText && i18n.broadcast.ongoing } },
         titleAsText && i18n.broadcast.ongoing,
       )
     : round.finished &&
-      h(
+      hl(
         'span.round-state.finished',
         { attrs: { ...dataIcon(licon.Checkmark), title: !titleAsText && i18n.site.finished } },
         titleAsText && i18n.site.finished,
@@ -490,14 +475,14 @@ const broadcastImageOrStream = (ctx: RelayViewContext) => {
   const d = relay.data,
     embedVideo = (d.videoUrls || relay.isPinnedStreamOngoing()) && allowVideo;
 
-  return h(
+  return hl(
     `div.relay-tour__header__image${embedVideo ? '.video' : ''}`,
     embedVideo
       ? relay.videoPlayer?.render()
       : d.tour.image
-        ? h('img', { attrs: { src: d.tour.image } })
+        ? hl('img', { attrs: { src: d.tour.image } })
         : ctx.study.members.isOwner()
-          ? h(
+          ? hl(
               'a.button.relay-tour__header__image-upload',
               { attrs: { href: `/broadcast/${d.tour.id}/edit` } },
               i18n.broadcast.uploadImage,

--- a/ui/analyse/src/study/relay/relayView.ts
+++ b/ui/analyse/src/study/relay/relayView.ts
@@ -1,6 +1,6 @@
 import { view as cevalView } from 'lib/ceval/ceval';
 import { onClickAway } from 'lib';
-import { bind, dataIcon, looseH as h, onInsert, type VNode } from 'lib/snabbdom';
+import { bind, dataIcon, hl, onInsert, type VNode } from 'lib/snabbdom';
 import * as licon from 'lib/licon';
 import type AnalyseCtrl from '../../ctrl';
 import { view as keyboardView } from '../../keyboard';
@@ -40,13 +40,13 @@ export function relayView(
     ctx,
     ctrl.keyboardHelp && keyboardView(ctrl),
     deps.studyView.overboard(study),
-    ...(ctx.hasRelayTour ? renderTourView() : renderBoardView(ctx)),
+    ctx.hasRelayTour ? renderTourView() : renderBoardView(ctx),
   );
 }
 
 export const backToLiveView = (ctrl: AnalyseCtrl) =>
   ctrl.study?.isRelayAwayFromLive()
-    ? h(
+    ? hl(
         'button.fbt.relay-back-to-live.text',
         {
           attrs: dataIcon(licon.PlayTriangle),
@@ -69,9 +69,9 @@ export function renderStreamerMenu(relay: RelayCtrl): VNode {
     url.searchParams.set('embed', id);
     return url.toString();
   };
-  return h(
+  return hl(
     'div.streamer-menu-anchor',
-    h(
+    hl(
       'div.streamer-menu',
       {
         hook: onInsert(
@@ -82,9 +82,9 @@ export function renderStreamerMenu(relay: RelayCtrl): VNode {
         ),
       },
       relay.streams.map(([id, info]) =>
-        h('a.streamer.text', { attrs: { 'data-icon': licon.Mic, href: makeUrl(id) } }, [
+        hl('a.streamer.text', { attrs: { 'data-icon': licon.Mic, href: makeUrl(id) } }, [
           info.name,
-          h('i', info.lang),
+          hl('i', info.lang),
         ]),
       ),
     ),

--- a/ui/analyse/src/study/relay/videoPlayer.ts
+++ b/ui/analyse/src/study/relay/videoPlayer.ts
@@ -1,4 +1,4 @@
-import { looseH as h, type Redraw, type VNode, onInsert } from 'lib/snabbdom';
+import { hl, type VNode, onInsert } from 'lib/snabbdom';
 import { allowVideo } from './relayView';
 
 export class VideoPlayer {
@@ -66,14 +66,14 @@ export class VideoPlayer {
 
   render = () => {
     return this.o.embed
-      ? h('div#video-player-placeholder', {
+      ? hl('div#video-player-placeholder', {
           hook: {
             insert: (vnode: VNode) => this.cover(vnode.elm as HTMLElement),
             update: (_, vnode: VNode) => this.cover(vnode.elm as HTMLElement),
           },
         })
-      : h('div#video-player-placeholder.link', [
-          h('div.image', {
+      : hl('div#video-player-placeholder.link', [
+          hl('div.image', {
             attrs: { style: `background-image: url(${this.o.image})` },
             hook: onInsert((el: HTMLElement) => {
               el.addEventListener('click', e => {
@@ -83,12 +83,12 @@ export class VideoPlayer {
               el.addEventListener('contextmenu', () => window.open(this.o.redirect, '_blank'));
             }),
           }),
-          h('img.video-player-close', {
+          hl('img.video-player-close', {
             attrs: { src: site.asset.flairSrc('symbols.cancel') },
             hook: onInsert((el: HTMLElement) => el.addEventListener('click', () => this.onEmbed('no'))),
           }),
-          this.o.text && h('div.text-box', h('div', this.o.text)),
-          h(
+          this.o.text && hl('div.text-box', hl('div', this.o.text)),
+          hl(
             'svg.play-button',
             {
               attrs: {
@@ -97,14 +97,14 @@ export class VideoPlayer {
               },
             },
             [
-              h('circle', {
+              hl('circle', {
                 attrs: {
                   cx: '100',
                   cy: '100',
                   r: '90',
                 },
               }),
-              h('path', {
+              hl('path', {
                 attrs: {
                   d: 'M 68 52 A 5 5 0 0 1 74 46 L 154 96 A 5 5 0 0 1 154 104 L 74 154 A 5 5 0 0 1 68 148 Z',
                 },

--- a/ui/analyse/src/study/studyChapters.ts
+++ b/ui/analyse/src/study/studyChapters.ts
@@ -1,6 +1,6 @@
 import { defined, prop, Prop, scrollToInnerSelector } from 'lib';
 import * as licon from 'lib/licon';
-import { type VNode, bind, dataIcon, iconTag, looseH as h } from 'lib/snabbdom';
+import { type VNode, bind, dataIcon, iconTag, hl } from 'lib/snabbdom';
 import type AnalyseCtrl from '../ctrl';
 import type { StudySocketSend } from '../socket';
 import { StudyChapterEditForm } from './chapterEditForm';
@@ -187,7 +187,7 @@ export function view(ctrl: StudyCtrl): VNode {
     }
   }
 
-  return h(
+  return hl(
     'div.study__chapters',
     {
       hook: {
@@ -220,7 +220,7 @@ export function view(ctrl: StudyCtrl): VNode {
       .map((chapter, i) => {
         const editing = ctrl.chapters.editForm.isEditing(chapter.id),
           active = !ctrl.vm.loading && current?.id === chapter.id;
-        return h(
+        return hl(
           'button',
           {
             key: chapter.id,
@@ -228,20 +228,20 @@ export function view(ctrl: StudyCtrl): VNode {
             class: { active, editing, draggable: canContribute },
           },
           [
-            h('span', (i + 1).toString()),
-            h('h3', chapter.name),
-            chapter.status && h('res', chapter.status),
+            hl('span', (i + 1).toString()),
+            hl('h3', chapter.name),
+            chapter.status && hl('res', chapter.status),
             canContribute &&
-              h('i.act', { attrs: { ...dataIcon(licon.Gear), title: i18n.study.editChapter } }),
+              hl('i.act', { attrs: { ...dataIcon(licon.Gear), title: i18n.study.editChapter } }),
           ],
         );
       })
       .concat(
         ctrl.members.canContribute()
           ? [
-              h('button.add', { hook: bind('click', ctrl.chapters.toggleNewForm, ctrl.redraw) }, [
-                h('span', iconTag(licon.PlusButton)),
-                h('h3', i18n.study.addNewChapter),
+              hl('button.add', { hook: bind('click', ctrl.chapters.toggleNewForm, ctrl.redraw) }, [
+                hl('span', iconTag(licon.PlusButton)),
+                hl('h3', i18n.study.addNewChapter),
               ]),
             ]
           : [],

--- a/ui/analyse/src/study/studyForm.ts
+++ b/ui/analyse/src/study/studyForm.ts
@@ -3,7 +3,7 @@ import { prop } from 'lib';
 import { snabDialog } from 'lib/view/dialog';
 import { confirm, prompt } from 'lib/view/dialogs';
 import flairPickerLoader from 'bits/flairPicker';
-import { type VNode, bindSubmit, bindNonPassive, onInsert, looseH as h } from 'lib/snabbdom';
+import { type VNode, bindSubmit, bindNonPassive, onInsert, hl } from 'lib/snabbdom';
 import { emptyRedButton } from '../view/util';
 import type { StudyData } from './interfaces';
 import type RelayCtrl from './relay/relayCtrl';
@@ -56,11 +56,11 @@ export class StudyForm {
 }
 
 const select = (s: Select): VNode =>
-  h('div.form-group.form-half' + (s.visible ? '' : '.none'), [
-    h('label.form-label', { attrs: { for: 'study-' + s.key } }, s.name),
-    h(
+  hl('div.form-group.form-half' + (s.visible ? '' : '.none'), [
+    hl('label.form-label', { attrs: { for: 'study-' + s.key } }, s.name),
+    hl(
       `select#study-${s.key}.form-control`,
-      s.choices.map(o => h('option', { attrs: { value: o[0], selected: s.selected === o[0] } }, o[1])),
+      s.choices.map(o => hl('option', { attrs: { value: o[0], selected: s.selected === o[0] } }, o[1])),
     ),
   ]);
 
@@ -84,34 +84,34 @@ export function view(ctrl: StudyForm): VNode {
     ['everyone', i18n.study.everyone],
   ];
   const formFields = [
-    h('div.form-split.flair-and-name' + (ctrl.relay ? '.none' : ''), [
-      h('div.form-group', [
-        h('label.form-label', 'Flair'),
-        h(
+    hl('div.form-split.flair-and-name' + (ctrl.relay ? '.none' : ''), [
+      hl('div.form-group', [
+        hl('label.form-label', 'Flair'),
+        hl(
           'div.form-control.emoji-details',
           {
             hook: onInsert(el => flairPickerLoader(el)),
           },
           [
-            h('div.emoji-popup-button', [
-              h(
+            hl('div.emoji-popup-button', [
+              hl(
                 'select#study-flair.form-control',
                 { attrs: { name: 'flair' } },
-                data.flair && h('option', { attrs: { value: data.flair, selected: true } }),
+                data.flair && hl('option', { attrs: { value: data.flair, selected: true } }),
               ),
-              h('img', { attrs: { src: data.flair ? site.asset.flairSrc(data.flair) : '' } }),
+              hl('img', { attrs: { src: data.flair ? site.asset.flairSrc(data.flair) : '' } }),
             ]),
-            h(
+            hl(
               'div.flair-picker.none',
               data.admin || { attrs: { 'data-except-emojis': 'activity.lichess' } },
-              h('button.button.button-metal.emoji-remove', { attrs: { type: 'button' } }, 'clear'),
+              hl('button.button.button-metal.emoji-remove', { attrs: { type: 'button' } }, 'clear'),
             ),
           ],
         ),
       ]),
-      h('div.form-group', [
-        h('label.form-label', { attrs: { for: 'study-name' } }, i18n.site.name),
-        h('input#study-name.form-control', {
+      hl('div.form-group', [
+        hl('label.form-label', { attrs: { for: 'study-name' } }, i18n.site.name),
+        hl('input#study-name.form-control', {
           attrs: { minlength: 3, maxlength: 100 },
           hook: {
             insert: vnode => {
@@ -126,7 +126,7 @@ export function view(ctrl: StudyForm): VNode {
         }),
       ]),
     ]),
-    h('div.form-split', [
+    hl('div.form-split', [
       select({
         key: 'visibility',
         name: i18n.study.visibility,
@@ -146,7 +146,7 @@ export function view(ctrl: StudyForm): VNode {
         visible: isEditable,
       }),
     ]),
-    h('div.form-split', [
+    hl('div.form-split', [
       select({
         key: 'computer',
         name: i18n.site.computerAnalysis,
@@ -162,7 +162,7 @@ export function view(ctrl: StudyForm): VNode {
         visible: isEditable,
       }),
     ]),
-    h('div.form-split', [
+    hl('div.form-split', [
       select({
         key: 'cloneable',
         name: i18n.study.allowCloning,
@@ -178,7 +178,7 @@ export function view(ctrl: StudyForm): VNode {
         visible: isEditable,
       }),
     ]),
-    h('div.form-split', [
+    hl('div.form-split', [
       select({
         key: 'sticky',
         name: i18n.study.enableSync,
@@ -203,8 +203,8 @@ export function view(ctrl: StudyForm): VNode {
   ];
   const relayLinks =
     ctrl.relay &&
-    h('div.form-actions-secondary', [
-      h(
+    hl('div.form-actions-secondary', [
+      hl(
         'a.text',
         {
           attrs: {
@@ -214,14 +214,14 @@ export function view(ctrl: StudyForm): VNode {
         },
         'Tournament settings',
       ),
-      h(
+      hl(
         'a.text',
         { attrs: { 'data-icon': licon.RadioTower, href: `/broadcast/round/${data.id}/edit` } },
         'Round settings',
       ),
     ]);
-  const deleteForms = h('div', { attrs: { style: 'display: flex' } }, [
-    h(
+  const deleteForms = hl('div', { attrs: { style: 'display: flex' } }, [
+    hl(
       'form',
       {
         attrs: { action: '/study/' + data.id + '/delete', method: 'post' },
@@ -234,10 +234,10 @@ export function view(ctrl: StudyForm): VNode {
           });
         }),
       },
-      [h(emptyRedButton, isNew ? i18n.site.cancel : i18n.study.deleteStudy)],
+      [hl(emptyRedButton, isNew ? i18n.site.cancel : i18n.study.deleteStudy)],
     ),
     !isNew &&
-      h(
+      hl(
         'form',
         {
           attrs: { action: '/study/' + data.id + '/clear-chat', method: 'post' },
@@ -248,7 +248,7 @@ export function view(ctrl: StudyForm): VNode {
             });
           }),
         },
-        [h(emptyRedButton, i18n.study.clearChat)],
+        [hl(emptyRedButton, i18n.study.clearChat)],
       ),
   ]);
   return snabDialog({
@@ -260,11 +260,11 @@ export function view(ctrl: StudyForm): VNode {
     modal: true,
     noClickAway: true,
     vnodes: [
-      h(
+      hl(
         'h2',
         ctrl.relay ? i18n.broadcast.editRoundStudy : isNew ? i18n.study.createStudy : i18n.study.editStudy,
       ),
-      h(
+      hl(
         'form.form3',
         {
           hook: bindSubmit(e => {
@@ -291,11 +291,11 @@ export function view(ctrl: StudyForm): VNode {
           }, ctrl.redraw),
         },
         [
-          ...formFields,
+          formFields,
           relayLinks,
-          h('div.form-actions', [
+          hl('div.form-actions', [
             deleteForms,
-            h('button.button', { attrs: { type: 'submit' } }, isNew ? i18n.study.start : i18n.study.save),
+            hl('button.button', { attrs: { type: 'submit' } }, isNew ? i18n.study.start : i18n.study.save),
           ]),
         ],
       ),

--- a/ui/analyse/src/study/studyMembers.ts
+++ b/ui/analyse/src/study/studyMembers.ts
@@ -1,6 +1,6 @@
 import type { AnalyseSocketSend } from '../socket';
 import * as licon from 'lib/licon';
-import { type VNode, iconTag, bind, onInsert, dataIcon, bindNonPassive, looseH as h } from 'lib/snabbdom';
+import { type VNode, iconTag, bind, onInsert, dataIcon, bindNonPassive, hl } from 'lib/snabbdom';
 import { makeCtrl as inviteFormCtrl, type StudyInviteFormCtrl } from './inviteForm';
 import type { NotifCtrl } from './notif';
 import { prop, Prop, scrollTo } from 'lib';
@@ -137,7 +137,7 @@ export function view(ctrl: StudyCtrl): VNode {
 
   function statusIcon(member: StudyMember) {
     const contrib = member.role === 'w';
-    return h(
+    return hl(
       'span.status',
       {
         class: {
@@ -153,7 +153,7 @@ export function view(ctrl: StudyCtrl): VNode {
 
   function configButton(ctrl: StudyCtrl, member: StudyMember) {
     if (isOwner && (member.user.id !== members.opts.myId || ctrl.data.admin))
-      return h('i.act', {
+      return hl('i.act', {
         attrs: dataIcon(licon.Gear),
         hook: bind(
           'click',
@@ -162,7 +162,7 @@ export function view(ctrl: StudyCtrl): VNode {
         ),
       });
     if (!isOwner && member.user.id === members.opts.myId)
-      return h('i.act.leave', {
+      return hl('i.act.leave', {
         attrs: { 'data-icon': licon.InternalArrow, title: i18n.study.leaveTheStudy },
         hook: bind('click', members.leave, ctrl.redraw),
       });
@@ -171,16 +171,16 @@ export function view(ctrl: StudyCtrl): VNode {
 
   function memberConfig(member: StudyMember): VNode {
     const roleId = 'member-role';
-    return h(
+    return hl(
       'm-config',
       {
         key: member.user.id + '-config',
         hook: onInsert(el => scrollTo($(el).parent('.study__members')[0] as HTMLElement, el)),
       },
       [
-        h('div.role', [
-          h('div.switch', [
-            h('input.cmn-toggle', {
+        hl('div.role', [
+          hl('div.switch', [
+            hl('input.cmn-toggle', {
               attrs: { id: roleId, type: 'checkbox', checked: member.role === 'w' },
               hook: bind(
                 'change',
@@ -188,13 +188,13 @@ export function view(ctrl: StudyCtrl): VNode {
                 ctrl.redraw,
               ),
             }),
-            h('label', { attrs: { for: roleId } }),
+            hl('label', { attrs: { for: roleId } }),
           ]),
-          h('label', { attrs: { for: roleId } }, i18n.study.contributor),
+          hl('label', { attrs: { for: roleId } }, i18n.study.contributor),
         ]),
-        h(
+        hl(
           'div.kick',
-          h(
+          hl(
             'a.button.button-red.button-empty.text',
             { attrs: dataIcon(licon.X), hook: bind('click', _ => members.kick(member.user.id), ctrl.redraw) },
             i18n.study.kick,
@@ -206,13 +206,13 @@ export function view(ctrl: StudyCtrl): VNode {
 
   const ordered: StudyMember[] = members.ordered();
 
-  return h('div.study__members', { hook: onInsert(() => pubsub.emit('chat.resize')) }, [
-    ...ordered
+  return hl('div.study__members', { hook: onInsert(() => pubsub.emit('chat.resize')) }, [
+    ordered
       .map(member => {
         const confing = members.confing() === member.user.id;
         return [
-          h('div', { key: member.user.id, class: { editing: !!confing } }, [
-            h('div.left', [statusIcon(member), userLink({ ...member.user, line: false })]),
+          hl('div', { key: member.user.id, class: { editing: !!confing } }, [
+            hl('div.left', [statusIcon(member), userLink({ ...member.user, line: false })]),
             configButton(ctrl, member),
           ]),
           confing && memberConfig(member),
@@ -221,15 +221,15 @@ export function view(ctrl: StudyCtrl): VNode {
       .reduce((a, b) => a.concat(b), []),
     isOwner &&
       ordered.length < members.max &&
-      h('button.add', { key: 'add', hook: bind('click', members.inviteForm.toggle) }, [
-        h('div.left', [
-          h('span.status', iconTag(licon.PlusButton)),
-          h('div.user-link', i18n.study.addMembers),
+      hl('button.add', { key: 'add', hook: bind('click', members.inviteForm.toggle) }, [
+        hl('div.left', [
+          hl('span.status', iconTag(licon.PlusButton)),
+          hl('div.user-link', i18n.study.addMembers),
         ]),
       ]),
     !members.canContribute() &&
       ctrl.data.admin &&
-      h(
+      hl(
         'form.admin',
         {
           key: ':admin',
@@ -238,7 +238,7 @@ export function view(ctrl: StudyCtrl): VNode {
             return false;
           }),
         },
-        [h('button.button.button-red.button-thin', 'Enter as admin')],
+        [hl('button.button.button-red.button-thin', 'Enter as admin')],
       ),
   ]);
 }

--- a/ui/analyse/src/study/studyShare.ts
+++ b/ui/analyse/src/study/studyShare.ts
@@ -1,6 +1,6 @@
 import { prop } from 'lib';
 import * as licon from 'lib/licon';
-import { type VNode, bind, dataIcon, looseH as h } from 'lib/snabbdom';
+import { type VNode, bind, dataIcon, hl } from 'lib/snabbdom';
 import { copyMeInput } from 'lib/view/controls';
 import { text as xhrText, url as xhrUrl } from 'lib/xhr';
 import { renderIndexAndMove } from '../view/moveView';
@@ -10,17 +10,17 @@ import type RelayCtrl from './relay/relayCtrl';
 
 function fromPly(ctrl: StudyShare): VNode {
   const renderedMove = renderIndexAndMove({ withDots: true, showEval: false }, ctrl.currentNode());
-  return h(
+  return hl(
     'div.ply-wrap',
     ctrl.onMainline() &&
-      h('label.ply', [
-        h('input', {
+      hl('label.ply', [
+        hl('input', {
           attrs: { type: 'checkbox', checked: ctrl.withPly() },
           hook: bind('change', e => ctrl.withPly((e.target as HTMLInputElement).checked), ctrl.redraw),
         }),
-        ...(renderedMove
-          ? i18n.study.startAtX.asArray(h('strong', renderedMove))
-          : [i18n.study.startAtInitialPosition]),
+        renderedMove
+          ? i18n.study.startAtX.asArray(hl('strong', renderedMove))
+          : [i18n.study.startAtInitialPosition],
       ]),
   );
 }
@@ -69,20 +69,24 @@ export function view(ctrl: StudyShare): VNode {
   const addPly = (path: string) =>
     ctrl.onMainline() ? (ctrl.withPly() ? `${path}#${ctrl.currentNode().ply}` : path) : `${path}#last`;
   const youCanPasteThis = () =>
-    h('p.form-help.text', { attrs: dataIcon(licon.InfoCircle) }, i18n.study.youCanPasteThisInTheForumToEmbed);
-  return h(
+    hl(
+      'p.form-help.text',
+      { attrs: dataIcon(licon.InfoCircle) },
+      i18n.study.youCanPasteThisInTheForumToEmbed,
+    );
+  return hl(
     'div.study__share',
     ctrl.shareable()
       ? [
-          h('div.downloads', [
+          hl('div.downloads', [
             ctrl.cloneable() &&
-              h(
+              hl(
                 'a.button.text',
                 { attrs: { ...dataIcon(licon.StudyBoard), href: `/study/${studyId}/clone` } },
                 i18n.study.cloneStudy,
               ),
             ctrl.relay &&
-              h(
+              hl(
                 'a.button.text',
                 {
                   attrs: {
@@ -93,7 +97,7 @@ export function view(ctrl: StudyShare): VNode {
                 },
                 i18n.broadcast.downloadAllRounds,
               ),
-            h(
+            hl(
               'a.button.text',
               {
                 attrs: {
@@ -104,7 +108,7 @@ export function view(ctrl: StudyShare): VNode {
               },
               ctrl.relay ? i18n.site.downloadAllGames : i18n.study.studyPgn,
             ),
-            h(
+            hl(
               'a.button.text',
               {
                 attrs: {
@@ -115,7 +119,7 @@ export function view(ctrl: StudyShare): VNode {
               },
               ctrl.relay ? i18n.study.downloadGame : i18n.study.chapterPgn,
             ),
-            h(
+            hl(
               'a.button.text',
               {
                 attrs: {
@@ -144,7 +148,7 @@ export function view(ctrl: StudyShare): VNode {
               },
               i18n.study.copyChapterPgn,
             ),
-            h(
+            hl(
               'a.button.text',
               {
                 attrs: {
@@ -162,7 +166,7 @@ export function view(ctrl: StudyShare): VNode {
               },
               'Board',
             ),
-            h(
+            hl(
               'a.button.text',
               {
                 attrs: {
@@ -177,8 +181,8 @@ export function view(ctrl: StudyShare): VNode {
               'GIF',
             ),
           ]),
-          h('form.form3', [
-            ...(ctrl.relay
+          hl('form.form3', [
+            (ctrl.relay
               ? [
                   [ctrl.relay.data.tour.name, ctrl.relay.tourPath()],
                   [ctrl.data.name, ctrl.relay.roundPath()],
@@ -189,45 +193,42 @@ export function view(ctrl: StudyShare): VNode {
                   [i18n.study.currentChapterUrl, addPly(`/study/${studyId}/${chapter.id}`), true],
                 ]
             ).map(([text, path, pastable]: [string, string, boolean]) =>
-              h('div.form-group', [
-                h('label.form-label', text),
+              hl('div.form-group', [
+                hl('label.form-label', text),
                 copyMeInput(`${baseUrl()}${path}`),
                 pastable && fromPly(ctrl),
                 pastable && isPrivate && youCanPasteThis(),
               ]),
             ),
-            ...(isPrivate
-              ? []
-              : [
-                  h('div.form-group', [
-                    h('label.form-label', i18n.study.embedInYourWebsite),
-                    copyMeInput(
-                      !isPrivate
-                        ? `<iframe ${
-                            ctrl.gamebook ? 'width="320" height="320"' : 'width="600" height="371"'
-                          } src="${baseUrl()}${addPly(
-                            `/study/embed/${studyId}/${chapter.id}`,
-                          )}" frameborder=0></iframe>`
-                        : i18n.study.onlyPublicStudiesCanBeEmbedded,
-                      { disabled: isPrivate },
-                    ),
-                    fromPly(ctrl),
-                    h(
-                      'a.form-help.text',
-                      {
-                        attrs: {
-                          href: '/developers#embed-study',
-                          target: '_blank',
-                          ...dataIcon(licon.InfoCircle),
-                        },
-                      },
-                      i18n.study.readMoreAboutEmbedding,
-                    ),
-                  ]),
-                ]),
+            isPrivate ||
+              hl('div.form-group', [
+                hl('label.form-label', i18n.study.embedInYourWebsite),
+                copyMeInput(
+                  !isPrivate
+                    ? `<iframe ${
+                        ctrl.gamebook ? 'width="320" height="320"' : 'width="600" height="371"'
+                      } src="${baseUrl()}${addPly(
+                        `/study/embed/${studyId}/${chapter.id}`,
+                      )}" frameborder=0></iframe>`
+                    : i18n.study.onlyPublicStudiesCanBeEmbedded,
+                  { disabled: isPrivate },
+                ),
+                fromPly(ctrl),
+                hl(
+                  'a.form-help.text',
+                  {
+                    attrs: {
+                      href: '/developers#embed-study',
+                      target: '_blank',
+                      ...dataIcon(licon.InfoCircle),
+                    },
+                  },
+                  i18n.study.readMoreAboutEmbedding,
+                ),
+              ]),
           ]),
-          h('div.form-group', [h('label.form-label', 'FEN'), copyMeInput(ctrl.currentNode().fen)]),
+          hl('div.form-group', [hl('label.form-label', 'FEN'), copyMeInput(ctrl.currentNode().fen)]),
         ]
-      : h('div', 'Sharing and exporting were disabled by the study owner.'),
+      : hl('div', 'Sharing and exporting were disabled by the study owner.'),
   );
 }

--- a/ui/analyse/src/study/studyView.ts
+++ b/ui/analyse/src/study/studyView.ts
@@ -3,7 +3,7 @@ import * as glyphForm from './studyGlyph';
 import * as practiceView from './practice/studyPracticeView';
 import type AnalyseCtrl from '../ctrl';
 import * as licon from 'lib/licon';
-import { type VNode, iconTag, bind, dataIcon, type MaybeVNodes, looseH as h } from 'lib/snabbdom';
+import { type VNode, iconTag, bind, dataIcon, type MaybeVNodes, hl } from 'lib/snabbdom';
 import { playButtons as gbPlayButtons, overrideButton as gbOverrideButton } from './gamebook/gamebookButtons';
 import type { Tab, ToolTab } from './interfaces';
 import { view as chapterEditFormView } from './chapterEditForm';
@@ -34,7 +34,7 @@ interface ToolButtonOpts {
 }
 
 function toolButton(opts: ToolButtonOpts): VNode {
-  return h(
+  return hl(
     'span.' + opts.tab,
     {
       attrs: { role: 'tab', title: opts.hint },
@@ -48,7 +48,7 @@ function toolButton(opts: ToolButtonOpts): VNode {
         opts.ctrl.redraw,
       ),
     },
-    [!!opts.count && h('count.data-count', { attrs: { 'data-count': opts.count } }), opts.icon],
+    [!!opts.count && hl('count.data-count', { attrs: { 'data-count': opts.count } }), opts.icon],
   );
 }
 
@@ -57,28 +57,28 @@ function buttons(root: AnalyseCtrl): VNode {
     canContribute = ctrl.members.canContribute(),
     showSticky = ctrl.data.features.sticky && (canContribute || (ctrl.vm.behind && ctrl.isUpdatedRecently())),
     gbButton = gbOverrideButton(ctrl);
-  return h('div.study__buttons', [
-    h('div.left-buttons.tabs-horiz', { attrs: { role: 'tablist' } }, [
+  return hl('div.study__buttons', [
+    hl('div.left-buttons.tabs-horiz', { attrs: { role: 'tablist' } }, [
       // distinct classes (sync, write) allow snabbdom to differentiate buttons
       !!showSticky &&
-        h(
+        hl(
           'a.mode.sync',
           {
             attrs: { title: i18n.study.allSyncMembersRemainOnTheSamePosition },
             class: { on: ctrl.vm.mode.sticky },
             hook: bind('click', ctrl.toggleSticky),
           },
-          [ctrl.vm.behind ? h('span.behind', '' + ctrl.vm.behind) : h('i.is'), 'SYNC'],
+          [ctrl.vm.behind ? hl('span.behind', '' + ctrl.vm.behind) : hl('i.is'), 'SYNC'],
         ),
       canContribute &&
-        h(
+        hl(
           'a.mode.write',
           {
             attrs: { title: i18n.study.shareChanges },
             class: { on: ctrl.vm.mode.write },
             hook: bind('click', ctrl.toggleWrite),
           },
-          [h('i.is'), 'REC'],
+          [hl('i.is'), 'REC'],
         ),
       toolButton({ ctrl, tab: 'tags', hint: i18n.study.pgnTags, icon: iconTag(licon.Tag) }),
       canContribute &&
@@ -97,7 +97,7 @@ function buttons(root: AnalyseCtrl): VNode {
           ctrl,
           tab: 'glyphs',
           hint: i18n.study.annotateWithGlyphs,
-          icon: h('i.glyph-icon'),
+          icon: hl('i.glyph-icon'),
           count: (root.node.glyphs || []).length,
         }),
       (canContribute || root.data.analysis) &&
@@ -112,25 +112,25 @@ function buttons(root: AnalyseCtrl): VNode {
       toolButton({ ctrl, tab: 'share', hint: i18n.study.shareAndExport, icon: iconTag(shareIcon()) }),
       !ctrl.relay &&
         !ctrl.data.chapter.gamebook &&
-        h('span.help', {
+        hl('span.help', {
           attrs: { title: i18n.study.getTheTour, ...dataIcon(licon.InfoCircle) },
           hook: bind('click', ctrl.startTour),
         }),
     ]),
-    gbButton && h('div.right', gbButton),
+    gbButton && hl('div.right', gbButton),
   ]);
 }
 
 function metadata(ctrl: StudyCtrl): VNode {
   const d = ctrl.data,
     title = `${d.name}: ${ctrl.currentChapter().name}`;
-  return h('div.study__metadata', [
-    h('h2', [
-      h('span.name', { attrs: { title } }, [
-        d.flair && h('img.icon-flair', { attrs: { src: site.asset.flairSrc(d.flair) } }),
+  return hl('div.study__metadata', [
+    hl('h2', [
+      hl('span.name', { attrs: { title } }, [
+        d.flair && hl('img.icon-flair', { attrs: { src: site.asset.flairSrc(d.flair) } }),
         title,
       ]),
-      h(
+      hl(
         'span.liking.text',
         {
           class: { liked: d.liked },
@@ -152,7 +152,7 @@ export function side(ctrl: StudyCtrl, withSearch: boolean): VNode {
   const activeTab = ctrl.vm.tab();
 
   const makeTab = (key: Tab, name: string) =>
-    h(
+    hl(
       `span.${key}`,
       {
         class: { active: activeTab === key },
@@ -166,16 +166,16 @@ export function side(ctrl: StudyCtrl, withSearch: boolean): VNode {
     (ctrl.chapters.list.looksNew() && !ctrl.members.canContribute()) ||
     makeTab('chapters', i18n.study[ctrl.relay ? 'nbGames' : 'nbChapters'](ctrl.chapters.list.size()));
 
-  const tabs = h('div.tabs-horiz', { attrs: { role: 'tablist' } }, [
+  const tabs = hl('div.tabs-horiz', { attrs: { role: 'tablist' } }, [
     chaptersTab,
     ctrl.members.size() > 0 && makeTab('members', i18n.study.nbMembers(ctrl.members.size())),
     withSearch &&
-      h('span.search.narrow', {
+      hl('span.search.narrow', {
         attrs: { ...dataIcon(licon.Search) },
         hook: bind('click', () => ctrl.search.open(true)),
       }),
     ctrl.members.isOwner() &&
-      h('span.more.narrow', {
+      hl('span.more.narrow', {
         attrs: { ...dataIcon(licon.Hamburger), title: i18n.study.editStudy },
         hook: bind('click', () => ctrl.form.open(!ctrl.form.open()), ctrl.redraw),
       }),
@@ -183,13 +183,13 @@ export function side(ctrl: StudyCtrl, withSearch: boolean): VNode {
 
   const content = (activeTab === 'members' ? memberView : chapterView)(ctrl);
 
-  return h('div.study__side', [tabs, content]);
+  return hl('div.study__side', [tabs, content]);
 }
 
 export function contextMenu(ctrl: StudyCtrl, path: Tree.Path, node: Tree.Node): VNode[] {
   return ctrl.vm.mode.write
     ? [
-        h(
+        hl(
           'a',
           {
             attrs: dataIcon(licon.BubbleSpeech),
@@ -200,7 +200,7 @@ export function contextMenu(ctrl: StudyCtrl, path: Tree.Path, node: Tree.Node): 
           },
           i18n.study.commentThisMove,
         ),
-        h(
+        hl(
           'a.glyph-icon',
           {
             hook: bind('click', () => {
@@ -259,7 +259,7 @@ export function underboard(ctrl: AnalyseCtrl): MaybeVNodes {
       break;
     case 'serverEval':
       panel = serverEvalView(study.serverEval);
-      if (study?.relay) panel = h('div.eval-chart-and-training', [panel, renderTrainingView(ctrl)]);
+      if (study?.relay) panel = hl('div.eval-chart-and-training', [panel, renderTrainingView(ctrl)]);
       break;
     case 'share':
       panel = studyShareView(study.share);

--- a/ui/analyse/src/treeView/contextMenu.ts
+++ b/ui/analyse/src/treeView/contextMenu.ts
@@ -1,5 +1,5 @@
 import * as licon from 'lib/licon';
-import { type VNode, onInsert, looseH as h } from 'lib/snabbdom';
+import { type VNode, onInsert, hl } from 'lib/snabbdom';
 import type AnalyseCtrl from '../ctrl';
 import * as studyView from '../study/studyView';
 import { patch, nodeFullName } from '../view/util';
@@ -59,7 +59,7 @@ function action(
   onHover?: () => void,
   onLeave?: () => void,
 ): VNode {
-  return h(
+  return hl(
     'a',
     {
       attrs: { 'data-icon': icon },
@@ -91,7 +91,7 @@ function view(opts: Opts, coords: Coords): VNode {
     node = ctrl.tree.nodeAtPath(opts.path),
     onMainline = ctrl.tree.pathIsMainline(opts.path) && !ctrl.tree.pathIsForcedVariation(opts.path),
     extendedPath = opts.root.tree.extendPath(opts.path, onMainline);
-  return h(
+  return hl(
     'div#' + elementId + '.visible',
     {
       hook: {
@@ -103,7 +103,7 @@ function view(opts: Opts, coords: Coords): VNode {
       },
     },
     [
-      h('p.title', nodeFullName(node)),
+      hl('p.title', nodeFullName(node)),
 
       !onMainline &&
         action(licon.UpTriangle, i18n.site.promoteVariation, () => ctrl.promote(opts.path, false)),
@@ -122,7 +122,7 @@ function view(opts: Opts, coords: Coords): VNode {
 
       action(licon.MinusButton, i18n.site.collapseVariations, () => ctrl.setAllCollapsed(opts.path, true)),
 
-      ...(ctrl.study ? studyView.contextMenu(ctrl.study, opts.path, node) : []),
+      ctrl.study && studyView.contextMenu(ctrl.study, opts.path, node),
 
       onMainline &&
         action(licon.InternalArrow, i18n.site.forceVariation, () => ctrl.forceVariation(opts.path, true)),

--- a/ui/analyse/src/treeView/inlineView.ts
+++ b/ui/analyse/src/treeView/inlineView.ts
@@ -112,7 +112,7 @@ function renderMoveAndChildrenOf(ctx: Ctx, node: Tree.Node, opts: Opts): MaybeVN
         parentPath: path,
         isMainline: opts.isMainline,
         depth: opts.depth,
-        truncate: opts.truncate ? opts.truncate - 1 : undefined,
+        truncate: !!opts.truncate ? opts.truncate - 1 : undefined,
         withIndex: !!comments[0],
       }) || [],
     );

--- a/ui/analyse/src/view/actionMenu.ts
+++ b/ui/analyse/src/view/actionMenu.ts
@@ -2,7 +2,7 @@ import { isEmpty } from 'lib';
 import * as licon from 'lib/licon';
 import { isTouchDevice } from 'lib/device';
 import { domDialog } from 'lib/view/dialog';
-import { type VNode, bind, dataIcon, type MaybeVNodes, looseH as h } from 'lib/snabbdom';
+import { type VNode, type LooseVNodes, bind, dataIcon, type MaybeVNodes, hl } from 'lib/snabbdom';
 import type { AutoplayDelay } from '../autoplay';
 import { toggle, type ToggleSettings } from 'lib/view/controls';
 import type AnalyseCtrl from '../ctrl';
@@ -38,11 +38,11 @@ function autoplayButtons(ctrl: AnalyseCtrl): VNode {
     ...(d.game.speed !== 'correspondence' && !isEmpty(d.game.moveCentis) ? [realtimeSpeed] : []),
     ...(d.analysis ? [cplSpeed] : []),
   ];
-  return h(
+  return hl(
     'div.autoplay',
     speeds.map(speed => {
       const active = ctrl.autoplay.getDelay() === speed.delay;
-      return h(
+      return hl(
         'a.button',
         {
           class: { active, 'button-empty': !active },
@@ -54,11 +54,11 @@ function autoplayButtons(ctrl: AnalyseCtrl): VNode {
   );
 }
 
-const hiddenInput = (name: string, value: string) => h('input', { attrs: { type: 'hidden', name, value } });
+const hiddenInput = (name: string, value: string) => hl('input', { attrs: { type: 'hidden', name, value } });
 
 function studyButton(ctrl: AnalyseCtrl) {
   if (ctrl.study || ctrl.ongoing) return;
-  return h(
+  return hl(
     'form',
     {
       attrs: { method: 'post', action: '/study/as' },
@@ -75,7 +75,7 @@ function studyButton(ctrl: AnalyseCtrl) {
       hiddenInput('orientation', ctrl.bottomColor()),
       hiddenInput('variant', ctrl.data.game.variant.key),
       hiddenInput('fen', ctrl.tree.root.fen),
-      h('button', { attrs: { type: 'submit', 'data-icon': licon.StudyBoard } }, i18n.site.toStudy),
+      hl('button', { attrs: { type: 'submit', 'data-icon': licon.StudyBoard } }, i18n.site.toStudy),
     ],
   );
 }
@@ -88,8 +88,8 @@ export function view(ctrl: AnalyseCtrl): VNode {
     linkAttrs = { rel: ctrl.isEmbed ? '' : 'nofollow', target: ctrl.isEmbed ? '_blank' : '' };
 
   const tools: MaybeVNodes = [
-    h('div.action-menu__tools', [
-      h(
+    hl('div.action-menu__tools', [
+      hl(
         'a',
         {
           hook: bind('click', () => {
@@ -102,7 +102,7 @@ export function view(ctrl: AnalyseCtrl): VNode {
         i18n.site.flipBoard,
       ),
       !ctrl.ongoing &&
-        h(
+        hl(
           'a',
           {
             attrs: {
@@ -121,7 +121,7 @@ export function view(ctrl: AnalyseCtrl): VNode {
           i18n.site.boardEditor,
         ),
       canContinue &&
-        h(
+        hl(
           'a',
           {
             hook: bind('click', () =>
@@ -133,7 +133,7 @@ export function view(ctrl: AnalyseCtrl): VNode {
         ),
       studyButton(ctrl),
       ctrl.persistence?.isDirty &&
-        h(
+        hl(
           'a',
           {
             attrs: {
@@ -147,49 +147,45 @@ export function view(ctrl: AnalyseCtrl): VNode {
     ]),
   ];
 
-  const cevalConfig: MaybeVNodes =
-    ceval?.possible && ceval.allowed()
-      ? [
-          h('h2', i18n.site.computerAnalysis),
-          ctrlToggle(
-            {
-              name: i18n.site.enable,
-              title: (mandatoryCeval ? 'Required by practice mode' : 'Stockfish') + ' (Hotkey: z)',
-              id: 'all',
-              checked: ctrl.showComputer(),
-              disabled: mandatoryCeval,
-              change: ctrl.toggleComputer,
-            },
-            ctrl,
-          ),
-          ...(ctrl.showComputer()
-            ? [
-                ctrlToggle(
-                  {
-                    name: i18n.site.bestMoveArrow,
-                    title: 'Hotkey: a',
-                    id: 'shapes',
-                    checked: ctrl.showAutoShapes(),
-                    change: ctrl.toggleAutoShapes,
-                  },
-                  ctrl,
-                ),
-                ctrlToggle(
-                  {
-                    name: i18n.site.evaluationGauge,
-                    id: 'gauge',
-                    checked: ctrl.showGauge(),
-                    change: ctrl.toggleGauge,
-                  },
-                  ctrl,
-                ),
-              ]
-            : []),
-        ]
-      : [];
+  const cevalConfig: LooseVNodes = ceval?.possible &&
+    ceval.allowed() && [
+      hl('h2', i18n.site.computerAnalysis),
+      ctrlToggle(
+        {
+          name: i18n.site.enable,
+          title: (mandatoryCeval ? 'Required by practice mode' : 'Stockfish') + ' (Hotkey: z)',
+          id: 'all',
+          checked: ctrl.showComputer(),
+          disabled: mandatoryCeval,
+          change: ctrl.toggleComputer,
+        },
+        ctrl,
+      ),
+      ctrl.showComputer() && [
+        ctrlToggle(
+          {
+            name: i18n.site.bestMoveArrow,
+            title: 'Hotkey: a',
+            id: 'shapes',
+            checked: ctrl.showAutoShapes(),
+            change: ctrl.toggleAutoShapes,
+          },
+          ctrl,
+        ),
+        ctrlToggle(
+          {
+            name: i18n.site.evaluationGauge,
+            id: 'gauge',
+            checked: ctrl.showGauge(),
+            change: ctrl.toggleGauge,
+          },
+          ctrl,
+        ),
+      ],
+    ];
 
   const displayConfig = [
-    h('h2', 'Display'),
+    hl('h2', 'Display'),
     ctrlToggle(
       {
         name: i18n.site.inlineNotation,
@@ -227,14 +223,14 @@ export function view(ctrl: AnalyseCtrl): VNode {
       ),
   ];
 
-  return h('div.action-menu', [
-    ...tools,
-    ...displayConfig,
-    ...cevalConfig,
-    ...(ctrl.mainline.length > 4 ? [h('h2', i18n.site.replayMode), autoplayButtons(ctrl)] : []),
+  return hl('div.action-menu', [
+    tools,
+    displayConfig,
+    cevalConfig,
+    ctrl.mainline.length > 4 && [hl('h2', i18n.site.replayMode), autoplayButtons(ctrl)],
     canContinue &&
-      h('div.continue-with.none.g_' + d.game.id, [
-        h(
+      hl('div.continue-with.none.g_' + d.game.id, [
+        hl(
           'a.button',
           {
             attrs: {
@@ -246,7 +242,7 @@ export function view(ctrl: AnalyseCtrl): VNode {
           },
           i18n.site.playWithTheMachine,
         ),
-        h(
+        hl(
           'a.button',
           {
             attrs: {

--- a/ui/analyse/src/view/components.ts
+++ b/ui/analyse/src/view/components.ts
@@ -5,11 +5,12 @@ import * as licon from 'lib/licon';
 import {
   type VNode,
   type LooseVNode,
+  type LooseVNodes,
   bind,
   bindNonPassive,
   onInsert,
   dataIcon,
-  looseH as h,
+  hl,
 } from 'lib/snabbdom';
 import { playable } from 'lib/game/game';
 import { bindMobileMousedown, isMobile } from 'lib/device';
@@ -88,10 +89,10 @@ export function viewContext(ctrl: AnalyseCtrl, deps?: typeof studyDeps): ViewCon
 
 export function renderMain(
   { ctrl, playerBars, gaugeOn, gamebookPlayView, needsInnerCoords, hasRelayTour }: ViewContext,
-  ...kids: LooseVNode[]
+  ...kids: LooseVNodes[]
 ): VNode {
   const isRelay = defined(ctrl.study?.relay);
-  return h(
+  return hl(
     'main.analyse.variant-' + ctrl.data.game.variant.key,
     {
       hook: {
@@ -127,24 +128,24 @@ export function renderMain(
 }
 
 export function renderTools({ ctrl, deps, concealOf, allowVideo }: ViewContext, embedded?: LooseVNode) {
-  return h(addChapterId(ctrl.study, 'div.analyse__tools'), [
+  return hl(addChapterId(ctrl.study, 'div.analyse__tools'), [
     allowVideo && embedded,
-    ...(ctrl.actionMenu()
+    ctrl.actionMenu()
       ? [actionMenu(ctrl)]
       : [
-          ...cevalView.renderCeval(ctrl),
+          cevalView.renderCeval(ctrl),
           !ctrl.retro?.isSolving() && !ctrl.practice && cevalView.renderPvs(ctrl),
           renderMoveList(ctrl, deps, concealOf),
           deps?.gbEdit.running(ctrl) ? deps?.gbEdit.render(ctrl) : undefined,
           backToLiveView(ctrl),
           forkView(ctrl, concealOf),
           retroView(ctrl) || practiceView(ctrl) || explorerView(ctrl),
-        ]),
+        ],
   ]);
 }
 
 export function renderBoard({ ctrl, study, playerBars, playerStrips }: ViewContext) {
-  return h(
+  return hl(
     addChapterId(study, 'div.analyse__board.main-board'),
     {
       hook:
@@ -171,7 +172,7 @@ export function renderBoard({ ctrl, study, playerBars, playerStrips }: ViewConte
             ),
     },
     [
-      ...(playerStrips || []),
+      playerStrips,
       playerBars?.[ctrl.bottomIsWhite() ? 1 : 0],
       chessground.render(ctrl),
       playerBars?.[ctrl.bottomIsWhite() ? 0 : 1],
@@ -181,7 +182,7 @@ export function renderBoard({ ctrl, study, playerBars, playerStrips }: ViewConte
 }
 
 export function renderUnderboard({ ctrl, deps, study }: ViewContext) {
-  return h(
+  return hl(
     'div.analyse__underboard',
     {
       hook:
@@ -194,10 +195,10 @@ export function renderUnderboard({ ctrl, deps, study }: ViewContext) {
 export function renderInputs(ctrl: AnalyseCtrl): VNode | undefined {
   if (ctrl.ongoing || !ctrl.data.userAnalysis) return;
   if (ctrl.redirecting) return spinner();
-  return h('div.copyables', [
-    h('div.pair', [
-      h('label.name', 'FEN'),
-      h('input.copyable', {
+  return hl('div.copyables', [
+    hl('div.pair', [
+      hl('label.name', 'FEN'),
+      hl('input.copyable', {
         attrs: { spellcheck: 'false', enterkeyhint: 'done' },
         hook: {
           insert: vnode => {
@@ -221,10 +222,10 @@ export function renderInputs(ctrl: AnalyseCtrl): VNode | undefined {
         },
       }),
     ]),
-    h('div.pgn', [
-      h('div.pair', [
-        h('label.name', 'PGN'),
-        h('textarea.copyable', {
+    hl('div.pgn', [
+      hl('div.pair', [
+        hl('label.name', 'PGN'),
+        hl('textarea.copyable', {
           attrs: { spellcheck: 'false' },
           class: { 'is-error': !!ctrl.pgnError },
           hook: {
@@ -250,7 +251,7 @@ export function renderInputs(ctrl: AnalyseCtrl): VNode | undefined {
           },
         }),
         !isMobile() &&
-          h(
+          hl(
             'button.button.button-thin.bottom-item.bottom-action.text',
             {
               attrs: dataIcon(licon.PlayTriangle),
@@ -261,7 +262,7 @@ export function renderInputs(ctrl: AnalyseCtrl): VNode | undefined {
             },
             i18n.site.importPgn,
           ),
-        h(
+        hl(
           'div.bottom-item.bottom-error',
           { attrs: dataIcon(licon.CautionTriangle), class: { 'is-error': !!ctrl.pgnError } },
           renderPgnError(ctrl.pgnError),
@@ -275,7 +276,7 @@ export function renderControls(ctrl: AnalyseCtrl) {
   const canJumpPrev = ctrl.path !== '',
     canJumpNext = !!ctrl.node.children[0],
     menuIsOpen = ctrl.actionMenu();
-  return h(
+  return hl(
     'div.analyse__controls.analyse-controls',
     {
       hook: onInsert(
@@ -297,16 +298,16 @@ export function renderControls(ctrl: AnalyseCtrl) {
       ),
     },
     [
-      h(
+      hl(
         'div.features',
         ctrl.studyPractice
           ? [
-              h('button.fbt', {
+              hl('button.fbt', {
                 attrs: { title: i18n.site.analysis, 'data-act': 'analysis', 'data-icon': licon.Microscope },
               }),
             ]
           : [
-              h('button.fbt', {
+              hl('button.fbt', {
                 attrs: {
                   title: i18n.site.openingExplorerAndTablebase,
                   'data-act': 'explorer',
@@ -321,7 +322,7 @@ export function renderControls(ctrl: AnalyseCtrl) {
                 ctrl.ceval.allowed() &&
                 !ctrl.isGamebook() &&
                 !ctrl.isEmbed &&
-                h('button.fbt', {
+                hl('button.fbt', {
                   attrs: {
                     title: i18n.site.practiceWithComputer,
                     'data-act': 'practice',
@@ -331,15 +332,15 @@ export function renderControls(ctrl: AnalyseCtrl) {
                 }),
             ],
       ),
-      h('div.jumps', [
+      hl('div.jumps', [
         jumpButton(licon.JumpFirst, 'first', canJumpPrev),
         jumpButton(licon.JumpPrev, 'prev', canJumpPrev),
         jumpButton(licon.JumpNext, 'next', canJumpNext),
         jumpButton(licon.JumpLast, 'last', canJumpNext),
       ]),
       ctrl.studyPractice
-        ? h('div.noop')
-        : h('button.fbt', {
+        ? hl('div.noop')
+        : hl('button.fbt', {
             class: { active: menuIsOpen },
             attrs: { title: i18n.site.menu, 'data-act': 'menu', 'data-icon': licon.Hamburger },
           }),
@@ -350,8 +351,8 @@ export function renderControls(ctrl: AnalyseCtrl) {
 export function renderResult(ctrl: AnalyseCtrl): VNode[] {
   const termination = () => ctrl.study && findTag(ctrl.study.data.chapter.tags, 'termination');
   const render = (result: string, status: string) => [
-    h('div.result', result),
-    h('div.status', [termination() && `${termination()} • `, status]),
+    hl('div.result', result),
+    hl('div.status', [termination() && `${termination()} • `, status]),
   ];
   if (ctrl.data.game.status.id >= 30) {
     const winner = ctrl.data.game.winner;
@@ -371,8 +372,8 @@ export function renderResult(ctrl: AnalyseCtrl): VNode[] {
 }
 
 const renderMoveList = (ctrl: AnalyseCtrl, deps?: typeof studyDeps, concealOf?: ConcealOf): VNode =>
-  h('div.analyse__moves.areplay', [
-    h(`div.areplay__v${ctrl.treeVersion}`, [renderTreeView(ctrl, concealOf), ...renderResult(ctrl)]),
+  hl('div.analyse__moves.areplay', [
+    hl(`div.areplay__v${ctrl.treeVersion}`, [renderTreeView(ctrl, concealOf), renderResult(ctrl)]),
     !ctrl.practice && !deps?.gbEdit.running(ctrl) && renderNextChapter(ctrl),
   ]);
 
@@ -428,7 +429,7 @@ function forceInnerCoords(ctrl: AnalyseCtrl, v: boolean) {
 }
 
 const jumpButton = (icon: string, effect: string, enabled: boolean): VNode =>
-  h('button.fbt', { class: { disabled: !enabled }, attrs: { 'data-act': effect, 'data-icon': icon } });
+  hl('button.fbt', { class: { disabled: !enabled }, attrs: { 'data-act': effect, 'data-icon': icon } });
 
 const dataAct = (e: Event): string | null => {
   const target = e.target as HTMLElement;
@@ -437,7 +438,7 @@ const dataAct = (e: Event): string | null => {
 
 function renderPlayerStrips(ctrl: AnalyseCtrl): [VNode, VNode] | undefined {
   const renderPlayerStrip = (cls: string, materialDiff: VNode, clock?: VNode): VNode =>
-    h('div.analyse__player_strip.' + cls, [materialDiff, clock]);
+    hl('div.analyse__player_strip.' + cls, [materialDiff, clock]);
 
   const clocks = renderClocks(ctrl, ctrl.path),
     whitePov = ctrl.bottomIsWhite(),

--- a/ui/analyse/src/view/main.ts
+++ b/ui/analyse/src/view/main.ts
@@ -1,6 +1,6 @@
 import { view as cevalView } from 'lib/ceval/ceval';
 import * as licon from 'lib/licon';
-import { type VNode, onInsert, looseH as h } from 'lib/snabbdom';
+import { type VNode, onInsert, hl } from 'lib/snabbdom';
 import { playable } from 'lib/game/game';
 import * as router from 'lib/game/router';
 import { render as trainingView } from './roundTraining';
@@ -49,7 +49,7 @@ function analyseView(ctrl: AnalyseCtrl, deps?: typeof studyDeps): VNode {
     trainingView(ctrl),
     ctrl.studyPractice
       ? deps?.studyPracticeView.side(study!)
-      : h(
+      : hl(
           'aside.analyse__side',
           {
             hook: onInsert(elm => {
@@ -67,9 +67,9 @@ function analyseView(ctrl: AnalyseCtrl, deps?: typeof studyDeps): VNode {
                   ctrl.forecast && forecastView(ctrl, ctrl.forecast),
                   !ctrl.synthetic &&
                     playable(ctrl.data) &&
-                    h(
+                    hl(
                       'div.back-to-game',
-                      h(
+                      hl(
                         'a.button.button-empty.text',
                         {
                           attrs: {
@@ -83,6 +83,6 @@ function analyseView(ctrl: AnalyseCtrl, deps?: typeof studyDeps): VNode {
                 ],
         ),
     ctrl.chatCtrl && renderChat(ctrl.chatCtrl),
-    h('div.chat__members.none', { hook: onInsert(watchers) }),
+    hl('div.chat__members.none', { hook: onInsert(watchers) }),
   );
 }

--- a/ui/bits/src/bits.voiceChat.ts
+++ b/ui/bits/src/bits.voiceChat.ts
@@ -1,4 +1,4 @@
-import { looseH as h } from 'lib/snabbdom';
+import { hl } from 'lib/snabbdom';
 import * as licon from 'lib/licon';
 import Peer from 'peerjs';
 import { pubsub } from 'lib/pubsub';
@@ -206,7 +206,7 @@ export function initModule(opts: VoiceChatOpts): VoiceChat | undefined {
     render: () => {
       const connections = allOpenConnections();
       return devices
-        ? h(
+        ? hl(
             'div.mchat__tab.voicechat.data-count.voicechat-' + state,
             {
               attrs: {
@@ -222,7 +222,7 @@ export function initModule(opts: VoiceChatOpts): VoiceChat | undefined {
             },
             state === 'on'
               ? connections.map(c =>
-                  h('audio.voicechat__audio.' + c.peer, {
+                  hl('audio.voicechat__audio.' + c.peer, {
                     attrs: { autoplay: true },
                     hook: {
                       insert(vnode) {

--- a/ui/botDev/src/devSideView.ts
+++ b/ui/botDev/src/devSideView.ts
@@ -1,5 +1,5 @@
 import * as co from 'chessops';
-import { type VNode, looseH as h, onInsert, bind } from 'lib/snabbdom';
+import { type VNode, hl, onInsert, bind } from 'lib/snabbdom';
 import * as licon from 'lib/licon';
 import { storedBooleanProp, storedIntProp } from 'lib/storage';
 import { domDialog } from 'lib/view/dialog';
@@ -14,11 +14,11 @@ import type { LocalSpeed, LocalSetup } from 'lib/bot/types';
 import { env } from './devEnv';
 
 export function renderDevSide(): VNode {
-  return h('div.dev-side.dev-view', [
-    h('div', player(co.opposite(env.game.screenOrientation))),
+  return hl('div.dev-side.dev-view', [
+    hl('div', player(co.opposite(env.game.screenOrientation))),
     dashboard(),
     progress(),
-    h('div', player(env.game.screenOrientation)),
+    hl('div', player(env.game.screenOrientation)),
   ]);
 }
 
@@ -30,7 +30,7 @@ function player(color: Color): VNode {
     white: isLight ? '.button-metal' : '.button-inverse',
     black: isLight ? '.button-inverse' : '.button-metal',
   };
-  return h(
+  return hl(
     `div.player`,
     {
       attrs: { 'data-color': color },
@@ -38,18 +38,18 @@ function player(color: Color): VNode {
     },
     [
       env.bot[color] &&
-        h(`button.upper-right`, {
+        hl(`button.upper-right`, {
           attrs: { 'data-action': 'remove', 'data-icon': licon.Cancel },
           hook: bind('click', e => {
             reset({ ...env.bot.uids, [color]: undefined });
             e.stopPropagation();
           }),
         }),
-      h('img', { attrs: { src: imgUrl } }),
+      hl('img', { attrs: { src: imgUrl } }),
       (!(env.bot.white || env.bot.black) || (p && !('level' in p))) &&
-        h('div.bot-actions', [
+        hl('div.bot-actions', [
           //p instanceof Bot &&
-          h(
+          hl(
             'button.button' + buttonClass[color],
             {
               hook: onInsert(el =>
@@ -63,7 +63,7 @@ function player(color: Color): VNode {
           ),
           p &&
             !('level' in p) &&
-            h(
+            hl(
               'button.button' + buttonClass[color],
               {
                 hook: onInsert(el =>
@@ -82,11 +82,11 @@ function player(color: Color): VNode {
               'rate',
             ),
         ]),
-      h('div.stats', [
-        h('span', env.game.nameOf(color)),
+      hl('div.stats', [
+        hl('span', env.game.nameOf(color)),
         p && ratingSpan(p),
-        p instanceof Bot && h('span.stats', p.statsText),
-        h('span', resultsString(env.dev.log, env.bot[color]?.uid)),
+        p instanceof Bot && hl('span.stats', p.statsText),
+        hl('span', resultsString(env.dev.log, env.bot[color]?.uid)),
       ]),
     ],
   );
@@ -99,8 +99,8 @@ function ratingText(uid: string, speed: LocalSpeed): string {
 
 function ratingSpan(p: Bot): VNode {
   const glicko = env.dev.getRating(p.uid, env.game.speed);
-  return h('span.stats', [
-    h('i', { attrs: { 'data-icon': speedIcon(env.game.speed) } }),
+  return hl('span.stats', [
+    hl('i', { attrs: { 'data-icon': speedIcon(env.game.speed) } }),
     `${glicko.r}${glicko.rd > 80 ? '?' : ''}`,
   ]);
 }
@@ -124,11 +124,11 @@ async function editBot(color: Color) {
 }
 
 function clockOptions() {
-  return h('span', [
-    ...(['initial', 'increment'] as const).map(type => {
-      return h('label', [
+  return hl('span', [
+    (['initial', 'increment'] as const).map(type => {
+      return hl('label', [
         type === 'initial' ? 'clk' : 'inc',
-        h(
+        hl(
           `select.${type}`,
           {
             hook: onInsert(el =>
@@ -138,11 +138,9 @@ function clockOptions() {
               }),
             ),
           },
-          [
-            ...rangeTicks[type].map(([secs, label]) =>
-              h('option', { attrs: { value: secs, selected: secs === env.game[type] } }, label),
-            ),
-          ],
+          rangeTicks[type].map(([secs, label]) =>
+            hl('option', { attrs: { value: secs, selected: secs === env.game[type] } }, label),
+          ),
         ),
       ]);
     }),
@@ -156,22 +154,22 @@ function reset(params: Partial<LocalSetup>): void {
 }
 
 function dashboard() {
-  return h('div.dev-dashboard', [
+  return hl('div.dev-dashboard', [
     fen(),
     clockOptions(),
-    h('span', [
-      h('div', [
-        h('label', { attrs: { title: 'instantly deduct bot move times. disable animations and sound' } }, [
-          h('input', {
+    hl('span', [
+      hl('div', [
+        hl('label', { attrs: { title: 'instantly deduct bot move times. disable animations and sound' } }, [
+          hl('input', {
             attrs: { type: 'checkbox', checked: env.dev.hurryProp() },
             hook: bind('change', e => env.dev.hurryProp((e.target as HTMLInputElement).checked)),
           }),
           'hurry',
         ]),
       ]),
-      h('label', [
+      hl('label', [
         'games',
-        h('input.num-games', {
+        hl('input.num-games', {
           attrs: { type: 'text', value: storedIntProp('botdev.numGames', 1)() },
           hook: bind('input', e => {
             const el = e.target as HTMLInputElement;
@@ -183,26 +181,26 @@ function dashboard() {
         }),
       ]),
     ]),
-    h('span', [
-      h(
+    hl('span', [
+      hl(
         'button.button.button-metal',
         { hook: bind('click', () => showSetupDialog(env.game.live.setup)) },
         'setup',
       ),
-      h('button.button.button-metal', { hook: bind('click', () => roundRobin()) }, 'tour'),
-      h('div.spacer'),
-      h('button.button.button-metal', {
+      hl('button.button.button-metal', { hook: bind('click', () => roundRobin()) }, 'tour'),
+      hl('div.spacer'),
+      hl('button.button.button-metal', {
         attrs: { 'data-icon': licon.ShareIos },
         hook: bind('click', () => report()),
       }),
-      h(`button.board-action.button.button-metal`, {
+      hl(`button.board-action.button.button-metal`, {
         attrs: { 'data-icon': licon.Switch },
         hook: bind('click', () => {
           env.game.load({ white: env.bot.uids.black, black: env.bot.uids.white });
           env.redraw();
         }),
       }),
-      h(`button.board-action.button.button-metal`, {
+      hl(`button.board-action.button.button-metal`, {
         attrs: { 'data-icon': licon.Reload },
         hook: onInsert(el =>
           el.addEventListener('click', () => {
@@ -217,19 +215,19 @@ function dashboard() {
 }
 
 function progress() {
-  return h('div.dev-progress', [
-    h('div.results', [
+  return hl('div.dev-progress', [
+    hl('div.results', [
       env.dev.log.length > 0 &&
-        h('button.button.button-empty.button-red.icon-btn.upper-right', {
+        hl('button.button.button-empty.button-red.icon-btn.upper-right', {
           attrs: { 'data-icon': licon.Cancel },
           hook: bind('click', () => {
             env.dev.log = [];
             env.redraw();
           }),
         }),
-      ...playersWithResults(env.dev.log).map(p => {
+      playersWithResults(env.dev.log).map(p => {
         const bot = env.bot.info(p)!;
-        return h(
+        return hl(
           'div',
           `${bot?.name ?? p} ${ratingText(p, env.game.speed)} ${resultsString(env.dev.log, p)}`,
         );
@@ -242,7 +240,7 @@ function renderPlayPause(): VNode {
   const boardTurn = env.game.rewind?.turn ?? env.game.live.turn;
   const disabled = !env.bot[boardTurn];
   const paused = env.game.isStopped || env.game.rewind || env.game.live.finished;
-  return h(
+  return hl(
     `button.play-pause.button.button-metal${disabled ? '.play.disabled' : paused ? '.play' : '.pause'}`,
     {
       hook: onInsert(el =>
@@ -272,7 +270,7 @@ function renderPlayPause(): VNode {
 
 function fen(): VNode {
   const boardFen = env.game.rewind?.fen ?? env.game.live.fen;
-  return h('input.fen', {
+  return hl('input.fen', {
     key: boardFen,
     attrs: {
       type: 'text',

--- a/ui/botDev/src/gameView.ts
+++ b/ui/botDev/src/gameView.ts
@@ -1,10 +1,10 @@
-import { looseH as h, VNode } from 'lib/snabbdom';
+import { hl, VNode } from 'lib/snabbdom';
 
 export function renderGameView(side?: VNode): VNode {
-  return h('main.round', [
-    side ? h('aside.round__side', side) : undefined,
-    h('div.round__app', [h('div.round__app__board.main-board'), h('div.col1-rmoves-preload')]),
-    h('div.round__underboard', [h('div.round__now-playing')]),
-    h('div.round__underchat'),
+  return hl('main.round', [
+    side ? hl('aside.round__side', side) : undefined,
+    hl('div.round__app', [hl('div.round__app__board.main-board'), hl('div.col1-rmoves-preload')]),
+    hl('div.round__underboard', [hl('div.round__now-playing')]),
+    hl('div.round__underchat'),
   ]);
 }

--- a/ui/botPlay/src/play/view/playView.ts
+++ b/ui/botPlay/src/play/view/playView.ts
@@ -1,5 +1,5 @@
 import * as licon from 'lib/licon';
-import { bind, looseH as h, onInsert, type LooseVNodes, dataIcon, type VNode } from 'lib/snabbdom';
+import { bind, hl, onInsert, type LooseVNodes, dataIcon, type VNode } from 'lib/snabbdom';
 import { Chessground } from '@lichess-org/chessground';
 import { stepwiseScroll } from 'lib/view/controls';
 import type PlayCtrl from '../playCtrl';
@@ -17,10 +17,10 @@ import { type TopOrBottom } from 'lib/game/game';
 import { renderClock } from 'lib/game/clock/clockView';
 
 export const playView = (ctrl: PlayCtrl) =>
-  h('main.bot-app.bot-game.unique-game-' + ctrl.game.id, [
+  hl('main.bot-app.bot-game.unique-game-' + ctrl.game.id, [
     viewBoard(ctrl),
-    h('div.bot-game__table'),
-    ...viewTable(ctrl),
+    hl('div.bot-game__table'),
+    viewTable(ctrl),
   ]);
 
 const viewTable = (ctrl: PlayCtrl) => {
@@ -36,20 +36,20 @@ const viewTable = (ctrl: PlayCtrl) => {
 };
 
 const viewClockMat = (ctrl: PlayCtrl, position: TopOrBottom, material: VNode) =>
-  h(`div.bot-game__clock-mat.bot-game__clock-mat--${position}`, [
+  hl(`div.bot-game__clock-mat.bot-game__clock-mat--${position}`, [
     ctrl.clock && renderClock(ctrl.clock, ctrl.colorAt(position), position, () => []),
     material,
   ]);
 
 const viewActions = (ctrl: PlayCtrl) =>
-  h('div.bot-game__actions', [
-    ctrl.game.end && h('button.bot-game__rematch', { hook: bind('click', ctrl.opts.rematch) }, 'Rematch'),
-    h(
+  hl('div.bot-game__actions', [
+    ctrl.game.end && hl('button.bot-game__rematch', { hook: bind('click', ctrl.opts.rematch) }, 'Rematch'),
+    hl(
       'button.bot-game__close.text',
       { attrs: dataIcon(licon.Back), hook: bind('click', ctrl.opts.close) },
       'More opponents',
     ),
-    h(
+    hl(
       'button.bot-game__restart.text',
       { attrs: dataIcon(licon.Reload), hook: bind('click', ctrl.opts.rematch) },
       'New game',
@@ -68,9 +68,9 @@ const viewResult = (ctrl: PlayCtrl) => {
     variant: 'standard',
   };
   return result
-    ? h('div.result-wrap', [
-        h('p.result', result || ''),
-        h(
+    ? hl('div.result-wrap', [
+        hl('p.result', result || ''),
+        hl(
           'p.status',
           {
             hook: onInsert(() => {
@@ -91,13 +91,13 @@ const viewMoves = (ctrl: PlayCtrl) => {
 
   const els: LooseVNodes = [];
   for (let i = 1; i <= pairs.length; i++) {
-    els.push(h('turn', i + ''));
+    els.push(hl('turn', i + ''));
     els.push(viewMove(i * 2 - 1, pairs[i - 1][0], ctrl.board.onPly));
     els.push(viewMove(i * 2, pairs[i - 1][1], ctrl.board.onPly));
   }
   els.push(viewResult(ctrl));
 
-  return h(
+  return hl(
     'div.bot-game__moves',
     {
       hook: onInsert(el => {
@@ -122,20 +122,20 @@ const viewMoves = (ctrl: PlayCtrl) => {
 };
 
 const viewMove = (ply: number, san: San, curPly: number) =>
-  h('move', { class: { current: ply === curPly } }, san);
+  hl('move', { class: { current: ply === curPly } }, san);
 
 const viewNavigation = (ctrl: PlayCtrl) => {
-  return h('div.bot-game__nav', [
+  return hl('div.bot-game__nav', [
     boardMenu(ctrl),
-    h('div.noop'),
-    ...[
+    hl('div.noop'),
+    [
       [licon.JumpFirst, 0],
       [licon.JumpPrev, ctrl.board.onPly - 1],
       [licon.JumpNext, ctrl.board.onPly + 1],
       [licon.JumpLast, ctrl.game.ply()],
     ].map((b: [string, number], i) => {
       const enabled = ctrl.board.onPly !== b[1] && b[1] >= 0 && b[1] <= ctrl.game.ply();
-      return h('button.fbt.repeatable', {
+      return hl('button.fbt.repeatable', {
         class: { glowing: i === 3 && !ctrl.isOnLastPly() },
         attrs: { disabled: !enabled, 'data-icon': b[0], 'data-ply': enabled ? b[1] : '-' },
         hook: onInsert(bindMobileMousedown(e => goThroughMoves(ctrl, e))),
@@ -158,22 +158,22 @@ const goThroughMoves = (ctrl: PlayCtrl, e: Event) => {
 };
 
 const viewOpponentImage = (bot: BotInfo) =>
-  bot.image && h('img', { attrs: { src: botAssetUrl('image', bot.image) } });
+  bot.image && hl('img', { attrs: { src: botAssetUrl('image', bot.image) } });
 
 const viewOpponent = (bot: BotInfo) =>
-  h('div.bot-game__opponent', [
-    h('div.bot-game__opponent__head', [
+  hl('div.bot-game__opponent', [
+    hl('div.bot-game__opponent__head', [
       viewOpponentImage(bot),
-      h('span.bot-game__opponent__name', bot.name),
-      h('span.bot-game__opponent__rating', '' + Bot.rating(bot, 'classical')),
+      hl('span.bot-game__opponent__name', bot.name),
+      hl('span.bot-game__opponent__rating', '' + Bot.rating(bot, 'classical')),
     ]),
-    h('div.bot-game__opponent__description', bot.description),
+    hl('div.bot-game__opponent__description', bot.description),
   ]);
 
 const viewBoard = (ctrl: PlayCtrl) =>
-  h(`div.bot-game__board.main-board${ctrl.blindfold() ? '.blindfold' : ''}`, { hook: boardScroll(ctrl) }, [
+  hl(`div.bot-game__board.main-board${ctrl.blindfold() ? '.blindfold' : ''}`, { hook: boardScroll(ctrl) }, [
     ctrl.promotion.view(),
-    h('div.cg-wrap', {
+    hl('div.cg-wrap', {
       hook: onInsert(el => ctrl.ground(Chessground(el, initialGround(ctrl)))),
     }),
   ]);

--- a/ui/botPlay/src/setup/setupView.ts
+++ b/ui/botPlay/src/setup/setupView.ts
@@ -1,45 +1,45 @@
 import { botAssetUrl } from 'lib/bot/botLoader';
-import { bind, looseH as h } from 'lib/snabbdom';
+import { bind, hl } from 'lib/snabbdom';
 import type SetupCtrl from './setupCtrl';
 import { type BotInfo, Bot } from 'lib/bot/bot';
 import { miniBoard } from '../ground';
 
 export const setupView = (ctrl: SetupCtrl) =>
-  h('main.bot-app.bot-setup', [viewOngoing(ctrl), viewBotList(ctrl)]);
+  hl('main.bot-app.bot-setup', [viewOngoing(ctrl), viewBotList(ctrl)]);
 
 const viewOngoing = (ctrl: SetupCtrl) => {
   const g = ctrl.ongoingGame();
   return g && !g.game.end
-    ? h('div.bot-setup__ongoing', { hook: bind('click', ctrl.resume, ctrl.redraw) }, [
-        h('div.bot-setup__ongoing__preview', miniBoard(g.board, g.game.pov)),
+    ? hl('div.bot-setup__ongoing', { hook: bind('click', ctrl.resume, ctrl.redraw) }, [
+        hl('div.bot-setup__ongoing__preview', miniBoard(g.board, g.game.pov)),
         g.bot.image &&
-          h('img.bot-setup__ongoing__image', {
+          hl('img.bot-setup__ongoing__image', {
             attrs: { src: botAssetUrl('image', g.bot.image) },
           }),
-        h('div.bot-setup__ongoing__content', [
-          h('h2.bot-setup__ongoing__name', g.bot.name),
-          h('p.bot-setup__ongoing__text', 'Should we resume our game?'),
+        hl('div.bot-setup__ongoing__content', [
+          hl('h2.bot-setup__ongoing__name', g.bot.name),
+          hl('p.bot-setup__ongoing__text', 'Should we resume our game?'),
         ]),
       ])
     : undefined;
 };
 
 const viewBotList = (ctrl: SetupCtrl) =>
-  h(
+  hl(
     'div.bot-setup__bots',
     ctrl.opts.bots.map(bot => viewBotCard(ctrl, bot)),
   );
 
 const viewBotCard = (ctrl: SetupCtrl, bot: BotInfo) =>
-  h('div.bot-card', { hook: bind('click', () => ctrl.play(bot)) }, [
-    h('img.bot-card__image', {
+  hl('div.bot-card', { hook: bind('click', () => ctrl.play(bot)) }, [
+    hl('img.bot-card__image', {
       attrs: { src: bot?.image && botAssetUrl('image', bot.image) },
     }),
-    h('div.bot-card__content', [
-      h('div.bot-card__header', [
-        h('h2.bot-card__name', bot.name),
-        h('span.bot-card__rating', Bot.rating(bot, 'classical').toString()),
+    hl('div.bot-card__content', [
+      hl('div.bot-card__header', [
+        hl('h2.bot-card__name', bot.name),
+        hl('span.bot-card__rating', Bot.rating(bot, 'classical').toString()),
       ]),
-      h('p.bot-card__description', bot.description),
+      hl('p.bot-card__description', bot.description),
     ]),
   ]);

--- a/ui/coordinateTrainer/src/view.ts
+++ b/ui/coordinateTrainer/src/view.ts
@@ -1,5 +1,5 @@
 import type { VNode, VNodeStyle } from 'snabbdom';
-import { bind, looseH as h } from 'lib/snabbdom';
+import { bind, hl } from 'lib/snabbdom';
 import { renderVoiceBar } from 'voice';
 import chessground from './chessground';
 import CoordinateTrainerCtrl, { DURATION } from './ctrl';
@@ -10,11 +10,11 @@ const textOverlay = (ctrl: CoordinateTrainerCtrl): VNode | false => {
   return (
     ctrl.playing &&
     ctrl.mode() === 'findSquare' &&
-    h(
+    hl(
       'svg.coords-svg',
       { attrs: { viewBox: '0 0 100 100' } },
       ['current', 'next'].map((modifier: CoordModifier) =>
-        h(
+        hl(
           `g.${modifier}`,
           {
             key: `${ctrl.score}-${modifier}`,
@@ -25,7 +25,7 @@ const textOverlay = (ctrl: CoordinateTrainerCtrl): VNode | false => {
                   } as unknown as VNodeStyle)
                 : undefined,
           },
-          h('text', modifier === 'current' ? ctrl.currentKey : ctrl.nextKey),
+          hl('text', modifier === 'current' ? ctrl.currentKey : ctrl.nextKey),
         ),
       ),
     )
@@ -33,22 +33,22 @@ const textOverlay = (ctrl: CoordinateTrainerCtrl): VNode | false => {
 };
 
 const explanation = (ctrl: CoordinateTrainerCtrl): VNode => {
-  return h('div.explanation.box', [
-    h('h1', i18n.coordinates.coordinates),
-    h('p', i18n.coordinates.knowingTheChessBoard),
-    h('ul', [
-      h('li', i18n.coordinates.mostChessCourses),
-      h('li', i18n.coordinates.talkToYourChessFriends),
-      h('li', i18n.coordinates.youCanAnalyseAGameMoreEffectively),
+  return hl('div.explanation.box', [
+    hl('h1', i18n.coordinates.coordinates),
+    hl('p', i18n.coordinates.knowingTheChessBoard),
+    hl('ul', [
+      hl('li', i18n.coordinates.mostChessCourses),
+      hl('li', i18n.coordinates.talkToYourChessFriends),
+      hl('li', i18n.coordinates.youCanAnalyseAGameMoreEffectively),
     ]),
-    h('strong', i18n.coordinates[ctrl.mode()]),
-    h(
+    hl('strong', i18n.coordinates[ctrl.mode()]),
+    hl(
       'p',
       i18n.coordinates[
         ctrl.mode() === 'findSquare' ? 'aCoordinateAppears' : 'aSquareIsHighlightedExplanation'
       ],
     ),
-    h(
+    hl(
       'p',
       i18n.coordinates[ctrl.timeControl() === 'thirtySeconds' ? 'youHaveThirtySeconds' : 'goAsLongAsYouWant'],
     ),
@@ -56,10 +56,10 @@ const explanation = (ctrl: CoordinateTrainerCtrl): VNode => {
 };
 
 const table = (ctrl: CoordinateTrainerCtrl): VNode => {
-  return h('div.table', [
+  return hl('div.table', [
     !ctrl.hasPlayed && explanation(ctrl),
     !ctrl.playing &&
-      h(
+      hl(
         'button.start.button.button-fat',
         { hook: bind('click', ctrl.start) },
         i18n.coordinates.startTraining,
@@ -68,20 +68,20 @@ const table = (ctrl: CoordinateTrainerCtrl): VNode => {
 };
 
 const progress = (ctrl: CoordinateTrainerCtrl): VNode => {
-  return h(
+  return hl(
     'div.progress',
     ctrl.hasPlayed &&
-      h('div.progress__bar', { style: { width: `${100 * (1 - ctrl.timeLeft / DURATION)}%` } }),
+      hl('div.progress__bar', { style: { width: `${100 * (1 - ctrl.timeLeft / DURATION)}%` } }),
   );
 };
 
 const coordinateInput = (ctrl: CoordinateTrainerCtrl): VNode | false => {
   const coordinateInput = [
     ctrl.coordinateInputMethod() === 'buttons' &&
-      h(
+      hl(
         'div.files-ranks',
         'abcdefgh12345678'.split('').map((fileOrRank: string) =>
-          h(
+          hl(
             'button.file-rank',
             {
               on: {
@@ -97,29 +97,29 @@ const coordinateInput = (ctrl: CoordinateTrainerCtrl): VNode | false => {
           ),
         ),
       ),
-    h('div.voice-container', renderVoiceBar(ctrl.voice, ctrl.redraw, 'coords')),
-    h('div.keyboard-container', [
-      h('span', [
-        h('input.keyboard', {
+    hl('div.voice-container', renderVoiceBar(ctrl.voice, ctrl.redraw, 'coords')),
+    hl('div.keyboard-container', [
+      hl('span', [
+        hl('input.keyboard', {
           hook: { insert: vnode => (ctrl.keyboardInput = vnode.elm as HTMLInputElement) },
           on: { keyup: ctrl.onKeyboardInputKeyUp },
         }),
-        ctrl.playing ? h('span', 'Enter the coordinate') : h('strong', 'Press <enter> to start'),
+        ctrl.playing ? hl('span', 'Enter the coordinate') : hl('strong', 'Press <enter> to start'),
       ]),
-      h(
+      hl(
         'a',
         { on: { click: () => ctrl.toggleInputMethod() } },
         ctrl.coordinateInputMethod() === 'text' ? 'Show buttons' : 'Hide buttons',
       ),
     ]),
   ];
-  return ctrl.mode() === 'nameSquare' && h('div.coordinate-input', [...coordinateInput]);
+  return ctrl.mode() === 'nameSquare' && hl('div.coordinate-input', coordinateInput);
 };
 
 const view = (ctrl: CoordinateTrainerCtrl): VNode =>
-  h('div.trainer', { class: { wrong: ctrl.wrong } }, [
+  hl('div.trainer', { class: { wrong: ctrl.wrong } }, [
     side(ctrl),
-    h('div.main-board', chessground(ctrl)),
+    hl('div.main-board', chessground(ctrl)),
     textOverlay(ctrl),
     table(ctrl),
     progress(ctrl),

--- a/ui/dasher/src/board.ts
+++ b/ui/dasher/src/board.ts
@@ -3,7 +3,7 @@ import { hyphenToCamel, Toggle, toggle } from 'lib';
 import { debounce } from 'lib/async';
 import * as licon from 'lib/licon';
 import { text as xhrText, form as xhrForm } from 'lib/xhr';
-import { bind, looseH as h, type VNode } from 'lib/snabbdom';
+import { bind, hl, type VNode } from 'lib/snabbdom';
 import { type DasherCtrl, PaneCtrl } from './interfaces';
 import { pubsub } from 'lib/pubsub';
 
@@ -30,10 +30,10 @@ export class BoardCtrl extends PaneCtrl {
   }
 
   render = (): VNode =>
-    h(`div.sub.board.${this.dimension}`, [
+    hl(`div.sub.board.${this.dimension}`, [
       header(i18n.site.board, this.close),
-      h('div.selector.large', [
-        h(
+      hl('div.selector.large', [
+        hl(
           'button.text',
           {
             class: { active: !this.is3d },
@@ -42,7 +42,7 @@ export class BoardCtrl extends PaneCtrl {
           },
           '2D',
         ),
-        h(
+        hl(
           'button.text',
           {
             class: { active: this.is3d },
@@ -52,9 +52,9 @@ export class BoardCtrl extends PaneCtrl {
           '3D',
         ),
       ]),
-      ...this.propSliders(),
+      this.propSliders(),
       this.showReset() &&
-        h(
+        hl(
           'button.text.reset',
           {
             attrs: { 'data-icon': licon.Back, type: 'button' },
@@ -62,10 +62,10 @@ export class BoardCtrl extends PaneCtrl {
           },
           i18n.site.boardReset,
         ),
-      h(
+      hl(
         'div.list',
         this.boardList.map((t: string) =>
-          h(
+          hl(
             'button',
             {
               key: t,
@@ -73,7 +73,7 @@ export class BoardCtrl extends PaneCtrl {
               attrs: { title: t, type: 'button' },
               class: { active: this.current === t },
             },
-            h('span.' + t),
+            hl('span.' + t),
           ),
         ),
       ),
@@ -183,12 +183,12 @@ export class BoardCtrl extends PaneCtrl {
   };
 
   private propSlider = (prop: string, label: string, range: Range, title?: (v: number) => string) =>
-    h(
+    hl(
       `div.${prop}`,
       { attrs: { title: title ? title(this.getVar(prop)) : `${Math.round(this.getVar(prop))}%` } },
       [
-        h('label', label),
-        h('input.range', {
+        hl('label', label),
+        hl('input.range', {
           key: this.sliderKey + prop,
           attrs: { ...range, type: 'range', value: this.getVar(prop) },
           hook: {

--- a/ui/dasher/src/ctrl.ts
+++ b/ui/dasher/src/ctrl.ts
@@ -5,7 +5,7 @@ import { BackgroundCtrl } from './background';
 import { BoardCtrl } from './board';
 import { PieceCtrl } from './piece';
 import { LinksCtrl } from './links';
-import type { MaybeVNode, Redraw } from 'lib/snabbdom';
+import type { MaybeVNode } from 'lib/snabbdom';
 import type { DasherData, Mode, PaneCtrl } from './interfaces';
 import { type Prop, prop } from 'lib';
 import { pubsub } from 'lib/pubsub';

--- a/ui/dasher/src/dasher.ts
+++ b/ui/dasher/src/dasher.ts
@@ -1,4 +1,3 @@
-import type { Redraw } from 'lib/snabbdom';
 import { DasherCtrl } from './ctrl';
 import { json as xhrJson } from 'lib/xhr';
 import { spinnerVdom, spinnerHtml } from 'lib/view/controls';

--- a/ui/dasher/src/interfaces.ts
+++ b/ui/dasher/src/interfaces.ts
@@ -1,7 +1,7 @@
 import type { LangsData } from './langs';
 import type { BackgroundData } from './background';
 import type { DasherCtrl } from './ctrl';
-import type { Redraw, VNode } from 'lib/snabbdom';
+import type { VNode } from 'lib/snabbdom';
 
 export { DasherCtrl };
 

--- a/ui/dasher/src/links.ts
+++ b/ui/dasher/src/links.ts
@@ -1,4 +1,4 @@
-import { type Attrs, looseH as h, type VNode, bind } from 'lib/snabbdom';
+import { type Attrs, hl, type VNode, bind } from 'lib/snabbdom';
 import * as licon from 'lib/licon';
 import { type Mode, type DasherCtrl, PaneCtrl } from './interfaces';
 import { pubsub } from 'lib/pubsub';
@@ -10,17 +10,17 @@ export class LinksCtrl extends PaneCtrl {
 
   render = (): VNode => {
     const modeCfg = this.modeCfg;
-    return h('div', [
+    return hl('div', [
       this.userLinks(),
-      h('div.subs', [
-        h('button.sub', modeCfg('langs'), i18n.site.language),
-        h('button.sub', modeCfg('sound'), i18n.site.sound),
-        h('button.sub', modeCfg('background'), i18n.site.background),
-        h('button.sub', modeCfg('board'), i18n.site.board),
-        h('button.sub', modeCfg('piece'), i18n.site.pieceSet),
+      hl('div.subs', [
+        hl('button.sub', modeCfg('langs'), i18n.site.language),
+        hl('button.sub', modeCfg('sound'), i18n.site.sound),
+        hl('button.sub', modeCfg('background'), i18n.site.background),
+        hl('button.sub', modeCfg('board'), i18n.site.board),
+        hl('button.sub', modeCfg('piece'), i18n.site.pieceSet),
         this.root.opts.zenable &&
-          h('div.zen.selector', [
-            h(
+          hl('div.zen.selector', [
+            hl(
               'button.text',
               {
                 attrs: { 'data-icon': licon.DiscBigOutline, title: 'Keyboard: z', type: 'button' },
@@ -42,16 +42,16 @@ export class LinksCtrl extends PaneCtrl {
     const d = this.data,
       linkCfg = this.linkCfg;
     return d.user
-      ? h('div.links', [
-          h(
+      ? hl('div.links', [
+          hl(
             'a.user-link.online.text.is-green',
             linkCfg(`/@/${d.user.name}`, d.user.patron ? licon.Wings : licon.Disc),
             i18n.site.profile,
           ),
 
-          h('a.text', linkCfg('/inbox', licon.Envelope), i18n.site.inbox),
+          hl('a.text', linkCfg('/inbox', licon.Envelope), i18n.site.inbox),
 
-          h(
+          hl(
             'a.text',
             linkCfg(
               '/account/profile',
@@ -61,12 +61,12 @@ export class LinksCtrl extends PaneCtrl {
             i18n.preferences.preferences,
           ),
 
-          d.coach && h('a.text', linkCfg('/coach/edit', licon.GraduateCap), i18n.site.coachManager),
+          d.coach && hl('a.text', linkCfg('/coach/edit', licon.GraduateCap), i18n.site.coachManager),
 
-          d.streamer && h('a.text', linkCfg('/streamer/edit', licon.Mic), i18n.site.streamerManager),
+          d.streamer && hl('a.text', linkCfg('/streamer/edit', licon.Mic), i18n.site.streamerManager),
 
-          h('form.logout', { attrs: { method: 'post', action: '/logout' } }, [
-            h('button.text', { attrs: { type: 'submit', 'data-icon': licon.Power } }, i18n.site.logOut),
+          hl('form.logout', { attrs: { method: 'post', action: '/logout' } }, [
+            hl('button.text', { attrs: { type: 'submit', 'data-icon': licon.Power } }, i18n.site.logOut),
           ]),
         ])
       : null;

--- a/ui/dasher/src/util.ts
+++ b/ui/dasher/src/util.ts
@@ -1,16 +1,16 @@
 import * as licon from 'lib/licon';
-import { bind, looseH as h, type VNode } from 'lib/snabbdom';
+import { bind, hl, type VNode } from 'lib/snabbdom';
 import { memoize, Toggle } from 'lib';
 
 export const header = (name: string, close: () => void): VNode =>
-  h(
+  hl(
     'button.head.text',
     { attrs: { 'data-icon': licon.LessThan, type: 'button' }, hook: bind('click', close) },
     name,
   );
 
 export const moreButton = (toggle: Toggle): VNode =>
-  h(
+  hl(
     'button.button.more',
     {
       attrs: { title: i18n.site.more },

--- a/ui/insight/src/view.ts
+++ b/ui/insight/src/view.ts
@@ -11,7 +11,7 @@ import info from './info';
 import boards from './boards';
 import type Ctrl from './ctrl';
 import type { ViewTab } from './interfaces';
-import { bind, looseH as h } from 'lib/snabbdom';
+import { bind, hl } from 'lib/snabbdom';
 
 let forceRender = false;
 
@@ -46,17 +46,17 @@ const cacheKey = (ctrl: Ctrl) => {
 
 const renderMain = (ctrl: Ctrl, _cacheKey: string | boolean) => {
   if (!ctrl.vm.answer) {
-    return h('div'); // returning undefined breaks snabbdom's thunks
+    return hl('div'); // returning undefined breaks snabbdom's thunks
   } else if (ctrl.vm.broken) {
-    return h('div.broken', [
-      h('i', { attrs: { 'data-icon': licon.DiscBig } }),
+    return hl('div.broken', [
+      hl('i', { attrs: { 'data-icon': licon.DiscBig } }),
       'Insights are unavailable.',
-      h('br'),
+      hl('br'),
       'Please try again later.',
     ]);
   }
   const sizer = widthStyle(mainW());
-  return h('div', sizer, [chart(ctrl), vert(ctrl, sizer), boards(ctrl, sizer)]);
+  return hl('div', sizer, [chart(ctrl), vert(ctrl, sizer), boards(ctrl, sizer)]);
 };
 
 const panelTabData = (ctrl: Ctrl, panel: 'filter' | 'preset') => ({
@@ -71,24 +71,24 @@ const viewTabData = (ctrl: Ctrl, view: ViewTab) => ({
 });
 
 function header(ctrl: Ctrl) {
-  return h('header', widthStyle(mainW()), [
+  return hl('header', widthStyle(mainW()), [
     isAtLeastXSmall(mainW())
-      ? h('h2.text', { attrs: { 'data-icon': licon.Target } }, 'Chess Insights')
+      ? hl('h2.text', { attrs: { 'data-icon': licon.Target } }, 'Chess Insights')
       : isAtLeastXXSmall(mainW())
-        ? h('h2.text', { attrs: { 'data-icon': licon.Target } }, 'Insights')
-        : mainW() >= 460 && h('h2.text', 'Insights'),
+        ? hl('h2.text', { attrs: { 'data-icon': licon.Target } }, 'Insights')
+        : mainW() >= 460 && hl('h2.text', 'Insights'),
     axis(ctrl, mainW() < 460 ? { attrs: { style: 'justify-content: space-evenly;' } } : null),
   ]);
 }
 
 function landscapeView(ctrl: Ctrl) {
-  return h('main#insight', containerStyle(), [
-    h('div', { attrs: { class: ctrl.vm.loading ? 'loading' : 'ready' } }, [
-      h('div', widthStyle(sideW()), [
+  return hl('main#insight', containerStyle(), [
+    hl('div', { attrs: { class: ctrl.vm.loading ? 'loading' : 'ready' } }, [
+      hl('div', widthStyle(sideW()), [
         info(ctrl),
-        h('div.panel-tabs', [
-          h('a.tab.preset', panelTabData(ctrl, 'preset'), 'Presets'),
-          h('a.tab.filter', panelTabData(ctrl, 'filter'), 'Filters'),
+        hl('div.panel-tabs', [
+          hl('a.tab.preset', panelTabData(ctrl, 'preset'), 'Presets'),
+          hl('a.tab.filter', panelTabData(ctrl, 'filter'), 'Filters'),
           Object.keys(ctrl.vm.filters).length && clearBtn(ctrl),
         ]),
         ctrl.vm.panel === 'filter' && filters(ctrl),
@@ -96,7 +96,7 @@ function landscapeView(ctrl: Ctrl) {
         help(ctrl),
       ]),
       spacer(),
-      h('div', widthStyle(mainW()), [
+      hl('div', widthStyle(mainW()), [
         header(ctrl),
         thunk('div.insight__main.box', renderMain, [ctrl, cacheKey(ctrl)]),
       ]),
@@ -105,18 +105,18 @@ function landscapeView(ctrl: Ctrl) {
 }
 
 function portraitView(ctrl: Ctrl) {
-  return h('main#insight', containerStyle(), [
-    h('div.view-tabs', [
-      h('div.tab', viewTabData(ctrl, 'presets'), 'Presets'),
-      h('div.tab', viewTabData(ctrl, 'filters'), 'Filters'),
-      h('div.tab', viewTabData(ctrl, 'insights'), 'Insights'),
+  return hl('main#insight', containerStyle(), [
+    hl('div.view-tabs', [
+      hl('div.tab', viewTabData(ctrl, 'presets'), 'Presets'),
+      hl('div.tab', viewTabData(ctrl, 'filters'), 'Filters'),
+      hl('div.tab', viewTabData(ctrl, 'insights'), 'Insights'),
     ]),
-    h(
+    hl(
       'div',
       { attrs: { class: ctrl.vm.loading ? 'loading' : 'ready', style: 'display: block' } },
       ctrl.vm.view === 'insights'
         ? [header(ctrl), thunk('div.insight__main.box', renderMain, [ctrl, cacheKey(ctrl)])]
-        : h('div.left-side', [
+        : hl('div.left-side', [
             info(ctrl),
             ctrl.vm.view === 'filters' && clearBtn(ctrl),
             ctrl.vm.view === 'presets' ? presets(ctrl) : filters(ctrl),
@@ -127,7 +127,7 @@ function portraitView(ctrl: Ctrl) {
 
 function clearBtn(ctrl: Ctrl) {
   const btn = () =>
-    h(
+    hl(
       'a.clear',
       {
         attrs: { title: 'Clear all filters', 'data-icon': licon.X },
@@ -135,7 +135,7 @@ function clearBtn(ctrl: Ctrl) {
       },
       isLandscapeLayout() ? 'CLEAR' : 'CLEAR FILTERS',
     );
-  return isLandscapeLayout() ? btn() : h('div.center-clear', btn());
+  return isLandscapeLayout() ? btn() : hl('div.center-clear', btn());
 }
 
 type Point = { x: number; y: number }; // y = f(x), not necessarily a point onscreen
@@ -160,7 +160,7 @@ const gapW = () =>
 
 const mainW = () => availW() - (!isLandscapeLayout() ? 0 : sideW() + gapW());
 
-const spacer = () => (isLandscapeLayout() ? h('span', widthStyle(gapW())) : null); // between side & main
+const spacer = () => (isLandscapeLayout() ? hl('span', widthStyle(gapW())) : null); // between side & main
 
 const widthStyle = (width: number) => ({ attrs: { style: `width: ${width}px;` } });
 

--- a/ui/lib/src/ceval/view/main.ts
+++ b/ui/lib/src/ceval/view/main.ts
@@ -1,7 +1,7 @@
 import { povChances } from '../winningChances';
 import * as licon from '../../licon';
 import { stepwiseScroll } from '../../view/controls';
-import { type VNode, type LooseVNodes, onInsert, bind, looseH as h } from '../../snabbdom';
+import { type VNode, type LooseVNodes, onInsert, bind, hl } from '../../snabbdom';
 import { defined, notNull, requestIdleCallback } from '../../common';
 import { type ParentCtrl, type NodeEvals, CevalState } from '../types';
 import type { Position } from 'chessops/chess';
@@ -20,7 +20,7 @@ type EvalInfo = { knps: number; npsText: string; depthText: string };
 
 let gaugeLast = 0;
 const gaugeTicks: VNode[] = [...Array(8).keys()].map(i =>
-  h(i === 3 ? 'tick.zero' : 'tick', { attrs: { style: `height: ${(i + 1) * 12.5}%` } }),
+  hl(i === 3 ? 'tick.zero' : 'tick', { attrs: { style: `height: ${(i + 1) * 12.5}%` } }),
 );
 
 function localEvalNodes(ctrl: ParentCtrl, evs: NodeEvals): Array<VNode | string> {
@@ -36,7 +36,7 @@ function localEvalNodes(ctrl: ParentCtrl, evs: NodeEvals): Array<VNode | string>
   const t: Array<VNode | string> = [];
   if (ceval.canGoDeeper)
     t.push(
-      h('a.deeper', {
+      hl('a.deeper', {
         attrs: { title: i18n.site.goDeeper, 'data-icon': licon.PlusButton },
         hook: bind('click', ceval.goDeeper),
       }),
@@ -45,8 +45,8 @@ function localEvalNodes(ctrl: ParentCtrl, evs: NodeEvals): Array<VNode | string>
 
   t.push(depthText);
   if (evs.client.cloud && !ceval.isComputing)
-    t.push(h('span.cloud', { attrs: { title: i18n.site.cloudAnalysis } }, 'Cloud'));
-  if (ceval.isInfinite) t.push(h('span.infinite', { attrs: { title: i18n.site.infiniteAnalysis } }, '∞'));
+    t.push(hl('span.cloud', { attrs: { title: i18n.site.cloudAnalysis } }, 'Cloud'));
+  if (ceval.isInfinite) t.push(hl('span.infinite', { attrs: { title: i18n.site.infiniteAnalysis } }, '∞'));
   if (npsText) t.push(' · ' + npsText);
   return t;
 }
@@ -83,7 +83,7 @@ function localInfo(ctrl: ParentCtrl, ev?: Tree.ClientEval | false): EvalInfo {
 
 function threatButton(ctrl: ParentCtrl): VNode | null {
   if (ctrl.getCeval().download || ctrl.disableThreatMode?.()) return null;
-  return h('button.show-threat', {
+  return hl('button.show-threat', {
     class: { active: ctrl.threatMode(), hidden: !!ctrl.getNode().check },
     attrs: { 'data-icon': licon.Target, title: i18n.site.showThreat + ' (x)' },
     hook: bind('click', ctrl.toggleThreatMode),
@@ -94,24 +94,24 @@ function engineName(ctrl: CevalCtrl): VNode[] {
   const engine = ctrl.engines.active;
   return engine
     ? [
-        h('span', { attrs: { title: engine.name } }, engine.short ?? engine.name),
+        hl('span', { attrs: { title: engine.name } }, engine.short ?? engine.name),
         ctrl.engines.isExternalEngineInfo(engine)
-          ? h(
+          ? hl(
               'span.technology.good',
               { attrs: { title: 'Engine running outside of the browser' } },
               engine.tech,
             )
           : engine.requires.includes('simd')
-            ? h(
+            ? hl(
                 'span.technology.good',
                 { attrs: { title: 'Multi-threaded WebAssembly with SIMD' } },
                 engine.tech,
               )
             : engine.requires.includes('sharedMem')
-              ? h('span.technology.good', { attrs: { title: 'Multi-threaded WebAssembly' } }, engine.tech)
+              ? hl('span.technology.good', { attrs: { title: 'Multi-threaded WebAssembly' } }, engine.tech)
               : engine.requires.includes('wasm')
-                ? h('span.technology', { attrs: { title: 'Single-threaded WebAssembly' } }, engine.tech)
-                : h('span.technology', { attrs: { title: 'Single-threaded JavaScript' } }, engine.tech),
+                ? hl('span.technology', { attrs: { title: 'Single-threaded WebAssembly' } }, engine.tech)
+                : hl('span.technology', { attrs: { title: 'Single-threaded JavaScript' } }, engine.tech),
       ]
     : [];
 }
@@ -126,14 +126,14 @@ export function renderGauge(ctrl: ParentCtrl): VNode | undefined {
     ev = povChances('white', bestEv);
     gaugeLast = ev;
   } else ev = gaugeLast;
-  return h(
+  return hl(
     'div.eval-gauge',
     { class: { empty: !defined(bestEv), reverse: ctrl.getOrientation() === 'black' } },
-    [h('div.black', { attrs: { style: `height: ${100 - (ev + 1) * 50}%` } }), ...gaugeTicks],
+    [hl('div.black', { attrs: { style: `height: ${100 - (ev + 1) * 50}%` } }), gaugeTicks],
   );
 }
 
-export function renderCeval(ctrl: ParentCtrl): LooseVNodes {
+export function renderCeval(ctrl: ParentCtrl): VNode[] {
   const ceval = ctrl.getCeval();
   if (!ceval.allowed() || !ceval.possible) return [];
   if (!ctrl.showComputer()) return [analysisDisabled(ctrl)];
@@ -160,11 +160,11 @@ export function renderCeval(ctrl: ParentCtrl): LooseVNodes {
     pearl = '#' + bestEv.mate;
     percent = 100;
   } else {
-    if (!enabled) pearl = h('i');
+    if (!enabled) pearl = hl('i');
     else if (ctrl.outcome() || ctrl.getNode().threefold) pearl = '-';
     else if (ceval.state === CevalState.Failed)
-      pearl = h('i.is-red', { attrs: { 'data-icon': licon.CautionCircle } });
-    else pearl = h('i.ddloader');
+      pearl = hl('i.is-red', { attrs: { 'data-icon': licon.CautionCircle } });
+    else pearl = hl('i.ddloader');
     percent = 0;
   }
   if (download) percent = Math.min(100, Math.round((100 * download.bytes) / download.total));
@@ -172,9 +172,9 @@ export function renderCeval(ctrl: ParentCtrl): LooseVNodes {
 
   const progressBar: VNode | undefined =
     (enabled || download) &&
-    h(
+    hl(
       'div.bar',
-      h('span', {
+      hl('span', {
         class: { threat: enabled && threatMode },
         attrs: { style: `width: ${percent}%` },
         hook: {
@@ -194,10 +194,10 @@ export function renderCeval(ctrl: ParentCtrl): LooseVNodes {
 
   const body: LooseVNodes = enabled
     ? [
-        h('pearl', [pearl]),
-        h('div.engine', [
-          ...(threatMode ? [i18n.site.showThreat] : engineName(ceval)),
-          h(
+        hl('pearl', [pearl]),
+        hl('div.engine', [
+          threatMode ? [i18n.site.showThreat] : engineName(ceval),
+          hl(
             'span.info',
             ctrl.outcome()
               ? [i18n.site.gameOver]
@@ -210,28 +210,28 @@ export function renderCeval(ctrl: ParentCtrl): LooseVNodes {
         ]),
       ]
     : [
-        pearl && h('pearl', [pearl]),
-        h('div.engine', [
-          ...engineName(ceval),
-          h('br'),
+        pearl && hl('pearl', [pearl]),
+        hl('div.engine', [
+          engineName(ceval),
+          hl('br'),
           ceval.analysable ? i18n.site.inLocalBrowser : 'Illegal positions cannot be analyzed',
         ]),
       ];
 
   const switchButton: VNode | false =
     !ctrl.mandatoryCeval?.() &&
-    h('div.switch', { attrs: { title: i18n.site.toggleLocalEvaluation + ' (L)' } }, [
-      h('input#analyse-toggle-ceval.cmn-toggle.cmn-toggle--subtle', {
+    hl('div.switch', { attrs: { title: i18n.site.toggleLocalEvaluation + ' (L)' } }, [
+      hl('input#analyse-toggle-ceval.cmn-toggle.cmn-toggle--subtle', {
         attrs: { type: 'checkbox', checked: enabled, disabled: !ceval.analysable },
         hook: onInsert((el: HTMLInputElement) => {
           el.addEventListener('keydown', e => (e.key === 'Enter' || e.key === ' ') && ctrl.toggleCeval());
           el.addEventListener('change', () => ctrl.toggleCeval());
         }),
       }),
-      h('label', { attrs: { for: 'analyse-toggle-ceval' } }),
+      hl('label', { attrs: { for: 'analyse-toggle-ceval' } }),
     ]);
 
-  const settingsGear = h('button.settings-gear', {
+  const settingsGear = hl('button.settings-gear', {
     attrs: { 'data-icon': licon.Gear, title: 'Engine settings' },
     class: { active: ctrl.getCeval().showEnginePrefs() }, // must use ctrl.getCeval() rather than ceval here
     hook: bind(
@@ -243,15 +243,15 @@ export function renderCeval(ctrl: ParentCtrl): LooseVNodes {
   });
 
   return [
-    h('div.ceval' + (enabled ? '.enabled' : ''), { class: { computing: ceval.isComputing } }, [
+    hl('div.ceval' + (enabled ? '.enabled' : ''), { class: { computing: ceval.isComputing } }, [
       switchButton,
-      ...body,
+      body,
       threatButton(ctrl),
       settingsGear,
       progressBar,
     ]),
     renderCevalSettings(ctrl),
-  ];
+  ].filter((v): v is VNode => !!v);
 }
 
 function getElFen(el: HTMLElement): string {
@@ -314,7 +314,7 @@ export function renderPvs(ctrl: ParentCtrl): VNode | undefined {
   }
   const pos = setupPosition(lichessRules(ceval.opts.variant.key), setup);
 
-  return h(
+  return hl(
     'div.pv_box',
     {
       attrs: { 'data-fen': node.fen },
@@ -367,7 +367,7 @@ export function renderPvs(ctrl: ParentCtrl): VNode | undefined {
       },
     },
     [
-      ...[...Array(multiPv).keys()].map(i =>
+      [...Array(multiPv).keys()].map(i =>
         renderPv(threat, multiPv, pvs[i], pos.isOk ? pos.value : undefined),
       ),
       renderPvBoard(ctrl),
@@ -382,14 +382,14 @@ function renderPv(threat: boolean, multiPv: number, pv?: Tree.PvData, pos?: Posi
   const children: VNode[] = [renderPvWrapToggle()];
   if (pv) {
     if (!threat) data.attrs = { 'data-uci': pv.moves[0] };
-    if (multiPv > 1) children.push(h('strong', defined(pv.mate) ? '#' + pv.mate : renderEval(pv.cp!)));
+    if (multiPv > 1) children.push(hl('strong', defined(pv.mate) ? '#' + pv.mate : renderEval(pv.cp!)));
     if (pos) children.push(...renderPvMoves(pos.clone(), pv.moves.slice(0, MAX_NUM_MOVES)));
   }
-  return h('div.pv.pv--nowrap', data, children);
+  return hl('div.pv.pv--nowrap', data, children);
 }
 
 function renderPvWrapToggle(): VNode {
-  return h('span.pv-wrap-toggle', {
+  return hl('span.pv-wrap-toggle', {
     hook: {
       insert: (vnode: VNode) => {
         const el = vnode.elm as HTMLElement;
@@ -412,14 +412,14 @@ function renderPvMoves(pos: Position, pv: Uci[]): VNode[] {
     let text;
     if (pos.turn === 'white') text = `${pos.fullmoves}.`;
     else if (i === 0) text = `${pos.fullmoves}...`;
-    if (text) vnodes.push(h('span', { key: text }, text));
+    if (text) vnodes.push(hl('span', { key: text }, text));
     const uci = pv[i];
     const san = makeSanAndPlay(pos, parseUci(uci)!);
     const fen = makeBoardFen(pos.board); // Chessground uses only board fen
     if (san === '--') break;
     key += '|' + uci;
     vnodes.push(
-      h('span.pv-san', { key, attrs: { 'data-move-index': i, 'data-board': `${fen}|${uci}` } }, san),
+      hl('span.pv-san', { key, attrs: { 'data-move-index': i, 'data-board': `${fen}|${uci}` } }, san),
     );
   }
   return vnodes;
@@ -442,20 +442,20 @@ function renderPvBoard(ctrl: ParentCtrl): VNode | undefined {
       visible: false,
     },
   };
-  const cgVNode = h('div.cg-wrap.is2d', {
+  const cgVNode = hl('div.cg-wrap.is2d', {
     hook: {
       insert: (vnode: any) => (vnode.elm._cg = makeChessground(vnode.elm, cgConfig)),
       update: (vnode: any) => vnode.elm._cg?.set(cgConfig),
       destroy: (vnode: any) => vnode.elm._cg?.destroy(),
     },
   });
-  return h('div.pv-board', h('div.pv-board-square', cgVNode));
+  return hl('div.pv-board', hl('div.pv-board-square', cgVNode));
 }
 
-const analysisDisabled = (ctrl: ParentCtrl): VNode | undefined =>
-  h('div.comp-off__hint', [
-    h('span', i18n.site.computerAnalysisDisabled),
-    h(
+const analysisDisabled = (ctrl: ParentCtrl): VNode =>
+  hl('div.comp-off__hint', [
+    hl('span', i18n.site.computerAnalysisDisabled),
+    hl(
       'button',
       { hook: bind('click', () => ctrl.toggleComputer?.(), ctrl.redraw), attrs: { type: 'button' } },
       i18n.site.enable,

--- a/ui/lib/src/ceval/view/settings.ts
+++ b/ui/lib/src/ceval/view/settings.ts
@@ -3,7 +3,7 @@ import type CevalCtrl from '../ctrl';
 import { fewerCores } from '../util';
 import { rangeConfig } from '../../view/controls';
 import { isChrome } from '../../device';
-import { type VNode, onInsert, bind, dataIcon, looseH as h } from '../../snabbdom';
+import { type VNode, onInsert, bind, dataIcon, hl } from '../../snabbdom';
 import * as Licon from '../../licon';
 import { onClickAway } from '../../common';
 import { clamp } from '../../algo';
@@ -39,7 +39,7 @@ export function renderCevalSettings(ctrl: ParentCtrl): VNode | null {
   }
 
   function threadsTick(dir: 'up' | 'down') {
-    return h(`div.arrow-${dir}`, { hook: bind('click', () => clickThreads()) });
+    return hl(`div.arrow-${dir}`, { hook: bind('click', () => clickThreads()) });
   }
 
   function searchTick() {
@@ -50,10 +50,11 @@ export function renderCevalSettings(ctrl: ParentCtrl): VNode | null {
     );
   }
 
-  return ceval.showEnginePrefs()
-    ? h(
+  return !ceval.showEnginePrefs()
+    ? null
+    : hl(
         'div#ceval-settings-anchor',
-        h(
+        hl(
           'div#ceval-settings',
           {
             hook: onInsert(
@@ -64,30 +65,30 @@ export function renderCevalSettings(ctrl: ParentCtrl): VNode | null {
             ),
           },
           [
-            ...engineSelection(ctrl),
+            engineSelection(ctrl),
             !ceval.customSearch &&
               (id => {
-                return h('div.setting', { attrs: { title: 'Set time to evaluate fresh positions' } }, [
-                  h('label', 'Search time'),
-                  h('input#' + id, {
+                return hl('div.setting', { attrs: { title: 'Set time to evaluate fresh positions' } }, [
+                  hl('label', 'Search time'),
+                  hl('input#' + id, {
                     attrs: { type: 'range', min: 0, max: searchTicks.length - 1, step: 1 },
                     hook: rangeConfig(searchTick, n => {
                       ceval.storedMovetime(searchTicks[n][0]);
                       ctrl.restartCeval?.();
                     }),
                   }),
-                  h('div.range_value', searchTicks[searchTick()][1]),
+                  hl('div.range_value', searchTicks[searchTick()][1]),
                 ]);
               })('engine-search-ms'),
             !ceval.customSearch &&
               (id => {
                 const max = 5;
-                return h(
+                return hl(
                   'div.setting',
                   { attrs: { title: 'Set number of evaluation lines and move arrows on the board' } },
                   [
-                    h('label', { attrs: { for: id } }, i18n.site.multipleLines),
-                    h('input#' + id, {
+                    hl('label', { attrs: { for: id } }, i18n.site.multipleLines),
+                    hl('input#' + id, {
                       attrs: { type: 'range', min: 0, max, step: 1 },
                       hook: rangeConfig(
                         () => ceval.storedPv(),
@@ -97,13 +98,13 @@ export function renderCevalSettings(ctrl: ParentCtrl): VNode | null {
                         },
                       ),
                     }),
-                    h('div.range_value', `${ceval.storedPv()} / ${max}`),
+                    hl('div.range_value', `${ceval.storedPv()} / ${max}`),
                   ],
                 );
               })('analyse-multipv'),
             maxThreads > minThreads &&
               (id => {
-                return h(
+                return hl(
                   'div.setting',
                   {
                     attrs: {
@@ -114,9 +115,9 @@ export function renderCevalSettings(ctrl: ParentCtrl): VNode | null {
                     },
                   },
                   [
-                    h('label', { attrs: { for: id } }, 'Threads'),
-                    h('span', [
-                      h('input#' + id, {
+                    hl('label', { attrs: { for: id } }, 'Threads'),
+                    hl('span', [
+                      hl('input#' + id, {
                         attrs: {
                           type: 'range',
                           min: minThreads,
@@ -125,7 +126,7 @@ export function renderCevalSettings(ctrl: ParentCtrl): VNode | null {
                         },
                         hook: rangeConfig(() => ceval.threads, clickThreads),
                       }),
-                      h(
+                      hl(
                         'div.tick',
                         {
                           hook: {
@@ -145,14 +146,14 @@ export function renderCevalSettings(ctrl: ParentCtrl): VNode | null {
                         !ceval.engines.external && [threadsTick('up'), threadsTick('down')],
                       ),
                     ]),
-                    h('div.range_value', `${ceval.threads} / ${maxThreads}`),
+                    hl('div.range_value', `${ceval.threads} / ${maxThreads}`),
                   ],
                 );
               })('analyse-threads'),
             (id =>
-              h('div.setting', { attrs: { title: 'Higher values may improve performance' } }, [
-                h('label', { attrs: { for: id } }, i18n.site.memory),
-                h('input#' + id, {
+              hl('div.setting', { attrs: { title: 'Higher values may improve performance' } }, [
+                hl('label', { attrs: { for: id } }, i18n.site.memory),
+                hl('input#' + id, {
                   attrs: {
                     type: 'range',
                     min: 4,
@@ -169,12 +170,11 @@ export function renderCevalSettings(ctrl: ParentCtrl): VNode | null {
                   ),
                 }),
 
-                h('div.range_value', formatHashSize(ceval.hashSize)),
+                hl('div.range_value', formatHashSize(ceval.hashSize)),
               ]))('analyse-memory'),
           ],
         ),
-      )
-    : null;
+      );
 }
 
 function setupTick(v: VNode, ceval: CevalCtrl) {
@@ -197,9 +197,9 @@ function engineSelection(ctrl: ParentCtrl) {
     external = ceval.engines.external;
   if (!engines?.length || !ceval.possible || !ceval.allowed()) return [];
   return [
-    h('div.setting', [
+    hl('div.setting', [
       'Engine:',
-      h(
+      hl(
         'select.select-engine',
         {
           hook: bind('change', e => {
@@ -207,14 +207,12 @@ function engineSelection(ctrl: ParentCtrl) {
             ctrl.redraw?.();
           }),
         },
-        [
-          ...engines.map(engine =>
-            h('option', { attrs: { value: engine.id, selected: active?.id === engine.id } }, engine.name),
-          ),
-        ],
+        engines.map(engine =>
+          hl('option', { attrs: { value: engine.id, selected: active?.id === engine.id } }, engine.name),
+        ),
       ),
       external &&
-        h('button.delete', {
+        hl('button.delete', {
           attrs: { ...dataIcon(Licon.X), title: 'Delete external engine' },
           hook: bind('click', async e => {
             (e.currentTarget as HTMLElement).blur();
@@ -223,6 +221,6 @@ function engineSelection(ctrl: ParentCtrl) {
           }),
         }),
     ]),
-    h('br'),
+    hl('br'),
   ];
 }

--- a/ui/lib/src/chat/renderChat.ts
+++ b/ui/lib/src/chat/renderChat.ts
@@ -1,5 +1,5 @@
 import * as licon from '../licon';
-import { type VNode, looseH as h, bind } from '../snabbdom';
+import { type VNode, hl, bind } from '../snabbdom';
 import type { Tab, VoiceChat } from './interfaces';
 import discussionView from './discussion';
 import { noteView } from './note';
@@ -8,7 +8,7 @@ import { moderationView } from './moderation';
 import type { ChatCtrl } from './chatCtrl';
 
 export function renderChat(ctrl: ChatCtrl): VNode {
-  return h(
+  return hl(
     'section.mchat' + (ctrl.isOptional ? '.mchat-optional' : ''),
     { class: { 'mchat-mod': !!ctrl.moderation } },
     moderationView(ctrl.moderation) || normalView(ctrl),
@@ -20,7 +20,7 @@ function renderVoiceChat(ctrl: ChatCtrl) {
   if (!p.enabled()) return;
   return p.instance
     ? p.instance.render()
-    : h('div.mchat__tab.voicechat.voicechat-slot', {
+    : hl('div.mchat__tab.voicechat.voicechat-slot', {
         attrs: { 'data-icon': licon.Handset, title: 'Voice chat' },
         hook: bind('click', () => {
           if (!p.loaded) {
@@ -41,11 +41,11 @@ function renderVoiceChat(ctrl: ChatCtrl) {
 function normalView(ctrl: ChatCtrl) {
   const active = ctrl.getTab();
   return [
-    h('div.mchat__tabs.nb_' + ctrl.visibleTabs.length, { attrs: { role: 'tablist' } }, [
-      ...ctrl.visibleTabs.map(t => renderTab(ctrl, t, active)),
+    hl('div.mchat__tabs.nb_' + ctrl.visibleTabs.length, { attrs: { role: 'tablist' } }, [
+      ctrl.visibleTabs.map(t => renderTab(ctrl, t, active)),
       renderVoiceChat(ctrl),
     ]),
-    h(
+    hl(
       'div.mchat__content.' + active.key,
       active.key === 'note' && ctrl.note
         ? [noteView(ctrl.note, ctrl.vm.autofocus)]
@@ -57,7 +57,7 @@ function normalView(ctrl: ChatCtrl) {
 }
 
 const renderTab = (ctrl: ChatCtrl, tab: Tab, active: Tab) =>
-  h(
+  hl(
     'div.mchat__tab.' + tab.key,
     {
       attrs: { role: 'tab' },
@@ -76,17 +76,17 @@ function tabName(ctrl: ChatCtrl, tab: Tab) {
   if (tab.key === 'discussion') {
     const id = `chat-toggle-${ctrl.data.id}`;
     return [
-      h('span', ctrl.data.name),
+      hl('span', ctrl.data.name),
       ctrl.isOptional &&
-        h('div.switch', [
-          h(`input#${id}.cmn-toggle.cmn-toggle--subtle`, {
+        hl('div.switch', [
+          hl(`input#${id}.cmn-toggle.cmn-toggle--subtle`, {
             attrs: { type: 'checkbox', checked: ctrl.chatEnabled() },
             hook: bind('change', e => {
               ctrl.chatEnabled((e.target as HTMLInputElement).checked);
               ctrl.redraw();
             }),
           }),
-          h('label', {
+          hl('label', {
             attrs: {
               for: id,
               title: i18n.site.toggleTheChat,
@@ -95,7 +95,7 @@ function tabName(ctrl: ChatCtrl, tab: Tab) {
         ]),
     ];
   }
-  if (tab.key === 'note') return [h('span', i18n.site.notes)];
-  if (tab.key === ctrl.plugin?.key) return [h('span', ctrl.plugin.name)];
+  if (tab.key === 'note') return [hl('span', i18n.site.notes)];
+  if (tab.key === ctrl.plugin?.key) return [hl('span', ctrl.plugin.name)];
   return [];
 }

--- a/ui/lib/src/game/clock/clockView.ts
+++ b/ui/lib/src/game/clock/clockView.ts
@@ -1,6 +1,6 @@
 import type { ClockElements, ClockCtrl } from './clockCtrl';
 import type { Hooks } from 'snabbdom';
-import { looseH as h, type VNode, LooseVNodes } from '@/snabbdom';
+import { hl, type VNode, LooseVNodes } from '@/snabbdom';
 import { TopOrBottom } from '../game';
 import { displayColumns } from '@/device';
 
@@ -24,17 +24,17 @@ export function renderClock(
     insert: vnode => update(vnode.elm as HTMLElement),
     postpatch: (_, vnode) => update(vnode.elm as HTMLElement),
   };
-  return h(
+  return hl(
     // the player.color class ensures that when the board is flipped, the clock is redrawn. solves bug where clock
     // would be incorrectly latched to red color: https://github.com/lichess-org/lila/issues/10774
     `div.rclock.rclock-${position}.rclock-${color}`,
     { class: { outoftime: millis <= 0, running: isRunning, emerg: millis < ctrl.emergMs } },
     ctrl.opts.nvui
-      ? [h('div.time', { attrs: { role: 'timer' }, hook: timeHook })]
+      ? [hl('div.time', { attrs: { role: 'timer' }, hook: timeHook })]
       : [
           ctrl.showBar && ctrl.opts.bothPlayersHavePlayed() ? showBar(ctrl, color) : undefined,
-          h('div.time', { class: { hour: millis > 3600 * 1000 }, hook: timeHook }),
-          ...onTheSide(color, position),
+          hl('div.time', { class: { hour: millis > 3600 * 1000 }, hook: timeHook }),
+          onTheSide(color, position),
         ],
   );
 }
@@ -115,7 +115,7 @@ function showBar(ctrl: ClockCtrl, color: Color) {
   };
   return displayColumns() === 1
     ? undefined
-    : h('div.bar', {
+    : hl('div.bar', {
         class: { berserk: ctrl.opts.hasGoneBerserk(color) },
         hook: {
           insert: vnode => update(vnode.elm as HTMLElement),

--- a/ui/lib/src/snabbdom.ts
+++ b/ui/lib/src/snabbdom.ts
@@ -8,7 +8,6 @@ import {
 } from 'snabbdom';
 
 export type { Attrs, VNode };
-export type Redraw = () => void;
 export type MaybeVNode = VNode | string | null | undefined;
 export type MaybeVNodes = MaybeVNode[];
 
@@ -54,29 +53,38 @@ export const dataIcon = (icon: string): Attrs => ({
 
 export const iconTag = (icon: string): VNode => snabH('i', { attrs: dataIcon(icon) });
 
-export type LooseVNode = VNode | string | undefined | null | boolean;
-export type LooseVNodes = LooseVNode[];
-export type VNodeKids = LooseVNode | LooseVNodes;
+export type LooseVNode = VNode | string | number | undefined | null | boolean;
+export type LooseVNodes = LooseVNode | LooseVNodes[];
 
 // '' may be falsy but it's a valid VNode
 // 0 may be falsy but it's a valid VNode
-const kidFilter = (x: VNodeData | VNodeKids): boolean => (x && x !== true) || x === '';
+const kidFilter = (x: VNodeData | LooseVNodes): boolean => (x && x !== true) || x === '' || x === 0;
 
-const filterKids = (children: VNodeKids): VNodeChildElement[] =>
-  (Array.isArray(children) ? children : [children]).filter(kidFilter) as VNodeChildElement[];
+const filterKids = (children: LooseVNodes): VNodeChildElement[] => {
+  const flatKids: LooseVNode[] = [];
+  flattenKids(children, flatKids);
+  return flatKids.filter(kidFilter) as VNodeChildElement[];
+};
 
-/* obviate need for some ternary expressions in renders.  Allows
-     looseH('div', [ kids && h('div', 'kid') ])
-   instead of
-     h('div', [ isKid ? h('div', 'kid') : null ])
-   'true' values are filtered out of children array same as 'false' (for || case)
-*/
-export function looseH(sel: string, dataOrKids?: VNodeData | VNodeKids, kids?: VNodeKids): VNode {
+// obviate need for some ternary expressions in renders.  Allows
+//   hl('div', [ h(i), isKid && [hl('div', 'kid'), h('span')]])
+// instead of
+//   h('div', [ h(i), ...(isKid ? [h('div', 'kid'), h('span')] : [] ])
+// 'true' values are filtered out of children array same as 'false' (for || case)
+
+export function hl(sel: string, dataOrKids?: VNodeData | LooseVNodes, kids?: LooseVNodes): VNode {
   if (kids) return snabH(sel, dataOrKids as VNodeData, filterKids(kids));
   if (!kidFilter(dataOrKids)) return snabH(sel);
   if (Array.isArray(dataOrKids) || (typeof dataOrKids === 'object' && 'sel' in dataOrKids!))
-    return snabH(sel, filterKids(dataOrKids as VNodeKids));
+    return snabH(sel, filterKids(dataOrKids as LooseVNodes));
   else return snabH(sel, dataOrKids as VNodeData);
 }
+
+// for deep trees i think it's more efficient to flatten arrays here than to spread them in renders.
+// but we're mostly after cleaner syntax
+const flattenKids = (maybeArray: LooseVNodes, out: LooseVNode[]) => {
+  if (Array.isArray(maybeArray)) for (const el of maybeArray) flattenKids(el, out);
+  else out.push(maybeArray);
+};
 
 export const noTrans: (s: string) => VNode = s => snabH('span', { attrs: { lang: 'en' } }, s);

--- a/ui/lib/src/view/dialog.ts
+++ b/ui/lib/src/view/dialog.ts
@@ -1,4 +1,4 @@
-import { onInsert, looseH as h, type VNode, type Attrs, type LooseVNodes } from '@/snabbdom';
+import { onInsert, hl, type VNode, type Attrs, type LooseVNodes } from '@/snabbdom';
 import { isTouchDevice } from '@/device';
 import { frag } from '@/common';
 import { Janitor } from '@/event';
@@ -103,7 +103,7 @@ export function snabDialog(o: SnabDialogOpts): VNode {
   const ass = loadAssets(o);
   let dialog: HTMLDialogElement;
 
-  const dialogVNode = h(
+  const dialogVNode = hl(
     `dialog${isTouchDevice() ? '.touch-scroll' : ''}`,
     {
       key: o.class ?? 'dialog',
@@ -112,13 +112,13 @@ export function snabDialog(o: SnabDialogOpts): VNode {
     },
     [
       o.noCloseButton ||
-        h(
+        hl(
           'div.close-button-anchor',
-          h('button.close-button', { attrs: { 'data-icon': licon.X, 'aria-label': i18n.site.close } }),
+          hl('button.close-button', { attrs: { 'data-icon': licon.X, 'aria-label': i18n.site.close } }),
         ),
-      h(
+      hl(
         `div.${o.noScrollable ? 'not-' : ''}scrollable`,
-        h(
+        hl(
           'div.dialog-content' +
             (o.class
               ? '.' +
@@ -143,7 +143,7 @@ export function snabDialog(o: SnabDialogOpts): VNode {
     ],
   );
   if (!o.modal) return dialogVNode;
-  return h('div.snab-modal-mask' + (o.onInsert ? '.none' : ''), dialogVNode);
+  return hl('div.snab-modal-mask' + (o.onInsert ? '.none' : ''), dialogVNode);
 }
 
 class DialogWrapper implements Dialog {

--- a/ui/lib/src/view/dialogs.ts
+++ b/ui/lib/src/view/dialogs.ts
@@ -24,7 +24,7 @@ export async function info(msg: string, autoDismiss?: Millis): Promise<Dialog> {
     htmlText: escapeHtmlAddBreaks(msg),
     noCloseButton: true,
   });
-  if (autoDismiss) setTimeout(() => dlg.close(), autoDismiss);
+  if (!!autoDismiss) setTimeout(() => dlg.close(), autoDismiss);
   return dlg.show();
 }
 

--- a/ui/lib/src/view/verticalResize.ts
+++ b/ui/lib/src/view/verticalResize.ts
@@ -1,4 +1,4 @@
-import { looseH as h, type VNode } from '@/snabbdom';
+import { hl, type VNode } from '@/snabbdom';
 import { clamp } from '@/algo';
 import { storedMap } from '@/storage';
 import { myUserId } from '@/common';
@@ -16,7 +16,7 @@ type ResizerElement = HTMLElement & { observer: MutationObserver };
 
 export function verticalResizeSeparator(o: Opts): VNode {
   // add these directly after the vnode they resize
-  return h(
+  return hl(
     'div.vertical-resize-separator',
     {
       hook: {
@@ -62,7 +62,7 @@ export function verticalResizeSeparator(o: Opts): VNode {
         destroy: vn => (vn.elm as ResizerElement).observer?.disconnect(),
       },
     },
-    [o.kid, h('hr', { attrs: { role: 'separator' } })],
+    [o.kid, hl('hr', { attrs: { role: 'separator' } })],
   );
 }
 

--- a/ui/lobby/src/view/playing.ts
+++ b/ui/lobby/src/view/playing.ts
@@ -1,4 +1,4 @@
-import { looseH as h, onInsert } from 'lib/snabbdom';
+import { hl, onInsert } from 'lib/snabbdom';
 import type LobbyController from '../ctrl';
 import type { NowPlaying } from '../interfaces';
 import { initMiniBoard } from 'lib/view/miniBoard';
@@ -6,31 +6,32 @@ import { timeago } from 'lib/i18n';
 
 function timer(pov: NowPlaying) {
   const date = Date.now() + pov.secondsLeft! * 1000;
-  return h('time.timeago', { hook: onInsert(el => el.setAttribute('datetime', '' + date)) }, timeago(date));
+  return hl('time.timeago', { hook: onInsert(el => el.setAttribute('datetime', '' + date)) }, timeago(date));
 }
 
 export default function (ctrl: LobbyController) {
-  return h('div.now-playing', [
-    ...ctrl.data.nowPlaying.map(pov =>
-      h('a.' + pov.variant.key, { key: `${pov.gameId}${pov.lastMove}`, attrs: { href: '/' + pov.fullId } }, [
-        h('span.mini-board.cg-wrap.is2d', {
+  return hl(
+    'div.now-playing',
+    ctrl.data.nowPlaying.map(pov =>
+      hl('a.' + pov.variant.key, { key: `${pov.gameId}${pov.lastMove}`, attrs: { href: '/' + pov.fullId } }, [
+        hl('span.mini-board.cg-wrap.is2d', {
           attrs: { 'data-state': `${pov.fen},${pov.orientation || pov.color},${pov.lastMove}` },
           hook: { insert: vnode => initMiniBoard(vnode.elm as HTMLElement) },
         }),
-        h('span.meta', [
-          pov.opponent.ai
+        hl('span.meta', [
+          !!pov.opponent.ai
             ? i18n.site.aiNameLevelAiLevel('Stockfish', pov.opponent.ai)
             : pov.opponent.username,
-          h(
+          hl(
             'span.indicator',
             pov.isMyTurn
-              ? pov.secondsLeft && pov.hasMoved
+              ? !!pov.secondsLeft && pov.hasMoved
                 ? timer(pov)
                 : [i18n.site.yourTurn]
-              : h('span', '\xa0'),
-          ), // &nbsp;
+              : hl('span', '\xa0'),
+          ),
         ]),
       ]),
     ),
-  ]);
+  );
 }

--- a/ui/lobby/src/view/setup/components/timePickerAndSliders.ts
+++ b/ui/lobby/src/view/setup/components/timePickerAndSliders.ts
@@ -1,5 +1,5 @@
 import type { Prop } from 'lib';
-import { looseH as h } from 'lib/snabbdom';
+import { hl } from 'lib/snabbdom';
 import type LobbyController from '../../../ctrl';
 import type { InputValue, TimeMode } from '../../../interfaces';
 import { daysVToDays, incrementVToIncrement, sliderTimes, timeModes } from '../../../options';
@@ -17,9 +17,9 @@ const renderBlindModeTimePickers = (ctrl: LobbyController, allowAnonymous: boole
   return [
     renderTimeModePicker(ctrl, allowAnonymous),
     setupCtrl.timeMode() === 'realTime' &&
-      h('div.time-choice', [
-        h('label', { attrs: { for: 'sf_time' } }, i18n.site.minutesPerSide),
-        h(
+      hl('div.time-choice', [
+        hl('label', { attrs: { for: 'sf_time' } }, i18n.site.minutesPerSide),
+        hl(
           'select#sf_time',
           {
             on: { change: (e: Event) => setupCtrl.timeV(parseFloat((e.target as HTMLSelectElement).value)) },
@@ -30,9 +30,9 @@ const renderBlindModeTimePickers = (ctrl: LobbyController, allowAnonymous: boole
         ),
       ]),
     setupCtrl.timeMode() === 'realTime' &&
-      h('div.increment-choice', [
-        h('label', { attrs: { for: 'sf_increment' } }, i18n.site.incrementInSeconds),
-        h(
+      hl('div.increment-choice', [
+        hl('label', { attrs: { for: 'sf_increment' } }, i18n.site.incrementInSeconds),
+        hl(
           'select#sf_increment',
           {
             on: {
@@ -49,9 +49,9 @@ const renderBlindModeTimePickers = (ctrl: LobbyController, allowAnonymous: boole
         ),
       ]),
     setupCtrl.timeMode() === 'correspondence' &&
-      h('div.days-choice', [
-        h('label', { attrs: { for: 'sf_days' } }, i18n.site.daysPerTurn),
-        h(
+      hl('div.days-choice', [
+        hl('label', { attrs: { for: 'sf_days' } }, i18n.site.daysPerTurn),
+        hl(
           'select#sf_days',
           {
             on: { change: (e: Event) => setupCtrl.daysV(parseInt((e.target as HTMLSelectElement).value)) },
@@ -72,9 +72,9 @@ const renderTimeModePicker = (ctrl: LobbyController, allowAnonymous = false) => 
   const { setupCtrl } = ctrl;
   return (
     (ctrl.me || allowAnonymous) &&
-    h('div.label-select', [
-      h('label', { attrs: { for: 'sf_timeMode' } }, i18n.site.timeControl),
-      h(
+    hl('div.label-select', [
+      hl('label', { attrs: { for: 'sf_timeMode' } }, i18n.site.timeControl),
+      hl(
         'select#sf_timeMode',
         {
           on: {
@@ -88,7 +88,7 @@ const renderTimeModePicker = (ctrl: LobbyController, allowAnonymous = false) => 
 };
 
 const inputRange = (min: number, max: number, prop: Prop<InputValue>, classes?: Record<string, boolean>) =>
-  h('input.range', {
+  hl('input.range', {
     class: classes,
     attrs: { type: 'range', min, max, value: prop() },
     on: { input: (e: Event) => prop(parseFloat((e.target as HTMLInputElement).value)) },
@@ -96,32 +96,32 @@ const inputRange = (min: number, max: number, prop: Prop<InputValue>, classes?: 
 
 export const timePickerAndSliders = (ctrl: LobbyController, allowAnonymous = false) => {
   const { setupCtrl } = ctrl;
-  return h(
+  return hl(
     'div.time-mode-config.optional-config',
     site.blindMode
       ? renderBlindModeTimePickers(ctrl, allowAnonymous)
       : [
           renderTimeModePicker(ctrl, allowAnonymous),
           setupCtrl.timeMode() === 'realTime' &&
-            h('div.time-choice.range', [
+            hl('div.time-choice.range', [
               `${i18n.site.minutesPerSide}: `,
-              h('span', showTime(setupCtrl.time())),
+              hl('span', showTime(setupCtrl.time())),
               inputRange(0, 38, setupCtrl.timeV, {
                 failure: !setupCtrl.validTime() || !setupCtrl.validAiTime(),
               }),
             ]),
           setupCtrl.timeMode() === 'realTime'
-            ? h('div.increment-choice.range', [
+            ? hl('div.increment-choice.range', [
                 `${i18n.site.incrementInSeconds}: `,
-                h('span', `${setupCtrl.increment()}`),
+                hl('span', `${setupCtrl.increment()}`),
                 inputRange(0, 30, setupCtrl.incrementV, { failure: !setupCtrl.validTime() }),
               ])
             : setupCtrl.timeMode() === 'correspondence' &&
-              h(
+              hl(
                 'div.correspondence',
-                h('div.days-choice.range', [
+                hl('div.days-choice.range', [
                   `${i18n.site.daysPerTurn}: `,
-                  h('span', `${setupCtrl.days()}`),
+                  hl('span', `${setupCtrl.days()}`),
                   inputRange(1, 7, setupCtrl.daysV),
                 ]),
               ),

--- a/ui/lobby/src/view/setup/modal.ts
+++ b/ui/lobby/src/view/setup/modal.ts
@@ -25,7 +25,7 @@ export default function setupModal(ctrl: LobbyController): MaybeVNode {
       setupCtrl.root.redraw();
     },
     modal: true,
-    vnodes: [...views[setupCtrl.gameType](ctrl), ratingView(ctrl)],
+    vnodes: [views[setupCtrl.gameType](ctrl), ratingView(ctrl)],
     onInsert: dlg => {
       setupCtrl.closeModal = dlg.close;
       dlg.show();

--- a/ui/puzzle/src/view/after.ts
+++ b/ui/puzzle/src/view/after.ts
@@ -1,38 +1,38 @@
 import * as licon from 'lib/licon';
-import { type VNode, type MaybeVNodes, bind, dataIcon, looseH as h } from 'lib/snabbdom';
+import { type VNode, type MaybeVNodes, bind, dataIcon, hl } from 'lib/snabbdom';
 import type PuzzleCtrl from '../ctrl';
 
 const renderVote = (ctrl: PuzzleCtrl): VNode =>
-  h(
+  hl(
     'div.puzzle__vote',
     {},
     !ctrl.autoNexting() && [
       ctrl.session.isNew() &&
         ctrl.data.user?.provisional &&
-        h('div.puzzle__vote__help', [
-          h('p', i18n.puzzle.didYouLikeThisPuzzle),
-          h('p', i18n.puzzle.voteToLoadNextOne),
+        hl('div.puzzle__vote__help', [
+          hl('p', i18n.puzzle.didYouLikeThisPuzzle),
+          hl('p', i18n.puzzle.voteToLoadNextOne),
         ]),
-      h('div.puzzle__vote__buttons', { class: { enabled: !ctrl.voteDisabled } }, [
-        h('div.vote.vote-up', { hook: bind('click', () => ctrl.vote(true)) }),
-        h('div.vote.vote-down', { hook: bind('click', () => ctrl.vote(false)) }),
+      hl('div.puzzle__vote__buttons', { class: { enabled: !ctrl.voteDisabled } }, [
+        hl('div.vote.vote-up', { hook: bind('click', () => ctrl.vote(true)) }),
+        hl('div.vote.vote-down', { hook: bind('click', () => ctrl.vote(false)) }),
       ]),
     ],
   );
 
 const renderContinue = (ctrl: PuzzleCtrl) =>
-  h('a.continue', { hook: bind('click', ctrl.nextPuzzle) }, [
-    h('i', { attrs: dataIcon(licon.PlayTriangle) }),
+  hl('a.continue', { hook: bind('click', ctrl.nextPuzzle) }, [
+    hl('i', { attrs: dataIcon(licon.PlayTriangle) }),
     i18n.puzzle.continueTraining,
   ]);
 
 const renderStreak = (ctrl: PuzzleCtrl): MaybeVNodes => [
-  h('div.complete', [
-    h('span.game-over', 'GAME OVER'),
-    h('span', i18n.puzzle.yourStreakX.asArray(h('strong', `${ctrl.streak?.data.index ?? 0}`))),
+  hl('div.complete', [
+    hl('span.game-over', 'GAME OVER'),
+    hl('span', i18n.puzzle.yourStreakX.asArray(hl('strong', `${ctrl.streak?.data.index ?? 0}`))),
   ]),
-  h('a.continue', { attrs: { href: ctrl.routerWithLang('/streak') } }, [
-    h('i', { attrs: dataIcon(licon.PlayTriangle) }),
+  hl('a.continue', { attrs: { href: ctrl.routerWithLang('/streak') } }, [
+    hl('i', { attrs: dataIcon(licon.PlayTriangle) }),
     i18n.puzzle.newStreak,
   ]),
 ];
@@ -41,16 +41,16 @@ export default function (ctrl: PuzzleCtrl): VNode {
   const data = ctrl.data;
   const win = ctrl.lastFeedback === 'win';
   const canContinue = !ctrl.node.san?.includes('#');
-  return h(
+  return hl(
     'div.puzzle__feedback.after',
     ctrl.streak && !win
       ? renderStreak(ctrl)
       : [
-          h('div.complete', i18n.puzzle[win ? 'puzzleSuccess' : 'puzzleComplete']),
+          hl('div.complete', i18n.puzzle[win ? 'puzzleSuccess' : 'puzzleComplete']),
           data.user ? renderVote(ctrl) : renderContinue(ctrl),
-          h('div.puzzle__more', [
+          hl('div.puzzle__more', [
             canContinue
-              ? h('a', {
+              ? hl('a', {
                   attrs: {
                     'data-icon': licon.Bullseye,
                     href: `/analysis/${ctrl.node.fen.replace(/ /g, '_')}?color=${ctrl.pov}#practice`,
@@ -58,10 +58,10 @@ export default function (ctrl: PuzzleCtrl): VNode {
                     target: '_blank',
                   },
                 })
-              : h('a'),
+              : hl('a'),
             data.user &&
               !ctrl.autoNexting() &&
-              h(
+              hl(
                 'a',
                 { hook: bind('click', ctrl.nextPuzzle) },
                 i18n.puzzle[ctrl.streak ? 'continueTheStreak' : 'continueTraining'],

--- a/ui/puzzle/src/view/main.ts
+++ b/ui/puzzle/src/view/main.ts
@@ -7,7 +7,7 @@ import feedbackView from './feedback';
 import * as licon from 'lib/licon';
 import { stepwiseScroll } from 'lib/view/controls';
 import { type VNode, h } from 'snabbdom';
-import { onInsert, bindNonPassive, looseH as lh } from 'lib/snabbdom';
+import { onInsert, bindNonPassive, hl } from 'lib/snabbdom';
 import { bindMobileMousedown } from 'lib/device';
 import { render as treeView } from './tree';
 import { view as cevalView } from 'lib/ceval/ceval';
@@ -20,7 +20,7 @@ import type PuzzleCtrl from '../ctrl';
 import { dispatchChessgroundResize } from 'lib/chessgroundResize';
 import { storage } from 'lib/storage';
 
-const renderAnalyse = (ctrl: PuzzleCtrl): VNode => lh('div.puzzle__moves.areplay', [treeView(ctrl)]);
+const renderAnalyse = (ctrl: PuzzleCtrl): VNode => hl('div.puzzle__moves.areplay', [treeView(ctrl)]);
 
 function dataAct(e: Event): string | null {
   const target = e.target as HTMLElement;
@@ -28,15 +28,15 @@ function dataAct(e: Event): string | null {
 }
 
 function jumpButton(icon: string, effect: string, disabled: boolean, glowing = false): VNode {
-  return lh('button.fbt', { class: { disabled, glowing }, attrs: { 'data-act': effect, 'data-icon': icon } });
+  return hl('button.fbt', { class: { disabled, glowing }, attrs: { 'data-act': effect, 'data-icon': icon } });
 }
 
 function controls(ctrl: PuzzleCtrl): VNode {
   const node = ctrl.node;
   const nextNode = node.children[0];
   const notOnLastMove = ctrl.mode === 'play' && nextNode && nextNode.puzzle !== 'fail';
-  return lh('div.puzzle__controls.analyse-controls', [
-    lh(
+  return hl('div.puzzle__controls.analyse-controls', [
+    hl(
       'div.jumps',
       {
         hook: onInsert(
@@ -71,7 +71,7 @@ export default function (ctrl: PuzzleCtrl): VNode {
     if (!cevalShown) ctrl.autoScrollNow = true;
     cevalShown = showCeval;
   }
-  return lh(
+  return hl(
     `main.puzzle.puzzle-${ctrl.data.replay ? 'replay' : 'play'}${ctrl.streak ? '.puzzle--streak' : ''}`,
     {
       class: { 'gauge-on': gaugeOn },
@@ -88,14 +88,14 @@ export default function (ctrl: PuzzleCtrl): VNode {
       },
     },
     [
-      lh('aside.puzzle__side', [
+      hl('aside.puzzle__side', [
         replay(ctrl),
         puzzleBox(ctrl),
         ctrl.streak ? streakBox(ctrl) : userBox(ctrl),
         config(ctrl),
         theme(ctrl),
       ]),
-      lh(
+      hl(
         'div.puzzle__board.main-board' + (ctrl.blindfold() ? '.blindfold' : ''),
         {
           hook:
@@ -121,14 +121,14 @@ export default function (ctrl: PuzzleCtrl): VNode {
         [chessground(ctrl), ctrl.promotion.view()],
       ),
       cevalView.renderGauge(ctrl),
-      lh('div.puzzle__tools', [
+      hl('div.puzzle__tools', [
         ctrl.voiceMove ? renderVoiceBar(ctrl.voiceMove.ctrl, ctrl.redraw, 'puz') : null,
         // we need the wrapping div here
         // so the siblings are only updated when ceval is added
-        lh(
+        hl(
           'div.ceval-wrap',
           { class: { none: !showCeval } },
-          showCeval ? [...cevalView.renderCeval(ctrl), cevalView.renderPvs(ctrl)] : [],
+          showCeval ? [cevalView.renderCeval(ctrl), cevalView.renderPvs(ctrl)] : [],
         ),
         renderAnalyse(ctrl),
         feedbackView(ctrl),
@@ -144,8 +144,8 @@ export default function (ctrl: PuzzleCtrl): VNode {
 function session(ctrl: PuzzleCtrl) {
   const rounds = ctrl.session.get().rounds,
     current = ctrl.data.puzzle.id;
-  return lh('div.puzzle__session', [
-    ...rounds.map(round => {
+  return hl('div.puzzle__session', [
+    rounds.map(round => {
       const rd =
         round.ratingDiff && ctrl.opts.showRatings
           ? round.ratingDiff > 0
@@ -168,8 +168,8 @@ function session(ctrl: PuzzleCtrl) {
     }),
     rounds.find(r => r.id === current)
       ? !ctrl.streak &&
-        lh('a.session-new', { key: 'new', attrs: { href: `/training/${ctrl.session.theme}` } })
-      : lh(
+        hl('a.session-new', { key: 'new', attrs: { href: `/training/${ctrl.session.theme}` } })
+      : hl(
           'a.result-cursor.current',
           { key: current, attrs: ctrl.streak ? {} : { href: `/training/${ctrl.session.theme}/${current}` } },
           ctrl.streak && (ctrl.streak.data.index + 1).toString(),

--- a/ui/puzzle/src/view/side.ts
+++ b/ui/puzzle/src/view/side.ts
@@ -1,6 +1,6 @@
 import type { Puzzle, PuzzleGame, PuzzleDifficulty } from '../interfaces';
 import * as licon from 'lib/licon';
-import { type VNode, dataIcon, onInsert, type MaybeVNode, looseH as h } from 'lib/snabbdom';
+import { type VNode, dataIcon, onInsert, type MaybeVNode, hl } from 'lib/snabbdom';
 import { numberFormat } from 'lib/i18n';
 import perfIcons from 'lib/game/perfIcons';
 import { userLink } from 'lib/view/userLink';
@@ -9,7 +9,7 @@ import type PuzzleCtrl from '../ctrl';
 
 export function puzzleBox(ctrl: PuzzleCtrl): VNode {
   const data = ctrl.data;
-  return h('div.puzzle__side__metas', [
+  return hl('div.puzzle__side__metas', [
     puzzleInfos(ctrl, data.puzzle),
     gameInfos(ctrl, data.game, data.puzzle),
   ]);
@@ -23,15 +23,15 @@ const angleImg = (ctrl: PuzzleCtrl): string => {
 };
 
 const puzzleInfos = (ctrl: PuzzleCtrl, puzzle: Puzzle): VNode =>
-  h('div.infos.puzzle', [
-    h('img.infos__angle-img', { attrs: { src: angleImg(ctrl), alt: ctrl.data.angle.name } }),
-    h('div', [
-      h(
+  hl('div.infos.puzzle', [
+    hl('img.infos__angle-img', { attrs: { src: angleImg(ctrl), alt: ctrl.data.angle.name } }),
+    hl('div', [
+      hl(
         'p',
         i18n.puzzle.puzzleId.asArray(
           ctrl.streak && ctrl.mode === 'play'
-            ? h('span.hidden', i18n.puzzle.hidden)
-            : h(
+            ? hl('span.hidden', i18n.puzzle.hidden)
+            : hl(
                 'a',
                 {
                   attrs: {
@@ -44,38 +44,38 @@ const puzzleInfos = (ctrl: PuzzleCtrl, puzzle: Puzzle): VNode =>
         ),
       ),
       ctrl.opts.showRatings &&
-        h(
+        hl(
           'p',
           i18n.puzzle.ratingX.asArray(
             !ctrl.streak && ctrl.mode === 'play'
-              ? h('span.hidden', i18n.puzzle.hidden)
-              : h('strong', `${puzzle.rating}`),
+              ? hl('span.hidden', i18n.puzzle.hidden)
+              : hl('strong', `${puzzle.rating}`),
           ),
         ),
-      h('p', i18n.puzzle.playedXTimes.asArray(puzzle.plays, h('strong', numberFormat(puzzle.plays)))),
+      hl('p', i18n.puzzle.playedXTimes.asArray(puzzle.plays, hl('strong', numberFormat(puzzle.plays)))),
     ]),
   ]);
 
 function gameInfos(ctrl: PuzzleCtrl, game: PuzzleGame, puzzle: Puzzle): VNode {
   const gameName = game.clock && game.perf ? `${game.clock} • ${game.perf.name}` : 'import';
-  return h('div.infos', { attrs: game.perf && dataIcon(perfIcons[game.perf.key]) }, [
-    h('div', [
-      h(
+  return hl('div.infos', { attrs: game.perf && dataIcon(perfIcons[game.perf.key]) }, [
+    hl('div', [
+      hl(
         'p',
         i18n.puzzle.fromGameLink.asArray(
           ctrl.mode === 'play'
-            ? h('span', gameName)
-            : h('a', { attrs: { href: `/${game.id}/${ctrl.pov}#${puzzle.initialPly}` } }, gameName),
+            ? hl('span', gameName)
+            : hl('a', { attrs: { href: `/${game.id}/${ctrl.pov}#${puzzle.initialPly}` } }, gameName),
         ),
       ),
-      h(
+      hl(
         'div.players',
         game.players.map(p => {
           const user =
             p.name == 'ghost'
               ? p.rating?.toString() || ''
               : userLink({ ...p, rating: ctrl.opts.showRatings ? p.rating : undefined, line: false });
-          return h('div.player.color-icon.is.text.' + p.color, user);
+          return hl('div.player.color-icon.is.text.' + p.color, user);
         }),
       ),
     ]),
@@ -83,14 +83,14 @@ function gameInfos(ctrl: PuzzleCtrl, game: PuzzleGame, puzzle: Puzzle): VNode {
 }
 
 const renderStreak = (streak: PuzzleStreak) =>
-  h(
+  hl(
     'div.puzzle__side__streak',
     streak.data.index === 0
-      ? h('div.puzzle__side__streak__info', [
-          h('h1.text', { attrs: dataIcon(licon.ArrowThruApple) }, 'Puzzle Streak'),
-          h('p', i18n.puzzle.streakDescription),
+      ? hl('div.puzzle__side__streak__info', [
+          hl('h1.text', { attrs: dataIcon(licon.ArrowThruApple) }, 'Puzzle Streak'),
+          hl('p', i18n.puzzle.streakDescription),
         ])
-      : h(
+      : hl(
           'div.puzzle__side__streak__score.text',
           { attrs: dataIcon(licon.ArrowThruApple) },
           `${streak.data.index}`,
@@ -100,19 +100,19 @@ const renderStreak = (streak: PuzzleStreak) =>
 export const userBox = (ctrl: PuzzleCtrl): VNode => {
   const data = ctrl.data;
   if (!data.user)
-    return h('div.puzzle__side__user', [
-      h('p', i18n.puzzle.toGetPersonalizedPuzzles),
-      h('a.button', { attrs: { href: ctrl.routerWithLang('/signup') } }, i18n.site.signUp),
+    return hl('div.puzzle__side__user', [
+      hl('p', i18n.puzzle.toGetPersonalizedPuzzles),
+      hl('a.button', { attrs: { href: ctrl.routerWithLang('/signup') } }, i18n.site.signUp),
     ]);
   const diff = ctrl.round?.ratingDiff,
     ratedId = `puzzle-toggle-rated_hint-${ctrl.hintHasBeenShown()}`;
-  return h('div.puzzle__side__user', [
+  return hl('div.puzzle__side__user', [
     !data.replay &&
       !ctrl.streak &&
       data.user &&
-      h('div.puzzle__side__config__toggle', [
-        h('div.switch', [
-          h(`input#${ratedId}.cmn-toggle.cmn-toggle--subtle.`, {
+      hl('div.puzzle__side__config__toggle', [
+        hl('div.switch', [
+          hl(`input#${ratedId}.cmn-toggle.cmn-toggle--subtle.`, {
             attrs: {
               type: 'checkbox',
               checked: ctrl.rated() && !ctrl.hintHasBeenShown(),
@@ -120,25 +120,25 @@ export const userBox = (ctrl: PuzzleCtrl): VNode => {
             },
             hook: onInsert(el => el.addEventListener('change', ctrl.toggleRated)),
           }),
-          h('label', { attrs: { for: ratedId } }),
+          hl('label', { attrs: { for: ratedId } }),
         ]),
-        h('label', { attrs: { for: ratedId } }, i18n.site.rated),
+        hl('label', { attrs: { for: ratedId } }, i18n.site.rated),
       ]),
-    h(
+    hl(
       'div.puzzle__side__user__rating',
       ctrl.rated()
         ? ctrl.opts.showRatings &&
-            h('strong', [
+            hl('strong', [
               data.user.rating - (diff || 0),
-              ...(diff && diff > 0 ? [' ', h('good.rp', '+' + diff)] : []),
-              ...(diff && diff < 0 ? [' ', h('bad.rp', '−' + -diff)] : []),
+              !!diff && diff > 0 && [' ', hl('good.rp', '+' + diff)],
+              !!diff && diff < 0 && [' ', hl('bad.rp', '−' + -diff)],
             ])
-        : h('p.puzzle__side__user__rating__casual', i18n.puzzle.yourPuzzleRatingWillNotChange),
+        : hl('p.puzzle__side__user__rating__casual', i18n.puzzle.yourPuzzleRatingWillNotChange),
     ),
   ]);
 };
 
-export const streakBox = (ctrl: PuzzleCtrl) => h('div.puzzle__side__user', renderStreak(ctrl.streak!));
+export const streakBox = (ctrl: PuzzleCtrl) => hl('div.puzzle__side__user', renderStreak(ctrl.streak!));
 
 const difficulties: [PuzzleDifficulty, number][] = [
   ['easiest', -600],
@@ -158,9 +158,9 @@ export function replay(ctrl: PuzzleCtrl): MaybeVNode {
   if (!replay) return;
   const i = replay.i + (ctrl.mode === 'play' ? 0 : 1);
   const text = i18n.puzzleTheme[ctrl.data.angle.key];
-  return h('div.puzzle__side__replay', [
-    h('a', { attrs: { href: `/training/dashboard/${replay.days}` } }, ['« ', `Replaying ${text} puzzles`]),
-    h('div.puzzle__side__replay__bar', {
+  return hl('div.puzzle__side__replay', [
+    hl('a', { attrs: { href: `/training/dashboard/${replay.days}` } }, ['« ', `Replaying ${text} puzzles`]),
+    hl('div.puzzle__side__replay__bar', {
       attrs: {
         style: `---p:${replay.of ? Math.round((100 * i) / replay.of) : 1}%`,
         'data-text': `${i} / ${replay.of}`,
@@ -172,10 +172,10 @@ export function replay(ctrl: PuzzleCtrl): MaybeVNode {
 export function config(ctrl: PuzzleCtrl): MaybeVNode {
   const autoNextId = 'puzzle-toggle-autonext',
     data = ctrl.data;
-  return h('div.puzzle__side__config', [
-    h('div.puzzle__side__config__toggle', [
-      h('div.switch', [
-        h(`input#${autoNextId}.cmn-toggle.cmn-toggle--subtle`, {
+  return hl('div.puzzle__side__config', [
+    hl('div.puzzle__side__config__toggle', [
+      hl('div.switch', [
+        hl(`input#${autoNextId}.cmn-toggle.cmn-toggle--subtle`, {
           attrs: { type: 'checkbox', checked: ctrl.autoNext() },
           hook: {
             insert: vnode =>
@@ -187,21 +187,21 @@ export function config(ctrl: PuzzleCtrl): MaybeVNode {
               }),
           },
         }),
-        h('label', { attrs: { for: autoNextId } }),
+        hl('label', { attrs: { for: autoNextId } }),
       ]),
-      h('label', { attrs: { for: autoNextId } }, i18n.puzzle.jumpToNextPuzzleImmediately),
+      hl('label', { attrs: { for: autoNextId } }, i18n.puzzle.jumpToNextPuzzleImmediately),
     ]),
     !data.user || data.replay || ctrl.streak ? null : renderDifficultyForm(ctrl),
   ]);
 }
 
 export const renderDifficultyForm = (ctrl: PuzzleCtrl): VNode =>
-  h(
+  hl(
     'form.puzzle__side__config__difficulty',
     { attrs: { action: `/training/difficulty/${ctrl.data.angle.key}`, method: 'post' } },
     [
-      h('label', { attrs: { for: 'puzzle-difficulty' } }, i18n.puzzle.difficultyLevel),
-      h(
+      hl('label', { attrs: { for: 'puzzle-difficulty' } }, i18n.puzzle.difficultyLevel),
+      hl(
         'select#puzzle-difficulty.puzzle__difficulty__selector',
         {
           attrs: { name: 'difficulty' },
@@ -210,7 +210,7 @@ export const renderDifficultyForm = (ctrl: PuzzleCtrl): VNode =>
           ),
         },
         difficulties.map(([key, delta]) =>
-          h(
+          hl(
             'option',
             {
               attrs: {
@@ -230,18 +230,18 @@ export const renderDifficultyForm = (ctrl: PuzzleCtrl): VNode =>
   );
 
 export const renderColorForm = (ctrl: PuzzleCtrl): VNode =>
-  h(
+  hl(
     'div.puzzle__side__config__color',
-    h(
+    hl(
       'group.radio',
       colors.map(([key, i18nKey]) =>
-        h('div', [
-          h(
+        hl('div', [
+          hl(
             `a.label.color-${key}${key === (ctrl.opts.settings.color || 'random') ? '.active' : ''}`,
             {
               attrs: { href: `/training/${ctrl.data.angle.key}/${key}`, title: i18n.site[i18nKey] },
             },
-            h('i'),
+            hl('i'),
           ),
         ]),
       ),

--- a/ui/puzzle/src/view/theme.ts
+++ b/ui/puzzle/src/view/theme.ts
@@ -1,5 +1,5 @@
 import * as licon from 'lib/licon';
-import { type VNode, type MaybeVNode, bind, dataIcon, looseH as h } from 'lib/snabbdom';
+import { type VNode, type MaybeVNode, bind, dataIcon, hl } from 'lib/snabbdom';
 import type { ThemeKey, RoundThemes } from '../interfaces';
 import { renderColorForm } from './side';
 import type PuzzleCtrl from '../ctrl';
@@ -10,31 +10,38 @@ export default function theme(ctrl: PuzzleCtrl): MaybeVNode {
   const data = ctrl.data,
     angle = data.angle;
   const showEditor = ctrl.mode === 'view' && !ctrl.autoNexting();
-  if (data.replay) return showEditor ? h('div.puzzle__side__theme', editor(ctrl)) : null;
+  if (data.replay) return showEditor ? hl('div.puzzle__side__theme', editor(ctrl)) : null;
   const puzzleMenu = (v: VNode): VNode =>
-    h('a', { attrs: { href: ctrl.routerWithLang(`/training/${angle.opening ? 'openings' : 'themes'}`) } }, v);
+    hl(
+      'a',
+      { attrs: { href: ctrl.routerWithLang(`/training/${angle.opening ? 'openings' : 'themes'}`) } },
+      v,
+    );
   return ctrl.streak
     ? null
     : ctrl.isDaily
-      ? h('div.puzzle__side__theme.puzzle__side__theme--daily', puzzleMenu(h('h2', i18n.puzzle.dailyPuzzle)))
-      : h('div.puzzle__side__theme', [
-          puzzleMenu(h('h2', { class: { long: angle.name.length > 20 } }, ['« ', angle.name])),
+      ? hl(
+          'div.puzzle__side__theme.puzzle__side__theme--daily',
+          puzzleMenu(hl('h2', i18n.puzzle.dailyPuzzle)),
+        )
+      : hl('div.puzzle__side__theme', [
+          puzzleMenu(hl('h2', { class: { long: angle.name.length > 20 } }, ['« ', angle.name])),
           angle.opening
-            ? h('a', { attrs: { href: `/opening/${angle.opening.key}` } }, [
+            ? hl('a', { attrs: { href: `/opening/${angle.opening.key}` } }, [
                 'Learn more about ',
                 angle.opening.name,
               ])
-            : h('p', [
+            : hl('p', [
                 angle.desc,
                 angle.chapter &&
-                  h(
+                  hl(
                     'a.puzzle__side__theme__chapter.text',
                     { attrs: { href: `${studyUrl}/${angle.chapter}`, target: '_blank' } },
                     [' ', i18n.puzzle.example],
                   ),
               ]),
           showEditor
-            ? h('div.puzzle__themes', editor(ctrl))
+            ? hl('div.puzzle__themes', editor(ctrl))
             : !data.replay &&
               !ctrl.streak &&
               (angle.opening || angle.openingAbstract) &&
@@ -58,7 +65,7 @@ const editor = (ctrl: PuzzleCtrl): VNode[] => {
   const availableThemes = allThemes ? allThemes.dynamic.filter((t: ThemeKey) => !votedThemes[t]) : null;
   if (availableThemes) availableThemes.sort((a, b) => (themeTrans(a) < themeTrans(b) ? -1 : 1));
   return [
-    h(
+    hl(
       'div.puzzle__themes_list',
       {
         hook: bind('click', e => {
@@ -68,23 +75,23 @@ const editor = (ctrl: PuzzleCtrl): VNode[] => {
         }),
       },
       visibleThemes.map(key =>
-        h('div.puzzle__themes__list__entry', { class: { strike: votedThemes[key] === false } }, [
-          h(
+        hl('div.puzzle__themes__list__entry', { class: { strike: votedThemes[key] === false } }, [
+          hl(
             'a',
             { attrs: { href: `/training/${key}`, title: themeTrans(`${key}Description`) } },
             themeTrans(key),
           ),
           allThemes &&
-            h(
+            hl(
               'div.puzzle__themes__votes',
               allThemes.static.has(key)
-                ? [h('div.puzzle__themes__lock', h('i', { attrs: dataIcon(licon.Padlock) }))]
+                ? [hl('div.puzzle__themes__lock', hl('i', { attrs: dataIcon(licon.Padlock) }))]
                 : [
-                    h('span.puzzle__themes__vote.vote-up', {
+                    hl('span.puzzle__themes__vote.vote-up', {
                       class: { active: votedThemes[key] },
                       attrs: { 'data-theme': key },
                     }),
-                    h('span.puzzle__themes__vote.vote-down', {
+                    hl('span.puzzle__themes__vote.vote-down', {
                       class: { active: votedThemes[key] === false },
                       attrs: { 'data-theme': key },
                     }),
@@ -95,7 +102,7 @@ const editor = (ctrl: PuzzleCtrl): VNode[] => {
     ),
     ...(availableThemes
       ? [
-          h(
+          hl(
             `select.puzzle__themes__selector.cache-bust-${availableThemes.length}`,
             {
               hook: {
@@ -109,9 +116,9 @@ const editor = (ctrl: PuzzleCtrl): VNode[] => {
               },
             },
             [
-              h('option', { attrs: { value: '', selected: true } }, i18n.puzzle.addAnotherTheme),
-              ...availableThemes.map(theme =>
-                h(
+              hl('option', { attrs: { value: '', selected: true } }, i18n.puzzle.addAnotherTheme),
+              availableThemes.map(theme =>
+                hl(
                   'option',
                   { attrs: { value: theme, title: themeTrans(`${theme}Description`) } },
                   themeTrans(theme),
@@ -119,7 +126,7 @@ const editor = (ctrl: PuzzleCtrl): VNode[] => {
               ),
             ],
           ),
-          h(
+          hl(
             'a.puzzle__themes__study.text',
             { attrs: { 'data-icon': licon.InfoCircle, href: studyUrl, target: '_blank' } },
             'About puzzle themes',

--- a/ui/racer/src/view/main.ts
+++ b/ui/racer/src/view/main.ts
@@ -4,19 +4,19 @@ import renderClock from 'lib/puz/view/clock';
 import renderHistory from 'lib/puz/view/history';
 import * as licon from 'lib/licon';
 import { copyMeInput } from 'lib/view/controls';
-import { type VNode, type MaybeVNodes, bind, looseH as h } from 'lib/snabbdom';
+import { type VNode, type MaybeVNodes, bind, hl } from 'lib/snabbdom';
 import { playModifiers, renderCombo } from 'lib/puz/view/util';
 import { renderRace } from './race';
 import { renderBoard } from './board';
 import { povMessage } from 'lib/puz/run';
 
 export default function (ctrl: RacerCtrl): VNode {
-  return h(
+  return hl(
     'div.racer.racer-app.racer--play',
     { class: { ...playModifiers(ctrl.run), [`racer--${ctrl.status()}`]: true } },
     [
       renderBoard(ctrl),
-      h('div.puz-side', selectScreen(ctrl)),
+      hl('div.puz-side', selectScreen(ctrl)),
       renderRace(ctrl),
       ctrl.status() === 'post' && ctrl.run.history.length > 0 ? renderHistory(ctrl) : null,
     ],
@@ -26,13 +26,13 @@ export default function (ctrl: RacerCtrl): VNode {
 const selectScreen = (ctrl: RacerCtrl): MaybeVNodes => {
   switch (ctrl.status()) {
     case 'pre': {
-      const povMsg = h('p.racer__pre__message__pov', povMessage(ctrl.run));
+      const povMsg = hl('p.racer__pre__message__pov', povMessage(ctrl.run));
       return ctrl.race.lobby
         ? [
             waitingToStart(),
-            h('div.racer__pre__message.racer__pre__message--with-skip', [
-              h('div.racer__pre__message__text', [
-                h(
+            hl('div.racer__pre__message.racer__pre__message--with-skip', [
+              hl('div.racer__pre__message__text', [
+                hl(
                   'p',
                   ctrl.knowsSkip()
                     ? i18n.storm[ctrl.vm.startsAt ? 'getReady' : 'waitingForMorePlayers']
@@ -46,14 +46,14 @@ const selectScreen = (ctrl: RacerCtrl): MaybeVNodes => {
           ]
         : [
             waitingToStart(),
-            h('div.racer__pre__message', [
-              ...(ctrl.raceFull()
+            hl('div.racer__pre__message', [
+              ctrl.raceFull()
                 ? ctrl.isPlayer()
                   ? [renderStart(ctrl)]
                   : []
                 : ctrl.isPlayer()
                   ? [renderLink(ctrl), renderStart(ctrl)]
-                  : [renderJoin(ctrl)]),
+                  : [renderJoin(ctrl)],
               povMsg,
             ]),
             comboZone(ctrl),
@@ -62,11 +62,11 @@ const selectScreen = (ctrl: RacerCtrl): MaybeVNodes => {
     case 'racing': {
       const clock = renderClock(ctrl.run, ctrl.end, false);
       return ctrl.isPlayer()
-        ? [playerScore(ctrl), h('div.puz-clock', [clock, renderSkip(ctrl)]), comboZone(ctrl)]
+        ? [playerScore(ctrl), hl('div.puz-clock', [clock, renderSkip(ctrl)]), comboZone(ctrl)]
         : [
             spectating(),
-            h('div.racer__spectating', [
-              h('div.puz-clock', clock),
+            hl('div.racer__spectating', [
+              hl('div.puz-clock', clock),
               ctrl.race.lobby ? lobbyNext(ctrl) : waitForRematch(),
             ]),
             comboZone(ctrl),
@@ -74,16 +74,20 @@ const selectScreen = (ctrl: RacerCtrl): MaybeVNodes => {
     }
     case 'post': {
       const nextRace = ctrl.race.lobby ? lobbyNext(ctrl) : friendNext(ctrl);
-      const raceComplete = h('h2', i18n.storm.raceComplete);
+      const raceComplete = hl('h2', i18n.storm.raceComplete);
       return ctrl.isPlayer()
-        ? [playerScore(ctrl), h('div.racer__post', [raceComplete, yourRank(ctrl), nextRace]), comboZone(ctrl)]
-        : [spectating(), h('div.racer__post', [raceComplete, nextRace]), comboZone(ctrl)];
+        ? [
+            playerScore(ctrl),
+            hl('div.racer__post', [raceComplete, yourRank(ctrl), nextRace]),
+            comboZone(ctrl),
+          ]
+        : [spectating(), hl('div.racer__post', [raceComplete, nextRace]), comboZone(ctrl)];
     }
   }
 };
 
 const renderSkip = (ctrl: RacerCtrl) =>
-  h(
+  hl(
     'button.racer__skip.button.button-red',
     {
       class: { disabled: !ctrl.canSkip() },
@@ -93,28 +97,28 @@ const renderSkip = (ctrl: RacerCtrl) =>
     i18n.storm.skip,
   );
 
-const skipHelp = () => h('p', i18n.storm.skipHelp);
+const skipHelp = () => hl('p', i18n.storm.skipHelp);
 
-const puzzleRacer = () => h('strong', 'Puzzle Racer');
+const puzzleRacer = () => hl('strong', 'Puzzle Racer');
 
 const waitingToStart = () =>
-  h(
+  hl(
     'div.puz-side__top.puz-side__start',
-    h('div.puz-side__start__text', [puzzleRacer(), h('span', i18n.storm.waitingToStart)]),
+    hl('div.puz-side__start__text', [puzzleRacer(), hl('span', i18n.storm.waitingToStart)]),
   );
 
 const spectating = () =>
-  h(
+  hl(
     'div.puz-side__top.puz-side__start',
-    h('div.puz-side__start__text', [puzzleRacer(), h('span', i18n.storm.spectating)]),
+    hl('div.puz-side__start__text', [puzzleRacer(), hl('span', i18n.storm.spectating)]),
   );
 
 const renderBonus = (bonus: number) => `+${bonus}`;
 
 const renderControls = (ctrl: RacerCtrl): VNode =>
-  h(
+  hl(
     'div.puz-side__control',
-    h('a.puz-side__control__flip.button', {
+    hl('a.puz-side__control__flip.button', {
       class: { active: ctrl.flipped, 'button-empty': !ctrl.flipped },
       attrs: { 'data-icon': licon.ChasingArrows, title: i18n.site.flipBoard + ' (Keyboard: f)' },
       hook: bind('click', ctrl.flip),
@@ -122,23 +126,23 @@ const renderControls = (ctrl: RacerCtrl): VNode =>
   );
 
 const comboZone = (ctrl: RacerCtrl) =>
-  h('div.puz-side__table', [renderControls(ctrl), renderCombo(config, renderBonus)(ctrl.run)]);
+  hl('div.puz-side__table', [renderControls(ctrl), renderCombo(config, renderBonus)(ctrl.run)]);
 
 const playerScore = (ctrl: RacerCtrl): VNode =>
-  h('div.puz-side__top.puz-side__solved', [h('div.puz-side__solved__text', `${ctrl.myScore() || 0}`)]);
+  hl('div.puz-side__top.puz-side__solved', [hl('div.puz-side__solved__text', `${ctrl.myScore() || 0}`)]);
 
 const renderLink = (ctrl: RacerCtrl) =>
-  h('div.puz-side__link', [
-    h('p', i18n.site.toInviteSomeoneToPlayGiveThisUrl),
+  hl('div.puz-side__link', [
+    hl('p', i18n.site.toInviteSomeoneToPlayGiveThisUrl),
     copyMeInput(`${window.location.protocol}//${window.location.host}/racer/${ctrl.race.id}`),
   ]);
 
 const renderStart = (ctrl: RacerCtrl) =>
   ctrl.isOwner() &&
   !ctrl.vm.startsAt &&
-  h(
+  hl(
     'div.puz-side__start',
-    h(
+    hl(
       'button.button.button-fat',
       {
         class: { disabled: ctrl.players().length < 2 },
@@ -150,9 +154,9 @@ const renderStart = (ctrl: RacerCtrl) =>
   );
 
 const renderJoin = (ctrl: RacerCtrl) =>
-  h(
+  hl(
     'div.puz-side__join',
-    h('button.button.button-fat', { hook: bind('click', ctrl.join) }, i18n.storm.joinTheRace),
+    hl('button.button.button-fat', { hook: bind('click', ctrl.join) }, i18n.storm.joinTheRace),
   );
 
 const yourRank = (ctrl: RacerCtrl) => {
@@ -160,35 +164,35 @@ const yourRank = (ctrl: RacerCtrl) => {
   if (!score) return;
   const players = ctrl.players();
   const rank = players.filter(p => p.score > score).length + 1;
-  return h('strong.race__post__rank', i18n.storm.yourRankX(`${rank}/${players.length}`));
+  return hl('strong.race__post__rank', i18n.storm.yourRankX(`${rank}/${players.length}`));
 };
 
 const waitForRematch = () =>
-  h(
+  hl(
     `a.racer__new-race.button.button-fat.button-navaway.disabled`,
     { attrs: { disabled: true } },
     i18n.storm.waitForRematch,
   );
 
 const lobbyNext = (ctrl: RacerCtrl) =>
-  h('form', { attrs: { action: '/racer/lobby', method: 'post' } }, [
-    h(
+  hl('form', { attrs: { action: '/racer/lobby', method: 'post' } }, [
+    hl(
       `button.racer__new-race.button.button-navaway${ctrl.race.lobby ? '.button-fat' : '.button-empty'}`,
       i18n.storm.nextRace,
     ),
   ]);
 
 const friendNext = (ctrl: RacerCtrl) =>
-  h('div.racer__post__next', [
-    h(
+  hl('div.racer__post__next', [
+    hl(
       `a.racer__rematch.button.button-fat.button-navaway`,
       { attrs: { href: `/racer/${ctrl.race.id}/rematch` } },
       i18n.storm.joinRematch,
     ),
-    h(
+    hl(
       'form.racer__post__next__new',
       { attrs: { action: '/racer', method: 'post' } },
-      h(
+      hl(
         'button.racer__post__next__button.button.button-empty',
         { attrs: { type: 'submit' } },
         i18n.storm.createNewGame,

--- a/ui/recap/src/slides.ts
+++ b/ui/recap/src/slides.ts
@@ -1,6 +1,6 @@
 import { pieceGrams, totalGames } from './constants';
 import type { ByColor, Counted, Opening, Recap, Sources, RecapPerf } from './interfaces';
-import { onInsert, looseH as h, VNodeKids, VNode, dataIcon } from 'lib/snabbdom';
+import { onInsert, hl, LooseVNodes, VNode, dataIcon } from 'lib/snabbdom';
 import { formatNumber, loadOpeningLpv } from './ui';
 import { shuffle } from 'lib/algo';
 import { fullName, userFlair, userTitle } from 'lib/view/userLink';
@@ -8,10 +8,10 @@ import { spinnerVdom } from 'lib/view/controls';
 import { formatDuration, perfLabel, perfNames } from './util';
 import perfIcons from 'lib/game/perfIcons';
 
-const hi = (user: LightUser): VNode => h('h2', ['Hi, ', h('span.recap__user', [...fullName(user)])]);
+const hi = (user: LightUser): VNode => hl('h2', ['Hi, ', hl('span.recap__user', fullName(user))]);
 
 export const loading = (user: LightUser): VNode =>
-  slideTag('await')([hi(user), h('p', 'What have you been up to this year?'), spinnerVdom()]);
+  slideTag('await')([hi(user), hl('p', 'What have you been up to this year?'), spinnerVdom()]);
 
 export const init = (user: LightUser): VNode =>
   slideTag(
@@ -19,22 +19,22 @@ export const init = (user: LightUser): VNode =>
     3000,
   )([
     hi(user),
-    h('img.recap__logo', { attrs: { src: site.asset.url('logo/lichess-white.svg') } }),
-    h('h2', 'What a chess year you had!'),
+    hl('img.recap__logo', { attrs: { src: site.asset.url('logo/lichess-white.svg') } }),
+    hl('h2', 'What a chess year you had!'),
   ]);
 
 export const noGames = (): VNode =>
   slideTag('no-games')([
-    h('div.recap--massive', 'You did not play any games this year.'),
-    h('div', h('p', h('a', { attrs: { href: '/', target: '_blank' } }, 'Wanna play now?'))),
+    hl('div.recap--massive', 'You did not play any games this year.'),
+    hl('div', hl('p', hl('a', { attrs: { href: '/', target: '_blank' } }, 'Wanna play now?'))),
   ]);
 
 export const nbGames = (r: Recap): VNode => {
   return slideTag('games')([
-    h('div.recap--massive', [h('strong', animateNumber(r.games.nbs.total)), 'games played']),
-    h('div', [
-      r.games.nbs.win && h('p', ['And you won ', h('strong', animateNumber(r.games.nbs.win)), '!']),
-      h('p', 'What did it take to get there?'),
+    hl('div.recap--massive', [hl('strong', animateNumber(r.games.nbs.total)), 'games played']),
+    hl('div', [
+      r.games.nbs.win && hl('p', ['And you won ', hl('strong', animateNumber(r.games.nbs.win)), '!']),
+      hl('p', 'What did it take to get there?'),
     ]),
   ]);
 };
@@ -43,9 +43,9 @@ export const timeSpentPlaying = (r: Recap): VNode => {
   const s = r.games.timePlaying;
   const days = s / 60 / 60 / 24;
   return slideTag('time')([
-    h('div.recap--massive', [h('strong', animateTime(s)), 'spent playing!']),
-    h('div', [
-      h(
+    hl('div.recap--massive', [hl('strong', animateTime(s)), 'spent playing!']),
+    hl('div', [
+      hl(
         'p',
         days > 10
           ? 'That is way too much chess.'
@@ -53,7 +53,7 @@ export const timeSpentPlaying = (r: Recap): VNode => {
             ? 'That is a lot of chess.'
             : 'That seems like a reasonable amount of chess.',
       ),
-      h('p', 'How many moves did you play in all that time?'),
+      hl('p', 'How many moves did you play in all that time?'),
     ]),
   ]);
 };
@@ -63,23 +63,23 @@ export const nbMoves = (r: Recap): VNode => {
     'moves',
     6000,
   )([
-    h('div.recap--massive', [h('strong', animateNumber(r.games.moves)), 'moves played']),
-    h('div', [
-      h('p', ["That's ", h('strong', showGrams(r.games.moves * pieceGrams)), ' of wood pushed!']),
-      h('p', [h('small', 'Standard pieces weigh about 40g each')]),
+    hl('div.recap--massive', [hl('strong', animateNumber(r.games.moves)), 'moves played']),
+    hl('div', [
+      hl('p', ["That's ", hl('strong', showGrams(r.games.moves * pieceGrams)), ' of wood pushed!']),
+      hl('p', [hl('small', 'Standard pieces weigh about 40g each')]),
     ]),
   ]);
 };
 
 export const opponents = (r: Recap): VNode => {
   return slideTag('opponents')([
-    h('div.recap--massive', 'Your best chess foes'),
-    h(
+    hl('div.recap--massive', 'Your best chess foes'),
+    hl(
       'table.recap__data',
-      h(
+      hl(
         'tbody',
         r.games.opponents.map(o =>
-          h('tr', [h('td', opponentLink(o.value)), h('td', [animateNumber(o.count), ' games'])]),
+          hl('tr', [hl('td', opponentLink(o.value)), hl('td', [animateNumber(o.count), ' games'])]),
         ),
       ),
     ),
@@ -87,7 +87,7 @@ export const opponents = (r: Recap): VNode => {
 };
 
 const opponentLink = (o: LightUser): VNode =>
-  h('a', { attrs: { href: `/@/${o.name}` } }, [userFlair(o) || noFlair(o), userTitle(o), o.name]);
+  hl('a', { attrs: { href: `/@/${o.name}` } }, [userFlair(o) || noFlair(o), userTitle(o), o.name]);
 
 const userFallbackFlair = new Map<string, string>();
 const noFlair = (o: LightUser): VNode => {
@@ -104,17 +104,17 @@ const noFlair = (o: LightUser): VNode => {
           ])[0])(),
       )
       .get(o.id)!;
-  return h('img.uflair.noflair', { attrs: { src: site.asset.flairSrc(randomFlair) } });
+  return hl('img.uflair.noflair', { attrs: { src: site.asset.flairSrc(randomFlair) } });
 };
 
 export const firstMoves = (r: Recap, firstMove: Counted<string>): VNode => {
   const percent = Math.round((firstMove.count * 100) / r.games.nbWhite);
   return slideTag('first')([
-    h('div.recap--massive', [h('strong.animated-pulse', '1. ' + firstMove.value)]),
-    h('div', [
-      h('p', [
+    hl('div.recap--massive', [hl('strong.animated-pulse', '1. ' + firstMove.value)]),
+    hl('div', [
+      hl('p', [
         'is how you started ',
-        h('strong', animateNumber(firstMove.count)),
+        hl('strong', animateNumber(firstMove.count)),
         ' (',
         animateNumber(percent),
         '%) of your games as white',
@@ -127,12 +127,12 @@ export const openingColor = (os: ByColor<Counted<Opening>>, color: Color): VNode
   const o = os[color];
   if (!o.count) return;
   return slideTag('openings')([
-    h('div.lpv.lpv--todo.lpv--moves-bottom.is2d', {
+    hl('div.lpv.lpv--todo.lpv--moves-bottom.is2d', {
       hook: onInsert(el => loadOpeningLpv(el, color, o.value)),
     }),
-    h(
+    hl(
       'div',
-      h(
+      hl(
         'a',
         {
           attrs: { href: `/opening/${o.value.key}`, target: '_blank' },
@@ -140,13 +140,13 @@ export const openingColor = (os: ByColor<Counted<Opening>>, color: Color): VNode
         o.value.name,
       ),
     ),
-    h('div', [
-      h('p', [
+    hl('div', [
+      hl('p', [
         'Your most played opening as ',
         color,
-        h('br'),
+        hl('br'),
         'with ',
-        h('strong', animateNumber(o.count)),
+        hl('strong', animateNumber(o.count)),
         ' games.',
       ]),
     ]),
@@ -157,33 +157,36 @@ export const puzzles = (r: Recap): VNode => {
   return slideTag('puzzles')(
     r.puzzles.nbs.total
       ? [
-          h('div.recap--massive', [h('strong', animateNumber(r.puzzles.nbs.total)), 'puzzles solved']),
-          h('div', [
+          hl('div.recap--massive', [hl('strong', animateNumber(r.puzzles.nbs.total)), 'puzzles solved']),
+          hl('div', [
             r.puzzles.nbs.win &&
-              h('p', [
+              hl('p', [
                 'You won ',
-                h('strong', animateNumber(r.puzzles.nbs.win)),
+                hl('strong', animateNumber(r.puzzles.nbs.win)),
                 ' of them on the first try!',
               ]),
             r.puzzles.votes.nb
-              ? h('p', [
+              ? hl('p', [
                   'Thank you for voting on ',
-                  h('strong', animateNumber(r.puzzles.votes.nb)),
+                  hl('strong', animateNumber(r.puzzles.votes.nb)),
                   ' puzzles.',
                 ])
               : null,
             r.puzzles.votes.themes
-              ? h('p', [
+              ? hl('p', [
                   'You also helped tagging ',
-                  h('strong', animateNumber(r.puzzles.votes.themes)),
+                  hl('strong', animateNumber(r.puzzles.votes.themes)),
                   ' of them.',
                 ])
               : null,
           ]),
         ]
       : [
-          h('div.recap--massive', 'You did not solve any puzzles this year.'),
-          h('div', h('p', h('a', { attrs: { href: '/training', target: '_blank' } }, 'Wanna try some now?'))),
+          hl('div.recap--massive', 'You did not solve any puzzles this year.'),
+          hl(
+            'div',
+            hl('p', hl('a', { attrs: { href: '/training', target: '_blank' } }, 'Wanna try some now?')),
+          ),
         ],
   );
 };
@@ -203,13 +206,14 @@ export const sources = (r: Recap): VNode => {
   return (
     best[0] &&
     slideTag('sources')([
-      h('div.recap--massive', 'Where did you find games?'),
-      h(
+      hl('div.recap--massive', 'Where did you find games?'),
+      hl(
         'table.recap__data',
-        h(
+        hl(
           'tbody',
           best.map(
-            ([n, c]) => c > 0 && h('tr', [h('td', n), h('td', [h('strong', animateNumber(c)), ' games'])]),
+            ([n, c]) =>
+              c > 0 && hl('tr', [hl('td', n), hl('td', [hl('strong', animateNumber(c)), ' games'])]),
           ),
         ),
       ),
@@ -219,13 +223,13 @@ export const sources = (r: Recap): VNode => {
 
 export const perfs = (r: Recap): VNode => {
   return slideTag('perfs')([
-    h('div.recap--massive', 'What time controls and variants did you play?'),
-    h(
+    hl('div.recap--massive', 'What time controls and variants did you play?'),
+    hl(
       'table.recap__data',
-      h(
+      hl(
         'tbody',
         r.games.perfs.map(p =>
-          h('tr', [h('td', renderPerf(p)), h('td', [h('strong', animateNumber(p.games)), ' games'])]),
+          hl('tr', [hl('td', renderPerf(p)), hl('td', [hl('strong', animateNumber(p.games)), ' games'])]),
         ),
       ),
     ),
@@ -234,13 +238,16 @@ export const perfs = (r: Recap): VNode => {
 
 export const malware = (): VNode =>
   slideTag('malware')([
-    h('div.recap--massive', [h('strong.animated-pulse', '0'), 'ads and trackers loaded']),
-    h('ul', [h('li', "We didn't sell your personal data"), h('li', "We didn't use your device against you")]),
-    h(
+    hl('div.recap--massive', [hl('strong.animated-pulse', '0'), 'ads and trackers loaded']),
+    hl('ul', [
+      hl('li', "We didn't sell your personal data"),
+      hl('li', "We didn't use your device against you"),
+    ]),
+    hl(
       'p',
-      h('small', [
+      hl('small', [
         'But other websites do, so please ',
-        h('a', { attrs: { href: '/ads', target: '_blank' } }, 'be careful.'),
+        hl('a', { attrs: { href: '/ads', target: '_blank' } }, 'be careful.'),
       ]),
     ),
   ]);
@@ -249,31 +256,38 @@ export const lichessGames = (r: Recap): VNode => {
   const gamesPercentOfTotal = (r.games.nbs.total * 100) / totalGames;
   const showGamesPercentOfTotal = gamesPercentOfTotal.toFixed(6) + '%';
   return slideTag('lichess-games')([
-    h('div.recap--massive', [h('strong', animateNumber(totalGames)), 'games played on Lichess in ', r.year]),
-    h('div', [h('p', [h('strong', showGamesPercentOfTotal), ' of them are yours.'])]),
+    hl('div.recap--massive', [
+      hl('strong', animateNumber(totalGames)),
+      'games played on Lichess in ',
+      r.year,
+    ]),
+    hl('div', [hl('p', [hl('strong', showGamesPercentOfTotal), ' of them are yours.'])]),
   ]);
 };
 
 export const thanks = (): VNode =>
   slideTag('thanks')([
-    h('div.recap--massive', 'Thank you for playing on Lichess!'),
-    h('img.recap__logo', { attrs: { src: site.asset.url('logo/lichess-white.svg') } }),
-    h('div', "We're glad you're here. Have a great 2025!"),
+    hl('div.recap--massive', 'Thank you for playing on Lichess!'),
+    hl('img.recap__logo', { attrs: { src: site.asset.url('logo/lichess-white.svg') } }),
+    hl('div', "We're glad you're here. Have a great 2025!"),
   ]);
 
 const renderPerf = (perf: RecapPerf): VNode => {
-  return h('span', [h('i.text', { attrs: dataIcon(perfIcons[perf.key]) }), perfNames[perf.key] || perf.key]);
+  return hl('span', [
+    hl('i.text', { attrs: dataIcon(perfIcons[perf.key]) }),
+    perfNames[perf.key] || perf.key,
+  ]);
 };
 
 const stat = (value: string | VNode, label: string): VNode =>
-  h('div.stat', [h('div', h('strong', value)), h('div', h('small', label))]);
+  hl('div.stat', [hl('div', hl('strong', value)), hl('div', hl('small', label))]);
 
 export const shareable = (r: Recap): VNode =>
   slideTag('shareable')([
-    h('div.recap__shareable', [
-      h('img.logo', { attrs: { src: site.asset.url('logo/logo-with-name-dark.png') } }),
-      h('h2', 'My 2024 Recap'),
-      h('div.grid', [
+    hl('div.recap__shareable', [
+      hl('img.logo', { attrs: { src: site.asset.url('logo/logo-with-name-dark.png') } }),
+      hl('h2', 'My 2024 Recap'),
+      hl('div.grid', [
         stat(formatNumber(r.games.nbs.total), 'games played'),
         stat(formatNumber(r.games.moves), 'moves played'),
         stat(formatDuration(r.games.timePlaying, ' and '), 'spent playing'),
@@ -281,7 +295,7 @@ export const shareable = (r: Recap): VNode =>
         r.games.opponents.length && stat(opponentLink(r.games.opponents[0].value), 'most played opponent'),
         stat(formatNumber(r.puzzles.nbs.total), 'puzzles solved'),
       ]),
-      h('div.openings', [
+      hl('div.openings', [
         r.games.openings.white.count && stat(r.games.openings.white.value.name, 'as white'),
         r.games.openings.black.count && stat(r.games.openings.black.value.name, 'as black'),
       ]),
@@ -290,8 +304,8 @@ export const shareable = (r: Recap): VNode =>
 
 const slideTag =
   (key: string, millis: number = 5000) =>
-  (content: VNodeKids) =>
-    h(
+  (content: LooseVNodes) =>
+    hl(
       `div.swiper-slide.recap__slide--${key}`,
       {
         attrs: {
@@ -301,8 +315,8 @@ const slideTag =
       content,
     );
 
-const animateNumber = (n: number) => h('span.animated-number', { attrs: { 'data-value': n } }, '0');
-const animateTime = (n: number) => h('span.animated-time', { attrs: { 'data-value': n } }, '');
+const animateNumber = (n: number) => hl('span.animated-number', { attrs: { 'data-value': n } }, '0');
+const animateTime = (n: number) => hl('span.animated-time', { attrs: { 'data-value': n } }, '');
 
 const showGrams = (g: number) =>
-  g > 20_000 ? h('span', [animateNumber(g / 1000), ' Kilograms']) : h('span', [animateNumber(g), ' grams']);
+  g > 20_000 ? hl('span', [animateNumber(g / 1000), ' Kilograms']) : hl('span', [animateNumber(g), ' grams']);

--- a/ui/recap/src/view.ts
+++ b/ui/recap/src/view.ts
@@ -1,17 +1,17 @@
 import type { Opts, Recap } from './interfaces';
 import { type VNode } from 'snabbdom';
-import { looseH as h } from 'lib/snabbdom';
+import { hl } from 'lib/snabbdom';
 import * as slides from './slides';
 
 export function awaiter(user: LightUser): VNode {
-  return h('div#recap-swiper.swiper.swiper-initialized', [h('div.swiper-wrapper', [slides.loading(user)])]);
+  return hl('div#recap-swiper.swiper.swiper-initialized', [hl('div.swiper-wrapper', [slides.loading(user)])]);
 }
 
 export function view(r: Recap, opts: Opts): VNode {
-  return h('div#recap-swiper.swiper', [
-    h('div.swiper-wrapper', [
+  return hl('div#recap-swiper.swiper', [
+    hl('div.swiper-wrapper', [
       slides.init(opts.user),
-      ...(r.games.nbs.total
+      r.games.nbs.total
         ? [
             slides.nbGames(r),
             slides.timeSpentPlaying(r),
@@ -23,18 +23,18 @@ export function view(r: Recap, opts: Opts): VNode {
             slides.openingColor(r.games.openings, 'white'),
             slides.openingColor(r.games.openings, 'black'),
           ]
-        : [slides.noGames()]),
+        : [slides.noGames()],
       slides.puzzles(r),
       slides.malware(),
       slides.lichessGames(r),
       slides.thanks(),
       slides.shareable(r),
     ]),
-    ...(opts.navigation ? [h('div.swiper-button-next'), h('div.swiper-button-prev')] : []),
-    h('div.swiper-pagination'),
-    h('div.autoplay-progress', [
-      h('svg', { attrs: { viewBox: '0 0 48 48' } }, [h('circle', { attrs: { cx: 24, cy: 24, r: 20 } })]),
-      h('span'),
+    opts.navigation && [hl('div.swiper-button-next'), hl('div.swiper-button-prev')],
+    hl('div.swiper-pagination'),
+    hl('div.autoplay-progress', [
+      hl('svg', { attrs: { viewBox: '0 0 48 48' } }, [hl('circle', { attrs: { cx: 24, cy: 24, r: 20 } })]),
+      hl('span'),
     ]),
   ]);
 }

--- a/ui/round/src/corresClock/corresClockView.ts
+++ b/ui/round/src/corresClock/corresClockView.ts
@@ -1,4 +1,4 @@
-import { looseH as h, type VNode } from 'lib/snabbdom';
+import { hl, type VNode } from 'lib/snabbdom';
 import type { TopOrBottom } from 'lib/game/game';
 import type { CorresClockController } from './corresClockCtrl';
 import { moretime } from '../view/button';
@@ -44,13 +44,13 @@ export default function (
     },
     isPlayer = ctrl.root.data.player.color === color,
     direction = document.dir === 'rtl' && millis < 86400 * 1000 ? 'ltr' : undefined;
-  return h(
+  return hl(
     'div.rclock.rclock-correspondence.rclock-' + position,
     { class: { outoftime: millis <= 0, running: runningColor === color } },
     [
       ctrl.data.showBar &&
-        h('div.bar', [h('span', { attrs: { style: `width: ${ctrl.timePercent(color)}%` } })]),
-      h('div.time', {
+        hl('div.bar', [hl('span', { attrs: { style: `width: ${ctrl.timePercent(color)}%` } })]),
+      hl('div.time', {
         attrs: direction && { style: `direction: ${direction}` },
         hook: {
           insert: vnode => update(vnode.elm as HTMLElement),

--- a/ui/round/src/plugins/round.nvui.ts
+++ b/ui/round/src/plugins/round.nvui.ts
@@ -1,4 +1,4 @@
-import { LooseVNode, type VNode, looseH as h, noTrans, onInsert } from 'lib/snabbdom';
+import { type LooseVNodes, type VNode, hl, noTrans, onInsert } from 'lib/snabbdom';
 import type RoundController from '../ctrl';
 import { renderClock } from 'lib/game/clock/clockView';
 import { renderTableWatch, renderTablePlay, renderTableEnd } from '../view/table';
@@ -85,42 +85,42 @@ export function initModule(): NvuiPlugin {
           }),
         );
       }
-      return h('div.nvui', { hook: onInsert(_ => setTimeout(() => notify.set(gameText(ctrl)), 2000)) }, [
-        h('h1', gameText(ctrl)),
-        h('h2', i18n.nvui.gameInfo),
-        ...['white', 'black'].map((color: Color) =>
-          h('p', [i18n.site[color], ':', playerHtml(ctrl, ctrl.playerByColor(color))]),
+      return hl('div.nvui', { hook: onInsert(_ => setTimeout(() => notify.set(gameText(ctrl)), 2000)) }, [
+        hl('h1', gameText(ctrl)),
+        hl('h2', i18n.nvui.gameInfo),
+        ['white', 'black'].map((color: Color) =>
+          hl('p', [i18n.site[color], ':', playerHtml(ctrl, ctrl.playerByColor(color))]),
         ),
-        h('p', [i18n.site[d.game.rated ? 'rated' : 'casual'] + ' ' + transGamePerf(d.game.perf)]),
-        d.clock ? h('p', [i18n.site.clock, `${d.clock.initial / 60} + ${d.clock.increment}`]) : null,
-        h('h2', i18n.nvui.moveList),
-        h('p.moves', { attrs: { role: 'log', 'aria-live': 'off' } }, renderMoves(d.steps.slice(1), style)),
-        h('h2', i18n.nvui.pieces),
-        h('div.pieces', renderPieces(ctrl.chessground.state.pieces, style)),
-        pockets && h('div.pockets', renderPockets(pockets)),
-        h('h2', i18n.nvui.gameStatus),
-        h('div.status', { attrs: { role: 'status', 'aria-live': 'assertive', 'aria-atomic': 'true' } }, [
+        hl('p', [i18n.site[d.game.rated ? 'rated' : 'casual'] + ' ' + transGamePerf(d.game.perf)]),
+        d.clock ? hl('p', [i18n.site.clock, `${d.clock.initial / 60} + ${d.clock.increment}`]) : null,
+        hl('h2', i18n.nvui.moveList),
+        hl('p.moves', { attrs: { role: 'log', 'aria-live': 'off' } }, renderMoves(d.steps.slice(1), style)),
+        hl('h2', i18n.nvui.pieces),
+        hl('div.pieces', renderPieces(ctrl.chessground.state.pieces, style)),
+        pockets && hl('div.pockets', renderPockets(pockets)),
+        hl('h2', i18n.nvui.gameStatus),
+        hl('div.status', { attrs: { role: 'status', 'aria-live': 'assertive', 'aria-atomic': 'true' } }, [
           ctrl.data.game.status.name === 'started' ? i18n.site.playingRightNow : renderResult(ctrl),
         ]),
-        h('h2', i18n.nvui.lastMove),
-        h(
+        hl('h2', i18n.nvui.lastMove),
+        hl(
           'p.lastMove',
           { attrs: { 'aria-live': 'assertive', 'aria-atomic': 'true' } },
           // make sure consecutive moves are different so that they get re-read
           renderSan(step.san, step.uci, style) + (ctrl.ply % 2 === 0 ? '' : ' '),
         ),
         clocks.some(c => !!c) &&
-          h('div.clocks', [
-            h('h2', i18n.nvui.yourClock),
-            h('div.botc', clocks[0]),
-            h('h2', i18n.nvui.opponentClock),
-            h('div.topc', clocks[1]),
+          hl('div.clocks', [
+            hl('h2', i18n.nvui.yourClock),
+            hl('div.botc', clocks[0]),
+            hl('h2', i18n.nvui.opponentClock),
+            hl('div.topc', clocks[1]),
           ]),
         notify.render(),
         ctrl.isPlaying() &&
-          h('div.move-input', [
-            h('h2', i18n.nvui.inputForm),
-            h(
+          hl('div.move-input', [
+            hl('h2', i18n.nvui.inputForm),
+            hl(
               'form#move-form',
               {
                 hook: onInsert(el => {
@@ -134,9 +134,9 @@ export function initModule(): NvuiPlugin {
                 }),
               },
               [
-                h('label', [
+                hl('label', [
                   d.player.color === d.game.player ? i18n.site.yourTurn : i18n.site.waiting,
-                  h('input.move.mousetrap', {
+                  hl('input.move.mousetrap', {
                     attrs: {
                       name: 'move',
                       type: 'text',
@@ -148,44 +148,44 @@ export function initModule(): NvuiPlugin {
               ],
             ),
           ]),
-        ...(pageStyle.get() === 'actions-board'
-          ? [...renderActions(ctrl), ...renderBoard(ctrl)]
-          : [...renderBoard(ctrl), ...renderActions(ctrl)]),
-        h('h2', i18n.site.advancedSettings),
-        h('label', [noTrans('Move notation'), renderSetting(moveStyle, ctrl.redraw)]),
-        h('label', [noTrans('Page layout'), renderSetting(pageStyle, ctrl.redraw)]),
-        h('h3', noTrans('Board settings')),
-        h('label', [noTrans('Piece style'), renderSetting(pieceStyle, ctrl.redraw)]),
-        h('label', [noTrans('Piece prefix style'), renderSetting(prefixStyle, ctrl.redraw)]),
-        h('label', [noTrans('Show position'), renderSetting(positionStyle, ctrl.redraw)]),
-        h('label', [noTrans('Board layout'), renderSetting(boardStyle, ctrl.redraw)]),
-        h('h2', i18n.keyboardMove.keyboardInputCommands),
-        h('p', [
+        pageStyle.get() === 'actions-board'
+          ? [renderActions(ctrl), renderBoard(ctrl)]
+          : [renderBoard(ctrl), renderActions(ctrl)],
+        hl('h2', i18n.site.advancedSettings),
+        hl('label', [noTrans('Move notation'), renderSetting(moveStyle, ctrl.redraw)]),
+        hl('label', [noTrans('Page layout'), renderSetting(pageStyle, ctrl.redraw)]),
+        hl('h3', noTrans('Board settings')),
+        hl('label', [noTrans('Piece style'), renderSetting(pieceStyle, ctrl.redraw)]),
+        hl('label', [noTrans('Piece prefix style'), renderSetting(prefixStyle, ctrl.redraw)]),
+        hl('label', [noTrans('Show position'), renderSetting(positionStyle, ctrl.redraw)]),
+        hl('label', [noTrans('Board layout'), renderSetting(boardStyle, ctrl.redraw)]),
+        hl('h2', i18n.keyboardMove.keyboardInputCommands),
+        hl('p', [
           i18n.nvui.inputFormCommandList,
-          h('br'),
+          hl('br'),
           i18n.nvui.movePiece,
-          h('br'),
+          hl('br'),
           i18n.nvui.promotion,
-          h('br'),
-          ...inputCommands
+          hl('br'),
+          inputCommands
             .filter(c => !c.invalid?.(ctrl))
-            .flatMap(cmd => [`${cmd.cmd}${cmd.alt ? ` / ${cmd.alt}` : ''}: `, cmd.help, h('br')]),
+            .flatMap(cmd => [`${cmd.cmd}${cmd.alt ? ` / ${cmd.alt}` : ''}: `, cmd.help, hl('br')]),
         ]),
-        ...boardCommands(),
+        boardCommands(),
       ]);
     },
   };
 }
 
-function renderBoard(ctrl: RoundController): LooseVNode[] {
+function renderBoard(ctrl: RoundController): LooseVNodes {
   const prefixStyle = prefixSetting(),
     pieceStyle = pieceSetting(),
     positionStyle = positionSetting(),
     boardStyle = boardSetting();
 
   return [
-    h('h2', i18n.site.board),
-    h(
+    hl('h2', i18n.site.board),
+    hl(
       'div.board',
       {
         hook: onInsert(el => {
@@ -230,18 +230,18 @@ function renderBoard(ctrl: RoundController): LooseVNode[] {
         boardStyle.get(),
       ),
     ),
-    h('div.boardstatus', { attrs: { 'aria-live': 'polite', 'aria-atomic': 'true' } }, ''),
+    hl('div.boardstatus', { attrs: { 'aria-live': 'polite', 'aria-atomic': 'true' } }, ''),
   ];
 }
 
-function renderActions(ctrl: RoundController): LooseVNode[] {
+function renderActions(ctrl: RoundController): LooseVNodes {
   return [
-    h('h2', i18n.nvui.actions),
-    ...(ctrl.data.player.spectator
+    hl('h2', i18n.nvui.actions),
+    ctrl.data.player.spectator
       ? renderTableWatch(ctrl)
       : playable(ctrl.data)
         ? renderTablePlay(ctrl)
-        : renderTableEnd(ctrl)),
+        : renderTableEnd(ctrl),
   ];
 }
 
@@ -411,7 +411,7 @@ const renderMoves = (steps: Step[], style: MoveStyle) =>
   steps.reduce<(string | VNode)[]>((res, s) => {
     const turn = s.ply & 1 ? `${plyToTurn(s.ply)}.` : '';
     const san = `${renderSan(s.san, s.uci, style)}, `;
-    return res.concat(`${turn} ${san}`).concat(s.ply % 2 === 0 ? h('br') : []);
+    return res.concat(`${turn} ${san}`).concat(s.ply % 2 === 0 ? hl('br') : []);
   }, []);
 
 function playerHtml(ctrl: RoundController, player: Player) {
@@ -422,8 +422,8 @@ function playerHtml(ctrl: RoundController, player: Player) {
     rd = player.ratingDiff,
     ratingDiff = rd ? (rd > 0 ? '+' + rd : rd < 0 ? '−' + -rd : '') : '';
   return user
-    ? h('span', [
-        h(
+    ? hl('span', [
+        hl(
           'a',
           { attrs: { href: '/@/' + user.username } },
           user.title ? `${user.title} ${user.username}` : user.username,

--- a/ui/round/src/view/button.ts
+++ b/ui/round/src/view/button.ts
@@ -7,7 +7,7 @@ import { game as gameRoute } from 'lib/game/router';
 import type { RoundData } from '../interfaces';
 import type { ClockData } from 'lib/game/clock/clockCtrl';
 import type RoundController from '../ctrl';
-import { type LooseVNodes, type LooseVNode, looseH as h, bind, onInsert } from 'lib/snabbdom';
+import { type LooseVNodes, type LooseVNode, hl, bind, onInsert } from 'lib/snabbdom';
 import { pubsub } from 'lib/pubsub';
 
 export interface ButtonState {
@@ -28,7 +28,7 @@ function analysisButton(ctrl: RoundController): VNode | false {
     url = gameRoute(d, analysisBoardOrientation(d)) + '#' + ctrl.ply;
   return (
     replayable(d) &&
-    h(
+    hl(
       'a.fbt',
       {
         attrs: { href: url },
@@ -59,7 +59,7 @@ function rematchButtons(ctrl: RoundController): LooseVNodes {
   if (!rematchable(d)) return [];
   return [
     them &&
-      h(
+      hl(
         'button.rematch-decline',
         {
           attrs: { 'data-icon': licon.X, title: i18n.site.decline },
@@ -67,7 +67,7 @@ function rematchButtons(ctrl: RoundController): LooseVNodes {
         },
         ctrl.nvui ? i18n.site.decline : '',
       ),
-    h(
+    hl(
       'button.fbt.rematch.white',
       {
         class: { me, glowing: them, disabled },
@@ -95,7 +95,7 @@ function rematchButtons(ctrl: RoundController): LooseVNodes {
           ctrl.redraw,
         ),
       },
-      [me ? spinner() : h('span', i18n.site.rematch)],
+      [me ? spinner() : hl('span', i18n.site.rematch)],
     ),
   ];
 }
@@ -111,7 +111,7 @@ export function standard(
   // disabled if condition callback is provided and is falsy
   const enabled = () => !condition || condition(ctrl.data).enabled;
   const hintFn = () => condition?.(ctrl.data)?.overrideHint || hint;
-  return h(
+  return hl(
     'button.fbt.' + socketMsg,
     {
       attrs: ctrl.nvui ? { disabled: !enabled() } : { disabled: !enabled(), title: hintFn() },
@@ -119,7 +119,7 @@ export function standard(
         if (enabled()) onclick ? onclick() : ctrl.socket.sendLoading(socketMsg);
       }),
     },
-    ctrl.nvui ? [hintFn()] : [h('span', justIcon(icon))],
+    ctrl.nvui ? [hintFn()] : [hl('span', justIcon(icon))],
   );
 }
 
@@ -127,32 +127,32 @@ export function opponentGone(ctrl: RoundController): LooseVNode {
   const gone = ctrl.opponentGone();
   if (ctrl.data.game.rules?.includes('noClaimWin')) return null;
   return gone === true
-    ? h('div.suggestion', [
-        h('p', { hook: onSuggestionHook }, i18n.site.opponentLeftChoices),
-        h(
+    ? hl('div.suggestion', [
+        hl('p', { hook: onSuggestionHook }, i18n.site.opponentLeftChoices),
+        hl(
           'button.button',
           { hook: bind('click', () => ctrl.socket.sendLoading('resign-force')) },
           i18n.site.forceResignation,
         ),
-        h(
+        hl(
           'button.button',
           { hook: bind('click', () => ctrl.socket.sendLoading('draw-force')) },
           i18n.site.forceDraw,
         ),
       ])
     : gone !== false &&
-        h('div.suggestion', h('p', i18n.site.opponentLeftCounter.asArray(gone, h('strong', '' + gone))));
+        hl('div.suggestion', hl('p', i18n.site.opponentLeftCounter.asArray(gone, hl('strong', '' + gone))));
 }
 
 const fbtCancel = (f: (v: boolean) => void) =>
-  h('button.fbt.no', {
+  hl('button.fbt.no', {
     attrs: { title: i18n.site.cancel, 'data-icon': licon.X },
     hook: bind('click', () => f(false)),
   });
 
 export const resignConfirm = (ctrl: RoundController): VNode =>
-  h('div.act-confirm', [
-    h('button.fbt.yes', {
+  hl('div.act-confirm', [
+    hl('button.fbt.yes', {
       attrs: { title: i18n.site.resign, 'data-icon': licon.FlagOutline },
       hook: bind('click', () => ctrl.resign(true)),
     }),
@@ -160,8 +160,8 @@ export const resignConfirm = (ctrl: RoundController): VNode =>
   ]);
 
 export const drawConfirm = (ctrl: RoundController): VNode =>
-  h('div.act-confirm', [
-    h('button.fbt.yes.draw-yes', {
+  hl('div.act-confirm', [
+    hl('button.fbt.yes.draw-yes', {
       attrs: { title: i18n.site.offerDraw, 'data-icon': licon.OneHalf },
       hook: bind('click', () => ctrl.offerDraw(true)),
     }),
@@ -169,7 +169,7 @@ export const drawConfirm = (ctrl: RoundController): VNode =>
   ]);
 
 export const claimThreefold = (ctrl: RoundController, condition: (d: RoundData) => ButtonState): VNode =>
-  h(
+  hl(
     'button.button.draw-yes',
     {
       hook: bind('click', () =>
@@ -181,13 +181,13 @@ export const claimThreefold = (ctrl: RoundController, condition: (d: RoundData) 
       },
       class: { disabled: !condition(ctrl.data).enabled },
     },
-    h('span', '½'),
+    hl('span', '½'),
   );
 
 export function threefoldSuggestion(ctrl: RoundController): LooseVNode {
   return (
     ctrl.data.game.threefold &&
-    h('div.suggestion', [h('p', { hook: onSuggestionHook }, i18n.site.threefoldRepetition)])
+    hl('div.suggestion', [hl('p', { hook: onSuggestionHook }, i18n.site.threefoldRepetition)])
   );
 }
 
@@ -195,8 +195,8 @@ export function backToTournament(ctrl: RoundController): LooseVNode {
   const d = ctrl.data;
   return (
     d.tournament?.running &&
-    h('div.follow-up', [
-      h(
+    hl('div.follow-up', [
+      hl(
         'a.text.fbt.strong.glowing',
         {
           attrs: { 'data-icon': licon.PlayTriangle, href: '/tournament/' + d.tournament.id },
@@ -204,8 +204,8 @@ export function backToTournament(ctrl: RoundController): LooseVNode {
         },
         i18n.site.backToTournament,
       ),
-      h('form', { attrs: { method: 'post', action: '/tournament/' + d.tournament.id + '/withdraw' } }, [
-        h('button.text.fbt.weak', justIcon(licon.Pause), i18n.site.pause),
+      hl('form', { attrs: { method: 'post', action: '/tournament/' + d.tournament.id + '/withdraw' } }, [
+        hl('button.text.fbt.weak', justIcon(licon.Pause), i18n.site.pause),
       ]),
       analysisButton(ctrl),
     ])
@@ -216,8 +216,8 @@ export function backToSwiss(ctrl: RoundController): LooseVNode {
   const d = ctrl.data;
   return (
     d.swiss?.running &&
-    h('div.follow-up', [
-      h(
+    hl('div.follow-up', [
+      hl(
         'a.text.fbt.strong.glowing',
         {
           attrs: { 'data-icon': licon.PlayTriangle, href: '/swiss/' + d.swiss.id },
@@ -233,7 +233,7 @@ export function backToSwiss(ctrl: RoundController): LooseVNode {
 export function moretime(ctrl: RoundController): LooseVNode {
   return (
     moretimeable(ctrl.data) &&
-    h('a.moretime', {
+    hl('a.moretime', {
       attrs: {
         title: ctrl.data.clock
           ? i18n.site.giveNbSeconds(ctrl.data.clock.moretime)
@@ -256,13 +256,13 @@ export function followUp(ctrl: RoundController): VNode {
       !d.game.boosted,
     newable = (finished(d) || aborted(d)) && ['lobby', 'pool', 'local'].includes(d.game.source),
     rematchZone = rematchable || d.game.rematch ? rematchButtons(ctrl) : [];
-  return h('div.follow-up', [
-    ...rematchZone,
+  return hl('div.follow-up', [
+    rematchZone,
     d.tournament &&
-      h('a.fbt', { attrs: { href: '/tournament/' + d.tournament.id } }, i18n.site.viewTournament),
-    d.swiss && h('a.fbt', { attrs: { href: '/swiss/' + d.swiss.id } }, i18n.site.viewTournament),
+      hl('a.fbt', { attrs: { href: '/tournament/' + d.tournament.id } }, i18n.site.viewTournament),
+    d.swiss && hl('a.fbt', { attrs: { href: '/swiss/' + d.swiss.id } }, i18n.site.viewTournament),
     newable &&
-      h(
+      hl(
         'button.fbt.new-opponent',
         {
           hook: bind('click', () => {
@@ -281,14 +281,18 @@ export function watcherFollowUp(ctrl: RoundController): LooseVNode {
   const d = ctrl.data,
     content = [
       d.game.rematch &&
-        h('a.fbt.text', { attrs: { href: `/${d.game.rematch}/${d.opponent.color}` } }, i18n.site.viewRematch),
+        hl(
+          'a.fbt.text',
+          { attrs: { href: `/${d.game.rematch}/${d.opponent.color}` } },
+          i18n.site.viewRematch,
+        ),
       d.tournament &&
-        h('a.fbt', { attrs: { href: '/tournament/' + d.tournament.id } }, i18n.site.viewTournament),
+        hl('a.fbt', { attrs: { href: '/tournament/' + d.tournament.id } }, i18n.site.viewTournament),
 
-      d.swiss && h('a.fbt', { attrs: { href: '/swiss/' + d.swiss.id } }, i18n.site.viewTournament),
+      d.swiss && hl('a.fbt', { attrs: { href: '/swiss/' + d.swiss.id } }, i18n.site.viewTournament),
       analysisButton(ctrl),
     ];
-  return content.find(x => !!x) && h('div.follow-up', content);
+  return content.find(x => !!x) && hl('div.follow-up', content);
 }
 
 const onSuggestionHook: Hooks = onInsert(el => pubsub.emit('round.suggestion', el.textContent));

--- a/ui/round/src/view/clock.ts
+++ b/ui/round/src/view/clock.ts
@@ -1,4 +1,4 @@
-import { type LooseVNode, looseH as h, bind } from 'lib/snabbdom';
+import { type LooseVNode, hl, bind } from 'lib/snabbdom';
 import * as licon from 'lib/licon';
 import { renderClock } from 'lib/game/clock/clockView';
 import RoundController from '../ctrl';
@@ -35,10 +35,10 @@ const onTheSide = (round: RoundController) => (color: Color, position: TopOrBott
 function whosTurn(ctrl: RoundController, color: Color, position: TopOrBottom) {
   const d = ctrl.data;
   if (finished(d) || aborted(d)) return;
-  return h(
+  return hl(
     'div.rclock.rclock-turn.rclock-' + position,
     d.game.player === color &&
-      h(
+      hl(
         'div.rclock-turn__text',
         d.player.spectator
           ? i18n.site[d.game.player === 'white' ? 'whitePlays' : 'blackPlays']
@@ -51,12 +51,12 @@ const showBerserk = (ctrl: RoundController, color: Color): boolean =>
   ctrl.hasGoneBerserk(color) && !bothPlayersHavePlayed(ctrl.data) && playable(ctrl.data);
 
 const renderBerserk = (ctrl: RoundController, color: Color, position: TopOrBottom) =>
-  showBerserk(ctrl, color) ? h('div.berserked.' + position, justIcon(licon.Berserk)) : null;
+  showBerserk(ctrl, color) ? hl('div.berserked.' + position, justIcon(licon.Berserk)) : null;
 
 const goBerserk = (ctrl: RoundController, color: Color) =>
   berserkableBy(ctrl.data) &&
   !ctrl.hasGoneBerserk(color) &&
-  h('button.fbt.go-berserk', {
+  hl('button.fbt.go-berserk', {
     attrs: { title: 'GO BERSERK! Half the time, no increment, bonus point', 'data-icon': licon.Berserk },
     hook: bind('click', ctrl.goBerserk),
   });
@@ -69,4 +69,4 @@ const clockSide = (
 ) =>
   ranks &&
   !showBerserk(ctrl, color) &&
-  h('div.tour-rank.' + position, { attrs: { title: 'Current tournament rank' } }, '#' + ranks[color]);
+  hl('div.tour-rank.' + position, { attrs: { title: 'Current tournament rank' } }, '#' + ranks[color]);

--- a/ui/round/src/view/main.ts
+++ b/ui/round/src/view/main.ts
@@ -2,7 +2,7 @@ import { next, prev, view } from '../keyboard';
 import crazyView from '../crazy/crazyView';
 import type RoundController from '../ctrl';
 import { stepwiseScroll } from 'lib/view/controls';
-import { type VNode, looseH as h, bind } from 'lib/snabbdom';
+import { type VNode, hl, bind } from 'lib/snabbdom';
 import { render as renderKeyboardMove } from 'keyboardMove';
 import { render as renderGround } from '../ground';
 import { renderTable } from './table';
@@ -26,8 +26,8 @@ export function main(ctrl: RoundController): VNode {
   const hideBoard = ctrl.data.player.blindfold && playable(ctrl.data);
   return ctrl.nvui
     ? ctrl.nvui.render(ctrl)
-    : h('div.round__app.variant-' + d.game.variant.key, [
-        h(
+    : hl('div.round__app.variant-' + d.game.variant.key, [
+        hl(
           'div.round__app__board.main-board' + (hideBoard ? '.blindfold' : ''),
           {
             hook:
@@ -52,7 +52,7 @@ export function main(ctrl: RoundController): VNode {
         ctrl.voiceMove && renderVoiceBar(ctrl.voiceMove.ctrl, ctrl.redraw),
         ctrl.keyboardHelp && view(ctrl),
         crazyView(ctrl, topColor, 'top') || materialDiffs[0],
-        ...renderTable(ctrl),
+        renderTable(ctrl),
         crazyView(ctrl, bottomColor, 'bottom') || materialDiffs[1],
         ctrl.keyboardMove && renderKeyboardMove(ctrl.keyboardMove),
       ]);

--- a/ui/round/src/view/replay.ts
+++ b/ui/round/src/view/replay.ts
@@ -8,7 +8,7 @@ import viewStatus from 'lib/game/view/status';
 import { game as gameRoute } from 'lib/game/router';
 import type { Step } from '../interfaces';
 import { toggleButton as boardMenuToggleButton } from 'lib/view/boardMenu';
-import { type VNode, type LooseVNodes, type LooseVNode, looseH as h, onInsert } from 'lib/snabbdom';
+import { type VNode, type LooseVNodes, type LooseVNode, hl, onInsert } from 'lib/snabbdom';
 import boardMenu from './boardMenu';
 import { repeater } from 'lib';
 
@@ -42,15 +42,15 @@ const autoScroll = throttle(100, (movesEl: HTMLElement, ctrl: RoundController) =
   }),
 );
 
-const renderDrawOffer = () => h('draw', { attrs: { title: 'Draw offer' } }, '½?');
+const renderDrawOffer = () => hl('draw', { attrs: { title: 'Draw offer' } }, '½?');
 
 const renderMove = (step: Step, curPly: number, orEmpty: boolean, drawOffers: Set<number>) =>
   step
-    ? h(moveTag, { class: { a1t: step.ply === curPly } }, [
+    ? hl(moveTag, { class: { a1t: step.ply === curPly } }, [
         step.san[0] === 'P' ? step.san.slice(1) : step.san,
         drawOffers.has(step.ply) ? renderDrawOffer() : undefined,
       ])
-    : orEmpty && h(moveTag, '…');
+    : orEmpty && hl(moveTag, '…');
 
 export function renderResult(ctrl: RoundController): VNode | undefined {
   let result: string | undefined;
@@ -66,9 +66,9 @@ export function renderResult(ctrl: RoundController): VNode | undefined {
         result = '½-½';
     }
   if (result || aborted(ctrl.data)) {
-    return h('div.result-wrap', [
-      h('p.result', result || ''),
-      h(
+    return hl('div.result-wrap', [
+      hl('p.result', result || ''),
+      hl(
         'p.status',
         {
           hook: onInsert(() => {
@@ -103,7 +103,7 @@ function renderMoves(ctrl: RoundController): LooseVNodes {
   const els: LooseVNodes = [],
     curPly = ctrl.ply;
   for (let i = 0; i < pairs.length; i++) {
-    els.push(h(indexTag, i + indexOffset + ''));
+    els.push(hl(indexTag, i + indexOffset + ''));
     els.push(renderMove(pairs[i][0], curPly, true, drawPlies));
     els.push(renderMove(pairs[i][1], curPly, false, drawPlies));
   }
@@ -117,7 +117,7 @@ export function analysisButton(ctrl: RoundController): LooseVNode {
   return (
     userAnalysable(ctrl.data) &&
     !ctrl.data.local &&
-    h(
+    hl(
       'a.fbt.analysis',
       {
         class: { text: !!forecastCount },
@@ -127,7 +127,7 @@ export function analysisButton(ctrl: RoundController): LooseVNode {
           'data-icon': licon.Microscope,
         },
       },
-      forecastCount ? ['' + forecastCount] : [],
+      !!forecastCount && String(forecastCount),
     )
   );
 }
@@ -148,16 +148,16 @@ const goThroughMoves = (ctrl: RoundController, e: Event) => {
 function renderButtons(ctrl: RoundController) {
   const firstPly = util.firstPly(ctrl.data),
     lastPly = util.lastPly(ctrl.data);
-  return h(rbuttonsTag, [
-    analysisButton(ctrl) || h('div.noop'),
-    ...[
+  return hl(rbuttonsTag, [
+    analysisButton(ctrl) || hl('div.noop'),
+    [
       [licon.JumpFirst, firstPly],
       [licon.JumpPrev, ctrl.ply - 1],
       [licon.JumpNext, ctrl.ply + 1],
       [licon.JumpLast, lastPly],
     ].map((b: [string, number], i) => {
       const enabled = ctrl.ply !== b[1] && b[1] >= firstPly && b[1] <= lastPly;
-      return h('button.fbt.repeatable', {
+      return hl('button.fbt.repeatable', {
         class: { glowing: i === 3 && ctrl.isLate() },
         attrs: { disabled: !enabled, 'data-icon': b[0], 'data-ply': enabled ? b[1] : '-' },
         hook: onInsert(bindMobileMousedown(e => goThroughMoves(ctrl, e))),
@@ -174,17 +174,17 @@ function initMessage(ctrl: RoundController) {
     playable(d) &&
     d.game.turns === 0 &&
     !d.player.spectator &&
-    h('div.message', util.justIcon(licon.InfoCircle), [
-      h('div', [
+    hl('div.message', util.justIcon(licon.InfoCircle), [
+      hl('div', [
         i18n.site[d.player.color === 'white' ? 'youPlayTheWhitePieces' : 'youPlayTheBlackPieces'],
-        ...(d.player.color === 'white' ? [h('br'), h('strong', i18n.site.itsYourTurn)] : []),
+        d.player.color === 'white' && [hl('br'), hl('strong', i18n.site.itsYourTurn)],
       ]),
     ])
   );
 }
 
 const col1Button = (ctrl: RoundController, dir: number, icon: string, disabled: boolean) =>
-  h('button.fbt', {
+  hl('button.fbt', {
     attrs: { disabled: disabled, 'data-icon': icon, 'data-ply': ctrl.ply + dir },
     hook: onInsert(bindMobileMousedown(e => goThroughMoves(ctrl, e))),
   });
@@ -193,7 +193,7 @@ export function render(ctrl: RoundController): LooseVNode {
   const d = ctrl.data,
     moves =
       ctrl.replayEnabledByPref() &&
-      h(
+      hl(
         movesTag,
         {
           hook: onInsert(el => {
@@ -225,12 +225,12 @@ export function render(ctrl: RoundController): LooseVNode {
   const renderMovesOrResult = moves ? moves : renderResult(ctrl);
   return (
     !ctrl.nvui &&
-    h(rmovesTag, [
+    hl(rmovesTag, [
       renderButtons(ctrl),
       boardMenu(ctrl),
       initMessage(ctrl) ||
         (displayColumns() === 1
-          ? h('div.col1-moves', [
+          ? hl('div.col1-moves', [
               col1Button(ctrl, -1, licon.JumpPrev, ctrl.ply === util.firstPly(d)),
               renderMovesOrResult,
               col1Button(ctrl, 1, licon.JumpNext, ctrl.ply === util.lastPly(d)),

--- a/ui/round/src/view/table.ts
+++ b/ui/round/src/view/table.ts
@@ -5,7 +5,7 @@ import renderExpiration from './expiration';
 import { userHtml } from './user';
 import * as button from './button';
 import type RoundController from '../ctrl';
-import { type LooseVNodes, looseH as h, bind } from 'lib/snabbdom';
+import { type LooseVNodes, hl, bind } from 'lib/snabbdom';
 import { toggleButton as boardMenuToggleButton } from 'lib/view/boardMenu';
 import { anyClockView } from './clock';
 
@@ -14,20 +14,20 @@ function renderPlayer(ctrl: RoundController, position: TopOrBottom) {
   return ctrl.nvui
     ? undefined
     : player.ai
-      ? h('div.user-link.online.ruser.ruser-' + position, [
-          h('i.line'),
-          h('name', i18n.site.aiNameLevelAiLevel('Stockfish', player.ai)),
+      ? hl('div.user-link.online.ruser.ruser-' + position, [
+          hl('i.line'),
+          hl('name', i18n.site.aiNameLevelAiLevel('Stockfish', player.ai)),
         ])
       : userHtml(ctrl, player, position);
 }
 
 const isLoading = (ctrl: RoundController): boolean => ctrl.loading || ctrl.redirecting;
 
-const loader = () => h('i.ddloader');
+const loader = () => hl('i.ddloader');
 
-const renderTableWith = (ctrl: RoundController, buttons: LooseVNodes) => [
+const renderTableWith = (ctrl: RoundController, buttons: LooseVNodes[]) => [
   renderReplay(ctrl),
-  buttons.find(x => !!x) && h('div.rcontrols', buttons),
+  buttons.find(x => !!x) && hl('div.rcontrols', buttons),
 ];
 
 export const renderTableEnd = (ctrl: RoundController): LooseVNodes =>
@@ -48,15 +48,15 @@ const prompt = (ctrl: RoundController) => {
 
   const btn = (tpe: 'yes' | 'no', icon: string, text: string, action: () => void) =>
     ctrl.nvui
-      ? h('button', { hook: bind('click', action) }, text)
-      : h(`a.${tpe}`, { attrs: { 'data-icon': icon }, hook: bind('click', action) });
+      ? hl('button', { hook: bind('click', action) }, text)
+      : hl(`a.${tpe}`, { attrs: { 'data-icon': icon }, hook: bind('click', action) });
 
   const noBtn = o.no && btn('no', o.no.icon || licon.X, o.no.text || i18n.site.decline, o.no.action);
   const yesBtn =
     o.yes && btn('yes', o.yes.icon || licon.Checkmark, o.yes.text || i18n.site.accept, o.yes.action);
 
   return {
-    promptVNode: h('div.question', { key: o.prompt }, [noBtn, h('p', o.prompt), yesBtn]),
+    promptVNode: hl('div.question', { key: o.prompt }, [noBtn, hl('p', o.prompt), yesBtn]),
     isQuestion: o.no !== undefined || o.yes !== undefined,
   };
 };
@@ -79,7 +79,7 @@ export const renderTablePlay = (ctrl: RoundController): LooseVNodes => {
                   'takeback-yes',
                   ctrl.takebackYes,
                 ),
-            ctrl.drawConfirm
+            !!ctrl.drawConfirm
               ? button.drawConfirm(ctrl)
               : ctrl.data.game.threefold
                 ? button.claimThreefold(ctrl, d => {
@@ -100,7 +100,7 @@ export const renderTablePlay = (ctrl: RoundController): LooseVNodes => {
                     'draw-yes',
                     () => ctrl.offerDraw(true),
                   ),
-            ctrl.resignConfirm
+            !!ctrl.resignConfirm
               ? button.resignConfirm(ctrl)
               : button.standard(
                   ctrl,
@@ -118,26 +118,26 @@ export const renderTablePlay = (ctrl: RoundController): LooseVNodes => {
       : [promptVNode, button.opponentGone(ctrl), button.threefoldSuggestion(ctrl)];
   return [
     renderReplay(ctrl),
-    h('div.rcontrols', [
-      h(
+    hl('div.rcontrols', [
+      hl(
         'div.ricons',
         { class: { confirm: !!(ctrl.drawConfirm || ctrl.resignConfirm), empty: !icons.length } },
         icons,
       ),
-      ...buttons,
+      buttons,
     ]),
   ];
 };
 
 export const renderTable = (ctrl: RoundController): LooseVNodes => [
-  h('div.round__app__table'),
+  hl('div.round__app__table'),
   renderExpiration(ctrl),
   renderPlayer(ctrl, 'top'),
-  ...(ctrl.data.player.spectator
+  ctrl.data.player.spectator
     ? renderTableWatch(ctrl)
     : playable(ctrl.data)
       ? renderTablePlay(ctrl)
-      : renderTableEnd(ctrl)),
+      : renderTableEnd(ctrl),
   renderPlayer(ctrl, 'bottom'),
   /* render clocks after players so they display on top of them in col1,
    * since they occupy the same grid cell. This is required to avoid

--- a/ui/round/src/view/user.ts
+++ b/ui/round/src/view/user.ts
@@ -1,4 +1,4 @@
-import { looseH as h, type VNode } from 'lib/snabbdom';
+import { hl, type VNode } from 'lib/snabbdom';
 import * as licon from 'lib/licon';
 import type { Player, TopOrBottom } from 'lib/game/game';
 import type RoundController from '../ctrl';
@@ -22,7 +22,7 @@ export function userHtml(ctrl: RoundController, player: Player, position: TopOrB
 
   if (user) {
     const connecting = !player.onGame && ctrl.firstSeconds && user.online;
-    return h(
+    return hl(
       `div.ruser-${position}.ruser.user-link`,
       {
         class: {
@@ -33,7 +33,7 @@ export function userHtml(ctrl: RoundController, player: Player, position: TopOrB
         },
       },
       [
-        h('i.line' + (user.patron ? '.patron' : ''), {
+        hl('i.line' + (user.patron ? '.patron' : ''), {
           attrs: {
             title: connecting
               ? 'Connecting to the game'
@@ -50,34 +50,34 @@ export function userHtml(ctrl: RoundController, player: Player, position: TopOrB
           line: false,
         }),
         !!signal && signalBars(signal),
-        !!rating && h('rating', rating + (player.provisional ? '?' : '')),
+        !!rating && hl('rating', rating + (player.provisional ? '?' : '')),
         !!rating && ratingDiff(player),
         player.engine &&
-          h('span', {
+          hl('span', {
             attrs: { 'data-icon': licon.CautionCircle, title: i18n.site.thisAccountViolatedTos },
           }),
       ],
     );
   }
   const connecting = !player.onGame && ctrl.firstSeconds;
-  return h(
+  return hl(
     `div.ruser-${position}.ruser.user-link`,
     { class: { online: player.onGame, offline: !player.onGame, connecting } },
     [
-      h('i.line', {
+      hl('i.line', {
         attrs: {
           title: connecting ? 'Connecting to the game' : player.onGame ? 'Joined the game' : 'Left the game',
         },
       }),
-      h('name', player.name || i18n.site.anonymous),
+      hl('name', player.name || i18n.site.anonymous),
     ],
   );
 }
 
 const signalBars = (signal: number) => {
   const bars: VNode[] = [];
-  for (let i = 1; i <= 4; i++) bars.push(h(i <= signal ? 'i' : 'i.off'));
-  return h('signal.q' + signal, bars);
+  for (let i = 1; i <= 4; i++) bars.push(hl(i <= signal ? 'i' : 'i.off'));
+  return hl('signal.q' + signal, bars);
 };
 
 const myWsLagAsSignal = () => {

--- a/ui/simul/src/view/created.ts
+++ b/ui/simul/src/view/created.ts
@@ -3,7 +3,7 @@ import * as licon from 'lib/licon';
 import { domDialog } from 'lib/view/dialog';
 import { confirm } from 'lib/view/dialogs';
 
-import { bind, looseH as h } from 'lib/snabbdom';
+import { bind, hl } from 'lib/snabbdom';
 import type SimulCtrl from '../ctrl';
 import type { Applicant } from '../interfaces';
 import xhr from '../xhr';
@@ -17,19 +17,23 @@ export default function (showText: (ctrl: SimulCtrl) => VNode | false) {
       canJoin = ctrl.data.canJoin;
     const variantIconFor = (a: Applicant) => {
       const variant = ctrl.data.variants.find(v => a.variant === v.key);
-      return variant && h('td.variant', { attrs: { 'data-icon': variant.icon } });
+      return variant && hl('td.variant', { attrs: { 'data-icon': variant.icon } });
     };
     return [
-      h('div.box__top', [
+      hl('div.box__top', [
         util.title(ctrl),
-        h(
+        hl(
           'div.box__top__actions',
           ctrl.opts.userId
             ? isHost
               ? [startOrCancel(ctrl, accepted), randomButton(ctrl)]
               : ctrl.containsMe()
-                ? h('a.button', { hook: bind('click', () => xhr.withdraw(ctrl.data.id)) }, i18n.site.withdraw)
-                : h(
+                ? hl(
+                    'a.button',
+                    { hook: bind('click', () => xhr.withdraw(ctrl.data.id)) },
+                    i18n.site.withdraw,
+                  )
+                : hl(
                     'a.button.text' + (canJoin ? '' : '.disabled'),
                     {
                       attrs: { disabled: !canJoin, 'data-icon': licon.PlayTriangle },
@@ -53,7 +57,7 @@ export default function (showText: (ctrl: SimulCtrl) => VNode | false) {
                     },
                     i18n.site.join,
                   )
-            : h(
+            : hl(
                 'a.button.text',
                 {
                   attrs: {
@@ -67,41 +71,41 @@ export default function (showText: (ctrl: SimulCtrl) => VNode | false) {
       ]),
       showText(ctrl),
       ctrl.acceptedContainsMe()
-        ? h('p.instructions', 'You have been selected! Hold still, the simul is about to begin.')
+        ? hl('p.instructions', 'You have been selected! Hold still, the simul is about to begin.')
         : isHost &&
           ctrl.data.applicants.length < 6 &&
-          h('p.instructions', 'Share this page URL to let people enter the simul!'),
-      h(
+          hl('p.instructions', 'Share this page URL to let people enter the simul!'),
+      hl(
         'div.halves',
         { hook: { postpatch: (_old, vnode) => site.powertip.manualUserIn(vnode.elm as HTMLElement) } },
         [
-          h(
+          hl(
             'div.half.candidates',
-            h(
+            hl(
               'table.slist.slist-pad',
-              h(
+              hl(
                 'thead',
-                h(
+                hl(
                   'tr',
-                  h('th', { attrs: { colspan: 3 } }, [
-                    h('strong', `${candidates.length}`),
+                  hl('th', { attrs: { colspan: 3 } }, [
+                    hl('strong', `${candidates.length}`),
                     ' candidate players',
                   ]),
                 ),
               ),
-              h(
+              hl(
                 'tbody',
                 candidates.map(applicant => {
-                  return h(
+                  return hl(
                     'tr',
                     { key: applicant.player.id, class: { me: ctrl.opts.userId === applicant.player.id } },
                     [
-                      h('td', util.player(applicant.player, ctrl)),
+                      hl('td', util.player(applicant.player, ctrl)),
                       variantIconFor(applicant),
-                      h(
+                      hl(
                         'td.action',
                         isHost &&
-                          h('a.button', {
+                          hl('a.button', {
                             attrs: { 'data-icon': licon.Checkmark, title: 'Accept' },
                             hook: bind('click', () => xhr.accept(applicant.player.id)(ctrl.data.id)),
                           }),
@@ -112,35 +116,35 @@ export default function (showText: (ctrl: SimulCtrl) => VNode | false) {
               ),
             ),
           ),
-          h('div.half.accepted', [
-            h(
+          hl('div.half.accepted', [
+            hl(
               'table.slist.user_list',
-              h('thead', [
-                h(
+              hl('thead', [
+                hl(
                   'tr',
-                  h('th', { attrs: { colspan: 3 } }, [
-                    h('strong', `${accepted.length}`),
+                  hl('th', { attrs: { colspan: 3 } }, [
+                    hl('strong', `${accepted.length}`),
                     ' accepted players',
                   ]),
                 ),
                 isHost &&
                   candidates.length > 0 &&
                   !accepted.length &&
-                  h('tr.help', h('th', 'Now you get to accept some players, then start the simul')),
+                  hl('tr.help', hl('th', 'Now you get to accept some players, then start the simul')),
               ]),
-              h(
+              hl(
                 'tbody',
                 accepted.map(applicant => {
-                  return h(
+                  return hl(
                     'tr',
                     { key: applicant.player.id, class: { me: ctrl.opts.userId === applicant.player.id } },
                     [
-                      h('td', util.player(applicant.player, ctrl)),
+                      hl('td', util.player(applicant.player, ctrl)),
                       variantIconFor(applicant),
-                      h(
+                      hl(
                         'td.action',
                         isHost &&
-                          h('a.button.button-red', {
+                          hl('a.button.button-red', {
                             attrs: { 'data-icon': licon.X },
                             hook: bind('click', () => xhr.reject(applicant.player.id)(ctrl.data.id)),
                           }),
@@ -154,11 +158,11 @@ export default function (showText: (ctrl: SimulCtrl) => VNode | false) {
         ],
       ),
       ctrl.data.quote &&
-        h('blockquote.pull-quote', [h('p', ctrl.data.quote.text), h('footer', ctrl.data.quote.author)]),
-      h(
+        hl('blockquote.pull-quote', [hl('p', ctrl.data.quote.text), hl('footer', ctrl.data.quote.author)]),
+      hl(
         'div.continue-with.none',
         ctrl.data.variants.map(variant =>
-          h('button.button', { attrs: { 'data-variant': variant.key } }, variant.name),
+          hl('button.button', { attrs: { 'data-variant': variant.key } }, variant.name),
         ),
       ),
     ];
@@ -169,7 +173,7 @@ const byName = (a: Applicant, b: Applicant) => (a.player.name > b.player.name ? 
 
 const randomButton = (ctrl: SimulCtrl) =>
   ctrl.candidates().length > 0 &&
-  h(
+  hl(
     'a.button.text',
     {
       attrs: { 'data-icon': licon.Checkmark },
@@ -184,12 +188,12 @@ const randomButton = (ctrl: SimulCtrl) =>
 
 const startOrCancel = (ctrl: SimulCtrl, accepted: Applicant[]) =>
   accepted.length > 1
-    ? h(
+    ? hl(
         'a.button.button-green.text',
         { attrs: { 'data-icon': licon.PlayTriangle }, hook: bind('click', () => xhr.start(ctrl.data.id)) },
         `Start (${accepted.length})`,
       )
-    : h(
+    : hl(
         'a.button.button-red.text',
         {
           attrs: { 'data-icon': licon.X },

--- a/ui/simul/src/view/main.ts
+++ b/ui/simul/src/view/main.ts
@@ -1,4 +1,4 @@
-import { onInsert, looseH as h } from 'lib/snabbdom';
+import { onInsert, hl } from 'lib/snabbdom';
 import type SimulCtrl from '../ctrl';
 import { title } from './util';
 import created from './created';
@@ -12,8 +12,8 @@ import standaloneChat from 'lib/chat/standalone';
 export default function (ctrl: SimulCtrl) {
   const handler = ctrl.data.isRunning ? started : ctrl.data.isFinished ? finished : created(showText);
 
-  return h('main.simul', { class: { 'simul-created': ctrl.data.isCreated } }, [
-    h('aside.simul__side', {
+  return hl('main.simul', { class: { 'simul-created': ctrl.data.isCreated } }, [
+    hl('aside.simul__side', {
       hook: onInsert(el => {
         $(el).replaceWith(ctrl.opts.$side);
         if (ctrl.opts.chat) {
@@ -22,23 +22,23 @@ export default function (ctrl: SimulCtrl) {
         }
       }),
     }),
-    h('div.simul__main.box', { hook: { postpatch: () => initMiniGames() } }, handler(ctrl)),
-    h('div.chat__members.none', { hook: onInsert(watchers) }),
+    hl('div.simul__main.box', { hook: { postpatch: () => initMiniGames() } }, handler(ctrl)),
+    hl('div.chat__members.none', { hook: onInsert(watchers) }),
   ]);
 }
 
 const showText = (ctrl: SimulCtrl) =>
-  ctrl.data.text.length > 0 && h('div.simul-text', [h('p', { hook: richHTML(ctrl.data.text) })]);
+  ctrl.data.text.length > 0 && hl('div.simul-text', [hl('p', { hook: richHTML(ctrl.data.text) })]);
 
 const started = (ctrl: SimulCtrl) => [
-  h('div.box__top', title(ctrl)),
+  hl('div.box__top', title(ctrl)),
   showText(ctrl),
   results(ctrl),
   pairings(ctrl),
 ];
 
 const finished = (ctrl: SimulCtrl) => [
-  h('div.box__top', [title(ctrl), h('div.box__top__actions', h('div.finished', i18n.site.finished))]),
+  hl('div.box__top', [title(ctrl), hl('div.box__top__actions', hl('div.finished', i18n.site.finished))]),
   showText(ctrl),
   results(ctrl),
   pairings(ctrl),

--- a/ui/storm/src/view/end.ts
+++ b/ui/storm/src/view/end.ts
@@ -2,9 +2,9 @@ import type StormCtrl from '../ctrl';
 import { getNow } from 'lib/puz/util';
 import renderHistory from 'lib/puz/view/history';
 import { numberSpread } from 'lib/i18n';
-import { onInsert, type LooseVNodes, looseH as h } from 'lib/snabbdom';
+import { onInsert, type LooseVNodes, hl } from 'lib/snabbdom';
 
-const renderEnd = (ctrl: StormCtrl): LooseVNodes => [...renderSummary(ctrl), renderHistory(ctrl)];
+const renderEnd = (ctrl: StormCtrl): LooseVNodes => [renderSummary(ctrl), renderHistory(ctrl)];
 
 const newHighI18n = {
   day: i18n.storm.newDailyHighscore,
@@ -20,39 +20,42 @@ const renderSummary = (ctrl: StormCtrl): LooseVNodes => {
   const scoreSteps = Math.min(run.score, 50);
   return [
     high &&
-      h(
+      hl(
         'div.storm--end__high.storm--end__high-daily.bar-glider',
-        h('div.storm--end__high__content', [
-          h('div.storm--end__high__text', [
-            h('strong', newHighI18n[high.key]),
-            high.prev ? h('span', i18n.storm.previousHighscoreWasX(high.prev)) : null,
+        hl('div.storm--end__high__content', [
+          hl('div.storm--end__high__text', [
+            hl('strong', newHighI18n[high.key]),
+            high.prev ? hl('span', i18n.storm.previousHighscoreWasX(high.prev)) : null,
           ]),
         ]),
       ),
-    h('div.storm--end__score', [
-      h(
+    hl('div.storm--end__score', [
+      hl(
         'span.storm--end__score__number',
         { hook: onInsert(el => numberSpread(el, scoreSteps, Math.round(scoreSteps * 50), 0)(run.score)) },
         '0',
       ),
-      h('p', i18n.storm.puzzlesSolved),
+      hl('p', i18n.storm.puzzlesSolved),
     ]),
-    h('div.storm--end__stats.box.box-pad', [
-      h('table.slist', [
-        h('tbody', [
-          h('tr', [h('th', i18n.storm.moves), h('td', h('number', `${run.moves}`))]),
-          h('tr', [h('th', i18n.storm.accuracy), h('td', [h('number', Number(accuracy).toFixed(1)), '%'])]),
-          h('tr', [h('th', i18n.storm.combo), h('td', h('number', `${ctrl.run.combo.best}`))]),
-          h('tr', [h('th', i18n.storm.time), h('td', [h('number', `${Math.round(run.time)}`), 's'])]),
-          h('tr', [
-            h('th', i18n.storm.timePerMove),
-            h('td', [h('number', Number(run.time / run.moves).toFixed(2)), 's']),
+    hl('div.storm--end__stats.box.box-pad', [
+      hl('table.slist', [
+        hl('tbody', [
+          hl('tr', [hl('th', i18n.storm.moves), hl('td', hl('number', `${run.moves}`))]),
+          hl('tr', [
+            hl('th', i18n.storm.accuracy),
+            hl('td', [hl('number', Number(accuracy).toFixed(1)), '%']),
           ]),
-          h('tr', [h('th', i18n.storm.highestSolved), h('td', h('number', `${run.highest}`))]),
+          hl('tr', [hl('th', i18n.storm.combo), hl('td', hl('number', `${ctrl.run.combo.best}`))]),
+          hl('tr', [hl('th', i18n.storm.time), hl('td', [hl('number', `${Math.round(run.time)}`), 's'])]),
+          hl('tr', [
+            hl('th', i18n.storm.timePerMove),
+            hl('td', [hl('number', Number(run.time / run.moves).toFixed(2)), 's']),
+          ]),
+          hl('tr', [hl('th', i18n.storm.highestSolved), hl('td', hl('number', `${run.highest}`))]),
         ]),
       ]),
     ]),
-    h(
+    hl(
       'a.storm-play-again.button',
       { attrs: ctrl.run.endAt! < getNow() - 900 ? { href: '/storm' } : {} },
       i18n.storm.playAgain,

--- a/ui/storm/src/view/main.ts
+++ b/ui/storm/src/view/main.ts
@@ -8,7 +8,7 @@ import { makeConfig as makeCgConfig } from 'lib/puz/view/chessground';
 import { getNow } from 'lib/puz/util';
 import { playModifiers, renderCombo } from 'lib/puz/view/util';
 import * as licon from 'lib/licon';
-import { onInsert, looseH as h } from 'lib/snabbdom';
+import { onInsert, hl } from 'lib/snabbdom';
 import { Chessground as makeChessground } from '@lichess-org/chessground';
 import { pubsub } from 'lib/pubsub';
 
@@ -16,12 +16,12 @@ export default function (ctrl: StormCtrl): VNode {
   if (ctrl.vm.dupTab) return renderReload(i18n.storm.thisRunWasOpenedInAnotherTab);
   if (ctrl.vm.lateStart) return renderReload(i18n.storm.thisRunHasExpired);
   if (!ctrl.run.endAt)
-    return h('div.storm.storm-app.storm--play', { class: playModifiers(ctrl.run) }, renderPlay(ctrl));
-  return h('main.storm.storm--end', renderEnd(ctrl));
+    return hl('div.storm.storm-app.storm--play', { class: playModifiers(ctrl.run) }, renderPlay(ctrl));
+  return hl('main.storm.storm--end', renderEnd(ctrl));
 }
 
 const chessground = (ctrl: StormCtrl): VNode =>
-  h('div.cg-wrap', {
+  hl('div.cg-wrap', {
     hook: {
       insert: vnode => {
         ctrl.ground(
@@ -48,47 +48,47 @@ const renderPlay = (ctrl: StormCtrl): VNode[] => {
   const bonus = run.modifier.bonus;
   const now = getNow();
   return [
-    h('div.puz-board.main-board', [chessground(ctrl), ctrl.promotion.view()]),
-    h('div.puz-side', [
+    hl('div.puz-board.main-board', [chessground(ctrl), ctrl.promotion.view()]),
+    hl('div.puz-side', [
       run.clock.startAt ? renderSolved(ctrl) : renderStart(),
-      h('div.puz-clock', [
+      hl('div.puz-clock', [
         renderClock(run, ctrl.endNow, true),
-        !!malus && malus.at > now - 900 && h('div.puz-clock__malus', '-' + malus.seconds),
-        !!bonus && bonus.at > now - 900 && h('div.puz-clock__bonus', '+' + bonus.seconds),
-        ...(run.clock.started() ? [] : [h('span.puz-clock__pov', povMessage(run))]),
+        !!malus && malus.at > now - 900 && hl('div.puz-clock__malus', '-' + malus.seconds),
+        !!bonus && bonus.at > now - 900 && hl('div.puz-clock__bonus', '+' + bonus.seconds),
+        run.clock.started() || [hl('span.puz-clock__pov', povMessage(run))],
       ]),
-      h('div.puz-side__table', [renderControls(ctrl), renderCombo(config, renderBonus)(run)]),
+      hl('div.puz-side__table', [renderControls(ctrl), renderCombo(config, renderBonus)(run)]),
     ]),
   ];
 };
 
 const renderSolved = (ctrl: StormCtrl): VNode =>
-  h('div.puz-side__top.puz-side__solved', [h('div.puz-side__solved__text', `${ctrl.countWins()}`)]);
+  hl('div.puz-side__top.puz-side__solved', [hl('div.puz-side__solved__text', `${ctrl.countWins()}`)]);
 
 const renderControls = (ctrl: StormCtrl): VNode =>
-  h('div.puz-side__control', [
-    h('a.puz-side__control__flip.button', {
+  hl('div.puz-side__control', [
+    hl('a.puz-side__control__flip.button', {
       class: { active: ctrl.flipped, 'button-empty': !ctrl.flipped },
       attrs: { 'data-icon': licon.ChasingArrows, title: i18n.site.flipBoard + ' (Keyboard: f)' },
       hook: onInsert(el => el.addEventListener('click', ctrl.flip)),
     }),
-    h('a.puz-side__control__reload.button.button-empty', {
+    hl('a.puz-side__control__reload.button.button-empty', {
       attrs: { href: '/storm', 'data-icon': licon.Trash, title: i18n.storm.newRun },
     }),
-    h('a.puz-side__control__end.button.button-empty', {
+    hl('a.puz-side__control__end.button.button-empty', {
       attrs: { 'data-icon': licon.FlagOutline, title: i18n.storm.endRun },
       hook: onInsert(el => el.addEventListener('click', ctrl.endNow)),
     }),
   ]);
 
 const renderStart = () =>
-  h('div.puz-side__top.puz-side__start', [
-    h('div.puz-side__start__text', [h('strong', 'Puzzle Storm'), h('span', i18n.storm.moveToStart)]),
+  hl('div.puz-side__top.puz-side__start', [
+    hl('div.puz-side__start__text', [hl('strong', 'Puzzle Storm'), hl('span', i18n.storm.moveToStart)]),
   ]);
 
 const renderReload = (text: string) =>
-  h('div.storm.storm--reload.box.box-pad', [
-    h('i', { attrs: { 'data-icon': licon.Storm } }),
-    h('p', text),
-    h('a.storm--dup__reload.button', { attrs: { href: '/storm' } }, i18n.storm.clickToReload),
+  hl('div.storm.storm--reload.box.box-pad', [
+    hl('i', { attrs: { 'data-icon': licon.Storm } }),
+    hl('p', text),
+    hl('a.storm--dup__reload.button', { attrs: { href: '/storm' } }, i18n.storm.clickToReload),
   ]);

--- a/ui/swiss/src/view/main.ts
+++ b/ui/swiss/src/view/main.ts
@@ -1,6 +1,6 @@
 import * as licon from 'lib/licon';
 import { spinnerVdom as spinner } from 'lib/view/controls';
-import { type VNode, dataIcon, bind, onInsert, type LooseVNodes, looseH as h } from 'lib/snabbdom';
+import { type VNode, dataIcon, bind, onInsert, type LooseVNodes, hl } from 'lib/snabbdom';
 import { numberRow } from './util';
 import type SwissCtrl from '../ctrl';
 import { players, renderPager } from '../pagination';
@@ -22,19 +22,19 @@ export default function (ctrl: SwissCtrl) {
   const d = ctrl.data;
   const content =
     d.status === 'created' ? created(ctrl) : d.status === 'started' ? started(ctrl) : finished(ctrl);
-  return h('main.' + ctrl.opts.classes, { hook: { postpatch: () => initMiniGames() } }, [
-    h('aside.swiss__side', {
+  return hl('main.' + ctrl.opts.classes, { hook: { postpatch: () => initMiniGames() } }, [
+    hl('aside.swiss__side', {
       hook: onInsert(el => {
         $(el).replaceWith(ctrl.opts.$side);
         ctrl.opts.chat && standaloneChat(ctrl.opts.chat);
       }),
     }),
-    h('div.swiss__underchat', {
+    hl('div.swiss__underchat', {
       hook: onInsert(el => $(el).replaceWith($('.swiss__underchat.none').removeClass('none'))),
     }),
     playerInfo(ctrl) || stats(ctrl) || boards.top(d.boards, ctrl.opts),
-    h('div.swiss__main', [h('div.box.swiss__main-' + d.status, content), boards.many(d.boards, ctrl.opts)]),
-    ctrl.opts.chat && h('div.chat__members.none', { hook: onInsert(watchers) }),
+    hl('div.swiss__main', [hl('div.box.swiss__main-' + d.status, content), boards.many(d.boards, ctrl.opts)]),
+    ctrl.opts.chat && hl('div.chat__members.none', { hook: onInsert(watchers) }),
   ]);
 }
 
@@ -46,7 +46,7 @@ function created(ctrl: SwissCtrl): LooseVNodes {
     controls(ctrl, pag),
     standing(ctrl, pag, 'created'),
     ctrl.data.quote &&
-      h('blockquote.pull-quote', [h('p', ctrl.data.quote.text), h('footer', ctrl.data.quote.author)]),
+      hl('blockquote.pull-quote', [hl('p', ctrl.data.quote.text), hl('footer', ctrl.data.quote.author)]),
   ];
 }
 
@@ -57,7 +57,7 @@ const notice = (ctrl: SwissCtrl) => {
     !d.me.absent &&
     d.status === 'started' &&
     d.nextRound &&
-    h('div.swiss__notice.bar-glider', i18n.site.standByX(d.me.name))
+    hl('div.swiss__notice.bar-glider', i18n.site.standByX(d.me.name))
   );
 };
 
@@ -75,26 +75,26 @@ function started(ctrl: SwissCtrl): LooseVNodes {
 function finished(ctrl: SwissCtrl): LooseVNodes {
   const pag = players(ctrl);
   return [
-    h('div.podium-wrap', [confetti(ctrl.data), header(ctrl), podium(ctrl)]),
+    hl('div.podium-wrap', [confetti(ctrl.data), header(ctrl), podium(ctrl)]),
     controls(ctrl, pag),
     standing(ctrl, pag, 'finished'),
   ];
 }
 
 function controls(ctrl: SwissCtrl, pag: Pager): VNode {
-  return h('div.swiss__controls', [h('div.pager', renderPager(ctrl, pag)), joinButton(ctrl)]);
+  return hl('div.swiss__controls', [hl('div.pager', renderPager(ctrl, pag)), joinButton(ctrl)]);
 }
 
 function nextRound(ctrl: SwissCtrl): VNode | undefined {
   if (!ctrl.opts.schedule || ctrl.data.nbOngoing || ctrl.data.round === 0) return;
-  return h(
+  return hl(
     'form.schedule-next-round',
     {
       class: { required: !ctrl.data.nextRound },
       attrs: { action: `/api/swiss/${ctrl.data.id}/schedule-next-round`, method: 'post' },
     },
     [
-      h('input', {
+      hl('input', {
         attrs: { name: 'date', placeholder: 'Schedule the next round', value: ctrl.data.nextRound?.at || '' },
         hook: onInsert((el: HTMLInputElement) =>
           flatpickr(el, {
@@ -119,14 +119,14 @@ function nextRound(ctrl: SwissCtrl): VNode | undefined {
 function joinButton(ctrl: SwissCtrl): VNode | undefined {
   const d = ctrl.data;
   if (!ctrl.opts.userId)
-    return h(
+    return hl(
       'a.fbt.text.highlight',
       { attrs: { href: '/login?referrer=' + window.location.pathname, 'data-icon': licon.PlayTriangle } },
       i18n.site.signIn,
     );
 
   if (d.joinTeam)
-    return h(
+    return hl(
       'a.fbt.text.highlight',
       { attrs: { href: `/team/${d.joinTeam}`, 'data-icon': licon.Group } },
       i18n.team.joinTeam,
@@ -135,7 +135,7 @@ function joinButton(ctrl: SwissCtrl): VNode | undefined {
   if (d.canJoin)
     return ctrl.joinSpinner
       ? spinner()
-      : h(
+      : hl(
           'button.fbt.text.highlight',
           {
             attrs: dataIcon(licon.PlayTriangle),
@@ -157,14 +157,14 @@ function joinButton(ctrl: SwissCtrl): VNode | undefined {
     return d.me.absent
       ? ctrl.joinSpinner
         ? spinner()
-        : h(
+        : hl(
             'button.fbt.text.highlight',
             { attrs: dataIcon(licon.PlayTriangle), hook: bind('click', _ => ctrl.join(), ctrl.redraw) },
             i18n.site.join,
           )
       : ctrl.joinSpinner
         ? spinner()
-        : h(
+        : hl(
             'button.fbt.text',
             { attrs: dataIcon(licon.FlagOutline), hook: bind('click', ctrl.withdraw, ctrl.redraw) },
             i18n.site.withdraw,
@@ -177,9 +177,9 @@ function joinTheGame(ctrl: SwissCtrl) {
   const gameId = ctrl.data.me?.gameId;
   return (
     gameId &&
-    h('a.swiss__ur-playing.button.is.is-after', { attrs: { href: '/' + gameId } }, [
+    hl('a.swiss__ur-playing.button.is.is-after', { attrs: { href: '/' + gameId } }, [
       i18n.site.youArePlaying,
-      h('br'),
+      hl('br'),
       i18n.site.joinTheGame,
     ])
   );
@@ -190,7 +190,7 @@ function confetti(data: SwissData) {
     data.me &&
     data.isRecentlyFinished &&
     once('tournament.end.canvas.' + data.id) &&
-    h('canvas#confetti', {
+    hl('canvas#confetti', {
       hook: {
         insert: _ => site.asset.loadEsm('bits.confetti'),
       },
@@ -202,9 +202,9 @@ function stats(ctrl: SwissCtrl) {
   const s = ctrl.data.stats,
     slots = ctrl.data.round * ctrl.data.nbPlayers;
   if (!s) return undefined;
-  return h('div.swiss__stats', [
-    h('h2', i18n.site.tournamentComplete),
-    h('table', [
+  return hl('div.swiss__stats', [
+    hl('h2', i18n.site.tournamentComplete),
+    hl('table', [
       ctrl.opts.showRatings ? numberRow(i18n.site.averageElo, s.averageRating, 'raw') : null,
       numberRow(i18n.site.gamesPlayed, s.games),
       numberRow(i18n.site.whiteWins, [s.whiteWins, slots], 'percent'),
@@ -213,31 +213,31 @@ function stats(ctrl: SwissCtrl) {
       numberRow(i18n.swiss.byes, [s.byes, slots], 'percent'),
       numberRow(i18n.swiss.absences, [s.absences, slots], 'percent'),
     ]),
-    h('div.swiss__stats__links', [
-      h(
+    hl('div.swiss__stats__links', [
+      hl(
         'a',
         { attrs: { href: `/swiss/${ctrl.data.id}/round/1` } },
         i18n.swiss.viewAllXRounds(ctrl.data.round),
       ),
-      h('br'),
-      h(
+      hl('br'),
+      hl(
         'a.text',
         { attrs: { 'data-icon': licon.Download, href: `/swiss/${ctrl.data.id}.trf`, download: true } },
         'Download TRF file',
       ),
-      h(
+      hl(
         'a.text',
         { attrs: { 'data-icon': licon.Download, href: `/api/swiss/${ctrl.data.id}/games`, download: true } },
         i18n.site.downloadAllGames,
       ),
-      h(
+      hl(
         'a.text',
         {
           attrs: { 'data-icon': licon.Download, href: `/api/swiss/${ctrl.data.id}/results`, download: true },
         },
         'Download results as NDJSON',
       ),
-      h(
+      hl(
         'a.text',
         {
           attrs: {
@@ -248,8 +248,8 @@ function stats(ctrl: SwissCtrl) {
         },
         'Download results as CSV',
       ),
-      h('br'),
-      h(
+      hl('br'),
+      hl(
         'a.text',
         { attrs: { 'data-icon': licon.InfoCircle, href: 'https://lichess.org/api#tag/Swiss-tournaments' } },
         'Swiss API documentation',

--- a/ui/swiss/src/view/playerInfo.ts
+++ b/ui/swiss/src/view/playerInfo.ts
@@ -1,7 +1,7 @@
 import type { VNode } from 'snabbdom';
 import * as licon from 'lib/licon';
 import { spinnerVdom as spinner } from 'lib/view/controls';
-import { bind, dataIcon, looseH as h } from 'lib/snabbdom';
+import { bind, dataIcon, hl } from 'lib/snabbdom';
 import { player as renderPlayer, numberRow } from './util';
 import type { Pairing } from '../interfaces';
 import { isOutcome } from '../util';
@@ -13,35 +13,33 @@ export default function (ctrl: SwissCtrl): VNode | undefined {
   const data = ctrl.data.playerInfo;
   const tag = 'div.swiss__player-info.swiss__table';
   if (data?.user.id !== ctrl.playerInfoId)
-    return h(tag, [h('div.stats', [h('h2', ctrl.playerInfoId), spinner()])]);
+    return hl(tag, [hl('div.stats', [hl('h2', ctrl.playerInfoId), spinner()])]);
   const games = data.sheet.filter(p => !isOutcome(p) && p.g).length;
   const wins = data.sheet.filter(p => !isOutcome(p) && p.w).length;
   const avgOp: number | undefined = games
     ? Math.round(data.sheet.reduce((r, p) => r + (!isOutcome(p) ? p.rating : 1), 0) / games)
     : undefined;
-  return h(tag, { hook: { insert: setup, postpatch: (_, vnode) => setup(vnode) } }, [
-    h('a.close', {
+  return hl(tag, { hook: { insert: setup, postpatch: (_, vnode) => setup(vnode) } }, [
+    hl('a.close', {
       attrs: dataIcon(licon.X),
       hook: bind('click', () => ctrl.showPlayerInfo(data), ctrl.redraw),
     }),
-    h('div.stats', [
-      h('h2', [h('span.rank', data.rank + '. '), renderPlayer(data, true, false)]),
-      h('table', [
+    hl('div.stats', [
+      hl('h2', [hl('span.rank', data.rank + '. '), renderPlayer(data, true, false)]),
+      hl('table', [
         numberRow(i18n.site.points, data.points, 'raw'),
         numberRow(i18n.swiss.tieBreak, data.tieBreak, 'raw'),
-        ...(games
-          ? [
-              data.performance &&
-                ctrl.opts.showRatings &&
-                numberRow(i18n.site.performance, data.performance + (games < 3 ? '?' : ''), 'raw'),
-              numberRow(i18n.site.winRate, [wins, games], 'percent'),
-              ctrl.opts.showRatings && numberRow(i18n.site.averageOpponent, avgOp, 'raw'),
-            ]
-          : []),
+        games !== 0 && [
+          !!data.performance &&
+            ctrl.opts.showRatings &&
+            numberRow(i18n.site.performance, data.performance + (games < 3 ? '?' : ''), 'raw'),
+          numberRow(i18n.site.winRate, [wins, games], 'percent'),
+          ctrl.opts.showRatings && numberRow(i18n.site.averageOpponent, avgOp, 'raw'),
+        ],
       ]),
     ]),
-    h('div', [
-      h(
+    hl('div', [
+      hl(
         'table.pairings.sublist',
         {
           hook: bind('click', e => {
@@ -52,13 +50,13 @@ export default function (ctrl: SwissCtrl): VNode | undefined {
         data.sheet.map((p, i) => {
           const round = ctrl.data.round - i;
           if (isOutcome(p))
-            return h('tr.' + p, { key: round }, [
-              h('th', '' + round),
-              h('td.outcome', { attrs: { colspan: 3 } }, p),
-              h('td', p === 'absent' ? '-' : p === 'bye' ? '1' : '½'),
+            return hl('tr.' + p, { key: round }, [
+              hl('th', '' + round),
+              hl('td.outcome', { attrs: { colspan: 3 } }, p),
+              hl('td', p === 'absent' ? '-' : p === 'bye' ? '1' : '½'),
             ]);
           const res = result(p);
-          return h(
+          return hl(
             'tr.glpt.' + (res === '1' ? '.win' : res === '0' ? '.loss' : ''),
             {
               key: round,
@@ -66,11 +64,11 @@ export default function (ctrl: SwissCtrl): VNode | undefined {
               hook: { destroy: vnode => $.powerTip.destroy(vnode.elm as HTMLElement) },
             },
             [
-              h('th', '' + round),
-              h('td', fullName(p.user)),
-              ctrl.opts.showRatings && h('td', '' + p.rating),
-              h('td.is.color-icon.' + (p.c ? 'white' : 'black')),
-              h('td.result', res),
+              hl('th', '' + round),
+              hl('td', fullName(p.user)),
+              ctrl.opts.showRatings && hl('td', '' + p.rating),
+              hl('td.is.color-icon.' + (p.c ? 'white' : 'black')),
+              hl('td.result', res),
             ],
           );
         }),

--- a/ui/tournament/src/view/playerInfo.ts
+++ b/ui/tournament/src/view/playerInfo.ts
@@ -1,6 +1,6 @@
 import * as licon from 'lib/licon';
 import { spinnerVdom as spinner } from 'lib/view/controls';
-import { type VNode, bind, dataIcon, looseH as h } from 'lib/snabbdom';
+import { type VNode, bind, dataIcon, hl } from 'lib/snabbdom';
 import { numberRow, player as renderPlayer } from './util';
 import { fullName } from 'lib/view/userLink';
 import { teamName } from './battle';
@@ -20,7 +20,10 @@ function result(win: boolean, stat: number): string {
 }
 
 const playerTitle = (player: Player) =>
-  h('h2', [player.rank ? h('span.rank', `${player.rank}. `) : '', renderPlayer(player, true, false, false)]);
+  hl('h2', [
+    player.rank ? hl('span.rank', `${player.rank}. `) : '',
+    renderPlayer(player, true, false, false),
+  ]);
 
 function setup(vnode: VNode) {
   const el = vnode.elm as HTMLElement,
@@ -33,39 +36,37 @@ export default function (ctrl: TournamentController): VNode {
   const data = ctrl.playerInfo.data;
   const tag = 'div.tour__player-info.tour__actor-info';
   if (!data || data.player.id !== ctrl.playerInfo.id)
-    return h(tag, [h('div.stats', [playerTitle(ctrl.playerInfo.player!), spinner()])]);
+    return hl(tag, [hl('div.stats', [playerTitle(ctrl.playerInfo.player!), spinner()])]);
   const nb = data.player.nb,
     pairingsLen = data.pairings.length,
     avgOp = pairingsLen
       ? Math.round(data.pairings.reduce((a, b) => a + b.op.rating, 0) / pairingsLen)
       : undefined;
-  return h(tag, { hook: { insert: setup, postpatch: (_, vnode) => setup(vnode) } }, [
-    h('a.close', {
+  return hl(tag, { hook: { insert: setup, postpatch: (_, vnode) => setup(vnode) } }, [
+    hl('a.close', {
       attrs: dataIcon(licon.X),
       hook: bind('click', () => ctrl.showPlayerInfo(data.player), ctrl.redraw),
     }),
-    h('div.stats', [
+    hl('div.stats', [
       playerTitle(data.player),
       data.player.team &&
-        h('team', { hook: bind('click', () => ctrl.showTeamInfo(data.player.team!), ctrl.redraw) }, [
+        hl('team', { hook: bind('click', () => ctrl.showTeamInfo(data.player.team!), ctrl.redraw) }, [
           teamName(ctrl.data.teamBattle!, data.player.team),
         ]),
-      h('table', [
+      hl('table', [
         ctrl.opts.showRatings &&
           data.player.performance &&
           numberRow(i18n.site.performance, data.player.performance + (nb.game < 3 ? '?' : ''), 'raw'),
         numberRow(i18n.site.gamesPlayed, nb.game),
-        ...(nb.game
-          ? [
-              numberRow(i18n.site.winRate, [nb.win, nb.game], 'percent'),
-              numberRow(i18n.arena.berserkRate, [nb.berserk, nb.game], 'percent'),
-              ctrl.opts.showRatings && numberRow(i18n.site.averageOpponent, avgOp, 'raw'),
-            ]
-          : []),
+        nb.game > 0 && [
+          numberRow(i18n.site.winRate, [nb.win, nb.game], 'percent'),
+          numberRow(i18n.arena.berserkRate, [nb.berserk, nb.game], 'percent'),
+          ctrl.opts.showRatings && numberRow(i18n.site.averageOpponent, avgOp, 'raw'),
+        ],
       ]),
     ]),
-    h('div', [
-      h(
+    hl('div', [
+      hl(
         'table.pairings.sublist',
         {
           hook: bind('click', e => {
@@ -75,7 +76,7 @@ export default function (ctrl: TournamentController): VNode {
         },
         data.pairings.map(function (p, i) {
           const res = result(p.win, p.status);
-          return h(
+          return hl(
             'tr.glpt.' + (res === '1' ? ' win' : res === '0' ? ' loss' : ''),
             {
               key: p.id,
@@ -83,12 +84,12 @@ export default function (ctrl: TournamentController): VNode {
               hook: { destroy: vnode => $.powerTip.destroy(vnode.elm as HTMLElement) },
             },
             [
-              h('th', '' + (Math.max(nb.game, pairingsLen) - i)),
-              h('td', fullName(p.op)),
-              ctrl.opts.showRatings ? h('td', `${p.op.rating}`) : null,
+              hl('th', '' + (Math.max(nb.game, pairingsLen) - i)),
+              hl('td', fullName(p.op)),
+              ctrl.opts.showRatings ? hl('td', `${p.op.rating}`) : null,
               berserkTd(!!p.op.berserk),
-              h('td.is.color-icon.' + p.color),
-              h('td.result', res),
+              hl('td.is.color-icon.' + p.color),
+              hl('td.result', res),
               berserkTd(p.berserk),
             ],
           );
@@ -99,4 +100,4 @@ export default function (ctrl: TournamentController): VNode {
 }
 
 const berserkTd = (b: boolean) =>
-  b ? h('td.berserk', { attrs: { 'data-icon': licon.Berserk, title: 'Berserk' } }) : h('td.berserk');
+  b ? hl('td.berserk', { attrs: { 'data-icon': licon.Berserk, title: 'Berserk' } }) : hl('td.berserk');

--- a/ui/tournament/src/view/table.ts
+++ b/ui/tournament/src/view/table.ts
@@ -1,6 +1,6 @@
 import { opposite } from '@lichess-org/chessground/util';
 import * as licon from 'lib/licon';
-import { type VNode, bind, onInsert, looseH as h } from 'lib/snabbdom';
+import { type VNode, bind, onInsert, hl } from 'lib/snabbdom';
 import { player as renderPlayer } from './util';
 import type { Duel, DuelPlayer, FeaturedGame, TournamentOpts } from '../interfaces';
 import { teamName } from './battle';
@@ -9,22 +9,22 @@ import { initMiniGames } from 'lib/view/miniBoard';
 
 function featuredPlayer(game: FeaturedGame, color: Color, opts: TournamentOpts) {
   const player = game[color];
-  return h('span.mini-game__player', [
-    h('span.mini-game__user', [
-      h('strong', '#' + player.rank),
+  return hl('span.mini-game__player', [
+    hl('span.mini-game__user', [
+      hl('strong', '#' + player.rank),
       renderPlayer(player, true, opts.showRatings, false),
-      player.berserk && h('i', { attrs: { 'data-icon': licon.Berserk, title: 'Berserk' } }),
+      player.berserk && hl('i', { attrs: { 'data-icon': licon.Berserk, title: 'Berserk' } }),
     ]),
     game.c
-      ? h(`span.mini-game__clock.mini-game__clock--${color}`, {
+      ? hl(`span.mini-game__clock.mini-game__clock--${color}`, {
           attrs: { 'data-time': game.c[color], 'data-managed': 1 },
         })
-      : h('span.mini-game__result', game.winner ? (game.winner === color ? '1' : '0') : '½'),
+      : hl('span.mini-game__result', game.winner ? (game.winner === color ? '1' : '0') : '½'),
   ]);
 }
 
 function featured(game: FeaturedGame, opts: TournamentOpts): VNode {
-  return h(
+  return hl(
     `div.tour__featured.mini-game.mini-game-${game.id}.mini-game--init.is2d`,
     {
       attrs: { 'data-state': `${game.fen},${game.orientation},${game.lastMove}`, 'data-live': game.id },
@@ -32,44 +32,44 @@ function featured(game: FeaturedGame, opts: TournamentOpts): VNode {
     },
     [
       featuredPlayer(game, opposite(game.orientation), opts),
-      h('a.cg-wrap', { attrs: { href: `/${game.id}/${game.orientation}` } }),
+      hl('a.cg-wrap', { attrs: { href: `/${game.id}/${game.orientation}` } }),
       featuredPlayer(game, game.orientation, opts),
     ],
   );
 }
 
 const duelPlayerMeta = (p: DuelPlayer, ctrl: TournamentController) => [
-  h('em.rank', '#' + p.k),
-  p.t && h('em.utitle', p.t),
-  ctrl.opts.showRatings && h('em.rating', '' + p.r),
+  hl('em.rank', '#' + p.k),
+  p.t && hl('em.utitle', p.t),
+  ctrl.opts.showRatings && hl('em.rating', '' + p.r),
 ];
 
 function renderDuel(ctrl: TournamentController) {
   const battle = ctrl.data.teamBattle,
     duelTeams = ctrl.data.duelTeams;
   return (d: Duel) =>
-    h('a.glpt.force-ltr', { key: d.id, attrs: { href: '/' + d.id } }, [
+    hl('a.glpt.force-ltr', { key: d.id, attrs: { href: '/' + d.id } }, [
       battle &&
         duelTeams &&
-        h(
+        hl(
           'line.t',
           [0, 1].map(i => teamName(battle, duelTeams[d.p[i].n.toLowerCase()])),
         ),
-      h('line.a', [h('strong', d.p[0].n), h('span', duelPlayerMeta(d.p[1], ctrl).reverse())]),
-      h('line.b', [h('span', duelPlayerMeta(d.p[0], ctrl)), h('strong', d.p[1].n)]),
+      hl('line.a', [hl('strong', d.p[0].n), hl('span', duelPlayerMeta(d.p[1], ctrl).reverse())]),
+      hl('line.b', [hl('span', duelPlayerMeta(d.p[0], ctrl)), hl('strong', d.p[1].n)]),
     ]);
 }
 
 const initMiniGame = (node: VNode) => initMiniGames(node.elm as HTMLElement);
 
 export default function (ctrl: TournamentController): VNode {
-  return h('div.tour__table', { hook: { insert: initMiniGame, postpatch: initMiniGame } }, [
+  return hl('div.tour__table', { hook: { insert: initMiniGame, postpatch: initMiniGame } }, [
     ctrl.data.featured && featured(ctrl.data.featured, ctrl.opts),
     ctrl.data.duels.length > 0 &&
-      h(
+      hl(
         'section.tour__duels',
         { hook: bind('click', _ => !ctrl.disableClicks) },
-        [h('h2', i18n.site.topGames)].concat(ctrl.data.duels.map(renderDuel(ctrl))),
+        [hl('h2', i18n.site.topGames)].concat(ctrl.data.duels.map(renderDuel(ctrl))),
       ),
   ]);
 }

--- a/ui/voice/src/view.ts
+++ b/ui/voice/src/view.ts
@@ -1,5 +1,5 @@
 import * as licon from 'lib/licon';
-import { onInsert, bind, looseH as h, type VNode } from 'lib/snabbdom';
+import { onInsert, bind, hl, type VNode } from 'lib/snabbdom';
 import { jsonSimple } from 'lib/xhr';
 import { snabDialog, type Dialog } from 'lib/view/dialog';
 import { onClickAway } from 'lib';
@@ -7,29 +7,29 @@ import type { Entry, VoiceCtrl, MsgType } from './interfaces';
 import { supportedLangs } from './voice';
 
 export function renderVoiceBar(ctrl: VoiceCtrl, redraw: () => void, cls?: string): VNode {
-  return h(`div#voice-bar${cls ? '.' + cls : ''}`, [
-    h('div#voice-status-row', [
-      h('button#microphone-button', {
+  return hl(`div#voice-bar${cls ? '.' + cls : ''}`, [
+    hl('div#voice-status-row', [
+      hl('button#microphone-button', {
         hook: onInsert(el => el.addEventListener('click', () => ctrl.toggle())),
       }),
-      h('span#voice-status', {
+      hl('span#voice-status', {
         hook: onInsert(el => ctrl.mic.setController(voiceBarUpdater(ctrl, el))),
       }),
-      h('button#voice-help-button', {
+      hl('button#voice-help-button', {
         attrs: { 'data-icon': licon.InfoCircle, title: 'Voice help' },
         hook: bind('click', () => ctrl.showHelp(true), undefined, false),
       }),
-      h('button#voice-settings-button', {
+      hl('button#voice-settings-button', {
         attrs: { 'data-icon': licon.Gear, title: 'Voice settings' },
         class: { active: ctrl.showPrefs() },
         hook: bind('click', () => ctrl.showPrefs.toggle(), redraw, false),
       }),
     ]),
     ctrl.showPrefs() &&
-      h('div#voice-settings', { hook: onInsert(onClickAway(() => ctrl.showPrefs(false))) }, [
+      hl('div#voice-settings', { hook: onInsert(onClickAway(() => ctrl.showPrefs(false))) }, [
         deviceSelector(ctrl, redraw),
         langSetting(ctrl),
-        ...(ctrl.module()?.prefNodes(redraw) ?? []),
+        ctrl.module()?.prefNodes(redraw),
         pushTalkSetting(ctrl),
       ]),
     ctrl.showHelp() && renderHelpModal(ctrl),
@@ -55,38 +55,36 @@ function voiceBarUpdater(ctrl: VoiceCtrl, el: HTMLElement) {
 }
 
 function pushTalkSetting(ctrl: VoiceCtrl) {
-  return h('div.voice-setting', { attrs: { style: 'align-self: center' } }, [
-    h('div.switch', { attrs: { title: 'Hold the shift key while speaking' } }, [
-      h('input#wake-mode.cmn-toggle', {
+  return hl('div.voice-setting', { attrs: { style: 'align-self: center' } }, [
+    hl('div.switch', { attrs: { title: 'Hold the shift key while speaking' } }, [
+      hl('input#wake-mode.cmn-toggle', {
         attrs: { type: 'checkbox', checked: ctrl.pushTalk() },
         hook: bind('change', e => ctrl.pushTalk((e.target as HTMLInputElement).checked)),
       }),
-      h('label', { attrs: { for: 'wake-mode' } }),
+      hl('label', { attrs: { for: 'wake-mode' } }),
     ]),
-    h('label', { attrs: { for: 'wake-mode' } }, ['Push ', h('strong', 'shift'), ' key to talk']),
+    hl('label', { attrs: { for: 'wake-mode' } }, ['Push ', hl('strong', 'shift'), ' key to talk']),
   ]);
 }
 
 function langSetting(ctrl: VoiceCtrl) {
   return (
     supportedLangs.length > 1 &&
-    h('div.voice-setting', [
-      h('label', { attrs: { for: 'voice-lang' } }, 'Language'),
-      h(
+    hl('div.voice-setting', [
+      hl('label', { attrs: { for: 'voice-lang' } }, 'Language'),
+      hl(
         'select#voice-lang',
         {
           attrs: { name: 'lang' },
           hook: bind('change', e => ctrl.lang((e.target as HTMLSelectElement).value)),
         },
-        [
-          ...supportedLangs.map(l =>
-            h(
-              'option',
-              { attrs: l[0] === ctrl.lang() ? { value: l[0], selected: '' } : { value: l[0] } },
-              l[1],
-            ),
+        supportedLangs.map(l =>
+          hl(
+            'option',
+            { attrs: l[0] === ctrl.lang() ? { value: l[0], selected: '' } : { value: l[0] } },
+            l[1],
           ),
-        ],
+        ),
       ),
     ])
   );
@@ -102,9 +100,9 @@ const nullMic: MediaDeviceInfo = {
 
 let devices: MediaDeviceInfo[] = [nullMic];
 function deviceSelector(ctrl: VoiceCtrl, redraw: () => void) {
-  return h('div.voice-setting', [
-    h('label', { attrs: { for: 'voice-mic' } }, 'Microphone'),
-    h(
+  return hl('div.voice-setting', [
+    hl('label', { attrs: { for: 'voice-mic' } }, 'Microphone'),
+    hl(
       'select#voice-mic',
       {
         hook: onInsert((el: HTMLSelectElement) => {
@@ -116,7 +114,7 @@ function deviceSelector(ctrl: VoiceCtrl, redraw: () => void) {
         }),
       },
       devices.map(d =>
-        h(
+        hl(
           'option',
           {
             attrs: {


### PR DESCRIPTION
- rename `looseH` to `hl`
- convert all the `looseH as h` imports to `hl` (this search and replace is 99% of the PR)
- run strong linter to capture all the nullable numeric expressions used as bools in `hl` renders
- cast all those expressions explicitly to boolean
- allow 0 as a vnode once again and add `number` to the `LooseVNode` type union
- flatten nested child arrays in `hl` so that it's no longer necessary to optionally spread them within renders
- behavior shouldn't change except for relayPlayers.ts - you'll want to look at that closely. scores or ratingDiffs of 0 are no longer stripped, it seemed like a bug that they were but who knows :shrug:
