### PR TITLE
Fix broken broadcasts API doc link

### DIFF
--- a/app/controllers/Account.scala
+++ b/app/controllers/Account.scala
@@ -94,7 +94,7 @@ final class Account(
 
   val apiMe = Scoped() { ctx ?=> me ?=>
     def limited = rateLimited:
-      "Please don't poll this endpoint. Stream https://lichess.org/api#tag/board/get/apistreamevent instead."
+      "Please don't poll this endpoint. Stream https://lichess.org/api#tag/board/GET/api/stream/event instead."
     val wikiGranted = getBool("wiki") && isGranted(_.LichessTeam) && ctx.scopes.has(_.Web.Mod)
     if getBool("wiki") && !wikiGranted then Unauthorized(jsonError("Wiki access not granted"))
     else

--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -292,7 +292,7 @@ final class Api(env: Env, gameC: => Game) extends LilaController(env):
   val eventStream =
     Scoped(_.Bot.Play, _.Board.Play, _.Challenge.Read) { _ ?=> me ?=>
       def limited = rateLimited:
-        "Please don't poll this endpoint, it is intended to be streamed. See https://lichess.org/api#tag/bot/get/apibotgamestreamgameid."
+        "Please don't poll this endpoint, it is intended to be streamed. See https://lichess.org/api#tag/board/GET/api/board/game/stream/{gameId}."
       HTTPRequest.bearer(ctx.req).so { bearer =>
         limit.eventStream(bearer, limited, msg = s"${me.username} ${HTTPRequest.printClient(req)}"):
           for

--- a/app/controllers/PlayApi.scala
+++ b/app/controllers/PlayApi.scala
@@ -132,7 +132,7 @@ final class PlayApi(env: Env) extends LilaController(env):
       if me.noBot then
         BadRequest:
           jsonError:
-            "This endpoint can only be used with a Bot account. See https://lichess.org/api#tag/bot/post/apibotaccountupgrade"
+            "This endpoint can only be used with a Bot account. See https://lichess.org/api#tag/bot/POST/api/bot/account/upgrade"
       else
         isReallyBotCompatible(pov.game).flatMap:
           if _ then f(pov)

--- a/ui/analyse/src/study/relay/relayTourView.ts
+++ b/ui/analyse/src/study/relay/relayTourView.ts
@@ -240,7 +240,7 @@ const share = (ctx: RelayViewContext) => {
           'To synchronize ongoing games, use ',
           hl(
             'a',
-            { attrs: { href: '/api#tag/broadcasts/get/apistreambroadcastroundbroadcastroundidpgn' } },
+            { attrs: { href: '/api#tag/broadcasts/GET/api/stream/broadcast/round/{broadcastRoundId}.pgn' } },
             'our free streaming API',
           ),
           ' for stupendous speed and efficiency.',


### PR DESCRIPTION
Fix broken API documentation anchor links.

Some API doc URLs were missing slashes and used incorrect paths,
which resulted in invalid anchors.

Fixes #19718