### PR TITLE
simplify `storedProp` helper

### DIFF
--- a/ui/analyse/src/explorer/explorerConfig.ts
+++ b/ui/analyse/src/explorer/explorerConfig.ts
@@ -67,12 +67,7 @@ export class ExplorerConfigCtrl {
     const prevData = previous?.data;
     this.data = {
       open: prevData?.open || prop(false),
-      db: storedProp<ExplorerDb>(
-        'explorer.db2.' + variant,
-        this.allDbs[0],
-        str => str as ExplorerDb,
-        v => v,
-      ),
+      db: storedProp<ExplorerDb>('explorer.db2.' + variant, this.allDbs[0], str => str as ExplorerDb),
       rating: storedJsonProp('analyse.explorer.rating', () => allRatings.slice(1)),
       speed: storedJsonProp<ExplorerSpeed[]>('explorer.speed', () => allSpeeds.slice(1)),
       mode: storedJsonProp<ExplorerMode[]>('explorer.mode', () => allModes),

--- a/ui/analyse/src/study/chapterNewForm.ts
+++ b/ui/analyse/src/study/chapterNewForm.ts
@@ -42,12 +42,7 @@ export class StudyChapterNewForm {
     if (!val) this.dialog?.close();
   });
   initial = toggle(false);
-  tab = storedProp<ChapterTab>(
-    'analyse.study.form.tab',
-    'init',
-    str => str as ChapterTab,
-    v => v,
-  );
+  tab = storedProp<ChapterTab>('analyse.study.form.tab', 'init', str => str as ChapterTab);
   editor: LichessEditor | null = null;
   editorFen: Prop<FEN | null> = prop(null);
   isDefaultName = toggle(true);

--- a/ui/analyse/src/treeView/treeView.ts
+++ b/ui/analyse/src/treeView/treeView.ts
@@ -16,11 +16,8 @@ export class TreeView {
   private autoScrollRequest: 'instant' | 'smooth' | false = false;
 
   hidden = true;
-  modePreference = storedProp<'column' | 'inline'>(
-    'treeView',
-    'column',
-    str => (str === 'column' ? 'column' : 'inline'),
-    v => v,
+  modePreference = storedProp<'column' | 'inline'>('treeView', 'column', str =>
+    str === 'column' ? 'column' : 'inline',
   );
   mode: 'column' | 'inline';
 

--- a/ui/coordinateTrainer/src/ctrl.ts
+++ b/ui/coordinateTrainer/src/ctrl.ts
@@ -92,12 +92,7 @@ export default class CoordinateTrainerCtrl {
   }
 
   colorChoice: Prop<ColorChoice> = withEffect<ColorChoice>(
-    storedProp<ColorChoice>(
-      'coordinateTrainer.colorChoice',
-      'random',
-      str => str as ColorChoice,
-      v => v,
-    ),
+    storedProp<ColorChoice>('coordinateTrainer.colorChoice', 'random', str => str as ColorChoice),
     () => this.setOrientationFromColorChoice(),
   );
 
@@ -114,7 +109,6 @@ export default class CoordinateTrainerCtrl {
       'coordinateTrainer.mode',
       window.location.hash === '#name' ? 'nameSquare' : 'findSquare',
       str => str as Mode,
-      v => v,
     ),
     () => this.onModeChange(),
   );
@@ -148,7 +142,6 @@ export default class CoordinateTrainerCtrl {
       'coordinateTrainer.timeControl',
       document.body.classList.contains('kid') ? 'untimed' : 'thirtySeconds',
       str => str as TimeControl,
-      v => v,
     ),
     this.redraw,
   );
@@ -192,7 +185,6 @@ export default class CoordinateTrainerCtrl {
       'coordinateTrainer.coordinateInputMethod',
       window.innerWidth >= 980 ? 'text' : 'buttons',
       str => str as InputMethod,
-      v => v,
     ),
     this.redraw,
   );

--- a/ui/lib/src/storage.ts
+++ b/ui/lib/src/storage.ts
@@ -13,7 +13,12 @@ export function storedProp<V>(
   key: string,
   defaultValue: V,
   fromStr: (str: string) => V,
-  toStr: (v: V) => string,
+  toStr: (v: V) => string = (v: V) => {
+    if (v && typeof v.toString === 'function') {
+      return v.toString();
+    }
+    throw new Error(`storedProp: value ${typeof v} has no toString method, provide a custom stringifier`);
+  },
 ): StoredProp<V> {
   const compatKey = 'analyse.' + key;
   let cached: V;
@@ -35,20 +40,10 @@ export function storedProp<V>(
 }
 
 export const storedStringProp = (k: string, defaultValue: string): StoredProp<string> =>
-  storedProp<string>(
-    k,
-    defaultValue,
-    str => str,
-    v => v,
-  );
+  storedProp<string>(k, defaultValue, str => str);
 
 export const storedBooleanProp = (k: string, defaultValue: boolean): StoredProp<boolean> =>
-  storedProp<boolean>(
-    k,
-    defaultValue,
-    str => str === 'true',
-    v => v.toString(),
-  );
+  storedProp<boolean>(k, defaultValue, str => str === 'true');
 
 export const storedStringPropWithEffect = (
   k: string,
@@ -63,12 +58,7 @@ export const storedBooleanPropWithEffect = (
 ): Prop<boolean> => withEffect(storedBooleanProp(k, defaultValue), effect);
 
 export const storedIntProp = (k: string, defaultValue: number): StoredProp<number> =>
-  storedProp<number>(
-    k,
-    defaultValue,
-    str => Number(str),
-    v => v + '',
-  );
+  storedProp<number>(k, defaultValue, str => Number(str));
 
 export const storedIntPropWithEffect = (
   k: string,


### PR DESCRIPTION
# Why

We can avoid requiring stringify parameter for most of the use-cases of `storedProp`.

# How

Add default stringifier to `storedProp`, throw when default `toString` does not exist, correct usages.