### PR TITLE
Display dates for a user's activity in the timezone of the viewer.

### DIFF
--- a/modules/activity/src/main/ActivityUi.scala
+++ b/modules/activity/src/main/ActivityUi.scala
@@ -25,7 +25,7 @@ final class ActivityUi(helpers: Helpers)(
         .filterNot(_.isEmpty)
         .map: a =>
           st.section(
-            h2(semanticDate(a.interval.start)),
+            h2(semanticDate(a.interval.start, Some("b"))),
             div(cls := "entries")(
               a.patron.map(renderPatron),
               a.practice.map(renderPractice),

--- a/modules/ui/src/main/helper/DateHelper.scala
+++ b/modules/ui/src/main/helper/DateHelper.scala
@@ -13,6 +13,7 @@ trait DateHelper:
   self: StringHelper =>
 
   val datetimeAttr = attr("datetime")
+  private val formatAttr = attr("format")
 
   private val dateTimeFormatters = scalalib.ConcurrentMap[String, DateTimeFormatter](maxLangs)
   private val dateFormatters = scalalib.ConcurrentMap[String, DateTimeFormatter](maxLangs)
@@ -58,11 +59,8 @@ trait DateHelper:
   def showEnglishDate(instant: Instant): String = englishDateFormatter.print(instant)
   def showEnglishInstant(instant: Instant): String = englishDateTimeFormatter.print(instant)
 
-  def semanticDate(instant: Instant)(using t: Translate): Tag =
-    timeTag(datetimeAttr := isoDateTime(instant))(showDate(instant))
-
-  def semanticDate(date: LocalDate)(using t: Translate): Tag =
-    timeTag(datetimeAttr := isoDateTime(date.atStartOfDay.instant))(showDate(date))
+  def semanticDate(instant: Instant, format: Option[String] = None)(using t: Translate): Tag =
+    timeTag(datetimeAttr := isoDateTime(instant), format.map(formatAttr := _))(showDate(instant))
 
   def showMinutes(minutes: Int)(using Translate): String =
     lila.core.i18n.translateDuration(Duration.ofMinutes(minutes))

--- a/ui/lib/css/base/_elements.scss
+++ b/ui/lib/css/base/_elements.scss
@@ -63,6 +63,10 @@ time {
 
   /* don't use c-color-dim, it overrides too hard */
   unicode-bidi: plaintext;
+
+  .activity &[format]:not([data-localized]) {
+    visibility: hidden;
+  }
 }
 
 hr {

--- a/ui/site/src/boot.ts
+++ b/ui/site/src/boot.ts
@@ -37,6 +37,7 @@ export function boot() {
     updateTimeAgo(1000);
     pubsub.on('content-loaded', renderTimeAgo);
     renderLocalizedTimestamps();
+    pubsub.on('content-loaded', renderLocalizedTimestamps);
     pubsub.on('content-loaded', toggleBoxInit);
   });
   requestIdleCallback(() => {

--- a/ui/site/src/renderTimeAgo.ts
+++ b/ui/site/src/renderTimeAgo.ts
@@ -49,13 +49,14 @@ export const renderLocalizedTimestamps = (): void => {
         const date = toDate(node.getAttribute('datetime')!);
         node.textContent = datetimeFormat(date, format);
       }
+      node.toggleAttribute('data-localized', true);
     });
   });
 };
 
-const discordFormats: { [key: string]: Intl.DateTimeFormatOptions } = {
+const discordFormatsExtended: { [key: string]: Intl.DateTimeFormatOptions } = {
   d: { year: 'numeric', month: '2-digit', day: '2-digit' }, // 12/31/2025
-  D: { year: 'numeric', month: 'long', day: 'numeric' }, // December 31st, 2025
+  D: { year: 'numeric', month: 'long', day: 'numeric' }, // December 31, 2025
   t: { hour: 'numeric', minute: 'numeric' }, // 6:26 PM
   T: { hour: 'numeric', minute: 'numeric', second: 'numeric' }, // 6:26:00 PM
   f: {
@@ -64,7 +65,7 @@ const discordFormats: { [key: string]: Intl.DateTimeFormatOptions } = {
     day: 'numeric',
     hour: 'numeric',
     minute: 'numeric',
-  }, // December 31st, 2025 at 6:26 PM
+  }, // December 31, 2025 at 6:26 PM
   F: {
     weekday: 'long',
     year: 'numeric',
@@ -72,7 +73,7 @@ const discordFormats: { [key: string]: Intl.DateTimeFormatOptions } = {
     day: 'numeric',
     hour: 'numeric',
     minute: 'numeric',
-  }, // Wednesday, December 31st, 2025 at 6:26 PM
+  }, // Wednesday, December 31, 2025 at 6:26 PM
   s: {
     year: 'numeric',
     month: '2-digit',
@@ -88,6 +89,8 @@ const discordFormats: { [key: string]: Intl.DateTimeFormatOptions } = {
     minute: 'numeric',
     second: 'numeric',
   }, // 12/31/2025, 6:26:00 PM
+  // non-discord format:
+  b: { year: 'numeric', month: 'short', day: 'numeric' }, // Dec 31, 2025
 };
 
 const datetimeFormat = (date: Date, formatStr: string): string => {
@@ -95,7 +98,7 @@ const datetimeFormat = (date: Date, formatStr: string): string => {
     return timeago(date);
   }
 
-  const fmt = discordFormats[formatStr];
+  const fmt = discordFormatsExtended[formatStr];
 
   if (fmt) {
     const formatter = new Intl.DateTimeFormat(displayLocale, fmt);


### PR DESCRIPTION
Converting to draft since games still aren't always separated correctly according to viewer timezone.

Explanation of some of the changes:
- `semanticDate` updated to take an optional format.
- The other `semanticDate` is removed since it was never used.
- The new `.activity &[format]:not([data-localized])` scss rule is to prevent the old date format from flashing for a split second on page load. To see the effect of not having it, remove it and go to a few user profiles. When hitting refresh, you should notice a different date appearing briefly.
  - I'm not sure if there's a better way to accomplish what I want?
- The `pubsub.on('content-loaded', renderLocalizedTimestamps);` is so that the changes apply if going from the 'games' to 'activity' tab.