### PR TITLE
ui: update and align chart.js versions, fix type issues

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -217,8 +217,8 @@ importers:
         specifier: workspace:*
         version: link:../bits
       chart.js:
-        specifier: 4.4.3
-        version: 4.4.3
+        specifier: 4.5.1
+        version: 4.5.1
       editor:
         specifier: workspace:*
         version: link:../editor
@@ -250,17 +250,17 @@ importers:
   ui/chart:
     dependencies:
       chart.js:
-        specifier: 4.4.8
-        version: 4.4.8
+        specifier: 4.5.1
+        version: 4.5.1
       chartjs-adapter-dayjs-4:
         specifier: ^1.0.4
-        version: 1.0.4(chart.js@4.4.8)(dayjs@1.11.19)
+        version: 1.0.4(chart.js@4.5.1)(dayjs@1.11.19)
       chartjs-plugin-datalabels:
         specifier: ^2.2.0
-        version: 2.2.0(chart.js@4.4.8)
+        version: 2.2.0(chart.js@4.5.1)
       chartjs-plugin-zoom:
         specifier: ^2.2.0
-        version: 2.2.0(chart.js@4.4.8)
+        version: 2.2.0(chart.js@4.5.1)
       dayjs:
         specifier: ^1.11.19
         version: 1.11.19
@@ -342,11 +342,11 @@ importers:
         specifier: workspace:^
         version: link:../chart
       chart.js:
-        specifier: 4.4.8
-        version: 4.4.8
+        specifier: 4.5.1
+        version: 4.5.1
       chartjs-plugin-datalabels:
         specifier: ^2.2.0
-        version: 2.2.0(chart.js@4.4.8)
+        version: 2.2.0(chart.js@4.5.1)
       lib:
         specifier: workspace:*
         version: link:../lib
@@ -456,11 +456,11 @@ importers:
         specifier: ^3.1.9
         version: 3.1.9
       chart.js:
-        specifier: 4.4.8
-        version: 4.4.8
+        specifier: 4.5.1
+        version: 4.5.1
       chartjs-adapter-dayjs-4:
         specifier: ^1.0.4
-        version: 1.0.4(chart.js@4.4.8)(dayjs@1.11.19)
+        version: 1.0.4(chart.js@4.5.1)(dayjs@1.11.19)
       dayjs:
         specifier: ^1.11.19
         version: 1.11.19
@@ -477,8 +477,8 @@ importers:
         specifier: ^0.3.1
         version: 0.3.1
       chart.js:
-        specifier: 4.4.8
-        version: 4.4.8
+        specifier: 4.5.1
+        version: 4.5.1
       keyboardMove:
         specifier: workspace:*
         version: link:../keyboardMove
@@ -1196,14 +1196,6 @@ packages:
 
   canvas-confetti@1.9.4:
     resolution: {integrity: sha512-yxQbJkAVrFXWNbTUjPqjF7G+g6pDotOUHGbkZq2NELZUMDpiJ85rIEazVb8GTaAptNW2miJAXbs1BtioA251Pw==}
-
-  chart.js@4.4.3:
-    resolution: {integrity: sha512-qK1gkGSRYcJzqrrzdR6a+I0vQ4/R+SoODXyAjscQ/4mzuNzySaMCd+hyVxitSY1+L2fjPD1Gbn+ibNqRmwQeLw==}
-    engines: {pnpm: '>=8'}
-
-  chart.js@4.4.8:
-    resolution: {integrity: sha512-IkGZlVpXP+83QpMm4uxEiGqSI7jFizwVtF3+n5Pc3k7sMO+tkd0qxh2OzLhenM0K80xtmAONWGBn082EiBQSDA==}
-    engines: {pnpm: '>=8'}
 
   chart.js@4.5.1:
     resolution: {integrity: sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==}
@@ -2751,36 +2743,23 @@ snapshots:
 
   canvas-confetti@1.9.4: {}
 
-  chart.js@4.4.3:
-    dependencies:
-      '@kurkle/color': 0.3.4
-
-  chart.js@4.4.8:
-    dependencies:
-      '@kurkle/color': 0.3.4
-
   chart.js@4.5.1:
     dependencies:
       '@kurkle/color': 0.3.4
-
-  chartjs-adapter-dayjs-4@1.0.4(chart.js@4.4.8)(dayjs@1.11.19):
-    dependencies:
-      chart.js: 4.4.8
-      dayjs: 1.11.19
 
   chartjs-adapter-dayjs-4@1.0.4(chart.js@4.5.1)(dayjs@1.11.19):
     dependencies:
       chart.js: 4.5.1
       dayjs: 1.11.19
 
-  chartjs-plugin-datalabels@2.2.0(chart.js@4.4.8):
+  chartjs-plugin-datalabels@2.2.0(chart.js@4.5.1):
     dependencies:
-      chart.js: 4.4.8
+      chart.js: 4.5.1
 
-  chartjs-plugin-zoom@2.2.0(chart.js@4.4.8):
+  chartjs-plugin-zoom@2.2.0(chart.js@4.5.1):
     dependencies:
       '@types/hammerjs': 2.0.46
-      chart.js: 4.4.8
+      chart.js: 4.5.1
       hammerjs: 2.0.8
 
   cheerio-select@2.1.0:

--- a/ui/botDev/package.json
+++ b/ui/botDev/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@lichess-org/zerofish": "^0.0.40",
     "bits": "workspace:*",
-    "chart.js": "4.4.3",
+    "chart.js": "4.5.1",
     "editor": "workspace:*",
     "fast-diff": "^1.3.0",
     "json-stringify-pretty-compact": "4.0.0",

--- a/ui/chart/package.json
+++ b/ui/chart/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "chart.js": "4.4.8",
+    "chart.js": "4.5.1",
     "chartjs-adapter-dayjs-4": "^1.0.4",
     "chartjs-plugin-datalabels": "^2.2.0",
     "chartjs-plugin-zoom": "^2.2.0",

--- a/ui/chart/src/chart.relayStats.ts
+++ b/ui/chart/src/chart.relayStats.ts
@@ -190,7 +190,7 @@ const makeChart = ($el: Cash, data: RoundStats) => {
           caretPadding: 5,
           usePointStyle: true,
           callbacks: {
-            title: items => (items.length ? dateFormat()(items[0].parsed.x) : ''),
+            title: items => (items.length && items[0].parsed.x ? dateFormat()(items[0].parsed.x) : ''),
           },
         },
         title: {
@@ -226,10 +226,11 @@ const fillData = (viewers: RoundStats['viewers']) => {
     .slice(0, viewers.length - 2)
     .reverse()
     .forEach(([behind, v]) => {
-      const minuteGap = points.find(({ x }) => x - behind <= 60);
-      if (!minuteGap) {
-        for (let i = behind; i < points[points.length - 1].x; i += 60) points.push({ x: i, y: v });
+      const minuteGap = points.find(({ x }) => x && x - behind <= 60);
+      const lastDate = points[points.length - 1].x;
+      if (!minuteGap && lastDate) {
+        for (let i = behind; i < lastDate; i += 60) points.push({ x: i, y: v });
       } else points.push({ x: behind, y: v });
     });
-  return points.map(p => ({ x: p.x * 1000, y: p.y })).reverse();
+  return points.map(p => ({ x: p.x ? p.x * 1000 : null, y: p.y })).reverse();
 };

--- a/ui/chart/src/division.ts
+++ b/ui/chart/src/division.ts
@@ -35,7 +35,7 @@ export default function (div?: Division): ChartDataset<'line'>[] {
       offset: -5,
       align: 45,
       rotation: 90,
-      formatter: (val: Point) => (val.y > 0 ? line.div : ''),
+      formatter: (val: Point) => (val.y && val.y > 0 ? line.div : ''),
     },
   }));
 }

--- a/ui/chart/src/movetime.ts
+++ b/ui/chart/src/movetime.ts
@@ -192,7 +192,9 @@ export default async function (
           displayColors: false,
           callbacks: {
             title: items =>
-              labels[items[0].dataset.label === 'bar' ? items[0].parsed.x * 2 : items[0].parsed.x],
+              items[0].parsed.x
+                ? labels[items[0].dataset.label === 'bar' ? items[0].parsed.x * 2 : items[0].parsed.x]
+                : '',
             label: () => '',
           },
         },

--- a/ui/insight/package.json
+++ b/ui/insight/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "dependencies": {
     "chart": "workspace:^",
-    "chart.js": "4.4.8",
+    "chart.js": "4.5.1",
     "chartjs-plugin-datalabels": "^2.2.0",
     "lib": "workspace:*"
   },

--- a/ui/opening/package.json
+++ b/ui/opening/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "dependencies": {
     "@types/debounce-promise": "^3.1.9",
-    "chart.js": "4.4.8",
+    "chart.js": "4.5.1",
     "chartjs-adapter-dayjs-4": "^1.0.4",
     "dayjs": "^1.11.19",
     "debounce-promise": "^3.1.2",

--- a/ui/puzzle/package.json
+++ b/ui/puzzle/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "dependencies": {
     "@badrap/result": "^0.3.1",
-    "chart.js": "4.4.8",
+    "chart.js": "4.5.1",
     "lib": "workspace:*",
     "keyboardMove": "workspace:*",
     "voice": "workspace:*"


### PR DESCRIPTION
# Why

Spotted that not all modules use the same `chart.js` version. Let's update it and align.

# How

Update `chart.js` across workspace, fix newly reported type issues.

> [!note]
> I have also spotted that broadcast relay page does not show "Stats" tab, but spectators over time chart is accessible by switching hash to `#stats`, i.e.: https://lichess.org/broadcast/hungarian-superleague-202526/round-4/bkrLOOie#stats. Is it intended?

# Preview

<img width="1680" height="602" alt="Screenshot 2026-02-18 at 14 50 20" src="https://github.com/user-attachments/assets/40ae1c96-b826-422a-975a-4df18d6f77a9" />

