### PR TITLE
let lichess devs see user agents

### DIFF
--- a/app/controllers/User.scala
+++ b/app/controllers/User.scala
@@ -402,11 +402,12 @@ final class User(
         val otherUsers = isGranted(_.AccountInfo).so[Fu[Frag]]:
           othersAndLogins.map(_._1())
 
-        val identification = (isGranted(_.AccountInfo) || isGranted(_.ViewPrintNoIP)).so:
-          for
-            logins <- userLoginsFu
-            others <- othersAndLogins
-          yield views.user.mod.identification(logins, others._2.othersPartiallyLoaded)
+        val identification =
+          (isGranted(_.AccountInfo) || isGranted(_.ViewPrintNoIP) || isGranted(_.ViewUserAgent)).so:
+            for
+              logins <- userLoginsFu
+              others <- othersAndLogins
+            yield views.user.mod.identification(logins.pp, others._2.othersPartiallyLoaded.pp)
 
         val kaladin = isGranted(_.MarkEngine).so:
           env.irwin.kaladinApi.get(user).map(_.flatMap(_.response).so(views.irwin.kaladin.report))

--- a/app/views/user/mod.scala
+++ b/app/views/user/mod.scala
@@ -197,7 +197,7 @@ object mod:
     val canIpBan = Granter.opt(_.IpBan)
     val canFpBan = Granter.opt(_.PrintBan)
     val canLocate = Granter.opt(_.Admin)
-    val canViewUA = Granter.opt(_.AccountInfo)
+    val canViewUA = Granter.opt(_.ViewUserAgent)
     val canViewPrint = Granter.opt(_.ViewPrintNoIP)
     mzSection("identification")(
       canLocate.option:

--- a/modules/core/src/main/perm.scala
+++ b/modules/core/src/main/perm.scala
@@ -106,11 +106,12 @@ enum Permission(val key: String, val alsoGrants: List[Permission], val name: Str
   case ApiChallengeAdmin extends Permission("API_CHALLENGE_ADMIN", "API Challenge admin")
   case LichessTeam extends Permission("LICHESS_TEAM", List(Beta), "Lichess team")
   case BotEditor extends Permission("BOT_EDITOR", "Bot editor")
+  case ViewUserAgent extends Permission("VIEW_USER_AGENT", "View user agent")
   case Diagnostics extends Permission("DIAGNOSTICS", "Diagnostics")
   case DeveloperTeam
       extends Permission(
         "DEVELOPER_TEAM",
-        List(LichessTeam, Diagnostics, UserModView, BotEditor, ApiHog, StickyPosts),
+        List(LichessTeam, Diagnostics, UserModView, BotEditor, ApiHog, StickyPosts, ViewUserAgent),
         "Developer Team"
       )
   case TimeoutMod
@@ -136,7 +137,8 @@ enum Permission(val key: String, val alsoGrants: List[Permission], val name: Str
           ModMessage,
           ModNote,
           ViewPrintNoIP,
-          SendToZulip
+          SendToZulip,
+          ViewUserAgent
         ),
         "Boost Hunter"
       )
@@ -158,7 +160,8 @@ enum Permission(val key: String, val alsoGrants: List[Permission], val name: Str
           ModMessage,
           ModNote,
           ViewPrintNoIP,
-          SendToZulip
+          SendToZulip,
+          ViewUserAgent
         ),
         "Cheat Hunter"
       )
@@ -180,7 +183,8 @@ enum Permission(val key: String, val alsoGrants: List[Permission], val name: Str
           ModLog,
           ModNote,
           ViewPrintNoIP,
-          SendToZulip
+          SendToZulip,
+          ViewUserAgent
         ),
         "Shusher"
       )


### PR DESCRIPTION
broaden AccountInfo guard so that user agents show up. add a discrete permission for user agent, it can't be part of AccountInfo without granting other powers that devs don't need.

note - mod zone lacks the convenience of a powertip when parsing long forum threads where many different users report a problem. it's quicker to hover than open each profile in a separate tab and click mod view. making it more difficult to access might be the goal, but i just wanted to point out the use case.

maybe if it was available on hover, we could require the ctrl key on mouseenter to make it more of a conscious action.