### PR TITLE
ui: fix mchat scroll bar track color in dark theme

### DIFF
--- a/ui/lib/css/chat/_discussion.scss
+++ b/ui/lib/css/chat/_discussion.scss
@@ -112,6 +112,11 @@
         background: $m-accent_bg--mix-10;
       }
     }
+
+    &::-webkit-scrollbar,
+    &::-webkit-scrollbar-corner {
+      background: unset;
+    }
   }
 
   &__say {


### PR DESCRIPTION
# Why

While working on previous fix for mchat spotted that chat scrollbar track color does not match container color, leading to small visual glitch in dark mode.

<img width="854" height="1314" alt="Screenshot 2026-03-04 at 13 39 00" src="https://github.com/user-attachments/assets/9847cff0-6757-42fd-921e-7b37de54940b" />

# How

Unset the global (`body` level) background color set to custom scroll track, so it uses the transparent color to match given scroll container background. 

# Preview

<img width="854" height="1314" alt="Screenshot 2026-03-04 at 13 31 30" src="https://github.com/user-attachments/assets/889cb937-1b32-4ec6-9706-4902c1fe3bd3" />
