### PR TITLE
restore daily puzzle title styling

### DIFF
--- a/ui/puzzle/css/_side.scss
+++ b/ui/puzzle/css/_side.scss
@@ -211,11 +211,10 @@
     }
 
     &--daily {
-      outline: 3px solid $m-secondary_bg-page--mix-50;
+      outline: 3px solid $m-primary_bg-page--mix-50;
       a {
         margin: 0;
         text-align: center;
-        text-transform: uppercase;
       }
     }
   }

--- a/ui/puzzle/src/view/theme.ts
+++ b/ui/puzzle/src/view/theme.ts
@@ -20,7 +20,10 @@ export default function theme(ctrl: PuzzleCtrl): MaybeVNode {
   return ctrl.streak
     ? null
     : ctrl.isDaily
-      ? hl('div.puzzle__side__theme.puzzle__side__theme--daily', backToTheme({}, [i18n.puzzle.dailyPuzzle]))
+      ? hl(
+          'div.puzzle__side__theme.puzzle__side__theme--daily',
+          backToTheme({}, ['« ', i18n.puzzle.dailyPuzzle]),
+        )
       : hl('div.puzzle__side__theme', [
           backToTheme({ class: { long: angle.name.length > 20 } }, ['« ', angle.name]),
           angle.opening


### PR DESCRIPTION
on https://lichess.org/training/daily

| previous styling | current styling |
| - | - |
| <img width="526" height="761" alt="image" src="https://github.com/user-attachments/assets/eb251830-14c9-490f-be6d-a400620346f0" /> | <img width="524" height="936" alt="image" src="https://github.com/user-attachments/assets/7191a5bc-c7a0-41d3-ac3e-97ded8227fb9" /> |

The generated HTML changed so this PR updates the selector:

### Previous HTML
```html
<div class="puzzle__side__theme puzzle__side__theme--daily">
   <a href="/training/themes"><h2>Daily Puzzle</h2></a>
</div>
```

### Current HTML
```html
<div class="puzzle__side__theme puzzle__side__theme--daily">
   <a class="puzzle__side__theme__back" href="/training/themes">Daily Puzzle</a>
</div>
```
