### PR TITLE
Add API claim-draw for disconnected opponents

### DIFF
--- a/app/controllers/PlayApi.scala
+++ b/app/controllers/PlayApi.scala
@@ -95,6 +95,9 @@ final class PlayApi(env: Env) extends LilaController(env):
         case Array("game", id, "claim-victory") =>
           as(GameAnyId(id).gameId): pov =>
             env.bot.player.claimVictory(pov).pipe(toResult)
+        case Array("game", id, "claim-draw") =>
+          as(GameAnyId(id).gameId): pov =>
+            env.bot.player.claimDraw(pov).pipe(toResult)
         case Array("game", id, "berserk") =>
           as(GameAnyId(id).gameId): pov =>
             if !me.isBot && env.bot.player.berserk(pov.game) then jsonOkResult

--- a/modules/bot/src/main/BotPlayer.scala
+++ b/modules/bot/src/main/BotPlayer.scala
@@ -102,6 +102,18 @@ final class BotPlayer(
             if _ then funit
             else clientError("You cannot claim the win on this game")
 
+  def claimDraw(pov: Pov): Funit =
+    pov.game.drawable.so:
+      tellRound(pov.gameId, RoundBus.DrawClaimForce(pov.playerId))
+      lila.common.LilaFuture.delay(500.millis):
+        gameRepo
+          .finished(pov.gameId)
+          .map:
+            _.exists(_.drawn)
+          .flatMap:
+            if _ then funit
+            else clientError("You cannot claim draw on this game")
+
   def berserk(game: Game)(using me: Me): Boolean =
     game.berserkable.so:
       Bus.pub(Berserk(game.id, me))

--- a/modules/bot/src/main/BotPlayer.scala
+++ b/modules/bot/src/main/BotPlayer.scala
@@ -92,27 +92,26 @@ final class BotPlayer(
 
   def claimVictory(pov: Pov): Funit =
     pov.mightClaimWin.so:
-      tellRound(pov.gameId, RoundBus.ResignForce(pov.playerId))
-      lila.common.LilaFuture.delay(500.millis):
-        gameRepo
-          .finished(pov.gameId)
-          .map:
-            _.exists(_.winner.map(_.id).has(pov.playerId))
-          .flatMap:
-            if _ then funit
-            else clientError("You cannot claim the win on this game")
+      finishRoundThenFetchGame(pov, RoundBus.ResignForce(pov.playerId))
+        .map:
+          _.exists(_.winner.map(_.id).has(pov.playerId))
+        .flatMap:
+          if _ then funit
+          else clientError("You cannot claim the win on this game")
 
   def claimDraw(pov: Pov): Funit =
     pov.game.drawable.so:
-      tellRound(pov.gameId, RoundBus.DrawClaimForce(pov.playerId))
-      lila.common.LilaFuture.delay(500.millis):
-        gameRepo
-          .finished(pov.gameId)
-          .map:
-            _.exists(_.drawn)
-          .flatMap:
-            if _ then funit
-            else clientError("You cannot claim draw on this game")
+      finishRoundThenFetchGame(pov, RoundBus.DrawForce(pov.playerId))
+        .map:
+          _.exists(_.drawn)
+        .flatMap:
+          if _ then funit
+          else clientError("You cannot claim draw on this game")
+
+  private def finishRoundThenFetchGame(pov: Pov, event: RoundBus): Fu[Option[Game]] =
+    tellRound(pov.gameId, event)
+    lila.common.LilaFuture.delay(500.millis):
+      gameRepo.finished(pov.gameId)
 
   def berserk(game: Game)(using me: Me): Boolean =
     game.berserkable.so:

--- a/modules/core/src/main/round.scala
+++ b/modules/core/src/main/round.scala
@@ -28,6 +28,7 @@ enum RoundBus extends NotBuseable:
   case Resign(playerId: GamePlayerId)
   case ResignForce(playerId: GamePlayerId)
   case Takeback(playerId: GamePlayerId, takeback: Boolean)
+  case DrawClaimForce(playerId: GamePlayerId)
 
 case class Tell(id: GameId, msg: RoundBus)
 case class TellMany(ids: Seq[GameId], msg: StartClock.type | RoundBus.QuietFlag.type)

--- a/modules/core/src/main/round.scala
+++ b/modules/core/src/main/round.scala
@@ -27,8 +27,8 @@ enum RoundBus extends NotBuseable:
   case Rematch(playerId: GamePlayerId, rematch: Boolean)
   case Resign(playerId: GamePlayerId)
   case ResignForce(playerId: GamePlayerId)
+  case DrawForce(playerId: GamePlayerId)
   case Takeback(playerId: GamePlayerId, takeback: Boolean)
-  case DrawClaimForce(playerId: GamePlayerId)
 
 case class Tell(id: GameId, msg: RoundBus)
 case class TellMany(ids: Seq[GameId], msg: StartClock.type | RoundBus.QuietFlag.type)
@@ -60,7 +60,6 @@ case class SocketExists(gameId: GameId, promise: Promise[Boolean])
 
 case object Threefold
 case object ResignAi
-case class DrawForce(playerId: GamePlayerId)
 case class DrawClaim(playerId: GamePlayerId)
 case class Blindfold(playerId: GamePlayerId, blindfold: Boolean)
 object Moretime:

--- a/modules/round/src/main/RoundAsyncActor.scala
+++ b/modules/round/src/main/RoundAsyncActor.scala
@@ -269,6 +269,13 @@ final private class RoundAsyncActor(
           else finisher.other(game, _.Resign, Some(!game.player.color))
 
     case RoundBus.Draw(playerId, draw) => handle(playerId)(drawer(_, draw))
+    case RoundBus.DrawClaimForce(playerId)  =>
+      handle(playerId): pov =>
+        (pov.game.forceDrawable && !pov.game.hasAi && pov.game.hasClock && !pov.isMyTurn).so:
+          getPlayer(!pov.color).isLongGone.flatMap:
+            if _ then drawer.force(pov.game)
+            else fuccess(List(Event.Reload))
+
     case DrawClaim(playerId)           => handle(playerId)(drawer.claim)
     case Cheat(color)                  =>
       handle: game =>

--- a/modules/round/src/main/RoundAsyncActor.scala
+++ b/modules/round/src/main/RoundAsyncActor.scala
@@ -237,9 +237,9 @@ final private class RoundAsyncActor(
               )
             else fuccess(List(Event.Reload))
 
-    case DrawForce(playerId) =>
+    case RoundBus.DrawForce(playerId) =>
       handle(playerId): pov =>
-        (pov.game.forceDrawable && !pov.game.hasAi && pov.game.hasClock && !pov.isMyTurn).so:
+        (pov.game.forceDrawable && pov.game.hasClock && !pov.isMyTurn).so:
           getPlayer(!pov.color).isLongGone.flatMap:
             if _ then finisher.rageQuit(pov.game, None)
             else fuccess(List(Event.Reload))
@@ -268,13 +268,7 @@ final private class RoundAsyncActor(
           if game.abortable then finisher.other(game, _.Aborted, None)
           else finisher.other(game, _.Resign, Some(!game.player.color))
 
-    case RoundBus.Draw(playerId, draw)     => handle(playerId)(drawer(_, draw))
-    case RoundBus.DrawClaimForce(playerId) =>
-      handle(playerId): pov =>
-        (pov.game.forceDrawable && !pov.game.hasAi && pov.game.hasClock && !pov.isMyTurn).so:
-          getPlayer(!pov.color).isLongGone.flatMap:
-            if _ then drawer.force(pov.game)
-            else fuccess(List(Event.Reload))
+    case RoundBus.Draw(playerId, draw) => handle(playerId)(drawer(_, draw))
 
     case DrawClaim(playerId) => handle(playerId)(drawer.claim)
     case Cheat(color)        =>

--- a/modules/round/src/main/RoundAsyncActor.scala
+++ b/modules/round/src/main/RoundAsyncActor.scala
@@ -268,16 +268,16 @@ final private class RoundAsyncActor(
           if game.abortable then finisher.other(game, _.Aborted, None)
           else finisher.other(game, _.Resign, Some(!game.player.color))
 
-    case RoundBus.Draw(playerId, draw) => handle(playerId)(drawer(_, draw))
-    case RoundBus.DrawClaimForce(playerId)  =>
+    case RoundBus.Draw(playerId, draw)     => handle(playerId)(drawer(_, draw))
+    case RoundBus.DrawClaimForce(playerId) =>
       handle(playerId): pov =>
         (pov.game.forceDrawable && !pov.game.hasAi && pov.game.hasClock && !pov.isMyTurn).so:
           getPlayer(!pov.color).isLongGone.flatMap:
             if _ then drawer.force(pov.game)
             else fuccess(List(Event.Reload))
 
-    case DrawClaim(playerId)           => handle(playerId)(drawer.claim)
-    case Cheat(color)                  =>
+    case DrawClaim(playerId) => handle(playerId)(drawer.claim)
+    case Cheat(color)        =>
       handle: game =>
         (game.playable && !game.sourceIs(_.Import)).so:
           finisher.other(game, _.Cheat, Some(!color))

--- a/modules/round/src/main/RoundSocket.scala
+++ b/modules/round/src/main/RoundSocket.scala
@@ -117,7 +117,7 @@ final class RoundSocket(
         case "resign-force"  => forward(RoundBus.ResignForce(_))
         case "blindfold-yes" => forward(Blindfold(_, true))
         case "blindfold-no"  => forward(Blindfold(_, false))
-        case "draw-force"    => forward(DrawForce(_))
+        case "draw-force"    => forward(RoundBus.DrawForce(_))
         case "abort"         => forward(RoundBus.Abort(_))
         case "outoftime"     => forward(_ => RoundBus.QuietFlag) // mobile app BC
         case t               => logger.warn(s"Unhandled round socket message: $t")


### PR DESCRIPTION
Here's a implementation proposal for adding claim-draw via API when opponent has disconnected.  

The codebase already uses names like `Draw`, `DrawForce`, `DrawClaim` which seem to relate to "claim of Threefold Repetition", whilst this draw claim is about making the result a draw because the opponent has left - similar to claiming a win when the opponent has left.
This adds the name `DrawClaimForce` to the codebase... 😭   

Adds `/api/board/game/{gameId}/claim-draw`,
similar to already existing `/api/board/game/{gameId}/claim-victory`,
https://lichess.org/api#tag/Board/operation/boardGameClaimVictory

Resolves: lichess-org/api#501


<details>
<summary>ClaimDraw.jsh</summary>

```java
if (! Files.exists(Path.of("chariot.jar"))) Files.copy(URI.create(
  "https://repo1.maven.org/maven2/io/github/tors42/chariot/0.1.18/chariot-0.1.18.jar"
  ).toURL().openStream(), Path.of("chariot.jar"))
/env --enable-preview --module-path . --add-modules chariot

import module chariot;
import module java.net.http;

URI api = URI.create("http://localhost:8080/");
String whiteToken = "lip_guang";
String blackToken = "lip_yulia";

ClientAuth initClient(String token, URI api) {
    var client = Client.basic(c -> c.api(api)).withToken(token);
    switch (client.scopes()) {
        case Entries(var stream) -> {
            stream.filter(Client.Scope.board_play::equals)
                .findAny().orElseThrow(() ->
                  new RuntimeException(token +
                      " - missing board:play"));
        }
        case Fail<?> f ->
            throw new RuntimeException(token +
                    " - failed to lookup scopes - " + f);
    }
    return client;
}

void claimDraw(String id) {
    //client.board().claimDraw(id); // not implemented yet
    try { var res = HttpClient.newHttpClient().send(
        HttpRequest.newBuilder(api.resolve("/api/board/game/%s/claim-draw"
                .formatted(id)))
        .POST(HttpRequest.BodyPublishers.noBody())
        .header("authorization", "Bearer %s".formatted(blackToken))
        .build(), HttpResponse.BodyHandlers.ofString());
    if (res.statusCode() / 100 != 2)
        IO.println(res.statusCode() + " " + res.body());
    } catch (Exception e) {}
}

void main() {
    var white = initClient(whiteToken, api);
    var black = initClient(blackToken, api);

    String whiteId = white.account().profile().get().id();
    String id = black.challenges().challenge(whiteId,
            p -> p.clockBlitz3m2s()
            .color(c -> c.black())
            .rated())
        .get().id();
    white.challenges().acceptChallenge(id);

    IO.println("""
       Game created %s
       (Don't open as %s, as that would hinder Opponent Gone)
       """.formatted(api.resolve(id), whiteId));

    ExecutorService executor = Executors.newCachedThreadPool();
    // setup shutdown event
    executor.submit(() -> white.board().connect().stream().forEach(event -> {
        switch (event) {
            case Event.GameStopEvent stop -> {
                IO.println(stop.outcome());
                executor.shutdownNow();
            }
            default -> {}
        }}));
    executor.submit(() -> black.board().connect().stream().forEach(_ -> {}));

    var whiteGameStream = white.board().connectToGame(id).stream();
    var blackGameStream = black.board().connectToGame(id).stream();

    executor.submit(() -> whiteGameStream.forEach(_ -> {}));
    // setup opponent gone handler
    executor.submit(() -> blackGameStream.forEach(event -> {
        switch (event) {
            case GameStateEvent.OpponentGone(_,GameStateEvent.Soon(var duration)) ->
                IO.println("Can claim in %d seconds".formatted(duration.toSeconds()));
            case GameStateEvent.OpponentGone(_, GameStateEvent.Yes()) -> claimDraw(id);
            default -> {}
        }}));

    white.board().move(id, "e2e4");
    black.board().move(id, "e7e6");
    white.board().chat(id, "Really?"); whiteGameStream.close(); // rage quit
    IO.println(whiteId + " left game. Events should show up in 10:ish seconds.");
    IO.println("Attempting immediate claim-draw (before opponent gone message)");
    claimDraw(id);
    IO.println("Waiting for opponent gone");
    try { executor.awaitTermination(60, TimeUnit.SECONDS); } catch (Exception e) {}
}

main()
/exit
```

</details>


<details>
<summary>Example</summary>

```
$ path/to/jdk-24/bin/jshell ClaimDraw.jsh
Game created http://localhost:8080/g7SP7VfC
(Don't open as guang, as that would hinder Opponent Gone)

guang left game. Events should show up in 10:ish seconds.
Attempting immediate claim-draw (before opponent gone message)
400 {"error":"You cannot claim draw on this game"}
Waiting for opponent gone
Can claim in 30 seconds
Can claim in 24 seconds
Can claim in 19 seconds
Can claim in 14 seconds
Can claim in 9 seconds
Can claim in 4 seconds
draw
```

lila.log
```
...
lila-1  | [info] 15:47:46.653 [info] http - 200 browser HEAD /api/account Account.apiMe 24ms
lila-1  | [info] 15:47:46.672 [info] http - 200 browser HEAD /api/account Account.apiMe 5ms
lila-1  | [info] 15:47:46.682 [info] http - 200 browser GET /api/account Account.apiMe 3ms
lila-1  | [info] 15:47:46.784 [info] http - 200 browser POST /api/challenge/guang Challenge.apiCreate 63ms
lila-1  | [info] 15:47:46.808 [info] http - 200 browser POST /api/challenge/g7SP7VfC/accept Challenge.apiAccept 15ms
lila-1  | [info] 15:47:47.821 [info] http - 200 browser GET /api/stream/event Api.eventStream 18ms
lila-1  | [info] 15:47:47.821 [info] http - 200 browser GET /api/board/game/stream/g7SP7VfC PlayApi.boardGameStream 6ms
lila-1  | [info] 15:47:47.821 [info] http - 200 browser GET /api/stream/event Api.eventStream 8ms
lila-1  | [info] 15:47:48.846 [info] http - 200 browser GET /api/board/game/stream/g7SP7VfC PlayApi.boardGameStream 5ms
lila-1  | [info] 15:47:48.881 [info] http - 200 browser POST /api/board/game/g7SP7VfC/move/e2e4 PlayApi.boardMove 21ms
lila-1  | [info] 15:47:48.889 [info] http - 200 browser POST /api/board/game/g7SP7VfC/move/e7e6 PlayApi.boardMove 4ms
lila-1  | [info] 15:47:49.911 [info] http - 200 browser POST /api/board/game/g7SP7VfC/chat PlayApi.boardCommandPost 12ms
lila-1  | [info] 15:47:50.446 [info] http - 400 browser POST /api/board/game/g7SP7VfC/claim-draw PlayApi.boardCommandPost 526ms
lila-1  | [info] 15:48:32.256 [info] http - 200 browser POST /api/board/game/g7SP7VfC/claim-draw PlayApi.boardCommandPost 531ms
...
```

</details>
