### PR TITLE
Fix lobby view toggle not updating immediately

### DIFF
--- a/ui/lobby/src/view/main.ts
+++ b/ui/lobby/src/view/main.ts
@@ -29,7 +29,7 @@ export default function (ctrl: LobbyController) {
         break;
     }
   const contentKey = ctrl.tab === 'real_time' ? `${ctrl.tab}-${ctrl.mode}` : ctrl.tab;
-  return h('div.lobby__app.lobby__app-' + ctrl.tab, [
+  return h(`div.lobby__app.lobby__app-${ctrl.tab}.lck-${contentKey}`, [
     h('div.tabs-horiz', { attrs: { role: 'tablist' } }, renderTabs(ctrl)),
     h(`div.lobby__app__content.l${redirBlock ? 'redir' : ctrl.tab}`, { key: contentKey, ...data }, body),
   ]);


### PR DESCRIPTION
Add a key to the content div that includes the mode when on the real_time tab. This ensures snabbdom properly re-renders when switching between list and chart views instead of trying to patch incompatible DOM structures.

Closes lichess-org#17174