### PR TITLE
patron color selector: explicit width for tier name

### DIFF
--- a/ui/bits/css/plan/_style-selector.scss
+++ b/ui/bits/css/plan/_style-selector.scss
@@ -84,6 +84,7 @@
         box-shadow: 0 0 23px $color;
       }
       .pss__color__tier-name {
+        width: 100%;
         background-color: var(--c-paco#{$id});
       }
     }


### PR DESCRIPTION
so that the background color fills the entire width of the selector for Safari 18. fix #18254

| | Before | After |
|--------|--------|--------|
| Safari | <img width="1172" height="498" alt="image" src="https://github.com/user-attachments/assets/e3552c6c-846c-4783-b85a-eb9e66cb604f" /> | <img width="1220" height="511" alt="image" src="https://github.com/user-attachments/assets/7a7c83e0-0695-4e7d-9047-e6a1ca05c5e8" /> |
| Chrome | <img width="1186" height="505" alt="image" src="https://github.com/user-attachments/assets/8e1c5e0b-ffa9-40c6-93e8-847628e5f591" /> | <img width="1180" height="494" alt="image" src="https://github.com/user-attachments/assets/4b9b8b80-e310-42de-b0fb-43773c2c55f8" /> |
| Firefox | <img width="1061" height="634" alt="image" src="https://github.com/user-attachments/assets/e990c627-b390-4037-b832-aaed4fe795f5" /> | <img width="1060" height="588" alt="image" src="https://github.com/user-attachments/assets/7564b2a9-3aca-4865-b830-daf73d0fc56e" /> | 