### PR TITLE
ui: fix number menu tabs UI quirks

### DIFF
--- a/ui/user/css/_number-menu.scss
+++ b/ui/user/css/_number-menu.scss
@@ -25,8 +25,9 @@
     margin-top: 0.7em;
     padding-bottom: 0.8em;
 
-    @include transition;
+    @include transition(background);
 
+    border: 1px solid transparent;
     border-bottom: $border;
 
     &:first-child {
@@ -47,7 +48,7 @@
     &.active {
       color: $c-font-clear;
       border: $border;
-      border-bottom: 0;
+      border-bottom-color: transparent;
       background: $c-bg-box;
     }
   }


### PR DESCRIPTION
# Why

Spotted that number menu tabs border flashes on active state change, and also content shifts a bit between states.

https://github.com/user-attachments/assets/00fa0f54-6696-4c8a-8fbf-e2679d1d3262

# How

Apply transition only to the background, always render borders to prevent the content shifts, but use transparent color when border should not be visible.

# Preview

https://github.com/user-attachments/assets/68ca08fc-f867-4d23-b484-9667243d54b2
