### PR TITLE
Fix bug with report block button

### DIFF
--- a/ui/bits/src/bits.ts
+++ b/ui/bits/src/bits.ts
@@ -263,7 +263,9 @@ function thanksReport() {
   const $button = $('button.report-block');
   $button.one('click', function () {
     $button.find('span').text('Blocking...');
-    fetch($button.attr('action')!, { method: 'post' }).then(() => $button.find('span').text('Blocked!'));
+    fetch($button.data('action')!, { method: 'post' }).then(async res =>
+      $button.find('span').text(res.ok ? 'Blocked!' : 'Block error'),
+    );
   });
 }
 


### PR DESCRIPTION
After reporting a user, there is sometimes an option to block them. The button appears to work after being clicked, but it actually doesn't block the user. The reason is because `action` is not an attribute the button has.