### PR TITLE
Some minor improvement for lila extensions

### DIFF
--- a/modules/core/src/main/lilaism/LilaLibraryExtensions.scala
+++ b/modules/core/src/main/lilaism/LilaLibraryExtensions.scala
@@ -19,9 +19,9 @@ trait LilaLibraryExtensions extends CoreExports:
   def fuccess[A](a: A): Fu[A] = Future.successful(a)
   def fufail[X](t: Throwable): Fu[X] = Future.failed(t)
   def fufail[X](s: String): Fu[X] = fufail(LilaException(s))
-  val funit = Future.unit
-  val fuTrue = fuccess(true)
-  val fuFalse = fuccess(false)
+  val funit: Future[Unit] = Future.unit
+  val fuTrue: Future[Boolean] = fuccess(true)
+  val fuFalse: Future[Boolean] = fuccess(false)
 
   /* Raise error if the condition met */
   inline def raiseIf[E, A](cond: Boolean, e: => E)(fa: => Fu[A]): FuRaise[E, A] =
@@ -99,6 +99,7 @@ trait LilaLibraryExtensions extends CoreExports:
           acc.flatMap: bs =>
             f(a).map(_ :: bs)
         .map(_.reverse)
+
     def sequentiallyVoid(f: A => Fu[?])(using Executor): Funit =
       list
         .foldLeft(funit): (acc, a) =>
@@ -111,7 +112,7 @@ trait LilaLibraryExtensions extends CoreExports:
 
     def parallelVoid[B](f: A => Fu[B])(using Executor): Fu[Unit] =
       list.iterator
-        .foldLeft(fuccess(()))((fr, a) => fr.zipWith(f(a))((_, _) => ()))
+        .foldLeft(funit)((fr, a) => fr.zipWith(f(a))((_, _) => ()))
 
   extension [A, M[A] <: IterableOnce[A]](list: M[Fu[A]])
 
@@ -120,7 +121,7 @@ trait LilaLibraryExtensions extends CoreExports:
 
     def parallelVoid(using Executor): Fu[Unit] =
       list.iterator
-        .foldLeft(fuccess(()))((fr, fa) => fr.zipWith(fa)((_, _) => ()))
+        .foldLeft(funit)((fr, fa) => fr.zipWith(fa)((_, _) => ()))
 
   extension [A](fua: Fu[A])
 
@@ -166,6 +167,7 @@ trait LilaLibraryExtensions extends CoreExports:
 
     infix def flatMapz[B](fub: => Fu[B])(using zero: Zero[B]): Fu[B] =
       fua.flatMap { if _ then fub else fuccess(zero.zero) }(using EC.parasitic)
+
     def mapz[B](fb: => B)(using zero: Zero[B]): Fu[B] =
       fua.map { if _ then fb else zero.zero }(using EC.parasitic)
 


### PR DESCRIPTION
- Add some typings for public values
- reuse `funit` for `fuccess(())`