### PR TITLE
Fix castling premove to respect rookCastle preference

### DIFF
--- a/ui/round/src/premove.ts
+++ b/ui/round/src/premove.ts
@@ -183,10 +183,13 @@ const king: cg.Mobility = (ctx: cg.MobilityContext) =>
   (ctx.canCastle &&
     ctx.orig.pos[1] === ctx.dest.pos[1] &&
     ctx.orig.pos[1] === (ctx.color === 'white' ? 0 : 7) &&
-    ((ctx.orig.pos[0] === 4 &&
-      ((ctx.dest.pos[0] === 2 && ctx.rookFilesFriendlies.includes(0)) ||
-        (ctx.dest.pos[0] === 6 && ctx.rookFilesFriendlies.includes(7)))) ||
-      ctx.rookFilesFriendlies.includes(ctx.dest.pos[0])) &&
+    (ctx.rookCastle
+      ? // Rook castling: king moves onto rook
+        ctx.rookFilesFriendlies.includes(ctx.dest.pos[0])
+      : // Standard castling: king moves two squares
+        ctx.orig.pos[0] === 4 &&
+        ((ctx.dest.pos[0] === 2 && ctx.rookFilesFriendlies.includes(0)) ||
+          (ctx.dest.pos[0] === 6 && ctx.rookFilesFriendlies.includes(7)))) &&
     (ctx.unrestrictedPremoves ||
       /* The following checks if no non-rook friendly piece is in the way between the king and its castling destination.
          Note that for the Chess960 edge case of Kb1 "long castling", the check passes even if there is a piece in the way


### PR DESCRIPTION
Update king mobility function in premove validation to only allow the user's preferred castling method. This matches the fix in chessground and ensures premoves work correctly with both castling preferences.

For issue: https://github.com/lichess-org/lila/issues/18586
Depends on: https://github.com/lichess-org/chessground/pull/366