### PR TITLE
ui: fix boxes compositing context in picture background mode

### DIFF
--- a/ui/lib/css/component/_box.scss
+++ b/ui/lib/css/component/_box.scss
@@ -3,7 +3,6 @@ $vp-max-width: 1200px;
 
 .box {
   @extend %box-shadow;
-  @include backdrop-blur-if-transparent;
 
   background: $c-bg-box;
 
@@ -38,6 +37,11 @@ $vp-max-width: 1200px;
 
   &__pad {
     @extend %box-padding-horiz;
+  }
+
+  @include if-transp {
+    position: relative;
+    @include back-blur;
   }
 }
 


### PR DESCRIPTION
# Why

Fixes #19573

* #19573

# How

Do not apply backdrop filter directly to the box element, rather create pseudo element children with a backdrop blur to avoid affecting global compositing context, since it will mess up elements positioned by `z-index` which are added earlier in the DOM.

# Preview

<img width="2804" height="1816" alt="Screenshot 2026-02-22 at 23 20 39" src="https://github.com/user-attachments/assets/dd29d57e-2410-4924-af1d-6ab7efa62a9a" />

