### PR TITLE
Fix 'chess' compatibility in editor

### DIFF
--- a/ui/editor/src/ctrl.ts
+++ b/ui/editor/src/ctrl.ts
@@ -210,7 +210,7 @@ export default class EditorCtrl {
     return {
       fen: this.getFen(),
       legalFen: legalFen,
-      playable: this.variant === 'standard' && this.isPlayable(),
+      playable: ['standard', 'chess960', 'fromPosition'].includes(this.variant) && this.isPlayable(),
       enPassantOptions: legalFen ? this.getEnPassantOptions(legalFen) : [],
     };
   }


### PR DESCRIPTION
fixes #19188 

Forgot 2 variants when using lichess variant key instead of chessops rules .. see chessops [compat.ts](https://github.com/niklasf/chessops/blob/ab557cf68283b81b0b15806597814e76e94953ed/src/compat.ts#L75)