### PR TITLE
Fix best move arrows in game reviews

### DIFF
--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -1060,7 +1060,7 @@ export default class AnalyseCtrl implements CevalHandler {
     this.keyboardMove?.update({ fen, canMove: true });
   };
 
-  showBestMoveArrows = () => this.showBestMoveArrowsProp() && !this.retro;
+  showBestMoveArrows = () => this.showBestMoveArrowsProp() && !!this.retro;
 
   private resetAutoShapes = () => {
     if (this.showBestMoveArrows() || this.showMoveAnnotation() || this.variationArrowOpacity())


### PR DESCRIPTION
Fixes https://github.com/lichess-org/lila/issues/18304

Before:
<img width="1057" height="705" alt="Screenshot 2025-10-01 at 12 40 39 PM" src="https://github.com/user-attachments/assets/f3cf2a0c-c789-43c7-a862-906be5f5d61b" />

After:
<img width="1055" height="721" alt="Screenshot 2025-10-01 at 12 39 59 PM" src="https://github.com/user-attachments/assets/819e6d6b-559e-4d97-b6b3-6f6ce652904f" />

I believe this was a bug introduced in [this line](https://github.com/lichess-org/lila/commit/718a740db8e2f15e348d142332ec891283d9d72b#diff-3fb6afb2750b9fa08c30a9bfe082f9c35dd9b1d121cbde0f3dc1599ac61e20b7L1055). Previously it was checking `!!this.retro`, but in this commit it changed to `!this.retro`.

I originally thought this might be a copy/paste bug, but the commit message also includes this... @ornicar for SA, is there a reason we should be hiding the best move arrows when reviewing a game?