### PR TITLE
Remove commented-out dead code

### DIFF
--- a/ui/botDev/src/devAssets.ts
+++ b/ui/botDev/src/devAssets.ts
@@ -310,15 +310,6 @@ function blobArrayBuffer(file: Blob): Promise<ArrayBuffer> {
   });
 }
 
-// function blobString(file: Blob): Promise<string> {
-//   return new Promise((resolve, reject) => {
-//     const reader = new FileReader();
-//     reader.onload = () => resolve(reader.result as string);
-//     reader.onerror = reject;
-//     reader.readAsText(file);
-//   });
-// }
-
 function mimeOf(filename: string) {
   // go live with webp and mp3 only, but support more formats during dev work
   switch (filename.slice(filename.lastIndexOf('.') + 1).toLowerCase()) {

--- a/ui/dgt/src/play.ts
+++ b/ui/dgt/src/play.ts
@@ -457,15 +457,6 @@ export default function (token: string): void {
     //Determine new value for currentGameId. First create an array with only the started games
     //So then there is none or more than one started game
     const playableGames = playableGamesArray();
-    //If there is only one started game, then it's easy
-    /*
-    if (playableGames.length === 1) {
-      currentGameId = playableGames[0].gameId;
-      attachCurrentGameIdToDGTBoard(); //Let the board know which color the player is actually playing and setup the position
-      console.log('Active game updated. currentGameId: ' + currentGameId);
-    }
-    else
-    */
     if (playableGames.length === 0) {
       console.log(
         'No started playable games, challenges or games are disconnected. Please start a new game or fix connection.',
@@ -655,14 +646,10 @@ export default function (token: string): void {
       'Last Move': string;
     }> = [];
     const keys = Array.from(gameConnectionMap.keys());
-    //The for each iterator is not used since we don't want to continue execution. We want a synchronous result
-    //for (let [gameId, networkState] of gameConnectionMap) {
-    //    if (gameConnectionMap.get(gameId).connected && gameStateMap.get(gameId).status == "started") {
     for (let i = 0; i < keys.length; i++) {
       if (gameConnectionMap.get(keys[i])?.connected && gameStateMap.get(keys[i])?.status == 'started') {
         //Game is good for commands
         const gameInfo = gameInfoMap.get(keys[i]);
-        //var gameState = gameStateMap.get(keys[i]);
         const lastMove = getLastUCIMove(keys[i]);
         const versus =
           gameInfo.black.id == me.id
@@ -696,16 +683,7 @@ export default function (token: string): void {
       const gameInfo = gameInfoMap.get(gameId);
       const gameState = gameStateMap.get(gameId);
       const lastMove = getLastUCIMove(gameId);
-      console.log(''); //process.stdout.write("\n"); Changed to support browser
-      /* Log before migrating to browser
-      if (verbose) console.table({
-        'Title': { white: ((gameInfo.white.title) ? gameInfo.white.title : '@'), black: ((gameInfo.black.title) ? gameInfo.black.title : '@'), game: 'Id: ' + gameInfo.id },
-        'Username': { white: gameInfo.white.name, black: gameInfo.black.name, game: 'Status: ' + gameState.status },
-        'Rating': { white: gameInfo.white.rating, black: gameInfo.black.rating, game: gameInfo.variant.short + ' ' + (gameInfo.rated ? 'rated' : 'unrated') },
-        'Timer': { white: formattedTimer(gameState.wtime), black: formattedTimer(gameState.btime), game: gameInfo.speed + ' ' + ((gameInfo.clock) ? (String(gameInfo.clock.initial / 60000) + "'+" + String(gameInfo.clock.increment / 1000) + "''") : '∞') },
-        'Last Move': { white: (lastMove.player == 'white' ? lastMove.move : '?'), black: (lastMove.player == 'black' ? lastMove.move : '?'), game: lastMove.player },
-      });
-      */
+      console.log('');
       const innerTable =
         `<table class="dgt-table"><tr><th> - </th><th>Title</th><th>Username</th><th>Rating</th><th>Timer</th><th>Last Move</th><th>gameId: ${gameInfo.id}</th></tr>` +
         `<tr><td>White</td><td>${gameInfo.white.title ? gameInfo.white.title : '@'}</td><td>${
@@ -1260,16 +1238,6 @@ export default function (token: string): void {
     }
     return false;
   }
-
-  /*
-  function opponent(): { color: string, id: string, name: string } {
-    //"white":{"id":"godking666","name":"Godking666","title":null,"rating":1761},"black":{"id":"andrescavallin","name":"andrescavallin","title":null
-    if (gameInfoMap.get(currentGameId).white.id == me.id)
-      return { color: 'black', id: gameInfoMap.get(currentGameId).black.id, name: gameInfoMap.get(currentGameId).black.name };
-    else
-      return { color: 'white', id: gameInfoMap.get(currentGameId).white.id, name: gameInfoMap.get(currentGameId).white.name };
-  }
-  */
 
   function start() {
     console.log('');

--- a/ui/serviceWorker/src/serviceWorker.ts
+++ b/ui/serviceWorker/src/serviceWorker.ts
@@ -1,7 +1,6 @@
 const sw = self as unknown as ServiceWorkerGlobalScope;
 const searchParams = new URL(sw.location.href).searchParams;
 const assetBase = new URL(searchParams.get('asset-url')!, sw.location.href).href;
-//let hasLocalCache = caches.has('local');
 
 function assetUrl(path: string): string {
   return `${assetBase}assets/${path}`;
@@ -63,90 +62,3 @@ async function handleNotificationClick(e: NotificationEvent) {
 }
 
 sw.addEventListener('notificationclick', (e: NotificationEvent) => e.waitUntil(handleNotificationClick(e)));
-
-// experimental stuff below
-
-// sw.addEventListener('message', async (e: ExtendableMessageEvent) => {
-//   if (e.data && e.data.type !== 'cache') return;
-//   if (e.data.value) {
-//     const cache = await caches.open('local');
-//     hasLocalCache = Promise.resolve(true);
-//     await cacheLocalAssets(cache);
-//   } else {
-//     await caches.delete('local');
-//     hasLocalCache = Promise.resolve(false);
-//   }
-// });
-
-// sw.addEventListener('fetch', (e: FetchEvent) => {
-//   if (e.request.method !== 'GET') return;
-//   const path = new URL(e.request.url).pathname.match(
-//     /^\/local(?:[/?#]?.*)?$|^\/assets\/lifat\/bots\/.+$|\/assets\/npm\/zerofish.+$/,
-//   )?.[0];
-//   if (!path) return;
-//   e.respondWith(hasLocalCache.then(haz => (haz ? fetchLocalCache(e, path) : fetch(e.request))));
-// });
-
-// async function fetchLocalCache(e: FetchEvent, path: string): Promise<Response> {
-//   const cache = await caches.open('local');
-
-//   try {
-//     if (!sw.navigator.onLine) throw new Response('offline', { status: 503 });
-//     if (path.startsWith('/assets')) {
-//       const rsp = await cache.match(e.request);
-//       if (rsp) return rsp;
-//     }
-//     const netRsp = await fetch(e.request);
-//     if (netRsp.status >= 300 && netRsp.status < 400) {
-//       const redirectUrl = netRsp.headers.get('Location');
-//       if (redirectUrl) return await fetch(redirectUrl);
-//     }
-//     //
-//     if (!netRsp.ok) throw netRsp;
-
-//     cache.put(e.request, netRsp.clone());
-//     cacheLocalAssets(cache);
-
-//     return netRsp;
-//   } catch (err) {
-//     console.log('serving cached content', err);
-
-//     return (
-//       (await caches.match(e.request)) ??
-//       (err instanceof Response ? err : new Response('bad', { status: 500 }))
-//     );
-//   }
-// }
-
-// async function cacheLocalAssets(cache: Cache): Promise<void[]> {
-//   const promises: Promise<void>[] = [];
-//   const assetPaths: string[] = [];
-//   const assets: Record<string, string[]> = await fetch('/bots/assets').then(res => res.json());
-
-//   console.log('caching assets');
-//   for (const [type, list] of Object.entries(assets)) {
-//     for (const key of list) {
-//       assetPaths.push(
-//         ...(type === 'book'
-//           ? [`data/bot/book/${key}.bin`, `lifat/bots/book/${key}.png`]
-//           : [`data/bot/${type}/${key}`]),
-//       );
-//     }
-//   }
-
-//   for (const path of assetPaths) {
-//     const assetRequest = new Request(assetUrl(path));
-//     const cachedAsset = await cache.match(assetRequest);
-
-//     if (cachedAsset) continue;
-//     promises.push(
-//       fetch(assetRequest).then(assetRsp => {
-//         if (assetRsp.ok) {
-//           return cache.put(assetRequest, assetRsp.clone());
-//         }
-//       }),
-//     );
-//   }
-
-//   return Promise.all(promises);
-// }


### PR DESCRIPTION
## Summary

Removes commented-out dead code from three frontend modules. Each block was investigated via git history to confirm it's genuinely dead.

### serviceWorker (`-88 lines`)

Experimental cache/fetch handlers for bot local asset caching. **History:** actively developed by schlawg (Jonathan Gamble) from Aug–Sep 2024 (`69a2151a`, `b6fe6513`), then deliberately commented out by him on Mar 30, 2025 in `8031ae67` ("refactor before moving base bot code to lib"). The orphaned `hasLocalCache` variable on line 4 was only referenced by this commented code.

### botDev/devAssets (`-9 lines`)

A `blobString` helper (FileReader → string). **History:** was already commented out when the file was first created in `8e3f2791` (Mar 30, 2025, same refactor as above). Never used — the codebase uses `blobArrayBuffer` instead.

### dgt/play (`-34 lines`)

Four blocks from original DGT board development (2020, Juan Cavallin):
- `opponent()` function — commented out since initial commit, never called
- `console.table` block (lines 700–708) — superseded by the HTML table rendering directly below it
- `if (playableGames.length === 1)` block — replaced by the current board-position-matching logic
- Stale commented-out loop syntax and unused variable assignment