### PR TITLE
Fix API doesn't send opponent presence on reconnect

### DIFF
--- a/modules/bot/src/main/GameStateStream.scala
+++ b/modules/bot/src/main/GameStateStream.scala
@@ -13,7 +13,7 @@ import lila.core.game.{ AbortedBy, FinishGame, WithInitialFen }
 import lila.core.round.{ Tell, RoundBus }
 import lila.core.user.KidMode
 import lila.core.net.UserAgent
-import lila.core.round.actorApi.{ GetSocketStatus, SocketStatus }
+import lila.round.actorApi.{ GetSocketStatus, SocketStatus }
 import lila.game.actorApi.{
   BoardDrawOffer,
   BoardGone,


### PR DESCRIPTION
Query SocketStatus on stream start and send initial opponentGone event to sync client with current server state.

- `Add SyncOpponentPresence` handler
- Query socket status in preStart
- Send initial opponent presence state on client start

Fixes lichess-org/lila#18665