### PR TITLE
ui: avoid querying the same DOM element multiple times

### DIFF
--- a/ui/bits/src/bits.markdownTextarea.ts
+++ b/ui/bits/src/bits.markdownTextarea.ts
@@ -53,7 +53,7 @@ function wireMarkdownTextarea(markdown: HTMLElement) {
   });
   if (!markdown.dataset.imageUploadUrl) return;
 
-  markdown.querySelector<HTMLElement>('.upload-image')?.addEventListener('click', () => {
+  uploadBtn?.addEventListener('click', () => {
     const input = frag<HTMLInputElement>('<input type="file" accept="image/*" multiple />');
     input.onchange = () => {
       if (!input.files) return;

--- a/ui/bits/src/flairPicker.ts
+++ b/ui/bits/src/flairPicker.ts
@@ -30,7 +30,7 @@ export default async function flairPickerLoader(element: HTMLElement): Promise<v
     site.asset.loadCssPath('bits.flairPicker'),
     site.asset.loadEsm('bits.flairPicker', {
       init: {
-        element: element.querySelector('.flair-picker')!,
+        element: pickerEl,
         onEmojiSelect,
         close: (e: PointerEvent) => {
           if (!isOpen() || selectEl.contains(e.target as Node)) return;
@@ -53,6 +53,6 @@ export default async function flairPickerLoader(element: HTMLElement): Promise<v
   if (!CSS.supports('selector(:has(option))')) {
     // let old browsers set and remove flairs
     element.querySelector('img')!.style.display = 'block';
-    element.querySelector<HTMLElement>('.emoji-remove')!.style.display = 'block';
+    removeEl.style.display = 'block';
   }
 }

--- a/ui/botDev/src/editDialog.ts
+++ b/ui/botDev/src/editDialog.ts
@@ -154,12 +154,14 @@ export class EditDialog {
   }
 
   private async save() {
-    const behaviorScroll = this.view.querySelector('.behavior')!.scrollTop;
-    const filtersScroll = this.view.querySelector('.filters')!.scrollTop;
+    const behaviorEl = this.view.querySelector('.behavior')!;
+    const filtersEl = this.view.querySelector('.filters')!;
+    const behaviorScroll = behaviorEl.scrollTop;
+    const filtersScroll = filtersEl.scrollTop;
     await env.bot.storeBot(deadStrip(this.editing()));
     this.update();
-    this.view.querySelector('.behavior')!.scrollTop = behaviorScroll ?? 0;
-    this.view.querySelector('.filters')!.scrollTop = filtersScroll ?? 0;
+    behaviorEl.scrollTop = behaviorScroll ?? 0;
+    filtersEl.scrollTop = filtersScroll ?? 0;
   }
 
   private selectBot(uid: string | null = this.uid): void {


### PR DESCRIPTION
## Why

Several files call `querySelector` for elements that are already cached in local variables, resulting in unnecessary DOM lookups.

## How

Use already-cached variables instead of re-querying: `pickerEl`/`removeEl` in `flairPicker.ts`, cached `.behavior`/`.filters` in `editDialog.ts`, `uploadBtn` in `bits.markdownTextarea.ts`.

## Testing

- Opened `/account/profile`, verified flair picker elements (`.flair-picker` and `.emoji-remove`) found in DOM — cached selectors working