### PR TITLE
Revert "Update reactivemongo-shaded-native-linux-x86-64 to 1.1.0-RC18"

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -83,7 +83,7 @@ object Dependencies {
   object reactivemongo {
     val driver = ("org.reactivemongo" %% "reactivemongo" % "1.1.0-RC16")
     val stream = "org.reactivemongo" %% "reactivemongo-akkastream" % "1.1.0-RC18"
-    val shaded = "org.reactivemongo" % s"reactivemongo-shaded-native-$os-$dashArch" % "1.1.0-RC18"
+    val shaded = "org.reactivemongo" % s"reactivemongo-shaded-native-$os-$dashArch" % "1.1.0-RC15"
     // val kamon  = "org.reactivemongo" %% "reactivemongo-kamon"         % "1.0.8"
     def bundle = Seq(driver, stream)
   }


### PR DESCRIPTION
Reverts lichess-org/lila#18344

```


10:15:14.226 [error] akka.actor.OneForOneStrategy - 'java.util.Queue reactivemongo.io.netty.channel.epoll.EpollEventLoop.newTaskQueue0(int)'
akka.actor.ActorInitializationException: akka://reactivemongo/user/main: exception during creation, root cause message: ['java.util.Queue reactivemongo.io.netty.channel.epoll.EpollEventLoop.newTaskQueue0(int)']
	at akka.actor.ActorInitializationException$.apply(Actor.scala:196)
	at akka.actor.ActorCell.create(ActorCell.scala:668)
	at akka.actor.ActorCell.invokeAll$1(ActorCell.scala:513)
	at akka.actor.ActorCell.systemInvoke(ActorCell.scala:535)
	at akka.dispatch.Mailbox.processAllSystemMessages(Mailbox.scala:295)
	at akka.dispatch.Mailbox.run(Mailbox.scala:230)
	at akka.dispatch.Mailbox.exec(Mailbox.scala:243)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:387)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1312)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1843)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1808)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:188)
Caused by: java.lang.reflect.InvocationTargetException: null
	at java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:74)
	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:502)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:486)
	at reactivemongo.core.netty.Pack$.$anonfun$4(Pack.scala:97)
	at reactivemongo.core.netty.ChannelFactory.<init>(ChannelFactory.scala:51)
	at reactivemongo.core.actors.StandardDBSystem.newChannelFactory(MongoDBSystem.scala:2160)
	at reactivemongo.core.actors.MongoDBSystem.preStart(MongoDBSystem.scala:398)
	at reactivemongo.core.actors.MongoDBSystem.preStart$(MongoDBSystem.scala:94)
	at reactivemongo.core.actors.StandardDBSystem.preStart(MongoDBSystem.scala:2150)
	at akka.actor.Actor.aroundPreStart(Actor.scala:548)
	at akka.actor.Actor.aroundPreStart$(Actor.scala:471)
	at reactivemongo.core.actors.StandardDBSystem.aroundPreStart(MongoDBSystem.scala:2150)
	at akka.actor.ActorCell.create(ActorCell.scala:643)
	at akka.actor.ActorCell.invokeAll$1(ActorCell.scala:513)
	at akka.actor.ActorCell.systemInvoke(ActorCell.scala:535)
	at akka.dispatch.Mailbox.processAllSystemMessages(Mailbox.scala:295)
	at akka.dispatch.Mailbox.run(Mailbox.scala:230)
	at akka.dispatch.Mailbox.exec(Mailbox.scala:243)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:387)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1312)
Caused by: java.lang.NoSuchMethodError: 'java.util.Queue reactivemongo.io.netty.channel.epoll.EpollEventLoop.newTaskQueue0(int)'
	at reactivemongo.io.netty.channel.epoll.EpollEventLoop.newTaskQueue(EpollEventLoop.java:59)
	at reactivemongo.io.netty.channel.epoll.EpollEventLoop.<init>(EpollEventLoop.java:52)
	at reactivemongo.io.netty.channel.epoll.EpollEventLoopGroup.newChild(EpollEventLoopGroup.java:198)
	at reactivemongo.io.netty.channel.MultiThreadIoEventLoopGroup.newChild(MultiThreadIoEventLoopGroup.java:193)
	at reactivemongo.io.netty.channel.MultiThreadIoEventLoopGroup.newChild(MultiThreadIoEventLoopGroup.java:30)
	at reactivemongo.io.netty.util.concurrent.MultithreadEventExecutorGroup.<init>(MultithreadEventExecutorGroup.java:84)
	at reactivemongo.io.netty.util.concurrent.MultithreadEventExecutorGroup.<init>(MultithreadEventExecutorGroup.java:60)
	at reactivemongo.io.netty.util.concurrent.MultithreadEventExecutorGroup.<init>(MultithreadEventExecutorGroup.java:49)
	at reactivemongo.io.netty.channel.MultithreadEventLoopGroup.<init>(MultithreadEventLoopGroup.java:59)
	at reactivemongo.io.netty.channel.MultiThreadIoEventLoopGroup.<init>(MultiThreadIoEventLoopGroup.java:144)
	at reactivemongo.io.netty.channel.epoll.EpollEventLoopGroup.<init>(EpollEventLoopGroup.java:123)
	at reactivemongo.io.netty.channel.epoll.EpollEventLoopGroup.<init>(EpollEventLoopGroup.java:110)
	at reactivemongo.io.netty.channel.epoll.EpollEventLoopGroup.<init>(EpollEventLoopGroup.java:87)
	at reactivemongo.io.netty.channel.epoll.EpollEventLoopGroup.<init>(EpollEventLoopGroup.java:63)
	at reactivemongo.io.netty.channel.epoll.EpollEventLoopGroup.<init>(EpollEventLoopGroup.java:56)
	at java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62)
	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:502)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:486)
	at reactivemongo.core.netty.Pack$.$anonfun$4(Pack.scala:97)
	at reactivemongo.core.netty.ChannelFactory.<init>(ChannelFactory.scala:51)
10:15:14.230 [info] a.actor.RepointableActorRef - Message [reactivemongo.core.actors.RegisterMonitor$] from Actor[akka://reactivemongo/user/Monitor-main#-675148838] to Actor[akka://reactivemongo/user/main#1671398268] was not delivered. [1] dead letters encountered. If this is not an expected behavior then Actor[akka://reactivemongo/user/main#1671398268] may have terminated unexpectedly. This logging can be turned off or adjusted with configuration settings 'akka.log-dead-letters' and 'akka.log-dead-letters-during-shutdown'.
[E] Oops, cannot start the server.

```