### PR TITLE
Broadcasts: remove empty-like tag values from source PGN

### DIFF
--- a/modules/relay/src/main/RelayFidePlayerApi.scala
+++ b/modules/relay/src/main/RelayFidePlayerApi.scala
@@ -1,7 +1,7 @@
 package lila.relay
 
 import chess.{ ByColor, FideId, FideTC, PlayerTitle }
-import chess.format.pgn.{ Tag, Tags }
+import chess.format.pgn.{ Tag, Tags, TagType }
 
 import lila.core.fide.Player
 
@@ -15,9 +15,9 @@ final private class RelayFidePlayerApi(guessPlayer: lila.core.fide.GuessPlayer)(
   def enrichTags(tour: RelayTour): Tags => Fu[Tags] =
     enrichTags(_, tour.info.fideTCOrGuess)
 
+  private val titlesAndRatings = Set[TagType](Tag.WhiteTitle, Tag.BlackTitle, Tag.WhiteElo, Tag.BlackElo)
   private def removeEmptyFieldTags(tags: Tags): Tags =
-    val titlesAndRatings = List(Tag.WhiteTitle, Tag.BlackTitle, Tag.WhiteElo, Tag.BlackElo)
-    tags.map(_.filterNot(tag => titlesAndRatings.contains(tag.name) && tag.value == "-"))
+    tags.map(_.filter(tag => tag.value != "-" || !titlesAndRatings(tag.name)))
 
   private def enrichTags(tags: Tags, tc: FideTC): Fu[Tags] =
     (tags.fideIds


### PR DESCRIPTION
LCC now sends `[WhiteTitle "-"]` when there is no title instead of omitting it. I've accounted for elo tags too just in case they start doing it there as well.