### PR TITLE
Fix- 0 Game Count Despite Games Played

### DIFF
--- a/modules/perfStat/src/main/PerfStatIndexer.scala
+++ b/modules/perfStat/src/main/PerfStatIndexer.scala
@@ -48,7 +48,11 @@ final class PerfStatIndexer(
             case Some(perfStat) => storage.update(perfStat, perfStat.agg(pov))
             case None =>
               val newStat = PerfStat.init(userId, perf).agg(pov)
-              storage.insert(newStat).recoverWith(recoverDuplicateKey { _ =>
-                storage.find(userId, perf).flatMapz: perfStat =>
-                  storage.update(perfStat, perfStat.agg(pov))
-              })
+              storage
+                .insert(newStat)
+                .recoverWith(recoverDuplicateKey { _ =>
+                  storage
+                    .find(userId, perf)
+                    .flatMapz: perfStat =>
+                      storage.update(perfStat, perfStat.agg(pov))
+                })


### PR DESCRIPTION
To address issue https://github.com/lichess-org/lila/issues/18694 

The PerfStatIndexer now correctly initializes statistics for the first game played by a user, ensuring that performance pages reflect accurate game data. This change addresses the issue where the performance page showed zero games despite existing game records.

Previously, `PerfStatIndexer` would silently fail if the `PerfStat` document didn't exist, relying on a lazy creation mechanism that was prone to replication lag (reading from secondary).

This change ensures that `PerfStatIndexer` creates and inserts the `PerfStat` document immediately if it is missing, handling potential race conditions with `recoverDuplicateKey`.