### PR TITLE
ui: fix mchat overflow on very long, single word, messages

### DIFF
--- a/ui/lib/css/chat/_discussion.scss
+++ b/ui/lib/css/chat/_discussion.scss
@@ -21,6 +21,7 @@
       line-height: 1.2em;
       overflow-y: hidden;
       user-select: text;
+      overflow-wrap: anywhere;
 
       &.me {
         border-inline-start: 3px solid $c-secondary-dim;


### PR DESCRIPTION
# Why

It has been reported that on some team details pages chat box can cause an overflow.

<img width="2288" height="1314" alt="Screenshot 2026-03-04 at 13 22 40" src="https://github.com/user-attachments/assets/7b82833e-4437-4e07-9a4d-1aec649ab743" />

# How

Add `overflow-wrap` to the message container to prevent overflow on very long, single word, messages.

# Preview

<img width="868" height="1314" alt="Screenshot 2026-03-04 at 13 19 26" src="https://github.com/user-attachments/assets/55555692-a6b2-4613-b8a1-a40a0001ccc7" />
