### PR TITLE
ui: game chat and underboard a11y

### DIFF
--- a/modules/analyse/src/main/ui/ReplayUi.scala
+++ b/modules/analyse/src/main/ui/ReplayUi.scala
@@ -113,7 +113,7 @@ final class ReplayUi(helpers: Helpers)(analyseUi: AnalyseUi):
                 div(cls := "analyse__underboard")(
                   div(role := "tablist", cls := "analyse__underboard__menu")(
                     analysable.option(
-                      span(
+                      button(
                         role := "tab",
                         cls := "computer-analysis",
                         dataPanel := "computer-analysis",
@@ -123,13 +123,13 @@ final class ReplayUi(helpers: Helpers)(analyseUi: AnalyseUi):
                     (!game.isPgnImport).option(
                       frag(
                         (game.ply > 1).option(
-                          span(role := "tab", dataPanel := "move-times", textAndTitle(trans.site.moveTimes))
+                          button(role := "tab", dataPanel := "move-times", textAndTitle(trans.site.moveTimes))
                         ),
                         crosstable.isDefined.option:
-                          span(role := "tab", dataPanel := "ctable", textAndTitle(trans.site.crosstable))
+                          button(role := "tab", dataPanel := "ctable", textAndTitle(trans.site.crosstable))
                       )
                     ),
-                    span(role := "tab", dataPanel := "fen-pgn", textAndTitle(trans.study.shareAndExport))
+                    button(role := "tab", dataPanel := "fen-pgn", textAndTitle(trans.study.shareAndExport))
                   ),
                   div(cls := "analyse__underboard__panels")(
                     analysable.option(

--- a/ui/analyse/css/_round-underboard.scss
+++ b/ui/analyse/css/_round-underboard.scss
@@ -15,7 +15,7 @@ $col2-panel-height: 240px;
     justify-content: center;
     align-items: flex-start;
 
-    > span {
+    > button {
       @extend %roboto, %box-radius-top, %page-text, %ellipsis;
 
       flex: 1 1 0;

--- a/ui/analyse/src/serverSideUnderboard.ts
+++ b/ui/analyse/src/serverSideUnderboard.ts
@@ -100,7 +100,7 @@ export default function (element: HTMLElement, ctrl: AnalyseCtrl) {
     if ((panel === 'computer-analysis' || ctrl.opts.hunter) && $('#acpl-chart-container').length)
       setTimeout(startAdvantageChart, 200);
   };
-  $menu.on('mousedown', 'span', function (this: HTMLElement) {
+  $menu.on('click', 'button', function (this: HTMLElement) {
     const panel = this.dataset.panel!;
     store.set(panel);
     setPanel(panel);

--- a/ui/analyse/src/study/studyView.ts
+++ b/ui/analyse/src/study/studyView.ts
@@ -217,12 +217,12 @@ interface ToolButtonOpts {
 
 function toolButton(opts: ToolButtonOpts): VNode {
   return hl(
-    'span.' + opts.tab,
+    'button.' + opts.tab,
     {
       attrs: { role: 'tab', title: opts.hint },
       class: { active: opts.tab === opts.ctrl.vm.toolTab() },
       hook: bind(
-        'mousedown',
+        'click',
         () => {
           if (opts.onClick) opts.onClick();
           opts.ctrl.vm.toolTab(opts.tab);

--- a/ui/bits/src/bits.voiceChat.ts
+++ b/ui/bits/src/bits.voiceChat.ts
@@ -195,7 +195,7 @@ export function initModule(opts: VoiceChatOpts): VoiceChat | undefined {
       const connections = allOpenConnections();
       return devices
         ? hl(
-            'div.mchat__tab.voicechat.data-count.voicechat-' + state,
+            'button.mchat__tab.voicechat.data-count.voicechat-' + state,
             {
               attrs: {
                 'data-icon': licon.Handset,

--- a/ui/lib/src/chat/renderChat.ts
+++ b/ui/lib/src/chat/renderChat.ts
@@ -22,7 +22,7 @@ function renderVoiceChat(ctrl: ChatCtrl) {
   if (!p.enabled()) return;
   return p.instance
     ? p.instance.render()
-    : hl('div.mchat__tab.voicechat.voicechat-slot', {
+    : hl('button.mchat__tab.voicechat.voicechat-slot', {
         attrs: { 'data-icon': licon.Handset, title: 'Voice chat' },
         hook: bind('click', () => {
           if (!p.loaded) {
@@ -60,7 +60,7 @@ function normalView(ctrl: ChatCtrl) {
 
 const renderTab = (ctrl: ChatCtrl, tab: Tab, active: Tab) =>
   hl(
-    'div.mchat__tab.' + tab.key,
+    'button.mchat__tab.' + tab.key,
     {
       attrs: { role: 'tab' },
       class: { 'mchat__tab-active': tab.key === active.key },


### PR DESCRIPTION
# Why

Spotted that not all interactive elements on the game replay page are focusable/accessible by keyboard.

# How

Convert `span`s and `div`s to buttons, update listeners to allow both mouse and keyboard interactions.

# Preview

https://github.com/user-attachments/assets/2bf43c82-de16-4c4b-b2df-3d27fd9575ee