### PR TITLE
refactor and update `numberRow` between swiss and arenas to show on h…

### DIFF
--- a/ui/lib/src/view/util.ts
+++ b/ui/lib/src/view/util.ts
@@ -1,0 +1,27 @@
+import { h, type VNode, type VNodeChildren } from 'snabbdom';
+import { numberFormat } from '../i18n';
+
+const ratio2percent = (r: number): string => Math.round(100 * r) + '%';
+
+export function numberRow(name: string, value: number): VNode;
+// should only be used for games percentage, due to title speaking about games
+export function numberRow(name: string, value: [number, number], typ: 'percent'): VNode;
+export function numberRow(name: string, value: VNodeChildren, typ: 'raw'): VNode;
+export function numberRow(name: string, value: any, typ?: string): VNode {
+  return h('tr', [
+    h('th', name),
+    h(
+      'td',
+      {
+        attrs: typ === 'percent' ? { title: i18n.site.nbGames(value[0]) } : {},
+      },
+      typ === 'raw'
+        ? value
+        : typ === 'percent'
+          ? value[1] > 0
+            ? ratio2percent(value[0] / value[1])
+            : 0
+          : numberFormat(value),
+    ),
+  ]);
+}

--- a/ui/swiss/src/view/main.ts
+++ b/ui/swiss/src/view/main.ts
@@ -1,7 +1,7 @@
 import * as licon from 'lib/licon';
 import { spinnerVdom as spinner } from 'lib/view/controls';
 import { type VNode, dataIcon, bind, onInsert, type LooseVNodes, hl } from 'lib/snabbdom';
-import { numberRow } from './util';
+import { numberRow } from 'lib/view/util';
 import type SwissCtrl from '../ctrl';
 import { players, renderPager } from '../pagination';
 import type { SwissData, Pager } from '../interfaces';

--- a/ui/swiss/src/view/playerInfo.ts
+++ b/ui/swiss/src/view/playerInfo.ts
@@ -1,8 +1,9 @@
 import type { VNode } from 'snabbdom';
 import * as licon from 'lib/licon';
 import { spinnerVdom as spinner } from 'lib/view/controls';
+import { numberRow } from 'lib/view/util';
 import { bind, dataIcon, hl } from 'lib/snabbdom';
-import { player as renderPlayer, numberRow } from './util';
+import { player as renderPlayer } from './util';
 import type { Pairing } from '../interfaces';
 import { isOutcome } from '../util';
 import type SwissCtrl from '../ctrl';

--- a/ui/swiss/src/view/util.ts
+++ b/ui/swiss/src/view/util.ts
@@ -1,6 +1,5 @@
 import { h } from 'snabbdom';
 import type { BasePlayer } from '../interfaces';
-import { numberFormat } from 'lib/i18n';
 import { fullName, userLine, userRating } from 'lib/view/userLink';
 
 export function player(p: BasePlayer, asLink: boolean, withRating: boolean) {
@@ -16,22 +15,4 @@ export function player(p: BasePlayer, asLink: boolean, withRating: boolean) {
       withRating ? h('span.rating', userRating({ ...p, brackets: false })) : null,
     ],
   );
-}
-
-export const ratio2percent = (r: number) => Math.round(100 * r) + '%';
-
-export function numberRow(name: string, value: any, typ?: string) {
-  return h('tr', [
-    h('th', name),
-    h(
-      'td',
-      typ === 'raw'
-        ? value
-        : typ === 'percent'
-          ? value[1] > 0
-            ? ratio2percent(value[0] / value[1])
-            : 0
-          : numberFormat(value),
-    ),
-  ]);
 }

--- a/ui/tournament/src/view/arena.ts
+++ b/ui/tournament/src/view/arena.ts
@@ -1,8 +1,9 @@
 import { h, type VNode } from 'snabbdom';
 import * as licon from 'lib/licon';
 import { bind, dataIcon, type MaybeVNodes } from 'lib/snabbdom';
+import { numberRow } from 'lib/view/util';
 import type TournamentController from '../ctrl';
-import { player as renderPlayer, ratio2percent } from './util';
+import { player as renderPlayer } from './util';
 import { teamName } from './battle';
 import type { Pagination, PodiumPlayer, StandingPlayer } from '../interfaces';
 import { joinWithdraw } from './button';
@@ -75,10 +76,8 @@ function podiumStats(p: PodiumPlayer, berserkable: boolean, ctrl: TournamentCont
     h('tr', [h('th', i18n.site.gamesPlayed), h('td', nb.game)]),
     ...(nb.game
       ? [
-          h('tr', [h('th', i18n.site.winRate), h('td', ratio2percent(nb.win / nb.game))]),
-          berserkable
-            ? h('tr', [h('th', i18n.arena.berserkRate), h('td', ratio2percent(nb.berserk / nb.game))])
-            : null,
+          numberRow(i18n.site.winRate, [nb.win, nb.game], 'percent'),
+          berserkable ? numberRow(i18n.arena.berserkRate, [nb.berserk, nb.game], 'percent') : null,
         ]
       : []),
   ]);

--- a/ui/tournament/src/view/finished.ts
+++ b/ui/tournament/src/view/finished.ts
@@ -8,7 +8,7 @@ import { teamStanding } from './battle';
 import header from './header';
 import playerInfo from './playerInfo';
 import teamInfo from './teamInfo';
-import { numberRow } from './util';
+import { numberRow } from 'lib/view/util';
 import { type MaybeVNodes } from 'lib/snabbdom';
 import { once } from 'lib/storage';
 

--- a/ui/tournament/src/view/playerInfo.ts
+++ b/ui/tournament/src/view/playerInfo.ts
@@ -1,8 +1,9 @@
 import * as licon from 'lib/licon';
 import { spinnerVdom as spinner } from 'lib/view/controls';
 import { type VNode, bind, dataIcon, hl } from 'lib/snabbdom';
-import { numberRow, player as renderPlayer } from './util';
+import { player as renderPlayer } from './util';
 import { fullName } from 'lib/view/userLink';
+import { numberRow } from 'lib/view/util';
 import { teamName } from './battle';
 import { status } from 'lib/game/game';
 import type TournamentController from '../ctrl';

--- a/ui/tournament/src/view/teamInfo.ts
+++ b/ui/tournament/src/view/teamInfo.ts
@@ -1,9 +1,10 @@
 import { h, type VNode } from 'snabbdom';
 import * as licon from 'lib/licon';
 import { spinnerVdom as spinner } from 'lib/view/controls';
+import { numberRow } from 'lib/view/util';
 import { bind, dataIcon } from 'lib/snabbdom';
 import type TournamentController from '../ctrl';
-import { numberRow, player as renderPlayer } from './util';
+import { player as renderPlayer } from './util';
 import { teamName } from './battle';
 
 export default function (ctrl: TournamentController): VNode | undefined {

--- a/ui/tournament/src/view/util.ts
+++ b/ui/tournament/src/view/util.ts
@@ -1,11 +1,8 @@
-import { h, type VNode, type VNodeChildren } from 'snabbdom';
+import { h } from 'snabbdom';
 import * as licon from 'lib/licon';
-import { numberFormat } from 'lib/i18n';
 import { dataIcon } from 'lib/snabbdom';
 import { fullName, userLine, userRating } from 'lib/view/userLink';
 import type { SimplePlayer } from '../interfaces';
-
-export const ratio2percent = (r: number) => Math.round(100 * r) + '%';
 
 export const player = (
   p: SimplePlayer,
@@ -29,22 +26,3 @@ export const player = (
       withRating ? h('span.rating', userRating({ ...p, brackets: false })) : null,
     ],
   );
-
-export function numberRow(name: string, value: number): VNode;
-export function numberRow(name: string, value: [number, number], typ: 'percent'): VNode;
-export function numberRow(name: string, value: VNodeChildren, typ: 'raw'): VNode;
-export function numberRow(name: string, value: any, typ?: string) {
-  return h('tr', [
-    h('th', name),
-    h(
-      'td',
-      typ === 'raw'
-        ? value
-        : typ === 'percent'
-          ? value[1] > 0
-            ? ratio2percent(value[0] / value[1])
-            : 0
-          : numberFormat(value),
-    ),
-  ]);
-}


### PR DESCRIPTION
refactor and update `numberRow` between swiss and arenas to show on hover the number of games involved when displaying a percent

<img width="430" height="307" alt="image" src="https://github.com/user-attachments/assets/a96d65f1-71da-4991-905a-f5fae01eaa86" />
Applies to berserk, draw and standings as well.

`ui/lib/src/view/util.ts` name and location is tentative, maybe there's a better location+name