### PR TITLE
ui: extract shared redirectFirst into lib/view/pagination

### DIFF
--- a/ui/lib/src/view/pagination.ts
+++ b/ui/lib/src/view/pagination.ts
@@ -1,5 +1,6 @@
 import { h, type VNode } from 'snabbdom';
 import * as licon from '../licon';
+import { storage } from '../storage';
 import { bind, type MaybeVNodes } from './snabbdom';
 
 export const maxPerPage = 10;
@@ -101,4 +102,16 @@ export function pagerData<A>(ctrl: PaginatedCtrl<A>): PagerData<A> {
 
 export function myPage(ctrl: PaginatedCtrl<unknown>): number | undefined {
   return ctrl.data.me ? Math.floor((ctrl.data.me.rank - 1) / 10) + 1 : undefined;
+}
+
+const lastRedirectStorage = storage.make('last-redirect');
+
+export function redirectFirst(gameId: string, rightNow?: boolean): void {
+  const delay = rightNow || document.hasFocus() ? 10 : 1000 + Math.random() * 500;
+  setTimeout(() => {
+    if (lastRedirectStorage.get() !== gameId) {
+      lastRedirectStorage.set(gameId);
+      site.redirect('/' + gameId, true);
+    }
+  }, delay);
 }

--- a/ui/swiss/src/ctrl.ts
+++ b/ui/swiss/src/ctrl.ts
@@ -2,8 +2,7 @@ import { makeSocket, type SwissSocket } from './socket';
 import xhr from './xhr';
 import { throttlePromiseDelay } from 'lib/async';
 import type { SwissData, SwissOpts, Pages, Standing, Player } from './interfaces';
-import { storage } from 'lib/storage';
-import { maxPerPage, myPage, pagerData } from 'lib/view/pagination';
+import { maxPerPage, myPage, pagerData, redirectFirst } from 'lib/view/pagination';
 
 export default class SwissCtrl {
   data: SwissData;
@@ -16,8 +15,6 @@ export default class SwissCtrl {
   playerInfoId?: string;
   disableClicks = true;
   searching = false;
-
-  private lastStorage = storage.make('last-redirect');
 
   constructor(
     readonly opts: SwissOpts,
@@ -58,18 +55,8 @@ export default class SwissCtrl {
 
   private redirectToMyGame() {
     const gameId = this.myGameId();
-    if (gameId) this.redirectFirst(gameId);
+    if (gameId) redirectFirst(gameId);
   }
-
-  redirectFirst = (gameId: string, rightNow?: boolean) => {
-    const delay = rightNow || document.hasFocus() ? 10 : 1000 + Math.random() * 500;
-    setTimeout(() => {
-      if (this.lastStorage.get() !== gameId) {
-        this.lastStorage.set(gameId);
-        site.redirect('/' + gameId, true);
-      }
-    }, delay);
-  };
 
   scrollToMe = () => this.setPage(myPage(this));
 

--- a/ui/swiss/src/socket.ts
+++ b/ui/swiss/src/socket.ts
@@ -1,4 +1,5 @@
 import type SwissCtrl from './ctrl';
+import { redirectFirst } from 'lib/view/pagination';
 
 export interface SwissSocket {
   send: SocketSend;
@@ -13,7 +14,7 @@ export function makeSocket(send: SocketSend, ctrl: SwissCtrl) {
       else ctrl.askReload();
     },
     redirect(fullId: string) {
-      ctrl.redirectFirst(fullId.slice(0, 8), true);
+      redirectFirst(fullId.slice(0, 8), true);
       return true;
     },
   };

--- a/ui/tournament/src/ctrl.ts
+++ b/ui/tournament/src/ctrl.ts
@@ -10,11 +10,11 @@ import type {
   Standing,
   Player,
 } from './interfaces';
-import { storage, storedMapAsProp } from 'lib/storage';
+import { storedMapAsProp } from 'lib/storage';
 import { pubsub } from 'lib/pubsub';
 import { alerts, prompt } from 'lib/view';
 import type { Prop } from 'lib';
-import { maxPerPage, myPage, pagerData } from 'lib/view/pagination';
+import { maxPerPage, myPage, pagerData, redirectFirst } from 'lib/view/pagination';
 
 interface CtrlTeamInfo {
   requested?: string;
@@ -38,8 +38,6 @@ export default class TournamentController {
   redraw: () => void;
   nbWatchers = 0;
   collapsedDescription: Prop<boolean>;
-
-  private lastStorage = storage.make('last-redirect');
 
   constructor(opts: TournamentOpts, redraw: () => void) {
     this.opts = opts;
@@ -106,18 +104,8 @@ export default class TournamentController {
 
   private redirectToMyGame() {
     const gameId = this.myGameId();
-    if (gameId) this.redirectFirst(gameId);
+    if (gameId) redirectFirst(gameId);
   }
-
-  redirectFirst = (gameId: string, rightNow?: boolean) => {
-    const delay = rightNow || document.hasFocus() ? 10 : 1000 + Math.random() * 500;
-    setTimeout(() => {
-      if (this.lastStorage.get() !== gameId) {
-        this.lastStorage.set(gameId);
-        site.redirect('/' + gameId, true);
-      }
-    }, delay);
-  };
 
   pager = () => pagerData(this);
 

--- a/ui/tournament/src/socket.ts
+++ b/ui/tournament/src/socket.ts
@@ -1,4 +1,5 @@
 import type TournamentController from './ctrl';
+import { redirectFirst } from 'lib/view/pagination';
 
 export interface TournamentSocket {
   send: SocketSend;
@@ -9,7 +10,7 @@ export function makeSocket(send: SocketSend, ctrl: TournamentController) {
   const handlers = {
     reload: ctrl.askReload,
     redirect(fullId: string) {
-      ctrl.redirectFirst(fullId.slice(0, 8), true);
+      redirectFirst(fullId.slice(0, 8), true);
       return true; // prevent default redirect
     },
   };


### PR DESCRIPTION
## Why

`tournament/ctrl.ts` and `swiss/ctrl.ts` both implement an identical `redirectFirst` method with a `lastStorage` field for debouncing game redirects.

## How

Move `redirectFirst` and `lastRedirectStorage` into `lib/view/pagination.ts`. Update both ctrl and socket files to use the shared function.

## Testing

- Tournament and swiss pages load correctly on localhost
- `redirectFirst` is event-driven (fires on live game pairing via WebSocket), import wiring verified via page load