### PR TITLE
ui: improve videos reveal node readability in picture bg mode

### DIFF
--- a/ui/bits/css/_video.scss
+++ b/ui/bits/css/_video.scss
@@ -66,6 +66,8 @@
 
     .reveal {
       @extend %metal;
+      @include transition;
+      @include backdrop-blur-if-transparent;
 
       position: absolute;
       top: 100%;
@@ -75,8 +77,6 @@
       z-index: 1;
       padding: 10px 10px 0 10px;
       opacity: 0;
-
-      @include transition;
     }
 
     &:hover .reveal {


### PR DESCRIPTION
# Why

When browsing site in picture mode I have spotted that video reveal node is a bit unreadable in picture background mode.

<img width="800" height="724" alt="Screenshot 2026-02-25 at 09 13 52" src="https://github.com/user-attachments/assets/5705cc11-b3e2-4d93-91d0-7ab285b45f9c" />

# How

Add backdrop blur to vide reveal  in picture background mode.

# Preview

<img width="800" height="724" alt="Screenshot 2026-02-25 at 09 15 12" src="https://github.com/user-attachments/assets/5ef8ef2b-6fd1-441d-9a23-0b57d393d518" />
