### PR TITLE
Fix for tournaments with no streak bonuses should still have wins coloured green 

### DIFF
--- a/ui/tournament/src/view/arena.ts
+++ b/ui/tournament/src/view/arena.ts
@@ -12,7 +12,7 @@ import { userLink } from 'lib/view/userLink';
 const renderScoreString = (scoreString: string, streakable: boolean) => {
   const values = scoreString.split('').map(s => parseInt(s));
   values.reverse(); // in place!
-  if (!streakable) return values.map(v => h('score', v));
+  if (!streakable) return values.map(v => h(v > 1 ? 'streak' : 'score', v));
   const nodes = [];
   let streak = 0;
   for (const v of values) {


### PR DESCRIPTION
Tournaments with no streak bonuses should still have wins coloured green #17880

Issue:
When streaks are disabled, the "renderScoreString" function in "ui/tournament/src/view/arena.ts" wraps each score in a tag with no further differentiation. This means all wins are rendered with the neutral `<score>` tag (which appears grey by default) instead of the green `<streak>` tag.

Fix:
The fix made in my fork modifies the early return in this function (when streakable is not true) to tag wins as `<streak>`, instead of returning all scores as `<score>`. This means any score greater than 1 (i.e. 2 points for a win, or 3 points for a berserk win) in a `<streak>` tag even when streaks are disabled, resulting in a green display on the score sheet.

This does not affect the scoring, purely the visual display.

from

`if (!streakable) return values.map(v => h('score', v));`

to

`if (!streakable) return values.map(v => h(v > 1 ? 'streak' : 'score', v));`