### PR TITLE
More specific Safari UA test for WebKit WASM bug

### DIFF
--- a/ui/lib/src/device.ts
+++ b/ui/lib/src/device.ts
@@ -115,7 +115,7 @@ export const reducedMotion: () => boolean = memoize<boolean>(
 
 function sharedMemoryTest(): boolean {
   // Avoid WebKit crash: https://bugs.webkit.org/show_bug.cgi?id=303387
-  if (navigator.userAgent.includes('AppleWebKit/605.1.15')) return false;
+  if (lowerAgent.includes('version/26.2')) return false;
 
   if (typeof Atomics !== 'object' || typeof SharedArrayBuffer !== 'function') return false;
 


### PR DESCRIPTION
For #18894
|-|Before|After|
|---|---|---|
|iOS 26.1|<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/7ce7fb4d-31e1-43e6-b397-4697bdf19883" />|<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/2d163d83-01a5-419b-afcb-52fcae7d9fe8" />|
|Safari 26.2 (Problem version)|<img width="419" height="93" alt="image" src="https://github.com/user-attachments/assets/70690611-71ae-42b0-a43a-6f364ae3a634" />|<img width="419" height="93" alt="image" src="https://github.com/user-attachments/assets/0dc49f79-7f8d-44a7-ac8a-ec0b63c0a655" />|