### PR TITLE
Prevent accidental double submissions from clicking reply twice.

### DIFF
--- a/ui/bits/src/bits.forum.ts
+++ b/ui/bits/src/bits.forum.ts
@@ -204,6 +204,7 @@ site.load.then(() => {
   });
 
   $('form.reply').on('submit', () => {
+    if (submittingReply) return false;
     replyStorage.remove();
     submittingReply = true;
   });


### PR DESCRIPTION
Closes #19085.

To consistently reproduce the bug, wrap the `create` function of `app/controllers/ForumPost.scala` in a timeout (e.g. 1500ms). Then in the ui, after typing a reply and solving the captcha, do the following instead of manually clicking reply:
- Right click on the reply button and click inspect.
- Then in the console tab, run this code:
```
const el = $0;
const fire = (type, Ctor) => el.dispatchEvent(new Ctor(type, { bubbles: true, cancelable: true, view: window, buttons: 1 }));
fire('click', MouseEvent);
setTimeout(() => {
  fire('click', MouseEvent);
}, 30);
```
- The Lila logs will show two `303 browser POST /forum/community-blog-discussions` requests sent. With the if guard in this PR it'll just be one request.