### PR TITLE
API Fix to show ranking - working as documented in the docs

### DIFF
--- a/modules/user/src/main/JsonView.scala
+++ b/modules/user/src/main/JsonView.scala
@@ -100,11 +100,9 @@ object JsonView:
     JsObject:
       p.perfsList.collect:
         case (key, perf) if perf.nb > 0 || lila.rating.PerfType.standardSet(key) =>
-          val perfJson = perfWrites.writes(perf)
-          key.value -> rankMap
-            .flatMap(_.get(key))
-            .fold(perfJson): rank =>
-              perfJson + ("rank" -> JsNumber(rank))
+          key.value -> perfWrites
+            .writes(perf)
+            .add("rank" -> rankMap.flatMap(_.get(key)))
     .add("storm", p.storm.option)
       .add("racer", p.racer.option)
       .add("streak", p.streak.option)


### PR DESCRIPTION
Fix for #18808 

## Context

This fix resolves:
- Missing rank field in user API responses
- Incomplete implementation of rank parameter
- Discrepancy between API documentation and actual behavior

## BEFORE FIX ❌

```json
{
  "id": "teem1",
  "username": "teem1",
  "perfs": {
    "bullet": {
      "games": 802,
      "rating": 3120,
      "rd": 49,
      "prog": 14
      // ❌ rank field is MISSING
    },
    "blitz": {
      "games": 888,
      "rating": 2969,
      "rd": 45,
      "prog": -10
      // ❌ rank field is MISSING
    }
  }
}
```

**Problem:** Even though `rank=true` is specified and the user is on leaderboards, no rank information is returned.

---

## AFTER FIX ✅

```json
{
  "id": "teem1",
  "username": "teem1",
  "perfs": {
    "bullet": {
      "games": 802,
      "rating": 3120,
      "rd": 49,
      "prog": 14,
      "rank": 1  // ✅ rank field is NOW PRESENT
    },
    "blitz": {
      "games": 888,
      "rating": 2969,
      "rd": 45,
      "prog": -10,
      "rank": 15  // ✅ rank field is NOW PRESENT
    }
  }
}

## Testing

### Test on production (before fix):
```bash
curl "https://lichess.org/api/user/teem1?rank=true" | jq '.perfs.bullet.rank'
# Output: null (field doesn't exist)
```

### Test on local instance (after fix):
```bash
curl "http://localhost:8080/api/user/ana?rank=true" | jq '.perfs.bullet.rank'
# Output: 1 (field exists with correct value)
```

### Verify with different users:
```bash
# User with high ranking
curl "http://localhost:8080/api/user/ana?rank=true" | jq '.perfs | to_entries[] | select(.value.rank) | {key: .key, rank: .value.rank}'

# User without ranking (no games)
curl "http://localhost:8080/api/user/admin?rank=true" | jq '.perfs.bullet.rank'
# Output: null (correct - no games played)
```
