### PR TITLE
show action menu in crowded user profiles on mobile

### DIFF
--- a/ui/user/css/_show.scss
+++ b/ui/user/css/_show.scss
@@ -28,7 +28,6 @@
     background: $c-bg-zebra;
 
     .number-menu {
-      flex: 0 0 auto;
       overflow-x: auto;
       margin: 0 0 0.2em 1em;
     }


### PR DESCRIPTION

<img width="400" height="423" alt="image" src="https://github.com/user-attachments/assets/40958c6b-ba47-44df-b916-ab3d4f2a223b" />

after

<img width="400" height="423" alt="image" src="https://github.com/user-attachments/assets/7dc33f02-ca86-41e3-a823-fd7cafd299ee" />
