### PR TITLE
require showscores to be enabled when submitting tiebreaks

### DIFF
--- a/modules/relay/src/main/RelayTourForm.scala
+++ b/modules/relay/src/main/RelayTourForm.scala
@@ -76,6 +76,10 @@ final class RelayTourForm(langList: lila.core.i18n.LangList, groupForm: RelayGro
       "pinnedStream" -> optional(pinnedStreamMapping),
       "note" -> optional(nonEmptyText(maxLength = 20_000))
     )(Data.apply)(unapply)
+      .verifying(
+        "Tiebreaks submitted without automatic scoring enabled",
+        tour => tour.tiebreaks.forall(_ => tour.showScores)
+      )
   ).fill(Data.empty)
 
   def create = form


### PR DESCRIPTION
Decided to go this route so that the broadcaster gets some feedback rather than them applying tiebreaks and us silently ignoring it