### PR TITLE
ui: use faded accent color for tabs-horiz border when hovered

### DIFF
--- a/ui/lib/css/component/_tabs-horiz.scss
+++ b/ui/lib/css/component/_tabs-horiz.scss
@@ -1,4 +1,5 @@
 $c-tabs-active: $c-accent !default;
+$c-tabs-hover: $m-accent--fade-50 !default;
 
 .tabs-horiz {
   @extend %flex-center-nowrap, %page-text;
@@ -31,7 +32,7 @@ $c-tabs-active: $c-accent !default;
     }
 
     &:hover {
-      border-color: $m-accent--fade-50;
+      border-color: $c-tabs-hover;
     }
 
     &.active {


### PR DESCRIPTION
# Why

Add a bit more visual distinction between tabs-horiz states.

# How

Use faded accent color for tabs-horiz border when hovered, styles cleanup.

# Preview

<img width="1406" height="258" alt="Screenshot 2026-02-25 at 09 23 50" src="https://github.com/user-attachments/assets/43329138-3b48-4372-b3a6-6224ba00ed7d" />
