### PR TITLE
add forever closed to actions and use it to hide mod close/open button - closes issue #19725

### DIFF
--- a/app/controllers/User.scala
+++ b/app/controllers/User.scala
@@ -383,10 +383,9 @@ final class User(
             .zip(env.playban.api.bans(user.id))
             .map(ui.showRageSitAndPlaybans)
 
-        val actions = for
-          deleted <- env.user.repo.isDeleted(user)
-          foreverClosed <- env.user.repo.isForeverClosed(user)
-        yield ui.actions(user, emails, deleted, foreverClosed, env.mod.presets.getPmPresets)
+        val actions =
+          for flags <- env.user.repo.closedFlags(user)
+          yield ui.actions(user, emails, flags, env.mod.presets.getPmPresets)
 
         val userLoginsFu = env.security.userLogins(user, nbOthers)
         val othersAndLogins = for
@@ -454,17 +453,9 @@ final class User(
       .orFail(s"No such user $username")
       .flatMap:
         case WithPerfsAndEmails(user, emails) =>
-          for
-            deleted <- env.user.repo.isDeleted(user)
-            foreverClosed <- env.user.repo.isForeverClosed(user)
+          for flags <- env.user.repo.closedFlags(user)
           yield Ok.snip:
-            views.mod.user.actions(
-              user,
-              emails,
-              deleted,
-              foreverClosed,
-              env.mod.presets.getPmPresets
-            )
+            views.mod.user.actions(user, emails, flags, env.mod.presets.getPmPresets)
 
   def writeNote(username: UserStr) = AuthBody { ctx ?=> me ?=>
     bindForm(lila.user.UserForm.note)(

--- a/modules/mod/src/main/ui/ModUserUi.scala
+++ b/modules/mod/src/main/ui/ModUserUi.scala
@@ -5,7 +5,7 @@ import lila.core.perm.Permission
 import lila.core.playban.RageSit
 import lila.evaluation.Display
 import lila.ui.*
-import lila.user.WithPerfsAndEmails
+import lila.user.{ ClosedFlags, WithPerfsAndEmails }
 
 import ScalatagsTemplate.{ *, given }
 import lila.report.Report
@@ -43,8 +43,7 @@ final class ModUserUi(helpers: Helpers, modUi: ModUi):
   def actions(
       u: User,
       emails: lila.core.user.Emails,
-      deleted: Boolean,
-      foreverClosed: Boolean,
+      closedFlags: Option[ClosedFlags],
       pmPresets: ModPresets
   )(using Context, Me): Frag =
     mzSection("actions")(
@@ -209,8 +208,8 @@ final class ModUserUi(helpers: Helpers, modUi: ModUi):
               )(
                 submitButton(cls := "btn-rack__btn")("Close")
               )
-            else if foreverClosed then "Forever closed"
-            else if deleted then "Deleted"
+            else if closedFlags.exists(_.forever) then "Forever closed"
+            else if closedFlags.exists(_.deleted) then "Deleted"
             else
               frag(
                 postForm(

--- a/modules/security/src/main/Reopen.scala
+++ b/modules/security/src/main/Reopen.scala
@@ -37,8 +37,8 @@ final class Reopen(
     modClosed <- closedByMod(user)
     _ <- raiseIf(modClosed):
       "nope" -> "Sorry, that account can no longer be reopened."
-    forever <- userRepo.isForeverClosed(user)
-    _ <- raiseIf(forever):
+    flags <- userRepo.closedFlags(user)
+    _ <- raiseIf(flags.exists(_.forever)):
       "nope" -> "Sorry, but you explicitly requested that your account could never be reopened."
   yield user
 
@@ -67,9 +67,10 @@ ${trans.common_orPaste.txt()}"""),
   def confirm(token: String): Fu[Option[User]] =
     tokener.read(token).flatMapz(userRepo.disabledById).flatMapz { user =>
       for
-        forever <- userRepo.isForeverClosed(user)
-        _ <- forever.not.so(userRepo.reopen(user.id))
-        reopened = forever.not.option(user)
+        flags <- userRepo.closedFlags(user)
+        canReopen = flags.exists(_.forever).not
+        _ <- canReopen.so(userRepo.reopen(user.id))
+        reopened = canReopen.option(user)
       yield
         if reopened.isDefined
         then lila.common.Bus.pub(lila.core.security.ReopenAccount(user))

--- a/modules/user/src/main/User.scala
+++ b/modules/user/src/main/User.scala
@@ -12,6 +12,8 @@ object TotpToken extends OpaqueString[TotpToken]
 
 case class UserDelete(requested: Instant, done: Boolean = false)
 
+case class ClosedFlags(forever: Boolean, deleted: Boolean)
+
 object PlayTime:
   extension (p: PlayTime)
     def totalDuration = Duration.ofSeconds(p.total)

--- a/modules/user/src/main/UserRepo.scala
+++ b/modules/user/src/main/UserRepo.scala
@@ -566,13 +566,12 @@ final class UserRepo(c: Coll)(using Executor) extends lila.core.user.UserRepo(c)
   def byIdAs[A: BSONDocumentReader](id: String, proj: Bdoc): Fu[Option[A]] =
     coll.one[A]($id(id), proj)
 
-  def isDeleted(user: User): Fu[Boolean] =
+  def closedFlags(user: User): Fu[Option[ClosedFlags]] =
     user.enabled.no.so:
-      coll.exists($id(user.id) ++ $doc(s"${F.delete}.done" -> true))
-
-  def isForeverClosed(user: User): Fu[Boolean] =
-    user.enabled.no.so:
-      coll.exists($id(user.id) ++ $doc(F.foreverClosed -> true))
+      coll
+        .exists($id(user.id) ++ $doc(F.foreverClosed -> true))
+        .zip(coll.exists($id(user.id) ++ $doc(s"${F.delete}.done" -> true)))
+        .map(ClosedFlags(_, _).some)
 
   def filterClosedOrInactiveIds(since: Instant)(ids: Iterable[UserId]): Fu[List[UserId]] =
     coll.distinctEasy[UserId, List](F.id, $inIds(ids) ++ $or(disabledSelect, F.seenAt.$lt(since)), _.sec)


### PR DESCRIPTION
Created with help from deepwiki - prompts for finding where the close button is managed in ModUserUi, then followed the same idea as "deleted"

Confirmed working locally:
<img width="1026" height="349" alt="image" src="https://github.com/user-attachments/assets/35c367b6-0fb1-493a-95bf-665345d2319d" />
