### PR TITLE
RelayTour.player API endpoint to work with study:read tokens

### DIFF
--- a/app/controllers/RelayTour.scala
+++ b/app/controllers/RelayTour.scala
@@ -255,7 +255,7 @@ final class RelayTour(env: Env, apiC: => Api, roundC: => RelayRound) extends Lil
           yield res
         case None => JsonBadRequest("Search query cannot be empty")
 
-  def player(tourId: RelayTourId, id: String) = AnonOrScoped(_.Web.Mobile): ctx ?=>
+  def player(tourId: RelayTourId, id: String) = AnonOrScoped(_.Study.Read, _.Web.Mobile): ctx ?=>
     Found(env.relay.api.tourById(tourId)): tour =>
       val decoded = lila.common.String.decodeUriPathSegment(id) | id
       val json =


### PR DESCRIPTION
currently: `Missing scope: web:mobile`