### PR TITLE
fix: promotion does not complete study practice

### DIFF
--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -703,8 +703,8 @@ export default class AnalyseCtrl implements CevalHandler {
         this.setAutoShapes();
         if (!isThreat) {
           this.retro?.onCeval();
-          this.practice?.onCeval();
           this.study?.practice?.onCeval();
+          this.practice?.onCeval();
           this.study?.multiCloudEval?.onLocalCeval(node, ev);
           this.evalCache.onLocalCeval();
         }


### PR DESCRIPTION
call onCeval in the correct order: first check if the practice was successful, then check the next ceval, otherwise there might be a race condition where we check the success state of the next move and skip the promotion check.

example: https://lichess.org/practice/pawn-endgames/key-squares/xebrDvFe/o3Hq4RZ0