### PR TITLE
Fix timeago on user show

### DIFF
--- a/modules/user/src/main/ui/UserShow.scala
+++ b/modules/user/src/main/ui/UserShow.scala
@@ -90,7 +90,7 @@ final class UserShow(helpers: Helpers, bits: UserBits):
         ),
       div(cls := "upt__details")(
         span(trans.site.nbGames.plural(u.count.game, u.count.game.localize)),
-        span(trans.site.joinedX(momentFromNowServerText(u.createdAt))),
+        span(trans.site.joinedX(momentFromNow(u.createdAt))),
         (Granter.opt(_.UserModView) && (u.lameOrTroll || u.enabled.no || u.marks.rankban))
           .option(span(cls := "upt__details__marks")(userMarks))
       ),


### PR DESCRIPTION
fixes #17956 

<img width="472" height="170" alt="image" src="https://github.com/user-attachments/assets/d836a259-d3f1-4ff0-b504-3c344bf932d1" />


<img width="489" height="198" alt="image" src="https://github.com/user-attachments/assets/cf43b60d-9940-4695-9810-e922eac7bd97" />

Note for @superuser-does 
There should be more context in crowdin (site.joinedX)
Look at the German version
EDIT: I fixed it on crowdin

<img width="413" height="246" alt="image" src="https://github.com/user-attachments/assets/da37781e-bcea-40d7-91f8-a494ee08323c" />




