### PR TITLE
ui: improve `transition` mixin, support multiple props

### DIFF
--- a/ui/coordinateTrainer/css/_svgAnimation.scss
+++ b/ui/coordinateTrainer/css/_svgAnimation.scss
@@ -33,9 +33,7 @@ svg.coords-svg {
     }
 
     // for animating the removal of this element
-    transition:
-      opacity $timing,
-      transform $timing;
+    @include transition(opacity transform, $timing);
   }
 
   g.next {

--- a/ui/lib/css/abstract/_mixins.scss
+++ b/ui/lib/css/abstract/_mixins.scss
@@ -28,8 +28,16 @@
   }
 }
 
-@mixin transition($prop: all, $dur: $transition-duration) {
-  transition: $prop $dur;
+@mixin transition($prop: all, $dur: $transition-duration, $timing: ease) {
+  @if type-of($prop) == 'list' and length($prop) > 1 {
+    $out: ();
+    @for $i from 1 through length($prop) {
+      $out: append($out, nth($prop, $i) $dur $timing, comma);
+    }
+    transition: $out;
+  } @else {
+    transition: $prop $dur $timing;
+  }
 }
 
 @mixin hoverflow {

--- a/ui/lib/css/component/_chart.scss
+++ b/ui/lib/css/component/_chart.scss
@@ -100,7 +100,6 @@
   }
   .noUi-state-tap .noUi-connect,
   .noUi-state-tap .noUi-origin {
-    -webkit-transition: transform 0.3s;
     transition: transform 0.3s;
   }
   .noUi-state-drag * {
@@ -117,11 +116,11 @@
   .noUi-horizontal .noUi-handle {
     width: 5px;
     height: 21px;
-    right: 0px;
+    right: 0;
     top: -6px;
   }
   .noUi-txt-dir-rtl.noUi-horizontal .noUi-handle {
-    left: 0px;
+    left: 0;
     right: auto;
   }
   /* Styling;

--- a/ui/lib/css/component/_mselect.scss
+++ b/ui/lib/css/component/_mselect.scss
@@ -82,13 +82,9 @@ $c-mselect: $c-primary;
     padding: 0.3em 1em;
     visibility: hidden;
     opacity: 0;
-
-    transition:
-      background $transition-duration,
-      border-color $transition-duration;
-
     color: $c-mselect;
     border-left: 3px solid transparent;
+    @include transition(background-color border-color);
 
     &.current {
       background: $c-bg-zebra;

--- a/ui/lib/css/component/_tabs-horiz.scss
+++ b/ui/lib/css/component/_tabs-horiz.scss
@@ -23,13 +23,9 @@ $c-tabs-active: $c-accent !default;
     border: 0;
     background: none;
     border-bottom: 2px solid transparent;
-
-    transition:
-      color 0.25s,
-      border-color 0.25s;
-
     min-width: 15%;
     letter-spacing: -0.5px;
+    @include transition(color border-color, 0.25s);
 
     @media (min-width: at-least($xx-small)) {
       letter-spacing: inherit;

--- a/ui/lib/css/form/_check.scss
+++ b/ui/lib/css/form/_check.scss
@@ -28,9 +28,7 @@
   cursor: pointer;
   height: 24px;
   width: 24px;
-  transition:
-    border-color 0.1s ease-in-out,
-    background-color 0.1s ease-in-out;
+  @include transition(background-color border-color, 0.1s ease-in-out);
   &:hover {
     border-color: $c-good;
   }

--- a/ui/lib/css/form/_cmn-toggle.scss
+++ b/ui/lib/css/form/_cmn-toggle.scss
@@ -22,10 +22,7 @@
   border-radius: 24px;
   background-clip: padding-box;
   background-color: $c-font-dimmer;
-
-  transition:
-    background $transition-duration,
-    box-shadow $transition-duration;
+  @include transition(background box-shadow);
 
   &::before,
   &::after {
@@ -46,9 +43,7 @@
     line-height: 22px;
     content: $licon-X;
     color: $c-font-dimmer;
-    transition:
-      margin $transition-duration,
-      color $transition-duration;
+    @include transition(margin color);
   }
 
   &::after {
@@ -58,9 +53,7 @@
     }
     border-radius: 100%;
     box-shadow: 0 1px 2.5px rgba(0, 0, 0, 0.3);
-    transition:
-      margin $transition-duration,
-      box-shadow $transition-duration;
+    @include transition(margin box-shadow);
   }
 }
 

--- a/ui/lib/css/header/_header.scss
+++ b/ui/lib/css/header/_header.scss
@@ -20,9 +20,7 @@ body > header {
     width: 100%;
     padding: 0 var(---site-header-sticky-padding);
     border-bottom: 1px solid transparent;
-    transition:
-      transform $transition-duration ease-in-out,
-      border-color $transition-duration ease-in-out;
+    @include transition(transform border-color, $transition-duration, ease-in-out);
 
     &.scrolled {
       background-image: linear-gradient(to bottom, $c-body-gradient, $m-body-gradient_bg-page--mix-50 60px);

--- a/ui/lib/css/vendor/_flatpickr.scss
+++ b/ui/lib/css/vendor/_flatpickr.scss
@@ -242,7 +242,6 @@
 }
 .flatpickr-months .flatpickr-prev-month svg path,
 .flatpickr-months .flatpickr-next-month svg path {
-  -webkit-transition: fill 0.1s;
   transition: fill 0.1s;
   fill: inherit;
 }

--- a/ui/user/css/_sub-rating.scss
+++ b/ui/user/css/_sub-rating.scss
@@ -16,10 +16,7 @@
       font-size: 3em;
       opacity: 0.5;
       margin-inline-end: 0.2em;
-
-      transition:
-        opacity $transition-duration,
-        color $transition-duration;
+      @include transition(opacity color);
     }
 
     &[href=''] {


### PR DESCRIPTION
# Why

When Thibault was reviewing one of my PRs on the stream we spotted that `transition` mixin cannot be used with multiple props.

# How

Improve `transition` mixin, support passing multiple props and timing function. 

Replace several multi-prop raw CSS usages, remove no longer needed `-webkit-transition` props and units for `0` values.

# Preview

<img width="3364" height="1020" alt="Screenshot 2026-02-10 at 14 24 18" src="https://github.com/user-attachments/assets/527b4ad8-02f3-4517-abe5-546f7f44fbd3" />
