### PR TITLE
ui: add class to tutor header containers with selects, allow overflow

### DIFF
--- a/modules/tutor/src/main/ui/TutorOpening.scala
+++ b/modules/tutor/src/main/ui/TutorOpening.scala
@@ -39,7 +39,7 @@ final class TutorOpening(helpers: Helpers, bits: TutorBits, perfUi: TutorPerfUi)
       menu = perfUi.menu(perfReport, "opening".some)(using full.config)
     )(cls := "tutor__opening tutor-layout"):
       frag(
-        div(cls := "box")(
+        div(cls := "tutor-header box")(
           boxTop(
             h1(
               a(href := full.url.angle(perfReport.perf, "opening"), dataIcon := Icon.LessThan),
@@ -97,7 +97,7 @@ final class TutorOpening(helpers: Helpers, bits: TutorBits, perfUi: TutorPerfUi)
       cls := "tutor__openings tutor-layout"
     ):
       frag(
-        div(cls := "box")(
+        div(cls := "tutor-header box")(
           boxTop(
             h1(
               a(href := full.config.url.perf(report.perf), dataIcon := Icon.LessThan),

--- a/modules/tutor/src/main/ui/TutorPerfUi.scala
+++ b/modules/tutor/src/main/ui/TutorPerfUi.scala
@@ -13,7 +13,7 @@ final class TutorPerfUi(helpers: Helpers, bits: TutorBits):
     given TutorConfig = full.config
     bits.page(menu = menu(report, none))(cls := "tutor__perf tutor-layout"):
       frag(
-        div(cls := "box")(
+        div(cls := "tutor-header box")(
           boxTop(
             h1(
               a(href := full.url.root, dataIcon := Icon.LessThan),
@@ -143,7 +143,7 @@ final class TutorPerfUi(helpers: Helpers, bits: TutorBits):
     given TutorConfig = full.config
     bits.page(menu = menu(report, "phases".some))(cls := "tutor__phases tutor-layout"):
       frag(
-        div(cls := "box")(
+        div(cls := "tutor-header box")(
           frag(
             angleTop(full, report, "phases"),
             bits.mascotSays(ul(report.phases.highlights(3).map(compare.show(_))))
@@ -192,7 +192,7 @@ final class TutorPerfUi(helpers: Helpers, bits: TutorBits):
     given TutorConfig = full.config
     bits.page(menu = menu(report, "pieces".some))(cls := "tutor__pieces tutor-layout"):
       frag(
-        div(cls := "box")(
+        div(cls := "tutor-header box")(
           frag(
             angleTop(full, report, "pieces"),
             bits.mascotSays(ul(report.pieces.highlights(3).map(compare.show(_, "with"))))
@@ -222,7 +222,7 @@ final class TutorPerfUi(helpers: Helpers, bits: TutorBits):
     given TutorConfig = full.config
     bits.page(menu = menu(report, "skills".some))(cls := "tutor__skills tutor-layout"):
       frag(
-        div(cls := "box")(
+        div(cls := "tutor-header box")(
           angleTop(full, report, "skills"),
           bits.mascotSays(
             ul(report.skillHighlights(3).map(compare.show(_)))
@@ -240,7 +240,7 @@ final class TutorPerfUi(helpers: Helpers, bits: TutorBits):
     given TutorConfig = full.config
     bits.page(menu = menu(report, "time".some))(cls := "tutor__time tutor-layout"):
       frag(
-        div(cls := "box")(
+        div(cls := "tutor-header box")(
           angleTop(full, report, "time"),
           bits.mascotSays(
             ul(report.timeHighlights(5).map(compare.show(_)))

--- a/ui/tutor/css/_title.scss
+++ b/ui/tutor/css/_title.scss
@@ -11,6 +11,9 @@
       height: 1.5em;
     }
   }
+  .tutor-header {
+    overflow: visible;
+  }
   @media (max-width: at-most($xx-small)) {
     gap: 0.5ch;
     .mselect {


### PR DESCRIPTION
# Why

Fixes #19653

* #19653

# How

Add `tutor-header` class to tutor head/title containers with selects, allow overflow.

Was also thinking about relying on `> .box` selector, but this might be too broad, and apply style to some other boxes which are part of tutor page.

# Preview

<img width="2542" height="1418" alt="Screenshot 2026-03-01 at 12 17 17" src="https://github.com/user-attachments/assets/602fd150-4b8a-4598-8aef-22fd74d3fee8" />

