### PR TITLE
ui: enhance dragging behavior for chess pieces in Safari

### DIFF
--- a/ui/lib/css/theme/board/_chessground.scss
+++ b/ui/lib/css/theme/board/_chessground.scss
@@ -137,6 +137,10 @@ piece {
   &.dragging {
     cursor: move;
     z-index: $z-cg__piece_dragging-204 !important;
+    // Safari: force pointer-events through so the square under the piece receives
+    // events and destination highlights work (see https://github.com/lichess-org/lila/issues/17811)
+    pointer-events: none !important;
+    opacity: 0.92; // allow square highlight to show through while dragging
   }
 
   &.anim {


### PR DESCRIPTION
## Fix: Square highlight when dragging a piece on Safari (#17811)

### Problem

On Safari (macOS), when dragging a piece over the board, the square under the piece does not show the destination highlight. The same flow works in Chrome. This affects:

- **Your turn:** dragging a piece over legal destination squares (move-dest highlight).
- **Opponent's turn:** dragging for premove (premove-dest highlight).

### Root cause

Safari's hit-testing can still treat the **dragging piece** (transformed, high z-index) as the target of pointer events even when the base `piece` rule has `pointer-events: none`. As a result:

- Events do not reliably reach the squares under the cursor.
- Destination squares do not get (or keep) the highlight, and the "square under cursor" behavior is wrong.

This matches known WebKit/Safari behavior around `pointer-events` and transformed elements (e.g. [WebKit bug 167021](https://bugs.webkit.org/show_bug.cgi?id=167021)).

### Solution

In **`ui/lib/css/theme/board/_chessground.scss`**, for the dragging piece we:

1. **Force pointer-events through** — Add `pointer-events: none !important` on `piece.dragging` so Safari consistently ignores the piece for hit-testing and events go to the board/squares underneath. That restores correct highlighting and event handling during drag.
2. **Slight transparency while dragging** — Add `opacity: 0.92` on `piece.dragging` so the square highlight is visible under the piece.

No JS or chessground API changes; the fix is CSS-only in the board theme.

### How to review

- **Logic:** Confirm that only the dragging state is styled (`.dragging`), and that we do not change behavior for non-dragging pieces or other themes.
- **Scope:** Change is limited to `_chessground.scss`; no other files modified.
- **Manual check (ideal):** On Safari (macOS), play a game, drag a piece over legal squares and over premove squares and confirm that destination highlights appear and stay correct under the cursor.

### Testing

- **Chrome/other browsers:** No behavior change expected; they already handle pointer-events correctly.
- **Safari:** Move and premove destination highlights should now show correctly while dragging a piece.