### PR TITLE
Submarine/1

### DIFF
--- a/modules/core/src/main/lilaism/LilaLibraryExtensions.scala
+++ b/modules/core/src/main/lilaism/LilaLibraryExtensions.scala
@@ -106,6 +106,24 @@ trait LilaLibraryExtensions extends CoreExports:
           acc.flatMap: _ =>
             f(a).void
 
+    /** traverse the list sequentially, short-circuiting on the first error.
+      *
+      * returning the first error if there is and the successfully processed elements
+      */
+    def sequentiallyRaise[E, B](f: A => FuRaise[E, B])(using EC): Fu[(List[B], Option[E])] =
+      import cats.mtl.Handle.*
+      list
+        .foldLeft(fuccess((List.empty[B], none[E]))): (facc, a) =>
+          facc.flatMap:
+            case xss @ (bs, acc) =>
+              acc match
+                case Some(_) => fuccess(xss) // short-circuit on first error
+                case None =>
+                  allow:
+                    f(a).map(b => (b :: bs) -> none)
+                  .rescue: e =>
+                    fuccess((bs, e.some))
+
   extension [A, M[A] <: IterableOnce[A]](list: M[A])
     def parallel[B](f: A => Fu[B])(using Executor, BuildFrom[M[A], B, M[B]]): Fu[M[B]] =
       Future.traverse(list)(f)

--- a/modules/study/src/main/ChapterMaker.scala
+++ b/modules/study/src/main/ChapterMaker.scala
@@ -226,7 +226,7 @@ private[study] object ChapterMaker:
       isDefaultName: Boolean = true
   ) extends ChapterData:
 
-    def manyGames =
+    def manyGames: Option[List[Data]] =
       game
         .so(_.linesIterator.take(Study.maxChapters.value).toList)
         .map(_.trim)

--- a/modules/study/src/main/Study.scala
+++ b/modules/study/src/main/Study.scala
@@ -37,7 +37,7 @@ case class Study(
 
   def canChat(id: UserId) = Settings.UserSelection.allows(settings.chat, this, id.some)
 
-  def canContribute[U: UserIdOf](u: U) =
+  def canContribute[U: UserIdOf](u: U): Boolean =
     isOwner(u) || members.get(u.id).exists(_.canContribute) || u.is(UserId.lichess)
 
   def canView(id: Option[UserId]) = !isPrivate || id.exists(members.contains)


### PR DESCRIPTION
My goal is create a better feedback to users, hence enhance their
experiences. With this commit, We only change StudyApi.importPgns
to returns a pair of successful imported chapters and an optional error.
The other methods in StudyApi are using allow/rescue to keep the same
semantic as before.

In `controller.Study.importPgn`, we could show some feedback to user,
like: you tried to import 10 chapters, but only success 6, with error:
"Reach chapter limit, a study has 64 chapter at most".

but I'm not sure how, I tried `flashFailure` but it seems doesn't work.
Any ideas are welcomed.