### PR TITLE
Add REGISTER link and spacing to anonDasher UI - Issue #18697

### DIFF
--- a/modules/web/src/main/ui/layout.scala
+++ b/modules/web/src/main/ui/layout.scala
@@ -134,8 +134,10 @@ final class layout(helpers: Helpers, assetHelper: lila.web.ui.AssetFullHelper)(
   def anonDasher(using ctx: Context) =
     val prefs = trans.preferences.preferences.txt()
     frag(
-      a(href := s"${routes.Auth.login.url}?referrer=${ctx.req.path}", cls := "signin")(trans.site.signIn()),
-      a(href := routes.Auth.signup, cls := "signup")(trans.site.signUp()),
+      div(cls := "signin-or-signup")(
+        a(href := s"${routes.Auth.login.url}?referrer=${ctx.req.path}", cls := "signin")(trans.site.signIn()),
+        a(href := routes.Auth.signup, cls := "button signup")(trans.site.signUp())
+      ),
       div(cls := "dasher")(
         button(cls := "toggle anon link", title := prefs, aria.label := prefs, dataIcon := Icon.Gear),
         div(id := "dasher_app", cls := "dropdown")
@@ -334,7 +336,8 @@ final class layout(helpers: Helpers, assetHelper: lila.web.ui.AssetFullHelper)(
             ctx.me
               .map: me =>
                 frag(allNotifications(challenges, notifications), dasher(me))
-              .getOrElse { (!error).option(anonDasher) }
+              .getOrElse:
+                error.not.option(anonDasher)
         )
       )
 

--- a/ui/lib/css/header/_buttons.scss
+++ b/ui/lib/css/header/_buttons.scss
@@ -75,9 +75,9 @@
     }
   }
 
-  .signin {
-    text-transform: uppercase;
-    padding: 0 0.7rem;
+  .signin-or-signup {
+    @extend %flex-center;
+    gap: 1em;
   }
 
   .link-center {


### PR DESCRIPTION
This PR improves the anonymous user navigation bar (anonDasher) by adding a REGISTER link next to SIGN IN.

Changes:
- Added new REGISTER link using `routes.Auth.signup.url`
- Display REGISTER in uppercase for consistency with SIGN IN
- Added non-breaking spaces to ensure proper visual spacing (“SIGN IN or REGISTER”)
- Verified layout using lila-docker local instance

This makes the sign-up path more visible for new users.

Screenshot of the updated UI:
<img width="292" height="53" alt="image" src="https://github.com/user-attachments/assets/0e11a43f-602a-40b9-9819-9d614554e7bc" />

