### PR TITLE
ui: fix `.fbt` anchors color

### DIFF
--- a/ui/lib/css/component/_fbt.scss
+++ b/ui/lib/css/component/_fbt.scss
@@ -1,4 +1,5 @@
 .fbt {
+  color: $c-font;
   text-transform: uppercase;
   line-height: 1.5;
 


### PR DESCRIPTION
# Why

Fixes https://github.com/lichess-org/lila/pull/19409#issuecomment-3902808592

# How

Overwrite default link color for `.fbt` buttons based on anchor.

# Preview

<img width="726" height="614" alt="Screenshot 2026-02-15 at 11 06 15" src="https://github.com/user-attachments/assets/4d080c7e-bc57-4d6b-9d62-a0dbe7453f71" />
