### PR TITLE
Add berserk tags to non-JSON PGN export

### DIFF
--- a/modules/game/src/main/PgnDump.scala
+++ b/modules/game/src/main/PgnDump.scala
@@ -103,12 +103,6 @@ final class PgnDump(
       Tag(_.Date, importedDate | Tag.UTCDate.format.print(game.createdAt)).some,
       Tag(_.Round, importedTags.flatMap(_.apply(_.Round)) | "-").some,
       Tag(_.White, player(game.whitePlayer, users.white)).some,
-      game.whitePlayer.berserk.option:
-        Tag("WhiteBerserk", game.whitePlayer.berserk)
-      ,
-      game.blackPlayer.berserk.option:
-        Tag("BlackBerserk", game.blackPlayer.berserk)
-      ,
       Tag(_.Black, player(game.blackPlayer, users.black)).some,
       Tag(_.Result, result(game)).some,
       importedDate.isEmpty.option:
@@ -127,6 +121,8 @@ final class PgnDump(
       fideIds.black.map(Tag(_.BlackFideId, _)),
       teams.map(t => Tag("WhiteTeam", t.white)),
       teams.map(t => Tag("BlackTeam", t.black)),
+      game.whitePlayer.berserk.option(Tag("WhiteBerserk", game.whitePlayer.berserk)),
+      game.blackPlayer.berserk.option(Tag("BlackBerserk", game.blackPlayer.berserk)),
       Tag(_.Variant, game.variant.name.capitalize).some,
       Tag.timeControl(game.clock.map(_.config)).some,
       Tag(_.ECO, game.opening.fold("?")(_.opening.eco)).some,


### PR DESCRIPTION
PR to implement feature as requested in issue #3795 : add berserk tags (when applicable) to non-JSON pgn output.

