### PR TITLE
Blog carousel api

### DIFF
--- a/conf/routes
+++ b/conf/routes
@@ -114,6 +114,7 @@ GET   /blog/topic/:topic               controllers.Ublog.topic(topic, filter: Op
 GET   /blog/monthly                    controllers.Ublog.thisMonth(filter: Option[BlogQualityFilter] ?= None, by: BlogsBy ?= BlogsBy.newest, page: Int ?= 1)
 GET   /blog/monthly/:year/:month       controllers.Ublog.byMonth(year: Int, month: Int, filter: Option[BlogQualityFilter] ?= None, by: BlogsBy ?= BlogsBy.newest, page: Int ?= 1)
 GET   /blog.atom                       controllers.Main.movedPermanently(to = "/@/Lichess/blog.atom")
+GET   /api/blog/carousel               controllers.Ublog.apiCarousel
 GET   /blog/friends                    controllers.Ublog.friends(page: Int ?= 1)
 GET   /blog/liked                      controllers.Ublog.liked(page: Int ?= 1)
 GET   /blog/search                     controllers.Ublog.search(text ?= "", by: BlogsBy ?= BlogsBy.score, page: Int ?= 1)

--- a/modules/ublog/src/main/Env.scala
+++ b/modules/ublog/src/main/Env.scala
@@ -21,6 +21,7 @@ final class Env(
     userRepo: lila.core.user.UserRepo,
     userApi: lila.core.user.UserApi,
     picfitApi: lila.memo.PicfitApi,
+    picfitUrl: lila.memo.PicfitUrl,
     ircApi: lila.core.irc.IrcApi,
     relationApi: lila.core.relation.RelationApi,
     shutupApi: lila.core.shutup.ShutupApi,
@@ -54,6 +55,8 @@ final class Env(
   val form = wire[UblogForm]
 
   val viewCounter = wire[UblogViewCounter]
+
+  val jsonView = wire[UblogJsonView]
 
   val lastPostsCache: AsyncLoadingCache[Unit, List[UblogPost.PreviewPost]] =
     cacheApi.unit[List[UblogPost.PreviewPost]]:

--- a/modules/ublog/src/main/UblogJsonView.scala
+++ b/modules/ublog/src/main/UblogJsonView.scala
@@ -1,0 +1,29 @@
+package lila.ublog
+
+import play.api.libs.json.*
+import lila.core.LightUser
+import lila.common.Json.given
+
+final class UblogJsonView(picfitUrl: lila.core.misc.PicfitUrl):
+  import writers.given
+
+  def previewPost(using LightUser.GetterSync)(post: UblogPost.PreviewPost): JsObject =
+    Json.toJsObject(post)
+
+  object writers:
+
+    given (using lightUser: LightUser.GetterSync): OWrites[UblogPost.PreviewPost] = OWrites: p =>
+      Json
+        .obj(
+          "id" -> p.id,
+          "title" -> p.title,
+          "slug" -> p.slug,
+          "createdAt" -> p.created.at,
+          "url" -> urlOfPost(p).url
+        )
+        .add("author" -> lightUser(p.created.by))
+        .add("image" -> p.image.map(i => UblogPost.thumbnail(picfitUrl, i.id, _.Size.Small)))
+
+    def urlOfPost(post: UblogPost.BasePost) = post.blog match
+      case UblogBlog.Id.User(userId) =>
+        routes.Ublog.post(userId, post.slug, post.id)


### PR DESCRIPTION
I think the blog carousel as it is displayed on lichess home page would be a nice addition to the mobile app.

This is currently a draft, as the `/api/mobile/home` part if missing for now. Should not be hard to add as I have the atomic route.

My scala is rusted, and I have never really done serious Scala 3... so feel free to correct anything here as you please.