### PR TITLE
remove "Analysis" button from contributor preview UI

### DIFF
--- a/ui/analyse/src/study/gamebook/gamebookPlayView.ts
+++ b/ui/analyse/src/study/gamebook/gamebookPlayView.ts
@@ -90,13 +90,14 @@ function renderEnd(ctrl: GamebookPlayCtrl) {
       },
       i18n.study.playAgain,
     ),
-    hl(
-      'button.analyse',
-      {
-        attrs: { 'data-icon': licon.Microscope, type: 'button' },
-        hook: bind('click', () => study.setGamebookOverride('analyse'), ctrl.redraw),
-      },
-      i18n.site.analysis,
-    ),
+    !study.vm.gamebookOverride &&
+      hl(
+        'button.analyse',
+        {
+          attrs: { 'data-icon': licon.Microscope, type: 'button' },
+          hook: bind('click', () => study.setGamebookOverride('analyse'), ctrl.redraw),
+        },
+        i18n.site.analysis,
+      ),
   ]);
 }

--- a/ui/analyse/src/study/studyCtrl.ts
+++ b/ui/analyse/src/study/studyCtrl.ts
@@ -614,6 +614,7 @@ export default class StudyCtrl {
     this.configureAnalysis();
     this.ctrl.userJump(this.ctrl.path);
     if (!o) this.xhrReload();
+    else if (o === 'analyse') this.ctrl.startCeval();
   };
   explorerGame = (gameId: string, insert: boolean) =>
     this.makeChange('explorerGame', this.withPosition({ gameId, insert }));


### PR DESCRIPTION
fix #13110

we dont need orthogonal gamebook overrides to track both 'play' and 'analyse' because contributors can always leave preview mode to analyse.

fix bug where clicking "analysis board" on completion as a regular member fails to start ceval (it spins on "Calculating...")