### PR TITLE
ui: avoid unnecessary template string usages

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -32,6 +32,7 @@
     "typescript/consistent-indexed-object-style": "error",
     "typescript/no-confusing-non-null-assertion": "error",
     "typescript/no-extra-non-null-assertion": "error",
+    "typescript/no-unnecessary-template-expression": "error",
     "typescript/no-unnecessary-type-arguments": "error",
     "typescript/no-unnecessary-type-assertion": "error",
     "typescript/no-unnecessary-type-constraint": "error",

--- a/ui/.build/src/env.ts
+++ b/ui/.build/src/env.ts
@@ -100,7 +100,7 @@ export const env = new (class {
   done(ctx: Context, code: number | undefined): void {
     if (code !== undefined && code !== this.status[ctx] && ['tsc', 'esbuild', 'sass', 'i18n'].includes(ctx)) {
       this.log(
-        `${code === 0 ? 'Done' : c.red('Failed')}` + (this.watch ? ` - ${c.grey('Watching')}...` : ''),
+        `${code === 0 ? 'Done' : c.red('Failed')}${this.watch ? ` - ${c.grey('Watching')}...` : ''}`,
         ctx,
       );
     }

--- a/ui/.build/src/tsc.ts
+++ b/ui/.build/src/tsc.ts
@@ -157,7 +157,7 @@ function tscError({ code, text, file, line, col }: ErrorMessage['data']): void {
   const key = `${code}:${text}:${file}`;
   if (performance.now() > (spamGuard.get(key) ?? -Infinity)) {
     const prelude = `${errorMark} ts${code} `;
-    const message = `${ts.flattenDiagnosticMessageText(text, '\n', 0)}`;
+    const message = ts.flattenDiagnosticMessageText(text, '\n', 0);
     let location = '';
     if (file) {
       location = `${c.grey('in')} '${c.cyan(relative(env.uiDir, file))}`;

--- a/ui/analyse/src/study/relay/relayGames.ts
+++ b/ui/analyse/src/study/relay/relayGames.ts
@@ -69,7 +69,7 @@ export const gamesList = (study: StudyCtrl, relay: RelayCtrl) => {
                             hl('span.name', [userTitle(p), p.name]),
                           ]),
                           coloredResult
-                            ? hl(`${coloredResult.tag}`, [coloredResult.points])
+                            ? hl(coloredResult.tag, [coloredResult.points])
                             : showResults && hl('span', clocks[i]),
                         ]
                       : [hl('span.mini-game__user', hl('span.name', 'Unknown player'))],

--- a/ui/analyse/src/study/relay/relayPlayers.ts
+++ b/ui/analyse/src/study/relay/relayPlayers.ts
@@ -303,7 +303,7 @@ export const renderPlayers = (
               hl(
                 'th.tiebreak',
                 { attrs: { 'data-sort': tb.points, title: tb.description, 'aria-label': tb.description } },
-                `${tb.extendedCode}`,
+                tb.extendedCode,
               ),
             ),
           ]),
@@ -445,7 +445,7 @@ const renderPlayerGames = (ctrl: RelayPlayers, p: RelayPlayerWithGames, withTips
     if (!coloredResult) return;
 
     return hl(
-      `${coloredResult.tag}`,
+      coloredResult.tag,
       customPoints && points.replace('1/2', '0.5') !== customPoints.toString()
         ? customPoints
         : coloredResult.points,

--- a/ui/analyse/src/study/relay/relayTeamLeaderboard.ts
+++ b/ui/analyse/src/study/relay/relayTeamLeaderboard.ts
@@ -65,7 +65,7 @@ export default class RelayTeamLeaderboard {
           [
             hl('thead', [
               hl('tr', [
-                hl('th.text', { attrs: dataIcon(Group) }, `${i18n.team.team}`),
+                hl('th.text', { attrs: dataIcon(Group) }, i18n.team.team),
                 hl('th', i18n.broadcast.matches),
                 hl('th', { attrs: { 'data-sort-default': 1 } }, i18n.broadcast.matchPoints),
                 hl('th', i18n.broadcast.gamePoints),
@@ -160,10 +160,7 @@ export default class RelayTeamLeaderboard {
                 ),
                 hl(
                   'td.score',
-                  hl(
-                    `${match.points === '1' ? 'good' : match.points === '0' ? 'bad' : 'draw'}`,
-                    match.mp ?? '*',
-                  ),
+                  hl(match.points === '1' ? 'good' : match.points === '0' ? 'bad' : 'draw', match.mp ?? '*'),
                 ),
                 hl('td.score', match.gp ?? '*'),
               ]),

--- a/ui/analyse/src/view/nvuiView.ts
+++ b/ui/analyse/src/view/nvuiView.ts
@@ -109,7 +109,7 @@ export function renderNvui(ctx: AnalyseNvuiContext): VNode {
       !ctrl.retro && liveText(renderCurrentNode(ctx), 'polite', 'p.position.lastMove'),
       clocks &&
         hl('div.clocks', [
-          hl('h2', `${i18n.site.clock}`),
+          hl('h2', i18n.site.clock),
           hl('div.clocks', [hl('div.topc', clocks[0]), hl('div.botc', clocks[1])]),
         ]),
       hl('h2', i18n.nvui.inputForm),

--- a/ui/botDev/src/pane.ts
+++ b/ui/botDev/src/pane.ts
@@ -345,7 +345,7 @@ export class RangeSetting<Info extends RangeInfo = RangeInfo> extends NumberSett
 function getRequirementIds(r: Requirement | undefined): string[] {
   if (typeof r === 'string') {
     const req = r.trim();
-    if (req.startsWith('!')) return [`${req.slice(1).trim()}`];
+    if (req.startsWith('!')) return [req.slice(1).trim()];
     const [left, right] = req.split(requiresOpRe).map(x => x.trim());
     const ids = [];
     if (left && isNaN(Number(left))) ids.push(left);

--- a/ui/chart/src/chart.relayStats.ts
+++ b/ui/chart/src/chart.relayStats.ts
@@ -51,7 +51,7 @@ const makeDataset = (data: RoundStats, el: HTMLCanvasElement): chart.ChartDatase
       indexAxis: 'x',
       type: 'line',
       data: fillData(data.viewers),
-      label: `${data.round.name}`,
+      label: data.round.name,
       pointBorderColor: '#fff',
       pointBackgroundColor: blue,
       backgroundColor: gradient,

--- a/ui/coordinateTrainer/src/side.ts
+++ b/ui/coordinateTrainer/src/side.ts
@@ -192,7 +192,7 @@ const scoreCharts = (ctrl: CoordinateTrainerCtrl): VNode =>
       ].map(([color, fmt, scoreList]: [Color, I18nFormat, number[]]) =>
         scoreList.length
           ? h('div.color-chart', [
-              h('p', fmt.asArray(h('strong', `${average(scoreList).toFixed(2)}`))),
+              h('p', fmt.asArray(h('strong', average(scoreList).toFixed(2)))),
               h('div.sparkline-box', [
                 h('svg.sparkline', {
                   attrs: { height: '80px', 'stroke-width': '3', id: `${color}-sparkline` },

--- a/ui/lib/src/ceval/view/main.ts
+++ b/ui/lib/src/ceval/view/main.ts
@@ -73,9 +73,8 @@ function localInfo(ctrl: CevalHandler, ev?: ClientEval | false): EvalInfo {
   const knps = ev.nodes / (ev?.millis ?? Number.POSITIVE_INFINITY);
 
   if (knps > 0) {
-    info.npsText = `${
-      knps > 1000 ? (knps / 1000).toFixed(knps > 10000 ? 0 : 1) + ' Mn/s' : Math.round(knps) + ' kn/s'
-    }`;
+    info.npsText =
+      knps > 1000 ? (knps / 1000).toFixed(knps > 10000 ? 0 : 1) + ' Mn/s' : Math.round(knps) + ' kn/s';
     info.knps = knps;
   }
   return info;

--- a/ui/lib/src/nvui/render.ts
+++ b/ui/lib/src/nvui/render.ts
@@ -57,7 +57,7 @@ export const renderPockets = (pockets: NodeCrazy['pockets']): VNode =>
   h(
     'div.pieces',
     COLORS.map((color, i) =>
-      h(`div.${color}-pieces`, [h('h3', i18n.site[color]), `${pocketsStr(pockets[i])}` || '0']),
+      h(`div.${color}-pieces`, [h('h3', i18n.site[color]), pocketsStr(pockets[i]) ?? '0']),
     ),
   );
 

--- a/ui/puzzle/src/view/nvuiView.ts
+++ b/ui/puzzle/src/view/nvuiView.ts
@@ -87,7 +87,7 @@ export function renderNvui({
           h('label', [
             ctrl.mode === 'view'
               ? 'Command input'
-              : `${i18n.puzzle[ctrl.pov === 'white' ? 'findTheBestMoveForWhite' : 'findTheBestMoveForBlack']}`,
+              : i18n.puzzle[ctrl.pov === 'white' ? 'findTheBestMoveForWhite' : 'findTheBestMoveForBlack'],
             h('input.move.mousetrap', {
               attrs: { name: 'move', type: 'text', autocomplete: 'off', autofocus: true },
             }),

--- a/ui/voice/src/move/voice.move.ts
+++ b/ui/voice/src/move/voice.move.ts
@@ -453,7 +453,7 @@ export function initModule({
           if ((nsrc & 7) === (other & 7)) rank = uci[1];
           else file = uci[0];
         }
-        for (const piece of [`${srole}${file}${rank}`, `${srole}`]) {
+        for (const piece of [`${srole}${file}${rank}`, srole]) {
           if (dp) addToks(`${piece}x${udest}`, uci);
           addToks(`${piece}${udest}`, uci);
         }


### PR DESCRIPTION
# Why

Template string expression adds unnecessary complexity and reduce code readability.

# How

Enable [`typescript/no-unnecessary-template-expression`](https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-unnecessary-template-expression) rule, fix reported warnings.
