### PR TITLE
renames castling and en passant to be more clear

### DIFF
--- a/translation/source/site.xml
+++ b/translation/source/site.xml
@@ -664,7 +664,7 @@
   <string name="onlyExistingConversations">Only existing conversations</string>
   <string name="onlyFriends">Only friends</string>
   <string name="menu">Menu</string>
-  <string name="castling">Castling</string>
+  <string name="castling">Castling rights</string>
   <string name="whiteCastlingKingside">White O-O</string>
   <string name="blackCastlingKingside">Black O-O</string>
   <plurals name="nbForumPosts">
@@ -1027,5 +1027,5 @@ All operating costs, development, and content are funded solely by user donation
   <string name="search">Search</string>
   <string name="clearSearch">Clear search</string>
   <string name="tags">Tags</string>
-  <string name="enPassant">En passant</string>
+  <string name="enPassant">En passant rights</string>
 </resources>

--- a/ui/@types/lichess/i18n.d.ts
+++ b/ui/@types/lichess/i18n.d.ts
@@ -3183,7 +3183,7 @@ interface I18n {
     'captcha.fail': string;
     /** Capture */
     capture: string;
-    /** Castling */
+    /** Castling rights */
     castling: string;
     /** Casual */
     casual: string;
@@ -3453,7 +3453,7 @@ interface I18n {
     endgamePositions: string;
     /** Error loading engine */
     engineFailed: string;
-    /** En passant */
+    /** En passant rights */
     enPassant: string;
     /** This email address is invalid */
     'error.email': string;


### PR DESCRIPTION
This pr resolves #19076 by renaming "castling" to "castling rights".
