### PR TITLE
updated opening explorer wiki books display

### DIFF
--- a/ui/opening/src/wiki.ts
+++ b/ui/opening/src/wiki.ts
@@ -9,18 +9,27 @@ export default function wikiTheory(data: OpeningPage): void {
 
 async function fetchAndRender(data: OpeningPage, render: (html: string) => void) {
   const wikiBooksUrl = 'https://en.wikibooks.org';
-  const apiArgs =
-    'redirects&origin=*&action=query&prop=extracts&formatversion=2&format=json&exchars=1200&stable=1';
+  const apiArgs = 'redirects&origin=*&action=query&prop=extracts&formatversion=2&format=json&stable=1';
 
-  const removeH1 = (html: string) => html.replace(/<h1>.+<\/h1>/g, '');
+  const removeH1 = (html: string) => html.replace(/<h1.+<\/h1>/g, '');
   const removeEmptyParagraph = (html: string) => html.replace(/<p>(<br \/>|\s)*<\/p>/g, '');
-  const removeTableHeader = (html: string) =>
-    html.replace('<h2><span id="Theory_table">Theory table</span></h2>', '');
-  const removeTableExpl = (html: string) =>
+  const removeTheoryTableSection = (html: string) =>
+    html.replace(/<h2 data-mw-anchor="Theory_table">Theory table<\/h2>.*?(?=<h[1-6]|$)/gs, '');
+
+  const removeAllBlacksMovesSection = (html: string) =>
     html.replace(
-      /For explanation of theory tables see theory table and for notation see algebraic notation.?/,
+      /<h2 data-mw-anchor="All_possible_Black's_moves" data-mw-fallback-anchor="All_possible_Black\.27s_moves">All possible Black's moves<\/h2>.*?(?=<h[1-6]|$)/gs,
       '',
     );
+
+  const removeAllPossibleRepliesSection = (html: string) =>
+    html.replace(
+      /<h2 data-mw-anchor="All_possible_replies">All possible replies<\/h2>.*?(?=<h[1-6]|$)/gs,
+      '',
+    );
+
+  const removeExternalLinksSection = (html: string) =>
+    html.replace(/<h2 data-mw-anchor="External_links">External links<\/h2>.*?(?=<h[1-6]|$)/gs, '');
   const removeContributing = (html: string) =>
     html.replace('When contributing to this Wikibook, please follow the Conventions for organization.', '');
 
@@ -28,8 +37,15 @@ async function fetchAndRender(data: OpeningPage, render: (html: string) => void)
     `<p><a target="_blank" href="${wikiBooksUrl}/wiki/${title}">Read more on WikiBooks</a></p>`;
 
   const transform = (html: string, title: string) =>
-    removeH1(removeEmptyParagraph(removeTableHeader(removeTableExpl(removeContributing(html))))) +
-    readMore(title);
+    removeH1(
+      removeEmptyParagraph(
+        removeTheoryTableSection(
+          removeAllBlacksMovesSection(
+            removeAllPossibleRepliesSection(removeExternalLinksSection(removeContributing(html))),
+          ),
+        ),
+      ),
+    ) + readMore(title);
 
   const plyPrefix = (ply: number) => `${Math.floor((ply + 1) / 2)}${ply % 2 === 1 ? '._' : '...'}`;
   const pathParts = data.sans.map((san, i) => `${plyPrefix(i + 1)}${san}`);


### PR DESCRIPTION
Implemented the changes requested in #17957 about the truncation of descriptions from wikibooks in the opening explorer.

**What Changed**
I updated the api request not to have a max characters argument so it could fetch the entire page from wikibooks. I updated the `removeH1` function to work correctly (the format of the html was `<h1 data-mw-anchor=...</h2>`)

I removed the entirety of the Theory table section (and it's similar counterparts All possible Black's moves and All possible replies) since these tables aren't actually returned by the API requests so these sections were essentially empty. To do this, I used a regex search to match the header and then delete everything until the next header was encountered.

<img width="1023" height="454" alt="Screenshot 2025-09-25 at 3 44 59 PM" src="https://github.com/user-attachments/assets/011232b8-7220-4a76-977a-f2d0574e974f" />
^^Empty Theory Table: Now this section is not shown

<img width="1025" height="231" alt="Screenshot 2025-09-25 at 3 45 32 PM" src="https://github.com/user-attachments/assets/36a4389b-22ad-4851-9f28-5c5922228919" />
^^Header previously not being deleted: Now it is

<img width="561" height="242" alt="Screenshot 2025-09-25 at 3 46 27 PM" src="https://github.com/user-attachments/assets/e9ec5182-6efe-40e4-b48b-e131a61cf518" />
^^Old truncation: Now there is no truncation, users can scroll and see the whole thing
