### PR TITLE
fix: add  check for missing rating history canvas on advanced search …

### DIFF
--- a/ui/chart/src/chart.ratingHistory.ts
+++ b/ui/chart/src/chart.ratingHistory.ts
@@ -84,7 +84,7 @@ export function initModule({ data, singlePerfName }: Opts): void {
   $('.spinner').remove();
 
   const $el = $('canvas.rating-history');
-  if (!$el.length || !($el[0] instanceof HTMLCanvasElement)) return;
+  if (!$el.length) return;
   const singlePerfIndex = data.findIndex(x => x.name === singlePerfName);
   if (singlePerfName && !data[singlePerfIndex]?.points.length) {
     $el.hide();


### PR DESCRIPTION
…page

**Problem:**
In the user profile page, when the user clicks Advanced Search, the rating distribution history chart is hidden. As a result, no canvas element exists in the DOM. `initModule` within `chart.ratingHistory` is still called and tries to access the canvas, which leads to a runtime error in chart.ts.




| Default| Advanced search page|
|--------|--------|
| <img width="1062" height="604" alt="image" src="https://github.com/user-attachments/assets/d10fe9b8-9d55-4327-9de9-d609ce5e05f6" /> |<img width="1064" height="768" alt="image" src="https://github.com/user-attachments/assets/2413b481-9fa2-4250-b4ba-e17e17a4fbc4" /> |

**Changes made:**
Before running the initialization logic, check whether the canvas element exists. If it does not exist, exit early to prevent runtime errors.

**Related Issues**
fixes #18122