### PR TITLE
remove misleading "in lost positions" from sitting warning

### DIFF
--- a/modules/playban/src/main/PlaybanFeedback.scala
+++ b/modules/playban/src/main/PlaybanFeedback.scala
@@ -16,7 +16,7 @@ final private class PlaybanFeedback(
   def sitting(pov: Pov): Unit =
     tell(
       pov,
-      s"Reminder, {user}. Repeatedly letting time run out or delaying resignation in lost positions $tempBan"
+      s"Reminder, {user}. Repeatedly letting time run out $tempBan"
     )
 
   def quickResign(pov: Pov): Unit = tell(pov, s"Warning, {user}. Resigning games too quickly $tempBan")


### PR DESCRIPTION
the sitting detection is purely time-based — it doesn't evaluate the position at all. but the warning message says "in lost positions", which is often wrong. players get this while winning, equal, or genuinely thinking in complex endgames, and it feels like an accusation rather than a reminder.

this came up in #19320 and across at least 3 forum threads ([1](https://lichess.org/forum/lichess-feedback/can-we-stop-the-threatening-messages), [2](https://lichess.org/forum/lichess-feedback/wrong-and-obnixious--lichesss-message-warning--letting-the-time-fly-in-lost-position), [3](https://lichess.org/forum/lichess-feedback/warning-about-letting-the-time-pass-instead-of-resigning)) with 65+ combined replies. the [original 2018 commit](https://github.com/lichess-org/lila/commit/29d54bd) that added this feature just said "letting time run out instead of resigning" — the "lost positions" language was added later without any actual position evaluation backing it.

the fix just removes "or delaying resignation in lost positions" from the message. the warning still fires in the same situations, still warns the sitter, still reassures the opponent — just without the false claim about position evaluation.

before: `Reminder, {user}. Repeatedly letting time run out or delaying resignation in lost positions may lead to temporary playing restrictions.`

after: `Reminder, {user}. Repeatedly letting time run out may lead to temporary playing restrictions.`

closes #19390
refs #19320