### PR TITLE
Accuracy as the default Insights metric

### DIFF
--- a/app/controllers/Insight.scala
+++ b/app/controllers/Insight.scala
@@ -15,7 +15,7 @@ final class Insight(env: Env) extends LilaController(env):
   def index(username: UserStr) = OpenOrScoped(): ctx ?=>
     Accessible(username): user =>
       negotiate(
-        html = doPath(user, InsightMetric.MeanCpl.key, InsightDimension.Perf.key, ""),
+        html = doPath(user, InsightMetric.MeanAccuracy.key, InsightDimension.Perf.key, ""),
         json = env.insight.api.userStatus(user).map { status =>
           Ok(Json.obj("status" -> status.toString))
         }


### PR DESCRIPTION
The Lichess [page](https://lichess.org/page/accuracy#why-not-just-use-stockfish-centipawns) that describes its accuracy metric also explains the drawbacks of using centipawn loss for human game analyses.

Currently, however, Lichess Insights default to a centipawn loss x variant view.

This PR changes its default to an accuracy x variant view.