### PR TITLE
Subscribe to events before creating challenge

### DIFF
--- a/modules/challenge/src/main/ChallengeKeepAliveStream.scala
+++ b/modules/challenge/src/main/ChallengeKeepAliveStream.scala
@@ -1,16 +1,17 @@
 package lila.challenge
 
-import lila.core.challenge.PositiveEvent
 import akka.stream.scaladsl.*
 import play.api.libs.json.*
-
-import lila.common.Bus
 
 final class ChallengeKeepAliveStream(api: ChallengeApi)(using
     ec: Executor,
     scheduler: Scheduler
 ):
-  def apply(challenge: Challenge, initialJson: JsObject): Source[JsValue, ?] =
+  def apply(
+      challenge: Challenge,
+      initialJson: JsObject,
+      challengeResult: Future[String]
+  ): Source[JsValue, ?] =
     Source(List(initialJson)).concat:
       Source
         .queue[JsObject](1, akka.stream.OverflowStrategy.dropHead)
@@ -22,16 +23,9 @@ final class ChallengeKeepAliveStream(api: ChallengeApi)(using
           def completeWith(msg: String) =
             for _ <- queue.offer(Json.obj("done" -> msg)) yield queue.complete()
 
-          val subPositive = Bus.sub[PositiveEvent]:
-            case PositiveEvent.Accept(c, _) if c.id == challenge.id => completeWith("accepted")
-
-          val subNegative = Bus.sub[NegativeEvent]:
-            case NegativeEvent.Decline(c) if c.id == challenge.id => completeWith("declined")
-            case NegativeEvent.Cancel(c) if c.id == challenge.id  => completeWith("canceled")
+          challengeResult.map(completeWith)
 
           queue
             .watchCompletion()
             .addEffectAnyway:
               keepAliveInterval.cancel()
-              Bus.unsub[PositiveEvent](subPositive)
-              Bus.unsub[NegativeEvent](subNegative)


### PR DESCRIPTION
Problem report - https://discord.com/channels/280713822073913354/1377421217601949788

This commit sets up Bus subscriptions before creating a challenge, in the case the API user is using keepAliveStream, to make sure that any quick responses aren't missed.

One way to reproduce the problem of missed events more easy,
is to modify the code by inserting a `Thread.sleep(5000)` after creating the challenge.

https://github.com/lichess-org/lila/blob/218a4dfd/app/controllers/Challenge.scala#L311
```scala
...
env.challenge.api.create(challenge).flatMap {
  Thread.sleep(5000)
  if _ then
...
```

Then create a challenge with the keepAliveStream,
and have the challenged user decline the challenge quickly.
The expected "declined" message won't show up in the ndstream.


Maybe this can/should be implemented in a more "akka"-way,
but that is currently out of my reach...

