### PR TITLE
avoid cpu icon at small size

### DIFF
--- a/ui/analyse/css/_tools-mobile.scss
+++ b/ui/analyse/css/_tools-mobile.scss
@@ -107,7 +107,8 @@
       content: $licon-X;
     }
     [data-mode='ceval']::after {
-      content: $licon-Cpu;
+      content: $licon-Cogs;
+      color: $c-font-dimmer;
       padding-inline-end: 10px;
     }
     [data-mode='ceval']:has(eval)::after {

--- a/ui/lobby/css/_table.scss
+++ b/ui/lobby/css/_table.scss
@@ -25,7 +25,7 @@
       }
       &::before {
         @extend %data-icon;
-        font-size: 1.7em;
+        font-size: 32px;
         color: $c-font-dimmer;
       }
       &--hook.button::before {


### PR DESCRIPTION
make create game button icons slightly bigger (so the vs computer icon looks less circular).


<img width="359" height="168" alt="image" src="https://github.com/user-attachments/assets/eb0d393d-a7b0-44f0-bc6d-41f34b23f8ca" />

##

on the mobile engine tab, the icon looks like exactly like an outlined zero. i tried larger fonts until it looked vaguely square, but this caused size mismatch with the other buttons. i propose you just use cogs here.


<img width="371" height="88" alt="image" src="https://github.com/user-attachments/assets/b197a945-6223-46d7-a4ae-3c1ee18f9e88" />

##

CPU looks great at larger sizes, but the arced package traces surrounding the die make it unsuitable for 24px and below.
