### PR TITLE
Revert "Approaching the vehicle to the text"

### DIFF
--- a/ui/racer/css/_home.scss
+++ b/ui/racer/css/_home.scss
@@ -29,7 +29,6 @@
       font-size: 9em;
       display: block;
       margin-top: -0.5em;
-      top: 0.2em;
     }
     &:hover {
       opacity: 1;


### PR DESCRIPTION
Reverts lichess-org/lila#18270 to fix https://github.com/lichess-org/lila/issues/18307

Chrome in MacOS be like