### PR TITLE
ui: don't link to self on opening details page

### DIFF
--- a/modules/opening/src/main/ui/OpeningUi.scala
+++ b/modules/opening/src/main/ui/OpeningUi.scala
@@ -80,12 +80,10 @@ final class OpeningUi(helpers: Helpers, bits: OpeningBits, wiki: WikiUi):
                     case Left(move) => span(cls := "opening__name__move")((i > 0).option(", "), move)
                     case Right((name, key)) =>
                       val className = s"opening__name__section opening__name__section--${i + 1}"
+                      val tag = key.ifFalse(isLast).fold(span)(k => a(href := openingKeyUrl(k)))
                       frag(
                         if i == 0 then emptyFrag else if i == 1 then ": " else ", ",
-                        (key, isLast) match
-                          case (_, true) => span(cls := className)(name)
-                          case (None, false) => span(cls := className)(name)
-                          case (Some(k), false) => a(href := openingKeyUrl(k))(cls := className)(name)
+                        tag(cls := className)(name)
                       )
                 )
             )


### PR DESCRIPTION
# Why

Spotted that header links on the opening details page can link to itself, which is a bit confusing.

# How

Don't link to self in opening details page header links.

# Preview

https://github.com/user-attachments/assets/cc362f16-dfbb-4050-b00e-6ca78fab33b4


