### PR TITLE
add userAgent brands in diagnotic

### DIFF
--- a/ui/bits/src/bits.diagnosticDialog.ts
+++ b/ui/bits/src/bits.diagnosticDialog.ts
@@ -19,8 +19,8 @@ export async function initModule(opts?: DiagnosticOpts): Promise<void> {
     opts?.text ??
     `Browser: ${navigator.userAgent}\n` +
       ('userAgentData' in navigator
-        //@ts-ignore userAgentData not documented in TypeScript https://developer.mozilla.org/en-US/docs/Web/API/Navigator/userAgentData
-        ? `Brand: "${navigator.userAgentData.brands.map(b => `${b.brand} ${b.version}`).join('; ')}", `
+        ? //@ts-ignore userAgentData not documented in TypeScript https://developer.mozilla.org/en-US/docs/Web/API/Navigator/userAgentData
+          `Brand: "${navigator.userAgentData.brands.map(b => `${b.brand} ${b.version}`).join('; ')}", `
         : '') +
       `Cores: ${navigator.hardwareConcurrency}, ` +
       `Touch: ${isTouchDevice()} ${navigator.maxTouchPoints}, ` +


### PR DESCRIPTION
identify better Chrome Version used

### Examples:
- Chrome
<img width="745" height="235" alt="Captura de ecrã de 2026-01-17 22-00-20" src="https://github.com/user-attachments/assets/ee5db3e2-db00-40c4-8e3b-01cd9234bd9c" />

- Brave
<img width="1068" height="237" alt="Captura de ecrã de 2026-01-17 21-56-16" src="https://github.com/user-attachments/assets/f1107281-34ef-41ff-817d-c14ca3614732" />

- Opera
<img width="1068" height="237" alt="Captura de ecrã de 2026-01-17 21-57-00" src="https://github.com/user-attachments/assets/6fc521b0-bebf-46a1-95b4-bd0bc15615d2" />

- Edge
<img width="1410" height="246" alt="Captura de ecrã de 2026-01-17 21-59-17" src="https://github.com/user-attachments/assets/b8f60219-11c2-4f0f-9aab-9b8e4efa7ff2" />

- Firefox no have support
<img width="1225" height="241" alt="Captura de ecrã de 2026-01-17 22-01-43" src="https://github.com/user-attachments/assets/906b6078-1852-4a00-8bfc-dfcfbb03fd47" />
