### PR TITLE
Toggle unplayed termination tag

### DIFF
--- a/modules/relay/src/main/RelayGame.scala
+++ b/modules/relay/src/main/RelayGame.scala
@@ -88,7 +88,7 @@ private object RelayGame:
           then tag.copy(value = Outcome.showPoints(Outcome.pointsFromResult(tag.value)))
           else tag)
     .pipe(_ - Tag.Date) // trust the chapter date, not the source date
-      .pipe(withUnplayedTermination(_, res))
+      .pipe(toggleUnplayedTermination(_, res))
     RelayGame(
       tags = fixedTags,
       variant = res.variant,
@@ -107,9 +107,11 @@ private object RelayGame:
         Option.when(clean.size > 1 && clean.toLowerCase != "unknown"):
           tag.copy(value = clean)
 
-  private def withUnplayedTermination(tags: Tags, res: lila.study.StudyPgnImport.Result) =
-    if res.ending.isDefined && res.root.mainline.sizeIs < 2
-    then tags + unplayedTag
+  private def toggleUnplayedTermination(tags: Tags, res: lila.study.StudyPgnImport.Result) =
+    if res.ending.isDefined then
+      if res.root.mainline.sizeIs < 2
+      then tags + unplayedTag
+      else tags.map(_.filter(_ != unplayedTag))
     else tags
 
   import scalalib.Iso


### PR DESCRIPTION
To fix the bug where games previously marked as unplayed keep the tag even if moves are later pushed to it