### PR TITLE
broadcast mon roundId instead of name

### DIFF
--- a/modules/common/src/main/mon.scala
+++ b/modules/common/src/main/mon.scala
@@ -291,8 +291,8 @@ object mon:
       timer("relay.http.get").withTags:
         tags("code" -> code.toLong, "host" -> host, "etag" -> etag, "proxy" -> proxy.getOrElse("none"))
     val dedup = counter("relay.fetch.dedup").withoutTags()
-    def push(name: String, user: UserName, client: String)(moves: Int, errors: Int) =
-      val ts = tags("name" -> name, "user" -> user, "client" -> client)
+    def push(roundId: RelayRoundId, user: UserName, client: String)(moves: Int, errors: Int) =
+      val ts = tags("roundId" -> roundId, "user" -> user, "client" -> client)
       histogram("relay.push.moves").withTags(ts).record(moves)
       histogram("relay.push.errors").withTags(ts).record(errors)
 

--- a/modules/relay/src/main/RelayPush.scala
+++ b/modules/relay/src/main/RelayPush.scala
@@ -56,7 +56,7 @@ final class RelayPush(
       .flatMap(_.value.split("as:").headOption)
       .orElse(ua.map(_.value))
       .fold("unknown")(_.trim)
-    lila.mon.relay.push(name = rt.fullName, user = me.username, client = client)(
+    lila.mon.relay.push(roundId = rt.round.id, user = me.username, client = client)(
       moves = results.collect { case Right(a) => a.moves }.sum,
       errors = results.count(_.isLeft)
     )


### PR DESCRIPTION
tested locally against influxdb

```bash
$ curl --get http://localhost:8086/query \
    --header "Authorization: Token secret" \
    --data-urlencode 'db=kamon' \
    --data-urlencode 'q=show tag keys from "relay.push.moves"'

{"results":[{"statement_id":0,"series":[{"name":"relay.push.moves","columns":["tagKey"],"values":[["client"],["instance"],["roundId"],["user"]]}]}]}
```