### PR TITLE
focus password input after toggling visibility

### DIFF
--- a/ui/lib/src/view/controls.ts
+++ b/ui/lib/src/view/controls.ts
@@ -90,6 +90,7 @@ export const addPasswordVisibilityToggleListener = (): void => {
       const type = $input.attr('type') === 'password' ? 'text' : 'password';
       $input.attr('type', type);
       $button.toggleClass('revealed', type === 'text');
+      $input[0]?.focus();
     });
   });
 };


### PR DESCRIPTION
After clicking the icon to toggle the reveal, re-focus the password input. For mobile browsers so the virtual keyboard stays visible.

<img width="485" height="146" alt="image" src="https://github.com/user-attachments/assets/cb4b9b4f-72a8-419b-b1bb-ccac3660174e" />
