### PR TITLE
Revert "Clears Message Input When Playing Against New Opponent: Issue  14602"

### DIFF
--- a/app/views/round/player.scala
+++ b/app/views/round/player.scala
@@ -29,8 +29,7 @@ def player(
           withNoteAge = ctx.isAuth.option(pov.game.secondsSinceCreation),
           public = false,
           resourceId = lila.chat.Chat.ResourceId(s"game/${c.chat.id}"),
-          voiceChat = ctx.canVoiceChat,
-          opponentId = pov.opponent.userId
+          voiceChat = ctx.canVoiceChat
         )
       case Right((c, res)) =>
         views.chat.json(
@@ -39,8 +38,7 @@ def player(
           name = trans.site.chatRoom.txt(),
           timeout = c.timeout,
           public = true,
-          resourceId = res,
-          opponentId = pov.opponent.userId
+          resourceId = res
         )
 
   val opponentNameOrZen = if ctx.pref.isZen || ctx.pref.isZenAuto then "ZEN" else playerText(pov.opponent)

--- a/app/views/round/watcher.scala
+++ b/app/views/round/watcher.scala
@@ -25,8 +25,7 @@ def watcher(
       withNoteAge = ctx.isAuth.option(pov.game.secondsSinceCreation),
       public = true,
       resourceId = lila.chat.Chat.ResourceId(s"game/${c.chat.id}"),
-      voiceChat = ctx.canVoiceChat,
-      opponentId = pov.opponent.userId
+      voiceChat = ctx.canVoiceChat
     )
 
   ui.RoundPage(pov.game.variant, s"${gameVsText(pov.game, withRatings = ctx.pref.showRatings)} • spectator")

--- a/modules/chat/src/main/ChatUi.scala
+++ b/modules/chat/src/main/ChatUi.scala
@@ -32,8 +32,7 @@ object ChatUi:
       withNoteAge: Option[Int] = None,
       writeable: Boolean = true,
       localMod: Boolean = false,
-      voiceChat: Boolean = false,
-      opponentId: Option[UserId] = None
+      voiceChat: Boolean = false
   )(using Context): JsObject =
     json(
       chat.chat,
@@ -46,8 +45,7 @@ object ChatUi:
       resourceId = resourceId,
       restricted = chat.restricted,
       localMod = localMod,
-      voiceChat = voiceChat,
-      opponentId = opponentId
+      voiceChat = voiceChat
     )
 
   def json(
@@ -63,8 +61,7 @@ object ChatUi:
       localMod: Boolean = false,
       broadcastMod: Boolean = false,
       voiceChat: Boolean = false,
-      hostIds: List[UserId] = Nil,
-      opponentId: Option[UserId] = None
+      hostIds: List[UserId] = Nil
   )(using ctx: Context): JsObject =
     val noteId = (withNoteAge.isDefined && ctx.noBlind).option(chat.id.value.take(8))
     if ctx.kid.yes then
@@ -86,10 +83,7 @@ object ChatUi:
             .add("userId" -> ctx.userId)
             .add("loginRequired" -> chat.loginRequired)
             .add("restricted" -> restricted)
-            .add("voiceChat" -> (voiceChat && ctx.isAuth))
-            .add(
-              "opponent" -> opponentId.map(id => Json.obj("user" -> Json.obj("id" -> id.value)))
-            ),
+            .add("voiceChat" -> (voiceChat && ctx.isAuth)),
           "writeable" -> writeable,
           "public" -> public,
           "permissions" -> Json

--- a/ui/lib/src/chat/discussion.ts
+++ b/ui/lib/src/chat/discussion.ts
@@ -108,12 +108,7 @@ function prependChatInput(chatInput: HTMLInputElement, prefix: string): void {
 let mouchListener: EventListener;
 
 const setupHooks = (ctrl: ChatCtrl, chatEl: HTMLInputElement) => {
-  const oppId = ctrl.opts.data.opponent?.user?.id ?? 'anon';
-  const key = `chat.input.${oppId}`;
-  Object.keys(sessionStorage)
-    .filter(k => k.startsWith('chat.input.') && k !== key)
-    .forEach(k => sessionStorage.removeItem(k));
-  const storage = tempStorage.make(key);
+  const storage = tempStorage.make('chat.input');
   const previousText = storage.get();
   if (previousText) {
     chatEl.value = previousText;

--- a/ui/lib/src/chat/interfaces.ts
+++ b/ui/lib/src/chat/interfaces.ts
@@ -41,7 +41,6 @@ export interface ChatData {
   restricted: boolean;
   voiceChat: boolean;
   hostIds?: string[];
-  opponent?: { user?: { id?: string } };
 }
 
 export interface Line {


### PR DESCRIPTION
Reverts lichess-org/lila#18053

Sorry, that's not it. No UI widget should ever traverse all unrelated session objects. Who knows how many there are? This could add subtle and impossible to debug performance problems.

The idea to clean-up previous chat storages was good however, to avoid the proliferation of chat storage keys. But another implementation has to be found.