### PR TITLE
ui: hide default Edge password input reveal icon

### DIFF
--- a/ui/lib/css/base/_form.scss
+++ b/ui/lib/css/base/_form.scss
@@ -51,9 +51,3 @@ select:-webkit-autofill {
   -webkit-text-fill-color: $c-font;
   box-shadow: 0 0 0 1000px $m-secondary_bg--mix-10 inset;
 }
-
-input[type='password'] {
-  &::-ms-reveal {
-    display: none;
-  }
-}

--- a/ui/lib/css/form/_password.scss
+++ b/ui/lib/css/form/_password.scss
@@ -1,3 +1,8 @@
+input[type='password'] {
+  &::-ms-reveal {
+    display: none;
+  }
+}
 .password-complexity {
   margin-top: -2rem;
   margin-bottom: 3rem;


### PR DESCRIPTION
# Why

Fixes #19579

* #19579

# How

Hide default Edge password input reveal icon, refs:
* https://learn.microsoft.com/en-us/microsoft-edge/web-platform/password-reveal

# Preview

<img width="1635" height="1123" alt="Screenshot 2026-02-23 142742 1" src="https://github.com/user-attachments/assets/aba9e9df-612a-4e95-9761-84e246acb40c" />
