### PR TITLE
ui: match user profile side height with chart

### DIFF
--- a/ui/user/css/_profile.scss
+++ b/ui/user/css/_profile.scss
@@ -27,7 +27,7 @@
     @extend %flex-column;
 
     flex: 1 0 300px;
-    height: 332px;
+    height: 350px;
     border-inline-start: $border;
     overflow: hidden;
   }


### PR DESCRIPTION
# Why

Spotted that user profile side info panel has a bit of vertical spacing. Looks like it's height has been desynced with rating chart height at some point in time.

<img width="2174" height="936" alt="Screenshot 2026-02-15 at 11 20 34" src="https://github.com/user-attachments/assets/9de54efc-bdd5-4ec6-9947-84be7edf7310" />

# How

Match side panel height with the chart.

# Preview

<img width="2174" height="936" alt="Screenshot 2026-02-15 at 11 21 33" src="https://github.com/user-attachments/assets/5d7c1b55-54fc-40d8-8179-9f45c7b30304" />
