### PR TITLE
dont turn ceval off when switching engines

### DIFF
--- a/ui/lib/src/ceval/ctrl.ts
+++ b/ui/lib/src/ceval/ctrl.ts
@@ -63,6 +63,7 @@ export default class CevalCtrl {
     if (this.worker?.getInfo().id !== this.engines?.activate()?.id) {
       this.worker?.destroy();
       this.worker = undefined;
+      this.lastStarted = false;
     }
   }
 


### PR DESCRIPTION
fix ceval switching itself off when a different engine is selected from the settings dropdown.