### PR TITLE
ui: move new patrons section up and add missing hover style on patrons page

### DIFF
--- a/ui/bits/css/plan/_page.scss
+++ b/ui/bits/css/plan/_page.scss
@@ -279,12 +279,15 @@
     }
 
     h2 {
-      margin: 300px 0 0.4em 0;
+      margin: 188px 0 0.4em 0;
       border-bottom: $border;
     }
 
     a {
       color: $c-font-page;
+      &:hover {
+        color: $c-link;
+      }
     }
   }
 }


### PR DESCRIPTION
# Why

Spotted that new patrons links lacks interaction effect (default hover color is overwritten by custom link color.

# How

Move new patrons section slightly up and add missing hover style on patrons page.

# Preview

<img width="1614" height="1410" alt="Screenshot 2026-03-01 at 15 06 44" src="https://github.com/user-attachments/assets/31ca9e48-ebb0-4d43-80a7-f840f795af2b" />
