### PR TITLE
ui: align advanced search form appearance

### DIFF
--- a/ui/bits/css/_search.scss
+++ b/ui/bits/css/_search.scss
@@ -12,9 +12,14 @@
 
     select,
     input[type='text'],
-    input[type='number'] {
+    input[type='number'],
+    input[type='date'] {
       padding: 0.3em 1em;
       width: 100%;
+    }
+
+    input[type='date'] {
+      padding-right: 0.3em;
     }
 
     #dl-button {
@@ -58,6 +63,7 @@
     span.help {
       color: $c-secondary;
       text-decoration: underline $c-secondary;
+      cursor: help;
     }
 
     .error {

--- a/ui/user/css/_search.scss
+++ b/ui/user/css/_search.scss
@@ -28,14 +28,15 @@
       text-align: right;
     }
 
-    .date td {
-      padding: 0.1em 0;
-    }
-
     input[type='text'],
+    input[type='date'],
     select {
       padding: 0.3em 1em;
       width: 100%;
+    }
+
+    input[type='date'] {
+      padding-right: 0.3em;
     }
 
     label {
@@ -45,6 +46,12 @@
 
     .action {
       text-align: right;
+    }
+
+    span.help {
+      color: $c-secondary;
+      text-decoration: underline $c-secondary;
+      cursor: help;
     }
   }
 

--- a/ui/user/css/build/user.show.search.scss
+++ b/ui/user/css/build/user.show.search.scss
@@ -1,3 +1,4 @@
 @import '../../../lib/css/plugin';
+@import '../../../lib/css/form/check';
 @import '../../../lib/css/form/cmn-toggle';
 @import '../search';


### PR DESCRIPTION
# Why

Spotted that search UI in user profile differs from main games search UI.

<img width="2160" height="1184" alt="Screenshot 2026-02-21 at 12 46 01" src="https://github.com/user-attachments/assets/52065f33-127f-4a7d-8df0-e1b27203549e" />

# How

Align advanced search form appearance between search view and user profile search, attach missing checkbox styles, tweaks for date input.

# Preview

<img width="2160" height="1202" alt="Screenshot 2026-02-21 at 12 37 18" src="https://github.com/user-attachments/assets/20865bf1-35e6-4dc8-a326-10fea62feea0" />

<img width="2102" height="1520" alt="Screenshot 2026-02-21 at 12 36 07" src="https://github.com/user-attachments/assets/d3829394-b422-459a-b99c-991ba45ddba1" />
