### PR TITLE
Add deep link to Broadcaster App from broadcast manager section

### DIFF
--- a/ui/analyse/src/study/relay/deepLink.ts
+++ b/ui/analyse/src/study/relay/deepLink.ts
@@ -1,4 +1,4 @@
-export const openInApp = (url: string): string => {
+export const broadcasterDeepLink = (url: string): string => {
   const parsed = new URL(url);
   return 'lichess-broadcaster:/' + parsed.pathname;
 };

--- a/ui/analyse/src/study/relay/deepLink.ts
+++ b/ui/analyse/src/study/relay/deepLink.ts
@@ -1,9 +1,8 @@
 export const openInApp = (url: string): string => {
-  const parsed = URL.parse(url);
-
-  if (parsed) {
+  try {
+    const parsed = new URL(url);
     return 'lichess-broadcaster:/' + parsed.pathname;
+  } catch (e) {
+    throw new Error('Cannot parse URL');
   }
-
-  throw new Error('Cannot parse URL');
 };

--- a/ui/analyse/src/study/relay/deepLink.ts
+++ b/ui/analyse/src/study/relay/deepLink.ts
@@ -1,8 +1,4 @@
 export const openInApp = (url: string): string => {
-  try {
-    const parsed = new URL(url);
-    return 'lichess-broadcaster:/' + parsed.pathname;
-  } catch (e) {
-    throw new Error('Cannot parse URL');
-  }
+  const parsed = new URL(url);
+  return 'lichess-broadcaster:/' + parsed.pathname;
 };

--- a/ui/analyse/src/study/relay/deepLink.ts
+++ b/ui/analyse/src/study/relay/deepLink.ts
@@ -1,0 +1,9 @@
+export const openInApp = (url: string): string => {
+  const parsed = URL.parse(url);
+
+  if (parsed) {
+    return 'lichess-broadcaster:/' + parsed.pathname;
+  }
+
+  throw new Error('Cannot parse URL');
+};

--- a/ui/analyse/src/study/relay/interfaces.ts
+++ b/ui/analyse/src/study/relay/interfaces.ts
@@ -30,6 +30,7 @@ export interface RelayRound {
   id: RoundId;
   name: string;
   slug: string;
+  url: string;
   finished?: boolean;
   ongoing?: boolean;
   startsAt?: number;

--- a/ui/analyse/src/study/relay/relayManagerView.ts
+++ b/ui/analyse/src/study/relay/relayManagerView.ts
@@ -5,6 +5,7 @@ import type RelayCtrl from './relayCtrl';
 import { memoize } from 'lib';
 import { studySideNodes } from '../studyView';
 import type StudyCtrl from '../studyCtrl';
+import { openInApp } from './deepLink';
 
 export default function (ctrl: RelayCtrl, study: StudyCtrl): MaybeVNode {
   const contributor = study.members.canContribute(),
@@ -21,7 +22,7 @@ export default function (ctrl: RelayCtrl, study: StudyCtrl): MaybeVNode {
             ]),
             sync?.url || sync?.ids || sync?.urls || sync?.users
               ? (sync.ongoing ? stateOn : stateOff)(ctrl)
-              : statePush(),
+              : statePush(ctrl),
             renderLog(ctrl),
           ]),
         (contributor || study.data.admin) && studySideNodes(study, false),
@@ -86,8 +87,18 @@ const stateOff = (ctrl: RelayCtrl) =>
     [hl('div.fat', 'Click to connect')],
   );
 
-const statePush = () =>
-  hl('div.state.push', { attrs: dataIcon(licon.UploadCloud) }, ['Listening to Broadcaster App']);
+const statePush = (ctrl: RelayCtrl) => {
+  return hl('div.state.push', { attrs: dataIcon(licon.UploadCloud) }, [
+    hl('div', [
+      'Listening to ',
+      hl('a', { attrs: { href: '/broadcast/app' } }, 'Broadcaster App'),
+      hl('br'),
+      hl('small', [
+        hl('a', { attrs: { href: openInApp(ctrl.currentRound().url) } }, 'Open this round in the app'),
+      ]),
+    ]),
+  ]);
+};
 
 const dateFormatter = memoize(
   () =>

--- a/ui/analyse/src/study/relay/relayManagerView.ts
+++ b/ui/analyse/src/study/relay/relayManagerView.ts
@@ -5,7 +5,7 @@ import type RelayCtrl from './relayCtrl';
 import { memoize } from 'lib';
 import { studySideNodes } from '../studyView';
 import type StudyCtrl from '../studyCtrl';
-import { openInApp } from './deepLink';
+import { broadcasterDeepLink } from './deepLink';
 
 export default function (ctrl: RelayCtrl, study: StudyCtrl): MaybeVNode {
   const contributor = study.members.canContribute(),
@@ -94,7 +94,7 @@ const statePush = (ctrl: RelayCtrl) =>
       hl('a', { attrs: { href: '/broadcast/app' } }, 'Broadcaster App'),
       hl('br'),
       hl('small', [
-        hl('a', { attrs: { href: openInApp(ctrl.currentRound().url) } }, 'Open this round in the app'),
+        hl('a', { attrs: { href: broadcasterDeepLink(ctrl.currentRound().url) } }, 'Open this round in the app'),
       ]),
     ]),
   ]);

--- a/ui/analyse/src/study/relay/relayManagerView.ts
+++ b/ui/analyse/src/study/relay/relayManagerView.ts
@@ -87,8 +87,8 @@ const stateOff = (ctrl: RelayCtrl) =>
     [hl('div.fat', 'Click to connect')],
   );
 
-const statePush = (ctrl: RelayCtrl) => {
-  return hl('div.state.push', { attrs: dataIcon(licon.UploadCloud) }, [
+const statePush = (ctrl: RelayCtrl) =>
+  hl('div.state.push', { attrs: dataIcon(licon.UploadCloud) }, [
     hl('div', [
       'Listening to ',
       hl('a', { attrs: { href: '/broadcast/app' } }, 'Broadcaster App'),
@@ -98,7 +98,6 @@ const statePush = (ctrl: RelayCtrl) => {
       ]),
     ]),
   ]);
-};
 
 const dateFormatter = memoize(
   () =>

--- a/ui/analyse/src/study/relay/relayManagerView.ts
+++ b/ui/analyse/src/study/relay/relayManagerView.ts
@@ -94,7 +94,11 @@ const statePush = (ctrl: RelayCtrl) =>
       hl('a', { attrs: { href: '/broadcast/app' } }, 'Broadcaster App'),
       hl('br'),
       hl('small', [
-        hl('a', { attrs: { href: broadcasterDeepLink(ctrl.currentRound().url) } }, 'Open this round in the app'),
+        hl(
+          'a',
+          { attrs: { href: broadcasterDeepLink(ctrl.currentRound().url) } },
+          'Open this round in the app',
+        ),
       ]),
     ]),
   ]);

--- a/ui/analyse/tests/deepLink.test.ts
+++ b/ui/analyse/tests/deepLink.test.ts
@@ -1,7 +1,7 @@
-import { expect, test } from 'vitest';
+import { expect, it } from 'vitest';
 import { openInApp } from '../src/study/relay/deepLink';
 
-test('openInApp', () => {
+it('creates deep link from URL', () => {
   expect(openInApp('https://lichess.org/broadcast/fide-grand-swiss-2025--open/round-1/xSCoiNg0')).toBe(
     'lichess-broadcaster://broadcast/fide-grand-swiss-2025--open/round-1/xSCoiNg0',
   );

--- a/ui/analyse/tests/deepLink.test.ts
+++ b/ui/analyse/tests/deepLink.test.ts
@@ -2,9 +2,9 @@ import { expect, it } from 'vitest';
 import { broadcasterDeepLink } from '../src/study/relay/deepLink';
 
 it('creates deep link from URL', () => {
-  expect(broadcasterDeepLink('https://lichess.org/broadcast/fide-grand-swiss-2025--open/round-1/xSCoiNg0')).toBe(
-    'lichess-broadcaster://broadcast/fide-grand-swiss-2025--open/round-1/xSCoiNg0',
-  );
+  expect(
+    broadcasterDeepLink('https://lichess.org/broadcast/fide-grand-swiss-2025--open/round-1/xSCoiNg0'),
+  ).toBe('lichess-broadcaster://broadcast/fide-grand-swiss-2025--open/round-1/xSCoiNg0');
 });
 
 it('throws on invalid URL', () => {

--- a/ui/analyse/tests/deepLink.test.ts
+++ b/ui/analyse/tests/deepLink.test.ts
@@ -5,5 +5,5 @@ test('openInApp', () => {
   expect(openInApp('https://lichess.org/broadcast/fide-grand-swiss-2025--open/round-1/xSCoiNg0')).toBe(
     'lichess-broadcaster://broadcast/fide-grand-swiss-2025--open/round-1/xSCoiNg0',
   );
-  expect(() => openInApp('invalid-url')).toThrow('Cannot parse URL');
+  expect(() => openInApp('invalid-url')).toThrow('Invalid URL: invalid-url');
 });

--- a/ui/analyse/tests/deepLink.test.ts
+++ b/ui/analyse/tests/deepLink.test.ts
@@ -1,9 +1,12 @@
 import { expect, it } from 'vitest';
-import { openInApp } from '../src/study/relay/deepLink';
+import { broadcasterDeepLink } from '../src/study/relay/deepLink';
 
 it('creates deep link from URL', () => {
-  expect(openInApp('https://lichess.org/broadcast/fide-grand-swiss-2025--open/round-1/xSCoiNg0')).toBe(
+  expect(broadcasterDeepLink('https://lichess.org/broadcast/fide-grand-swiss-2025--open/round-1/xSCoiNg0')).toBe(
     'lichess-broadcaster://broadcast/fide-grand-swiss-2025--open/round-1/xSCoiNg0',
   );
-  expect(() => openInApp('invalid-url')).toThrow('Invalid URL: invalid-url');
+});
+
+it('throws on invalid URL', () => {
+  expect(() => broadcasterDeepLink('invalid-url')).toThrow('Invalid URL: invalid-url');
 });

--- a/ui/analyse/tests/deepLink.test.ts
+++ b/ui/analyse/tests/deepLink.test.ts
@@ -1,0 +1,9 @@
+import { expect, test } from 'vitest';
+import { openInApp } from '../src/study/relay/deepLink';
+
+test('openInApp', () => {
+  expect(openInApp('https://lichess.org/broadcast/fide-grand-swiss-2025--open/round-1/xSCoiNg0')).toBe(
+    'lichess-broadcaster://broadcast/fide-grand-swiss-2025--open/round-1/xSCoiNg0',
+  );
+  expect(() => openInApp('invalid-url')).toThrow('Cannot parse URL');
+});


### PR DESCRIPTION
| before | after |
| - | - |
| <img width="491" height="150" alt="image" src="https://github.com/user-attachments/assets/1ab0c250-c9f7-43c8-8a23-567a51e75d81" /> | <img width="494" height="146" alt="image" src="https://github.com/user-attachments/assets/fe0d62e8-fddd-453a-a022-78bd0ff22d9d" /> |

The Broadcaster app now supports deep links. Clicking this link will start the app (or bring it to focus if already opened) and then navigate directly to that round.