### PR TITLE
Sort all the flags

### DIFF
--- a/modules/user/src/main/Flags.scala
+++ b/modules/user/src/main/Flags.scala
@@ -275,8 +275,7 @@ object Flags extends FlagApi:
     F("YT", "Mayotte"),
     F("ZA", "South Africa"),
     F("ZM", "Zambia"),
-    F("ZW", "Zimbabwe")
-  ).sortBy(_.name) ::: List(
+    F("ZW", "Zimbabwe"),
     // whatever
     F("EU", "European Union"),
     F("_adygea", "Adygea"),
@@ -286,7 +285,7 @@ object Flags extends FlagApi:
     F("_russia-wbw", "Russia White-blue-white"),
     F("_united-nations", "United Nations"),
     F("_earth", "Earth")
-  )
+  ).sortBy(_.name)
 
   val map: Map[FlagCode, Flag] = all.mapBy(_.code)
 


### PR DESCRIPTION
From [forum](https://lichess.org/forum/lichess-feedback/profile-country-selection-two-choices-not-in-alphabetical-order-hidden-in-the-bottom)

For some reason, the list of flags is in 2 parts ... users may not be aware that there are 2 options for Russia and Belarus

<img width="565" height="423" alt="image" src="https://github.com/user-attachments/assets/7d6c4bdb-c1c4-4673-a8bf-c41fab7f5f76" />
