### PR TITLE
Clock logic improvements

### DIFF
--- a/ui/@types/lichess/index.d.ts
+++ b/ui/@types/lichess/index.d.ts
@@ -231,6 +231,7 @@ type UserId = string;
 type Uci = string;
 type San = string;
 type Ply = number;
+type Hours = number;
 type Minutes = number;
 type Seconds = number;
 type Centis = number;

--- a/ui/lib/css/game/_clock.scss
+++ b/ui/lib/css/game/_clock.scss
@@ -157,6 +157,11 @@
     &.low {
       opacity: 0.15;
     }
+    @media (prefers-reduced-motion: reduce) {
+      &.low {
+        opacity: 0.5;
+      }
+    }
   }
 
   &.running .time {


### PR DESCRIPTION
- Parse clock from millis using math, instead of with Date()
- Remove animation hack for Brave browser. Initial commit 5e783052
  indicates it can probably be removed now. If not, we should be
  scope this to UserAgent imo, as it may harm animation for others.
- Ensure clock ticks are probably scheduled for blind users.
  (updated comments here as well)

Opinionated changes with respect to reduce motion:
- Personally I do not find a smooth motion like the time bar
distracting. Given that it can be disabled in preferences, I
don't think we need to hide it.
- However, I do find the blinking separator somewhat distracting,
and it's definitely unnecessary motion. So remove that in
scss. (though it could also be done in clockView). Definitely
opinionated, in that some may have reduce motion but still want
a blinking clock.
