### PR TITLE
Maintain flipped board orientation in puzzles when cancelling premove

### DIFF
--- a/ui/puzzle/src/ctrl.ts
+++ b/ui/puzzle/src/ctrl.ts
@@ -76,6 +76,7 @@ export default class PuzzleCtrl implements ParentCtrl {
   voteDisabled?: boolean;
   isDaily: boolean;
   blindfolded: StoredProp<boolean>;
+  cgVersion = 1;
   private report: Report;
 
   constructor(
@@ -636,6 +637,7 @@ export default class PuzzleCtrl implements ParentCtrl {
 
   flip = () => {
     this.flipped.toggle();
+    this.cgVersion++;
     this.withGround(g => g.toggleOrientation());
     this.redraw();
   };

--- a/ui/puzzle/src/view/chessground.ts
+++ b/ui/puzzle/src/view/chessground.ts
@@ -6,7 +6,7 @@ import { storage } from 'lib/storage';
 import { Chessground as makeChessground } from '@lichess-org/chessground';
 
 export default function (ctrl: PuzzleCtrl): VNode {
-  return h('div.cg-wrap', {
+  return h('div.cg-wrap.cgv' + ctrl.cgVersion, {
     hook: {
       insert: vnode => ctrl.setChessground(makeChessground(vnode.elm as HTMLElement, makeConfig(ctrl))),
       destroy: () => ctrl.ground().destroy(),


### PR DESCRIPTION
Fixes #17180.

I think this should be the clean way to fix this bug? When I compared the puzzle UI to the analysis UI (the latter of which did not have this bug), the cgVersion approach seems to be the key to why the behavior is different.

(Note: I noticed that, generally speaking, flipped state is also maintained between puzzles - which was not what I expected but perhaps it is intended behavior. This patch does not seem to affect that so on that aspect it keeps things as they are.)