### PR TITLE
Persevere order choice for study search

### DIFF
--- a/modules/study/src/main/ui/ListUi.scala
+++ b/modules/study/src/main/ui/ListUi.scala
@@ -174,7 +174,7 @@ final class ListUi(helpers: Helpers, bits: StudyBits):
 
   def searchForm(placeholder: String, value: String, order: StudyOrder) =
     form(cls := "search", action := routes.Study.search(), method := "get")(
-      input(name := "order", `type` := "hidden", st.value := order.key),
+      form3.hidden("order", order.key),
       input(name := "q", st.placeholder := placeholder, st.value := value, enterkeyhint := "search"),
       submitButton(cls := "button", dataIcon := Icon.Search)
     )


### PR DESCRIPTION
Currently when never we click `search` in study search, it resets order to `relevant` and ignore the current active `order`.

I'm not sure why our current code didn't work, but this fixed it. Feel free to fix it in another way.