### PR TITLE
Have `pvIndex` equal `null` initially, not `undefined`.

### DIFF
--- a/ui/lib/src/ceval/view/main.ts
+++ b/ui/lib/src/ceval/view/main.ts
@@ -325,7 +325,7 @@ export function renderPvs(ctrl: CevalHandler): VNode | undefined {
   let pvs: Tree.PvData[],
     threat = false,
     pvMoves: (string | null)[],
-    pvIndex: number | null;
+    pvIndex: number | null = null;
   if (ctrl.threatMode() && node.threat) {
     pvs = node.threat.pvs;
     threat = true;


### PR DESCRIPTION
Technically this variable was typed wrong, since it initially equals undefined. Only functional change this has is on the `if (pvIndex !== null)` check later on. Since `undefined !== null` is true, this block can run if `pvIndex` is still undefined, causing an exception to be thrown.

I'm not sure if this ever caused a bug in prod, but it's my bad (I changed the `!=` to `!==` in 2024, missing that even though it wasn't typed that way, `pvIndex` initially equaled `undefined`).