### PR TITLE
ui: improve blog cards hover appearance

### DIFF
--- a/ui/bits/css/ublog/_post.scss
+++ b/ui/bits/css/ublog/_post.scss
@@ -154,9 +154,6 @@
       display: block;
     }
   }
-  .ublog-post-card--link:hover {
-    box-shadow: none;
-  }
 }
 
 #mod-tools {

--- a/ui/lobby/css/_layout.scss
+++ b/ui/lobby/css/_layout.scss
@@ -63,7 +63,7 @@
     }
 
     &__blog {
-      margin: 1.2em 0;
+      padding: 1.2em 0;
     }
 
     &__support {

--- a/ui/lobby/css/_lobby.scss
+++ b/ui/lobby/css/_lobby.scss
@@ -103,7 +103,8 @@ body {
   .ublog-post-card {
     background: $c-bg-box;
     &:hover {
-      box-shadow: none;
+      @extend %box-shadow;
+      background: $c-bg-zebra;
     }
     .user-link {
       border-radius: $box-radius-size 0 0 0;


### PR DESCRIPTION
# Why

Spotted that blog cards on post page lack visible hover effect, and card shadow is clipped on the home page.

# How

Restore blue glow on blog cards on the post page, add background alteration and retain default shadow on hover for lobby blog cards, alter container to prevent shadow clipping.

# Preview

<img width="1880" height="1802" alt="Screenshot 2026-02-27 at 11 38 34" src="https://github.com/user-attachments/assets/d85511d1-d9e1-4258-a91e-76dbfbb040ff" />
<img width="1562" height="626" alt="Screenshot 2026-02-27 at 11 49 31" src="https://github.com/user-attachments/assets/37103ae9-13d7-4752-a707-f309a430b8ba" />
