### PR TITLE
nvui - improve forum navigation

### DIFF
--- a/modules/forum/src/main/ui/PostUi.scala
+++ b/modules/forum/src/main/ui/PostUi.scala
@@ -23,6 +23,7 @@ final class PostUi(helpers: Helpers, bits: ForumBits):
         div(cls := "forum-post__metas")(
           (!post.erased || canModCateg).option(
             div(
+              ctx.blind.option(h2(a(cls := "anchor", href := url)(s"Post ${post.number}"))),
               bits.authorLink(
                 post = post,
                 cssClass = s"author${(topic.userId == post.userId).so(" author--op")}".some
@@ -96,7 +97,7 @@ final class PostUi(helpers: Helpers, bits: ForumBits):
               )
             )
           ),
-          a(cls := "anchor", href := url)(s"#${post.number}")
+          if !ctx.blind then a(cls := "anchor", href := url)(s"#${post.number}")
         ),
         frag:
           val postFrag = div(cls := s"forum-post__message expand-text")(


### PR DESCRIPTION
At the moment, to discover forum posts, blind users rely on the links.

In details:
- Forum title is heading level 1 (good)
- Reply to this topic is heading level 2 (good)
- The rest is a mixture of links and plain text (bad)
The article element used for posts is not discoverable as a landmark because it is nested in the main landmark (screen readers don't support that)

Solution:
move the anchor #n to the beginning of the post and make it a heading level 2

That way, blind mode users can find and skip posts easily using h



<img width="2074" height="1468" alt="image" src="https://github.com/user-attachments/assets/80a11af1-16fa-4ad6-bf01-17ffea2710fe" />

instead of 

<img width="2180" height="1432" alt="image" src="https://github.com/user-attachments/assets/6eca60bd-6fb4-4dd0-9ab8-95b61e1942bd" />
