### PR TITLE
ui: remove redundant coords reset when showing powerTip

### DIFF
--- a/ui/site/src/powertip.ts
+++ b/ui/site/src/powertip.ts
@@ -557,11 +557,6 @@ class TooltipController {
       tipHeight,
       coords = cssCoordinates();
 
-    // set the tip to 0,0 to get the full expanded width
-    coords.top = 0;
-    coords.left = 0;
-    this.tipElement.css(coords);
-
     // to support elastic tooltips we need to check for a change in the
     // rendered dimensions after the tooltip has been positioned
     do {


### PR DESCRIPTION
# Why

Refs https://github.com/lichess-org/lila/commit/dfcb9d0326160a8f9cfd8ba31cbbd042e1e97657

# How

Since we reset position on hide now, and we relay on `visibility` instead of display repositioning powerTip content before actual position, calculation on show should no longer be needed.

# Tests plan

Tested the changes out locally on few different elements with powerTip attached.