### PR TITLE
Fix nvui puzzles

### DIFF
--- a/modules/puzzle/src/main/ui/PuzzleUi.scala
+++ b/modules/puzzle/src/main/ui/PuzzleUi.scala
@@ -31,7 +31,7 @@ final class PuzzleUi(helpers: Helpers, val bits: PuzzleBits)(
       .css(ctx.pref.hasVoice.option("voice"))
       .css(ctx.blind.option("round.nvui"))
       .i18n(_.puzzle, _.puzzleTheme, _.storm, _.nvui)
-      // .i18nOpt(ctx.blind, _.keyboardMove, _.nvui)
+      .i18nOpt(ctx.blind, _.keyboardMove)
       .js(ctx.blind.option(Esm("puzzle.nvui")))
       .js(
         PageModule(


### PR DESCRIPTION
The i18n.keyboardMove file was forgotten when reorganizing the puzzle page (scala)