### PR TITLE
ui: fix lobby tournament section header border

### DIFF
--- a/ui/lobby/css/_box.scss
+++ b/ui/lobby/css/_box.scss
@@ -46,7 +46,7 @@
       @extend %nowrap-ellipsis;
 
       padding: 0.5em 0.4em;
-      border-top: $border;
+      border-bottom: $border;
       max-width: 21ch;
       @media (max-width: at-most($x-small)) {
         max-width: 18ch;
@@ -62,6 +62,10 @@
           color: $c-link;
         }
       }
+    }
+
+    tr:last-child td {
+      border-bottom: none;
     }
 
     tr:nth-child(even) {

--- a/ui/lobby/css/_table.scss
+++ b/ui/lobby/css/_table.scss
@@ -71,9 +71,15 @@
     }
   }
 
-  .lobby__tournaments-simuls .timeago {
-    @media (max-width: at-most($x-small)) {
-      display: none;
+  .lobby__tournaments-simuls {
+    .lobby__box__top {
+      border-bottom: $border;
+    }
+
+    .timeago {
+      @media (max-width: at-most($x-small)) {
+        display: none;
+      }
     }
   }
 }


### PR DESCRIPTION
# Why

Spotted that header does not have border and row border is the one separating it from content, however it looks off when tournament section is scrollable.

https://github.com/user-attachments/assets/8e8efb7c-0a1a-473b-803d-db7b11f00cbc

# How

Add bottom border to the tournament section header, refactor table cell styling to use bottom border, remove borders from last row.

# Preview

https://github.com/user-attachments/assets/0471e538-4215-42fa-a9cb-f3d7e3fb17fe
