### PR TITLE
'r' shortcut additions

### DIFF
--- a/modules/coreI18n/src/main/key.scala
+++ b/modules/coreI18n/src/main/key.scala
@@ -2124,6 +2124,7 @@ object I18nKey:
     val `keyShowOrHideComments`: I18nKey = "keyShowOrHideComments"
     val `keyEnterOrExitVariation`: I18nKey = "keyEnterOrExitVariation"
     val `keyRequestComputerAnalysis`: I18nKey = "keyRequestComputerAnalysis"
+    val `keyRequestComputerAnalysisStudyVersion`: I18nKey = "keyRequestComputerAnalysisStudyVersion"
     val `keyPreviousBranch`: I18nKey = "keyPreviousBranch"
     val `keyNextBranch`: I18nKey = "keyNextBranch"
     val `toggleVariationArrows`: I18nKey = "toggleVariationArrows"

--- a/modules/web/src/main/ui/help.scala
+++ b/modules/web/src/main/ui/help.scala
@@ -102,7 +102,11 @@ object help:
           row(kbd("z"), trans.site.toggleAllAnalysis()),
           row(kbd("a"), trans.site.bestMoveArrow()),
           row(kbd("v"), trans.site.toggleVariationArrows()),
-          row(kbd("r"), trans.site.keyRequestComputerAnalysis()),
+          row(
+            kbd("r"),
+            if isStudy then trans.site.keyRequestComputerAnalysisStudyVersion()
+            else trans.site.keyRequestComputerAnalysis()
+          ),
           row(kbd("c"), trans.site.focusChat()),
           helpDialog,
           row(kbd("e"), trans.site.openingEndgameExplorer()),

--- a/translation/source/site.xml
+++ b/translation/source/site.xml
@@ -722,6 +722,7 @@
   <string name="keyShowOrHideComments">show/hide comments</string>
   <string name="keyEnterOrExitVariation">enter/exit variation</string>
   <string name="keyRequestComputerAnalysis">Request computer analysis, Learn from your mistakes</string>
+  <string name="keyRequestComputerAnalysisStudyVersion">Request computer analysis</string>
   <string name="keyPreviousBranch">Previous branch</string>
   <string name="keyNextBranch">Next branch</string>
   <string name="toggleVariationArrows">Toggle variation arrows</string>

--- a/ui/@types/lichess/i18n.d.ts
+++ b/ui/@types/lichess/i18n.d.ts
@@ -3723,6 +3723,8 @@ interface I18n {
     keyPreviousBranch: string;
     /** Request computer analysis, Learn from your mistakes */
     keyRequestComputerAnalysis: string;
+    /** Request computer analysis */
+    keyRequestComputerAnalysisStudyVersion: string;
     /** show/hide comments */
     keyShowOrHideComments: string;
     /** Kid mode */

--- a/ui/analyse/src/keyboard.ts
+++ b/ui/analyse/src/keyboard.ts
@@ -5,10 +5,10 @@ import { snabDialog } from 'lib/view';
 import type { VNode } from 'snabbdom';
 import { pubsub } from 'lib/pubsub';
 
-export const keyToMouseEvent = (key: string, eventName: string, selector: string) =>
+export const keyToMouseEvent = (key: string, eventName: string, selector: string, bubbles?: boolean) =>
   window.site.mousetrap.bind(key, () =>
     $(selector).each(function (this: HTMLElement) {
-      this.dispatchEvent(new MouseEvent(eventName));
+      this.dispatchEvent(new MouseEvent(eventName, { bubbles }));
     }),
   );
 
@@ -99,14 +99,23 @@ export const bind = (ctrl: AnalyseCtrl) => {
       ctrl.redraw();
     });
 
-  //'Request computer analysis' & 'Learn From Your Mistakes' (mutually exclusive)
-  keyToMouseEvent(
-    'r',
-    'click',
-    '.analyse__underboard__panels .computer-analysis button, .analyse__round-training .advice-summary a.button',
-  );
+  if (ctrl.study)
+    kbd.bind('r', () => {
+      ctrl.study?.vm.toolTab('serverEval');
+      ctrl.study?.serverEval.request();
+      ctrl.redraw();
+    });
+  else {
+    keyToMouseEvent('r', 'click', '.analyse__underboard__menu .computer-analysis', true);
+    keyToMouseEvent(
+      'r',
+      'click',
+      // 'request computer analysis' & 'learn From your mistakes' use cases are mutually exclusive:
+      '.analyse__underboard__panels .computer-analysis button, .analyse__round-training .advice-summary a.button',
+    );
+  }
 
-  //First explorer move
+  // First explorer move
   kbd.bind('shift+space', () => {
     const move = document
       .querySelector('.explorer-box:not(.loading) tbody tr[data-uci]')

--- a/ui/analyse/src/study/serverEval.ts
+++ b/ui/analyse/src/study/serverEval.ts
@@ -31,6 +31,14 @@ export default class ServerEval {
   };
 
   request = () => {
+    if (
+      !longEnoughForAnalysis(this) ||
+      !userHasAnalysisRequestPermission(this) ||
+      !this.root.showFishnetAnalysis() ||
+      this.root.data.analysis ||
+      this.requested
+    )
+      return;
     this.root.socket.send('requestAnalysis', this.chapterId());
     this.requested = true;
   };
@@ -66,24 +74,26 @@ const disabled = () => h('div.study__server-eval.disabled.padded', 'You disabled
 
 const requested = () => h('div.study__server-eval.requested.padded', spinnerVdom());
 
-function requestButton(ctrl: ServerEval) {
-  const root = ctrl.root;
-  return h(
+const longEnoughForAnalysis = (ctrl: ServerEval) => ctrl.root.mainline.length >= 5;
+
+const userHasAnalysisRequestPermission = (ctrl: ServerEval) => ctrl.root.study!.members.canContribute();
+
+const requestButton = (ctrl: ServerEval) =>
+  h(
     'div.study__message',
-    root.mainline.length < 5
+    !longEnoughForAnalysis(ctrl)
       ? h('p', i18n.study.theChapterIsTooShortToBeAnalysed)
-      : !root.study!.members.canContribute()
+      : !userHasAnalysisRequestPermission(ctrl)
         ? [i18n.study.onlyContributorsCanRequestAnalysis]
         : [
             h('p', [i18n.study.getAFullComputerAnalysis, h('br'), i18n.study.makeSureTheChapterIsComplete]),
             h(
               'a.button.text',
               {
-                attrs: { 'data-icon': licon.BarChart, disabled: root.mainline.length < 5 },
-                hook: bind('click', ctrl.request, root.redraw),
+                attrs: { 'data-icon': licon.BarChart },
+                hook: bind('click', ctrl.request, ctrl.root.redraw),
               },
               i18n.site.requestAComputerAnalysis,
             ),
           ],
   );
-}


### PR DESCRIPTION
- Adds the 'r' shortcut to studies (only requests a computer analysis, doesn't learn from your mistakes since that's not a feature in studies atm).
- For the 'r' shortcut in plain analysis boards, now also opens the computer analysis tab.
- In `ui/analyse/src/study/serverEval.ts`, removes `disabled: root.mainline.length < 5` attr, since from what I can tell the expression is always false at that point.