### PR TITLE
Fix analysis scroll to top on fast-backward

### DIFF
--- a/ui/analyse/src/treeView/common.ts
+++ b/ui/analyse/src/treeView/common.ts
@@ -51,7 +51,7 @@ function eventPath(e: MouseEvent): Tree.Path | null {
 
 const autoScroll = throttle(200, (moveListEl: HTMLElement) => {
   const moveEl = moveListEl.querySelector<HTMLElement>('.active');
-  if (!moveEl) return;
+  if (!moveEl) return moveListEl.scrollTo({ top: 0, behavior: 'auto' });
   const [move, view] = [moveEl.getBoundingClientRect(), moveListEl.getBoundingClientRect()];
   const visibleHeight = Math.min(view.bottom, window.innerHeight) - Math.max(view.top, 0);
   moveListEl.scrollTo({


### PR DESCRIPTION
fixes #18035 

Note: there is a similar problem on puzzle, but the cause is different: the autoscroll is not called at all when fast-backward