### PR TITLE
Unintentional hover effect edge case (mobile)

### DIFF
--- a/ui/lib/css/theme/board/_chessground.scss
+++ b/ui/lib/css/theme/board/_chessground.scss
@@ -102,17 +102,19 @@ square {
     }
   }
 
-  &.move-dest:hover {
-    background: rgba(20, 85, 30, 0.3);
+  @media (hover: hover) {
+    &.move-dest:hover {
+      background: rgba(20, 85, 30, 0.3);
 
-    body[data-board='horsey'] .is2d & {
-      background: url(../images/board/horsey.move-dest.png);
-      background-size: cover;
+      body[data-board='horsey'] .is2d & {
+        background: url(../images/board/horsey.move-dest.png);
+        background-size: cover;
+      }
     }
-  }
 
-  &.premove-dest:hover {
-    background: rgba(20, 30, 85, 0.2);
+    &.premove-dest:hover {
+      background: rgba(20, 30, 85, 0.2);
+    }
   }
 
   &.bh1 piece {


### PR DESCRIPTION
To reproduce:

1) On mobile, start a game (e.g., as White) and play Nf3.
2) Then, click and release the h1-rook. The g1-square should appear as a possible dest.
3) Touch-down with your finger just below the g1-square (but off the board).
4) Quickly drag your finger up to the g1-square and release.
5) The g1-square will be highlighted as if it were being hovered.

This is an edge case, although I stumbled upon it naturally when playing a game.

Also, I'm assuming there's no use case where a hovered square is intentionally highlighted on mobile (e.g., I tried dragging a piece over a potential dest on Safari and Chrome, but no hover highlight was given). If there is however, this PR might break it.