### PR TITLE
ui: convert close buttons from a to button for keyboard accessibility

### DIFF
--- a/ui/swiss/src/view/playerInfo.ts
+++ b/ui/swiss/src/view/playerInfo.ts
@@ -20,7 +20,7 @@ export default function (ctrl: SwissCtrl): VNode | undefined {
     ? Math.round(data.sheet.reduce((r, p) => r + (!isOutcome(p) ? p.rating : 1), 0) / games)
     : undefined;
   return hl(tag, { hook: { insert: setup, postpatch: (_, vnode) => setup(vnode) } }, [
-    hl('a.close', {
+    hl('button.close', {
       attrs: dataIcon(licon.X),
       hook: bind('click', () => ctrl.showPlayerInfo(data), ctrl.redraw),
     }),

--- a/ui/tournament/src/view/playerInfo.ts
+++ b/ui/tournament/src/view/playerInfo.ts
@@ -34,7 +34,7 @@ export default function (ctrl: TournamentController): VNode {
       ? Math.round(data.pairings.reduce((a, b) => a + b.op.rating, 0) / pairingsLen)
       : undefined;
   return hl(tag, { hook: { insert: setup, postpatch: (_, vnode) => setup(vnode) } }, [
-    hl('a.close', {
+    hl('button.close', {
       attrs: dataIcon(licon.X),
       hook: bind('click', () => ctrl.showPlayerInfo(data.player), ctrl.redraw),
     }),

--- a/ui/tournament/src/view/teamInfo.ts
+++ b/ui/tournament/src/view/teamInfo.ts
@@ -20,7 +20,7 @@ export default function (ctrl: TournamentController): VNode | undefined {
     site.powertip.manualUserIn(vnode.elm as HTMLElement);
   };
   return h(tag, { hook: { insert: setup, postpatch: (_, vnode) => setup(vnode) } }, [
-    h('a.close', {
+    h('button.close', {
       attrs: dataIcon(licon.X),
       hook: bind('click', () => ctrl.showTeamInfo(data.id), ctrl.redraw),
     }),


### PR DESCRIPTION
## Why

Close buttons in tournament player info, tournament team info, and swiss player info panels use `<a>` tags without `href`. These are not focusable or activatable via keyboard by default. `<button>` is the semantically correct element for interactive controls.

## How

Change `a.close` to `button.close` in `tournament/playerInfo.ts`, `tournament/teamInfo.ts`, and `swiss/playerInfo.ts`.

## Testing

- Opened tournament, clicked player to open info panel
- Verified close element is `<button>` via DOM query: `Tag: <button>, focusable: true`
- Clicked close button — panel dismissed correctly