### PR TITLE
Mac scroll

### DIFF
--- a/ui/analyse/src/view/components.ts
+++ b/ui/analyse/src/view/components.ts
@@ -15,7 +15,7 @@ import {
   stepwiseScroll,
 } from 'lib/view';
 import { playable } from 'lib/game';
-import { isMobile, requiresMoreDeltaForStepwiseScroll } from 'lib/device';
+import { isMobile } from 'lib/device';
 import * as materialView from 'lib/game/view/material';
 import { path as treePath } from 'lib/tree/tree';
 import { view as actionMenu } from './actionMenu';
@@ -144,9 +144,8 @@ export function renderTools({ ctrl, deps, concealOf, allowVideo }: ViewContext, 
   ]);
 }
 
-export const renderBoard = ({ ctrl, study, playerBars, playerStrips }: ViewContext): VNode => {
-  let accumulatedDelta = 0;
-  return hl(
+export const renderBoard = ({ ctrl, study, playerBars, playerStrips }: ViewContext): VNode =>
+  hl(
     addChapterId(study, 'div.analyse__board.main-board'),
     {
       hook:
@@ -154,22 +153,16 @@ export const renderBoard = ({ ctrl, study, playerBars, playerStrips }: ViewConte
           ? undefined
           : bindNonPassive(
               'wheel',
-              stepwiseScroll((e: WheelEvent, scroll: boolean) => {
-                const target = e.target as HTMLElement;
-                if (
-                  ctrl.gamebookPlay() ||
-                  !scroll ||
-                  !['PIECE', 'SQUARE', 'CG-BOARD'].includes(target.tagName)
-                )
-                  return;
-                e.preventDefault();
-                accumulatedDelta += e.deltaY;
-                if (requiresMoreDeltaForStepwiseScroll(accumulatedDelta, e.deltaMode)) return;
-                accumulatedDelta = 0;
-                if (e.deltaY > 0) control.next(ctrl);
-                else if (e.deltaY < 0) control.prev(ctrl);
-                ctrl.redraw();
-              }),
+              stepwiseScroll(
+                e => {
+                  if (e.deltaY > 0) control.next(ctrl);
+                  else if (e.deltaY < 0) control.prev(ctrl);
+                  ctrl.redraw();
+                },
+                e =>
+                  !!ctrl.gamebookPlay() ||
+                  !['PIECE', 'SQUARE', 'CG-BOARD'].includes((e.target as HTMLElement).tagName),
+              ),
             ),
     },
     [
@@ -180,7 +173,6 @@ export const renderBoard = ({ ctrl, study, playerBars, playerStrips }: ViewConte
       ctrl.promotion.view(ctrl.data.game.variant.key === 'antichess'),
     ],
   );
-};
 
 export const renderUnderboard = ({ ctrl, deps, study }: ViewContext): VNode =>
   hl(

--- a/ui/botPlay/src/play/view/playView.ts
+++ b/ui/botPlay/src/play/view/playView.ts
@@ -193,11 +193,13 @@ const boardScroll = (ctrl: PlayCtrl) =>
     ? undefined
     : bind(
         'wheel',
-        stepwiseScroll((e: WheelEvent, scroll: boolean) => {
-          e.preventDefault();
-          if (e.deltaY > 0 && scroll) ctrl.goDiff(1);
-          else if (e.deltaY < 0 && scroll) ctrl.goDiff(-1);
-        }),
+        stepwiseScroll(
+          e => {
+            if (e.deltaY > 0) ctrl.goDiff(1);
+            else if (e.deltaY < 0) ctrl.goDiff(-1);
+          },
+          () => false,
+        ),
         undefined,
         false,
       );

--- a/ui/lib/src/ceval/view/main.ts
+++ b/ui/lib/src/ceval/view/main.ts
@@ -17,7 +17,7 @@ import { uciToMove } from '@lichess-org/chessground/util';
 import { renderCevalSettings } from './settings';
 import type CevalCtrl from '../ctrl';
 import { Chessground as makeChessground } from '@lichess-org/chessground';
-import { isTouchDevice, requiresMoreDeltaForStepwiseScroll } from '@/device';
+import { isTouchDevice } from '@/device';
 import type { ClientEval, LocalEval, PvData } from '@/tree/types';
 
 type EvalInfo = { knps: number; npsText: string; depthText: string };
@@ -377,23 +377,22 @@ export function renderPvs(ctrl: CevalHandler): VNode | undefined {
               ceval.setPvBoard({ fen, uci });
             }
           });
-          let accumulatedDelta = 0;
           el.addEventListener(
             'wheel',
-            stepwiseScroll((e: WheelEvent, scroll: boolean) => {
-              if (scroll) e.preventDefault();
-              if (pvIndex === null) return;
-              accumulatedDelta += e.deltaY;
-              if (requiresMoreDeltaForStepwiseScroll(accumulatedDelta, e.deltaMode)) return;
-              accumulatedDelta = 0;
-              if (e.deltaY < 0 && pvIndex > 0 && scroll) pvIndex -= 1;
-              else if (e.deltaY > 0 && pvIndex < pvMoves.length - 1 && scroll) pvIndex += 1;
-              const pvBoard = pvMoves[pvIndex];
-              if (pvBoard) {
-                const [fen, uci] = pvBoard.split('|');
-                ctrl.ceval.setPvBoard({ fen, uci });
-              }
-            }),
+            stepwiseScroll(
+              e => {
+                if (pvIndex === null) return; // should never be true, just for type inference
+                if (e.deltaY < 0 && pvIndex > 0) pvIndex -= 1;
+                else if (e.deltaY > 0 && pvIndex < pvMoves.length - 1) pvIndex += 1;
+                const pvBoard = pvMoves[pvIndex];
+                if (pvBoard) {
+                  const [fen, uci] = pvBoard.split('|');
+                  ctrl.ceval.setPvBoard({ fen, uci });
+                }
+              },
+              () => pvIndex === null,
+              true,
+            ),
           );
           el.addEventListener('mouseout', () => setHovering(ceval, null));
           el.addEventListener('mouseleave', resetPvIndexAndBoard);

--- a/ui/lib/src/device.ts
+++ b/ui/lib/src/device.ts
@@ -150,6 +150,3 @@ export function isVersionCompatible(version: string | undefined | false, vc?: Ve
     return false;
   }
 }
-
-export const requiresMoreDeltaForStepwiseScroll = (accumulatedDelta: number, deltaMode: number): boolean =>
-  deltaMode === 0 && isMac() && Math.abs(accumulatedDelta) < 10;

--- a/ui/lib/src/view/controls.ts
+++ b/ui/lib/src/view/controls.ts
@@ -4,6 +4,7 @@ import { h, type Hooks, type VNode, type Attrs } from 'snabbdom';
 import { toggle as baseToggle, type Toggle } from '@/index';
 import * as xhr from '@/xhr';
 import * as licon from '@/licon';
+import { isMac } from '@/device';
 
 export function enter<E extends HTMLElement>(effect: (target: E) => void) {
   return (e: Event): void => {
@@ -38,8 +39,24 @@ export const boolPrefXhrToggle = (prefKey: string, val: boolean, effect: () => v
     effect();
   });
 
-export function stepwiseScroll(inner: (e: WheelEvent, scroll: boolean) => void): (e: WheelEvent) => void {
-  return (e: WheelEvent) => inner(e, !e.ctrlKey); // if touchpad zooming, e.ctrlKey is true
+export function stepwiseScroll(
+  scrollAction: (e: WheelEvent) => void,
+  shouldSkip: (e: WheelEvent) => boolean,
+  ifSkipShouldStillPreventDefault?: boolean,
+): (e: WheelEvent) => void {
+  let accumulatedDelta = 0;
+  return (e: WheelEvent) => {
+    if (e.ctrlKey) return; // if touchpad zooming, e.ctrlKey is true
+    if (shouldSkip(e)) {
+      if (ifSkipShouldStillPreventDefault) e.preventDefault();
+      return;
+    }
+    e.preventDefault();
+    accumulatedDelta += e.deltaY;
+    if (e.deltaMode === 0 && isMac() && Math.abs(accumulatedDelta) < 10) return;
+    accumulatedDelta = 0;
+    scrollAction(e);
+  };
 }
 
 export function copyMeInput(content: string, inputAttrs: Attrs = {}): VNode {

--- a/ui/puzzle/src/view/main.ts
+++ b/ui/puzzle/src/view/main.ts
@@ -25,7 +25,6 @@ import { Coords } from 'lib/prefs';
 import type PuzzleCtrl from '../ctrl';
 import { dispatchChessgroundResize } from 'lib/chessgroundResize';
 import { storage } from 'lib/storage';
-import { requiresMoreDeltaForStepwiseScroll } from 'lib/device';
 
 const renderAnalyse = (ctrl: PuzzleCtrl): VNode => hl('div.puzzle__moves.areplay', [treeView(ctrl)]);
 
@@ -79,7 +78,6 @@ export default function (ctrl: PuzzleCtrl): VNode {
     if (!cevalShown) ctrl.autoScrollNow = true;
     cevalShown = ctrl.showAnalysis();
   }
-  let accumulatedDelta = 0;
   return hl(
     `main.puzzle.puzzle-${ctrl.data.replay ? 'replay' : 'play'}${ctrl.streak ? '.puzzle--streak' : ''}`,
     {
@@ -113,17 +111,14 @@ export default function (ctrl: PuzzleCtrl): VNode {
               ? undefined
               : bindNonPassive(
                   'wheel',
-                  stepwiseScroll((e: WheelEvent, scroll: boolean) => {
-                    const target = e.target as HTMLElement;
-                    if (!scroll || !['PIECE', 'SQUARE', 'CG-BOARD'].includes(target.tagName)) return;
-                    e.preventDefault();
-                    accumulatedDelta += e.deltaY;
-                    if (requiresMoreDeltaForStepwiseScroll(accumulatedDelta, e.deltaMode)) return;
-                    accumulatedDelta = 0;
-                    if (e.deltaY > 0) control.next(ctrl);
-                    else if (e.deltaY < 0) control.prev(ctrl);
-                    ctrl.redraw();
-                  }),
+                  stepwiseScroll(
+                    e => {
+                      if (e.deltaY > 0) control.next(ctrl);
+                      else if (e.deltaY < 0) control.prev(ctrl);
+                      ctrl.redraw();
+                    },
+                    e => !['PIECE', 'SQUARE', 'CG-BOARD'].includes((e.target as HTMLElement).tagName),
+                  ),
                 ),
         },
         [chessground(ctrl), ctrl.promotion.view()],

--- a/ui/round/src/view/main.ts
+++ b/ui/round/src/view/main.ts
@@ -10,7 +10,7 @@ import { renderMaterialDiffs } from 'lib/game/view/material';
 import { renderVoiceBar } from 'voice';
 import { playable } from 'lib/game';
 import { storage } from 'lib/storage';
-import { displayColumns, isTouchDevice, requiresMoreDeltaForStepwiseScroll } from 'lib/device';
+import { displayColumns, isTouchDevice } from 'lib/device';
 
 export function main(ctrl: RoundController): VNode {
   const d = ctrl.data,
@@ -25,7 +25,6 @@ export function main(ctrl: RoundController): VNode {
       ctrl.ply,
     );
   const hideBoard = ctrl.data.player.blindfold && playable(ctrl.data);
-  let accumulatedDelta = 0;
   return ctrl.nvui
     ? ctrl.nvui.render()
     : hl(
@@ -45,16 +44,14 @@ export function main(ctrl: RoundController): VNode {
                   ? undefined
                   : bind(
                       'wheel',
-                      stepwiseScroll((e: WheelEvent, scroll: boolean) => {
-                        if (!scroll || ctrl.isPlaying()) return;
-                        e.preventDefault();
-                        accumulatedDelta += e.deltaY;
-                        if (requiresMoreDeltaForStepwiseScroll(accumulatedDelta, e.deltaMode)) return;
-                        accumulatedDelta = 0;
-                        if (e.deltaY > 0) next(ctrl);
-                        else if (e.deltaY < 0) prev(ctrl);
-                        ctrl.redraw();
-                      }),
+                      stepwiseScroll(
+                        e => {
+                          if (e.deltaY > 0) next(ctrl);
+                          else if (e.deltaY < 0) prev(ctrl);
+                          ctrl.redraw();
+                        },
+                        () => ctrl.isPlaying(),
+                      ),
                       undefined,
                       false,
                     ),


### PR DESCRIPTION
Closes #19486.

Changes:
- For move scrolling (in analysis, round, puzzle, ceval, botplay), require a larger delta if scrolling with mac.
- Also in puzzles and botplay, allow for touchpad zooming in on board.
- The changes in cf13ea778 should all be non-functional.

Caveat: I haven't tested the botplay changes since I haven't had time to figure out how to get it running locally yet.