### PR TITLE
Have volume being greater than 0 a requirement for the `enabled` function.

### DIFF
--- a/ui/site/src/sound.ts
+++ b/ui/site/src/sound.ts
@@ -167,7 +167,7 @@ export default new (class implements SoundI {
     else this.voiceStorage.set(JSON.stringify({ name: o.name, lang: o.lang }));
   };
 
-  enabled = () => this.theme !== 'silent';
+  enabled = () => this.theme !== 'silent' && this.getVolume() !== 0;
 
   speech = (v?: boolean): boolean => {
     if (defined(v)) this.speechStorage.set(v);


### PR DESCRIPTION
This makes it so that for all themes (except `Speech`, which is handled differently), having the volume at zero is equivalent to being on the `Silent` theme. This causes the browser to not try to play sounds unnecessarily, which has a few tiny benefits:
- No red mute icon appearing.
- Any other audio the user might have playing won't be paused/stopped.
- Small efficiency gain?