### PR TITLE
ui: remove no longer needed `button-none` extension

### DIFF
--- a/ui/analyse/css/_action-menu.scss
+++ b/ui/analyse/css/_action-menu.scss
@@ -45,7 +45,7 @@
 
     button,
     > a {
-      @extend %button-none;
+      color: $c-font;
       display: flex;
       align-items: center;
       line-height: 1.2em;

--- a/ui/analyse/css/_forecast.scss
+++ b/ui/analyse/css/_forecast.scss
@@ -25,23 +25,20 @@
   }
 
   .entry {
-    @extend %button-none, %flex-center-nowrap;
-    width: 100%;
+    @extend %flex-center-nowrap;
+    @include padding-direction(0.7em, 0.1em, 0.7em, 0.6em);
+    @include transition;
 
+    width: 100%;
     cursor: pointer;
+    position: relative;
+    border-bottom: $border;
+    margin-inline-start: -0.1em;
+
     &:hover {
       background: $c-primary;
       color: $c-over;
     }
-
-    @include padding-direction(0.7em, 0.1em, 0.7em, 0.6em);
-
-    margin-inline-start: -0.1em;
-
-    @include transition;
-
-    position: relative;
-    border-bottom: $border;
 
     &::before {
       margin-inline-start: -0.6em;
@@ -50,22 +47,18 @@
 
     .del {
       @extend %button-shadow;
-      @extend %button-none;
+      @include inline-end(8px);
+      @include transition;
 
       position: absolute;
-      @include inline-end(8px);
       width: 1.5em;
       height: 1.5em;
       line-height: 1;
       opacity: 0;
-
       display: flex;
       justify-content: center;
       align-items: center;
       padding-inline-end: 0.5px;
-
-      @include transition;
-
       background: $c-bad;
       color: $c-over;
       border-radius: 50%;
@@ -86,7 +79,7 @@
   }
 
   .add {
-    @extend %button-none, %flex-center-nowrap;
+    @extend %flex-center-nowrap;
 
     width: 100%;
     padding: 0.7em;
@@ -101,11 +94,10 @@
 
     &.enabled {
       @extend %metal;
+      @include transition;
 
       cursor: pointer;
       color: $c-font;
-
-      @include transition;
 
       &::before {
         opacity: 0.7;

--- a/ui/analyse/css/_tools.scss
+++ b/ui/analyse/css/_tools.scss
@@ -31,8 +31,6 @@
     text-align: center;
 
     button {
-      @extend %button-none;
-
       margin-inline-start: 1em;
       color: $c-link;
 

--- a/ui/analyse/css/explorer/_config.scss
+++ b/ui/analyse/css/explorer/_config.scss
@@ -122,13 +122,12 @@
         text-transform: none;
       }
       .remove {
-        @extend %button-none;
         $remove-button-diameter: 1.75em;
+        @include inline-end(-0.65em);
         margin-inline-start: -$remove-button-diameter;
         width: $remove-button-diameter;
         height: $remove-button-diameter;
         top: -1.5em;
-        @include inline-end(-0.65em);
         background-color: $c-bg-popup;
         position: relative;
         border-radius: 50%;

--- a/ui/analyse/css/gamebook/_play.scss
+++ b/ui/analyse/css/gamebook/_play.scss
@@ -82,8 +82,6 @@
     }
 
     button {
-      @extend %button-none;
-
       text-align: start;
 
       &.hint {
@@ -116,7 +114,7 @@
   }
 
   .feedback {
-    @extend %flex-column, %box-radius, %button-none;
+    @extend %flex-column, %box-radius;
 
     flex: 1 1 100%;
     height: 8rem;
@@ -200,7 +198,7 @@
       font-size: 0.8em;
 
       button {
-        @extend %flex-column, %button-none;
+        @extend %flex-column;
 
         flex: 1 1 100%;
         background: $m-primary_bg--mix-80;

--- a/ui/analyse/css/study/_chapters.scss
+++ b/ui/analyse/css/study/_chapters.scss
@@ -16,7 +16,6 @@ $span-width: 1.7em;
 
   .study-list > button,
   > button {
-    @extend %button-none;
     width: 100%;
 
     &.active,

--- a/ui/analyse/css/study/_members.scss
+++ b/ui/analyse/css/study/_members.scss
@@ -2,8 +2,6 @@
   @extend %study-list;
 
   button {
-    @extend %button-none;
-
     width: 100%;
     text-align: start;
   }

--- a/ui/analyse/css/study/_search.scss
+++ b/ui/analyse/css/study/_search.scss
@@ -12,7 +12,6 @@
     margin-top: 1em;
     text-align: start;
     button {
-      @extend %button-none;
       width: 100%;
       padding: 0.5em 1em;
     }

--- a/ui/analyse/css/study/panel/_glyph.scss
+++ b/ui/analyse/css/study/panel/_glyph.scss
@@ -10,7 +10,7 @@
   }
 
   button {
-    @extend %flex-center-nowrap, %button-none;
+    @extend %flex-center-nowrap;
 
     height: 2.3em;
     line-height: 2.3em;

--- a/ui/analyse/css/study/relay/_tour.scss
+++ b/ui/analyse/css/study/relay/_tour.scss
@@ -25,7 +25,6 @@ $hover-bg: $m-primary_bg--mix-30;
       flex: 0 0 $player-height;
       button {
         @extend %flex-center-nowrap, %metal;
-        border: none;
         outline: none;
         &:hover {
           background: $hover-bg;

--- a/ui/bits/css/forum/_reactions.scss
+++ b/ui/bits/css/forum/_reactions.scss
@@ -8,8 +8,7 @@
   }
 
   button {
-    @extend %button-none, %flex-center;
-
+    @extend %flex-center;
     @include transition;
 
     padding: 0.3em 0.6em;

--- a/ui/botPlay/css/play/_table.scss
+++ b/ui/botPlay/css/play/_table.scss
@@ -89,9 +89,6 @@
 }
 .bot-game__actions {
   @extend %flex-between;
-  button {
-    @extend %button-none;
-  }
   .bot-game__close,
   .bot-game__restart {
     font-size: 0.9em;

--- a/ui/challenge/css/_challenge.scss
+++ b/ui/challenge/css/_challenge.scss
@@ -68,10 +68,9 @@
       padding: 0;
       background: transparent;
       font-size: 1.5rem;
+      box-shadow: none;
 
       @include transition;
-
-      box-shadow: none;
     }
 
     button,

--- a/ui/dasher/css/_board.scss
+++ b/ui/dasher/css/_board.scss
@@ -8,12 +8,10 @@
   }
 
   .list button {
+    @extend %flex-center;
+
     flex: 0 0 33%;
     height: 40px;
-
-    @extend %flex-center;
-    @extend %button-none;
-
     justify-content: center;
   }
 
@@ -39,7 +37,6 @@
   }
 
   .reset {
-    @extend %button-none;
     padding: 0.5rem 1rem;
     &:hover {
       color: $c-primary;

--- a/ui/dasher/css/_dasher.scss
+++ b/ui/dasher/css/_dasher.scss
@@ -41,8 +41,6 @@
   }
 
   .head {
-    @extend %button-none;
-
     display: block;
     padding: 1rem;
     border-bottom: $border;
@@ -67,8 +65,6 @@
       button {
         display: block;
         padding: 0.7rem 0.7rem 0.7rem 1rem;
-        border: none;
-        background: none;
         width: 100%;
         text-align: left;
 
@@ -106,8 +102,6 @@
     margin: 0.5rem 0;
 
     button {
-      @extend %button-none;
-
       display: block;
       padding: 0.7rem 1rem;
       width: 100%;

--- a/ui/dasher/css/_link.scss
+++ b/ui/dasher/css/_link.scss
@@ -8,7 +8,6 @@
   .links button,
   .subs .sub {
     @extend %nowrap-hidden;
-    @extend %button-none;
 
     display: block;
     padding: 0.5rem 1rem;
@@ -50,8 +49,6 @@
   .links button {
     width: 100%;
     text-align: start;
-    border: 0;
-    background: none;
   }
 
   .subs:not(:first-child) {

--- a/ui/dasher/css/_piece.scss
+++ b/ui/dasher/css/_piece.scss
@@ -21,8 +21,6 @@
     }
 
     .no-square {
-      @extend %button-none;
-
       width: 75px;
       height: 75px;
       position: relative;

--- a/ui/learn/css/_table.scss
+++ b/ui/learn/css/_table.scss
@@ -97,7 +97,6 @@
       font-weight: bold;
       text-transform: uppercase;
       background: #fff;
-      border: none;
       border-radius: 5px;
       padding: 5px 10px;
       box-shadow: 0 0 5px 5px rgba(255, 255, 255, 0.5);

--- a/ui/lib/css/abstract/_extends.scss
+++ b/ui/lib/css/abstract/_extends.scss
@@ -156,21 +156,13 @@
 }
 
 %button-raised-shadow {
-  box-shadow: 0 4px 10px 0px hsla(0, 0, 0, 0.225);
-}
-
-%button-none {
-  background: none;
-  border: none;
-  outline: none;
-  color: $c-font;
-  align-items: normal;
+  box-shadow: 0 4px 10px 0 hsla(0, 0, 0, 0.225);
 }
 
 %checkbox {
   @extend %box-radius;
 
-  -webkit-appearance: none;
+  appearance: none;
   background: $c-bg-page;
   border: 1px solid $c-bg-low;
   display: inline-block;

--- a/ui/lib/css/base/_elements.scss
+++ b/ui/lib/css/base/_elements.scss
@@ -49,7 +49,7 @@ button {
   appearance: none;
   background: none;
   border: none;
-  color: inherit;
+  color: $c-font;
 }
 
 p {

--- a/ui/lib/css/ceval/_ctrl.scss
+++ b/ui/lib/css/ceval/_ctrl.scss
@@ -67,7 +67,6 @@
   }
 
   .show-threat {
-    @extend %button-none;
     flex: 0 0 18px;
     color: $c-font-dim;
     font-size: 16px;
@@ -87,7 +86,6 @@
   }
 
   .settings-gear {
-    @extend %button-none;
     color: $c-font-dim;
     font-size: 16px;
     padding: 0 6px;

--- a/ui/lib/css/ceval/_settings.scss
+++ b/ui/lib/css/ceval/_settings.scss
@@ -53,7 +53,6 @@
     }
 
     button.delete {
-      @extend %button-none;
       width: 20px;
       height: 20px;
       border-radius: 100%;

--- a/ui/lib/css/component/_button.scss
+++ b/ui/lib/css/component/_button.scss
@@ -61,8 +61,6 @@
   }
 
   &-link {
-    @extend %button-none;
-
     color: $c-link;
 
     &:hover,

--- a/ui/lib/css/component/_fbt.scss
+++ b/ui/lib/css/component/_fbt.scss
@@ -1,6 +1,4 @@
 .fbt {
-  @extend %button-none;
-
   text-transform: uppercase;
   line-height: 1.5;
 

--- a/ui/lib/css/component/_tabs-horiz.scss
+++ b/ui/lib/css/component/_tabs-horiz.scss
@@ -20,8 +20,6 @@ $c-tabs-active: $c-accent !default;
     padding: 0.5em 0.2em;
     cursor: pointer;
     position: relative;
-    border: 0;
-    background: none;
     border-bottom: 2px solid transparent;
     min-width: 15%;
     letter-spacing: -0.5px;

--- a/ui/lib/css/form/_password.scss
+++ b/ui/lib/css/form/_password.scss
@@ -15,7 +15,6 @@
 }
 
 .password-reveal {
-  @extend %button-none;
   float: right;
   margin-right: 1em;
   margin-top: -2.2em;

--- a/ui/lib/css/form/_range.scss
+++ b/ui/lib/css/form/_range.scss
@@ -18,7 +18,7 @@
 }
 
 input.range {
-  -webkit-appearance: none;
+  appearance: none;
   background: none;
   border: 0;
 
@@ -33,7 +33,7 @@ input.range {
   &::-webkit-slider-thumb {
     @include range-thumb;
 
-    -webkit-appearance: none;
+    appearance: none;
   }
 
   &::-moz-range-track {

--- a/ui/lib/css/header/_buttons.scss
+++ b/ui/lib/css/header/_buttons.scss
@@ -36,10 +36,6 @@
     @extend %top-icon;
   }
 
-  button.toggle {
-    @extend %button-none;
-  }
-
   .initiating {
     @extend %flex-center;
 

--- a/ui/lib/css/vendor/_flatpickr.scss
+++ b/ui/lib/css/vendor/_flatpickr.scss
@@ -262,7 +262,7 @@
 .numInputWrapper input::-webkit-outer-spin-button,
 .numInputWrapper input::-webkit-inner-spin-button {
   margin: 0;
-  -webkit-appearance: none;
+  appearance: none;
 }
 .numInputWrapper span {
   position: absolute;

--- a/ui/lobby/css/_carousel.scss
+++ b/ui/lobby/css/_carousel.scss
@@ -26,7 +26,6 @@
     pointer-events: none;
 
     button {
-      @extend %button-none;
       padding: 0;
       font-size: 3em;
       pointer-events: auto;

--- a/ui/lobby/css/_setup.scss
+++ b/ui/lobby/css/_setup.scss
@@ -205,7 +205,7 @@ $c-slider: $c-setup;
         gap: 0.3rem;
 
         .preset-btn {
-          @extend %button-none, %box-radius;
+          @extend %box-radius;
           color: $c-font-dim;
           padding: 0.2rem 0.5rem;
           font-size: 0.9rem;

--- a/ui/mod/css/_mod-timeline.scss
+++ b/ui/mod/css/_mod-timeline.scss
@@ -71,9 +71,6 @@
 .mod-timeline__report-form--open .button {
   background: $c-bad;
 }
-.mod-timeline__report-form:not(.mod-timeline__report-form--open) .button {
-  @extend %button-none;
-}
 .mod-timeline__text {
   @extend %break-word-hard;
   font-size: 0.9em;

--- a/ui/opening/css/_panels.scss
+++ b/ui/opening/css/_panels.scss
@@ -5,7 +5,7 @@ $c-op-panels: $c-brag;
     gap: 1em;
     margin-bottom: 3em;
     &__tab {
-      @extend %button-none, %box-radius;
+      @extend %box-radius;
       color: $c-op-panels;
       @include mq-col-many {
         font-size: 1.3em;

--- a/ui/tournament/css/_side.scss
+++ b/ui/tournament/css/_side.scss
@@ -2,7 +2,6 @@
   @extend %flex-column;
 
   .disclosure {
-    @extend %button-none;
     position: absolute;
     right: 1em;
     bottom: 1em;

--- a/ui/voice/css/_voice.scss
+++ b/ui/voice/css/_voice.scss
@@ -21,7 +21,6 @@
   }
 
   > button {
-    @extend %button-none;
     color: $c-font-dim;
     font-size: 16px;
     padding: 0 6px;


### PR DESCRIPTION
# Why

In 6a8a0f516842e182aa4777c5a386f5dbe0ebf25d @ornicar added the global style reset for `button`, which made `%button-none` SCSS extension unnecessary.

# How

Remove `%button-none` extends, make sure that some styles are still applied when selector is shared with other element (i.e. `a`), clean up `background/border` manual reset for few buttons, switch color from `inherit` to `$c-font` to match previously expected styling.

# Preview

<img width="684" height="392" alt="Screenshot 2026-02-13 at 13 13 14" src="https://github.com/user-attachments/assets/8946dae6-545d-4836-9530-4545dfff66aa" />

<img width="588" height="290" alt="Screenshot 2026-02-13 at 13 19 43" src="https://github.com/user-attachments/assets/2cce49a0-e3aa-4c96-a9f0-bbc21a4a84fd" />

<img width="1222" height="150" alt="Screenshot 2026-02-13 at 13 21 31" src="https://github.com/user-attachments/assets/7c8d8709-91e1-430e-ae5c-12979966e18b" />
