### PR TITLE
Do not play the take sound in the case of failure.

### DIFF
--- a/ui/learn/src/levelCtrl.ts
+++ b/ui/learn/src/levelCtrl.ts
@@ -172,8 +172,7 @@ export class LevelCtrl {
       if (this.isAppleLevel()) this.setShapes();
       if (!vm.failed && detectSuccess()) this.complete();
       if (vm.willComplete) return;
-      if (took) take();
-      else if (inScenario) take();
+      if ((!vm.failed && took) || inScenario) take();
       else moveSound();
       if (vm.failed) {
         if (blueprint.showFailureFollowUp && !captured)


### PR DESCRIPTION
E.g., [here](https://lichess.org/learn#/9/4) both initial knight captures fail the exercise.