### PR TITLE
Fix tablesort header alignment

### DIFF
--- a/ui/lib/css/component/_tablesort.scss
+++ b/ui/lib/css/component/_tablesort.scss
@@ -4,20 +4,19 @@ th[role='columnheader']:not(.no-sort) {
 }
 
 th[role='columnheader']:not(.no-sort):after {
+  @extend %data-icon;
   @include prevent-select;
-  content: '';
-  float: right;
-  margin-top: 7px;
-  border-width: 0 5px 5px;
-  border-style: solid;
-  border-color: $c-accent transparent;
+  content: $licon-UpTriangle;
+  display: inline;
+  margin-inline-start: 0.5em;
+  color: $c-accent;
   visibility: hidden;
   opacity: 0;
+  font-size: 14px;
 }
 
 th[aria-sort='descending']:not(.no-sort):after {
-  border-bottom: none;
-  border-width: 5px 5px 0;
+  content: $licon-DownTriangle;
 }
 
 th[aria-sort]:not(.no-sort) {
@@ -26,7 +25,6 @@ th[aria-sort]:not(.no-sort) {
   &:after {
     visibility: visible;
     opacity: 0.7;
-    margin-inline-start: 1ch;
   }
 }
 


### PR DESCRIPTION
Inline with a licon arrow because it is easier for me to inline text than parts of a bounding box.

Closes #18161 