### PR TITLE
ui: fix broadcast source log overflow

### DIFF
--- a/ui/analyse/css/study/relay/_admin.scss
+++ b/ui/analyse/css/study/relay/_admin.scss
@@ -30,7 +30,8 @@
     }
 
     > span {
-      @extend %break-word, %ellipsis;
+      @extend %ellipsis;
+      overflow-wrap: anywhere;
     }
 
     .fat {
@@ -58,11 +59,11 @@
   }
 
   .log {
-    @extend %break-word;
     overflow-x: hidden;
     overflow-y: auto;
     padding: 0.3em 0.7em;
     max-height: 20vh;
+    overflow-wrap: anywhere;
 
     > div {
       @extend %flex-center-nowrap;


### PR DESCRIPTION
# Why

In some cases tournament broadcast log can cause overflow. On desktop is was properly hidden, but on mobile it was causing layout expansion.

<img width="736" height="558" alt="Screenshot 2026-03-04 at 14 10 07" src="https://github.com/user-attachments/assets/fb572518-1fc0-4bc5-bcba-cad72bdb6971" />

# How

Apply `overflow-wrap` instead of word-break to properly handle links without characters which are eligible to wrap with `break-word` style.

# Preview

<img width="736" height="690" alt="Screenshot 2026-03-04 at 14 10 56" src="https://github.com/user-attachments/assets/ce4b9924-c550-4f23-bae9-01b6a4bc2e72" />
