### PR TITLE
Don't reposition lists in dialogs

### DIFF
--- a/ui/lib/css/component/_mselect.scss
+++ b/ui/lib/css/component/_mselect.scss
@@ -68,6 +68,12 @@ $c-mselect: $c-primary;
         position: fixed;
         top: 50%;
         transform: translateY(-50%) scale(1, 1);
+
+        dialog & {
+          position: absolute;
+          top: 0;
+          transform: scale(1, 1);
+        }
       }
 
       * {

--- a/ui/lobby/css/_setup.scss
+++ b/ui/lobby/css/_setup.scss
@@ -44,7 +44,6 @@ $c-slider: $c-setup;
     }
 
     .mselect__list {
-      transform: none;
       opacity: 1;
       visibility: visible;
     }


### PR DESCRIPTION
Dialogs are already centered

https://lichess.org/forum/lichess-feedback/it-is-not-possible-to-play-atomic-chess-with-a-computer

Fixes inadvertent change caused by https://github.com/lichess-org/lila/pull/19369