### PR TITLE
MarkdownRender sourceMap throws exception when 2 @usernames are on the same line

### DIFF
--- a/modules/web/src/test/common/MarkdownTest.scala
+++ b/modules/web/src/test/common/MarkdownTest.scala
@@ -122,3 +122,8 @@ class MarkdownTest extends munit.FunSuite:
       Html("""<h1><a href="#heading" id="heading"></a>heading</h1>
 """)
     )
+
+  test("prod forum exception"):
+    val text = """@Betcomcpiey @QuieroAprender"""
+    val render = MarkdownRender(sourceMap = true)("test")
+    assert(render(Markdown(text)).value.contains("QuieroAprender"))


### PR DESCRIPTION
Like on https://lichess.org/forum/team-classical-champions-league/cit-2025?page=2

Unit test included

```
java.lang.StringIndexOutOfBoundsException: endIndex: 176 out of range: [122, 161]
        at com.vladsch.flexmark.util.sequence.SequenceUtils.validateStartEnd(SequenceUtils.java:1159)
        at com.vladsch.flexmark.util.sequence.SubSequence.subSequence(SubSequence.java:122)
        at com.vladsch.flexmark.util.sequence.SubSequence.subSequence(SubSequence.java:15)
        at lila.common.MarkdownRender$.body$proxy1$1(MarkdownRender.scala:364)
        at lila.common.MarkdownRender$.lila$common$MarkdownRender$$anon$11$$_$text$$anonfun$1(MarkdownRender.scala:364)
        at scala.runtime.function.JProcedure1.apply(JProcedure1.java:15)
        at scala.runtime.function.JProcedure1.apply(JProcedure1.java:10)
        at scala.collection.IterableOnceOps.foreach(IterableOnce.scala:619)
        at scala.collection.IterableOnceOps.foreach$(IterableOnce.scala:617)
        at scala.collection.AbstractIterator.foreach(Iterator.scala:1306)
        at lila.common.MarkdownRender$$anon$11.text(MarkdownRender.scala:359)
        at lila.common.MarkdownRender$$anon$11.getNodeRenderingHandlers$$anonfun$5(MarkdownRender.scala:345)
        at com.vladsch.flexmark.html.renderer.NodeRenderingHandler.render(NodeRenderingHandler.java:16)
        at com.vladsch.flexmark.html.HtmlRenderer$MainNodeRenderer.renderNode(HtmlRenderer.java:779)
        at com.vladsch.flexmark.html.HtmlRenderer$MainNodeRenderer.renderChildrenNode(HtmlRenderer.java:798)
        at com.vladsch.flexmark.html.HtmlRenderer$MainNodeRenderer.renderChildren(HtmlRenderer.java:790)
        at com.vladsch.flexmark.html.renderer.CoreNodeRenderer.renderTextBlockParagraphLines(CoreNodeRenderer.java:256)
        at com.vladsch.flexmark.html.renderer.CoreNodeRenderer.lambda$renderLooseParagraph$8(CoreNodeRenderer.java:307)
        at com.vladsch.flexmark.util.html.HtmlAppendableBase.tag(HtmlAppendableBase.java:349)
        at com.vladsch.flexmark.util.html.HtmlAppendableBase.tagLine(HtmlAppendableBase.java:398)
        at com.vladsch.flexmark.html.renderer.CoreNodeRenderer.renderLooseParagraph(CoreNodeRenderer.java:307)
        at com.vladsch.flexmark.html.renderer.CoreNodeRenderer.render(CoreNodeRenderer.java:315)
        at com.vladsch.flexmark.html.renderer.NodeRenderingHandler.render(NodeRenderingHandler.java:16)
        at com.vladsch.flexmark.html.HtmlRenderer$MainNodeRenderer.renderNode(HtmlRenderer.java:779)
        at com.vladsch.flexmark.html.HtmlRenderer$MainNodeRenderer.renderChildrenNode(HtmlRenderer.java:798)
        at com.vladsch.flexmark.html.HtmlRenderer$MainNodeRenderer.renderChildren(HtmlRenderer.java:790)
        at com.vladsch.flexmark.html.renderer.CoreNodeRenderer.render(CoreNodeRenderer.java:113)
        at com.vladsch.flexmark.html.renderer.NodeRenderingHandler.render(NodeRenderingHandler.java:16)
        at com.vladsch.flexmark.html.HtmlRenderer$MainNodeRenderer.renderNode(HtmlRenderer.java:761)
        at com.vladsch.flexmark.html.HtmlRenderer$MainNodeRenderer.render(HtmlRenderer.java:683)
        at com.vladsch.flexmark.html.HtmlRenderer.render(HtmlRenderer.java:213)
        at com.vladsch.flexmark.html.HtmlRenderer.render(HtmlRenderer.java:197)
        at com.vladsch.flexmark.html.HtmlRenderer.render(HtmlRenderer.java:230)
        at lila.common.MarkdownRender.apply$$anonfun$1(MarkdownRender.scala:103)
        ```