### PR TITLE
recap i18n: Remove leading space on en strings

### DIFF
--- a/translation/source/recap.xml
+++ b/translation/source/recap.xml
@@ -37,8 +37,8 @@
 		<item quantity="other">Your most played opening as white with %s games</item>
 	</plurals>
 	<plurals name="openingsMostPlayedAsBlack" comment="%s is the number of games">
-		<item quantity="one"> Your most played opening as black with %s game</item>
-		<item quantity="other"> Your most played opening as black with %s games</item>
+		<item quantity="one">Your most played opening as black with %s game</item>
+		<item quantity="other">Your most played opening as black with %s games</item>
 	</plurals>
 	<plurals name="puzzlesThanksVoting" comment="%s is the number of puzzles. It is also translated.">
         <item quantity="one">Thank you for voting on %s puzzle.</item>


### PR DESCRIPTION
Hopefully safe to do; matches a commit @allanjoseph98 made to the equivalent strings for white as part of #18806 - specifically https://github.com/lichess-org/lila/pull/18806/commits/74d31316fa3a2643350c0754a2f2aa84d19e2548