### PR TITLE
ui: tweak tournament streamers link appearance

### DIFF
--- a/ui/lib/css/component/_context-streamer.scss
+++ b/ui/lib/css/component/_context-streamer.scss
@@ -4,19 +4,20 @@
 }
 
 .context-streamer {
-  @extend %nowrap-hidden, %box-radius-bottom, %box-shadow, %flex-center-nowrap;
+  @extend %nowrap-hidden, %box-radius, %flex-center-nowrap;
+  @include transition;
 
   height: 2em;
   padding-inline-start: 0.2em;
   background: $c-bg-box;
   color: $c-font-dim;
+  margin-top: 2px;
+
   strong {
     color: $c-brag;
     font-weight: normal;
     padding-inline-end: 0.7ch;
   }
-
-  @include transition;
 
   &::before {
     font-size: 1.3em;
@@ -24,6 +25,7 @@
   }
 
   &:hover {
-    color: $c-brag;
+    color: $c-font-dim;
+    background: $c-bg-zebra;
   }
 }


### PR DESCRIPTION
# Why

On one of live tournament I have spotted that streamer links have a bit unusal appearance and hover effect is not that visible at the first glance.

<img width="748" height="266" alt="Screenshot 2026-02-16 at 19 31 15" src="https://github.com/user-attachments/assets/da94915c-0f82-4707-b841-5b96441cde91" />
<img width="748" height="266" alt="Screenshot 2026-02-16 at 19 37 09" src="https://github.com/user-attachments/assets/566627ea-b396-4f14-bb33-eff9381f9ddc" />

# How

Separate links visually to their own boxes, remove shadow, improve hover style.

# Preview

<img width="748" height="266" alt="Screenshot 2026-02-16 at 19 31 45" src="https://github.com/user-attachments/assets/17ba7a02-cf25-4cb0-91a0-5f4c983de7e1" />
<img width="732" height="274" alt="Screenshot 2026-02-16 at 19 42 42" src="https://github.com/user-attachments/assets/e51f1f5e-0adf-4f3e-a205-918bbf3f9a12" />

