### PR TITLE
ui: improve markdown editor styles, align more with lichess

### DIFF
--- a/ui/bits/css/_markdown-toastui.scss
+++ b/ui/bits/css/_markdown-toastui.scss
@@ -11,27 +11,29 @@
   }
   .toastui-editor {
     &-defaultUI {
+      @extend %base-font;
       border: none;
       &-toolbar {
-        @extend %metal, %box-radius-top;
-        border-radius: 3px 3px 0 0 !important;
+        @extend %metal;
+        border-radius: $box-radius-size $box-radius-size 0 0 !important;
         border: $border;
-        border-bottom: 0;
         flex-flow: row wrap;
       }
     }
     &-toolbar {
+      height: auto;
       &-icons {
         border-color: $c-border;
         &:not(:disabled) {
+          background-color: $c-bg-zebra;
           &:hover {
             background-color: $c-bg-box;
           }
-          &.active {
-            background-color: $c-bg-zebra;
-          }
         }
       }
+    }
+    &-toolbar-group button {
+      margin: 6px 3px;
     }
     &-dropdown {
       &-toolbar {
@@ -50,10 +52,7 @@
       }
     }
     &-md-tab-container {
-      background: none;
-      /* preview is not accurate to what lichess shows */
       display: none;
-      width: 0;
     }
     &-tabs {
       @extend %flex-center;
@@ -68,13 +67,27 @@
       }
     }
     &-popup {
+      @extend %box-radius;
+      border: $border;
+      background-color: $c-bg-page;
       margin-left: 0;
+
+      @include if-light {
+        background-color: $c-bg;
+      }
+
+      button {
+        text-align: center;
+      }
+    }
+    &-ok-button {
+      background-color: $c-primary !important;
     }
     &-ww-container,
     &-md-container {
+      @extend %box-radius-bottom;
       border: $border;
       border-top: 0;
-      border-radius: 0 0 3px 3px;
     }
     &.ww-mode,
     &.md-mode,
@@ -107,11 +120,18 @@
       background: none;
       border: none;
     }
-    &-popup-body li[data-type='Heading'] {
-      &[data-level='1'],
-      &[data-level='5'],
-      &[data-level='6'] {
-        display: none;
+    &-popup-body {
+      li[data-type='Heading'] {
+        &[data-level='1'],
+        &[data-level='5'],
+        &[data-level='6'] {
+          display: none;
+        }
+      }
+      input {
+        width: 100%;
+        border: $border;
+        border-radius: $box-radius-size !important;
       }
     }
   }


### PR DESCRIPTION
# Why

Fixes #19646

# How

Improve 3rd-party markdown editor styles to align more with lichess, use correct font, apply expected text align to buttons, improve readability.

# Preview

<img width="2276" height="802" alt="Screenshot 2026-02-27 at 11 12 59" src="https://github.com/user-attachments/assets/9890910c-c8e1-4798-af9a-699da25f2819" />
<img width="2276" height="802" alt="Screenshot 2026-02-27 at 11 12 33" src="https://github.com/user-attachments/assets/322a309f-9e78-482f-82c2-2595e28f2abc" />
