### PR TITLE
Initialize light isPatron

### DIFF
--- a/modules/core/src/main/user.scala
+++ b/modules/core/src/main/user.scala
@@ -57,7 +57,7 @@ object user:
 
     def hasTitle: Boolean = title.exists(PlayerTitle.BOT != _)
 
-    def light = LightUser(id, username, title, flair, false)
+    def light = LightUser(id, username, title, flair, isPatron = isPatron)
 
     def profileOrDefault = profile | Profile.default
 


### PR DESCRIPTION
I think this piece of code was missed out in previous revert, 5275771f

It seems in forums, for instance, a circle can be rendered when a patron wing should be rendered.

Reproduce:
1. Gift patron to test user
2. Make a forum post with test user
3. Restarting lila and opening forum page shows wings on first load
4. Reload page, shows circle
