### PR TITLE
UX: create two submit buttons - one for saving, the other for (un)publishing and saving

### DIFF
--- a/modules/ublog/src/main/ui/UblogFormUi.scala
+++ b/modules/ublog/src/main/ui/UblogFormUi.scala
@@ -88,6 +88,16 @@ final class UblogFormUi(helpers: Helpers, ui: UblogUi)(
             attr("data-image-count-max") := 10
           )
         ),
+
+      // Keep the `live` field in the form for binding, but hide it. The secondary submit button will toggle
+      // this value before submit (via bits.ublogForm.ts).
+      input(
+        tpe := "hidden",
+        id := "form3-live",
+        name := form("live").name,
+        value := form("live").value.getOrElse("false")
+      ),
+
       post.toOption match
         case None =>
           form3.group(form("topics"), frag(trans.ublog.selectPostTopics()))(
@@ -110,9 +120,9 @@ final class UblogFormUi(helpers: Helpers, ui: UblogUi)(
                 half = true
               ),
               form3.checkboxGroup(
-                form("live"),
-                trans.ublog.publishOnYourBlog(),
-                help = trans.ublog.publishHelp().some,
+                form("ads"),
+                "Includes promoted/sponsored content or referral links",
+                help = ads.some,
                 half = true
               )
             ),
@@ -121,12 +131,6 @@ final class UblogFormUi(helpers: Helpers, ui: UblogUi)(
                 form("sticky"),
                 trans.ublog.stickyPost(),
                 help = trans.ublog.stickyPostHelp().some,
-                half = true
-              ),
-              form3.checkboxGroup(
-                form("ads"),
-                "Includes promoted/sponsored content or referral links",
-                help = ads.some,
                 half = true
               )
             )
@@ -140,7 +144,22 @@ final class UblogFormUi(helpers: Helpers, ui: UblogUi)(
         )(
           trans.site.cancel()
         ),
-        form3.submit((if post.isRight then trans.site.apply else trans.ublog.saveDraft) ())
+        frag(
+          submitButton(cls := "button button-empty")(trans.site.save()),
+          post match
+            case Left(_) =>
+              submitButton(
+                cls := "button",
+                data("set-live") := "true"
+              )("Save and publish")
+            case Right(p) =>
+              submitButton(
+                cls := "button",
+                data("set-live") := (!p.live).toString
+              )(
+                if p.live then "Save and unpublish" else "Save and publish"
+              )
+        )
       )
     )
 

--- a/ui/bits/src/bits.ublogForm.ts
+++ b/ui/bits/src/bits.ublogForm.ts
@@ -22,6 +22,11 @@ site.load.then(() => {
     selectClicks: $('.select-image, .drop-target'),
     selectDrags: $('.drop-target'),
   });
+  $('button[data-set-live]').on('click', e => {
+    const v = (e.currentTarget as HTMLButtonElement).dataset.setLive;
+    const input = document.getElementById('form3-live') as HTMLInputElement | null;
+    if (input && typeof v === 'string') input.value = v;
+  });
 });
 
 const setupTopics = (el: HTMLTextAreaElement) =>


### PR DESCRIPTION
Opinions might differ on whether this is worth it, but imo it improves the UX. Currently, expecting the user to remember to check one of the checkboxes before clicking "submit" is a bit unintuitive (especially since "submit" gives the impression of publishing, rather than just saving).

Explanation of changes:
- Now two submit buttons (one for just saving, the other for saving & (un)publishing). Clicking on them will assign true or false to `data("set-live")`.
- The latter button will set the property to true _iff_ the blog is currently unpublished.
- The publish checkbox is removed, and replaced with an invisible form ("form3-live"). This form's value is programatically assigned the aforementioned `set-live` property.

<img width="1118" height="415" alt="Screenshot 2026-02-03 at 9 29 58 PM" src="https://github.com/user-attachments/assets/00d2c044-5a9c-4627-a1fc-5fe14fcb3583" />
<br></br>
<img width="1115" height="418" alt="Screenshot 2026-02-03 at 9 30 07 PM" src="https://github.com/user-attachments/assets/ae76ec6e-9184-430f-9989-75c540b7ed22" />
