### PR TITLE
Avoid remounting when cssClass changes between levels.

### DIFF
--- a/ui/learn/src/run/runView.ts
+++ b/ui/learn/src/run/runView.ts
@@ -7,7 +7,7 @@ import type { LevelCtrl } from '../levelCtrl';
 import type { RunCtrl } from './runCtrl';
 import { mapSideView } from '../mapSideView';
 import type { LearnCtrl } from '../ctrl';
-import { h, type VNode } from 'snabbdom';
+import { h, type Classes, type VNode } from 'snabbdom';
 import { bind } from 'lib/view';
 import { makeStars, progressView } from '../progressView';
 import { promotionView } from '../promotionView';
@@ -34,7 +34,7 @@ const renderCompleted = (level: LevelCtrl): VNode =>
 export const runView = (ctrl: LearnCtrl) => {
   const runCtrl = ctrl.runCtrl;
   const { stage, levelCtrl } = runCtrl;
-  const rootClass: Record<string, boolean> = {
+  const rootClass: Classes = {
     starting: !!levelCtrl.vm.starting,
     completed: levelCtrl.vm.completed && !levelCtrl.blueprint.nextButton,
     'last-step': !!levelCtrl.vm.lastStep,


### PR DESCRIPTION
Fixes the following use case:

1. Open dev tools and go to e.g. https://lichess.org/learn#/6/1
2. Then, click on the 7th level.
3. While there seem to be no actual bugs in the UI, you should see errors from chessground:

<img width="756" height="238" alt="image" src="https://github.com/user-attachments/assets/a153ce63-9cd2-4d43-b6d6-0e139bafd51c" />

This appears to be caused by remounting due to the vnode root selector changing. In the example above the second rank becomes highlighted, and currently we add the necessary classes directly onto the selector string.