### PR TITLE
workspace: fix lint-staged configs, lint styles, add scalafmt command

### DIFF
--- a/bin/git-hooks/pre-commit
+++ b/bin/git-hooks/pre-commit
@@ -4,7 +4,7 @@
 # when no files match, and we execute lint-stage directly, it still delays
 # the commit by .15s or so, which is annoying.
 if \git --no-pager diff-index -z --name-only --no-renames --cached HEAD | \
-  \grep -qzE '\.(json|scss|ts)$'; then
+  \grep -qzE '\.(json|ts|mts|mjs|scss)$'; then
   # NOTE! grep must be kept in sync with lint-staged config (ui/lint-staged-config.mjs)
 
   ROOT_DIR="$(dirname -- $0)/../.."

--- a/package.json
+++ b/package.json
@@ -39,19 +39,20 @@
   ],
   "scripts": {
     "format": "oxfmt",
+    "format:scala": "./lila.sh scalafmtAll",
     "check-format": "oxfmt --check",
-    "add-hooks": "git config get --all core.hooksPath | grep -Fxq bin/git-hooks || git config set --append core.hooksPath bin/git-hooks",
-    "remove-hooks": "git config unset --value=bin/git-hooks core.hooksPath || true",
     "lint": "oxlint --type-aware --tsconfig=ui/tsconfig.base.json && stylelint \"**/*.scss\"",
     "lint:fix": "oxlint --type-aware --tsconfig=ui/tsconfig.base.json --fix && stylelint \"**/*.scss\" --fix",
     "journal": "journalctl --user -fu lila -o cat",
     "metals": "tail -F .metals/metals.log | stdbuf -oL cut -c 21- | rg -v '(notification for request|handleCancellation)'",
     "serverlog": "pnpm journal & pnpm metals",
     "i18n-file-gen": "pnpx tsx bin/i18n-file-gen.ts",
-    "multilog": "pnpm serverlog & ui/build -w"
+    "multilog": "pnpm serverlog & ui/build -w",
+    "add-hooks": "git config get --all core.hooksPath | grep -Fxq bin/git-hooks || git config set --append core.hooksPath bin/git-hooks",
+    "remove-hooks": "git config unset --value=bin/git-hooks core.hooksPath || true"
   },
   "lint-staged": {
-    "*.{json,scss,ts,mts,mjs}": "pnpm lint --fix && pnpm format"
+    "*.{json,scss,ts,mts,mjs,scss}": "pnpm lint:fix && pnpm format"
   },
   "browserslist": [
     "defaults",

--- a/ui/lint-staged.config.mjs
+++ b/ui/lint-staged.config.mjs
@@ -1,9 +1,19 @@
-import { lstatSync } from 'fs';
+import { lstatSync } from 'node:fs';
+
+function filterSymbolicLinks(files) {
+  return files.filter(f => !lstatSync(f).isSymbolicLink());
+}
 
 export default {
   // NOTE: these patterns must stay in sync with bin/git-hooks/pre-commit!
-  'ui/*.{json,scss,ts}': files => {
-    const regularFiles = files.filter(f => !lstatSync(f).isSymbolicLink());
-    return regularFiles.length ? `oxfmt --config=ui/.oxfmtrc.json --write ${regularFiles.join(' ')}` : 'true';
+  'ui/*.{json,ts,mts,mjs}': files => {
+    const regularFiles = filterSymbolicLinks(files);
+    return regularFiles.length
+      ? `oxlint --type-aware --config=.oxlintrc.json --tsconfig=./ui/tsconfig.base.json --fix ${regularFiles.join(' ')} && oxfmt`
+      : 'true';
+  },
+  'ui/*.scss': files => {
+    const regularFiles = filterSymbolicLinks(files);
+    return regularFiles.length ? `stylelint ${regularFiles.join(' ')} --fix && oxfmt` : 'true';
   },
 };


### PR DESCRIPTION
# Why

Spotted that `lint-staged` config has been a bit outdated in comparison to repository lint setup.

# How

Fix `lint-staged` configs, add styles lint, add formatting to the command chain, update extension list in `pre-commit` hook and add `format:scala` command to the workspace as a `./lila.sh scalafmtAll` shorthand.
