### PR TITLE
Make no game found plural for English.

### DIFF
--- a/translation/source/site.xml
+++ b/translation/source/site.xml
@@ -102,7 +102,7 @@
     <item quantity="other">Mate in %s half-moves</item>
   </plurals>
   <string name="dtzWithRounding">DTZ50'' with rounding, based on number of half-moves until next capture, pawn move, or checkmate</string>
-  <string name="noGameFound">No game found</string>
+  <string name="noGameFound">No games found</string>
   <string name="maxDepthReached">Max depth reached!</string>
   <string name="maybeIncludeMoreGamesFromThePreferencesMenu">Maybe include more games from the preferences menu?</string>
   <string name="openings">Openings</string>

--- a/ui/@types/lichess/i18n.d.ts
+++ b/ui/@types/lichess/i18n.d.ts
@@ -3777,7 +3777,7 @@ interface I18n {
     noConditionalPremoves: string;
     /** You cannot draw before 30 moves are played in a Swiss tournament. */
     noDrawBeforeSwissLimit: string;
-    /** No game found */
+    /** No games found */
     noGameFound: string;
     /** No mistakes found for black */
     noMistakesFoundForBlack: string;


### PR DESCRIPTION
Also made a translation request for US English on [crowdin](https://crowdin.com/editor/lichess/47/en-enus?view=side-by-side&filter=basic&value=0#q=no+game+found).