### PR TITLE
ui: tweak spacing on the Learn page, more concise display on mobile

### DIFF
--- a/ui/learn/css/_map.scss
+++ b/ui/learn/css/_map.scss
@@ -14,35 +14,42 @@
   .categ_stages {
     ---min-width: 100vw;
 
-    @media (min-width: at-least($xx-small)) {
+    @media (width >= $xx-small) {
       ---min-width: 400px;
     }
 
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(var(---min-width), 1fr));
     gap: 1em;
-    margin: 0.8em 0 3em 0;
+    margin: 1.5em 0 3em 0;
   }
 
   .stage {
     @extend %box-radius, %flex-center-nowrap;
-
     @include transition;
 
     position: relative;
     height: 90px;
     color: #fff;
-    margin-top: 13px;
     box-shadow:
       0 3px 5px 0 rgba(0, 0, 0, 0.3),
       0 1px 1px 0 rgba(0, 0, 0, 0.2);
     font-size: 1.2em;
 
+    @media (width < $xx-small) {
+      height: fit-content;
+    }
+
     img {
       width: 80px;
       height: 80px;
-      margin: 0 13px;
+      margin: 0 1em;
       opacity: 0.9;
+
+      @media (width < $xx-small) {
+        width: 50px;
+        height: 64px;
+      }
     }
 
     h3 {
@@ -179,7 +186,7 @@
     @extend %page-text-shadow !optional;
     width: 100%;
     text-align: center;
-    margin: 20px 0;
+    margin: 0.5em 0 1.5em;
     font-size: 1.2em;
   }
 }

--- a/ui/learn/css/_side-home.scss
+++ b/ui/learn/css/_side-home.scss
@@ -88,7 +88,6 @@
 
   .actions {
     padding: 20px 10px;
-    text-align: left;
   }
 
   a {

--- a/ui/learn/src/mapSideView.ts
+++ b/ui/learn/src/mapSideView.ts
@@ -64,9 +64,10 @@ function renderHome(ctrl: SideCtrl) {
         },
       }),
     ]),
-    h('div.actions', [
-      progress > 0
-        ? h(
+    progress > 0
+      ? h(
+          'div.actions',
+          h(
             'a.confirm',
             {
               hook: bind('click', async () => {
@@ -74,8 +75,8 @@ function renderHome(ctrl: SideCtrl) {
               }),
             },
             i18n.learn.resetMyProgress,
-          )
-        : null,
-    ]),
+          ),
+        )
+      : null,
   ]);
 }


### PR DESCRIPTION
# Why

Spotted some inconsistent spacing on the Learn tiles page.

# How

Adjust the headers and lesson tiles spacing, do not render empty `actions` node on progress/main tile, decrease the size of icons on mobile.

# Preview

<img width="2834" height="1720" alt="Screenshot 2026-02-27 at 10 29 44" src="https://github.com/user-attachments/assets/0529e9a8-6b58-4191-a8bc-583afb259552" />

<img width="828" height="1604" alt="Screenshot 2026-02-27 at 10 30 19" src="https://github.com/user-attachments/assets/fb655127-402f-4748-8e47-010e50ce256f" />

