### PR TITLE
Include showRatings info in addChapter socket msg

### DIFF
--- a/modules/study/src/main/StudySocket.scala
+++ b/modules/study/src/main/StudySocket.scala
@@ -129,8 +129,9 @@ final private class StudySocket(
 
         case "addChapter" =>
           reading[ChapterMaker.Data](o): data =>
-            val sticky = o.obj("d").flatMap(_.boolean("sticky")) | true
-            applyWho(api.addChapter(studyId, data, sticky = sticky, withRatings = true))
+            val sticky      = o.obj("d").flatMap(_.boolean("sticky")) | true
+            val withRatings = o.obj("d").flatMap(_.boolean("showRatings")) | true
+            applyWho(api.addChapter(studyId, data, sticky = sticky, withRatings = withRatings))
 
         case "setChapter" =>
           o.get[StudyChapterId]("d")

--- a/ui/analyse/src/socket.ts
+++ b/ui/analyse/src/socket.ts
@@ -47,7 +47,7 @@ export type StudySocketSendParams =
   | [t: 'explorerGame', d: ReqPosition & { gameId: string; insert: boolean }]
   | [t: 'setChapter', chapterId: string]
   | [t: 'setRole', d: { userId: string; role: string }]
-  | [t: 'addChapter', d: ChapterData & { sticky?: boolean }]
+  | [t: 'addChapter', d: ChapterData & { sticky?: boolean; showRatings?: boolean }]
   | [t: 'editChapter', d: EditChapterData]
   | [t: 'descStudy', desc: string]
   | [t: 'descChapter', d: { id: string; desc: string }]

--- a/ui/analyse/src/study/chapterNewForm.ts
+++ b/ui/analyse/src/study/chapterNewForm.ts
@@ -87,7 +87,8 @@ export class StudyChapterNewForm {
   };
   submit = (d: Omit<ChapterData, 'initial'>) => {
     const study = this.root.study!;
-    const dd = { ...d, sticky: study.vm.mode.sticky, initial: this.initial() };
+    const showRatings = study.data.showRatings ? undefined : false; // define only if false
+    const dd = { ...d, sticky: study.vm.mode.sticky, showRatings: showRatings, initial: this.initial() };
     if (!dd.pgn) this.send('addChapter', dd);
     else
       importPgn(study.data.id, dd).catch(e => {


### PR DESCRIPTION
If user wants to hide ratings,
include showRatings=false in addChapter socket message.

(If user wants to see ratings, showRatings is undefined and won't be included in the message - default behaviour of showing ratings applies.)

Resolves: #17725