### PR TITLE
correctly filter eval by current display prefs

### DIFF
--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -648,6 +648,10 @@ export default class AnalyseCtrl implements CevalHandler {
     this.redraw();
   }
 
+  allowedEval(node: Tree.Node = this.node): Tree.ClientEval | Tree.ServerEval | false | undefined {
+    return (this.cevalEnabled() && node.ceval) || (this.showFishnetAnalysis() && node.eval);
+  }
+
   outcome(node?: Tree.Node): Outcome | undefined {
     return this.position(node || this.node).unwrap(
       pos => pos.outcome(),

--- a/ui/analyse/src/treeView/inlineView.ts
+++ b/ui/analyse/src/treeView/inlineView.ts
@@ -162,14 +162,14 @@ export class InlineView {
         ?.map(g => this.glyphs[g.id - 1])
         .filter(Boolean)
         .forEach(cls => (classes[cls] = true));
-
     return hl('move', { attrs: { p: path }, class: classes }, [
       parentDisclose && this.disclosureBtn(parentNode, parentPath),
       withIndex && renderIndex(node.ply, true),
       renderMoveNodes(
         node,
-        ctrl.showFishnetAnalysis() && isMainline && !this.inline,
+        isMainline && !this.inline,
         (!!ctrl.study && !ctrl.study.relay) || ctrl.showFishnetAnalysis(),
+        ctrl.allowedEval(node) || false,
       ),
     ]);
   }

--- a/ui/analyse/src/view/components.ts
+++ b/ui/analyse/src/view/components.ts
@@ -298,9 +298,20 @@ export const renderIndexAndMove = (node: Tree.Node, withEval: boolean, withGlyph
 export const renderIndex = (ply: Ply, withDots: boolean): VNode =>
   hl(`index.sbhint${ply}`, plyToTurn(ply) + (withDots ? (ply % 2 === 1 ? '.' : '...') : ''));
 
-export function renderMoveNodes(node: Tree.Node, withEval: boolean, withGlyphs: boolean): LooseVNodes {
-  const ev = node.ceval ?? node.eval;
-  const evalText = ev?.cp !== undefined ? normalizeEval(ev.cp) : ev?.mate !== undefined ? `#${ev.mate}` : '';
+export function renderMoveNodes(
+  node: Tree.Node,
+  withEval: boolean,
+  withGlyphs: boolean,
+  ev?: Tree.ClientEval | Tree.ServerEval | false,
+): LooseVNodes {
+  ev ??= node.ceval ?? node.eval; // ev = false will override withEval
+  const evalText = !ev
+    ? ''
+    : ev?.cp !== undefined
+      ? normalizeEval(ev.cp)
+      : ev?.mate !== undefined
+        ? `#${ev.mate}`
+        : '';
   return [
     hl('san', fixCrazySan(node.san!)),
     withGlyphs && node.glyphs?.map(g => hl('glyph', { attrs: { title: g.name } }, g.symbol)),

--- a/ui/analyse/src/view/controls.ts
+++ b/ui/analyse/src/view/controls.ts
@@ -99,7 +99,7 @@ function renderPracticeTab(ctrl: AnalyseCtrl): LooseVNode {
 
 function renderMobileCevalTab(ctrl: AnalyseCtrl): LooseVNode {
   const engineMode = ctrl.activeControlMode() || 'ceval',
-    ev = ctrl.node.ceval ?? (ctrl.showFishnetAnalysis() ? ctrl.node.eval : undefined),
+    ev = ctrl.allowedEval() || undefined,
     evalstr = ev?.cp !== undefined ? renderEval(ev.cp) : ev?.mate ? '#' + ev.mate : '',
     active = ctrl.activeControlMode() && !ctrl.activeControlBarTool(),
     latent = ctrl.activeControlMode() && !!ctrl.activeControlBarTool();


### PR DESCRIPTION
in column view mainline and mobile ceval tab:
- if browser engine is enabled and node.ceval is defined, show ceval
- else if "show fishnet analysis" is true and node.eval is defined, show fishnet eval
- else show nothing

fix #18413