### PR TITLE
Fix broadcast round info text cutoff at certain widths

### DIFF
--- a/ui/analyse/css/study/relay/_tour.scss
+++ b/ui/analyse/css/study/relay/_tour.scss
@@ -309,7 +309,7 @@ $hover-bg: $m-primary_bg--mix-30;
     .mselect__list {
       left: unset;
       right: 0;
-      overflow-x: hidden;
+      overflow-x: auto;
       overflow-y: auto;
       max-height: 50vh;
       @media (max-width: at-most($medium)) {


### PR DESCRIPTION
Change overflow-x from hidden to auto on the round select dropdown so the table content is scrollable instead of being silently clipped when the dropdown is narrower than the table at certain browser widths.

Fixes lichess-org#17590