### PR TITLE
Add horizontal spacing between trophy and username on perf page.

### DIFF
--- a/ui/user/css/_perf-stat.scss
+++ b/ui/user/css/_perf-stat.scss
@@ -3,6 +3,7 @@
 
   .box__top__title {
     @extend %flex-center-nowrap;
+    gap: 0.4em;
   }
 
   h1 span {


### PR DESCRIPTION
Before:
<img width="474" height="148" alt="Screenshot 2026-02-04 at 11 24 58 PM" src="https://github.com/user-attachments/assets/ea6b83e7-4623-4a80-9714-bd99052f8d87" />

After:
<img width="472" height="141" alt="Screenshot 2026-02-04 at 11 24 30 PM" src="https://github.com/user-attachments/assets/a8ad5e7b-127a-40c6-8dd8-ed1e18042d9f" />
