### PR TITLE
Fix embedded puzzle button scaling on mobile

### DIFF
--- a/ui/bits/css/build/bits.lpv.scss
+++ b/ui/bits/css/build/bits.lpv.scss
@@ -19,6 +19,5 @@
   font-size: 1.5em;
   white-space: normal;
   max-width: 90%;
-  box-sizing: border-box;
   text-align: center;
 }


### PR DESCRIPTION
Add max-width: 90% to prevent the Start button from overflowing
on small screens. Also add box-sizing: border-box for proper
padding calculation and text-align: center for consistent alignment.

Closes lichess-org#16748