### PR TITLE
add # and ## back to forums

### DIFF
--- a/modules/forum/src/main/ForumExpand.scala
+++ b/modules/forum/src/main/ForumExpand.scala
@@ -7,7 +7,7 @@ import lila.core.config.NetDomain
 
 final class ForumTextExpand(markdown: lila.memo.MarkdownCache)(using Executor, Scheduler):
 
-  val markdownOptions = lila.memo.MarkdownOptions.all.copy(header = false, maxPgns = lila.memo.Max(10))
+  val markdownOptions = lila.memo.MarkdownOptions.all.copy(maxPgns = lila.memo.Max(10))
 
   private def one(post: ForumPost)(using NetDomain): Fu[Frag] =
     if post.hasMarkdown then

--- a/ui/bits/css/forum/_post.scss
+++ b/ui/bits/css/forum/_post.scss
@@ -161,13 +161,30 @@
   font-size: 1.1rem;
 }
 .forum-post__message,
-.comment-preview {
-  @include rendered-markdown(1em, 1600px);
+.forum-topic .comment-preview {
+  @include rendered-markdown(1em, 1600px, $h1: false, $h2: false);
   @include rendered-markdown--code;
   @include rendered-markdown--quote;
   @include rendered-markdown--img;
   @include rendered-markdown--embed;
-
+  h1,
+  h2 {
+    font-size: 1.5em;
+    line-height: 1.5em;
+    font-weight: bold;
+    margin-block: 0.5em;
+    border-bottom: 1px solid $m-border--fade-20;
+    padding-bottom: 0.3em;
+  }
+  h2 {
+    font-size: 1.4em;
+    line-height: 1.4em;
+    border-bottom: 1px solid $m-border--fade-40;
+  }
+  h3,
+  h4 {
+    font-size: 1.3em;
+  }
   blockquote {
     padding: 0.3em 0.7em;
     border-left: 0.3em solid;


### PR DESCRIPTION
if you want to discourage abuse, dilute the styles.

it's better to make blind users hit tab a few more to navigate an annoying forum thread than to deliver partial support. people will just think it's a bug and spam github/forum about it.