### PR TITLE
Support playing out multiple engine moves on mobile.

### DIFF
--- a/ui/lib/src/ceval/view/main.ts
+++ b/ui/lib/src/ceval/view/main.ts
@@ -284,6 +284,11 @@ function getElUci(e: TouchEvent | MouseEvent): string | undefined {
   );
 }
 
+function getElPvIndex(e: TouchEvent | MouseEvent): number | null {
+  const moveIndex = (e.target as HTMLElement).dataset.moveIndex;
+  return moveIndex === undefined ? null : Number(moveIndex);
+}
+
 function getElUciList(e: TouchEvent | MouseEvent): string[] {
   return getElPvMoves(e)
     .filter(notNull)
@@ -347,6 +352,7 @@ export function renderPvs(ctrl: CevalHandler): VNode | undefined {
           el.addEventListener('pointerdown', (e: PointerEvent) => {
             const uciList = getElUciList(e);
             if ((e.target as HTMLElement).closest('.pv-wrap-toggle')) return;
+            if (isTouchDevice()) pvIndex = getElPvIndex(e);
             if (uciList.length > (pvIndex ?? 0) && !ctrl.threatMode()) {
               ctrl.playUciList(uciList.slice(0, (pvIndex ?? 0) + 1));
               e.preventDefault();
@@ -358,7 +364,7 @@ export function renderPvs(ctrl: CevalHandler): VNode | undefined {
             setHovering(ceval, getElFen(el), getElUci(e));
             const pvBoard = (e.target as HTMLElement).dataset.board;
             if (pvBoard) {
-              pvIndex = Number((e.target as HTMLElement).dataset.moveIndex);
+              pvIndex = getElPvIndex(e);
               pvMoves = getElPvMoves(e);
               const [fen, uci] = pvBoard.split('|');
               ceval.setPvBoard({ fen, uci });


### PR DESCRIPTION
Closes #19033.

Reason for this behaviour is that the move to play to is determined by the last one hovered. But on a mobile device this obviously isn't possible.