### PR TITLE
ui: add hover styles to checkbox element

### DIFF
--- a/ui/lib/css/form/_check.scss
+++ b/ui/lib/css/form/_check.scss
@@ -28,7 +28,9 @@
   cursor: pointer;
   height: 24px;
   width: 24px;
-  transition: border-color 0.1s ease-in-out, background-color 0.1s ease-in-out;
+  transition:
+    border-color 0.1s ease-in-out,
+    background-color 0.1s ease-in-out;
   &:hover {
     border-color: $c-good;
   }


### PR DESCRIPTION
# Why

Spotted that custom checkbox inputs only handle two states - normal and checked. From a11y perspective is also nice to have altered style on hover, especially when user interacts on label to toggle the checked state.

# How

Add hover styles to input checkbox element and its label for both checked and unchecked states. 

The opacity change for hovered checked element might not be ideal, happy to experiment further with alternate styling like border color adjustment if you don't like it.

# Preview

https://github.com/user-attachments/assets/61f88dc1-1317-4b8f-8aee-55e022e8b5bb

