### PR TITLE
fix: ensure clear button only renders when filters are present

### DIFF
--- a/ui/insight/src/view.ts
+++ b/ui/insight/src/view.ts
@@ -89,7 +89,7 @@ function landscapeView(ctrl: Ctrl) {
         hl('div.panel-tabs', [
           hl('a.tab.preset', panelTabData(ctrl, 'preset'), 'Presets'),
           hl('a.tab.filter', panelTabData(ctrl, 'filter'), 'Filters'),
-          Object.keys(ctrl.vm.filters).length && clearBtn(ctrl),
+          !!Object.keys(ctrl.vm.filters).length && clearBtn(ctrl),
         ]),
         ctrl.vm.panel === 'filter' && filters(ctrl),
         ctrl.vm.panel === 'preset' && presets(ctrl),


### PR DESCRIPTION
fix https://github.com/lichess-org/lila/issues/17813