### PR TITLE
fix forum sticky query

### DIFF
--- a/modules/forum/src/main/BSONHandlers.scala
+++ b/modules/forum/src/main/BSONHandlers.scala
@@ -27,15 +27,3 @@ private object BSONHandlers:
 
   given BSONDocumentHandler[ForumPostMini] = Macros.handler
   given BSONDocumentHandler[ForumTopicMini] = Macros.handler
-
-  given BSONHandler[ForumTopic.Sticky] = lila.db.dsl.quickHandler(
-    {
-      case BSONBoolean(true) => Left(true)
-      case BSONString(str) => Right(UserId(str))
-      case _ => Left(false)
-    },
-    {
-      case Left(v) => BSONBoolean(v)
-      case Right(userId) => BSONString(userId.value)
-    }
-  )

--- a/modules/forum/src/main/ForumTopic.scala
+++ b/modules/forum/src/main/ForumTopic.scala
@@ -18,7 +18,7 @@ case class ForumTopic(
     lastPostIdTroll: ForumPostId,
     troll: Boolean,
     closed: Boolean,
-    sticky: Option[ForumTopic.Sticky],
+    sticky: Option[UserId],
     userId: Option[UserId] = None, // only since SB mutes
     ublogId: Option[UblogPostId] = None
 ):
@@ -32,14 +32,6 @@ case class ForumTopic(
   def open = !closed
 
   def isTooBig = nbPosts > (if isTeam then 500 else 50)
-
-  def isSticky: Boolean = sticky.exists:
-    case Left(v) => v
-    case _ => true
-
-  def toggleSticky(using me: Me): ForumTopic.Sticky = if isSticky then Left(false) else Right(me.userId)
-
-  def whoToggledSticky: Option[UserId] = sticky.flatMap(_.toOption)
 
   def isAuthor(user: User): Boolean = userId contains user.id
   def isUblog = ublogId.isDefined
@@ -67,8 +59,6 @@ case class ForumTopic(
     (nbPosts + maxPerPage.value - 1) / maxPerPage.value
 
 object ForumTopic:
-
-  type Sticky = Either[Boolean, UserId]
 
   def nameToId(name: String) =
     val slug = scalalib.StringOps.slug(name)

--- a/modules/forum/src/main/ForumTopicApi.scala
+++ b/modules/forum/src/main/ForumTopicApi.scala
@@ -178,10 +178,10 @@ final private class ForumTopicApi(
   def closedByMod(topic: ForumTopic)(using Me): Fu[Boolean] =
     topic.closed.so(topicRepo.closedByMod(topic.id))
 
-  def toggleSticky(categ: ForumCateg, topic: ForumTopic)(using Me): Funit =
-    topicRepo.sticky(topic.id, topic.toggleSticky) >>
+  def toggleSticky(categ: ForumCateg, topic: ForumTopic)(using me: Me): Funit =
+    topicRepo.sticky(topic.id, topic.sticky.isEmpty.option(me.userId)) >>
       MasterGranter(_.ModerateForum).so:
-        modLog.toggleStickyTopic(categ.id, topic.slug, !topic.isSticky)
+        modLog.toggleStickyTopic(categ.id, topic.slug, topic.sticky.isEmpty)
 
   private[forum] def denormalize(topic: ForumTopic): Funit = for
     nbPosts <- postRepo.countByTopic(topic)

--- a/modules/forum/src/main/ui/TopicUi.scala
+++ b/modules/forum/src/main/ui/TopicUi.scala
@@ -164,7 +164,7 @@ final class TopicUi(helpers: Helpers, bits: ForumBits, postUi: PostUi)(
               (canModCateg || Granter.opt(_.StickyPosts)).option:
                 postForm(action := routes.ForumTopic.sticky(categ.id, topic.slug))(
                   button(cls := "button button-empty button-brag"):
-                    if topic.isSticky then s"${topic.whoToggledSticky.so(_.value)} Unsticky" else "Sticky"
+                    topic.sticky.fold("Sticky")(by => s"$by Unsticky")
                 )
               ,
               (canModCateg || ctx.me.exists(topic.isAuthor)).option(deleteModal),


### PR DESCRIPTION
Since #18938, documents in `f_topic` collection can have:

1. no `sticky` property
2. `sticky: false`
3. `sticky: true`
4. `sticky: 'userId-who-stickied-it'`

This fixes the query to show the stickied topics at the top of each category list.