### PR TITLE
zh study layout

### DIFF
--- a/ui/analyse/css/study/_layout.scss
+++ b/ui/analyse/css/study/_layout.scss
@@ -27,7 +27,7 @@
   }
   .analyse.variant-crazyhouse {
     $pocket-height: 60px;
-    grid-template-rows: $pocket-height auto var(---chat-height) $pocket-height auto 1fr;
+    grid-template-rows: $pocket-height auto var(---chat-height) $pocket-height minmax(0px, auto) 1fr;
     grid-template-areas:
       'side    . board   gauge pocket-top'
       'side    . board   gauge tools'


### PR DESCRIPTION
fixes #19038 

https://github.com/user-attachments/assets/357b247d-ea7d-4ada-a6ec-5d07b0674cad

Better, but notice there is still a small offset when keyboard move is not present (kb-move area)

Standard:
<img width="1491" height="907" alt="image" src="https://github.com/user-attachments/assets/9d6eca80-1b6c-4756-bd6a-03f59e9d1d2b" />

Crazyhouse:
<img width="1481" height="946" alt="image" src="https://github.com/user-attachments/assets/d04441f3-d351-47fd-902a-b3e2d86e885f" />



