### PR TITLE
prevent stacking of duplicated pvs

### DIFF
--- a/ui/lib/src/ceval/protocol.ts
+++ b/ui/lib/src/ceval/protocol.ts
@@ -131,8 +131,8 @@ export class Protocol {
           mate: isMate ? ev : undefined,
           pvs: [pvData],
         };
-      } else if (this.currentEval) {
-        this.currentEval.pvs[multiPv - 1] = pvData;
+      } else if (this.currentEval && this.currentEval.pvs.length < multiPv) {
+        this.currentEval.pvs.push(pvData);
         this.currentEval.depth = Math.min(this.currentEval.depth, depth);
       }
 


### PR DESCRIPTION
This prevents duplicated pvs to stack in the `this.currentEval.pvs`.

**After** the `movetime` in the ceval configuration expires, sometimes (~7%, my estimate) PVs are added again for some reason (perhaps by another worker). This results in `this.currentEval.pvs` of type `[pv1, pv2, pv2, pv3, pv3]`, and such evals are also cached, for example (positions after random moves):

https://lichess.org/api/cloud-eval?fen=rn1qkb1r/pb3ppp/1p2pn2/2ppN3/5P2/3P2P1/PPP1P1BP/RNBQ1RK1%20b%20kq%20-%201%207&multiPv=3 (`1. f4 d5 2. d3 c5 3. Nf3 Nf6 4. g3 b6 5. Bg2 Bb7 6. O-O e6 7. Ne5`)
https://lichess.org/api/cloud-eval?fen=rnbqkbnr/pp1ppp1p/2p3p1/8/8/5NP1/PPPPPP1P/RNBQKB1R%20w%20KQkq%20-%200%203&multiPv=5 (`1. g3 g6 2. Nf3 c6`)

I don't know the root cause of the duplication, maybe someone with a better understanding can suggest a better fix.