### PR TITLE
ui: do not apply hover style for disabled radio inputs

### DIFF
--- a/ui/lib/css/form/_radio.scss
+++ b/ui/lib/css/form/_radio.scss
@@ -23,8 +23,16 @@ group.radio {
     cursor: pointer;
     border-inline-end: $border;
 
+    &.disabled {
+      background: $c-metal-top;
+
+      @include if-light {
+        background: $c-metal-bottom;
+      }
+    }
+
     @media (hover: hover) {
-      &:hover {
+      &:not(.disabled):hover {
         background: linear-gradient(to bottom, $c-metal-top-hover, $c-metal-bottom-hover);
         text-shadow: 0 1px 0 $c-font-shadow;
       }


### PR DESCRIPTION
# Why

Spotted that disabled radio inputs options (in togglable tabs) still apply hover styles.

# How

Do not apply hover styles to disabled elements, adjust disabled options background color.

# Preview

<img width="1320" height="1270" alt="Screenshot 2026-03-02 at 14 56 39" src="https://github.com/user-attachments/assets/18a33df7-ae1a-4070-bd6d-f671947172c7" />
<img width="1320" height="1270" alt="Screenshot 2026-03-02 at 14 56 50" src="https://github.com/user-attachments/assets/5fe75097-5912-4da3-b7ac-78b00a689793" />
<img width="1320" height="1270" alt="Screenshot 2026-03-02 at 14 57 05" src="https://github.com/user-attachments/assets/57554423-3f38-4e94-9cf9-c4e989c5ff73" />
