### PR TITLE
ui: remove padding from team name in tournament

### DIFF
--- a/ui/tournament/css/_team-battle.scss
+++ b/ui/tournament/css/_team-battle.scss
@@ -12,7 +12,6 @@ $team-colors: (
 );
 
 team {
-  padding: 1px 5px;
   font-size: 0.8em;
   font-weight: bold;
   color: $c-brag;


### PR DESCRIPTION
# Why

Spotted that team names are a bit misaligned on the tournament page.

<img width="3042" height="2160" alt="Screenshot 2026-02-16 at 19 45 55" src="https://github.com/user-attachments/assets/94540305-365c-4dfd-8b06-a8232e12c8f1" />

# How

Remove padding on the team name. I did not find a an UI where it might be a problem, please let me know if I miss any!

# Preview

<img width="3042" height="2160" alt="Screenshot 2026-02-16 at 19 46 10" src="https://github.com/user-attachments/assets/bdacc739-c44f-4636-a6dc-1b1ee3dc39e1" />
