### PR TITLE
Cancel stale premoves on game reload

### DIFF
--- a/ui/round/src/ctrl.ts
+++ b/ui/round/src/ctrl.ts
@@ -527,7 +527,8 @@ export default class RoundController implements MoveRootCtrl {
   }
 
   reload = (d: RoundData): void => {
-    if (d.steps.length !== this.data.steps.length) this.ply = d.steps[d.steps.length - 1].ply;
+    const posChanged = d.steps.length !== this.data.steps.length;
+    if (posChanged) this.ply = d.steps[d.steps.length - 1].ply;
     util.upgradeServerData(d);
     this.data = d;
     this.clearJust();
@@ -541,6 +542,7 @@ export default class RoundController implements MoveRootCtrl {
       });
     if (this.corresClock) this.corresClock.update(d.correspondence!.white, d.correspondence!.black);
     if (!this.replaying()) groundReload(this);
+    if (posChanged) this.chessground.cancelPremove();
     this.setTitle();
     this.moveOn.next();
     this.setQuietMode();


### PR DESCRIPTION
## Summary

- `ctrl.reload()` is called on socket reconnection, transient move expiry, and server-initiated reloads, but unlike `apiMove` (which calls `playPremove`), `jump`, and `takebackYes`, it did not clear premoves
- When the board position changes during a reload (e.g. opponent moved while disconnected), the old premove persisted via chessground's `deepMerge` preserving `premovable.current`, leaving an illegal ghost premove highlighted until manually cancelled
- Fix: add `this.chessground.cancelPremove()` in `ctrl.reload()` after `groundReload`, matching the existing pattern in `jump()` and `takebackYes()`

Related: #18586, #276
See also: https://lichess.org/forum/lichess-feedback/premove-bug