### PR TITLE
fix `ui/build`for cmn-toggle

### DIFF
--- a/ui/lib/src/ceval/view/main.ts
+++ b/ui/lib/src/ceval/view/main.ts
@@ -3,7 +3,7 @@
 import { povChances } from '../winningChances';
 import * as licon from '@/licon';
 import { stepwiseScroll, type VNode, type LooseVNodes, bind, hl } from '@/view';
-import { cmnToggle } from 'lib/view/cmn-toggle';
+import { cmnToggle } from '@/view/cmn-toggle';
 import { defined, notNull, requestIdleCallback } from '@/index';
 import { type CevalHandler, type NodeEvals, CevalState } from '../types';
 import type { Position } from 'chessops/chess';

--- a/ui/lib/src/chat/renderChat.ts
+++ b/ui/lib/src/chat/renderChat.ts
@@ -1,6 +1,6 @@
 import * as licon from '../licon';
 import { type VNode, hl, bind } from '@/view';
-import { cmnToggleProp } from 'lib/view/cmn-toggle';
+import { cmnToggleProp } from '@/view/cmn-toggle';
 import type { Tab, VoiceChat } from './interfaces';
 import discussionView from './discussion';
 import { noteView } from './note';


### PR DESCRIPTION
After cfef7479ae3d5b7eb62909356aaf3bd6b248f72c I started getting this error

`✘ [ERROR] ts5055 Cannot write file 'lila/ui/lib/dist/view/cmn-toggle.d.ts' because it would overwrite input file.`

The first `./ui/build --clean` is OK but then any subsequent `./ui/build` would give the error.

Updates other lib files to use internal path alias