### PR TITLE
Get usernames that contain a search query

### DIFF
--- a/modules/db/src/main/dsl.scala
+++ b/modules/db/src/main/dsl.scala
@@ -245,6 +245,7 @@ trait dsl:
     def $regex(value: String, options: String = ""): SimpleExpression[BSONRegex] =
       SimpleExpression(field, BSONRegex(value, options))
 
+    // TODO - find more usages where we'd prefer a general contains check (calling $regex directly).
     def $startsWith(value: String, options: String = ""): SimpleExpression[BSONRegex] =
       $regex(s"^$value", options)
 

--- a/modules/swiss/src/main/SwissApi.scala
+++ b/modules/swiss/src/main/SwissApi.scala
@@ -310,7 +310,7 @@ final class SwissApi(
       mongo.player.primitive[UserId](
         selector = $doc(
           f.swissId -> id,
-          f.userId.$startsWith(term.value)
+          f.userId.$regex(term.value)
         ),
         sort = $sort.desc(f.score),
         nb = nb,

--- a/modules/team/src/main/TeamApi.scala
+++ b/modules/team/src/main/TeamApi.scala
@@ -272,7 +272,7 @@ final class TeamApi(
       val canSee = fuccess(team.publicMembers) >>| me.so(me => cached.teamIds(me).map(_.contains(teamId)))
       canSee.flatMapz:
         memberRepo.coll.primitive[UserId](
-          selector = memberRepo.teamQuery(teamId) ++ $doc("user".$startsWith(term.value)),
+          selector = memberRepo.teamQuery(teamId) ++ $doc("user".$regex(term.value)),
           sort = $sort.desc("user"),
           nb = nb,
           field = "user"

--- a/modules/tournament/src/main/PlayerRepo.scala
+++ b/modules/tournament/src/main/PlayerRepo.scala
@@ -310,7 +310,7 @@ final class PlayerRepo(private[tournament] val coll: Coll)(using Executor):
     coll.primitive[UserId](
       selector = $doc(
         "tid" -> tourId,
-        "uid".$startsWith(term.value)
+        "uid".$regex(term.value)
       ),
       sort = $sort.desc("m"),
       nb = nb,


### PR DESCRIPTION
Just a few instances, still a number of other places that use `startsWith`. Imo doing a 'contains' check is better since you might not remember exactly how a username starts.

Places this affects:
- Player search in arena tourneys
- Player search in swiss tourneys
- Player search for a team (e.g., an admin searching for a player to kick).