### PR TITLE
feat: redirect all `/account` routes to `/login` for unauthenticated users

### DIFF
--- a/modules/common/src/main/HTTPRequest.scala
+++ b/modules/common/src/main/HTTPRequest.scala
@@ -142,17 +142,15 @@ object HTTPRequest:
       case LichobileVersionHeaderPattern(v) => ApiVersion.from(v.toIntOption)
       case _ => none
 
-  private def isDataDump(req: RequestHeader) = req.path == "/account/personal-data"
   private def isAppeal(req: RequestHeader) = req.path.startsWith("/appeal")
   private def isGameExport(req: RequestHeader) =
     "^/@/[\\w-]{2,30}/download$".r.matches(req.path) ||
       "^/(api/games/user|games/export)/[\\w-]{2,30}($|/.+)".r.matches(req.path)
   private def isStudyExport(req: RequestHeader) = "^/study/by/[\\w-]{2,30}/export.pgn$".r.matches(req.path)
-  private def isAccountClose(req: RequestHeader) =
-    req.path == "/account/close" || req.path == "/account/delete"
+  private def isAccount(req: RequestHeader) = req.path.startsWith("/account")
 
   def isClosedLoginPath(req: RequestHeader) =
-    isDataDump(req) || isAppeal(req) || isStudyExport(req) || isGameExport(req) || isAccountClose(req)
+    isAppeal(req) || isStudyExport(req) || isGameExport(req) || isAccount(req)
 
   def clientName(req: RequestHeader) =
     // lichobile sends XHR headers


### PR DESCRIPTION
Redirect all `/account` routes to `/login` for unauthenticated users. Previously, only `/account/close`, `/account/delete`, and `/account/personal-data` were redirected to `/login`, the others to `/signup`.

The rationale behind this is that all `/account` routes already require authentication to access. It would make sense to redirect users to `/login` when they aren't authenticated, as it provides the option of using an existing account, rather than assuming they don't have one. 

This is essentially a UX improvement.

This may be needed to merge lichess-org/mobile#2145.

Closes #18070