### PR TITLE
Update lila.sh

### DIFF
--- a/lila.sh
+++ b/lila.sh
@@ -65,6 +65,6 @@ java_env=(
 )
 
 # print info
-printf '%s\n' "java $java_version" "sbt ${java_env[*]} $*"
+printf '%s / %s\n' "java $java_version" "sbt ${java_env[*]} $*"
 
 exec sbt "${java_env[@]}" "$@"


### PR DESCRIPTION
Fixes:
- fixed argument splitting when `lila.sh` is invoked with extra args.
- fail if accidentally sourced
- set cwd (some parts use relative paths)
- fix JDK feature check where grep -q was accidentally checked for
  output and not exit code.
- replace echo with printf, which is more reliable (ignores control
  characters)

Improvements:
- bash has nicer sugar than sh, such as
  - bracket expansion for more consise file copy
  - arrays (for java_env if more flags are to be added)
- omit JAVA_HOME mismatch warning on Darwin when the PATH java
  is the system shim.
- replaced `which` with the builtin `command -v`
- use `exec` to launch sbt to avoid an extra process.
