### PR TITLE
Fix pgn import from a position

### DIFF
--- a/ui/analyse/src/pgnImport.ts
+++ b/ui/analyse/src/pgnImport.ts
@@ -67,6 +67,7 @@ export default function (pgn: string): Partial<AnalyseData> {
   return {
     game: {
       fen,
+      initialFen: fen,
       id: 'synthetic',
       opening: undefined, // TODO
       player: start.turn,


### PR DESCRIPTION
Closes #18769.

In `pgnExport.ts`, an FEN tag is only given to the pgn if the `Game` has an `initialFen` that isn't the starting position. But currently in `pgnImport.ts`, an `initialFen` is never set in the first place.