### PR TITLE
Move tiebreak sorting to lila. 

### DIFF
--- a/modules/relay/src/main/RelayPlayer.scala
+++ b/modules/relay/src/main/RelayPlayer.scala
@@ -31,6 +31,43 @@ case class RelayPlayer(
   def toTieBreakPlayer: Option[Tiebreak.Player] = player.id.map: id =>
     Tiebreak.Player(id = id.toString, rating = player.rating.map(_.into(Elo)))
 
+given Ordering[List[TiebreakPoint]] = new:
+  def compare(a: List[TiebreakPoint], b: List[TiebreakPoint]): Int =
+    @scala.annotation.tailrec
+    def loop(a: List[TiebreakPoint], b: List[TiebreakPoint]): Int = (a, b) match
+      case (Nil, Nil) => 0
+      case (Nil, _) => -1 // a is empty, b is not
+      case (_, Nil) => 1 // b is empty, a is not
+      case (ah :: at, bh :: bt) =>
+        val cmp = bh.value.compare(ah.value)
+        if cmp != 0 then cmp else loop(at, bt)
+    loop(a, b)
+
+given Ordering[Option[List[TiebreakPoint]]] = new Ordering[Option[List[TiebreakPoint]]]:
+  def compare(a: Option[List[TiebreakPoint]], b: Option[List[TiebreakPoint]]): Int =
+    (a, b) match
+      case (Some(ta), Some(tb)) => Ordering[List[TiebreakPoint]].compare(ta, tb)
+      case (Some(_), None) => 1 // a is defined, b is not
+      case (None, Some(_)) => -1 // b is defined, a is not
+      case (None, None) => 0
+
+given Ordering[RelayPlayer] = new Ordering[RelayPlayer]:
+  /* Sort players by:
+      1. Score (Descending)
+      2. Tiebreak points (compare each tiebreak in order, higher is better)
+      3. Player rating (Descending)
+      4. Player name (Alphabetical, ascending)
+   */
+  def compare(a: RelayPlayer, b: RelayPlayer): Int =
+    val scoreComparison = b.score.compare(a.score)
+    lazy val tiebreakComparison = Ordering[Option[List[TiebreakPoint]]]
+      .compare(a.tiebreaks.map(_.values.toList), b.tiebreaks.map(_.values.toList))
+    lazy val ratingComparison = b.rating.map(_.value).compare(a.rating.map(_.value))
+    if scoreComparison != 0 then scoreComparison
+    else if tiebreakComparison != 0 then tiebreakComparison
+    else if ratingComparison != 0 then ratingComparison
+    else a.player.name.map(_.value).compare(b.player.name.map(_.value))
+
 object RelayPlayer:
 
   opaque type Rank = Int
@@ -260,10 +297,16 @@ private final class RelayPlayerApi(
           p.toTieBreakPlayer.map: tbPlayer =>
             tbPlayer.id -> Tiebreak.PlayerWithGames(tbPlayer, p.games.flatMap(_.toTiebreakGame))
         .toMap
-    val result = Tiebreak.compute(tbGames, tiebreaks.toList).zipWithIndex
-    players.map: (id, rp) =>
-      val found = result.find((p, _) => p.player.id == id.toString)
-      id -> rp.copy(
-        tiebreaks = found.map(t => tiebreaks.zip(t._1.tiebreakPoints).to(SeqMap)),
-        rank = Rank.from(found.map(_._2 + 1))
-      )
+    val result = Tiebreak.compute(tbGames, tiebreaks.toList)
+    players
+      .map: (id, rp) =>
+        val found = result.find(p => p.player.id == id.toString)
+        id -> rp.copy(
+          tiebreaks = found.map(t => tiebreaks.zip(t.tiebreakPoints).to(SeqMap))
+        )
+      .toList
+      .sortBy(_._2)
+      .mapWithIndex:
+        case ((id, rp), index) =>
+          id -> rp.copy(rank = Rank.from((index + 1).some))
+      .to(SeqMap)

--- a/modules/relay/src/test/RelayPlayerTest.scala
+++ b/modules/relay/src/test/RelayPlayerTest.scala
@@ -1,5 +1,7 @@
 package lila.relay
 
+import scala.collection.immutable.SeqMap
+
 class RelayPlayerTest extends munit.FunSuite:
 
   test("dr. and prof."):
@@ -11,3 +13,53 @@ class RelayPlayerTest extends munit.FunSuite:
   test("comma"):
     assertEquals(RelayPlayerLine.tokenize("Zimmer, Gerald"), "gerald zimmer")
     assertEquals(RelayPlayerLine.tokenize("Zimmer,Gerald"), "gerald zimmer")
+
+  test("sorting by score"):
+    val p1 = RelayPlayer(
+      player = dummyPlayer("Alice", 2000),
+      score = Some(3.0f),
+      ratingDiff = None,
+      performance = None,
+      tiebreaks = None,
+      rank = None,
+      games = Vector.empty
+    )
+    val p2 = p1.copy(player = dummyPlayer("Bob", 2100), score = Some(4.0f))
+    val p3 = p1.copy(player = dummyPlayer("Carol", 2200), score = Some(2.0f))
+    val sorted = List(p1, p2, p3).sorted
+    assertEquals(sorted.map(_.player.player.name.map(_.value)), List("Bob".some, "Alice".some, "Carol".some))
+
+  test("sorting by tiebreakpoints"):
+    import chess.tiebreak.*
+    val tiebreaks = Tiebreak.preset.take(2)
+    val tb1 = SeqMap(tiebreaks(0) -> TiebreakPoint(10), tiebreaks(1) -> TiebreakPoint(5))
+    val tb2 = SeqMap(tiebreaks(0) -> TiebreakPoint(12), tiebreaks(1) -> TiebreakPoint(4))
+    val p1 = RelayPlayer(dummyPlayer("Alice", 2000), Some(3.0f), None, None, Some(tb1), None, Vector.empty)
+    val p2 = RelayPlayer(dummyPlayer("Bob", 2100), Some(3.0f), None, None, Some(tb2), None, Vector.empty)
+    val sorted = List(p1, p2).sorted
+    assertEquals(sorted.map(_.player.player.name.map(_.value)), List("Bob".some, "Alice".some))
+
+  test("sorting by rating"):
+    val p1 = RelayPlayer(dummyPlayer("Alice", 2000), Some(3.0f), None, None, None, None, Vector.empty)
+    val p2 = RelayPlayer(dummyPlayer("Bob", 2100), Some(3.0f), None, None, None, None, Vector.empty)
+    val sorted = List(p1, p2).sorted
+    assertEquals(sorted.map(_.player.player.name.map(_.value)), List("Bob".some, "Alice".some))
+
+  test("sorting by name"):
+    val p1 = RelayPlayer(dummyPlayer("Alice", 2000), Some(3.0f), None, None, None, None, Vector.empty)
+    val p2 = RelayPlayer(dummyPlayer("Bob", 2000), Some(3.0f), None, None, None, None, Vector.empty)
+    val sorted = List(p2, p1).sorted
+    assertEquals(sorted.map(_.player.player.name.map(_.value)), List("Alice".some, "Bob".some))
+
+  def dummyPlayer(name: String, rating: Int): lila.study.StudyPlayer.WithFed =
+    import lila.study.StudyPlayer
+    StudyPlayer.WithFed(
+      player = StudyPlayer(
+        fideId = None,
+        name = Some(chess.PlayerName(name)),
+        rating = Some(chess.IntRating(rating)),
+        title = None,
+        team = None
+      ),
+      fed = None
+    )


### PR DESCRIPTION
Corresponding removal in scalachess: https://github.com/lichess-org/scalachess/pull/748

Added further sorting:
* Sort players by:
      1. Score (Descending)
      2. Tiebreak points (compare each tiebreak in order, higher is better)
      3. Player rating (Descending)
      4. Player name (Alphabetical, ascending)

* Add tests for sorting (Copilot generated but checks out)