### PR TITLE
fix: add board menu toggle for spectators on mobile

### DIFF
--- a/ui/round/src/view/table.ts
+++ b/ui/round/src/view/table.ts
@@ -39,6 +39,7 @@ export const renderTableEnd = (ctrl: RoundController): LooseVNodes =>
 export const renderTableWatch = (ctrl: RoundController): LooseVNodes =>
   renderTableWith(ctrl, [
     isLoading(ctrl) ? loader() : playable(ctrl.data) ? undefined : button.watcherFollowUp(ctrl),
+    boardMenuToggleButton(ctrl.menu, i18n.site.menu),
   ]);
 
 const prompt = (ctrl: RoundController) => {


### PR DESCRIPTION
Spectators watching a game on mobile (col1 layout) couldn't access the board menu (flip board, zen mode, etc.) because the boardMenuToggleButton was only rendered in renderTablePlay but not in renderTableWatch.

Fixes #15217