### PR TITLE
Theme-vote API: fix checkFirst theme read from db

### DIFF
--- a/modules/puzzle/src/main/BsonHandlers.scala
+++ b/modules/puzzle/src/main/BsonHandlers.scala
@@ -47,7 +47,7 @@ private object BsonHandlers:
   private[puzzle] given BSONHandler[PuzzleRound.Theme] = tryHandler[PuzzleRound.Theme](
     { case BSONString(v) =>
       PuzzleTheme
-        .find(v.tail)
+        .findAny(v.tail)
         .fold[Try[PuzzleRound.Theme]](handlerBadValue(s"Invalid puzzle round theme $v")) { theme =>
           Success(PuzzleRound.Theme(theme.key, v.head == '+'))
         }

--- a/modules/puzzle/src/main/PuzzleAngle.scala
+++ b/modules/puzzle/src/main/PuzzleAngle.scala
@@ -46,7 +46,7 @@ object PuzzleAngle:
 
   def find(key: String): Option[PuzzleAngle] =
     PuzzleTheme
-      .find(key)
+      .findVisible(key)
       .map(apply)
       .orElse(LilaOpeningFamily.find(key).map(apply))
       .orElse(SimpleOpening.find(key).map(apply))

--- a/modules/puzzle/src/main/PuzzleApi.scala
+++ b/modules/puzzle/src/main/PuzzleApi.scala
@@ -141,7 +141,7 @@ final class PuzzleApi(
       PuzzleTheme
         .findDynamic(themeStr)
         .orElse:
-          me.is(UserId.lichess).so(PuzzleTheme.find(themeStr))
+          me.is(UserId.lichess).so(PuzzleTheme.findVisible(themeStr))
         .raiseIfNone(Fail(s"Unknown theme $themeStr"))
         .flatMap: theme =>
           if me.is(UserId.lichess) then lichessVote(id, theme.key, vote)

--- a/modules/puzzle/src/main/PuzzleDashboard.scala
+++ b/modules/puzzle/src/main/PuzzleDashboard.scala
@@ -136,7 +136,7 @@ final class PuzzleDashboardApi(
             for
               doc <- themeDocs
               themeStr <- doc.string("_id")
-              theme <- PuzzleTheme.find(themeStr)
+              theme <- PuzzleTheme.findVisible(themeStr)
               results <- readResults(doc)
             yield theme.key -> results
         yield PuzzleDashboard(

--- a/modules/puzzle/src/main/PuzzleTheme.scala
+++ b/modules/puzzle/src/main/PuzzleTheme.scala
@@ -241,8 +241,9 @@ object PuzzleTheme:
 
   def apply(key: Key): PuzzleTheme = byKey.getOrElse(key, mix)
 
-  def find(key: String) = byLowerKey.get(key.toLowerCase)
+  def findAny(key: String) = byLowerKey.get(key.toLowerCase)
+  def findVisible(key: String) = findAny(key).filterNot(hiddenThemes.contains)
 
-  def findOrMix(key: String) = find(key) | mix
+  def findOrMix(key: String) = findVisible(key) | mix
 
-  def findDynamic(key: String) = find(key).filterNot(t => staticThemes(t.key))
+  def findDynamic(key: String) = findVisible(key).filterNot(t => staticThemes(t.key))


### PR DESCRIPTION
It was the root of the issue causing 400 malformated requests for all puzzles containing the `checkFirst` theme, like `/training/02tYt`.

It was because it would fail mapping the BSONDocument/Bdoc to `PuzzleRound.Theme`.

```scala
PuzzleTheme
        .find(v.tail)
```
in the following snippet would fail because internally it's only looking at `visible` puzzles, which `checkFirst` is not.

```scala
  private[puzzle] given BSONHandler[PuzzleRound.Theme] = tryHandler[PuzzleRound.Theme](
    { case BSONString(v) =>
      PuzzleTheme
        .find(v.tail)
        .fold[Try[PuzzleRound.Theme]](handlerBadValue(s"Invalid puzzle round theme $v")) { theme =>
          Success(PuzzleRound.Theme(theme.key, v.head == '+'))
        }
    },
    rt => BSONString(s"${if rt.vote then "+" else "-"}${rt.theme}")
  )
```
so would fail, resulting in the following failing

```scala
    def themes(id: PuzzleRound.Id): Fu[Option[List[PuzzleRound.Theme]]] =
      colls.round:
        _.primitiveOne[List[PuzzleRound.Theme]]($id(id), PuzzleRound.BSONFields.themes)

```
resulting in returning `None` instead of a `List[PuzzleRound.Theme]`.

I was surprised by that behavior, I would have expected the parser to just skip the malformated elements, but still produce a List.

I guess it's the difference between `Option` and `Try` for parsers.


-----

I actually think a specific API would be better suited though, where one could vote for multiple themes at once, as well as a bulk-vote API (Lichess only)