### PR TITLE
preload piece svgs in head

### DIFF
--- a/modules/web/src/main/ui/PieceSetImages.scala
+++ b/modules/web/src/main/ui/PieceSetImages.scala
@@ -20,7 +20,9 @@ final class PieceSetImages(assets: AssetFullHelper):
           yield s"piece/$pieceSet/$c$r.svg" -> s"---$color-$role"
         val css = s"<style>:root{"
           + vars.map { (path, name) => s"$name:url(${assets.assetUrl(path)});" }.mkString
-          + "}</style>"
+          + "}</style>" + vars.map { (path, _) =>
+            s"""<link rel="preload" as="image" href="${assets.assetUrl(path)}" />"""
+          }.mkString
         if vars.exists { (path, _) => assets.manifest.hashed(path).isEmpty }
         then lila.log("layout").error(s"$pieceSet manifest incomplete")
         css


### PR DESCRIPTION
this is not to fetch them faster. i don't think layout has to wait for unresolved background-image properties.

preload links in \<head> just ensure that "hard reload" will fetch fresh copies and update the cache.