### PR TITLE
Disable 404 link to forum when in kid mode

### DIFF
--- a/modules/ublog/src/main/ui/UblogPostUi.scala
+++ b/modules/ublog/src/main/ui/UblogPostUi.scala
@@ -117,7 +117,7 @@ final class UblogPostUi(helpers: Helpers, ui: UblogUi)(connectLinks: Frag):
               )
             ),
             div(cls := "ublog-post__footer")(
-              (post.live && ~post.discuss).option(
+              (post.live && ~post.discuss && ctx.kid.no).option(
                 a(
                   href := routes.Ublog.discuss(post.id),
                   cls := "button text ublog-post__discuss",


### PR DESCRIPTION
Official blog posts by Lichess are shown in kid mode. This PR hides this button which returns a 404

<img width="623" height="70" alt="image" src="https://github.com/user-attachments/assets/e6f14c9b-5b3f-448c-bb70-14f6f03fed40" />
