### PR TITLE
Get the pv wrap toggle button to work.

### DIFF
--- a/ui/lib/src/ceval/view/main.ts
+++ b/ui/lib/src/ceval/view/main.ts
@@ -328,6 +328,7 @@ export function renderPvs(ctrl: ParentCtrl): VNode | undefined {
           const el = vnode.elm as HTMLElement;
           el.addEventListener('pointerdown', (e: PointerEvent) => {
             const uciList = getElUciList(e);
+            if ((e.target as HTMLElement)?.closest('.pv-wrap-toggle')) return;
             if (uciList.length > (pvIndex ?? 0) && !ctrl.threatMode()) {
               ctrl.playUciList(uciList.slice(0, (pvIndex ?? 0) + 1));
               e.preventDefault();


### PR DESCRIPTION
Fixes bug where clicking on the triangle button acts the same as clicking somewhere on the pv line.