### PR TITLE
dont filter touch scrolling

### DIFF
--- a/ui/chart/src/chart.ratingHistory.ts
+++ b/ui/chart/src/chart.ratingHistory.ts
@@ -245,6 +245,7 @@ export function initModule({ data, singlePerfName }: Opts): void {
     pubsub.on('chart.panning', () => {
       slider.set([chart.scales.x.min, chart.scales.x.max], false, true);
     });
+    $el[0]!.style.touchAction = 'pan-y';
     const activeIfDuration = (d: duration.Duration) => (initial.isSame(endDate.subtract(d)) ? 'active' : '');
     const timeBtn = (b: { t: TimeButton; duration: duration.Duration }) =>
       `<button class = "btn-rack__btn ${activeIfDuration(b.duration)}">${b.t}</button>`;


### PR DESCRIPTION
this is a usability fix to allow mobile touch scrolling on the ratings chart in profile views. no idea if there's a better way. chartjs seems to set touch-action: none in an inline style, so maybe there's a config option to do this cleaner.