### PR TITLE
dont hide request analysis button when fishnet toggle is off

### DIFF
--- a/ui/analyse/css/_round-underboard.scss
+++ b/ui/analyse/css/_round-underboard.scss
@@ -3,6 +3,7 @@
 $col1-panel-height: 30vh;
 $col2-panel-height: 240px;
 
+// show the request button even if analysis is disabled
 .comp-off .analyse__underboard:not(:has(.future-game-analysis)) .computer-analysis {
   display: none !important;
 }

--- a/ui/analyse/css/_round-underboard.scss
+++ b/ui/analyse/css/_round-underboard.scss
@@ -3,7 +3,7 @@
 $col1-panel-height: 30vh;
 $col2-panel-height: 240px;
 
-.comp-off .computer-analysis {
+.comp-off .analyse__underboard:not(:has(.future-game-analysis)) .computer-analysis {
   display: none !important;
 }
 

--- a/ui/analyse/src/serverSideUnderboard.ts
+++ b/ui/analyse/src/serverSideUnderboard.ts
@@ -15,13 +15,6 @@ export const stockfishName = 'Stockfish 17.1';
 
 export default function (element: HTMLElement, ctrl: AnalyseCtrl) {
   $(element).replaceWith(ctrl.opts.$underboard);
-  document.querySelectorAll<HTMLFormElement>('form.future-game-analysis')?.forEach(
-    form =>
-      (form.onsubmit = () => {
-        ctrl.showFishnetAnalysis(true);
-        ctrl.redraw();
-      }),
-  );
   const data = ctrl.data,
     $panels = $('.analyse__underboard__panels > div'),
     $menu = $('.analyse__underboard__menu'),
@@ -134,6 +127,9 @@ export default function (element: HTMLElement, ctrl: AnalyseCtrl) {
         });
         return false;
       }
+      // ensure the analysis tab remains visible, if it was only displayed to render the request button
+      ctrl.showFishnetAnalysis(true);
+      ctrl.redraw();
       xhrTextRaw(this.action, { method: this.method }).then(res => {
         if (res.ok) startAdvantageChart();
         else

--- a/ui/analyse/src/serverSideUnderboard.ts
+++ b/ui/analyse/src/serverSideUnderboard.ts
@@ -15,7 +15,13 @@ export const stockfishName = 'Stockfish 17.1';
 
 export default function (element: HTMLElement, ctrl: AnalyseCtrl) {
   $(element).replaceWith(ctrl.opts.$underboard);
-
+  document.querySelectorAll<HTMLFormElement>('form.future-game-analysis')?.forEach(
+    form =>
+      (form.onsubmit = () => {
+        ctrl.showFishnetAnalysis(true);
+        ctrl.redraw();
+      }),
+  );
   const data = ctrl.data,
     $panels = $('.analyse__underboard__panels > div'),
     $menu = $('.analyse__underboard__menu'),


### PR DESCRIPTION
https://lichess.org/forum/lichess-feedback/request-a-computer-analysis-feature-gone-from-mobile-chrome-users-android

not a bug, per se. but a confusing part of the app this person found that we can fix.