### PR TITLE
[Mobile] Use UA version to check if a firebase message should be sent

### DIFF
--- a/modules/common/src/main/HTTPRequest.scala
+++ b/modules/common/src/main/HTTPRequest.scala
@@ -54,6 +54,16 @@ object HTTPRequest:
     isLichobile(req) || (appOrigin(req).isDefined && !isLichessMobile(req))
   def isAndroid                     = UaMatcher("Android")
   def isLitools(req: RequestHeader) = userAgent(req).has(UserAgent("litools"))
+  def lichessMobileVersion(ua: UserAgent): Option[LichessMobileVersion] =
+    isLichessMobile(ua).so:
+      for
+        uaRest <- ua.value.split("/", 2).lift(1)
+        versionStr = uaRest.takeWhile(' ' != _)
+        version <- versionStr.split('.') match
+          case Array(major, minor, _) =>
+            (major.toIntOption, minor.toIntOption).mapN(LichessMobileVersion(_, _))
+          case _ => none
+      yield version
 
   def origin(req: RequestHeader): Option[String]  = req.headers.get(HeaderNames.ORIGIN)
   def referer(req: RequestHeader): Option[String] = req.headers.get(HeaderNames.REFERER)

--- a/modules/core/src/main/net.scala
+++ b/modules/core/src/main/net.scala
@@ -60,6 +60,12 @@ object net:
       osVersion: String,
       device: String
   )
+  case class LichessMobileVersion(major: Int, minor: Int)
+  object LichessMobileVersion:
+    val zero = LichessMobileVersion(0, 0)
+    given Ordering[LichessMobileVersion] with
+      def compare(x: LichessMobileVersion, y: LichessMobileVersion): Int =
+        (x.major, x.minor).compare((y.major, y.minor))
 
   opaque type ApiVersion = Int
   object ApiVersion extends RichOpaqueInt[ApiVersion]:

--- a/modules/push/src/main/Device.scala
+++ b/modules/push/src/main/Device.scala
@@ -1,6 +1,9 @@
 package lila.push
 
-import lila.core.net.UserAgent
+import scala.math.Ordered.orderingToOrdered
+
+import lila.core.net.{ UserAgent, LichessMobileVersion }
+import LichessMobileVersion.given
 
 final private case class Device(
     _id: String,      // Firebase token
@@ -11,11 +14,12 @@ final private case class Device(
 ):
   def isMobile = ua.exists(lila.common.HTTPRequest.isLichessMobile)
 
-  def isMobileVersionCompatible(version: String): Boolean =
-    ua.exists { userAgent =>
-      lila.common.HTTPRequest.isLichessMobile(userAgent) &&
-      userAgent.value.split('/').lift(1).exists(_.split(' ').headOption.exists(_ >= version))
-    }
+  def isMobileVersionCompatible(version: LichessMobileVersion): Boolean =
+    ua.exists: devUa =>
+      lila.common.HTTPRequest
+        .lichessMobileVersion(devUa)
+        .exists:
+          _ >= version
 
   def deviceId = platform match
     case "ios" => _id.grouped(8).mkString("<", " ", ">")

--- a/modules/push/src/main/Device.scala
+++ b/modules/push/src/main/Device.scala
@@ -11,6 +11,12 @@ final private case class Device(
 ):
   def isMobile = ua.exists(lila.common.HTTPRequest.isLichessMobile)
 
+  def isMobileVersionCompatible(version: String): Boolean =
+    ua.exists { userAgent =>
+      lila.common.HTTPRequest.isLichessMobile(userAgent) &&
+      userAgent.value.split('/').lift(1).exists(_.split(' ').headOption.exists(_ >= version))
+    }
+
   def deviceId = platform match
     case "ios" => _id.grouped(8).mkString("<", " ", ">")
     case _     => _id

--- a/modules/push/src/main/FirebasePush.scala
+++ b/modules/push/src/main/FirebasePush.scala
@@ -39,8 +39,8 @@ final private class FirebasePush(
             for
               data <- data.value
               _    <-
-                if !data.mobileCompatible && device.isMobile
-                then funit // mobile doesn't yet support all messages
+                if !data.mobileCompatibleVersion.exists(device.isMobileVersionCompatible)
+                then funit // don't send to mobile if incompatible version
                 else if data.firebaseMod.contains(PushApi.Data.FirebaseMod.DataOnly) && !device.isMobile
                 then funit // don't send data messages to lichobile
                 else

--- a/modules/push/src/main/FirebasePush.scala
+++ b/modules/push/src/main/FirebasePush.scala
@@ -39,7 +39,7 @@ final private class FirebasePush(
             for
               data <- data.value
               _    <-
-                if !data.mobileCompatibleVersion.exists(device.isMobileVersionCompatible)
+                if !data.mobileCompatible.exists(device.isMobileVersionCompatible)
                 then funit // don't send to mobile if incompatible version
                 else if data.firebaseMod.contains(PushApi.Data.FirebaseMod.DataOnly) && !device.isMobile
                 then funit // don't send data messages to lichobile

--- a/modules/push/src/main/PushApi.scala
+++ b/modules/push/src/main/PushApi.scala
@@ -68,7 +68,7 @@ final private class PushApi(
                 "gameId" -> game.id.value,
                 "fullId" -> pov.fullId.value
               ),
-              mobileCompatible = true,
+              mobileCompatibleVersion = "0.0.0".some,
               iosBadge = nbMyTurn.some,
               firebaseMod = offlineRoundNotif
             )
@@ -101,7 +101,7 @@ final private class PushApi(
                       stacking = Stacking.GameMove,
                       urgency = if pov.isMyTurn then Urgency.Normal else Urgency.Low,
                       payload = payload,
-                      mobileCompatible = true,
+                      mobileCompatibleVersion = "0.0.0".some,
                       iosBadge = nbMyTurn.some,
                       firebaseMod = offlineRoundNotif
                     )
@@ -132,7 +132,7 @@ final private class PushApi(
                       stacking = Stacking.GameTakebackOffer,
                       urgency = Urgency.Normal,
                       payload = payload,
-                      mobileCompatible = true,
+                      mobileCompatibleVersion = "0.0.0".some,
                       firebaseMod = offlineRoundNotif
                     )
                   IfAway(pov)(maybePushNotif(userId, _.takeback, PrefEvent.gameEvent, data)) >>
@@ -161,7 +161,7 @@ final private class PushApi(
                       urgency = Urgency.Normal,
                       payload = payload,
                       firebaseMod = offlineRoundNotif,
-                      mobileCompatible = true
+                      mobileCompatibleVersion = "0.0.0".some
                     )
                   IfAway(pov)(maybePushNotif(userId, _.draw, PrefEvent.gameEvent, data)) >>
                     alwaysPushFirebaseData(userId, _.draw, data)
@@ -179,7 +179,7 @@ final private class PushApi(
           stacking = Stacking.GameMove,
           urgency = Urgency.High,
           payload = payload,
-          mobileCompatible = true,
+          mobileCompatibleVersion = "0.0.0".some,
           firebaseMod = offlineRoundNotif
         )
       maybePushNotif(userId, _.corresAlarm, PrefEvent.gameEvent, data) >>
@@ -206,7 +206,7 @@ final private class PushApi(
           body = text,
           stacking = Stacking.PrivateMessage,
           urgency = Urgency.Normal,
-          mobileCompatible = false,
+          mobileCompatibleVersion = "0.17.0".some,
           payload = payload(to.userId)(
             "type"     -> "newMessage",
             "threadId" -> senderId.value
@@ -224,7 +224,7 @@ final private class PushApi(
           body = s"$invitedBy invited you to $studyName",
           stacking = Stacking.InvitedStudy,
           urgency = Urgency.Normal,
-          mobileCompatible = false,
+          mobileCompatibleVersion = None,
           payload = payload(to.userId)(
             "type"      -> "invitedStudy",
             "invitedBy" -> invitedBy,
@@ -255,7 +255,7 @@ final private class PushApi(
                     "type"        -> "challengeCreate",
                     "challengeId" -> c.id.value
                   ),
-                  mobileCompatible = false
+                  mobileCompatibleVersion = None
                 )
             )
 
@@ -276,7 +276,7 @@ final private class PushApi(
                   body = describeChallenge(c),
                   stacking = Stacking.ChallengeAccept,
                   urgency = Urgency.Normal,
-                  mobileCompatible = false,
+                  mobileCompatibleVersion = None,
                   payload = payload(challenger.id)(
                     "type"        -> "challengeAccept",
                     "challengeId" -> c.id.value
@@ -296,7 +296,7 @@ final private class PushApi(
             body = "The tournament is about to start!",
             stacking = Stacking.ChallengeAccept,
             urgency = Urgency.Normal,
-            mobileCompatible = false,
+            mobileCompatibleVersion = None,
             payload = payload(userId)(
               "type"     -> "tourSoon",
               "tourId"   -> tour.tourId,
@@ -319,7 +319,7 @@ final private class PushApi(
               body = post.fold(topicName)(p => shorten(p.text, 57 - 3, "...")),
               stacking = Stacking.ForumMention,
               urgency = Urgency.Low,
-              mobileCompatible = false,
+              mobileCompatibleVersion = None,
               payload = payload(to.userId)(
                 "type"        -> "forumMention",
                 "mentionedBy" -> mentionedBy,
@@ -342,7 +342,7 @@ final private class PushApi(
           "streamerId" -> streamerId.value,
           "url"        -> s"https://lichess.org/streamer/$streamerId/redirect"
         ),
-        mobileCompatible = false
+        mobileCompatibleVersion = None
       )
     val webRecips = recips.collect { case u if u.allows.web => u.userId }
     for _ <- webPush(webRecips, pushData).addEffects: res =>
@@ -368,7 +368,7 @@ final private class PushApi(
         stacking = Stacking.Generic,
         urgency = Urgency.Normal,
         payload = payload("url" -> url),
-        mobileCompatible = false
+        mobileCompatibleVersion = None
       )
     val webRecips = recips.collect { case u if u.allows.web => u.userId }
     for _ <- webPush(webRecips, pushData).addEffects: res =>
@@ -431,7 +431,7 @@ private object PushApi:
       stacking: Stacking,
       urgency: Urgency,
       payload: Data.Payload,
-      mobileCompatible: Boolean,
+      mobileCompatibleVersion: Option[String] = None,
       iosBadge: Option[Int] = None,
       // https://firebase.google.com/docs/cloud-messaging/concept-options#data_messages
       firebaseMod: Option[Data.FirebaseMod] = None

--- a/modules/push/src/main/PushApi.scala
+++ b/modules/push/src/main/PushApi.scala
@@ -12,6 +12,7 @@ import lila.core.misc.push.TourSoon
 import lila.core.notify.{ NotificationContent, PrefEvent, NotifyAllows }
 import lila.core.round.{ Tell, RoundBus, MoveEvent }
 import lila.core.study.data.StudyName
+import lila.core.net.LichessMobileVersion
 
 final private class PushApi(
     firebasePush: FirebasePush,
@@ -68,7 +69,7 @@ final private class PushApi(
                 "gameId" -> game.id.value,
                 "fullId" -> pov.fullId.value
               ),
-              mobileCompatibleVersion = "0.0.0".some,
+              mobileCompatible = LichessMobileVersion.zero.some,
               iosBadge = nbMyTurn.some,
               firebaseMod = offlineRoundNotif
             )
@@ -101,7 +102,7 @@ final private class PushApi(
                       stacking = Stacking.GameMove,
                       urgency = if pov.isMyTurn then Urgency.Normal else Urgency.Low,
                       payload = payload,
-                      mobileCompatibleVersion = "0.0.0".some,
+                      mobileCompatible = LichessMobileVersion.zero.some,
                       iosBadge = nbMyTurn.some,
                       firebaseMod = offlineRoundNotif
                     )
@@ -132,7 +133,7 @@ final private class PushApi(
                       stacking = Stacking.GameTakebackOffer,
                       urgency = Urgency.Normal,
                       payload = payload,
-                      mobileCompatibleVersion = "0.0.0".some,
+                      mobileCompatible = LichessMobileVersion.zero.some,
                       firebaseMod = offlineRoundNotif
                     )
                   IfAway(pov)(maybePushNotif(userId, _.takeback, PrefEvent.gameEvent, data)) >>
@@ -161,7 +162,7 @@ final private class PushApi(
                       urgency = Urgency.Normal,
                       payload = payload,
                       firebaseMod = offlineRoundNotif,
-                      mobileCompatibleVersion = "0.0.0".some
+                      mobileCompatible = LichessMobileVersion.zero.some
                     )
                   IfAway(pov)(maybePushNotif(userId, _.draw, PrefEvent.gameEvent, data)) >>
                     alwaysPushFirebaseData(userId, _.draw, data)
@@ -179,7 +180,7 @@ final private class PushApi(
           stacking = Stacking.GameMove,
           urgency = Urgency.High,
           payload = payload,
-          mobileCompatibleVersion = "0.0.0".some,
+          mobileCompatible = LichessMobileVersion.zero.some,
           firebaseMod = offlineRoundNotif
         )
       maybePushNotif(userId, _.corresAlarm, PrefEvent.gameEvent, data) >>
@@ -206,7 +207,7 @@ final private class PushApi(
           body = text,
           stacking = Stacking.PrivateMessage,
           urgency = Urgency.Normal,
-          mobileCompatibleVersion = "0.17.0".some,
+          mobileCompatible = LichessMobileVersion(0, 17).some,
           payload = payload(to.userId)(
             "type"     -> "newMessage",
             "threadId" -> senderId.value
@@ -224,7 +225,7 @@ final private class PushApi(
           body = s"$invitedBy invited you to $studyName",
           stacking = Stacking.InvitedStudy,
           urgency = Urgency.Normal,
-          mobileCompatibleVersion = None,
+          mobileCompatible = None,
           payload = payload(to.userId)(
             "type"      -> "invitedStudy",
             "invitedBy" -> invitedBy,
@@ -255,7 +256,7 @@ final private class PushApi(
                     "type"        -> "challengeCreate",
                     "challengeId" -> c.id.value
                   ),
-                  mobileCompatibleVersion = None
+                  mobileCompatible = None
                 )
             )
 
@@ -276,7 +277,7 @@ final private class PushApi(
                   body = describeChallenge(c),
                   stacking = Stacking.ChallengeAccept,
                   urgency = Urgency.Normal,
-                  mobileCompatibleVersion = None,
+                  mobileCompatible = None,
                   payload = payload(challenger.id)(
                     "type"        -> "challengeAccept",
                     "challengeId" -> c.id.value
@@ -296,7 +297,7 @@ final private class PushApi(
             body = "The tournament is about to start!",
             stacking = Stacking.ChallengeAccept,
             urgency = Urgency.Normal,
-            mobileCompatibleVersion = None,
+            mobileCompatible = None,
             payload = payload(userId)(
               "type"     -> "tourSoon",
               "tourId"   -> tour.tourId,
@@ -319,7 +320,7 @@ final private class PushApi(
               body = post.fold(topicName)(p => shorten(p.text, 57 - 3, "...")),
               stacking = Stacking.ForumMention,
               urgency = Urgency.Low,
-              mobileCompatibleVersion = None,
+              mobileCompatible = None,
               payload = payload(to.userId)(
                 "type"        -> "forumMention",
                 "mentionedBy" -> mentionedBy,
@@ -342,7 +343,7 @@ final private class PushApi(
           "streamerId" -> streamerId.value,
           "url"        -> s"https://lichess.org/streamer/$streamerId/redirect"
         ),
-        mobileCompatibleVersion = None
+        mobileCompatible = None
       )
     val webRecips = recips.collect { case u if u.allows.web => u.userId }
     for _ <- webPush(webRecips, pushData).addEffects: res =>
@@ -368,7 +369,7 @@ final private class PushApi(
         stacking = Stacking.Generic,
         urgency = Urgency.Normal,
         payload = payload("url" -> url),
-        mobileCompatibleVersion = None
+        mobileCompatible = None
       )
     val webRecips = recips.collect { case u if u.allows.web => u.userId }
     for _ <- webPush(webRecips, pushData).addEffects: res =>
@@ -431,7 +432,7 @@ private object PushApi:
       stacking: Stacking,
       urgency: Urgency,
       payload: Data.Payload,
-      mobileCompatibleVersion: Option[String] = None,
+      mobileCompatible: Option[LichessMobileVersion] = None,
       iosBadge: Option[Int] = None,
       // https://firebase.google.com/docs/cloud-messaging/concept-options#data_messages
       firebaseMod: Option[Data.FirebaseMod] = None

--- a/modules/web/src/test/common/HTTPRequestTest.scala
+++ b/modules/web/src/test/common/HTTPRequestTest.scala
@@ -1,0 +1,27 @@
+package lila.common
+
+import scala.math.Ordered.orderingToOrdered
+
+import lila.core.net.{ UserAgent, LichessMobileVersion }
+
+class HTTPRequestTest extends munit.FunSuite:
+
+  test("lichess mobile version from UA"):
+    assertEquals(
+      HTTPRequest.lichessMobileVersion(
+        UserAgent("Lichess Mobile/0.16.7 as:anon sri:vRUrTavyFqpbOxMN os:Android/14 dev:SM-A155N")
+      ),
+      Some(LichessMobileVersion(0, 16))
+    )
+    assertEquals(
+      HTTPRequest.lichessMobileVersion:
+        UserAgent:
+          "Mozilla/5.0 (iPhone; CPU iPhone OS 18_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148  Lichobile/8.0.0"
+      ,
+      None
+    )
+
+  test("lichess mobile version ordering"):
+    assert(LichessMobileVersion(0, 16) < LichessMobileVersion(0, 17))
+    assert(LichessMobileVersion(0, 9) < LichessMobileVersion(0, 10))
+    assert(LichessMobileVersion(1, 1) > LichessMobileVersion(0, 10))


### PR DESCRIPTION
Currently we are using a simple `boolean` to either send or not a Firebase push message to the mobile app.

In order to support the coming [Private messaging](https://github.com/lichess-org/mobile/pull/1981) feature (and other in the future) we need to also check the app version from the user agent to only send the messages to a supported app version.

So the `boolean` is replaced with an `Option[String]` which is compared with the version string in the UA.

The comparison function is quite simple and not robust but should work just fine as mobile versions strings always have same length.