### PR TITLE
ui: use default text size in board control menu

### DIFF
--- a/ui/lib/css/chess/_control.scss
+++ b/ui/lib/css/chess/_control.scss
@@ -3,7 +3,6 @@
   display: flex;
   justify-content: space-between;
   align-items: stretch;
-  font-size: 1.3rem;
 
   .fbt {
     @extend %box-radius-bottom;
@@ -17,6 +16,7 @@
   }
 
   .jumps {
+    font-size: 1.3rem;
     display: flex;
     padding: 4px;
 


### PR DESCRIPTION
# Why

Spotted that text and switches looked different in puzzles game menu than for example in game menu in analysis or during broadcast. This does not look intended, but might be.

<img width="784" height="990" alt="Screenshot 2026-02-21 at 11 00 25" src="https://github.com/user-attachments/assets/f16bde5e-9b9c-4efe-802c-8afaa08d9c9f" />

# How

Move the font size enlargement only to the `jumps` section, make sure that menu content matches the default after the change.

# Preview

<img width="844" height="796" alt="Screenshot 2026-02-21 at 10 52 43" src="https://github.com/user-attachments/assets/0aa6ea26-c49e-488a-9b92-956a2dcdeaf5" />
