### PR TITLE
fix: remove light mode button text shadow in blog

### DIFF
--- a/ui/bits/css/ublog/_ublog.scss
+++ b/ui/bits/css/ublog/_ublog.scss
@@ -189,6 +189,7 @@
       color: #fff;
       background: $m-primary--fade-10;
       border-color: $m-primary--fade-50;
+      text-shadow: none;
     }
   }
 }


### PR DESCRIPTION
fix https://github.com/lichess-org/lila/issues/17854

or is it safe to remove from `_btn-rack.scss`

https://github.com/lichess-org/lila/blob/adffe38350dd8af363868dd9daab06db6202f7c9/ui/lib/css/component/_btn-rack.scss#L16

https://github.com/lichess-org/lila/blob/adffe38350dd8af363868dd9daab06db6202f7c9/ui/lib/css/component/_btn-rack.scss#L27