### PR TITLE
nvui - add color when listing moves

### DIFF
--- a/ui/analyse/src/view/nvuiView.ts
+++ b/ui/analyse/src/view/nvuiView.ts
@@ -532,6 +532,7 @@ export function renderCurrentNode({
   if (!node.san || !node.uci) return i18n.nvui.gameStart;
   return [
     plyToTurn(node.ply),
+    node.ply % 2 === 1 ? i18n.site.white : i18n.site.black,
     renderSan(node.san, node.uci, moveStyle.get()),
     renderLineIndex(ctrl),
     !ctrl.retro && renderComments(node, moveStyle.get()),


### PR DESCRIPTION
fixes #18602 

Adding the color removes the possibility to have 2 consecutive identical texts (and this is also clearer)

Instead of hearing 1 e4 1 e5 we now hear 1 white e4 1 black e5
