### PR TITLE
Keep spinner if join/pause is still in progress

### DIFF
--- a/ui/tournament/src/ctrl.ts
+++ b/ui/tournament/src/ctrl.ts
@@ -72,6 +72,7 @@ export default class TournamentController {
   };
 
   reload = (data: TournamentData): void => {
+    const willChangeJoinStatus = !!this.data.me !== !!data.me || this.data.me?.withdraw !== data.me?.withdraw;
     // we joined a private tournament! Reload the page to load the chat
     if (!this.data.me && data.me && this.data.private) site.reload();
     this.data = { ...this.data, ...data, ...{ me: data.me } }; // to account for removal on withdraw
@@ -80,7 +81,7 @@ export default class TournamentController {
     if (this.focusOnMe) this.scrollToMe();
     sound.end(data);
     sound.countDown(data);
-    this.joinSpinner = false;
+    if (willChangeJoinStatus) this.joinSpinner = false;
     this.recountTeams();
     this.redirectToMyGame();
   };

--- a/ui/tournament/src/xhr.ts
+++ b/ui/tournament/src/xhr.ts
@@ -60,8 +60,8 @@ const reloadEndpointFallback = (ctrl: TournamentController) => `/tournament/${ct
 // don't use xhr.json to avoid getting the X-Requested-With header
 // that causes a CORS preflight check
 export const reloadNow: (ctrl: TournamentController) => Promise<void> = finallyDelay(
-  ctrl => Math.floor(ctrl.nbWatchers / 2) * (ctrl.data.me ? 1 : 3),
-  ctrl =>
+  (ctrl: TournamentController) => Math.floor(ctrl.nbWatchers / 2) * (ctrl.data.me ? 1 : 3),
+  (ctrl: TournamentController) =>
     fetch(
       xhr.url(ctrl.data.reloadEndpoint, {
         page: ctrl.focusOnMe ? undefined : ctrl.page,


### PR DESCRIPTION
Occasionally I notice that after clicking join/pause, the spinner reverts to the button it was before. This seems to be because the backend could send an unrelated reload first (maybe caused by some change with other users), where the current user's join status hasn't been updated yet.

To reproduce for testing locally:
- In `modules/tournament/src/main/TournamentApi.scala`, add a few seconds delay in `join`, that only runs for a particular user A.
- Log in as user A and user B on a different browser.
- Join as user A, and immediately join as user B.
- Current behaviour should show the spinner for user A incorrectly revert to the 'Join' button.

The same can be tried for user A pausing.