### PR TITLE
More cats-mtl `allow/rescue`

### DIFF
--- a/app/controllers/Challenge.scala
+++ b/app/controllers/Challenge.scala
@@ -90,7 +90,6 @@ final class Challenge(env: Env) extends LilaController(env):
       !challenge.challengerUserId.so(orig => me.exists(_.is(orig)))
 
   import cats.mtl.Handle.*
-  import cats.mtl.implicits.*
   def accept(id: ChallengeId, color: Option[Color]) = Open:
     Found(api.byId(id)): c =>
       isForMe(c).so:

--- a/build.sbt
+++ b/build.sbt
@@ -84,7 +84,7 @@ lazy val moduleCPDeps = moduleRefs map { sbt.ClasspathDependency(_, None) }
 
 lazy val core = module("core",
   Seq(),
-  Seq(scalatags, galimatias) ++ scalalib.bundle ++ reactivemongo.bundle ++ tests.bundle
+  Seq(catsMtl, scalatags, galimatias) ++ scalalib.bundle ++ reactivemongo.bundle ++ tests.bundle
 )
 
 lazy val coreI18n = module("coreI18n",

--- a/modules/challenge/src/main/ChallengeApi.scala
+++ b/modules/challenge/src/main/ChallengeApi.scala
@@ -152,15 +152,13 @@ final class ChallengeApi(
           for
             me <- withPerf
             pov <- joiner(c, me)
-            result <-
-              for _ <- repo.accept(c)
-              yield
-                uncacheAndNotify(c)
-                Bus.pub(PositiveEvent.Accept(c, pov.game, me.map(_.id)))
-                c.rematchOf.foreach: gameId =>
-                  Bus.pub(lila.game.actorApi.NotifyRematch(gameId, pov.game))
-                pov.some
-          yield result
+            _ <- repo.accept(c)
+          yield
+            uncacheAndNotify(c)
+            Bus.pub(PositiveEvent.Accept(c, pov.game, me.map(_.id)))
+            c.rematchOf.foreach: gameId =>
+              Bus.pub(lila.game.actorApi.NotifyRematch(gameId, pov.game))
+            pov.some
 
   def offerRematchForGame(game: Game, user: User): Fu[Boolean] =
     challengeMaker.makeRematchOf(game, user).flatMapz { challenge =>

--- a/modules/challenge/src/main/ChallengeApi.scala
+++ b/modules/challenge/src/main/ChallengeApi.scala
@@ -151,17 +151,15 @@ final class ChallengeApi(
         else
           for
             me <- withPerf
-            join <- joiner(c, me)
-            result <- join match
-              case Right(pov) =>
-                for _ <- repo.accept(c)
-                yield
-                  uncacheAndNotify(c)
-                  Bus.pub(PositiveEvent.Accept(c, pov.game, me.map(_.id)))
-                  c.rematchOf.foreach: gameId =>
-                    Bus.pub(lila.game.actorApi.NotifyRematch(gameId, pov.game))
-                  pov.some
-              case Left(err) => err.raise
+            pov <- joiner(c, me)
+            result <-
+              for _ <- repo.accept(c)
+              yield
+                uncacheAndNotify(c)
+                Bus.pub(PositiveEvent.Accept(c, pov.game, me.map(_.id)))
+                c.rematchOf.foreach: gameId =>
+                  Bus.pub(lila.game.actorApi.NotifyRematch(gameId, pov.game))
+                pov.some
           yield result
 
   def offerRematchForGame(game: Game, user: User): Fu[Boolean] =

--- a/modules/challenge/src/main/ChallengeApi.scala
+++ b/modules/challenge/src/main/ChallengeApi.scala
@@ -5,8 +5,6 @@ import lila.core.i18n.LangPicker
 import lila.core.challenge.PositiveEvent
 import lila.core.socket.SendTo
 import lila.memo.CacheApi.*
-import cats.mtl.Raise
-import cats.mtl.implicits.*
 
 final class ChallengeApi(
     repo: ChallengeRepo,
@@ -124,7 +122,7 @@ final class ChallengeApi(
       c: Challenge,
       sid: Option[String],
       requestedColor: Option[Color] = None
-  )(using me: Option[Me]): Raise[Fu, String] ?=> Fu[Option[Pov]] =
+  )(using me: Option[Me]): FuRaise[String, Option[Pov]] =
     acceptQueue:
       def withPerf = me.map(_.value).traverse(userApi.withPerf(_, c.perfType))
       if c.canceled

--- a/modules/challenge/src/main/ChallengeBulkSetup.scala
+++ b/modules/challenge/src/main/ChallengeBulkSetup.scala
@@ -96,7 +96,7 @@ final class ChallengeBulkSetupApi(
     key = "challenge.bulk"
   )
 
-  def apply(data: BulkFormData, me: User): Fu[Result] =
+  def apply(data: BulkFormData, me: User): FuRaise[ScheduleError, ScheduledBulk] =
     Source(extractTokenPairs(data.tokens))
       .mapConcat: (whiteToken, blackToken) =>
         List(whiteToken, blackToken) // flatten now, re-pair later!
@@ -111,7 +111,7 @@ final class ChallengeBulkSetupApi(
         case (Right(_), Left(bad)) => Left(bad :: Nil)
         case (Right(users), Right(scoped)) => Right(scoped.me.userId :: users)
       .flatMap:
-        case Left(errors) => fuccess(Left(ScheduleError.BadTokens(errors.reverse)))
+        case Left(errors) => ScheduleError.BadTokens(errors.reverse).raise
         case Right(allPlayers) =>
           lazy val dups = allPlayers
             .groupBy(identity)
@@ -121,7 +121,7 @@ final class ChallengeBulkSetupApi(
               case (u, nb) if nb > 1 => u
             .toList
           if !data.allowMultiplePairingsPerUser && dups.nonEmpty
-          then fuccess(Left(ScheduleError.DuplicateUsers(dups)))
+          then ScheduleError.DuplicateUsers(dups).raise
           else
             val pairs = allPlayers.reverse
               .grouped(2)
@@ -129,12 +129,11 @@ final class ChallengeBulkSetupApi(
               .toList
             val nbGames = pairs.size
             val cost = nbGames * (if me.isVerifiedOrChallengeAdmin || me.isApiHog then 1 else 3)
-            rateLimit(me.id, fuccess(Left(ScheduleError.RateLimited)), cost = cost):
+            rateLimit(me.id, ScheduleError.RateLimited.raise, cost = cost):
               lila.mon.api.challenge.bulk.scheduleNb(me.id).increment(nbGames)
               idGenerator
                 .games(nbGames)
-                .map:
-                  _.toList.zip(pairs)
+                .map(_.toList.zip(pairs))
                 .map:
                   _.map:
                     case (id, (w, b)) => ScheduledGame(id, w, b)
@@ -153,7 +152,6 @@ final class ChallengeBulkSetupApi(
                     scheduledAt = nowInstant,
                     fen = data.fen.filterNot(_.isInitial)
                   )
-                .dmap(Right.apply)
 
 object ChallengeBulkSetup:
 

--- a/modules/challenge/src/main/ChallengeJoiner.scala
+++ b/modules/challenge/src/main/ChallengeJoiner.scala
@@ -12,12 +12,11 @@ final private class ChallengeJoiner(
     onStart: lila.core.game.OnStart
 )(using Executor):
 
-  def apply(c: Challenge, destUser: GameUser): Fu[Either[String, Pov]] =
+  def apply(c: Challenge, destUser: GameUser): FuRaise[String, Pov] =
     gameRepo
       .exists(c.gameId)
-      .flatMap:
-        if _ then fuccess(Left("The challenge has already been accepted"))
-        else
+      .flatMap: exists =>
+        raiseIf(exists, "The challenge has already been accepted"):
           c.challengerUserId
             .so(userApi.byIdWithPerf(_, c.perfType))
             .flatMap: origUser =>
@@ -26,7 +25,7 @@ final private class ChallengeJoiner(
                 .insertDenormalized(game)
                 .inject:
                   onStart.exec(game.id)
-                  Right(Pov(game, !c.finalColor))
+                  Pov(game, !c.finalColor)
 
 private object ChallengeJoiner:
 

--- a/modules/core/src/main/lilaism/CoreExports.scala
+++ b/modules/core/src/main/lilaism/CoreExports.scala
@@ -1,9 +1,12 @@
 package lila.core.lilaism
 
+import cats.mtl.Raise
+
 trait CoreExports:
 
   type Fu[A] = Future[A]
   type Funit = Fu[Unit]
+  type FuRaise[E, +A] = Raise[Fu, E] ?=> Fu[A]
   type PairOf[A] = (A, A)
   type Update[A] = A => A
 
@@ -23,5 +26,7 @@ trait CoreExports:
   export cats.syntax.all.*
   export cats.{ Eq, Show }
   export cats.data.NonEmptyList
+
+  export cats.mtl.syntax.raise.*
 
 object Core extends CoreExports

--- a/modules/core/src/main/lilaism/LilaLibraryExtensions.scala
+++ b/modules/core/src/main/lilaism/LilaLibraryExtensions.scala
@@ -23,6 +23,14 @@ trait LilaLibraryExtensions extends CoreExports:
   val fuTrue = fuccess(true)
   val fuFalse = fuccess(false)
 
+  /* Raise error if the condition met */
+  inline def raiseIf[E, A](cond: Boolean, e: => E)(fa: => Fu[A]): FuRaise[E, A] =
+    if cond then e.raise else fa
+
+  /* Raise error if the condition not met */
+  inline def raiseUnless[E, A](cond: Boolean, e: => E)(fa: => Fu[A]): FuRaise[E, A] =
+    raiseIf(!cond, e)(fa)
+
   /* library-agnostic way to run a future after a delay */
   given (using sched: Scheduler, ec: Executor): FutureAfter =
     [A] => (duration: FiniteDuration) => (fua: () => Future[A]) => akka.pattern.after(duration, sched)(fua())


### PR DESCRIPTION
Follow up on https://github.com/lichess-org/lila/pull/17944, using `Raise` on more functions, all of them are around `challenge` module.

This demonstrates how `allow/rescue` and scala 3 type inference work so perfectly together in: https://github.com/lichess-org/lila/commit/8cfbdeabdc5057ade54b9847041e2a9a19e66a90

This also adds:
- type alias `type FuRaise[E, +A] = Raise[Fu, E] ?=> Fu[A]`
- some convenient functions when working with `Raise` (could potentially port to upstream library)