### PR TITLE
fix disclosure persistence bugs

### DIFF
--- a/ui/analyse/src/idbTree.ts
+++ b/ui/analyse/src/idbTree.ts
@@ -126,11 +126,12 @@ export class IdbTree {
   private isCollapsible(node: Tree.Node, isMainline: boolean): boolean {
     if (this.noCollapse || !node) return false;
     const { tree, treeView, showComputer } = this.ctrl;
-    if (node === tree.root && treeView.inline()) return false;
+    //if (node === tree.root && treeView.inline()) return false;
     const [main, second, third] = node.children.filter(x => showComputer() || !x.comp);
     return Boolean(
       third ||
         (main && Boolean(main.comments?.length) && isMainline && !treeView.inline()) ||
+        (main && main.forceVariation && treeView.inline()) ||
         (second && ((isMainline && !treeView.inline()) || hasBranching(second, 6))),
     );
   }

--- a/ui/analyse/src/treeView/columnView.ts
+++ b/ui/analyse/src/treeView/columnView.ts
@@ -38,10 +38,8 @@ interface Ctx extends BaseCtx {
 }
 
 interface Opts extends BaseOpts {
-  isMainline: boolean;
   conceal?: Conceal;
   noConceal?: boolean;
-  branch?: Tree.Node;
 }
 
 function renderSubtree(ctx: Ctx, node: Tree.Node, opts: Opts): LooseVNodes {

--- a/ui/analyse/src/treeView/columnView.ts
+++ b/ui/analyse/src/treeView/columnView.ts
@@ -97,17 +97,17 @@ function renderMainlineDescendantsOf(
     ];
   }
   const stdOpts: Opts = { parentPath, conceal, isMainline: true };
-  const commentTags = renderMainlineCommentsOf(ctx, main, conceal, true, path).filter(Boolean);
+  const comments = renderMainlineCommentsOf(ctx, main, conceal, true, path).filter(Boolean);
   return [
     isWhite && renderIndex(main.ply, false),
-    isEmpty(variations) && isEmpty(commentTags)
+    isEmpty(variations) && isEmpty(comments)
       ? renderSubtree(ctx, main, stdOpts)
       : [
           renderMove(ctx, main, { ...stdOpts, branch: disclose ? parent : undefined }),
           disclose !== 'collapsed' && [
             isWhite && emptyMove(conceal),
             hl('interrupt', { class: { anchor: disclose === 'expanded' } }, [
-              commentTags,
+              comments,
               renderLines(ctx, variations, {
                 ...stdOpts,
                 noConceal: !conceal,

--- a/ui/analyse/src/treeView/components.ts
+++ b/ui/analyse/src/treeView/components.ts
@@ -12,12 +12,17 @@ import { playable } from 'lib/game/game';
 import { PlusButton, MinusButton } from 'lib/licon';
 import { fixCrazySan, plyToTurn } from 'lib/game/chess';
 import { view as cevalView, renderEval as normalizeEval } from 'lib/ceval/ceval';
+import type { ConcealOf, Conceal } from '../interfaces';
 
 export interface Opts {
+  isMainline: boolean;
   parentPath: Tree.Path;
   inline?: Tree.Node;
   withIndex?: boolean;
   anchor?: 'interrupt' | 'lines' | false;
+  branch?: Tree.Node;
+  conceal?: Conceal; // <- TODO
+  noConceal?: boolean; // <- TODO
 }
 
 export interface Ctx extends MoveCtx {
@@ -25,6 +30,7 @@ export interface Ctx extends MoveCtx {
   showComputer: boolean;
   truncateComments: boolean;
   currentPath: Tree.Path | undefined;
+  concealOf?: ConcealOf;
 }
 
 export function mainHook(ctrl: AnalyseCtrl): Hooks {
@@ -37,8 +43,8 @@ export function mainHook(ctrl: AnalyseCtrl): Hooks {
         ctrl.redraw();
         return false;
       };
-      el.oncontextmenu = ctxMenuCallback;
-      if (isTouchDevice()) el.ondblclick = ctxMenuCallback; // long press horribad
+      //el.oncontextmenu = ctxMenuCallback;
+      /*if (isTouchDevice())*/ el.ondblclick = ctxMenuCallback; // long press horribad
       bindMobileTapHold(el, ctxMenuCallback, ctrl.redraw);
 
       el.addEventListener('mousedown', (e: MouseEvent) => {

--- a/ui/analyse/src/treeView/contextMenu.ts
+++ b/ui/analyse/src/treeView/contextMenu.ts
@@ -94,7 +94,7 @@ function view({ root: ctrl, path }: Opts, coords: Coords): VNode {
     inline = treeView.inline(),
     expand = inline || !onMainline ? path : path.slice(0, -2),
     collapse = idbTree.getCollapseTarget(expand);
-  console.log(expand, collapse, onMainline);
+
   return hl(
     'div#' + elementId + '.visible',
     {

--- a/ui/analyse/src/treeView/inlineView.ts
+++ b/ui/analyse/src/treeView/inlineView.ts
@@ -1,59 +1,139 @@
-import { hl, type VNode, type LooseVNodes } from 'lib/snabbdom';
+import { isEmpty } from 'lib';
+import { type VNode, type LooseVNode, type LooseVNodes, hl } from 'lib/snabbdom';
 import { ops as treeOps } from 'lib/tree/tree';
 import type AnalyseCtrl from '../ctrl';
 import {
+  type Ctx,
+  type Opts,
+  moveNodes,
+  nodeClasses,
   renderInlineCommentsOf,
   renderInlineMove,
   retroLine,
-  Ctx,
-  Opts,
+  renderIndex,
   renderingCtx,
+  disclosureBtn,
   disclosureConnector,
   showConnector,
 } from './components';
 
 export function renderInlineView(ctrl: AnalyseCtrl): VNode {
-  const ctx = renderingCtx(ctrl);
-  ctrl.tree.root.collapsed = false;
+  const ctx: Ctx = { ...renderingCtx(ctrl) };
+  ctx.ctrl.tree.root.collapsed = false;
   return hl('div.tview2.tview2-inline', { class: { hidden: ctrl.treeView.hidden } }, [
     renderInlineCommentsOf(ctx, ctrl.tree.root, ''),
-    renderDescendantsOf(ctx, ctrl.tree.root, { parentPath: '' }),
+    renderDescendantsOf(ctx, ctrl.tree.root, { parentPath: '', isMainline: true }),
   ]);
 }
 
-function renderDescendantsOf(ctx: Ctx, parent: Tree.Node, opts: Opts): LooseVNodes {
-  const { parentPath, anchor } = opts;
-  const kids = parent.children.filter(x => ctx.showComputer || !x.comp);
-  if (kids.length === 0) return;
-  const [main, second, third] = kids;
+function renderSubtree(ctx: Ctx, node: Tree.Node, opts: Opts): LooseVNodes {
+  const { parentPath, isMainline } = opts;
+  const path = parentPath + node.id;
+  const disclose = ctx.ctrl.idbTree.discloseOf(node, isMainline);
+  const comments = /*disclose !== 'collapsed' &&*/ renderInlineCommentsOf(ctx, node, path);
+  return [
+    renderMove(ctx, node, opts),
+    comments,
+    opts.inline &&
+      hl('inline', renderSubtree(ctx, opts.inline, { parentPath, withIndex: true, isMainline: false })),
+    renderDescendantsOf(ctx, node, {
+      parentPath: path,
+      isMainline,
+      anchor: disclose === 'expanded' && showConnector(comments) && 'lines',
+    }),
+  ];
+}
 
+function renderDescendantsOf(ctx: Ctx, parent: Tree.Node, opts: Opts): LooseVNodes {
+  const filteredKids = parent.children.filter(x => ctx.showComputer || !x.comp);
+  if (filteredKids.length === 0) return;
+  else if (opts.isMainline) return renderMainlineDescendantsOf(ctx, parent, filteredKids, opts);
+  else return renderVariationDescendantsOf(ctx, parent, filteredKids, opts);
+}
+
+function renderMainlineDescendantsOf(
+  ctx: Ctx,
+  parent: Tree.Node,
+  [main, ...variations]: Tree.Node[],
+  opts: Opts,
+): LooseVNodes {
+  const { parentPath } = opts;
+  const path = parentPath + main.id;
+  const disclose = ctx.ctrl.idbTree.discloseOf(parent, !main.forceVariation);
+  if (main.forceVariation) {
+    return [
+      disclose !== 'collapsed' &&
+        hl('interrupt', renderLines(ctx, [main, ...variations], { ...opts, isMainline: false })),
+    ];
+  }
+  const stdOpts: Opts = { parentPath, isMainline: true };
+  const commentTags = renderInlineCommentsOf(ctx, main, path).filter(Boolean); // ??
+  const interrupt = (nodes: LooseVNodes) => (disclose === 'expanded' ? hl('interrupt', nodes) : nodes);
+  return [
+    !disclose
+      ? [
+          renderMove(ctx, main, { ...stdOpts }),
+          commentTags,
+          renderDescendantsOf(ctx, main, { ...stdOpts, parentPath: path }),
+        ]
+      : [
+          renderMove(ctx, main, { ...stdOpts, branch: disclose ? parent : undefined }),
+          disclose !== 'collapsed' && [
+            commentTags,
+            interrupt([
+              renderLines(ctx, variations, {
+                ...stdOpts,
+                anchor: disclose === 'expanded' ? 'lines' : undefined, // TODO 'interrupt' : undefined,
+              }),
+            ]),
+          ],
+          renderDescendantsOf(ctx, main, { ...stdOpts, parentPath: path }),
+        ],
+  ];
+}
+
+function renderVariationDescendantsOf(
+  ctx: Ctx,
+  parent: Tree.Node,
+  kids: Tree.Node[],
+  opts: Opts,
+): LooseVNodes {
+  const [main, second, third] = kids;
   if (second && !third && !treeOps.hasBranching(second, 6))
     return renderSubtree(ctx, main, { ...opts, inline: second });
   else if ((main && !second) || ctx.ctrl.idbTree.discloseOf(parent) === 'collapsed')
     return renderSubtree(ctx, main, opts);
-  else
-    return hl('lines', { class: { anchor: anchor === 'lines' } }, [
-      anchor && disclosureConnector(),
-      kids.map(
-        n =>
-          retroLine(ctx, n) ||
-          hl('line', [hl('branch'), renderSubtree(ctx, n, { parentPath, withIndex: true })]),
-      ),
-    ]);
+  else return renderLines(ctx, kids, opts);
 }
 
-function renderSubtree(ctx: Ctx, node: Tree.Node, opts: Opts): LooseVNodes {
-  const { parentPath, inline } = opts;
-  const disclose = ctx.ctrl.idbTree.discloseOf(node);
-  const path = parentPath + node.id;
-  const comments = disclose !== 'collapsed' && renderInlineCommentsOf(ctx, node, path);
-  return [
-    renderInlineMove(ctx, node, opts),
-    comments,
-    inline && hl('inline', renderSubtree(ctx, inline, { parentPath, withIndex: true })),
-    renderDescendantsOf(ctx, node, {
-      parentPath: path,
-      anchor: disclose === 'expanded' && showConnector(comments) && 'lines',
-    }),
-  ];
+function renderLines(ctx: Ctx, nodes: Tree.Node[], opts: Opts): LooseVNodes {
+  const { parentPath, noConceal, anchor } = opts;
+  return hl('lines', { class: { anchor: anchor === 'lines', single: nodes.length === 1 } }, [
+    anchor && disclosureConnector(),
+    nodes.map(
+      n =>
+        retroLine(ctx, n) ||
+        hl('line', [
+          hl('branch'),
+          renderSubtree(ctx, n, { parentPath, isMainline: false, withIndex: true, noConceal }),
+        ]),
+    ),
+  ]);
+}
+
+function renderMove(ctx: Ctx, node: Tree.Node, opts: Opts): VNode {
+  const { isMainline, conceal, branch, parentPath } = opts;
+  const p = parentPath + node.id;
+  const classes = nodeClasses(ctx, node, p);
+  return isMainline
+    ? hl('move', { attrs: { p }, class: classes }, [
+        branch && disclosureBtn(ctx, branch, parentPath),
+        (opts.withIndex || node.ply % 2 === 1) && renderIndex(node.ply, true),
+        moveNodes(ctx, node, opts.isMainline),
+      ])
+    : hl('move', { attrs: { p }, class: classes }, [
+        (opts.withIndex || node.ply % 2 === 1) && renderIndex(node.ply, true),
+        moveNodes(ctx, node, false),
+        ctx.ctrl.idbTree.discloseOf(node) && disclosureBtn(ctx, node, p),
+      ]);
 }

--- a/ui/analyse/src/view/components.ts
+++ b/ui/analyse/src/view/components.ts
@@ -374,10 +374,7 @@ export function renderResult(ctrl: AnalyseCtrl): VNode[] {
 
 const renderMoveList = (ctrl: AnalyseCtrl, deps?: typeof studyDeps, concealOf?: ConcealOf): VNode =>
   hl('div.analyse__moves.areplay', { hook: mainHook(ctrl) }, [
-    hl(`div.areplay__v${ctrl.treeView.version}`, { classes: { hidden: ctrl.treeView.hidden } }, [
-      renderTreeView(ctrl, concealOf),
-      renderResult(ctrl),
-    ]),
+    hl(`div.areplay__v${ctrl.treeView.version}`, [renderTreeView(ctrl, concealOf), renderResult(ctrl)]),
     !ctrl.practice && !deps?.gbEdit.running(ctrl) && renderNextChapter(ctrl),
   ]);
 

--- a/ui/lib/css/tree/_tree.scss
+++ b/ui/lib/css/tree/_tree.scss
@@ -274,7 +274,8 @@
 
   move {
     @extend %box-radius;
-    font-size: 13px;
+    font-size: 13.5px;
+    font-weight: bold;
   }
   move index {
     padding-inline-end: 0.2em;
@@ -292,7 +293,7 @@
   }
 }
 
-.tview2-inline > .disclosure,
+.tview2-inline .disclosure,
 .tview2-column > move > .disclosure {
   align-self: center;
   @include padding-direction(0, 4px, 0, 0);

--- a/ui/lib/css/tree/_tree.scss
+++ b/ui/lib/css/tree/_tree.scss
@@ -275,7 +275,10 @@
   move {
     @extend %box-radius;
     font-size: 13.5px;
-    font-weight: bold;
+    &.m {
+      //color: color-mix(in srgb, var(--base) 70%, $c-secondary);
+      font-weight: bold;
+    }
   }
   move index {
     padding-inline-end: 0.2em;
@@ -291,6 +294,11 @@
   inline::after {
     vertical-align: 0.7em;
   }
+}
+
+.tview2-inline interrupt + move:has(.disclosure),
+.tview2-inline lines + move:has(.disclosure) {
+  margin-inline-start: -10px;
 }
 
 .tview2-inline .disclosure,


### PR DESCRIPTION
- fix flashing of expanded tree before stored collapse state is applied. seen on page loads and chapter switches
- don't apply disclosure state from a previous chapter to the current one (i picked the wrong chapter id)
- add a way for chessvision.ai, lichess tools, and anyone else to disable disclosure controls via local storage key
- refacterz