### PR TITLE
Only underline the time tag in the feed body

### DIFF
--- a/ui/lib/css/component/_markdown.scss
+++ b/ui/lib/css/component/_markdown.scss
@@ -133,7 +133,7 @@
     }
   }
 
-  time {
+  p time {
     border-bottom: 1px dashed $c-font-dim;
     cursor: help;
     font-size: 100%;


### PR DESCRIPTION
Removes the underline on the "8 hours ago" heading but keeps it in the body

<img width="783" height="110" alt="image" src="https://github.com/user-attachments/assets/1234896c-3ebc-420f-9f1d-21dadf9c0069" />
