### PR TITLE
ui: various select-related tweaks

### DIFF
--- a/ui/analyse/src/study/relay/relayTourView.ts
+++ b/ui/analyse/src/study/relay/relayTourView.ts
@@ -309,9 +309,6 @@ const tourSelect = (ctx: RelayViewContext, group: RelayGroup) => {
                   current: tour.id === relay.data.tour.id,
                 },
                 attrs: { href: study.embeddablePath(`/broadcast/-/${tour.id}`) },
-                on: {
-                  keydown: enter(target => target.click()),
-                },
               },
               [tour.name, tourStateIcon(tour, false)],
             ),

--- a/ui/lib/css/base/_form.scss
+++ b/ui/lib/css/base/_form.scss
@@ -35,6 +35,7 @@ textarea {
 }
 
 button,
+select:enabled,
 a {
   cursor: pointer;
 }
@@ -48,5 +49,5 @@ textarea:-webkit-autofill,
 select:-webkit-autofill {
   border: $border;
   -webkit-text-fill-color: $c-font;
-  -webkit-box-shadow: 0 0 0px 1000px $m-secondary_bg--mix-10 inset;
+  -webkit-box-shadow: 0 0 0 1000px $m-secondary_bg--mix-10 inset;
 }

--- a/ui/lib/css/component/_mselect.scss
+++ b/ui/lib/css/component/_mselect.scss
@@ -7,6 +7,7 @@ $c-mselect: $c-primary;
   &__toggle {
     position: absolute;
     z-index: -1;
+    opacity: 0;
   }
 
   &__label {

--- a/ui/puzzle/css/_side.scss
+++ b/ui/puzzle/css/_side.scss
@@ -116,10 +116,6 @@
       label {
         margin-inline-end: 1em;
       }
-
-      select {
-        border: none;
-      }
     }
 
     &__color {


### PR DESCRIPTION
# How

Various select-related tweaks for UI:
* make sure native select use correct cursor
* make sure that helper toggle checkbox for mselect is never visible (z-index was not always enough, fixes #19412)
* restore border for puzzle difficulty select
* remove no longer needed `keydown` in group tour select (after the recent fixed `a` is keyboard navigable, as it should)

# Preview

<img width="702" height="312" alt="Screenshot 2026-02-13 at 14 17 24" src="https://github.com/user-attachments/assets/efdc395f-b8c6-47b4-b134-60dc30735e85" />

<img width="762" height="262" alt="Screenshot 2026-02-13 at 14 22 40" src="https://github.com/user-attachments/assets/2129dae3-1c14-405f-b647-ffef02255319" />

https://github.com/user-attachments/assets/2df2fdc6-da89-44e8-9079-3661faa4edde