### PR TITLE
Update lila-search client 3.2.4

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -28,7 +28,7 @@ object Dependencies {
   val lettuce = "io.lettuce" % "lettuce-core" % "6.8.1.RELEASE"
   val nettyTransport =
     ("io.netty" % s"netty-transport-native-$notifier" % "4.2.6.Final").classifier(s"$os-$arch")
-  val lilaSearch = "com.github.lichess-org.lila-search" %% "client" % "3.2.0"
+  val lilaSearch = "com.github.lichess-org.lila-search" %% "client" % "3.2.4"
   val munit = "org.scalameta" %% "munit" % "1.2.0" % Test
   val uaparser = "org.uaparser" %% "uap-scala" % "0.20.0"
   val apacheText = "org.apache.commons" % "commons-text" % "1.14.0"


### PR DESCRIPTION
https://github.com/lichess-org/lila-search/releases/tag/v3.2.4