### PR TITLE
ui: fix game view overflow on very small mobile devices

### DIFF
--- a/ui/round/css/_control.scss
+++ b/ui/round/css/_control.scss
@@ -165,6 +165,10 @@
       display: block;
       margin-inline-start: 2em;
     }
+
+    @media (width <= $xxx-small) {
+      margin-inline-start: 0;
+    }
   }
 
   .rematch {


### PR DESCRIPTION
# Why

Fixes #19509

* #19509

# How

The overflow culprit was `rcontrols` bar which have a quite big margin set for some icons to better separate sections and with those margins in page started to overflow around `336px` viewport view. 

By removing the margins on very narrow devices (xxx-small - 400px) we can ensure that view properly shrinks down without overflow to width around `288px`, which should be sufficient for almost all mobile devices. 

# Preview

https://github.com/user-attachments/assets/2b0b861e-bf62-4bb2-acc0-8af8f3129323

