### PR TITLE
When DOM updates, have the 'c' shortcut still work to focus chat

### DIFF
--- a/ui/lib/src/chat/discussion.ts
+++ b/ui/lib/src/chat/discussion.ts
@@ -178,7 +178,7 @@ const setupHooks = (ctrl: ChatCtrl, chatEl: HTMLInputElement) => {
 
   site.mousetrap.bind(
     'c',
-    () => (document.querySelector('input.mchat__say') as HTMLElement)?.focus(),
+    () => document.querySelector<HTMLInputElement>('input.mchat__say')?.focus(),
     undefined,
     false,
   );


### PR DESCRIPTION
To reproduce bug:
- Open a study and do something to reload the chat DOM (such as toggling it off and back on).
- You'll find that the 'c' shortcut no longer works.

The reason for this is that the `site.mousetrap.bind` call will not rebind the new `chatEl`, due to the `multiple` param being false. So, we need to give it a callback that will work for the DOM in its current state and after any updates. Having it use `document.querySelector('input.mchat__say')` allows the callback to find the current `chatEl`.

Also updated a line in `mousetrap.ts` that reads clearer imo (non-functional).