### PR TITLE
Have the conceal flow call `updateChapter` as well.

### DIFF
--- a/modules/study/src/main/StudyApi.scala
+++ b/modules/study/src/main/StudyApi.scala
@@ -665,7 +665,7 @@ final class StudyApi(
               _ <- shouldResetPosition.so:
                 studyRepo.setPosition(study.id, study.position.withPath(UciPath.root))
             yield
-              if shouldReload
+              if shouldReload // `updateChapter` makes the client reload the whole thing with XHR
               then sendTo(study.id)(_.updateChapter(chapter.id, who))
               else reloadChapters(study)
         }


### PR DESCRIPTION
This'd be useful for something I'm working on with edit chapter atm.

Only functional change of this PR should be that if a user (un)sets the "Hide next moves" mode, they'll be marked as active.