### PR TITLE
change default picfit endpointGet to localhost

### DIFF
--- a/conf/base.conf
+++ b/conf/base.conf
@@ -351,7 +351,7 @@ memo {
   picfit {
     collection = picfit_image
     secretKey = "qix8rozsRE6Rsw5uvBjwJUCFfQhyaKbR" # request signature
-    endpointGet = "http://127.0.0.1:3001"
+    endpointGet = "http://localhost:3001"
     endpointPost = "http://127.0.0.1:3001"
   }
   cloudflare {


### PR DESCRIPTION
urls matching 127.0.0.1 are no longer image embedded.

to mitigate that, make sure that bare metal (i.e. not lila-docker) dev builds with local picfit servers are still covered as long as net.asset.domain remains localhost.