### PR TITLE
For semantic dates, add a tooltip that shows the date is in UTC.

### DIFF
--- a/modules/ui/src/main/helper/DateHelper.scala
+++ b/modules/ui/src/main/helper/DateHelper.scala
@@ -59,10 +59,10 @@ trait DateHelper:
   def showEnglishInstant(instant: Instant): String = englishDateTimeFormatter.print(instant)
 
   def semanticDate(instant: Instant)(using t: Translate): Tag =
-    timeTag(datetimeAttr := isoDateTime(instant))(showDate(instant))
-
-  def semanticDate(date: LocalDate)(using t: Translate): Tag =
-    timeTag(datetimeAttr := isoDateTime(date.atStartOfDay.instant))(showDate(date))
+    timeTag(
+      datetimeAttr := isoDateTime(instant),
+      title := s"${showInstant(instant)} UTC"
+    )(showDate(instant))
 
   def showMinutes(minutes: Int)(using Translate): String =
     lila.core.i18n.translateDuration(Duration.ofMinutes(minutes))


### PR DESCRIPTION
Places this affects:
- Dates in the activity tab on a user's profile.
- Blog post dates (both the preview cards and on the blog posts themselves).
- Edit ui for feed (I think this is just for people like lichess admins?).

Overload for `semanticDate` is also removed since it wasn't being used.