### PR TITLE
ui: tweak `kbd` appearance, add dark theme support

### DIFF
--- a/ui/.build/src/sass.ts
+++ b/ui/.build/src/sass.ts
@@ -217,6 +217,8 @@ async function buildColorMixes() {
             return clr.mix(c2, c1, clamp(mix.val, { min: 0, max: 100 }));
           case 'lighten':
             return c1.lighten(clamp(mix.val, { min: 0, max: 100 }));
+          case 'darken':
+            return c1.darken(clamp(mix.val, { min: 0, max: 100 }));
           case 'alpha':
             return c1.setAlpha(clamp(mix.val / 100, { min: 0, max: 1 }));
           case 'fade':
@@ -268,7 +270,7 @@ function parseColor(colorMix: string) {
   const validColor = (c: string) => themeColorMap.get('default')?.has(c) || clr(c).isValid();
   return validColor(c1) &&
     (op !== 'mix' || validColor(c2)) &&
-    ['mix', 'lighten', 'alpha', 'fade'].includes(op) &&
+    ['mix', 'lighten', 'darken', 'alpha', 'fade'].includes(op) &&
     val >= 0 &&
     val <= 100
     ? { c1, c2, op, val }

--- a/ui/lib/css/component/_keyboard.scss
+++ b/ui/lib/css/component/_keyboard.scss
@@ -1,13 +1,27 @@
 kbd {
+  --c-kbd-border: #{$m-border--lighten-5};
+  --c-kbd-border-bottom: #{$m-border--lighten-15};
+  --c-kbd-bg: #{$c-bg-zebra2};
+  --c-kbd-color: #{$c-font};
+
+  @include if-light {
+    --c-kbd-border: #{$m-border--darken-5};
+    --c-kbd-border-bottom: #{$m-border--darken-15};
+    --c-kbd-bg: #{$c-bg-zebra};
+  }
+
   display: inline-block;
-  padding: 0 5px;
+  padding: 0 4px 2px;
   margin-inline-start: 3px;
   font-family: monospace;
-  color: #444;
+  color: var(--c-kbd-color);
   vertical-align: middle;
-  background-color: #fcfcfc;
-  border: solid 1px #ccc;
-  border-bottom-color: #bbb;
+  background-color: var(--c-kbd-bg);
+  border: solid 1px var(--c-kbd-border);
+  border-bottom-color: var(--c-kbd-border-bottom);
   border-radius: 3px;
-  box-shadow: inset 0 -1px 0 #bbb;
+  box-shadow:
+    inset 0 -1px 0 var(--c-kbd-border-bottom),
+    0 1px 3px 0 rgba(0, 0, 0, 0.1);
+  line-height: 15px;
 }


### PR DESCRIPTION
# Why

Spotted that `kbd` elements are theme agnostic, let's add a proper dark theme support to them.

# How

Apply small appearance tweaks to `kbd`, add dark theme support.

Expand dynamically mix capabilities by allowing applying `darken` to the theme colors.

# Preview

<img width="532" height="142" alt="Screenshot 2026-02-26 at 11 04 50" src="https://github.com/user-attachments/assets/38b5b1fa-df0d-4933-a62a-70997f066889" />

<img width="532" height="142" alt="Screenshot 2026-02-26 at 11 04 39" src="https://github.com/user-attachments/assets/91c200e8-9bf2-4948-8f1e-e0c7da6422bd" />
