### PR TITLE
avoid redundant calculations

### DIFF
--- a/ui/chart/src/chart.lag.ts
+++ b/ui/chart/src/chart.lag.ts
@@ -83,11 +83,11 @@ export async function initModule(): Promise<void> {
             ctx.rotate(Math.PI * (dest + 1.5));
             ctx.beginPath();
             ctx.fillStyle = '#838382';
-            ctx.moveTo(10, 0);
+            ctx.moveTo(-10, 0);
             ctx.lineWidth = 1;
             ctx.lineTo(0, -outer);
             ctx.lineTo(10, 0);
-            ctx.lineTo(10, 0);
+            ctx.lineTo(-10, 0);
             ctx.fill();
 
             ctx.beginPath();


### PR DESCRIPTION
# Why

* https://github.com/lichess-org/lila/commit/88c8e9eac94f7b2dd98d50aae170f293c6dd4529#r177829734

# How

Avoid redundant calculations when plotting chart needle.