### PR TITLE
Show scoresheet scrollbar in Chromium browsers

### DIFF
--- a/ui/botPlay/css/play/_table.scss
+++ b/ui/botPlay/css/play/_table.scss
@@ -42,10 +42,6 @@
   line-height: 1.7;
   font-size: 1.1em;
 
-  &::-webkit-scrollbar {
-    width: 0px;
-  }
-
   turn {
     flex: 0 0 16.666%;
     display: flex;

--- a/ui/round/css/_moves-col2.scss
+++ b/ui/round/css/_moves-col2.scss
@@ -21,10 +21,6 @@
     will-change: scroll-position;
     line-height: 1.7;
     font-size: 1.1em;
-
-    &::-webkit-scrollbar {
-      width: 0px;
-    }
   }
 
   #{$index-tag} {


### PR DESCRIPTION
Remove webkit-scrollbar width:0 overrides that hide the vertical scrollbar on the move list in col2 layout. The global scrollbar styles from _scrollbar.scss now apply, restoring the scrollbar in Chromium-based browsers.

Fixes lichess-org#17814