### PR TITLE
Scroll to selected language if not currently visible.

### DIFF
--- a/ui/dasher/src/langs.ts
+++ b/ui/dasher/src/langs.ts
@@ -2,6 +2,7 @@ import { h, type VNode } from 'snabbdom';
 import * as licon from 'lib/licon';
 import { header } from './util';
 import { type DasherCtrl, PaneCtrl } from './interfaces';
+import { onInsert } from 'lib/view';
 
 type Code = string;
 type Name = string;
@@ -24,16 +25,16 @@ export class LangsCtrl extends PaneCtrl {
       header(i18n.site.language, this.close),
       h(
         'form',
-        {
-          attrs: { method: 'post', action: '/translation/select' },
-          hook: { insert: vnode => this.autoScrollToCurrent(vnode.elm as HTMLElement) },
-        },
+        { attrs: { method: 'post', action: '/translation/select' } },
         this.list().map(([code, name]: Lang) =>
           h(
             'button' +
               (this.data.current === code ? '.current' : '') +
               (this.data.accepted.includes(code) ? '.accepted' : ''),
-            { attrs: { type: 'submit', name: 'lang', value: code, title: code } },
+            {
+              attrs: { type: 'submit', name: 'lang', value: code, title: code },
+              hook: this.data.current === code ? onInsert(el => el.scrollIntoView({ block: 'center' })) : {},
+            },
             name,
           ),
         ),
@@ -53,16 +54,4 @@ export class LangsCtrl extends PaneCtrl {
     ...this.data.list.filter(lang => this.data.accepted.includes(lang[0])),
     ...this.data.list,
   ];
-
-  private autoScrollToCurrent(form: HTMLElement): void {
-    const current = form.querySelector('button.current') as HTMLElement | null;
-    if (current && !this.visible(current, form))
-      form.scrollTop = Math.max(0, current.offsetTop - form.clientHeight / 2 + current.offsetHeight / 2);
-  }
-
-  private visible(button: HTMLElement, form: HTMLElement): boolean {
-    const top = button.offsetTop,
-      viewTop = form.scrollTop;
-    return top >= viewTop && top + button.offsetHeight <= viewTop + form.clientHeight;
-  }
 }


### PR DESCRIPTION
Say a user has chosen e.g. Spanish, but their locale's accepted language is English (US). If they open the language menu again at some point, they'll see the following (which is a bit confusing imo):

<img width="506" height="1080" alt="image" src="https://github.com/user-attachments/assets/5ae8934f-218f-4a77-8171-4871f24a52cc" />