### PR TITLE
ui: move redirectFirst to lib/tournament

### DIFF
--- a/ui/lib/src/tournament.ts
+++ b/ui/lib/src/tournament.ts
@@ -1,0 +1,13 @@
+import { storage } from './storage';
+
+const lastRedirectStorage = storage.make('last-redirect');
+
+export function redirectFirst(gameId: string, rightNow?: boolean): void {
+  const delay = rightNow || document.hasFocus() ? 10 : 1000 + Math.random() * 500;
+  setTimeout(() => {
+    if (lastRedirectStorage.get() !== gameId) {
+      lastRedirectStorage.set(gameId);
+      site.redirect('/' + gameId, true);
+    }
+  }, delay);
+}

--- a/ui/lib/src/view/pagination.ts
+++ b/ui/lib/src/view/pagination.ts
@@ -1,6 +1,5 @@
 import { h, type VNode } from 'snabbdom';
 import * as licon from '../licon';
-import { storage } from '../storage';
 import { bind, type MaybeVNodes } from './snabbdom';
 
 export const maxPerPage = 10;
@@ -102,16 +101,4 @@ export function pagerData<A>(ctrl: PaginatedCtrl<A>): PagerData<A> {
 
 export function myPage(ctrl: PaginatedCtrl<unknown>): number | undefined {
   return ctrl.data.me ? Math.floor((ctrl.data.me.rank - 1) / 10) + 1 : undefined;
-}
-
-const lastRedirectStorage = storage.make('last-redirect');
-
-export function redirectFirst(gameId: string, rightNow?: boolean): void {
-  const delay = rightNow || document.hasFocus() ? 10 : 1000 + Math.random() * 500;
-  setTimeout(() => {
-    if (lastRedirectStorage.get() !== gameId) {
-      lastRedirectStorage.set(gameId);
-      site.redirect('/' + gameId, true);
-    }
-  }, delay);
 }

--- a/ui/swiss/src/ctrl.ts
+++ b/ui/swiss/src/ctrl.ts
@@ -2,7 +2,8 @@ import { makeSocket, type SwissSocket } from './socket';
 import xhr from './xhr';
 import { throttlePromiseDelay } from 'lib/async';
 import type { SwissData, SwissOpts, Pages, Standing, Player } from './interfaces';
-import { maxPerPage, myPage, pagerData, redirectFirst } from 'lib/view/pagination';
+import { maxPerPage, myPage, pagerData } from 'lib/view/pagination';
+import { redirectFirst } from 'lib/tournament';
 
 export default class SwissCtrl {
   data: SwissData;

--- a/ui/swiss/src/socket.ts
+++ b/ui/swiss/src/socket.ts
@@ -1,5 +1,5 @@
 import type SwissCtrl from './ctrl';
-import { redirectFirst } from 'lib/view/pagination';
+import { redirectFirst } from 'lib/tournament';
 
 export interface SwissSocket {
   send: SocketSend;

--- a/ui/tournament/src/ctrl.ts
+++ b/ui/tournament/src/ctrl.ts
@@ -14,7 +14,8 @@ import { storedMapAsProp } from 'lib/storage';
 import { pubsub } from 'lib/pubsub';
 import { alerts, prompt } from 'lib/view';
 import type { Prop } from 'lib';
-import { maxPerPage, myPage, pagerData, redirectFirst } from 'lib/view/pagination';
+import { maxPerPage, myPage, pagerData } from 'lib/view/pagination';
+import { redirectFirst } from 'lib/tournament';
 
 interface CtrlTeamInfo {
   requested?: string;

--- a/ui/tournament/src/socket.ts
+++ b/ui/tournament/src/socket.ts
@@ -1,5 +1,5 @@
 import type TournamentController from './ctrl';
-import { redirectFirst } from 'lib/view/pagination';
+import { redirectFirst } from 'lib/tournament';
 
 export interface TournamentSocket {
   send: SocketSend;


### PR DESCRIPTION
Move `redirectFirst` from `lib/view/pagination` to `lib/tournament` per ornicar's review on #19512.