### PR TITLE
don't show relay source url during broadcast

### DIFF
--- a/ui/analyse/src/study/relay/relayManagerView.ts
+++ b/ui/analyse/src/study/relay/relayManagerView.ts
@@ -62,7 +62,7 @@ function stateOn(ctrl: RelayCtrl) {
         sync && [
           !!sync.delay && `with ${sync.delay}s delay `,
           sync.url
-            ? ['to single URL source']
+            ? ['to', hl('br'), 'single URL source']
             : sync.ids
               ? ['to', hl('br'), sync.ids.length, ' game(s)']
               : sync.users


### PR DESCRIPTION
Broadcast managers can always open the round settings and look at the source. This is to prevent those streaming a broadcast from a manager's account from accidentally revealing their source server.