### PR TITLE
add invert clock option for right handers on mobile

### DIFF
--- a/ui/round/css/_app-layout.scss
+++ b/ui/round/css/_app-layout.scss
@@ -71,8 +71,13 @@
       display: none;
     }
 
-    &__table {
-      display: none;
+    &.invert-clock {
+      .ruser {
+        justify-content: end;
+      }
+      .rclock {
+        justify-self: start;
+      }
     }
     .ricons {
       margin: 0.5em 0;

--- a/ui/round/css/_table.scss
+++ b/ui/round/css/_table.scss
@@ -1,11 +1,3 @@
-.round__app {
-  &__table {
-    @extend %box-radius-right, %box-shadow;
-
-    background: $c-bg-box;
-  }
-}
-
 .expiration {
   @extend %flex-center;
 

--- a/ui/round/src/ctrl.ts
+++ b/ui/round/src/ctrl.ts
@@ -92,6 +92,7 @@ export default class RoundController implements MoveRootCtrl {
   server: Server;
   nvui?: NvuiPlugin;
   vibration: Prop<boolean> = storedBooleanProp('vibration', false);
+  invertClock: Prop<boolean> = storedBooleanProp('invertClock', false);
 
   constructor(
     readonly opts: RoundOpts,

--- a/ui/round/src/view/boardMenu.ts
+++ b/ui/round/src/view/boardMenu.ts
@@ -3,6 +3,7 @@ import type RoundController from '../ctrl';
 import { boardMenu as menuDropdown } from 'lib/view/boardMenu';
 import { toggle } from 'lib';
 import { toggle as cmnToggle, boolPrefXhrToggle } from 'lib/view/controls';
+import { displayColumns, isTouchDevice } from 'lib/device';
 
 export default function (ctrl: RoundController): LooseVNode {
   return menuDropdown(ctrl.redraw, ctrl.menu, menu => {
@@ -28,6 +29,17 @@ export default function (ctrl: RoundController): LooseVNode {
               id: 'haptics',
               checked: ctrl.vibration(),
               change: v => ctrl.vibration(v),
+            },
+            ctrl.redraw,
+          ),
+        isTouchDevice() &&
+          displayColumns() === 1 &&
+          cmnToggle(
+            {
+              name: 'Invert clock',
+              id: 'invertClock',
+              checked: ctrl.invertClock(),
+              change: v => ctrl.invertClock(v),
             },
             ctrl.redraw,
           ),

--- a/ui/round/src/view/main.ts
+++ b/ui/round/src/view/main.ts
@@ -10,6 +10,7 @@ import { renderMaterialDiffs } from 'lib/game/view/material';
 import { renderVoiceBar } from 'voice';
 import { playable } from 'lib/game/game';
 import { storage } from 'lib/storage';
+import { displayColumns, isTouchDevice } from 'lib/device';
 
 export function main(ctrl: RoundController): VNode {
   const d = ctrl.data,
@@ -26,36 +27,40 @@ export function main(ctrl: RoundController): VNode {
   const hideBoard = ctrl.data.player.blindfold && playable(ctrl.data);
   return ctrl.nvui
     ? ctrl.nvui.render()
-    : hl('div.round__app.variant-' + d.game.variant.key, [
-        hl(
-          'div.round__app__board.main-board' + (hideBoard ? '.blindfold' : ''),
-          {
-            hook:
-              'ontouchstart' in window || !storage.boolean('scrollMoves').getOrDefault(true)
-                ? undefined
-                : bind(
-                    'wheel',
-                    stepwiseScroll((e: WheelEvent, scroll: boolean) => {
-                      if (scroll && !ctrl.isPlaying()) {
-                        e.preventDefault();
-                        if (e.deltaY > 0) next(ctrl);
-                        else if (e.deltaY < 0) prev(ctrl);
-                        ctrl.redraw();
-                      }
-                    }),
-                    undefined,
-                    false,
-                  ),
-          },
-          [renderGround(ctrl), ctrl.promotion.view(ctrl.data.game.variant.key === 'antichess')],
-        ),
-        ctrl.voiceMove && renderVoiceBar(ctrl.voiceMove.ctrl, ctrl.redraw),
-        ctrl.keyboardHelp && view(ctrl),
-        crazyView(ctrl, topColor, 'top') || materialDiffs[0],
-        renderTable(ctrl),
-        crazyView(ctrl, bottomColor, 'bottom') || materialDiffs[1],
-        ctrl.keyboardMove && renderKeyboardMove(ctrl.keyboardMove),
-      ]);
+    : hl(
+        'div.round__app.variant-' + d.game.variant.key,
+        { class: { 'invert-clock': isTouchDevice() && displayColumns() === 1 && ctrl.invertClock() } },
+        [
+          hl(
+            'div.round__app__board.main-board' + (hideBoard ? '.blindfold' : ''),
+            {
+              hook:
+                'ontouchstart' in window || !storage.boolean('scrollMoves').getOrDefault(true)
+                  ? undefined
+                  : bind(
+                      'wheel',
+                      stepwiseScroll((e: WheelEvent, scroll: boolean) => {
+                        if (scroll && !ctrl.isPlaying()) {
+                          e.preventDefault();
+                          if (e.deltaY > 0) next(ctrl);
+                          else if (e.deltaY < 0) prev(ctrl);
+                          ctrl.redraw();
+                        }
+                      }),
+                      undefined,
+                      false,
+                    ),
+            },
+            [renderGround(ctrl), ctrl.promotion.view(ctrl.data.game.variant.key === 'antichess')],
+          ),
+          ctrl.voiceMove && renderVoiceBar(ctrl.voiceMove.ctrl, ctrl.redraw),
+          ctrl.keyboardHelp && view(ctrl),
+          crazyView(ctrl, topColor, 'top') || materialDiffs[0],
+          renderTable(ctrl),
+          crazyView(ctrl, bottomColor, 'bottom') || materialDiffs[1],
+          ctrl.keyboardMove && renderKeyboardMove(ctrl.keyboardMove),
+        ],
+      );
 }
 
 export function endGameView(): void {

--- a/ui/round/src/view/table.ts
+++ b/ui/round/src/view/table.ts
@@ -137,7 +137,6 @@ export const renderTablePlay = (ctrl: RoundController): LooseVNodes => {
 };
 
 export const renderTable = (ctrl: RoundController): LooseVNodes => [
-  hl('div.round__app__table'),
   renderExpiration(ctrl),
   renderPlayer(ctrl, 'top'),
   ctrl.data.player.spectator


### PR DESCRIPTION
i had a reply in mind for https://lichess.org/forum/lichess-feedback/i-want-clock-left-side#5 where they complained about all the steps in TotalNoob's suggestion to install Lichess Tools in order to move the clock to the left.

i was going to tell them they're right, TotalNoob's suggestion is shit - instead they should learn a rtl language like Arabic, then choose it in the account menu, and put the clock on the left that way.

then i remembered i no longer have an account, so i made this PR. but the good news is that nobody knows about the board menu, so plenty of right handers may still opt to learn Arabic and/or install Lichess Tools.
