### PR TITLE
Add a link to blind mode tutorial

### DIFF
--- a/modules/web/src/main/ui/layout.scala
+++ b/modules/web/src/main/ui/layout.scala
@@ -115,7 +115,9 @@ final class layout(helpers: Helpers, assetHelper: lila.web.ui.AssetFullHelper)(
       }"><input type="hidden" name="redirect" value="${ctx.req.path}"><button type="submit">${trans.site.accessibility
         .txt()} - ${
         if ctx.blind then trans.site.disableBlindMode.txt() else trans.site.enableBlindMode.txt()
-      } </button>&nbsp;-&nbsp;${a(href := "https://lichess.org/page/blind-mode-tutorial")("Blind mode tutorial")}</form>"""
+      } </button>&nbsp;-&nbsp;${a(href := "https://lichess.org/page/blind-mode-tutorial")(
+        "Blind mode tutorial"
+      )}</form>"""
 
   def zenZone(using Translate) = spaceless:
     s"""

--- a/modules/web/src/main/ui/layout.scala
+++ b/modules/web/src/main/ui/layout.scala
@@ -115,12 +115,12 @@ final class layout(helpers: Helpers, assetHelper: lila.web.ui.AssetFullHelper)(
       }"><input type="hidden" name="redirect" value="${ctx.req.path}"><button type="submit">${trans.site.accessibility
         .txt()} - ${
         if ctx.blind then trans.site.disableBlindMode.txt() else trans.site.enableBlindMode.txt()
-      } </button></form>"""
+      } </button>&nbsp;-&nbsp;${a(href := "https://lichess.org/page/blind-mode-tutorial")("Blind mode tutorial")}</form>"""
 
   def zenZone(using Translate) = spaceless:
     s"""
 <div id="zenzone">
-  <a href="/" class="zen-home"></a>
+  <a href="/" class="zen-home"></a>}
   <a data-icon="${Icon.Checkmark}" id="zentog" class="text fbt active">${trans.preferences.zenMode
         .txt()}</a>
 </div>"""

--- a/modules/web/src/main/ui/layout.scala
+++ b/modules/web/src/main/ui/layout.scala
@@ -122,7 +122,7 @@ final class layout(helpers: Helpers, assetHelper: lila.web.ui.AssetFullHelper)(
   def zenZone(using Translate) = spaceless:
     s"""
 <div id="zenzone">
-  <a href="/" class="zen-home"></a>}
+  <a href="/" class="zen-home"></a>
   <a data-icon="${Icon.Checkmark}" id="zentog" class="text fbt active">${trans.preferences.zenMode
         .txt()}</a>
 </div>"""


### PR DESCRIPTION
The link can be found by a new visitor and be skipped easily by a returning user.

Here is the new user experience with a link:

- New visitor opens lichess.org (with a screen reader)
NVDA start reading ...
- Control Home to go to the beginning of the page
NVDA announces

> button    button    Accessibility - Enable blind mode    -   link    Blind mode tutorial

- type k (for link)

NVDA announces

> Blind mode tutorial  visited  link  

- Hit enter and read the tutorial
 
Note: new link does not change the Enable/Disable Accessibility button behaviour

If accessibility is disabled, just go to the top of the page (control home) and hit enter