### PR TITLE
fix: string date formatter

### DIFF
--- a/ui/lib/src/i18n.ts
+++ b/ui/lib/src/i18n.ts
@@ -20,8 +20,7 @@ export const timeago: (d: DateLike) => string = (date: DateLike) =>
 // format Date / string / timestamp to Date instance.
 export const toDate = (input: DateLike): Date => {
   if (input instanceof Date) return input;
-  if (typeof input === 'string') return new Date(Number.isNaN(input) ? input : parseInt(input));
-  else return new Date(input);
+  return new Date(isNaN(input as any) ? input : parseInt(input as any));
 };
 
 export const use24h = (): boolean => !commonDateFormatter.resolvedOptions().hour12;


### PR DESCRIPTION
Reverts the change made in this pr: https://github.com/lichess-org/lila/pull/19659

This is what I saw when creating a 10 min announcement:
<img width="356" height="45" src="https://github.com/user-attachments/assets/49ed03d2-1411-493b-88d8-fc79b1062c75" />

https://github.com/lichess-org/lila/blob/daf649fd76e32c456e94ae5f6d5d1ca07aa022f1/ui/lib/src/i18n.ts#L21-L25

you can check by doing this;

```
var input = "2026-03-01T07:59:00.161611Z";
new Date(Number.isNaN(input) ? input : parseInt(input)) // "1970-01-01T00:00:02.026Z"
```

and this is the output that I expect:

```
var input = "2026-03-01T07:59:00.161611Z";
new Date(isNaN(input) ? input : parseInt(input)) // "2026-03-01T07:59:00.161Z"
```