### PR TITLE
remove green "create game" button outline from setup dlg on desktop

### DIFF
--- a/ui/lobby/css/_setup.scss
+++ b/ui/lobby/css/_setup.scss
@@ -79,6 +79,7 @@ $c-slider: $c-setup;
     padding-inline: 1rem 1.2rem;
     gap: 0.8rem;
     color: $c-font;
+    border: $border;
     &::before {
       color: $c-setup !important;
     }

--- a/ui/lobby/css/_setup.scss
+++ b/ui/lobby/css/_setup.scss
@@ -77,7 +77,6 @@ $c-slider: $c-setup;
     padding-inline: 1rem 1.2rem;
     gap: 0.8rem;
     color: $c-font;
-    border: 2px solid $c-setup;
     &::before {
       color: $c-setup !important;
     }
@@ -207,5 +206,8 @@ $c-slider: $c-setup;
 @media (pointer: coarse) {
   .game-setup select {
     font-size: 1.2rem;
+  }
+  .game-setup .lobby__start__button {
+    border: 2px solid $c-setup;
   }
 }


### PR DESCRIPTION
it looks neat. but it also looks like a focus ring when that element has no focus. 

this is a PR rather than an issue as the bare button seems fine to me, but maybe you can find a way to style things so it still pops without suggesting keyboard focus. the outline remains on touch devices.