### PR TITLE
ui: prevent stretching of player tip photo

### DIFF
--- a/ui/analyse/css/study/relay/_player-tip.scss
+++ b/ui/analyse/css/study/relay/_player-tip.scss
@@ -20,6 +20,7 @@
     gap: 1em;
     .fide-players__photo {
       width: 150px;
+      height: fit-content;
     }
     &__info {
       @extend %flex-column;


### PR DESCRIPTION
# Why

Fixes #19582

* #19582

# How

Make sure that player tip image is not stretched when there is a lot of content in the tip header.

# Preview

<img width="1098" height="728" alt="Screenshot 2026-02-23 at 13 39 09" src="https://github.com/user-attachments/assets/8b9bc783-ef62-4b99-91cd-dd4987425d6e" />
