### PR TITLE
reduce spurious force variation in broadcasts

### DIFF
--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -607,7 +607,7 @@ export default class AnalyseCtrl implements CevalHandler {
     }
 
     const relayPath = this.study?.data.chapter.relayPath;
-    if (relayPath && relayPath !== newPath) this.forceVariation(newPath, true);
+    if (relayPath && relayPath === path) this.forceVariation(newPath, true);
     else this.jump(newPath);
 
     this.redraw();


### PR DESCRIPTION
only force a variation if appending to the current game state. mostly fix #18326

force variation is still broken in a lot of ways. i'm not entirely sure why there is only one of them allowed in the tree. and it might be better to use a null first child in a parent's children array for this (rather than pollute the child itself with a data member informing structure that it should have no knowledge of). regardless, it can't hurt us if we don't use it, so here we use it less.