### PR TITLE
Fix scroll to config after adding member.

### DIFF
--- a/ui/analyse/src/study/studyMembers.ts
+++ b/ui/analyse/src/study/studyMembers.ts
@@ -175,7 +175,7 @@ export function view(ctrl: StudyCtrl): VNode {
       'm-config',
       {
         key: member.user.id + '-config',
-        hook: onInsert(el => scrollTo($(el).parents('.study__members')[0] as HTMLElement, el)),
+        hook: onInsert(el => scrollTo(el.closest('.study-list')!, el)),
       },
       [
         hl('div.role', [


### PR DESCRIPTION
Fyi I might be missing something - the previous change for this line was 90fb66e1, but I'm not sure what the fix was for there. Maybe having `$(el).parents('.study__members')` is needed for something I'm not aware of, though afaik it's not a scrollable element.