### PR TITLE
reduce setup modal flakiness involving spinner

### DIFF
--- a/ui/lib/css/component/_button.scss
+++ b/ui/lib/css/component/_button.scss
@@ -125,7 +125,7 @@
     @extend %metal;
 
     &,
-    &:hover {
+    &:not(.disabled):hover {
       color: $c-font-dim;
     }
 

--- a/ui/lobby/css/_setup.scss
+++ b/ui/lobby/css/_setup.scss
@@ -69,9 +69,11 @@ $c-slider: $c-setup;
 
   .footer {
     @extend %flex-center;
+    position: relative;
     justify-content: center;
-    padding: 1.1rem;
+    padding: 1.5rem;
   }
+
   .lobby__start__button {
     height: 3rem;
     padding-inline: 1rem 1.2rem;
@@ -81,6 +83,12 @@ $c-slider: $c-setup;
     &::before {
       color: $c-setup !important;
     }
+  }
+
+  .footer .spinner {
+    position: absolute;
+    width: 56px;
+    height: 56px;
   }
 
   .radio-pane {
@@ -116,14 +124,6 @@ $c-slider: $c-setup;
       &.random i {
         background-image: url(../images/wbK.svg);
       }
-    }
-
-    .spinner {
-      position: absolute;
-      width: 64px;
-      height: 64px;
-      right: calc(50% - 32px);
-      bottom: 6px;
     }
   }
 
@@ -191,6 +191,9 @@ $c-slider: $c-setup;
   @media (max-height: at-most(900px)) {
     h2 {
       margin-block: 1.1rem;
+    }
+    .footer {
+      padding: 1.1rem;
     }
     .setup-content {
       padding: 1.25rem 0.75rem;

--- a/ui/lobby/src/view/setup/modal.ts
+++ b/ui/lobby/src/view/setup/modal.ts
@@ -19,7 +19,7 @@ export default function setupModal(ctrl: LobbyController): VNode | null {
     friend: setupCtrl.friendUser ? i18n.site.challengeX(setupCtrl.friendUser) : i18n.site.challengeAFriend,
     ai: i18n.site.playAgainstComputer,
   }[setupCtrl.gameType];
-  const disabled = !setupCtrl.valid();
+  const disabled = !setupCtrl.valid() || setupCtrl.loading;
   return snabDialog({
     attrs: { dialog: { 'aria-labelledBy': 'lobby-setup-modal-title', 'aria-modal': 'true' } },
     class: 'game-setup',
@@ -33,20 +33,18 @@ export default function setupModal(ctrl: LobbyController): VNode | null {
     vnodes: [
       hl('h2', i18n.site.gameSetup),
       hl('div.setup-content', views[setupCtrl.gameType](ctrl)),
-      hl(
-        'div.footer',
-        setupCtrl.loading
-          ? spinnerVdom()
-          : hl(
-              `button.button.button-metal.lobby__start__button.lobby__start__button--${setupCtrl.friendUser ? 'friend-user' : setupCtrl.gameType}`,
-              {
-                attrs: { disabled },
-                class: { disabled },
-                on: { click: ctrl.setupCtrl.submit },
-              },
-              buttonText,
-            ),
-      ),
+      hl('div.footer', [
+        hl(
+          `button.button.button-metal.lobby__start__button.lobby__start__button--${setupCtrl.friendUser ? 'friend-user' : setupCtrl.gameType}`,
+          {
+            attrs: { disabled },
+            class: { disabled },
+            on: { click: ctrl.setupCtrl.submit },
+          },
+          buttonText,
+        ),
+        setupCtrl.loading && spinnerVdom(),
+      ]),
     ],
     onInsert: dlg => {
       setupCtrl.closeModal = dlg.close;


### PR DESCRIPTION
fatten up the chin a bit, don't disappear the create game button, and don't resize the dialog to show the spinner. jank like this can creep in unknowingly because it all happens in a heartbeat on dev instances.
