### PR TITLE
only throw exception when neither flair path can be resolved

### DIFF
--- a/modules/user/src/main/FlairApi.scala
+++ b/modules/user/src/main/FlairApi.scala
@@ -1,5 +1,7 @@
 package lila.user
 
+import scala.util.Try
+
 object FlairApi:
 
   private var db: Set[Flair] = Set.empty
@@ -40,14 +42,14 @@ final class FlairApi(getFile: lila.common.config.GetRelativeFile)(using Executor
 
   private def refresh(): Unit =
     val path1 = "public/flair/list.txt"
-    val path2 = getFile.exec("public/flair/list.txt").toPath.toString
-    scala.util
-      .Try(refreshFrom(scala.io.Source.fromFile(path1, "UTF-8")))
-      .orElse(scala.util.Try(refreshFrom(scala.io.Source.fromFile(path2, "UTF-8"))))
+    val path2 = getFile.exec(path1).toPath.toString
+    Try(refreshFrom(path1))
+      .orElse(Try(refreshFrom(path2)))
       .recover:
         case e: Exception => throw Exception(s"Cannot read flairs from either $path1 or $path2", e)
 
-  private def refreshFrom(source: scala.io.Source): Unit =
+  private def refreshFrom(path: String): Unit =
+    val source = scala.io.Source.fromFile(path, "UTF-8")
     try
       db = Flair.from(source.getLines.toSet)
       logger.info(s"Updated flair db with ${db.size} flairs")


### PR DESCRIPTION
prevents this sequence of logs at startup when it uses the fallback

<details>

<summary>flair setup logs</summary>

```
14:16:39.784 [error] user - Cannot read flairs, trying alternative path
java.io.FileNotFoundException: public/flair/list.txt (No such file or directory)
        at java.base/java.io.FileInputStream.open0(Native Method)
        at java.base/java.io.FileInputStream.open(FileInputStream.java:185)
        at java.base/java.io.FileInputStream.<init>(FileInputStream.java:139)
        at scala.io.Source$.fromFile(Source.scala:94)
        at scala.io.Source$.fromFile(Source.scala:79)
        at scala.io.Source$.fromFile(Source.scala:57)
        at scala.io.Source$.fromFile(Source.scala:63)
        at lila.user.FlairApi.lila$user$FlairApi$$refresh(FlairApi.scala:42)
        at lila.user.FlairApi.$init$$$anonfun$1(FlairApi.scala:55)
        at lila.user.FlairApi.$init$$$anonfun$adapted$1(FlairApi.scala:55)
        at scala.Function0.apply$mcV$sp(Function0.scala:42)
        at akka.actor.Scheduler$$anon$7.run(Scheduler.scala:479)
        at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.compute(ForkJoinTask.java:1750)
        at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.compute(ForkJoinTask.java:1742)
        at java.base/java.util.concurrent.ForkJoinTask$InterruptibleTask.exec(ForkJoinTask.java:1659)
        at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:511)
        at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1450)
        at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:2019)
        at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:187)
14:16:39.789 [info] user - Updated flair db with 3623 flairs
```

</details>