### PR TITLE
Highlight mod zone toggle when mod zone is active

### DIFF
--- a/ui/mod/src/mod.user.ts
+++ b/ui/mod/src/mod.user.ts
@@ -29,9 +29,12 @@ site.load.then(() => {
     source.onerror = () => source.close();
   }
 
+  const syncToggleActive = () => $toggle.toggleClass('active', !$zone.hasClass('none'));
+  window.addEventListener('resize', syncToggleActive);
   function loadZone() {
     $zone.html(spinnerHtml).removeClass('none');
     $('#main-wrap').addClass('full-screen-force');
+    syncToggleActive();
     $zone.html('');
     streamLoad();
     window.addEventListener('scroll', onScroll);
@@ -39,6 +42,7 @@ site.load.then(() => {
   }
   function unloadZone() {
     $zone.addClass('none');
+    syncToggleActive();
     $('#main-wrap').removeClass('full-screen-force');
     window.removeEventListener('scroll', onScroll);
     scrollTo('#top');


### PR DESCRIPTION
Adding some visual indication of whether the mod zone is active. It's less obvious at my permission level than the below screenshot where the mod zone tools take up a lot of real estate. Basically always knowing at a glance that you are in mod mode is nice. Kept the default ".active" styling.

<img width="1382" height="1016" alt="Screenshot 2026-03-02 at 11 45 37 PM" src="https://github.com/user-attachments/assets/aba244ec-42ee-4680-86d3-210ef2e1ca03" />
