### PR TITLE
ui: lobby code cleanup, type simplification

### DIFF
--- a/ui/lobby/src/ctrl.ts
+++ b/ui/lobby/src/ctrl.ts
@@ -202,7 +202,7 @@ export default class LobbyController {
     this.flushHooksTimeout = this.flushHooksSchedule();
   };
 
-  private flushHooksSchedule = (): number => setTimeout(this.flushHooks, 8000);
+  private flushHooksSchedule = () => setTimeout(this.flushHooks, 8000);
 
   setTab = (tab: Tab) => {
     if (tab !== this.tab) {

--- a/ui/lobby/src/seekRepo.ts
+++ b/ui/lobby/src/seekRepo.ts
@@ -1,12 +1,7 @@
 import type LobbyController from './ctrl';
-import type { Seek } from './interfaces';
-
-function order(a: Seek, b: Seek) {
-  return a.rating > b.rating ? -1 : 1;
-}
 
 export function sort(ctrl: LobbyController) {
-  ctrl.data.seeks.sort(order);
+  ctrl.data.seeks.sort((a, b) => (a.rating > b.rating ? -1 : 1));
 }
 
 export function initAll(ctrl: LobbyController) {

--- a/ui/lobby/src/setupCtrl.ts
+++ b/ui/lobby/src/setupCtrl.ts
@@ -211,7 +211,7 @@ export default class SetupController {
       );
   }, 300);
 
-  ratedModeDisabled = (): boolean =>
+  ratedModeDisabled = () =>
     // anonymous games cannot be rated
     !this.root.me ||
     this.timeControl.mode() === 'unlimited' ||
@@ -242,7 +242,7 @@ export default class SetupController {
       : null;
   };
 
-  propsToFormData = (color: ColorChoice): FormData =>
+  propsToFormData = (color: ColorChoice) =>
     xhr.form({
       variant: keyToId(this.variant(), variants).toString(),
       fen: this.variant() === 'fromPosition' ? this.fen() : undefined,
@@ -261,30 +261,34 @@ export default class SetupController {
       color,
     });
 
-  validFen = (): boolean => this.variant() !== 'fromPosition' || (!this.fenError && !!this.fen());
+  validFen = () => this.variant() !== 'fromPosition' || (!this.fenError && !!this.fen());
 
-  valid = (): boolean =>
+  valid = () =>
     this.validFen() && this.timeControl.valid(this.minimumTimeIfReal()) && this.validConstraints();
 
-  private validConstraints = (): boolean => {
+  private invalid = <A>(forced: A | undefined, current: A) => forced !== undefined && forced !== current;
+
+  private validConstraints = () => {
     if (this.forced) {
-      const invalid = <A>(forced: A | undefined, current: A) => forced !== undefined && forced !== current;
-      if (invalid(this.forced.variant, this.variant())) return false;
-      if (invalid(this.forced.mode, this.gameMode())) return false;
-      if (invalid(this.forced.timeMode, this.timeControl.mode())) return false;
-      if (invalid(this.forced.color, this.color())) return false;
-      if (this.timeControl.mode() === 'correspondence' && invalid(this.forced.days, this.timeControl.days()))
+      if (this.invalid(this.forced.variant, this.variant())) return false;
+      if (this.invalid(this.forced.mode, this.gameMode())) return false;
+      if (this.invalid(this.forced.timeMode, this.timeControl.mode())) return false;
+      if (this.invalid(this.forced.color, this.color())) return false;
+      if (
+        this.timeControl.mode() === 'correspondence' &&
+        this.invalid(this.forced.days, this.timeControl.days())
+      )
         return false;
       if (this.timeControl.mode() === 'realTime') {
-        if (invalid(this.forced.time, this.timeControl.time())) return false;
-        if (invalid(this.forced.increment, this.timeControl.increment())) return false;
+        if (this.invalid(this.forced.time, this.timeControl.time())) return false;
+        if (this.invalid(this.forced.increment, this.timeControl.increment())) return false;
       }
-      if (invalid(this.forced.fen?.replace(/_/g, ' '), this.fen())) return false;
+      if (this.invalid(this.forced.fen?.replace(/_/g, ' '), this.fen())) return false;
     }
     return true;
   };
 
-  minimumTimeIfReal = (): number => (this.gameType === 'ai' && this.variant() === 'fromPosition' ? 1 : 0);
+  minimumTimeIfReal = () => (this.gameType === 'ai' && this.variant() === 'fromPosition' ? 1 : 0);
 
   submit = async () => {
     const color = this.color();
@@ -311,14 +315,14 @@ export default class SetupController {
     } catch (_) {
       this.loading = false;
       this.root.redraw();
-      alert('Sorry, we encountered an error while creating your game. Please try again.');
+      await alert('Sorry, we encountered an error while creating your game. Please try again.');
       return;
     }
 
     const { ok, redirected, url } = response;
 
     if (!ok) {
-      const errs: { [key: string]: string } = await response.json();
+      const errs: Record<string, string> = await response.json();
       await alert(
         errs
           ? Object.keys(errs)

--- a/ui/lobby/src/view/correspondence.ts
+++ b/ui/lobby/src/view/correspondence.ts
@@ -1,8 +1,8 @@
 import { h, type VNode } from 'snabbdom';
 import { bind, type MaybeVNodes, confirm } from 'lib/view';
 import { tds, perfNames } from './util';
-import type LobbyController from '../ctrl';
-import type { Seek } from '../interfaces';
+import type LobbyController from '@/ctrl';
+import type { Seek } from '@/interfaces';
 import perfIcons from 'lib/game/perfIcons';
 
 function renderSeek(ctrl: LobbyController, seek: Seek): VNode {

--- a/ui/lobby/src/view/playing.ts
+++ b/ui/lobby/src/view/playing.ts
@@ -1,6 +1,6 @@
 import { hl, onInsert, initMiniBoard } from 'lib/view';
-import type LobbyController from '../ctrl';
-import type { NowPlaying } from '../interfaces';
+import type LobbyController from '@/ctrl';
+import type { NowPlaying } from '@/interfaces';
 import { timeago } from 'lib/i18n';
 
 function timer(pov: NowPlaying) {

--- a/ui/lobby/src/view/pools.ts
+++ b/ui/lobby/src/view/pools.ts
@@ -26,23 +26,21 @@ export const hooks = (ctrl: LobbyController): Hooks =>
     el.addEventListener('keydown', handler);
   });
 
-export function render(ctrl: LobbyController) {
-  const member = ctrl.poolMember;
-  return ctrl.pools
+export function render({ pools, poolMember, opts }: LobbyController) {
+  return pools
     .map(pool => {
-      const active = member?.id === pool.id,
-        transp = !!member && !active;
+      const active = poolMember?.id === pool.id;
       return h(
         'div.lpool',
         {
-          class: { active, transp },
+          class: { active, transp: !!poolMember && !active },
           attrs: { role: 'button', 'data-id': pool.id, tabindex: '0' },
         },
         [
           h('div.clock', `${pool.lim}+${pool.inc}`),
           active
-            ? member.range && ctrl.opts.showRatings
-              ? h('div.range', member.range.replace('-', '–'))
+            ? poolMember.range && opts.showRatings
+              ? h('div.range', poolMember.range.replace('-', '–'))
               : spinnerVdom()
             : h('div.perf', pool.perf),
         ],
@@ -52,7 +50,7 @@ export function render(ctrl: LobbyController) {
       h(
         'div.lpool',
         {
-          class: { transp: !!member },
+          class: { transp: !!poolMember },
           attrs: { role: 'button', 'data-id': 'custom', tabindex: '0' },
         },
         i18n.site.custom,

--- a/ui/lobby/src/view/realTime/filter.ts
+++ b/ui/lobby/src/view/realTime/filter.ts
@@ -4,7 +4,7 @@ import * as xhr from 'lib/xhr';
 import { bind } from 'lib/view';
 import type LobbyController from '@/ctrl';
 
-function initialize(ctrl: LobbyController, el: HTMLElement) {
+function initialize(ctrl: LobbyController, el: FilterNode) {
   const f = ctrl.filter.data?.form,
     $div = $(el),
     $ratingRange = $div.find('.rating-range'),
@@ -32,7 +32,7 @@ function initialize(ctrl: LobbyController, el: HTMLElement) {
       ctrl.filter.uiCacheBuster++;
       ctrl.redraw();
     })
-    .on('submit', (e: Event) => {
+    .on('submit', (e: SubmitEvent) => {
       e.preventDefault();
       ctrl.filter.open = false;
       ctrl.redraw();
@@ -59,11 +59,10 @@ function initialize(ctrl: LobbyController, el: HTMLElement) {
   changeRatingRange();
 }
 
-export function toggle(ctrl: LobbyController, nbFiltered: number) {
-  const filter = ctrl.filter;
+export function toggle({ filter, redraw }: LobbyController, nbFiltered: number) {
   return h('i.toggle.toggle-filter', {
     class: { gamesFiltered: nbFiltered > 0, active: filter.open },
-    hook: bind('mousedown', filter.toggle, ctrl.redraw),
+    hook: bind('mousedown', filter.toggle, redraw),
     attrs: { 'data-icon': filter.open ? licon.X : licon.Gear, title: i18n.site.filterGames },
   });
 }

--- a/ui/lobby/src/view/setup/components/colorButtons.ts
+++ b/ui/lobby/src/view/setup/components/colorButtons.ts
@@ -1,22 +1,16 @@
 import { hl } from 'lib/view';
-import type LobbyController from '@/ctrl';
 import { variantsWhereWhiteIsBetter } from '@/options';
 import { blindModeColorPicker, colorButtons as renderButtons } from 'lib/setup/view/color';
+import type SetupController from '@/setupCtrl';
 
-export const colorButtons = (ctrl: LobbyController) => {
-  const { setupCtrl } = ctrl;
-
+export const colorButtons = ({ gameMode, gameType, variant, color }: SetupController) => {
   const randomColorOnly =
-    setupCtrl.gameType === 'hook' ||
-    (setupCtrl.gameType !== 'ai' &&
-      setupCtrl.gameMode() === 'rated' &&
-      variantsWhereWhiteIsBetter.includes(setupCtrl.variant()));
+    gameType === 'hook' ||
+    (gameType !== 'ai' && gameMode() === 'rated' && variantsWhereWhiteIsBetter.includes(variant()));
 
   return randomColorOnly
     ? undefined
     : site.blindMode
-      ? setupCtrl.gameType !== 'hook'
-        ? hl('div', blindModeColorPicker(setupCtrl.color))
-        : undefined
-      : renderButtons(setupCtrl.color);
+      ? hl('div', blindModeColorPicker(color))
+      : renderButtons(color);
 };

--- a/ui/lobby/src/view/setup/components/gameModeButtons.ts
+++ b/ui/lobby/src/view/setup/components/gameModeButtons.ts
@@ -5,10 +5,9 @@ import type { GameMode } from '@/interfaces';
 import { gameModes } from '@/options';
 import { option } from 'lib/setup/option';
 
-export const gameModeButtons = (ctrl: LobbyController): MaybeVNode => {
-  if (!ctrl.me) return null;
+export const gameModeButtons = ({ setupCtrl, me }: LobbyController): MaybeVNode => {
+  if (!me) return null;
 
-  const { setupCtrl } = ctrl;
   return site.blindMode
     ? h('div', [
         h('label', { attrs: { for: 'sf_mode' } }, i18n.site.mode),
@@ -19,7 +18,7 @@ export const gameModeButtons = (ctrl: LobbyController): MaybeVNode => {
               change: (e: Event) => setupCtrl.gameMode((e.target as HTMLSelectElement).value as GameMode),
             },
           },
-          gameModes.map(({ key, name }) => option({ key: key, name: name }, setupCtrl.gameMode())),
+          gameModes.map(({ key, name }) => option({ key, name }, setupCtrl.gameMode())),
         ),
       ])
     : h('div.config-group', [

--- a/ui/lobby/src/view/setup/components/levelButtons.ts
+++ b/ui/lobby/src/view/setup/components/levelButtons.ts
@@ -1,22 +1,19 @@
 import { h } from 'snabbdom';
-import type LobbyController from '@/ctrl';
 import { option } from 'lib/setup/option';
+import type SetupController from '@/setupCtrl';
 
 const levels = [1, 2, 3, 4, 5, 6, 7, 8];
 
-export const levelButtons = (ctrl: LobbyController) => {
-  const { setupCtrl } = ctrl;
+export const levelButtons = ({ aiLevel }: SetupController) => {
   return site.blindMode
     ? [
         h('label', { attrs: { for: 'sf_level' } }, i18n.site.strength),
         h(
           'select#sf_level',
           {
-            on: { change: (e: Event) => setupCtrl.aiLevel(parseInt((e.target as HTMLSelectElement).value)) },
+            on: { change: (e: Event) => aiLevel(parseInt((e.target as HTMLSelectElement).value)) },
           },
-          levels
-            .map(l => l.toString())
-            .map(key => option({ key, name: key }, setupCtrl.aiLevel().toString())),
+          levels.map(l => l.toString()).map(key => option({ key, name: key }, aiLevel().toString())),
         ),
       ]
     : h('div.config-group', [
@@ -31,10 +28,10 @@ export const levelButtons = (ctrl: LobbyController) => {
                     name: 'level',
                     type: 'radio',
                     value: level,
-                    checked: level === setupCtrl.aiLevel(),
+                    checked: level === aiLevel(),
                   },
                   on: {
-                    change: (e: Event) => setupCtrl.aiLevel(parseInt((e.target as HTMLInputElement).value)),
+                    change: (e: Event) => aiLevel(parseInt((e.target as HTMLInputElement).value)),
                   },
                 }),
                 h('label', { attrs: { for: `sf_level_${level}` } }, level),

--- a/ui/lobby/src/view/setup/components/ratingDifferenceSliders.ts
+++ b/ui/lobby/src/view/setup/components/ratingDifferenceSliders.ts
@@ -1,10 +1,9 @@
 import { hl } from 'lib/view';
 import type LobbyController from '@/ctrl';
 
-export const ratingDifferenceSliders = (ctrl: LobbyController) => {
-  if (!ctrl.me || !ctrl.data.ratingMap) return null;
+export const ratingDifferenceSliders = ({ setupCtrl, me, data }: LobbyController) => {
+  if (!me || !data.ratingMap) return null;
 
-  const { setupCtrl } = ctrl;
   const isProvisional = setupCtrl.isProvisional();
 
   // Get current rating values or use default values if isProvisional

--- a/ui/lobby/src/view/setup/components/ratingView.ts
+++ b/ui/lobby/src/view/setup/components/ratingView.ts
@@ -3,32 +3,25 @@ import { h } from 'snabbdom';
 import type LobbyController from '@/ctrl';
 import { speeds, variants } from '@/options';
 
-export const ratingView = (ctrl: LobbyController): MaybeVNode => {
-  const { opts, data } = ctrl;
+export const ratingView = ({ opts, data, setupCtrl }: LobbyController): MaybeVNode => {
   if (site.blindMode || !data.ratingMap) return null;
 
-  const selectedPerf = ctrl.setupCtrl.selectedPerf();
-
-  const perfOrSpeed: { key: string; icon: string; name: string } | undefined =
+  const selectedPerf = setupCtrl.selectedPerf();
+  const perfOrSpeed =
     variants.find(({ key }) => key === selectedPerf) || speeds.find(({ key }) => key === selectedPerf);
 
-  if (perfOrSpeed) {
-    const perfIconAttrs = { attrs: { 'data-icon': perfOrSpeed.icon } };
-    return h(
-      'div.ratings',
-      !opts.showRatings
-        ? [h('i', perfIconAttrs), perfOrSpeed.name]
-        : [
-            ...i18n.site.yourRatingIsX.asArray(
-              h(
-                'strong',
-                perfIconAttrs,
-                ctrl.setupCtrl.myRating() + (ctrl.setupCtrl.isProvisional() ? '?' : ''),
-              ),
-            ),
-            perfOrSpeed.name,
-          ],
-    );
-  }
-  return undefined;
+  if (!perfOrSpeed) return undefined;
+
+  const perfIconAttrs = { attrs: { 'data-icon': perfOrSpeed.icon } };
+  return h(
+    'div.ratings',
+    !opts.showRatings
+      ? [h('i', perfIconAttrs), perfOrSpeed.name]
+      : [
+          ...i18n.site.yourRatingIsX.asArray(
+            h('strong', perfIconAttrs, setupCtrl.myRating() + (setupCtrl.isProvisional() ? '?' : '')),
+          ),
+          perfOrSpeed.name,
+        ],
+  );
 };

--- a/ui/lobby/src/view/setup/components/variantPicker.ts
+++ b/ui/lobby/src/view/setup/components/variantPicker.ts
@@ -1,12 +1,9 @@
 import { enter, hl } from 'lib/view';
-import type LobbyController from '@/ctrl';
 import { variants, variantsForGameType } from '@/options';
 import { option } from 'lib/setup/option';
-import type { VNode } from 'snabbdom';
+import type SetupController from '@/setupCtrl';
 
-export const variantPicker = (ctrl: LobbyController) => {
-  const { setupCtrl } = ctrl;
-
+export const variantPicker = (setupCtrl: SetupController) => {
   if (site.blindMode) {
     return hl('div.variant.label-select', [
       hl('label', { attrs: { for: 'sf_variant' } }, i18n.site.variant),
@@ -35,7 +32,7 @@ export const variantPicker = (ctrl: LobbyController) => {
     toggleVariant();
   };
 
-  const children: (VNode | string)[] = [
+  const children = [
     hl('input.mselect__toggle', {
       attrs: { type: 'checkbox', id: inputId },
       on: { change: toggleVariant },

--- a/ui/lobby/src/view/setup/modal.ts
+++ b/ui/lobby/src/view/setup/modal.ts
@@ -38,7 +38,7 @@ export default function setupModal(ctrl: LobbyController): VNode[] | null {
             {
               attrs: { disabled },
               class: { disabled },
-              on: { click: ctrl.setupCtrl.submit },
+              on: { click: setupCtrl.submit },
             },
             buttonText,
           ),
@@ -55,25 +55,25 @@ export default function setupModal(ctrl: LobbyController): VNode[] | null {
 
 const views = {
   hook: (ctrl: LobbyController): LooseVNodes => [
-    variantPicker(ctrl),
+    variantPicker(ctrl.setupCtrl),
     timePickerAndSliders(ctrl.setupCtrl.timeControl, 0),
     gameModeButtons(ctrl),
     ratingView(ctrl),
     ratingDifferenceSliders(ctrl),
-    colorButtons(ctrl),
+    colorButtons(ctrl.setupCtrl),
   ],
   friend: (ctrl: LobbyController): LooseVNodes => [
-    variantPicker(ctrl),
+    variantPicker(ctrl.setupCtrl),
     fenInput(ctrl.setupCtrl),
     timePickerAndSliders(ctrl.setupCtrl.timeControl, 0),
     gameModeButtons(ctrl),
-    colorButtons(ctrl),
+    colorButtons(ctrl.setupCtrl),
   ],
-  ai: (ctrl: LobbyController): LooseVNodes => [
-    variantPicker(ctrl),
-    fenInput(ctrl.setupCtrl),
-    timePickerAndSliders(ctrl.setupCtrl.timeControl, ctrl.setupCtrl.minimumTimeIfReal()),
-    levelButtons(ctrl),
-    colorButtons(ctrl),
+  ai: ({ setupCtrl }: LobbyController): LooseVNodes => [
+    variantPicker(setupCtrl),
+    fenInput(setupCtrl),
+    timePickerAndSliders(setupCtrl.timeControl, setupCtrl.minimumTimeIfReal()),
+    levelButtons(setupCtrl),
+    colorButtons(setupCtrl),
   ],
 };

--- a/ui/lobby/src/view/table.ts
+++ b/ui/lobby/src/view/table.ts
@@ -1,6 +1,6 @@
 import { bind, onInsert, hl, thunk } from 'lib/view';
-import type LobbyController from '../ctrl';
-import type { GameType } from '../interfaces';
+import type LobbyController from '@/ctrl';
+import type { GameType } from '@/interfaces';
 import renderSetupModal from './setup/modal';
 import { numberFormat } from 'lib/i18n';
 
@@ -44,16 +44,16 @@ export default function table(ctrl: LobbyController) {
   return hl('div.lobby__table', [
     hl('div.lobby__start', [site.blindMode && hl('h2', i18n.site.play), lobbyButtons.map(makeLobbyButton)]),
     renderSetupModal(ctrl),
-    // Use a thunk here so that snabbdom does not rerender; we will do so manually after insert
     site.blindMode
       ? undefined
-      : thunk(
+      : // Use a thunk here so that snabbdom does not rerender; we will do so manually after insert
+        thunk(
           'div.lobby__counters',
           () =>
             hl('div.lobby__counters', [
               hl(
                 'a',
-                { attrs: site.blindMode ? {} : { href: '/player' } },
+                { attrs: { href: '/player' } },
                 i18n.site.nbPlayers.asArray(
                   members,
                   hl(
@@ -70,7 +70,7 @@ export default function table(ctrl: LobbyController) {
               ),
               hl(
                 'a',
-                site.blindMode ? {} : { attrs: { href: '/games' } },
+                { attrs: { href: '/games' } },
                 i18n.site.nbGamesInPlay.asArray(
                   rounds,
                   hl(

--- a/ui/lobby/src/view/tabs.ts
+++ b/ui/lobby/src/view/tabs.ts
@@ -1,7 +1,7 @@
 import { h } from 'snabbdom';
 import { bind, type MaybeVNodes } from 'lib/view';
-import type LobbyController from '../ctrl';
-import type { Tab } from '../interfaces';
+import type LobbyController from '@/ctrl';
+import type { Tab } from '@/interfaces';
 
 function tab(ctrl: LobbyController, key: Tab, active: Tab, content: MaybeVNodes) {
   return h(


### PR DESCRIPTION
# Why

Was going through Lobby code and looking at places which still miss keyboard-friendly interactions, and made some small changes in the process.

# How

Summary of changes:
* remove redundant inline types which are correctly inferred
* use parameter destructuring to avoid variables redefinitions, and improve TS type checks
* pass downscoped parameters if possible
* avoid `invalid` helper redefinition in setup controller
* simplify import paths

> [!note]
> Let me know what do you think about changes like above. Happy to revert any part before merging if you think it's not necessary.