### PR TITLE
Display actual patron colour when searched on search bar

### DIFF
--- a/ui/lib/src/view/userComplete.ts
+++ b/ui/lib/src/view/userComplete.ts
@@ -42,6 +42,7 @@ export function userComplete(opts: UserCompleteOpts): void {
       debounced(t).then(({ term, result }) => (t === term ? result : Promise.reject('Debounced ' + t))),
     render(o: LightUserOnline) {
       const tag = opts.tag || 'a';
+      const patronClass = o.patronColor ? ` paco${o.patronColor}` : '';
       return (
         '<' +
         tag +
@@ -54,6 +55,7 @@ export function userComplete(opts: UserCompleteOpts): void {
         '">' +
         '<i class="line' +
         (o.patron ? ' patron' : '') +
+        patronClass +
         '"></i>' +
         (o.title
           ? '<span class="utitle"' +


### PR DESCRIPTION
After this pr,when we search for a player who have patron ,it shows the patron tier color instead of the old green one.
It happens in every search bar.
I tested it this time and it works.
![Testing](https://github.com/user-attachments/assets/7e55a1f9-8ff9-4502-a7e4-c4ff6872bd63)
Hoping for your merge.
Thank you.