### PR TITLE
Fix duplicate list entries (#19735)

### DIFF
--- a/modules/forum/src/main/ui/CategUi.scala
+++ b/modules/forum/src/main/ui/CategUi.scala
@@ -10,6 +10,8 @@ import ScalatagsTemplate.{ *, given }
 final class CategUi(helpers: Helpers, bits: ForumBits):
   import helpers.{ *, given }
 
+  private val dataDedup = attr("data-dedup")
+
   def index(categs: List[CategView])(using Context) =
     Page(trans.site.forum.txt())
       .css("bits.forum")
@@ -42,7 +44,7 @@ final class CategUi(helpers: Helpers, bits: ForumBits):
   )(using Context) =
 
     def showTopic(sticky: Boolean)(topic: TopicView) =
-      tr(cls := List("sticky" -> sticky))(
+      tr(cls := List("sticky" -> sticky), dataDedup := topic.id)(
         td(cls := "subject")(
           a(href := routes.ForumTopic.show(categ.id, topic.slug))(topic.name)
         ),
@@ -179,7 +181,7 @@ final class CategUi(helpers: Helpers, bits: ForumBits):
             thead(tr(th("User"), th("Topic"), th("Post"), th("Date"))),
             tbody(cls := "infinite-scroll")(
               posts.currentPageResults.map: p =>
-                tr(cls := "paginated")(
+                tr(cls := "paginated", dataDedup := p.post.id)(
                   td(userIdLink(p.post.userId)),
                   td(a(href := routes.ForumTopic.show(p.categ.id, p.topic.slug))(p.topic.name)),
                   td(shorten(Markdown(p.post.text).unlink, 400)),

--- a/modules/forum/src/main/ui/PostUi.scala
+++ b/modules/forum/src/main/ui/PostUi.scala
@@ -10,6 +10,7 @@ import ScalatagsTemplate.{ *, given }
 final class PostUi(helpers: Helpers, bits: ForumBits):
   import helpers.{ *, given }
 
+  private val dataDedup = attr("data-dedup")
   private val postId = attrData("post-id")
 
   def show(
@@ -28,7 +29,8 @@ final class PostUi(helpers: Helpers, bits: ForumBits):
       st.article(
         cls := List("forum-post" -> true, "erased" -> post.erased),
         id := post.number,
-        postId := post.id
+        postId := post.id,
+        dataDedup := post.id
       )(
         div(cls := "forum-post__metas")(
           (!post.erased || canModCateg).option(
@@ -206,7 +208,7 @@ final class PostUi(helpers: Helpers, bits: ForumBits):
                       br,
                       bits.authorLink(view.post)
                     )
-                  tr(cls := "paginated stack-row")(
+                  tr(cls := "paginated stack-row", dataDedup := view.post.id)(
                     if viewWithRead.canRead then
                       frag(
                         td(

--- a/modules/ublog/src/main/ui/UblogUi.scala
+++ b/modules/ublog/src/main/ui/UblogUi.scala
@@ -15,6 +15,8 @@ final class UblogUi(helpers: Helpers, atomUi: AtomUi, modMenu: Context ?=> Frag)
 ):
   import helpers.{ *, given }
 
+  private val dataDedup = attr("data-dedup")
+
   def thumbnail(post: UblogPost.BasePost, size: UblogPost.thumbnail.SizeSelector) =
     img(
       cls := "ublog-post-image",
@@ -40,7 +42,8 @@ final class UblogUi(helpers: Helpers, atomUi: AtomUi, modMenu: Context ?=> Frag)
   )(using Context) =
     a(
       cls := s"ublog-post-card ublog-post-card--link ublog-post-card--by-${post.created.by}",
-      href := makeUrl(post)
+      href := makeUrl(post),
+      dataDedup := post.id
     )(
       span(
         cls := s"ublog-post-card__top",


### PR DESCRIPTION
Fixes #19735

## Overview
Recent updates to the infinite scroll component made it rely strictly on the `data-dedup` attribute for its deduplication algorithm to execute. This pull request adds the missing `data-dedup` attributes to the Server-Side Rendered (SSR) Scala templates for Blogs and Forums so that `bits.infiniteScroll.ts` can do its job and not render duplicate entries.

## Changes Made
Added `private val dataDedup = attr("data-dedup")` and associated the IDs across three templates.

### 1. `modules/ublog/src/main/ui/UblogUi.scala`
Injected `dataDedup := post.id` into the main `card(...)` layout method to ensure that all blog post cards broadcast their ID for the client-side scroll dedup logic.

### 2. `modules/forum/src/main/ui/CategUi.scala`
Associated the `topic.id` and `p.post.id` for topics and mod feeds.

### 3. `modules/forum/src/main/ui/PostUi.scala`
Associated the `post.id` for standard posts inside forum topics and within forum search result rows.

## Validation
By applying `data-dedup` correctly on the Server-Side rendering steps in the Scala codebase, `bits.infiniteScroll.ts` is now capable of dropping duplicated nodes from the DOM, resolving the behavior reported in the ticket.
