### PR TITLE
Voice Chat display in Broadcasts and document title update

### DIFF
--- a/ui/analyse/src/study/studyCtrl.ts
+++ b/ui/analyse/src/study/studyCtrl.ts
@@ -361,7 +361,7 @@ export default class StudyCtrl {
     this.data.description = s.description;
     this.chapterDesc.set(this.data.chapter.description);
     this.studyDesc.set(this.data.description);
-    document.title = this.data.name;
+    document.title = this.relay?.fullRoundName() ?? this.data.name;
     this.members.dict(s.members);
     if (s.chapters) this.chapters.loadFromServer(s.chapters);
     this.ctrl.flipped = this.chapterFlipMapProp(this.data.chapter.id);


### PR DESCRIPTION
Enhance the Broadcast feature by ensuring Voice Chat visibility aligns with existing functionality. Update the document title to reflect the full round name when available, addressing issues related to board switching and title changes.

Fixes #14322 and and small thing about #14668