### PR TITLE
restrictive mod links

### DIFF
--- a/ui/mod/src/mod.autolink.ts
+++ b/ui/mod/src/mod.autolink.ts
@@ -22,11 +22,12 @@ const greedyAutoLinks = [
   'team',
   'tournament',
   '@',
-  '(?:[A-Za-z0-9]{8})(?:[a-zA-Z0-9]{4})?$',
+  'insights',
+  '(?:[A-Za-z0-9]{8})(?:[a-zA-Z0-9]{4})?', // game ids
 ];
 
 const pathMatchRe = new RegExp(
   `(?:(?:^|\\s)https://)?(?:${location.hostname.replace('.', '\\.')})?` +
-    `(/(?:${greedyAutoLinks.join('|')})[\\w/:(&;)=@-]+)`,
+    `(/(?:${greedyAutoLinks.join('|')})(?:/|\\?|#|$)[\\w/:(&;)=#@-]*)`,
   'gi',
 );


### PR DESCRIPTION
the reason why the replace is restricted to known path segments is because some of the urls we link have no hostname like /forum/blah/blah. we want to link those but we don't want to link /possibly/malicious/path/segment although it's hard to imagine how that could ever be abused.

maybe we'd prefer that vanishingly rare vulnerability over the regex complexity i've introduced. lmk