### PR TITLE
fix: hide overflow on .mini-(board/game) cg-board

### DIFF
--- a/ui/lib/css/component/_board.scss
+++ b/ui/lib/css/component/_board.scss
@@ -17,8 +17,11 @@ cg-board {
 }
 .mini-board cg-board,
 .mini-game cg-board {
-  overflow: hidden;
   border-radius: 4px;
+}
+.mini-board:not(.manipulable) cg-board,
+.mini-game cg-board {
+  overflow: hidden;
 }
 
 .mini-board,


### PR DESCRIPTION
Fixes #18797 by adding the suggested change in the issue.

With the fix: 
<img width="956" height="708" alt="Screenshot 2026-01-19 014532" src="https://github.com/user-attachments/assets/bae1f298-3ab4-42bc-a85b-06e07f225e3a" />
Without it: 
<img width="975" height="771" alt="Screenshot 2026-01-19 014538" src="https://github.com/user-attachments/assets/4014d932-1833-4fd6-af29-2611b10f2578" />
