### PR TITLE
Replace @next vesion with specified version that I ensure it's work for firefix and chromium

### DIFF
--- a/modules/web/src/main/ui/bits.scala
+++ b/modules/web/src/main/ui/bits.scala
@@ -84,6 +84,6 @@ z-index: 99;
   </head>
   <body>
     <redoc spec-url="https://raw.githubusercontent.com/lichess-org/api/master/doc/specs/lichess-api.yaml"></redoc>
-    <script src="https://cdn.jsdelivr.net/npm/redoc@2.0.0-rc.56/bundles/redoc.standalone.js"></script>  </body>
-  <body>
+    <script src="https://cdn.jsdelivr.net/npm/redoc@2.0.0-rc.56/bundles/redoc.standalone.js"></script>
+  </body>
 </html>"""


### PR DESCRIPTION
**Solution:**
Replaced `@next` with a specific stable version:

```html
<script src="https://cdn.jsdelivr.net/npm/redoc@2.0.0-rc.56/bundles/redoc.standalone.js"></script>
```

**Result:**
The API reference now renders correctly in both browsers:

![API Reference Screenshot](https://github.com/user-attachments/assets/80e1085f-2c76-42f9-907b-7520db0c836a)

---

### Pull Request & Issue Reference

This PR fixes the API rendering issue. Linked issue in the original repository:

```
Fixes #18810 
```
Close #18810 
