### PR TITLE
Don't expand bulkChallenge game creation messages to lpv

### DIFF
--- a/ui/lib/src/richText.ts
+++ b/ui/lib/src/richText.ts
@@ -12,8 +12,8 @@ export const userPattern: RegExp = /(^|[^\w@#/])@([a-z0-9_-]{2,30})/gi;
 // looks like it has a @mention or #gameid or a url.tld
 export const isMoreThanText = (str: string): boolean => /(\n|(@|#|\.)\w{2,}|(board|game) \d)/i.test(str);
 
-const linkHtml = (href: string, content: string): string =>
-  `<a target="_blank" rel="nofollow noreferrer" href="${href}">${content}</a>`;
+const linkHtml = (href: string, content: string, expandable: boolean = true): string =>
+  `<a ${expandable ? '' : 'class="text"'} target="_blank" rel="nofollow noreferrer" href="${href}">${content}</a>`;
 
 export function toLink(url: string): string {
   if (!url.match(/^[A-Za-z]+:\/\//)) url = 'https://' + url;
@@ -34,9 +34,13 @@ export const innerHTML = <A>(a: A, toHtml: (a: A) => string): Hooks => ({
   },
 });
 
-export function linkReplace(href: string, body?: string): string {
+export function linkReplace(href: string, body?: string, expandable: boolean = true): string {
   if (href.includes('&quot;')) return href;
-  return linkHtml(href.startsWith('/') || href.includes('://') ? href : '//' + href, body ? body : href);
+  return linkHtml(
+    href.startsWith('/') || href.includes('://') ? href : '//' + href,
+    body ? body : href,
+    expandable,
+  );
 }
 
 export const userLinkReplace = (_: string, prefix: string, user: string): string =>

--- a/ui/msg/src/view/enhance.ts
+++ b/ui/msg/src/view/enhance.ts
@@ -36,8 +36,9 @@ const expandUrls = (html: string) =>
 
 const expandGameIds = (html: string) =>
   html.replace(
-    /\s#([\w]{8})($|[^\w-])/g,
-    (_: string, id: string, suffix: string) => ' ' + linkReplace('/' + id, '#' + id) + suffix,
+    /(\s#)([\w]{8})($|[^\w-])/g,
+    (_: string, bulkStart: string, id: string, suffix: string) =>
+      ' ' + linkReplace('/' + id, '#' + id, !bulkStart) + suffix,
   );
 
 const expandTeamMessage = (html: string) =>


### PR DESCRIPTION
Closes #17481 

AFAICT only the bulk challenge message uses this format of `"#gameId"` https://github.com/lichess-org/lila/blob/ae014df67f6b9d96da0111187d332e0831180dc1/modules/challenge/src/main/ChallengeMsg.scala#L32