### PR TITLE
Prevent just a pointerdown on modal close button from closing dialog.

### DIFF
--- a/ui/lib/src/view/dialog.ts
+++ b/ui/lib/src/view/dialog.ts
@@ -163,13 +163,7 @@ class DialogWrapper implements Dialog {
     const justThen = Date.now();
     const cancelOnInterval = (e: PointerEvent) => {
       if (!this.dialog.isConnected) console.trace('likely zombie dialog. Always Be Close()ing');
-      if (Date.now() - justThen < 200) return;
-      const r = dialog.getBoundingClientRect();
-      if (
-        (e.clientX < r.left || e.clientX > r.right || e.clientY < r.top || e.clientY > r.bottom) &&
-        !dialog.contains(e.target as Node | null) // close button could be positioned outside the dialog
-      )
-        this.close('cancel');
+      if (Date.now() - justThen >= 200 && !dialog.contains(e.target as Node | null)) this.close('cancel');
     };
     this.observer.observe(document.body, { childList: true, subtree: true });
     document.body.style.setProperty('---viewport-height', `${window.innerHeight}px`);


### PR DESCRIPTION
To see the current behaviour, open a modal dialog and press down on the close button in its top-right area. This section of the close button is outside the dialog rectangle, so the standard modal behaviour applies (pointerdown outside => close dialog). This is slightly unexpected behaviour though, as it behaves differently from if we press down on the close button in say its bottom-left area.

The motivation came from trying to avoid the resulting behaviour of this use case:
- Open a study chapter with a number of moves.
- Scroll down a little and open the help dialog. E.g.:
<img width="2058" height="748" alt="image" src="https://github.com/user-attachments/assets/9a365b36-7ef4-4d1c-8cb9-e6da5ea5d02e" />
- If you then click on the close button in its top-right area, the dialog closes and you're taken to the move in the notation behind it. This is because pointerup on a notation move triggers its selection.