### PR TITLE
Fix typo in Indonesian translation for 'xWasPlayed'

### DIFF
--- a/translation/dest/site/id-ID.xml
+++ b/translation/dest/site/id-ID.xml
@@ -785,7 +785,7 @@
   <string name="learnFromThisMistake">Pelajari dari kesalahan ini</string>
   <string name="skipThisMove">Lewatkan langkah ini</string>
   <string name="next">Selanjutnya</string>
-  <string name="xWasPlayed">%s sedang diamainkan</string>
+  <string name="xWasPlayed">%s sedang dimainkan</string>
   <string name="findBetterMoveForWhite">Temukan langkah yang lebih baik untuk warna putih</string>
   <string name="findBetterMoveForBlack">Temukan langkah yang lebih baik untuk warna hitam</string>
   <string name="resumeLearning">Lanjutkan materi</string>


### PR DESCRIPTION
Fixed line 788 <"xWasPlayed"> from "%s sedang diamainkan" to "%s sedang dimainkan"