### PR TITLE
Subscribe to events before creating challenge

### DIFF
--- a/app/controllers/Challenge.scala
+++ b/app/controllers/Challenge.scala
@@ -4,7 +4,9 @@ import play.api.libs.json.Json
 import play.api.mvc.{ RequestHeader, Result }
 
 import lila.app.{ *, given }
-import lila.challenge.{ Challenge as ChallengeModel, Direction }
+import lila.challenge.{ Challenge as ChallengeModel, Direction, NegativeEvent }
+import lila.common.Bus
+import lila.core.challenge.PositiveEvent
 import lila.core.id.ChallengeId
 import lila.core.net.Bearer
 import lila.game.AnonCookie
@@ -307,6 +309,24 @@ final class Challenge(env: Env) extends LilaController(env):
                                     JsonBadRequest:
                                       jsonError(lila.challenge.ChallengeDenied.translated(denied))
                                 case _ =>
+
+                                  val challengeResponse = Promise[String]
+
+                                  if config.keepAliveStream then
+                                    val subPositive = Bus.sub[PositiveEvent]:
+                                      case PositiveEvent.Accept(c, _) if c.id == challenge.id =>
+                                        challengeResponse.success("accepted")
+
+                                    val subNegative = Bus.sub[NegativeEvent]:
+                                      case NegativeEvent.Decline(c) if c.id == challenge.id =>
+                                        challengeResponse.success("declined")
+                                      case NegativeEvent.Cancel(c) if c.id == challenge.id =>
+                                        challengeResponse.success("canceled")
+
+                                    challengeResponse.future.onComplete: _ =>
+                                      Bus.unsub[PositiveEvent](subPositive)
+                                      Bus.unsub[NegativeEvent](subNegative)
+
                                   env.challenge.api.create(challenge).flatMap {
                                     if _ then
                                       ctx.isMobileOauth
@@ -321,9 +341,19 @@ final class Challenge(env: Env) extends LilaController(env):
                                           if config.keepAliveStream then
                                             jsOptToNdJson:
                                               ndJson
-                                                .addKeepAlive(env.challenge.keepAliveStream(challenge, json))
+                                                .addKeepAlive(
+                                                  env.challenge.keepAliveStream(
+                                                    challenge,
+                                                    json,
+                                                    challengeResponse
+                                                  )
+                                                )
                                           else JsonOk(json)
-                                    else JsonBadRequest(jsonError("Challenge not created")).toFuccess
+                                    else
+                                      if config.keepAliveStream then
+                                        // trigger unsubscribe
+                                        challengeResponse.success("Challenge not created")
+                                      JsonBadRequest(jsonError("Challenge not created")).toFuccess
                                   }
                             yield res
               }


### PR DESCRIPTION
Problem report - https://discord.com/channels/280713822073913354/1377421217601949788

This commit sets up Bus subscriptions before creating a challenge, in the case the API user is using keepAliveStream, to make sure that any quick responses aren't missed.

One way to reproduce the problem of missed events more easy,
is to modify the code by inserting a `Thread.sleep(5000)` after creating the challenge.

https://github.com/lichess-org/lila/blob/218a4dfd/app/controllers/Challenge.scala#L311
```scala
...
env.challenge.api.create(challenge).flatMap {
  Thread.sleep(5000)
  if _ then
...
```

Then create a challenge with the keepAliveStream,
and have the challenged user decline the challenge quickly.
The expected "declined" message won't show up in the ndstream.


Maybe this can/should be implemented in a more "akka"-way,
but that is currently out of my reach...

(Closed previous PR https://github.com/lichess-org/lila/pull/17796 because test system was acting up, but that was because of the recent header checks in lila-ws which seems to not play nicely with my test system - so using lichess-org/lila-ws@d4154d0d3e
Compared with previous PR, this has an additional cleanup trigger in case challenger closes stream before challanged user responds)
