### PR TITLE
automod for comms

### DIFF
--- a/app/controllers/Dev.scala
+++ b/app/controllers/Dev.scala
@@ -36,6 +36,8 @@ final class Dev(env: Env) extends LilaController(env):
     env.relay.proxyDomainRegex,
     env.relay.proxyHostPort,
     env.relay.proxyCredentials,
+    env.report.api.modelSetting,
+    env.report.api.promptSetting,
     env.ublog.automod.modelSetting,
     env.ublog.automod.promptSetting
   )

--- a/app/controllers/ForumTopic.scala
+++ b/app/controllers/ForumTopic.scala
@@ -29,7 +29,10 @@ final class ForumTopic(env: Env) extends LilaController(env) with ForumControlle
               data =>
                 limit.forumTopic(ctx.ip, rateLimited):
                   topicApi.makeTopic(categ, data).map { topic =>
-                    Redirect(routes.ForumTopic.show(categ.id, topic.slug, 1))
+                    val userText = s"${data.name}\n${data.post.text}"
+                    val url = routes.ForumTopic.show(categ.id, topic.slug, 1).url
+                    discard { env.report.api.automodComms(userText, me, url) }
+                    Redirect(url)
                   }
             )
           }

--- a/app/controllers/Tournament.scala
+++ b/app/controllers/Tournament.scala
@@ -273,6 +273,8 @@ final class Tournament(env: Env, apiC: => Api)(using akka.stream.Materializer) e
               api
                 .createTournament(setup, teams, andJoin = ctx.isWebAuth)
                 .flatMap: tour =>
+                  val userText = s"${setup.name.getOrElse("")}\n${setup.description.getOrElse("")}"
+                  discard { env.report.api.automodComms(userText, me, routes.Tournament.show(tour.id).url) }
                   given GetMyTeamIds = _ => fuccess(teams.map(_.id))
                   negotiate(
                     html = Redirect {
@@ -301,6 +303,8 @@ final class Tournament(env: Env, apiC: => Api)(using akka.stream.Materializer) e
             data =>
               given GetMyTeamIds = _ => fuccess(teams.map(_.id))
               api.apiUpdate(tour, data).flatMap { tour =>
+                val userText = s"${data.name.getOrElse("")}\n${data.description.getOrElse("")}"
+                discard { env.report.api.automodComms(userText, me, routes.Tournament.show(tour.id).url) }
                 jsonView(
                   tour,
                   none,

--- a/build.sbt
+++ b/build.sbt
@@ -179,7 +179,7 @@ lazy val feed = module("feed",
 )
 
 lazy val ublog = module("ublog",
-  Seq(memo, ui, search),
+  Seq(memo, ui, search, report),
   Seq(bloomFilter)
 )
 

--- a/conf/base.conf
+++ b/conf/base.conf
@@ -334,10 +334,10 @@ forumSearch {
 ublog {
   searchPageSize = 12
   carouselSize = 9
-  automod {
-    apiKey = ""
-    url = "https://api.together.xyz/v1/chat/completions"
-  }
+}
+automod {
+  apiKey = ""
+  url = "https://api.together.xyz/v1/chat/completions"
 }
 message {
   thread.max_per_page = 30

--- a/modules/report/src/main/Automod.scala
+++ b/modules/report/src/main/Automod.scala
@@ -1,0 +1,50 @@
+package lila.report
+
+import play.api.{ ConfigLoader, Configuration }
+import play.api.libs.json.*
+import play.api.libs.ws.*
+import play.api.libs.ws.JsonBodyWritables.*
+import play.api.libs.ws.DefaultBodyReadables.readableAsString
+
+import lila.core.config.Secret
+import lila.common.autoconfig.AutoConfig
+import lila.common.config.given
+
+private[report] final class Automod(ws: StandaloneWSClient, appConfig: Configuration)(using Executor):
+  private val config = appConfig.get[Automod.Config]("automod")
+  private[report] def apply(
+      userText: String,
+      systemPrompt: String,
+      model: String,
+      temperature: Double
+  ): Fu[Option[JsObject]] =
+    (config.apiKey.value.nonEmpty && systemPrompt.nonEmpty && userText.nonEmpty).so:
+      val body = Json.obj(
+        "model" -> model,
+        "temperature" -> temperature,
+        "max_tokens" -> 4096,
+        "messages" -> Json.arr(
+          Json.obj("role" -> "system", "content" -> systemPrompt),
+          Json.obj("role" -> "user", "content" -> userText)
+        )
+      )
+      ws.url(config.url)
+        .withHttpHeaders(
+          "Authorization" -> s"Bearer ${config.apiKey.value}",
+          "Content-Type" -> "application/json"
+        )
+        .post(body)
+        .flatMap: rsp =>
+          (for
+            choices <- (Json.parse(rsp.body) \ "choices").asOpt[List[JsObject]]
+            if rsp.status == 200
+            best <- choices.headOption
+            msg <- (best \ "message" \ "content").asOpt[String]
+            trimmed = msg.slice(msg.indexOf('{', msg.indexOf("</think>")), msg.lastIndexOf('}') + 1)
+          yield Json.parse(trimmed).asOpt[JsObject]) match
+            case None => fufail(s"${rsp.status} ${rsp.body.take(500)}")
+            case Some(res) => fuccess(res)
+
+private[report] object Automod:
+  case class Config(val url: String, val apiKey: Secret)
+  given ConfigLoader[Config] = AutoConfig.loader[Config]

--- a/modules/report/src/main/Env.scala
+++ b/modules/report/src/main/Env.scala
@@ -17,7 +17,9 @@ final class Env(
     playbansOf: => lila.core.playban.BansOf,
     ircApi: lila.core.irc.IrcApi,
     settingStore: lila.memo.SettingStore.Builder,
-    cacheApi: lila.memo.CacheApi
+    cacheApi: lila.memo.CacheApi,
+    appConfig: play.api.Configuration,
+    ws: play.api.libs.ws.StandaloneWSClient
 )(using Executor, NetDomain)(using scheduler: Scheduler):
 
   private def lazyPlaybansOf = () => playbansOf
@@ -40,6 +42,7 @@ final class Env(
   private given UserIdOf[Report.SnoozeKey] = _.snoozerId
   private lazy val snoozer = new lila.memo.Snoozer[Report.SnoozeKey](cacheApi)
 
+  private val automod = Automod(ws, appConfig)
   lazy val api = wire[ReportApi]
 
   lazy val modFilters = new ModReportFilter

--- a/modules/ublog/src/main/Env.scala
+++ b/modules/ublog/src/main/Env.scala
@@ -6,16 +6,13 @@ import play.api.{ ConfigLoader, Configuration }
 import lila.core.config.*
 import lila.db.dsl.Coll
 import lila.common.autoconfig.{ *, given }
-import lila.common.config.given
 import lila.common.Bus
 
 @Module
 final private class UblogConfig(
     val searchPageSize: MaxPerPage,
-    val carouselSize: Int,
-    val automod: AutomodConfig
+    val carouselSize: Int
 )
-final private class AutomodConfig(val url: String, val apiKey: Secret)
 
 @Module
 final class Env(
@@ -32,13 +29,12 @@ final class Env(
     net: NetConfig,
     appConfig: Configuration,
     settingStore: lila.memo.SettingStore.Builder,
-    ws: play.api.libs.ws.StandaloneWSClient,
-    client: lila.search.client.SearchClient
+    client: lila.search.client.SearchClient,
+    reportApi: lila.report.ReportApi
 )(using Executor, Scheduler, play.api.Mode):
 
   export net.{ assetBaseUrl, baseUrl, domain, assetDomain }
 
-  private given ConfigLoader[AutomodConfig] = AutoConfig.loader[AutomodConfig]
   private val config = appConfig.get[UblogConfig]("ublog")(using AutoConfig.loader)
   private val colls = UblogColls(db(CollName("ublog_blog")), db(CollName("ublog_post")))
 

--- a/modules/ublog/src/main/UblogApi.scala
+++ b/modules/ublog/src/main/UblogApi.scala
@@ -197,7 +197,7 @@ final class UblogApi(
           for _ <- colls.post.updateField($id(post.id), "automod", result).void
           yield result.some
         .recoverWith: e =>
-          if n < 5 then delay((30 * math.pow(2, n).toInt).seconds)(attempt(n + 1))
+          if n < retries then delay((30 * math.pow(2, n).toInt).seconds)(attempt(n + 1))
           else
             logger.warn(s"automod ${post.id} failed after $retries retry attempts", e)
             fuccess(none)

--- a/modules/ublog/src/main/UblogAutomod.scala
+++ b/modules/ublog/src/main/UblogAutomod.scala
@@ -1,9 +1,6 @@
 package lila.ublog
 
 import play.api.libs.json.*
-import play.api.libs.ws.*
-import play.api.libs.ws.JsonBodyWritables.*
-import play.api.libs.ws.DefaultBodyReadables.readableAsString
 import com.roundeights.hasher.Algo
 
 import lila.core.data.Text
@@ -38,8 +35,7 @@ object UblogAutomod:
   private given Reads[FuzzyResult] = Json.reads[FuzzyResult]
 
 final class UblogAutomod(
-    ws: StandaloneWSClient,
-    config: AutomodConfig,
+    reportApi: lila.report.ReportApi,
     settingStore: lila.memo.SettingStore.Builder
 )(using Executor):
 
@@ -64,43 +60,22 @@ final class UblogAutomod(
     dedup(s"${post.id}:$text").so(assess(text, temperature))
 
   private def assess(userText: String, temperature: Double): Fu[Option[Assessment]] =
-    val prompt = promptSetting.get().value
-    (config.apiKey.value.nonEmpty && prompt.nonEmpty).so:
-      val body = Json.obj(
-        "model" -> modelSetting.get(),
-        "temperature" -> temperature,
-        "max_tokens" -> 4096,
-        "messages" -> Json.arr(
-          Json.obj("role" -> "system", "content" -> prompt),
-          Json.obj("role" -> "user", "content" -> userText)
-        )
+    reportApi
+      .automod(
+        userText = userText,
+        systemPrompt = promptSetting.get().value,
+        model = modelSetting.get(),
+        temperature = temperature
       )
-      ws.url(config.url)
-        .withHttpHeaders(
-          "Authorization" -> s"Bearer ${config.apiKey.value}",
-          "Content-Type" -> "application/json"
-        )
-        .post(body)
-        .flatMap: rsp =>
-          (for
-            choices <- (Json.parse(rsp.body) \ "choices").asOpt[List[JsObject]]
-            if rsp.status == 200
-            best <- choices.headOption
-            resultStr <- (best \ "message" \ "content").asOpt[String]
-            result <- normalize(resultStr)
-          yield result) match
-            case None => fufail(s"${rsp.status} ${rsp.body.take(500)}")
-            case Some(res) =>
-              lila.mon.ublog.automod.quality(res.quality.toString).increment()
-              lila.mon.ublog.automod.flagged(res.flagged.isDefined).increment()
-              val hash = Algo.sha256(userText).hex.take(12) // matches ublog-automod.mjs hash
-              fuccess(res.copy(hash = hash.some).some)
-        .monSuccess(_.ublog.automod.request)
+      .map:
+        _.flatMap(normalize).so: res =>
+          lila.mon.ublog.automod.quality(res.quality.toString).increment()
+          lila.mon.ublog.automod.flagged(res.flagged.isDefined).increment()
+          res.copy(hash = Algo.sha256(userText).hex.take(12).some).some // matches ublog-automod.mjs hash
+      .monSuccess(_.ublog.automod.request)
 
-  private def normalize(msg: String): Option[Assessment] = // keep in sync with bin/ublog-automod.mjs
-    val trimmed = msg.slice(msg.indexOf('{', msg.indexOf("</think>")), msg.lastIndexOf('}') + 1)
-    Json
-      .parse(trimmed)
+  private def normalize(rsp: JsObject): Option[Assessment] = // keep in sync with bin/ublog-automod.mjs
+    rsp
       .asOpt[FuzzyResult]
       .flatMap: res =>
         Quality


### PR DESCRIPTION
they'll probably want a dedicated mod account for these reports, so we'll need a `togetherai` user (mods will choose the exact name) alongside `irwin`, `kaladin`, and `lichess` at some point.

# prior to deployment restart
- move the automod comment block (with the together.ai key) outside of ublog in application.conf

# after restart
- paste sysadmins/prompts/comms-system-prompt.txt into the comms prompt text box in settings