### PR TITLE
workspace: add few lint rules, correct warnings

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -29,9 +29,14 @@
     "prefer-promise-reject-errors": "error",
     "promise/no-callback-in-promise": "error",
     "promise/no-multiple-resolved": "error",
+    "typescript/no-confusing-non-null-assertion": "error",
+    "typescript/no-extra-non-null-assertion": "error",
     "typescript/no-unnecessary-type-arguments": "error",
     "typescript/no-unnecessary-type-assertion": "error",
     "typescript/no-unnecessary-type-constraint": "error",
+    "unicorn/prefer-array-flat": "error",
+    "unicorn/prefer-array-flat-map": "error",
+    "unicorn/prefer-array-some": "error",
     "no-restricted-globals": [
       "error",
       "addEventListener",
@@ -219,9 +224,10 @@
   },
   "overrides": [
     {
-      "files": ["bin/**"],
+      "files": ["bin/**", "cron/**"],
       "rules": {
-        "no-unused-vars": "off"
+        "no-unused-vars": "off",
+        "unicorn/prefer-array-some": "off"
       }
     }
   ]

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lint-staged": "^16.2.6",
     "oxfmt": "^0.35.0",
     "oxlint": "^1.50.0",
-    "oxlint-tsgolint": "^0.14.2",
+    "oxlint-tsgolint": "^0.15.0",
     "snabbdom": "3.5.1",
     "stylelint": "^17.3.0",
     "stylelint-config-standard-scss": "^17.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,10 +42,10 @@ importers:
         version: 0.35.0
       oxlint:
         specifier: ^1.50.0
-        version: 1.50.0(oxlint-tsgolint@0.14.2)
+        version: 1.50.0(oxlint-tsgolint@0.15.0)
       oxlint-tsgolint:
-        specifier: ^0.14.2
-        version: 0.14.2
+        specifier: ^0.15.0
+        version: 0.15.0
       snabbdom:
         specifier: 3.5.1
         version: 3.5.1
@@ -968,33 +968,33 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@oxlint-tsgolint/darwin-arm64@0.14.2':
-    resolution: {integrity: sha512-03WxIXguCXf1pTmoG2C6vqRcbrU9GaJCW6uTIiQdIQq4BrJnVWZv99KEUQQRkuHK78lOLa9g7B4K58NcVcB54g==}
+  '@oxlint-tsgolint/darwin-arm64@0.15.0':
+    resolution: {integrity: sha512-d7Ch+A6hic+RYrm32+Gh1o4lOrQqnFsHi721ORdHUDBiQPea+dssKUEMwIbA6MKmCy6TVJ02sQyi24OEfCiGzw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxlint-tsgolint/darwin-x64@0.14.2':
-    resolution: {integrity: sha512-ksMLl1cIWz3Jw+U79BhyCPdvohZcJ/xAKri5bpT6oeEM2GVnQCHBk/KZKlYrd7hZUTxz0sLnnKHE11XFnLASNQ==}
+  '@oxlint-tsgolint/darwin-x64@0.15.0':
+    resolution: {integrity: sha512-Aoai2wAkaUJqp/uEs1gml6TbaPW4YmyO5Ai/vOSkiizgHqVctjhjKqmRiWTX2xuPY94VkwOLqp+Qr3y/0qSpWQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@oxlint-tsgolint/linux-arm64@0.14.2':
-    resolution: {integrity: sha512-2BgR535w7GLxBCyQD5DR3dBzbAgiBbG5QX1kAEVzOmWxJhhGxt5lsHdHebRo7ilukYLpBDkerz0mbMErblghCQ==}
+  '@oxlint-tsgolint/linux-arm64@0.15.0':
+    resolution: {integrity: sha512-4og13a7ec4Vku5t2Y7s3zx6YJP6IKadb1uA9fOoRH6lm/wHWoCnxjcfJmKHXRZJII81WmbdJMSPxaBfwN/S68Q==}
     cpu: [arm64]
     os: [linux]
 
-  '@oxlint-tsgolint/linux-x64@0.14.2':
-    resolution: {integrity: sha512-TUHFyVHfbbGtnTQZbUFgwvv3NzXBgzNLKdMUJw06thpiC7u5OW5qdk4yVXIC/xeVvdl3NAqTfcT4sA32aiMubg==}
+  '@oxlint-tsgolint/linux-x64@0.15.0':
+    resolution: {integrity: sha512-9b9xzh/1Harn3a+XiKTK/8LrWw3VcqLfYp/vhV5/zAVR2Mt0d63WSp4FL+wG7DKnI2T/CbMFUFHwc7kCQjDMzQ==}
     cpu: [x64]
     os: [linux]
 
-  '@oxlint-tsgolint/win32-arm64@0.14.2':
-    resolution: {integrity: sha512-OfYHa/irfVggIFEC4TbawsI7Hwrttppv//sO/e00tu4b2QRga7+VHAwtCkSFWSr0+BsO4InRYVA0+pun5BinpQ==}
+  '@oxlint-tsgolint/win32-arm64@0.15.0':
+    resolution: {integrity: sha512-nNac5hewHdkk5mowOwTqB1ZD76zB/FsUiyUvdCyupq5cG54XyKqSLEp9QGbx7wFJkWCkeWmuwRed4sfpAlKaeA==}
     cpu: [arm64]
     os: [win32]
 
-  '@oxlint-tsgolint/win32-x64@0.14.2':
-    resolution: {integrity: sha512-5gxwbWYE2pP+pzrO4SEeYvLk4N609eAe18rVXUx+en3qtHBkU8VM2jBmMcZdIHn+G05leu4pYvwAvw6tvT9VbA==}
+  '@oxlint-tsgolint/win32-x64@0.15.0':
+    resolution: {integrity: sha512-ioAY2XLpy83E2EqOLH9p1cEgj0G2qB1lmAn0a3yFV1jHQB29LIPIKGNsu/tYCClpwmHN79pT5KZAHZOgWxxqNg==}
     cpu: [x64]
     os: [win32]
 
@@ -1735,8 +1735,8 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
-  oxlint-tsgolint@0.14.2:
-    resolution: {integrity: sha512-XJsFIQwnYJgXFlNDz2MncQMWYxwnfy4BCy73mdiFN/P13gEZrAfBU4Jmz2XXFf9UG0wPILdi7hYa6t0KmKQLhw==}
+  oxlint-tsgolint@0.15.0:
+    resolution: {integrity: sha512-iwvFmhKQVZzVTFygUVI4t2S/VKEm+Mqkw3jQRJwfDuTcUYI5LCIYzdO5Dbuv4mFOkXZCcXaRRh0m+uydB5xdqw==}
     hasBin: true
 
   oxlint@1.50.0:
@@ -2548,22 +2548,22 @@ snapshots:
   '@oxfmt/binding-win32-x64-msvc@0.35.0':
     optional: true
 
-  '@oxlint-tsgolint/darwin-arm64@0.14.2':
+  '@oxlint-tsgolint/darwin-arm64@0.15.0':
     optional: true
 
-  '@oxlint-tsgolint/darwin-x64@0.14.2':
+  '@oxlint-tsgolint/darwin-x64@0.15.0':
     optional: true
 
-  '@oxlint-tsgolint/linux-arm64@0.14.2':
+  '@oxlint-tsgolint/linux-arm64@0.15.0':
     optional: true
 
-  '@oxlint-tsgolint/linux-x64@0.14.2':
+  '@oxlint-tsgolint/linux-x64@0.15.0':
     optional: true
 
-  '@oxlint-tsgolint/win32-arm64@0.14.2':
+  '@oxlint-tsgolint/win32-arm64@0.15.0':
     optional: true
 
-  '@oxlint-tsgolint/win32-x64@0.14.2':
+  '@oxlint-tsgolint/win32-x64@0.15.0':
     optional: true
 
   '@oxlint/binding-darwin-arm64@1.50.0':
@@ -3267,16 +3267,16 @@ snapshots:
       '@oxfmt/binding-win32-arm64-msvc': 0.35.0
       '@oxfmt/binding-win32-x64-msvc': 0.35.0
 
-  oxlint-tsgolint@0.14.2:
+  oxlint-tsgolint@0.15.0:
     optionalDependencies:
-      '@oxlint-tsgolint/darwin-arm64': 0.14.2
-      '@oxlint-tsgolint/darwin-x64': 0.14.2
-      '@oxlint-tsgolint/linux-arm64': 0.14.2
-      '@oxlint-tsgolint/linux-x64': 0.14.2
-      '@oxlint-tsgolint/win32-arm64': 0.14.2
-      '@oxlint-tsgolint/win32-x64': 0.14.2
+      '@oxlint-tsgolint/darwin-arm64': 0.15.0
+      '@oxlint-tsgolint/darwin-x64': 0.15.0
+      '@oxlint-tsgolint/linux-arm64': 0.15.0
+      '@oxlint-tsgolint/linux-x64': 0.15.0
+      '@oxlint-tsgolint/win32-arm64': 0.15.0
+      '@oxlint-tsgolint/win32-x64': 0.15.0
 
-  oxlint@1.50.0(oxlint-tsgolint@0.14.2):
+  oxlint@1.50.0(oxlint-tsgolint@0.15.0):
     optionalDependencies:
       '@oxlint/binding-darwin-arm64': 1.50.0
       '@oxlint/binding-darwin-x64': 1.50.0
@@ -3286,7 +3286,7 @@ snapshots:
       '@oxlint/binding-linux-x64-musl': 1.50.0
       '@oxlint/binding-win32-arm64-msvc': 1.50.0
       '@oxlint/binding-win32-x64-msvc': 1.50.0
-      oxlint-tsgolint: 0.14.2
+      oxlint-tsgolint: 0.15.0
 
   p-limit@2.3.0:
     dependencies:

--- a/ui/.build/src/parse.ts
+++ b/ui/.build/src/parse.ts
@@ -46,9 +46,7 @@ export async function parsePackages(): Promise<void> {
 export async function glob(glob: string[] | string | undefined, opts: fg.Options = {}): Promise<string[]> {
   if (!glob) return [];
   const results = await Promise.all(
-    Array()
-      .concat(glob)
-      .map(async g => fg.glob(g, { cwd: env.rootDir, absolute: true, ...opts })),
+    [glob].flatMap(async g => fg.glob(g, { cwd: env.rootDir, absolute: true, ...opts })),
   );
   return [...new Set(results.flat())];
 }
@@ -123,10 +121,11 @@ async function parsePackage(root: string): Promise<Package> {
   const normalizeObject = <T extends Record<string, any>>(o: T) =>
     Object.fromEntries(Object.entries(o).map(([k, v]) => [k, typeof v === 'string' ? normalize(v) : v]));
 
-  if ('hash' in build)
-    pkgInfo.hash = []
-      .concat(build.hash)
+  if ('hash' in build) {
+    pkgInfo.hash = [build.hash]
+      .flat()
       .map(g => (typeof g === 'string' ? { path: normalize(g) } : normalizeObject(g))) as Hash[];
+  }
 
   if ('sync' in build)
     pkgInfo.sync = Object.entries<string>(build.sync).map(x => ({
@@ -134,7 +133,8 @@ async function parsePackage(root: string): Promise<Package> {
       dest: normalize(x[1]),
     }));
 
-  if ('bundle' in build)
-    pkgInfo.bundle = [].concat(build.bundle).map(b => (typeof b === 'string' ? { module: b } : b));
+  if ('bundle' in build) {
+    pkgInfo.bundle = [build.bundle].flat().map(b => (typeof b === 'string' ? { module: b } : b));
+  }
   return pkgInfo;
 }

--- a/ui/.build/src/task.ts
+++ b/ui/.build/src/task.ts
@@ -88,7 +88,7 @@ export async function runTask(key: TaskKey): Promise<any> {
 
 export function taskOk(ctx?: Context): boolean {
   const all = [...tasks.values()].filter(w => (ctx ? w.ctx === ctx : true));
-  return all.filter(w => !w.monitorOnly).length > 0 && all.every(w => w.status === 'ok');
+  return all.some(w => !w.monitorOnly) && all.every(w => w.status === 'ok');
 }
 
 export const tasksIdle = (): boolean => activeTaskCount === 0;

--- a/ui/analyse/src/forecast/forecastCtrl.ts
+++ b/ui/analyse/src/forecast/forecastCtrl.ts
@@ -67,7 +67,7 @@ export default class ForecastCtrl {
   isCandidate = (fc: ForecastStep[]): boolean => {
     fc = this.truncate(fc);
     if (!this.isLongEnough(fc)) return false;
-    return !this.forecasts().find(f => this.contains(f, fc));
+    return !this.forecasts().some(f => this.contains(f, fc));
   };
 
   save = () => {

--- a/ui/analyse/src/nodeFinder.ts
+++ b/ui/analyse/src/nodeFinder.ts
@@ -4,7 +4,7 @@ import { defined } from 'lib';
 import { zip } from 'lib/algo';
 import type { TreeNode } from 'lib/tree/types';
 
-const hasCompChild = (node: TreeNode): boolean => !!node.children.find(c => !!c.comp);
+const hasCompChild = (node: TreeNode): boolean => node.children.some(c => !!c.comp);
 
 export const nextGlyphSymbol = (
   color: Color,

--- a/ui/analyse/src/study/gamebook/gamebookEdit.ts
+++ b/ui/analyse/src/study/gamebook/gamebookEdit.ts
@@ -16,7 +16,7 @@ export const running = (ctrl: AnalyseCtrl): boolean =>
 export function render(ctrl: AnalyseCtrl): VNode {
   const study = ctrl.study!,
     isMyMove = ctrl.turnColor() === ctrl.data.orientation,
-    isCommented = !!(ctrl.node.comments || []).find(c => c.text.length > 2),
+    isCommented = (ctrl.node.comments || []).some(c => c.text.length > 2),
     hasVariation = ctrl.tree.parentNode(ctrl.path).children.length > 1;
 
   let content: MaybeVNodes;

--- a/ui/analyse/src/study/practice/studyPracticeCtrl.ts
+++ b/ui/analyse/src/study/practice/studyPracticeCtrl.ts
@@ -81,7 +81,7 @@ export default class StudyPracticeCtrl {
 
   onJump = () => {
     // reset failure state if no failed move found in mainline history
-    if (this.success() === false && !this.root.nodeList.find(n => !!n.fail)) this.success(null);
+    if (this.success() === false && !this.root.nodeList.some(n => !!n.fail)) this.success(null);
     this.checkSuccess();
   };
   onCeval = this.checkSuccess;

--- a/ui/analyse/src/study/practice/studyPracticeView.ts
+++ b/ui/analyse/src/study/practice/studyPracticeView.ts
@@ -112,33 +112,30 @@ export function side(ctrl: StudyCtrl): VNode {
           return false;
         }),
       },
-      ctrl.chapters.list
-        .all()
-        .map(chapter => {
-          const loading = ctrl.vm.loading && chapter.id === ctrl.vm.nextChapterId,
-            active = !ctrl.vm.loading && current && current.id === chapter.id,
-            completion = data.completion[chapter.id] >= 0 ? 'done' : 'ongoing';
-          return [
-            h(
-              'a.ps__chapter',
-              {
-                key: chapter.id,
-                attrs: { href: data.url + '/' + chapter.id, 'data-id': chapter.id },
-                class: { active, loading },
-              },
-              [
-                h('span.status.' + completion, {
-                  attrs: {
-                    'data-icon':
-                      (loading || active) && completion === 'ongoing' ? licon.PlayTriangle : licon.Checkmark,
-                  },
-                }),
-                h('h3', chapter.name),
-              ],
-            ),
-          ];
-        })
-        .reduce((a, b) => a.concat(b), []),
+      ctrl.chapters.list.all().flatMap(chapter => {
+        const loading = ctrl.vm.loading && chapter.id === ctrl.vm.nextChapterId,
+          active = !ctrl.vm.loading && current && current.id === chapter.id,
+          completion = data.completion[chapter.id] >= 0 ? 'done' : 'ongoing';
+        return [
+          h(
+            'a.ps__chapter',
+            {
+              key: chapter.id,
+              attrs: { href: data.url + '/' + chapter.id, 'data-id': chapter.id },
+              class: { active, loading },
+            },
+            [
+              h('span.status.' + completion, {
+                attrs: {
+                  'data-icon':
+                    (loading || active) && completion === 'ongoing' ? licon.PlayTriangle : licon.Checkmark,
+                },
+              }),
+              h('h3', chapter.name),
+            ],
+          ),
+        ];
+      }),
     ),
     h('div.finally', [
       h('a.back', { attrs: { 'data-icon': licon.LessThan, href: '/practice', title: 'More practice' } }),

--- a/ui/analyse/src/study/studyGlyph.ts
+++ b/ui/analyse/src/study/studyGlyph.ts
@@ -21,7 +21,7 @@ const renderGlyph = (ctrl: GlyphForm, node: TreeNode) => (glyph: Glyph) =>
         blurIfPrimaryClick(e);
       }),
       attrs: { 'data-symbol': glyph.symbol, type: 'button' },
-      class: { active: !!node.glyphs && !!node.glyphs.find(g => g.id === glyph.id) },
+      class: { active: !!node.glyphs && node.glyphs.some(g => g.id === glyph.id) },
     },
     [glyph.name],
   );

--- a/ui/analyse/src/study/studyMembers.ts
+++ b/ui/analyse/src/study/studyMembers.ts
@@ -203,18 +203,16 @@ export function view(ctrl: StudyCtrl): VNode {
   return hl('div.study__members', [
     hl(
       'div.study-list',
-      ordered
-        .map(member => {
-          const confing = members.confing() === member.user.id;
-          return [
-            hl('div', { key: member.user.id, class: { editing: !!confing } }, [
-              hl('div.left', [statusIcon(member), userLink({ ...member.user, line: false })]),
-              configButton(ctrl, member),
-            ]),
-            confing && memberConfig(member),
-          ];
-        })
-        .reduce((a, b) => a.concat(b), []),
+      ordered.flatMap(member => {
+        const confing = members.confing() === member.user.id;
+        return [
+          hl('div', { key: member.user.id, class: { editing: !!confing } }, [
+            hl('div.left', [statusIcon(member), userLink({ ...member.user, line: false })]),
+            configButton(ctrl, member),
+          ]),
+          confing && memberConfig(member),
+        ];
+      }),
     ),
     isOwner &&
       ordered.length < members.max &&

--- a/ui/bits/src/crop.ts
+++ b/ui/bits/src/crop.ts
@@ -49,7 +49,8 @@ export const mimeAccept: string = imageTypes.map(t => `image/${t}`).join(',');
 
 export function supported(src: string): boolean {
   const ext = src.split('.').pop()?.toLowerCase();
-  return Boolean(ext && imageTypes.find(t => ext.startsWith(t.split('+')[0])));
+  if (!ext) return false;
+  return imageTypes.some(t => ext.startsWith(t.split('+')[0]));
 }
 
 if (isSafari()) wireCropDialog(); // preload

--- a/ui/botDev/src/devAssets.ts
+++ b/ui/botDev/src/devAssets.ts
@@ -83,7 +83,7 @@ export class DevAssets {
   }
 
   isLocalOnly(key: string): boolean {
-    return Boolean(this.find(k => k === key, 'local') && !this.find(k => k === key, 'server'));
+    return Boolean(this.findAsset(k => k === key, 'local') && !this.findAsset(k => k === key, 'server'));
   }
 
   isDeleted(key: string): boolean {
@@ -94,7 +94,7 @@ export class DevAssets {
   }
 
   nameOf(key: string): string | undefined {
-    return this.find(k => k === key)?.[1];
+    return this.findAsset(k => k === key)?.[1];
   }
 
   assetBlob(type: AssetType, key: string): AssetBlob | undefined {
@@ -228,7 +228,7 @@ export class DevAssets {
     pubsub.emit('botdev.import.book', key, oldKey);
   };
 
-  private find(
+  private findAsset(
     fn: (key: string, name: string, type: AssetType) => boolean,
     maps: 'local' | 'server' | 'both' = 'both',
   ): [key: string, name: string, type: AssetType] | undefined {

--- a/ui/insight/src/ctrl.ts
+++ b/ui/insight/src/ctrl.ts
@@ -36,14 +36,8 @@ export default class {
     this.domElement = domElement;
     this.redraw = redraw;
 
-    this.dimensions = Array.prototype.concat.apply(
-      [],
-      env.ui.dimensionCategs.map(c => c.items),
-    );
-    this.metrics = Array.prototype.concat.apply(
-      [],
-      env.ui.metricCategs.map(c => c.items),
-    );
+    this.dimensions = env.ui.dimensionCategs.flatMap(c => c.items);
+    this.metrics = env.ui.metricCategs.flatMap(c => c.items);
 
     this.vm = {
       metric: this.findMetric(this.env.initialQuestion.metric)!,

--- a/ui/learn/src/chess.ts
+++ b/ui/learn/src/chess.ts
@@ -152,7 +152,7 @@ export default function (fen: string, appleKeys: SquareName[]): ChessCtrl {
       const maybeCapture = findCaptures(pos).find(capture => {
         const clone = cloneWithCtx(pos);
         clone.play({ from: capture.from, to: capture.to });
-        return !findCaptures(clone).find(m => m.to === capture.to);
+        return !findCaptures(clone).some(m => m.to === capture.to);
       });
       return maybeCapture ? moveToCgMove(maybeCapture) : undefined;
     },

--- a/ui/lib/src/tree/tree.ts
+++ b/ui/lib/src/tree/tree.ts
@@ -86,7 +86,7 @@ export function makeTree(root: TreeNode): TreeWrapper {
 
   const pathExists = (path: TreePath): boolean => !!nodeAtPathOrNull(path);
 
-  const pathIsForcedVariation = (path: TreePath): boolean => !!getNodeList(path).find(n => n.forceVariation);
+  const pathIsForcedVariation = (path: TreePath): boolean => getNodeList(path).some(n => n.forceVariation);
 
   function lastMainlineNodeFrom(node: TreeNode, path: TreePath): TreeNode {
     if (path === '') return node;

--- a/ui/lobby/src/ctrl.ts
+++ b/ui/lobby/src/ctrl.ts
@@ -281,10 +281,10 @@ export default class LobbyController {
   };
 
   hasOngoingRealTimeGame = () =>
-    !!this.data.nowPlaying.find(nowPlaying => nowPlaying.isMyTurn && nowPlaying.speed !== 'correspondence');
+    this.data.nowPlaying.some(nowPlaying => nowPlaying.isMyTurn && nowPlaying.speed !== 'correspondence');
 
   gameActivity = (gameId: string) => {
-    if (this.data.nowPlaying.find(p => p.gameId === gameId))
+    if (this.data.nowPlaying.some(p => p.gameId === gameId))
       xhr.nowPlaying().then(povs => {
         this.data.nowPlaying = povs;
         this.startWatching();

--- a/ui/lobby/src/setupCtrl.ts
+++ b/ui/lobby/src/setupCtrl.ts
@@ -234,7 +234,7 @@ export default class SetupController {
       this.gameMode() === 'rated' &&
       this.timeControl.isRealTime();
     const id = this.timeControl.clockStr();
-    return valid && this.root.pools.find(p => p.id === id)
+    return valid && this.root.pools.some(p => p.id === id)
       ? {
           id,
           range: this.ratingRange(),

--- a/ui/opening/src/chart.ts
+++ b/ui/opening/src/chart.ts
@@ -17,7 +17,7 @@ chart.Chart.register(
 const firstDate = dayjs('2017-01-01');
 
 export const renderHistoryChart = (data: OpeningPage): void => {
-  if (!data.history.find(p => p > 0)) return;
+  if (!data.history.some(p => p > 0)) return;
   const canvas = $('.opening__popularity__chart')[0] as HTMLCanvasElement;
   new chart.Chart(canvas, {
     type: 'line',

--- a/ui/puzzle/src/view/main.ts
+++ b/ui/puzzle/src/view/main.ts
@@ -175,7 +175,7 @@ function session(ctrl: PuzzleCtrl): MaybeVNode {
             rd,
           );
         }),
-        rounds.find(r => r.id === current)
+        rounds.some(r => r.id === current)
           ? !ctrl.streak &&
             hl('a.session-new', { key: 'new', attrs: { href: `/training/${ctrl.session.theme}` } })
           : hl(


### PR DESCRIPTION
# Why

Ad few more lint rules to ensure codebase correctness and uniformity.

# How

This changeset focuses on array operations and non-null assertions. There were not that many issues, and fixes in almost all cases lead to simpler, more readable code.

In the process I have also upgraded the `oxlint-tsgolint` dependency, hope this will help with random panics spotted on CI and locally.