### PR TITLE
Logs all errors in search client

### DIFF
--- a/modules/search/src/main/LilaSearchClient.scala
+++ b/modules/search/src/main/LilaSearchClient.scala
@@ -1,6 +1,6 @@
 package lila.search
 
-import lila.search.client.{ SearchClient, SearchError }
+import lila.search.client.SearchClient
 import lila.search.spec.*
 
 class LilaSearchClient(client: SearchClient)(using Executor) extends SearchClient:
@@ -10,7 +10,7 @@ class LilaSearchClient(client: SearchClient)(using Executor) extends SearchClien
       client
         .count(query)
         .handleError:
-          case e: SearchError =>
+          case e =>
             logger.info(s"Count error: query={$query}", e)
             CountOutput(0)
 
@@ -19,7 +19,7 @@ class LilaSearchClient(client: SearchClient)(using Executor) extends SearchClien
       client
         .search(query, from, size)
         .handleError:
-          case e: SearchError =>
+          case e =>
             logger.info(s"Search error: query={$query}, from={$from}, size={$size}", e)
             SearchOutput(Nil)
 


### PR DESCRIPTION
to avoid
```
2025-10-02 08:18:11,832 ERROR p.c.s.netty.PlayRequestHandler Cannot invoke the action
scala.MatchError: java.net.SocketException: Connection reset (of class java.net.SocketException)
        at lila.search.LilaSearchClient.search$$anonfun$1(LilaSearchClient.scala:24)
        at cats.instances.FutureInstances$$anon$3.applyOrElse(future.scala:52)
        at cats.instances.FutureInstances$$anon$3.applyOrElse(future.scala:52)
        at scala.util.Failure.recover(Try.scala:242)
        at scala.concurrent.impl.Promise$Transformation.run(Promise.scala:487)
        at scala.concurrent.BatchingExecutor$AbstractBatch.runN(BatchingExecutor.scala:134)
        at scala.concurrent.BatchingExecutor$AsyncBatch.apply(BatchingExecutor.scala:163)
        at scala.concurrent.BatchingExecutor$AsyncBatch.apply(BatchingExecutor.scala:146)
        at scala.concurrent.BlockContext$.usingBlockContext(BlockContext.scala:107)
        at scala.concurrent.BatchingExecutor$AsyncBatch.run(BatchingExecutor.scala:154)
        at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(Unknown Source)
        at java.base/java.util.concurrent.ForkJoinTask.doExec(Unknown Source)
        at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(Unknown Source)
        at java.base/java.util.concurrent.ForkJoinPool.scan(Unknown Source)
        at java.base/java.util.concurrent.ForkJoinPool.runWorker(Unknown Source)
        at java.base/java.util.concurrent.ForkJoinWorkerThread.run(U
```