### PR TITLE
Align "Donate" button for not logged in users

### DIFF
--- a/ui/bits/css/_plan.scss
+++ b/ui/bits/css/_plan.scss
@@ -175,7 +175,6 @@
         .button {
           flex: 1 1 auto;
           font-weight: normal;
-          margin-inline-end: 1em;
           height: $button-height;
         }
 
@@ -183,6 +182,7 @@
           display: flex;
           height: $button-height;
           overflow: hidden;
+          margin-inline-start: 1em;
 
           iframe {
             color-scheme: normal;


### PR DESCRIPTION
In https://lichess.org/patron, Changed which button handles margin from the 'Donate' button (which caused a misalignment issue when the user is not logged in) to the PayPal button.

This causes the donation button to be aligned in both scenarios, and keeps the space between the Donation button and the PayPal button for signed-in users.

**Before:**
<img width="555" height="285" alt="GwgN7x1XEAEn7_m" src="https://github.com/user-attachments/assets/2a653745-a2a7-46a7-99ac-2b2876187879" />
**After:**
<img width="560" height="289" alt="image" src="https://github.com/user-attachments/assets/a1271724-8174-49a8-bdaf-881a95dc7c96" />
