### PR TITLE
make glyph -+ become −+, for consistency with +−

### DIFF
--- a/ui/lib/src/game/glyphs.ts
+++ b/ui/lib/src/game/glyphs.ts
@@ -132,7 +132,7 @@ const glyphToSvg: Dictionary<string> = {
   ),
 
   // Black is winning
-  '-+': composeGlyph(
+  '−+': composeGlyph(
     '#333',
     '<path d="M 71,27 L 71,73 M 94,50 L 48,50" stroke="#fff" stroke-width="8" fill="none"/><path stroke="#fff" stroke-width="8" fill="none" d="M 40,50 L 4,50"/>',
   ),


### PR DESCRIPTION
https://github.com/lichess-org/lila/blob/d206ee67560df086a4f53d33071781e1a50f3daa/ui/lib/src/game/glyphs.ts#L129-L138

Before this change the study annotations are inconsistent:
![image](https://github.com/user-attachments/assets/ce1f5784-7c06-4189-9254-d99d85d3a85f)
