### PR TITLE
Don't scroll back up then down

### DIFF
--- a/ui/analyse/src/study/studyCtrl.ts
+++ b/ui/analyse/src/study/studyCtrl.ts
@@ -269,7 +269,7 @@ export default class StudyCtrl {
   };
 
   setTab = (tab: Tab) => {
-    if (tab === 'chapters') this.chapters.scroller.request('instant');
+    if (tab === 'chapters' && this.vm.tab() !== 'chapters') this.chapters.scroller.request('instant');
     this.vm.tab(tab);
     this.redraw();
   };


### PR DESCRIPTION
Last of tonight's spam...

Use case this helps:
- Have a study with say 13+ chapters.
- Select an early one, then scroll to have it out of view.
- Make a new chapter.

Currently, you'll see an instant scroll up to the early chapter, followed by a scroll back down to the new chapter. This PR makes it so that the scroll is instantly done to the new chapter.