### PR TITLE
ui: use shared shuffle from lib/algo instead of local duplicate

### DIFF
--- a/ui/tournament/src/view/battle.ts
+++ b/ui/tournament/src/view/battle.ts
@@ -1,4 +1,5 @@
 import type TournamentController from '../ctrl';
+import { shuffle } from 'lib/algo';
 import { bind, type MaybeVNode, snabDialog } from 'lib/view';
 import { fullName, userFlair } from 'lib/view/userLink';
 import { h, type VNode } from 'snabbdom';
@@ -40,7 +41,7 @@ export function joinWithTeamSelector(ctrl: TournamentController) {
               h('p', i18n.arena.youMustJoinOneOfTheseTeamsToParticipate),
               h(
                 'ul',
-                shuffleArray(Object.keys(tb.teams)).map((id: string) =>
+                shuffle(Object.keys(tb.teams)).map((id: string) =>
                   h('li', h('a', { attrs: { href: '/team/' + id } }, renderTeamArray(tb.teams[id]))),
                 ),
               ),
@@ -136,13 +137,4 @@ function teamTr(ctrl: TournamentController, battle: TeamBattle, team: RankedTeam
       h('td.total', [h('strong', '' + team.score)]),
     ],
   );
-}
-
-/* Randomize array element order in-place. Using Durstenfeld shuffle algorithm. */
-function shuffleArray<A>(array: A[]) {
-  for (let i = array.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    [array[i], array[j]] = [array[j], array[i]];
-  }
-  return array;
 }


### PR DESCRIPTION
## Why

`battle.ts` has a local `shuffleArray` function that duplicates `shuffle` from `lib/algo`. Both are Fisher-Yates/Durstenfeld shuffles. The shared version is slightly safer as it copies the array first (`.slice()`) rather than mutating in-place.

## How

Import `shuffle` from `lib/algo`, replace the call, delete the local 8-line duplicate.
