### PR TITLE
ui: various types tweaks

### DIFF
--- a/ui/@types/lichess/chessground.d.ts
+++ b/ui/@types/lichess/chessground.d.ts
@@ -1,6 +1,6 @@
-import { Api } from '../../../node_modules/@lichess-org/chessground/dist/api';
-import { Config } from '../../../node_modules/@lichess-org/chessground/dist/config';
-import * as cg from '../../../node_modules/@lichess-org/chessground/dist/types';
+import { Api } from '@lichess-org/chessground/api';
+import { Config } from '@lichess-org/chessground/config';
+import * as cg from '@lichess-org/chessground/types';
 
 declare global {
   type CgApi = Api;

--- a/ui/analyse/src/crazy/crazyView.ts
+++ b/ui/analyse/src/crazy/crazyView.ts
@@ -1,10 +1,9 @@
 import { drag } from './crazyCtrl';
 import { h } from 'snabbdom';
-import type { MouchEvent } from '@lichess-org/chessground/types';
 import { onInsert } from 'lib/view';
 import type AnalyseCtrl from '../ctrl';
 
-const eventNames = ['mousedown', 'touchstart'];
+const eventNames = ['mousedown', 'touchstart'] as const;
 const oKeys = ['pawn', 'knight', 'bishop', 'rook', 'queen'] as const;
 
 type Position = 'top' | 'bottom';
@@ -23,7 +22,7 @@ export default function (ctrl: AnalyseCtrl, color: Color, position: Position) {
       class: { usable },
       hook: onInsert(el => {
         eventNames.forEach(name => {
-          el.addEventListener(name, e => drag(ctrl, color, e as MouchEvent));
+          el.addEventListener(name, e => drag(ctrl, color, e));
         });
       }),
     },

--- a/ui/analyse/src/study/topics.ts
+++ b/ui/analyse/src/study/topics.ts
@@ -66,7 +66,7 @@ export const formView = (ctrl: TopicsCtrl, userId?: string): VNode =>
     ],
     onInsert: dlg => {
       dlg.show();
-      (dlg.view.querySelector('.tagify__input') as HTMLElement)?.focus();
+      dlg.view.querySelector<HTMLElement>('.tagify__input')?.focus();
     },
   });
 

--- a/ui/analyse/src/treeView/treeView.ts
+++ b/ui/analyse/src/treeView/treeView.ts
@@ -13,7 +13,7 @@ import type { TreePath } from 'lib/tree/types';
 
 export class TreeView {
   constructor(readonly ctrl: AnalyseCtrl) {}
-  private autoScrollRequest: 'instant' | 'smooth' | false = false;
+  private autoScrollRequest: ScrollBehavior | false = false;
 
   hidden = true;
   modePreference = storedProp<'column' | 'inline'>(
@@ -33,7 +33,7 @@ export class TreeView {
     return this.mode === 'column' ? renderColumnView(this.ctrl, concealOf) : renderInlineView(this.ctrl);
   }
 
-  requestAutoScroll(request: 'instant' | 'smooth' | false) {
+  requestAutoScroll(request: ScrollBehavior | false) {
     this.autoScrollRequest = request;
   }
 
@@ -82,7 +82,7 @@ function eventPath(e: MouseEvent): TreePath | null {
   );
 }
 
-const autoScroll = throttle(200, (behavior: 'instant' | 'smooth' = 'instant') => {
+const autoScroll = throttle(200, (behavior: ScrollBehavior = 'instant') => {
   const scrollView = document.querySelector<HTMLElement>('.analyse__moves')!;
   const moveEl = scrollView.querySelector<HTMLElement>('.active');
   if (!moveEl) return scrollView.scrollTo({ top: 0, behavior });

--- a/ui/analyse/src/view/nvuiView.ts
+++ b/ui/analyse/src/view/nvuiView.ts
@@ -166,11 +166,12 @@ export function renderNvui(ctx: AnalyseNvuiContext): VNode {
               });
             });
             root.find('.copy-fen').on('click', function (this: HTMLElement) {
-              const inputFen = document.querySelector('.analyse__underboard__fen input') as HTMLInputElement;
-              const fen = inputFen.value;
-              navigator.clipboard.writeText(fen).then(() => {
-                notify.set(i18n.nvui.copiedToClipboard('FEN'));
-              });
+              const fen = document.querySelector<HTMLInputElement>('.analyse__underboard__fen input')?.value;
+              if (fen) {
+                navigator.clipboard.writeText(fen).then(() => {
+                  notify.set(i18n.nvui.copiedToClipboard('FEN'));
+                });
+              }
             });
           },
         },
@@ -346,7 +347,7 @@ function onSubmit(ctx: AnalyseNvuiContext, $input: Cash) {
     if (command && !command.invalid?.(ctrl)) command.cb(ctx, input);
     else {
       const move = inputToMove(input, ctrl.node.fen, ctrl.chessground);
-      const isDrop = (u: undefined | string | DropMove) => !!(u && typeof u !== 'string');
+      const isDrop = (u?: string | DropMove) => !!(u && typeof u !== 'string');
       const isInvalidDrop = (d: DropMove) =>
         !ctrl.crazyValid(d.role, d.key) || ctrl.chessground.state.pieces.has(d.key);
       const isInvalidCrazy = isDrop(move) && isInvalidDrop(move);

--- a/ui/bits/src/bits.coachForm.ts
+++ b/ui/bits/src/bits.coachForm.ts
@@ -91,7 +91,7 @@ site.load.then(() => {
     $editor.find('div.status').removeClass('saved');
   });
   const submit = debounce(() => {
-    const form = document.querySelector('form.async') as HTMLFormElement;
+    const form = document.querySelector<HTMLFormElement>('form.async');
     if (!form) return;
     xhr.formToXhr(form).then(() => {
       $editor.find('div.status').addClass('saved');

--- a/ui/bits/src/bits.confetti.ts
+++ b/ui/bits/src/bits.confetti.ts
@@ -15,7 +15,8 @@ export function initModule(
     fireworks: true,
   },
 ): void {
-  const canvas = document.querySelector('canvas#confetti') as HTMLCanvasElement;
+  const canvas = document.querySelector<HTMLCanvasElement>('canvas#confetti');
+  if (!canvas) return;
 
   const party = confetti.create(canvas, {
     disableForReducedMotion: true,

--- a/ui/bits/src/bits.gameSearch.ts
+++ b/ui/bits/src/bits.gameSearch.ts
@@ -1,7 +1,7 @@
 import { pubsub } from 'lib/pubsub';
 
 site.load.then(() => {
-  const form = document.querySelector('.search__form') as HTMLFormElement,
+  const form = document.querySelector<HTMLFormElement>('.search__form'),
     $form = $(form),
     $usernames = $form.find('.usernames input'),
     $userRows = $form.find('.user-row'),
@@ -65,8 +65,8 @@ site.load.then(() => {
 
   function serialize() {
     const params = new URLSearchParams();
-    for (const [k, v] of new FormData(form).entries()) {
-      if (v != '') params.set(k, v as string);
+    for (const [k, v] of new FormData(form ?? undefined).entries()) {
+      if (v != '') params.set(k, v.toString());
     }
     return params.toString();
   }

--- a/ui/bits/src/bits.ts
+++ b/ui/bits/src/bits.ts
@@ -63,7 +63,7 @@ function appeal() {
 }
 
 function autoForm({ selector, ops }: { selector: string; ops: string }) {
-  const el = document.querySelector(selector) as HTMLElement;
+  const el = document.querySelector<HTMLElement>(selector);
   const oplist = ops.split(' ');
   if (!el || oplist.length === 0) return;
   if (oplist.includes('focus')) el.focus();

--- a/ui/botPlay/src/play/view/autoScroll.ts
+++ b/ui/botPlay/src/play/view/autoScroll.ts
@@ -10,7 +10,7 @@ export const autoScroll = throttle(100, (movesEl: HTMLElement, ctrl: PlayCtrl) =
     if (ctrl.board.onPly < 3) st = 0;
     else if (ctrl.isOnLastPly()) st = scrollMax;
     else {
-      const plyEl = movesEl.querySelector('.current') as HTMLElement | undefined;
+      const plyEl = movesEl.querySelector<HTMLElement>('.current');
       if (plyEl)
         st =
           displayColumns() === 1

--- a/ui/mod/src/checkBoxes.ts
+++ b/ui/mod/src/checkBoxes.ts
@@ -23,7 +23,7 @@ export const expandCheckboxZone = (table: HTMLTableElement, tdSelector: string, 
   $(table).on('click', tdSelector, (e: MouseEvent) => {
     if ((e.target as HTMLElement).tagName === 'INPUT') onSelect(e.target as HTMLInputElement, e.shiftKey);
     else {
-      const input = (e.target as HTMLTableElement).querySelector('input') as HTMLInputElement | undefined;
+      const input = (e.target as HTMLTableElement).querySelector<HTMLInputElement>('input');
       if (input && !input.disabled) {
         input.checked = !input.checked;
         onSelect(input, e.shiftKey);

--- a/ui/puzzle/src/puzzle.opening.ts
+++ b/ui/puzzle/src/puzzle.opening.ts
@@ -1,7 +1,7 @@
 import { initMiniBoardWith } from 'lib/view';
 
 site.load.then(() => {
-  const rootEl = document.querySelector('.puzzle-openings') as HTMLElement | undefined;
+  const rootEl = document.querySelector<HTMLElement>('.puzzle-openings');
   if (rootEl && !('ontouchstart' in window)) loadBoardTips(rootEl);
 });
 

--- a/ui/round/src/view/replay.ts
+++ b/ui/round/src/view/replay.ts
@@ -34,7 +34,7 @@ const autoScroll = throttle(100, (movesEl: HTMLElement, ctrl: RoundController) =
     if (ctrl.ply < 3) st = 0;
     else if (ctrl.ply === util.lastPly(ctrl.data)) st = scrollMax;
     else {
-      const plyEl = movesEl.querySelector('.a1t') as HTMLElement | undefined;
+      const plyEl = movesEl.querySelector<HTMLElement>('.a1t');
       if (plyEl)
         st =
           displayColumns() === 1


### PR DESCRIPTION
# Why

Various types tweaks for issues spotted while working on previous PRs.

# How

Replace `*Element | undefined` cast with generic which yields `*Element | null`, replace few elements non-nullable cast where non existing value has already been handled in the flow anyway, switch to `ScrollBehaviour` type from manually typed `scrollTo` mode, plus few other small type-related changes.