### PR TITLE
Move column visibility logic to page-specific scopes

### DIFF
--- a/ui/bits/css/forum/_table.scss
+++ b/ui/bits/css/forum/_table.scss
@@ -1,66 +1,76 @@
-.forum .slist {
-  td {
-    padding-top: 1.5rem;
-    padding-bottom: 1.5rem;
+.forum {
+  &.index,
+  &.forum-categ {
+    .slist {
+      thead,
+      td:not(.subject):not(.right) {
+        display: none;
+
+        @media (min-width: at-least($xx-small)) {
+          display: table-cell;
+        }
+      }
+
+      .right {
+        display: none;
+
+        @media (min-width: at-least($small)) {
+          display: table-cell;
+        }
+      }
+
+      thead {
+        @media (min-width: at-least($xx-small)) {
+          display: table-header-group;
+        }
+      }
+
+      td:last-child {
+        white-space: nowrap;
+        padding-inline-end: 1em;
+
+        time {
+          color: $c-link;
+          font-size: 1em;
+        }
+      }
+    }
   }
 
-  td.right,
-  & th.right {
-    display: none;
-
-    @media (min-width: at-least($small)) {
-      display: table-cell;
+  .slist {
+    .right {
       text-align: right;
       padding-inline-end: 2em;
     }
-  }
 
-  td:last-child {
-    white-space: nowrap;
-    padding-inline-end: 1em;
-
-    time {
-      color: $c-link;
-      font-size: 1em;
+    td {
+      padding-top: 1.5rem;
+      padding-bottom: 1.5rem;
     }
 
-    display: none;
+    &.topics {
+      table-layout: fixed;
+      margin-bottom: 2rem;
 
-    @media (min-width: at-least($xx-small)) {
-      display: table-cell;
-    }
-  }
+      .subject {
+        font-size: 1.2em;
+      }
 
-  thead {
-    display: none;
+      th:nth-child(2) {
+        width: 7%;
+      }
 
-    @media (min-width: at-least($xx-small)) {
-      display: table-header-group;
-    }
-  }
+      th:nth-child(3) {
+        width: 26%;
+      }
 
-  &.topics {
-    table-layout: fixed;
-    margin-bottom: 2rem;
-
-    .subject {
-      font-size: 1.2em;
+      td:nth-child(3) {
+        overflow-x: hidden;
+      }
     }
 
-    th:nth-child(2) {
-      width: 7%;
+    &.categs .subject p {
+      margin-top: 0.3em;
     }
-
-    th:nth-child(3) {
-      width: 26%;
-    }
-
-    td:nth-child(3) {
-      overflow-x: hidden;
-    }
-  }
-
-  &.categs .subject p {
-    margin-top: 0.3em;
   }
 }


### PR DESCRIPTION
This prevents hiding columns from tables in forum topics (when the screen is small)
https://lichess.org/forum/general-chess-discussion/a-human?page=2#19

Before
<img width="466" height="345" alt="image" src="https://github.com/user-attachments/assets/9f9d3ccf-b82a-4bd9-b586-da1f57d99341" />
After
<img width="461" height="430" alt="image" src="https://github.com/user-attachments/assets/97997646-e0d5-4b95-b7e8-534cac3aaf17" />
