### PR TITLE
Game search: Add a better name for InsufficientMaterialClaim 

### DIFF
--- a/modules/gameSearch/src/main/FormHelpers.scala
+++ b/modules/gameSearch/src/main/FormHelpers.scala
@@ -84,4 +84,5 @@ object FormHelpers:
     case s if s.is(_.UnknownFinish) => none
     case s if s.is(_.Outoftime) => Some(s.id -> "Clock Flag")
     case s if s.is(_.VariantEnd) => Some(s.id -> "Variant End")
+    case s if s.is(_.InsufficientMaterialClaim) => Some(s.id -> "Insufficient Material")
     case s => Some(s.id -> s.toString)


### PR DESCRIPTION
## Summary
Adds the missing `InsufficientMaterialClaim` status to the game search form helpers, making it searchable in the advanced game search.

## Changes
- Added `InsufficientMaterialClaim` status mapping to `FormHelpers.scala` with display name "Insufficient Material"

## Context
The `InsufficientMaterialClaim` status was already properly handled throughout the codebase (UI display, PGN export, etc.) but was missing from the search form options.

Fixes - #17964 
