### PR TITLE
ui: allow focusing Home lobby tabs by keyboard

### DIFF
--- a/ui/lobby/src/ctrl.ts
+++ b/ui/lobby/src/ctrl.ts
@@ -213,6 +213,7 @@ export default class LobbyController {
         this.data.hooks = [];
       }
       this.tab = this.stores.tab.set(tab);
+      this.redraw();
     }
     this.filter.open = false;
   };

--- a/ui/lobby/src/lobby.ts
+++ b/ui/lobby/src/lobby.ts
@@ -62,7 +62,6 @@ export function initModule(opts: LobbyOpts) {
       },
     );
     lobbyCtrl.setTab('real_time');
-    lobbyCtrl.redraw();
     history.replaceState(null, '', '/');
   });
 

--- a/ui/lobby/src/view/tabs.ts
+++ b/ui/lobby/src/view/tabs.ts
@@ -5,11 +5,11 @@ import type { Tab } from '../interfaces';
 
 function tab(ctrl: LobbyController, key: Tab, active: Tab, content: MaybeVNodes) {
   return h(
-    'span',
+    'button',
     {
       attrs: { role: 'tab' },
       class: { active: key === active, glowing: key !== active && key === 'pools' && !!ctrl.poolMember },
-      hook: bind('mousedown', _ => ctrl.setTab(key), ctrl.redraw),
+      hook: bind('click', _ => ctrl.setTab(key)),
     },
     content,
   );


### PR DESCRIPTION
# Why

Improve keyboard nav on the Home page, follow up to the previous PR.

# How

Convert lobby tabs to buttons, move redraw to controller `setTab` function.

# Preview


https://github.com/user-attachments/assets/ed67479e-dbec-45a2-8498-7778147dbe09
