### PR TITLE
Do not repeat the variant name in the infos section.

### DIFF
--- a/ui/tournament/src/view/scheduleView.ts
+++ b/ui/tournament/src/view/scheduleView.ts
@@ -177,7 +177,6 @@ function renderTournament(tour: Tournament) {
         h('span.infos', [
           h('span.text', [
             displayClock(tour.clock) + ' ',
-            tour.variant.key === 'standard' ? null : tour.variant.name + ' ',
             tour.position ? 'Thematic ' : null,
             i18n.site[tour.rated ? 'ratedTournament' : 'casualTournament'],
           ]),


### PR DESCRIPTION
A tournament's variant is already stated in its name, and the icon for it is also shown. So repeating the variant name in the infos section shouldn't be needed.
The motivation here is to avoid hiding text. E.g., in the screenshot, the number of players for the antichess and koth tourneys are partially/fully hidden.

<img width="1898" height="398" alt="image" src="https://github.com/user-attachments/assets/05af70f5-d1b5-4072-8d69-83623e63624b" />
