### PR TITLE
When naming a chapter from an imported pgn, use the `ChapterName` tag if it exists

### DIFF
--- a/modules/study/src/main/ChapterMaker.scala
+++ b/modules/study/src/main/ChapterMaker.scala
@@ -63,13 +63,10 @@ final private class ChapterMaker(
     yield s"$white - $black"
     data.name.some
       .ifFalse(data.isDefaultName)
+      .orElse(parsed.chapterNameHint)
       .orElse:
         StudyChapterName.from:
-          parsed.chapterNameHint
-            .orElse(vsFromPgnTags)
-            .orElse(parsed.tags("Event"))
-            .map(_.trim)
-            .filter(_.nonEmpty)
+          vsFromPgnTags.orElse(parsed.tags("Event")).map(_.trim).filter(_.nonEmpty)
       .getOrElse(data.name)
 
   private def resolveOrientation(data: Data, root: Root, userId: UserId, tags: Tags = Tags.empty): Color =

--- a/modules/study/src/main/StudyPgnImport.scala
+++ b/modules/study/src/main/StudyPgnImport.scala
@@ -75,7 +75,7 @@ object StudyPgnImport:
           tags = StudyPgnTags
             .withRelevantTags(parsed.tags, Set(Tag.WhiteClock, Tag.BlackClock)),
           ending = ending,
-          chapterNameHint = parsed.tags("ChapterName").map(_.trim).filter(_.nonEmpty)
+          chapterNameHint = StudyChapterName.from(parsed.tags("ChapterName").map(_.trim).filter(_.nonEmpty))
         )
 
   case class Result(
@@ -83,7 +83,7 @@ object StudyPgnImport:
       variant: chess.variant.Variant,
       tags: Tags,
       ending: Option[Ending],
-      chapterNameHint: Option[String]
+      chapterNameHint: Option[StudyChapterName]
   )
 
   case class Ending(


### PR DESCRIPTION
E.g., say you copied a chapter pgn and used it to make a chapter in a different study. If you don't provide a custom name, and if the pgn has no `White` and `Black` tags, then the `Event` tag will be tried next to name the chapter. By default, this ends up being of the form "`StudyName`: `ChapterName`", when just the chapter name by itself would be preferable.