### PR TITLE
fix: table background color does not display properly when user has a long name

### DIFF
--- a/modules/tournament/src/main/ui/UserTournament.scala
+++ b/modules/tournament/src/main/ui/UserTournament.scala
@@ -188,5 +188,5 @@ final class UserTournament(helpers: Helpers, ui: TournamentUi):
               trans.site.stats()
             )
           ),
-          div(cls := "page-menu__tournament box")(body)
+          div(cls := "page-menu__content box")(body)
         )

--- a/modules/tournament/src/main/ui/UserTournament.scala
+++ b/modules/tournament/src/main/ui/UserTournament.scala
@@ -188,5 +188,5 @@ final class UserTournament(helpers: Helpers, ui: TournamentUi):
               trans.site.stats()
             )
           ),
-          div(cls := "page-menu__content box")(body)
+          div(cls := "page-menu__tournament box")(body)
         )

--- a/ui/lib/css/layout/_page-menu.scss
+++ b/ui/lib/css/layout/_page-menu.scss
@@ -24,6 +24,11 @@
     min-width: 0;
   }
 
+  &__tournament {
+    grid-area: content;
+    height: 100%;
+  }
+
   &__content.box {
     /* ensure the content is as high as the menu */
     min-height: 100%;

--- a/ui/lib/css/layout/_page-menu.scss
+++ b/ui/lib/css/layout/_page-menu.scss
@@ -21,12 +21,6 @@
   &__content {
     grid-area: content;
     height: 100%;
-    min-width: 0;
-  }
-
-  &__tournament {
-    grid-area: content;
-    height: 100%;
   }
 
   &__content.box {


### PR DESCRIPTION
closes #17680 

created a new css class because the class `page-menu__content` is used throughout the codebase and changing it might break things for other pages copied the original class and removed the min-width property