### PR TITLE
Close stream also if game is aborted

### DIFF
--- a/modules/bot/src/main/GameStateStream.scala
+++ b/modules/bot/src/main/GameStateStream.scala
@@ -78,7 +78,7 @@ final class GameStateStream(
         // prepend the full game JSON at the start of the stream
         queue.offer(json.some)
         // close stream if game is over
-        if init.game.finished then onGameOver(none)
+        if init.game.finishedOrAborted then onGameOver(none)
         else self ! SetOnline
       }
       lila.mon.bot.gameStream("start").increment()


### PR DESCRIPTION
When a game state stream notices a game is finished, it closes the stream.  
In case the game is aborted, the stream doesn't close. This seems to be an omission.  
This Pull Request also checks if game is aborted, to also close the stream.  

Relates: tors42/chariot#22