### PR TITLE
Puzzle report: make the threshold for multiple solutions scale with t…

### DIFF
--- a/ui/puzzle/src/report.ts
+++ b/ui/puzzle/src/report.ts
@@ -9,7 +9,7 @@ import { plyToTurn, pieceCount } from 'lib/game/chess';
 import type { ClientEval, PvData, TreeNode } from 'lib/tree/types';
 
 // bump when logic is changed, to distinguish cached clients from new ones
-const version = 10;
+const version = 11;
 
 export default class Report {
   // if local eval suspect multiple solutions, report the puzzle, once at most
@@ -58,7 +58,7 @@ export default class Report {
       const [bestEval, secondBestEval] = [ev.pvs[0], ev.pvs[1]];
       // stricter than lichess-puzzler v49 check in how it defines similar moves
       if (
-        (ev.depth > 50 || ev.nodes > 25_000_000) &&
+        (ev.depth > 50 || ev.nodes > 25_000_000 * (ev.pvs.length - 1)) &&
         bestEval &&
         secondBestEval &&
         winningChances.hasMultipleSolutions(ctrl.pov, bestEval, secondBestEval)


### PR DESCRIPTION
…he number of PVs

To account for the fact that:
- SF 18 produces more nodes than SF17 for the same strength
- If the number of nodes is spread across more PVs, the analysis is shallower