### PR TITLE
ui: improve copy-me button styling

### DIFF
--- a/ui/lib/css/component/_copy-me.scss
+++ b/ui/lib/css/component/_copy-me.scss
@@ -2,10 +2,9 @@
   @extend %box-radius, %flex-center-nowrap;
 }
 .copy-me__target {
-  @extend %ellipsis;
+  @extend %ellipsis, %box-radius-left;
   flex: 1 1 auto;
   white-space: nowrap;
-  border-radius: $box-radius-size 0 0 $box-radius-size;
   padding: 0.8em 1em;
   border: 0;
   outline: 0;
@@ -15,9 +14,9 @@
   min-height: 44px;
 }
 .copy-me__button {
+  @extend %box-radius-right;
   flex: 0 0 auto;
   border: $border;
   border-left: 0;
-  border-radius: 0 $box-radius-size $box-radius-size 0;
   min-height: 44px;
 }


### PR DESCRIPTION
# Why

Spotted that input with copy button embedded has an incorrect outline and button overflows + has different height than input (there is a small subpixel gap at top).

https://github.com/user-attachments/assets/7b9a306f-de36-4b80-a5c0-b6370403c8fe

# How

Apply border and border radius to the elements directly, set min height on the nearest full pixel value to avoid height miss-match.

# Preview

https://github.com/user-attachments/assets/58cbcf2c-8f6d-4f1c-8a4e-56a991edafe6


