### PR TITLE
When setting tab as chat on phone, do not autofocus.

### DIFF
--- a/ui/lib/src/chat/chatCtrl.ts
+++ b/ui/lib/src/chat/chatCtrl.ts
@@ -18,6 +18,7 @@ import { storedStringProp, storedBooleanProp } from '../storage';
 import { pubsub, type PubsubEvents } from '../pubsub';
 import { alert } from '../view/dialogs';
 import { isContained } from '@/algo';
+import { isMobile } from '@/device';
 
 type SubPair = { [K in keyof PubsubEvents]: [K, PubsubEvents[K]] }[keyof PubsubEvents];
 
@@ -179,7 +180,7 @@ export class ChatCtrl {
   };
 
   setTab = (tab: Tab = this.getTab()): Tab => {
-    this.vm.autofocus = true;
+    this.vm.autofocus = !isMobile();
     this.storedTabKey(tab.key);
     return tab;
   };


### PR DESCRIPTION
On a phone, autofocusing makes the keyboard come up, requiring the user to remove it if they don't want to type something at this moment (or in cases like e.g. arena tournaments, perhaps never).