### PR TITLE
ui: reuse ellipsis and nowrap extends where applicable

### DIFF
--- a/ui/analyse/css/_round-underboard.scss
+++ b/ui/analyse/css/_round-underboard.scss
@@ -16,7 +16,7 @@ $col2-panel-height: 240px;
     align-items: flex-start;
 
     > button {
-      @extend %roboto, %box-radius-top, %page-text, %ellipsis;
+      @extend %roboto, %box-radius-top, %page-text, %nowrap-ellipsis;
 
       flex: 1 1 0;
       text-align: center;
@@ -24,7 +24,6 @@ $col2-panel-height: 240px;
       padding: 0.4em 0.1em;
       cursor: pointer;
       position: relative;
-      white-space: nowrap;
       border-bottom: $border;
 
       &:hover {

--- a/ui/analyse/css/explorer/_explorer.scss
+++ b/ui/analyse/css/explorer/_explorer.scss
@@ -1,22 +1,21 @@
 @import './config';
 
 .explorer-box {
-  position: relative;
-  flex: 3 1 0px;
-  white-space: nowrap;
-
   @include transition;
 
+  position: relative;
+  flex: 3 1 0;
+  white-space: nowrap;
   transition-delay: 0.3s;
   overflow-x: hidden;
   overflow-y: auto;
   font-size: 0.9em;
 
   &.reduced {
-    flex: 0.3 3 0px;
+    flex: 0.3 3 0;
 
     &:hover {
-      flex: 1 2 0px;
+      flex: 1 2 0;
     }
   }
 
@@ -39,8 +38,7 @@
   }
 
   .title {
-    overflow: hidden;
-    text-overflow: ellipsis;
+    @extend %ellipsis;
     user-select: text;
   }
   .explorer-title {

--- a/ui/analyse/css/study/_player.scss
+++ b/ui/analyse/css/study/_player.scss
@@ -89,8 +89,7 @@ $player-height: 1.6rem;
 
     .team,
     .name {
-      overflow: hidden;
-      text-overflow: ellipsis;
+      @extend %ellipsis;
       max-width: fit-content;
       flex: 1;
     }

--- a/ui/analyse/css/study/_topics.scss
+++ b/ui/analyse/css/study/_topics.scss
@@ -15,12 +15,11 @@
     background: $m-primary_bg--mix-12;
     padding: 0.2em 0.6em;
     margin: 0.2em;
+    white-space: nowrap;
 
     &:hover {
       background: $m-primary_bg--mix-15;
     }
-
-    white-space: nowrap;
   }
 
   .box__pad & {

--- a/ui/analyse/css/study/relay/_board-player.scss
+++ b/ui/analyse/css/study/relay/_board-player.scss
@@ -78,8 +78,7 @@
 
   .team,
   .name {
-    overflow: hidden;
-    text-overflow: ellipsis;
+    @extend %ellipsis;
     max-width: fit-content;
     flex: 1;
   }

--- a/ui/analyse/css/study/relay/_tour.scss
+++ b/ui/analyse/css/study/relay/_tour.scss
@@ -337,9 +337,8 @@ $hover-bg: $m-primary_bg--mix-30;
       }
     }
     .name {
+      @include ellipsis;
       padding: 0.3em 0 0.3em 1em;
-      overflow: hidden;
-      text-overflow: ellipsis;
       width: 100%;
     }
     .time,
@@ -630,8 +629,7 @@ $hover-bg: $m-primary_bg--mix-30;
       display: none;
     }
     .player-intro__name {
-      overflow: hidden;
-      text-overflow: ellipsis;
+      @include ellipsis;
     }
   }
 }

--- a/ui/bits/css/build/bits.slist.scss
+++ b/ui/bits/css/build/bits.slist.scss
@@ -40,10 +40,9 @@
     td:nth-child(2) {
       padding-right: 0;
       a.user-link {
+        @include ellipsis;
         display: inline-block;
         max-width: min(26ch, 50vw);
-        overflow: hidden;
-        text-overflow: ellipsis;
         white-space: nowrap;
         vertical-align: middle;
       }

--- a/ui/lib/css/ceval/_settings.scss
+++ b/ui/lib/css/ceval/_settings.scss
@@ -34,12 +34,11 @@
     }
 
     select {
+      @extend %ellipsis;
       flex: 1 4 auto;
       min-width: 0;
       margin-inline-start: 1ch;
       padding: 4px;
-      overflow: hidden;
-      text-overflow: ellipsis;
     }
 
     #select-engine {

--- a/ui/lib/css/component/_copy-me.scss
+++ b/ui/lib/css/component/_copy-me.scss
@@ -2,9 +2,8 @@
   @extend %box-radius, %flex-center-nowrap;
 
   &__target {
-    @extend %ellipsis, %box-radius-left;
+    @extend %nowrap-ellipsis, %box-radius-left;
     flex: 1 1 auto;
-    white-space: nowrap;
     padding: 0 1em;
     outline: 0;
     background: none;

--- a/ui/lib/css/component/_mini-game.scss
+++ b/ui/lib/css/component/_mini-game.scss
@@ -38,8 +38,7 @@
   }
 
   .name {
-    overflow: hidden;
-    text-overflow: ellipsis;
+    @extend %ellipsis;
   }
 
   .rating {

--- a/ui/lib/css/component/_tagify.scss
+++ b/ui/lib/css/component/_tagify.scss
@@ -238,9 +238,8 @@
       transition: 0.13s ease-out;
 
       > * {
+        @extend %ellipsis;
         white-space: pre-wrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
         display: inline-block;
         vertical-align: top;
         min-width: var(--tag--min-width, $tag-min-width);

--- a/ui/lib/css/game/_row.scss
+++ b/ui/lib/css/game/_row.scss
@@ -38,9 +38,7 @@
     overflow: hidden;
 
     .notes {
-      white-space: nowrap;
-      text-overflow: ellipsis;
-      overflow: hidden;
+      @extend %nowrap-ellipsis;
     }
   }
 

--- a/ui/lib/css/tree/_tree.scss
+++ b/ui/lib/css/tree/_tree.scss
@@ -43,7 +43,6 @@ $disclosure-btn-size: calc(15px + var(---button-size-pointer-adjust, 0px));
   display: inline-block;
   color: var(--c-base);
   padding: 0.25em 0.17em;
-  white-space: nowrap;
   font-size: 1.092em;
   cursor: pointer;
 

--- a/ui/lib/css/vendor/_multiple-select.scss
+++ b/ui/lib/css/vendor/_multiple-select.scss
@@ -5,15 +5,14 @@
 }
 
 .ms-choice {
+  @extend %nowrap-hidden;
   display: block;
   width: 100%;
   height: 26px;
   padding: 0;
-  overflow: hidden;
   cursor: pointer;
   border: $border;
   text-align: left;
-  white-space: nowrap;
   line-height: 26px;
   text-decoration: none;
   border-radius: 2px;
@@ -27,13 +26,11 @@
 }
 
 .ms-choice > span {
+  @extend %nowrap-ellipsis;
   position: absolute;
   top: 0;
   left: 0;
   right: 20px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
   display: block;
   padding-left: 8px;
 }
@@ -126,11 +123,9 @@
 }
 
 .ms-drop ul > li.multiple label {
-  @extend %nowrap-hidden;
-
+  @extend %nowrap-ellipsis;
   width: 100%;
   display: block;
-  text-overflow: ellipsis;
 }
 
 .ms-drop ul > li label {

--- a/ui/lobby/css/_setup.scss
+++ b/ui/lobby/css/_setup.scss
@@ -37,8 +37,7 @@ $c-slider: $c-setup;
         }
 
         .desc {
-          overflow: hidden;
-          text-overflow: ellipsis;
+          @extend %ellipsis;
         }
       }
     }

--- a/ui/opening/css/_next.scss
+++ b/ui/opening/css/_next.scss
@@ -23,13 +23,10 @@
       @extend %flex-between-nowrap;
     }
     &__name {
-      @extend %roboto;
+      @extend %roboto, %nowrap-ellipsis;
       flex: 1 1 auto;
       font-size: 1.3em;
       margin: 0 0 0.2em 0.5em;
-      white-space: nowrap;
-      text-overflow: ellipsis;
-      overflow: hidden;
     }
     &__san {
       flex: 0 1 auto;

--- a/ui/puzzle/css/_side.scss
+++ b/ui/puzzle/css/_side.scss
@@ -15,10 +15,7 @@
     }
 
     .infos {
-      @extend %flex-center-nowrap;
-
-      overflow: hidden;
-      white-space: nowrap;
+      @extend %flex-center-nowrap, %nowrap-hidden;
 
       &__angle-img {
         height: 3.5rem;

--- a/ui/tutor/css/_preview.scss
+++ b/ui/tutor/css/_preview.scss
@@ -1,11 +1,9 @@
 .tutor-preview {
-  @extend %box-neat, %flex-between-nowrap;
+  @extend %box-neat, %flex-between-nowrap, %nowrap-hidden;
   background: $c-bg-box;
   padding: 1em var(---box-padding);
   color: $c-font;
-  white-space: nowrap;
   gap: 1em;
-  overflow: hidden;
 
   &:hover {
     background: $m-primary_bg--mix-10;

--- a/ui/user/css/_perf-stat.scss
+++ b/ui/user/css/_perf-stat.scss
@@ -131,10 +131,9 @@
 
   .resultStreak .streak,
   .playStreak .streak {
-    @extend %ellipsis;
+    @extend %nowrap-ellipsis;
 
     margin: 1em 0 1em 1.5em;
-    white-space: nowrap;
   }
 
   .playStreak {

--- a/ui/voice/css/_voice.scss
+++ b/ui/voice/css/_voice.scss
@@ -137,12 +137,11 @@ button#microphone-button {
   }
 
   select {
+    @extend %ellipsis;
     flex: 1 4 auto;
     min-width: 0;
     margin-inline-start: 1ch;
     padding: 4px;
-    overflow: hidden;
-    text-overflow: ellipsis;
   }
 
   .range_value {

--- a/ui/voice/css/_voiceMove.help.scss
+++ b/ui/voice/css/_voiceMove.help.scss
@@ -38,9 +38,8 @@
 
   .big-table {
     td {
+      @extend %nowrap-ellipsis;
       padding: 0 1em;
-      white-space: nowrap;
-      text-overflow: ellipsis;
     }
     tr {
       td:nth-child(even) {


### PR DESCRIPTION
# Why

Reduce the style code duplication, improve the learning process about available @extend/@include helpers by example.

# How

Reuse `ellipsis` and `nowrap-*` extends where applicable.

---

Also a question: What is the reason for using `@extend` prefixed with `%` instead of mixins and `@include`? The problem with simple extends (ones without nested class, just properties) is that they cannot be used inside media query blocks due to the way they extend styles, refs:
* https://sass-lang.com/documentation/at-rules/extend/#extends-or-mixins
