### PR TITLE
Revert "delete unused i18n.broadcast.standings key"

### DIFF
--- a/modules/coreI18n/src/main/key.scala
+++ b/modules/coreI18n/src/main/key.scala
@@ -185,6 +185,7 @@ object I18nKey:
     val `startVerySoon`: I18nKey = "broadcast:startVerySoon"
     val `notYetStarted`: I18nKey = "broadcast:notYetStarted"
     val `officialWebsite`: I18nKey = "broadcast:officialWebsite"
+    val `standings`: I18nKey = "broadcast:standings"
     val `officialStandings`: I18nKey = "broadcast:officialStandings"
     val `iframeHelp`: I18nKey = "broadcast:iframeHelp"
     val `webmastersPage`: I18nKey = "broadcast:webmastersPage"

--- a/translation/source/broadcast.xml
+++ b/translation/source/broadcast.xml
@@ -63,6 +63,7 @@
   <string name="startVerySoon">The broadcast will start very soon.</string>
   <string name="notYetStarted">The broadcast has not yet started.</string>
   <string name="officialWebsite">Official website</string>
+  <string name="standings">Standings</string>
   <string name="officialStandings">Official Standings</string>
   <string name="iframeHelp" comment="%s is 'webmasters page'">More options on the %s</string>
   <string name="webmastersPage">webmasters page</string>

--- a/ui/@types/lichess/i18n.d.ts
+++ b/ui/@types/lichess/i18n.d.ts
@@ -345,6 +345,8 @@ interface I18n {
     sourceSingleUrl: string;
     /** URL that Lichess will check to get PGN updates. It must be publicly accessible from the Internet. */
     sourceUrlHelp: string;
+    /** Standings */
+    standings: string;
     /** Optional, if you know when the event starts */
     startDateHelp: string;
     /** Start date in the tournament local timezone: %s */


### PR DESCRIPTION
This reverts commit 9285b19569dae98679897c8d102b26db300c859e.

Used here:

https://github.com/lichess-org/lila/blob/5f6ea867c4c0aaf42c0adcbf289d5ee4789b9b6f/ui/analyse/src/study/relay/relayTourView.ts#L136

Error when running `./ui/build`:

12:36:10 [tsc] - ✘ [ERROR] ts2339 in 'analyse/src/study/relay/relayTourView.ts:137:60' - Property 'standings' does not exist on type '{ aboutBroadcasts: string; addRound: string; ageThisYear: string; allBroadcastsByMonth: string; allTeams: string; backToLiveMove: string; boards: string; boardsCanBeLoaded: I18nFormat; ... 69 more ...; webmastersPage: string; }'.
