### PR TITLE
Updated wikibooks info for analysis page

### DIFF
--- a/ui/opening/src/wiki.ts
+++ b/ui/opening/src/wiki.ts
@@ -24,7 +24,7 @@ async function fetchAndRender(data: OpeningPage, render: (html: string) => void)
 
   const removeAllPossibleRepliesSection = (html: string) =>
     html.replace(
-      /<h2 data-mw-anchor="All_possible_replies">All possible replies<\/h2>.*?(?=<h[1-6]|$)/gs,
+      /<h3 data-mw-anchor="All_possible_replies">All possible replies<\/h3>.*?(?=<h[1-6]|$)/gs,
       '',
     );
 


### PR DESCRIPTION
Same changes to wikibooks info as #18277 but for analysis. I also noticed that the All possible replies header was `h3` not `h2` so I updated that for both the opening explorer and analysis.

**What Changed (Copy and pasted from #18277 since they are the same changes in a different file)**
I updated the api request not to have a max characters argument so it could fetch the entire page from wikibooks. I updated the removeH1 function to work correctly (the format of the html was <h1 data-mw-anchor=...</h2>)

I removed the entirety of the Theory table section (and it's similar counterparts All possible Black's moves and All possible replies) since these tables aren't actually returned by the API requests so these sections were essentially empty. To do this, I used a regex search to match the header and then delete everything until the next header was encountered.