### PR TITLE
return study features on broadcast round endpoint

### DIFF
--- a/modules/relay/src/main/JsonView.scala
+++ b/modules/relay/src/main/JsonView.scala
@@ -122,6 +122,8 @@ final class JsonView(
     def allowed(selection: Settings => Settings.UserSelection): Boolean =
       Settings.UserSelection.allows(selection(r.study.settings), r.study, me.map(_.userId))
 
+    val cheatable = r.relay.sync.isInternalWithoutDelay && !r.relay.isFinished
+
     Json.obj(
       "round" -> apply(r.relay)
         .add("url" -> s"$baseUrl${r.path}".some)
@@ -131,8 +133,8 @@ final class JsonView(
         "writeable" -> me.exists(r.study.canContribute),
         "features" -> Json.obj(
           "chat" -> allowed(_.chat),
-          "computer" -> allowed(_.computer),
-          "explorer" -> allowed(_.explorer)
+          "computer" -> (!cheatable && allowed(_.computer)),
+          "explorer" -> (!cheatable && allowed(_.explorer))
         )
       )
     )

--- a/modules/relay/src/main/RelayRound.scala
+++ b/modules/relay/src/main/RelayRound.scala
@@ -141,6 +141,8 @@ object RelayRound:
     private def pollingLag = Seconds(if isPush then 1 else 6)
     def delayMinusLag = delay.map(_ - pollingLag).filter(_.value > 0)
 
+    def isInternalWithoutDelay = upstream.exists(_.isInternal && delay.isEmpty)
+
     override def toString = upstream.toString
 
   object Sync:


### PR DESCRIPTION
to determine whether engine, opening book, etc should be enabled

```bash
curl --silent -H "Authorization: Bearer lip_admin" \
  http://localhost:8080/api/broadcast/-/-/4pZRY3dO \
  | jq .study
```

```json
{
  "writeable": true,
  "features": {
    "chat": false,
    "computer": true,
    "explorer": true,
    "cloneable": true,
    "shareable": true
  }
}
```