### PR TITLE
crosstable hovers south when player has under one minute

### DIFF
--- a/ui/@types/lichess/index.d.ts
+++ b/ui/@types/lichess/index.d.ts
@@ -73,6 +73,7 @@ interface LichessPowertip {
   manualGame(el: HTMLElement): void;
   manualUser(el: HTMLElement): void;
   manualUserIn(parent: HTMLElement): void;
+  forcePlacementHook?: (el: HTMLElement) => PowerTip.Placement | null;
 }
 
 interface QuestionChoice {

--- a/ui/round/src/ctrl.ts
+++ b/ui/round/src/ctrl.ts
@@ -549,6 +549,7 @@ export default class RoundController implements MoveRootCtrl {
   };
 
   endWithData = (o: ApiEnd): void => {
+    site.powertip.forcePlacementHook = undefined;
     const d = this.data;
     d.game.winner = o.winner;
     d.game.status = o.status;
@@ -629,7 +630,10 @@ export default class RoundController implements MoveRootCtrl {
       this.clock ??= new ClockCtrl(d.clock, d.pref, this.tickingClockColor(), this.makeClockOpts());
       this.clock.alarmAction = {
         seconds: 60,
-        fire: () => (this.chessground.state.touchIgnoreRadius = Math.SQRT2),
+        fire: () => {
+          this.chessground.state.touchIgnoreRadius = Math.SQRT2;
+          site.powertip.forcePlacementHook = (el: HTMLElement) => el.closest('.crosstable') && 's';
+        },
       };
     } else {
       this.clock = undefined;

--- a/ui/site/src/powertip.ts
+++ b/ui/site/src/powertip.ts
@@ -326,6 +326,8 @@ function placementCalculator() {
       tipHeight: number,
       offset: number,
     ) {
+      placement = site.powertip.forcePlacementHook?.(element[0]!) ?? placement;
+
       const placementBase = placement.split('-')[0], // ignore 'alt' for corners
         coords = cssCoordinates(),
         position = getHtmlPlacement(element, placementBase);


### PR DESCRIPTION
https://lichess.org/forum/lichess-feedback/stop-previous-games-popping-up-over-game-in-progress

The existing crosstable-specific code in powertip (which makes the popup behavior particularly frustrating and egregious in short time control games), still remains for analysis and when the player clock exceeds a minute. 