### PR TITLE
Unplayed tag fix when the source regresses

### DIFF
--- a/modules/relay/src/main/RelayGame.scala
+++ b/modules/relay/src/main/RelayGame.scala
@@ -4,7 +4,7 @@ import chess.Outcome
 import chess.format.UciPath
 import chess.format.pgn.{ Tag, TagType, Tags }
 
-import lila.study.{ MultiPgn, PgnDump }
+import lila.study.{ MultiPgn, PgnDump, StudyPgnImport }
 import lila.tree.{ Root, Clock }
 import lila.tree.Node.Comments
 
@@ -76,7 +76,7 @@ private object RelayGame:
     points = c.tags.points
   )
 
-  def fromStudyImport(res: lila.study.StudyPgnImport.Result): RelayGame =
+  def fromStudyImport(res: StudyPgnImport.Result): RelayGame =
     val fixedTags = cleanOrRemovePlayerNames:
       // remove wrong ongoing result tag if the board has a mate on it
       if res.ending.isDefined && res.tags(_.Result).has("*") then
@@ -88,7 +88,7 @@ private object RelayGame:
           then tag.copy(value = Outcome.showPoints(Outcome.pointsFromResult(tag.value)))
           else tag)
     .pipe(_ - Tag.Date) // trust the chapter date, not the source date
-      .pipe(toggleUnplayedTermination(_, res))
+      .pipe(toggleUnplayedTermination(_, res.ending.isDefined && res.root.mainline.sizeIs < 2))
     RelayGame(
       tags = fixedTags,
       variant = res.variant,
@@ -107,9 +107,8 @@ private object RelayGame:
         Option.when(clean.size > 1 && clean.toLowerCase != "unknown"):
           tag.copy(value = clean)
 
-  // Used during chapter creation. Also handled in RelaySync.
-  private def toggleUnplayedTermination(tags: Tags, res: lila.study.StudyPgnImport.Result) =
-    if res.ending.isDefined && res.root.mainline.sizeIs < 2
+  def toggleUnplayedTermination(tags: Tags, set: Boolean) =
+    if set
     then tags + unplayedTag
     else tags.map(_.filter(_ != unplayedTag))
 

--- a/modules/relay/src/main/RelaySync.scala
+++ b/modules/relay/src/main/RelaySync.scala
@@ -160,18 +160,14 @@ final private class RelaySync(
         !chapter.tags(_.Result).has(game.showResult)
     ).option(Tag(_.Result, game.showResult))
     val tags = newEndTag.fold(gameTags)(gameTags + _)
-    def toggleUnplayedTermination(tags: Tags): Tags =
-      import RelayGame.unplayedTag
-      // Only add the unplayed tag if both the source and the chapter have < 2 moves
-      if tags.points.isDefined && Seq(chapter.root, game.root).forall(_.mainline.sizeIs < 2)
-      then tags + unplayedTag
-      else tags.map(_.filter(_ != unplayedTag))
     val chapterNewTags = tags.value
       .filterNot: tag =>
         tagManualOverride.exists(chapter.id, tag.name)
       .foldLeft(chapter.tags): (chapterTags, tag) =>
         PgnTags(chapterTags + tag)
-      .pipe(toggleUnplayedTermination)
+      .pipe: tags =>
+        def fewMoves = Seq(chapter.root, game.root).forall(_.mainline.sizeIs < 2)
+        RelayGame.toggleUnplayedTermination(tags, tags.points.isDefined && fewMoves)
     if chapterNewTags == chapter.tags then fuccess(none -> false)
     else
       if vs(chapterNewTags) != vs(chapter.tags) then


### PR DESCRIPTION
There are now two `toggleUnplayedTermination` functions:
1. in `RelayGame` and its only use is for adding the tag at the time of chapter creation.
2. in `RelaySync` and is responsible from there on out.

You can technically get away with only the second implementation but the reason I kept it is because you have to wait for at least one sync event before the tag shows up/disappears after a round creation/reset.