### PR TITLE
markdown whitelist to include dev sites with port number

### DIFF
--- a/modules/common/src/main/MarkdownRender.scala
+++ b/modules/common/src/main/MarkdownRender.scala
@@ -142,7 +142,7 @@ object MarkdownRender:
       if url.scheme == "http" || url.scheme == "https"
       host <- Option(url.host).map(_.toHostString)
       if (assetDomain.toList ::: whitelist).exists(h =>
-        host == h.value.split(":").head || host.endsWith(s".$h")
+        h.value.split(":").headOption.contains(host) || host.endsWith(s".$h")
       )
     yield url.toString
 


### PR DESCRIPTION
Noticed while testing #18378

a local dev site that uses "localhost:8080" as `asset.domain` was not being whitelisted