### PR TITLE
ui: fix recap touchpad skipping pages

### DIFF
--- a/ui/recap/src/swiper.ts
+++ b/ui/recap/src/swiper.ts
@@ -33,7 +33,7 @@ export const makeSwiper =
       keyboard: { enabled: true },
       mousewheel: {
         thresholdDelta: 50,
-        thresholdTime: 800,
+        thresholdTime: 750,
       },
       pagination: {
         el: '.swiper-pagination',


### PR DESCRIPTION
# Before
A single touchpad swipe would skip through multiple pages.
https://github.com/user-attachments/assets/47245baf-8de0-4799-ae74-31e2ab0320ec

# After
Now a single swipe only skips one page at a time.
https://github.com/user-attachments/assets/e9d4946d-b7aa-4a70-84eb-9413ac853876

This fixes #18905
