### PR TITLE
Simplify `blurIfPrimaryClick` by using `document.activeElement`.

### DIFF
--- a/ui/analyse/src/study/studyChapters.ts
+++ b/ui/analyse/src/study/studyChapters.ts
@@ -185,7 +185,7 @@ export function view(ctrl: StudyCtrl): VNode {
                 const chapter = ctrl.chapters.list.get(id);
                 if (chapter) ctrl.chapters.editForm.toggle(chapter);
               } else ctrl.setChapter(id);
-              blurIfPrimaryClick(e, target.closest('button'));
+              blurIfPrimaryClick(e);
             });
             vnode.data!.li = {};
             ctrl.chapters.scroller.request('instant');

--- a/ui/lib/src/common.ts
+++ b/ui/lib/src/common.ts
@@ -163,9 +163,8 @@ export function repeater(f: () => void, additionalStopCond?: () => boolean): voi
 }
 
 // Prevents the clicked element from acquiring focus on primary mouse clicks.
-export function blurIfPrimaryClick(e: Event, el?: EventTarget | null): void {
-  if (e instanceof MouseEvent && e.detail !== 0 && e.button === 0) {
-    const target = el ?? e.currentTarget;
-    if (target instanceof HTMLElement) requestAnimationFrame(() => target.blur());
-  }
+export function blurIfPrimaryClick(e: Event): void {
+  const target = document.activeElement;
+  if (target instanceof HTMLElement && e instanceof MouseEvent && e.detail !== 0 && e.button === 0)
+    requestAnimationFrame(() => target.blur());
 }


### PR DESCRIPTION
Thx @Simek. This makes things simpler since now callers don't have to figure out what to pass (if anything) for `el`.