### PR TITLE
ui: fix forum posts overflow with long links

### DIFF
--- a/ui/bits/css/forum/_post.scss
+++ b/ui/bits/css/forum/_post.scss
@@ -40,6 +40,10 @@
     border-bottom: $border;
   }
 
+  &__message a {
+    overflow-wrap: anywhere;
+  }
+
   &.erased {
     color: $c-font-dimmer;
 


### PR DESCRIPTION
# Why

Fixes #19654

* https://github.com/lichess-org/lila/issues/19654

# How

Add overflow wrap property to the links inside forum posts.

# Preview

<img width="752" height="926" alt="Screenshot 2026-03-01 at 10 23 25" src="https://github.com/user-attachments/assets/541cb151-2bea-48a9-9640-611ccbc0d77e" />
