### PR TITLE
Limit unsticky button size

### DIFF
--- a/modules/forum/src/main/ui/TopicUi.scala
+++ b/modules/forum/src/main/ui/TopicUi.scala
@@ -164,7 +164,8 @@ final class TopicUi(helpers: Helpers, bits: ForumBits, postUi: PostUi)(
               (canModCateg || Granter.opt(_.StickyPosts)).option:
                 postForm(action := routes.ForumTopic.sticky(categ.id, topic.slug))(
                   button(cls := "button button-empty button-brag"):
-                    topic.sticky.fold("Sticky")(by => s"${by.toString().substring(0, 15)} Unsticky")
+                    topic.sticky.fold(frag("Sticky")): by =>
+                      span(title := trans.site.by.txt(usernameOrId(by)))("Unsticky")
                 )
               ,
               (canModCateg || ctx.me.exists(topic.isAuthor)).option(deleteModal),


### PR DESCRIPTION

<img width="1027" height="147" alt="image" src="https://github.com/user-attachments/assets/fcd12079-7b4d-463b-967a-bfa9ed0637e2" />



It is not the only place where long usernames can be a display problem ...

<img width="840" height="417" alt="image" src="https://github.com/user-attachments/assets/6756c530-9e1e-436e-84e6-0464e1fc9c48" />




Is there a definition of 'too long' somewhere?

