### PR TITLE
ui: improve form elements focus styling

### DIFF
--- a/ui/bits/css/_markdown-textarea.scss
+++ b/ui/bits/css/_markdown-textarea.scss
@@ -79,12 +79,6 @@
   .comment-content {
     overflow: visible; // don't clip textarea focus ring
     position: relative;
-
-    textarea:focus-visible {
-      outline-style: solid;
-      outline-offset: -2px;
-      outline-width: 2px;
-    }
   }
   .comment-preview {
     position: absolute;

--- a/ui/lib/css/base/_form.scss
+++ b/ui/lib/css/base/_form.scss
@@ -5,7 +5,10 @@ select,
 textarea {
   font: inherit;
   color: $c-font;
-  outline-color: $c-primary;
+  &:focus-visible {
+    outline: 2px solid $c-primary;
+    outline-offset: -2px;
+  }
 }
 
 option,


### PR DESCRIPTION
# Why

When working on markdown textarea tabs I have spotted that lila UI uses default outline styling for from inputs (outline: auto) and only modifies the color. 

Since `auto` is browser driven, and applies various additional styles based on the vendor, including ignoring the user provided color, it can lead to unexpected styling, see:
* https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/outline-style#auto

# How

Switch to `solid` style for focused form elements globally, remove no longer needed overwrite in markdown textarea tabs.

# Preview

### Before 

### Chrome

<img width="1614" height="304" alt="Screenshot 2026-02-05 at 12 04 14" src="https://github.com/user-attachments/assets/1cd0c95b-2f4a-46ac-b4b3-c5cc7aa62b85" />

### Safari

<img width="476" height="214" alt="Screenshot 2026-02-05 at 12 15 21" src="https://github.com/user-attachments/assets/aa4ad7bc-3e7a-4faa-a94d-1c4e5e897b42" />

### Firefox

<img width="476" height="214" alt="Screenshot 2026-02-05 at 12 29 44" src="https://github.com/user-attachments/assets/2c38908e-007c-4f1a-814c-d3f7115e6b14" />

### After

### Chrome

<img width="1614" height="304" alt="Screenshot 2026-02-05 at 12 04 22" src="https://github.com/user-attachments/assets/bd5d5fa7-60a4-48dd-a21a-28155cb05fe5" />

### Safari

<img width="476" height="214" alt="Screenshot 2026-02-05 at 12 28 54" src="https://github.com/user-attachments/assets/2715d27a-e62d-4e49-b324-efcef1138b24" />

### Firefox

<img width="476" height="214" alt="Screenshot 2026-02-05 at 12 29 52" src="https://github.com/user-attachments/assets/8b340819-2673-4be9-a5eb-10adfde39ac5" />
