### PR TITLE
restore active move hilite in browsers without css color module 4

### DIFF
--- a/ui/lib/css/tree/_tree.scss
+++ b/ui/lib/css/tree/_tree.scss
@@ -53,6 +53,7 @@ $disclosure-btn-size: calc(15px + var(---button-size-pointer-adjust, 0px));
 
   &.active {
     color: white;
+    background: $c-primary;
     background: color-mix(in srgb, var(--c-base) 85%, transparent);
 
     shapes,


### PR DESCRIPTION
possibly fix #18268