### PR TITLE
more approachable markdown reference

### DIFF
--- a/modules/ui/src/main/helper/FormHelper.scala
+++ b/modules/ui/src/main/helper/FormHelper.scala
@@ -37,7 +37,7 @@ trait FormHelper:
   def markdownAvailable(using Translate): Frag =
     trans.site.markdownAvailable:
       a(
-        href := "https://guides.github.com/features/mastering-markdown/",
+        href := "https://www.markdownguide.org/cheat-sheet/",
         targetBlank
       )("Markdown")
 


### PR DESCRIPTION
the [github markdown reference](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) is like diving into the middle of a technical manual. from pretty early on, it shifts focus to various github features and things that have nothing to do with markdown.

this [cheat sheet](https://www.markdownguide.org/cheat-sheet/) is more approachable and elements covered are a better match for what lila's flexmark config offers.

the reference material is open source, hosted at markdownguide.org, and versioned at https://github.com/mattcone/markdown-guide. he does sell a paperback version of markdown guide at the bottom of each page.