### PR TITLE
For move swiping, require horizontal swipe delta to be >= 2x the vertical swipe delta

### DIFF
--- a/ui/lib/src/pointer.ts
+++ b/ui/lib/src/pointer.ts
@@ -39,7 +39,7 @@ export function addPointerListeners(el: HTMLElement, listeners: PointerListeners
     const [dx, dy] = [e.clientX - g.x, e.clientY - g.y];
 
     if (!g.lastMove && Math.abs(dy) > 12) return reset(e);
-    if (!hscrub || Math.abs(dx) < 5) return;
+    if (!hscrub || Math.abs(dx) < 5 || Math.abs(dx) < Math.abs(dy) * 2) return;
     clearTimeout(g.timer);
     g.timer = 0;
 


### PR DESCRIPTION
Was teaching a chess lesson recently on my phone, and regularly had to scroll down to the chat and back up. This sometimes resulted in unintentional move swiping.