### PR TITLE
Fix Racing Kings practice mode defaulting to white

### DIFF
--- a/app/controllers/Round.scala
+++ b/app/controllers/Round.scala
@@ -140,7 +140,7 @@ final class Round(
   ): Fu[Result] =
     playablePovForReq(pov.game) match
       case Some(player) if userTv.isEmpty => renderPlayer(pov.withColor(player.color))
-      case _ if pov.game.variant == chess.variant.RacingKings && pov.color.black =>
+      case _ if pov.game.variant == chess.variant.RacingKings && pov.color.black && !pov.game.replayable =>
         if userTv.isDefined then watch(!pov, userTv)
         else Redirect(routes.Round.watcher(pov.gameId, Color.white))
       case _ =>


### PR DESCRIPTION
`bottomColor()` serves two purposes: board orientation and practice player color. The Racing Kings special case (added in #8976 to fix #8811) forces white-on-bottom, which is correct for the board but means practice mode always has you playing as white.

This gives practice mode its own `playerColor()` using the generic formula without the Racing Kings override. Board orientation stays correct, practice respects the actual player color, and flip-to-switch-sides still works.

Previous PRs (#19332, #19202, etc.) replaced `bottomColor()` with static values which broke the flip-to-switch-sides feature. This keeps it dynamic.

closes #14116

🤖 Generated with [Claude Code](https://claude.com/claude-code)