### PR TITLE
Remove legacy API documentation endpoint

### DIFF
--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -29,9 +29,6 @@ final class Api(env: Env, gameC: => Game) extends LilaController(env):
     val mustUpgrade = appVersion.exists(Mobile.AppVersion.mustUpgrade)
     JsonOk(apiStatusJson.add("mustUpgrade", mustUpgrade))
 
-  def index = Anon:
-    Ok.snip(views.bits.api)
-
   private val userShowApiRateLimit =
     env.security.ipTrust.rateLimit(8_000 * 2, 1.day, "user.show.api.ip", _.proxyMultiplier(4))
 

--- a/conf/routes
+++ b/conf/routes
@@ -714,7 +714,6 @@ GET   /api/mobile/my-games             controllers.Api.mobileGames
 GET    /stat/rating/distribution/:perf controllers.User.ratingDistribution(perf: PerfKey, username: Option[UserStr] ?= None)
 
 # API
-GET   /api                             controllers.Api.index
 POST  /api/users                       controllers.Api.usersByIds
 GET   /api/puzzle/daily                controllers.Puzzle.apiDaily
 GET   /api/puzzle/activity             controllers.Puzzle.activity

--- a/modules/oauth/src/main/ui/TokenUi.scala
+++ b/modules/oauth/src/main/ui/TokenUi.scala
@@ -31,7 +31,7 @@ final class TokenUi(helpers: Helpers)(
         standardFlash.map(div(cls := "box__pad")(_)),
         p(cls := "box__pad force-ltr")(
           ot.canMakeOauthRequests(
-            a(href := s"${routes.Api.index}#section/Introduction/Authentication")(ot.authorizationCodeFlow())
+            a(href := s"/api#section/Introduction/Authentication")(ot.authorizationCodeFlow())
           ),
           br,
           br,
@@ -47,7 +47,7 @@ final class TokenUi(helpers: Helpers)(
             a(href := "https://github.com/lichess-org/api/tree/master/example/oauth-personal-token")(
               ot.personalTokenAppExample()
             ),
-            a(href := routes.Api.index)(ot.apiDocumentation())
+            a(href := "/api")(ot.apiDocumentation())
           )
         ),
         tokens.headOption.filter(_.isBrandNew).map { token =>

--- a/modules/web/src/main/ui/SitePages.scala
+++ b/modules/web/src/main/ui/SitePages.scala
@@ -36,7 +36,7 @@ final class SitePages(helpers: Helpers):
       sep,
       a(activeCls("webmasters"), href := routes.Main.webmasters)(trans.site.webmasters()),
       a(activeCls("database"), href := "https://database.lichess.org")(trans.site.database(), external),
-      a(activeCls("api"), href := routes.Api.index)("API", external),
+      a(activeCls("api"), href := "/api")("API", external),
       sep,
       a(activeCls("lag"), href := routes.Main.lag)(trans.lag.isLichessLagging()),
       a(activeCls("ads"), href := "/ads")("Block ads")

--- a/modules/web/src/main/ui/bits.scala
+++ b/modules/web/src/main/ui/bits.scala
@@ -71,19 +71,3 @@ z-index: 99;
         noFollow
       )("Twitch")
     )
-
-  def api = raw:
-    """<!DOCTYPE html>
-<html>
-  <head>
-    <meta charset="utf-8">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'unsafe-inline'; script-src https://cdn.jsdelivr.net blob:; child-src blob:; connect-src https://raw.githubusercontent.com; img-src data: https://lichess.org https://lichess1.org;">
-    <title>Lichess.org API reference</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <style>body { margin: 0; padding: 0; }</style>
-  </head>
-  <body>
-    <redoc spec-url="https://raw.githubusercontent.com/lichess-org/api/master/doc/specs/lichess-api.yaml"></redoc>
-    <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"></script>
-  </body>
-</html>"""


### PR DESCRIPTION
Removed the dead code handling /api route. The API documentation is currently served via a reverse proxy to lichess-org/api, making this internal implementation obsolete and broken (causing white screen on dev environments)