### PR TITLE
Do not recreate the analyse DOM when going to a chapter with a different variant

### DIFF
--- a/ui/analyse/src/study/commentForm.ts
+++ b/ui/analyse/src/study/commentForm.ts
@@ -1,5 +1,4 @@
 import { prop } from 'lib';
-import { onInsert } from 'lib/view';
 import { throttle } from 'lib/async';
 import { h, type VNode } from 'snabbdom';
 import type AnalyseCtrl from '../ctrl';
@@ -72,9 +71,24 @@ export function view(root: AnalyseCtrl): VNode {
     }
   };
 
+  const syncWiki = (vnode: VNode, old?: VNode) => {
+    const shouldEnable = root.data.game.variant.key === 'standard';
+    if (old?.data?.wikiEnabled !== shouldEnable) root.enableWiki(shouldEnable);
+    vnode.data!.wikiEnabled = shouldEnable;
+  };
+
   return h(
     'div.study__comments',
-    { hook: onInsert(() => root.enableWiki(root.data.game.variant.key === 'standard')) },
+    {
+      hook: {
+        insert(vnode) {
+          syncWiki(vnode);
+        },
+        postpatch(old, vnode) {
+          syncWiki(vnode, old);
+        },
+      },
+    },
     [
       currentComments(root, !study.members.canContribute()),
       h('form.form3', [

--- a/ui/analyse/src/view/components.ts
+++ b/ui/analyse/src/view/components.ts
@@ -92,8 +92,9 @@ export function viewContext(ctrl: AnalyseCtrl, deps?: typeof studyDeps): ViewCon
 export function renderMain(ctx: ViewContext, ...kids: LooseVNodes[]): VNode {
   const { ctrl, playerBars, gaugeOn, gamebookPlayView, needsInnerCoords, hasRelayTour } = ctx;
   const isRelay = defined(ctrl.study?.relay);
+  const variantClass = 'variant-' + ctrl.data.game.variant.key;
   return hl(
-    'main.analyse.variant-' + ctrl.data.game.variant.key,
+    'main.analyse',
     {
       attrs: {
         'data-active-tool': ctrl.activeControlBarTool(),
@@ -114,6 +115,7 @@ export function renderMain(ctx: ViewContext, ...kids: LooseVNodes[]): VNode {
         },
       },
       class: {
+        [variantClass]: true,
         'comp-off': !ctrl.showFishnetAnalysis(),
         'gauge-on': gaugeOn,
         'has-players': !!playerBars,


### PR DESCRIPTION
Use case this is motivated by:
- Create study with a number of chapters (such that scrolling happens).
- Create a new chapter with a variant that's different from the current last chapter.
- If you then click between these two last chapters, you'll notice the scroll goes to the top and then scrolls down to them.

The changes in `commentForm.ts` are so that `syncWiki` runs when changing variants, since now `insert` will not run. I'm not sure if there are any other places in the codebase that also relied on the DOM being recreated.