### PR TITLE
Sort rating history tooltip items by rating

### DIFF
--- a/ui/chart/src/chart.ratingHistory.ts
+++ b/ui/chart/src/chart.ratingHistory.ts
@@ -3,6 +3,7 @@ import {
   type Point,
   type ChartConfiguration,
   type PointStyle,
+  type TooltipItem,
   Chart,
   PointElement,
   LinearScale,
@@ -186,6 +187,7 @@ export function initModule({ data, singlePerfName }: Opts): void {
           yAlign: 'center',
           caretPadding: 10,
           rtl: document.dir === 'rtl',
+          itemSort: (a: TooltipItem<'line'>, b: TooltipItem<'line'>) => b.parsed.y - a.parsed.y,
           callbacks: {
             title: items => dateFormat()(dayjs.utc(items[0].parsed.x).valueOf()),
           },


### PR DESCRIPTION
I was motivated to suggest this simple change based on my own user experience when interacting with the rating history chart. 

https://github.com/lichess-org/lila/issues/15072#issuecomment-2051769220 and [this forum post](https://lichess.org/forum/lichess-feedback/legend-misfits-ratings-chart#8) mention that it's inconsistent for the items in the legend to move around, which can be subjective. Would love to hear what people think!

Before:
<img width="450" alt="before" src="https://github.com/user-attachments/assets/e2bd0deb-7892-422a-924c-79e7f4128d40" />
After:
<img width="450" alt="after" src="https://github.com/user-attachments/assets/5a4568fb-acbe-49f2-b80c-497bcb39b09d" />
