### PR TITLE
ui: fix markdown textarea shift on "Write" tab focus

### DIFF
--- a/ui/bits/css/_markdown-textarea.scss
+++ b/ui/bits/css/_markdown-textarea.scss
@@ -51,15 +51,20 @@
     left: 0;
     right: 0;
     bottom: -2px;
-    height: 2px;
+    height: 4px;
     background-color: $c-bg-preview;
   }
   .header-tab.active.write::after {
     background-color: $c-bg-input;
   }
   &:has(textarea:focus) .write.active {
-    border-color: $c-primary;
-    border-width: 2px;
+    outline: 2px solid $c-primary;
+    outline-offset: -2px;
+
+    &::after {
+      left: 1px;
+      right: 1px;
+    }
   }
   .upload-image {
     all: unset;


### PR DESCRIPTION
# Why

The markdown textarea shifts a bit when "Write" tab gains focus due to changing the border width.

# How

Refactor active and focus styles to rely on outline instead, adjust the offset outline mask sizing and position, which results in stable markdown textarea element sizing/position no matter of the state or tab active.

# Preview

https://github.com/user-attachments/assets/6738c694-4a9a-445c-9c2c-ff6609f3a153

