### PR TITLE
ui: fix import cycles in various modules

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
-  "plugins": ["promise", "typescript", "unicorn"],
+  "plugins": ["import", "promise", "typescript", "unicorn"],
   "env": {
     "builtin": true
   },
@@ -26,6 +26,7 @@
         "caughtErrorsIgnorePattern": "^_"
       }
     ],
+    "import/no-cycle": "error",
     "prefer-promise-reject-errors": "error",
     "promise/no-callback-in-promise": "error",
     "promise/no-multiple-resolved": "error",
@@ -232,6 +233,12 @@
       "rules": {
         "no-unused-vars": "off",
         "unicorn/prefer-array-some": "off"
+      }
+    },
+    {
+      "files": ["ui/.build/**"],
+      "rules": {
+        "import/no-cycle": "off"
       }
     }
   ]

--- a/ui/analyse/src/api.ts
+++ b/ui/analyse/src/api.ts
@@ -1,5 +1,5 @@
 import * as control from './control';
-import AnalyseCtrl from './ctrl';
+import type AnalyseCtrl from './ctrl';
 
 export default function (ctrl: AnalyseCtrl) {
   return {

--- a/ui/analyse/src/explorer/explorerConfig.ts
+++ b/ui/analyse/src/explorer/explorerConfig.ts
@@ -8,7 +8,7 @@ import { storedProp, storedJsonProp, type StoredProp, storedStringProp } from 'l
 import { type Dialog, snabDialog, bind, dataIcon, iconTag, onInsert } from 'lib/view';
 import { userComplete } from 'lib/view/userComplete';
 
-import AnalyseCtrl from '../ctrl';
+import type AnalyseCtrl from '../ctrl';
 import { ucfirst } from './explorerUtil';
 import type { ExplorerDb, ExplorerSpeed, ExplorerMode } from './interfaces';
 

--- a/ui/analyse/src/explorer/explorerCtrl.ts
+++ b/ui/analyse/src/explorer/explorerCtrl.ts
@@ -8,12 +8,10 @@ import { storedBooleanProp } from 'lib/storage';
 
 import type AnalyseCtrl from '../ctrl';
 import { ExplorerConfigCtrl } from './explorerConfig';
-import { winnerOf } from './explorerUtil';
+import { MAX_ANALYSE_DEPTH, winnerOf } from './explorerUtil';
 import { clearLastShow } from './explorerView';
 import * as xhr from './explorerXhr';
 import type { Hovering, ExplorerData, OpeningData, SimpleTablebaseHit, ExplorerOpts } from './interfaces';
-
-export const MAX_DEPTH = 50;
 
 function tablebasePieces(variant: VariantKey) {
   switch (variant) {
@@ -157,7 +155,10 @@ export default class ExplorerCtrl {
     if (!this.enabled()) return;
     this.gameMenu(null);
     const node = this.root.node;
-    if ((!this.isAuth() || node.ply >= MAX_DEPTH) && !this.tablebaseRelevant(this.effectiveVariant, node.fen))
+    if (
+      (!this.isAuth() || node.ply >= MAX_ANALYSE_DEPTH) &&
+      !this.tablebaseRelevant(this.effectiveVariant, node.fen)
+    )
       this.cache[node.fen] = this.empty;
     const cached = this.cache[node.fen];
     if (cached) {

--- a/ui/analyse/src/explorer/explorerUtil.ts
+++ b/ui/analyse/src/explorer/explorerUtil.ts
@@ -6,6 +6,8 @@ import { fenColor } from 'lib/game/chess';
 import type AnalyseCtrl from '../ctrl';
 import type { TablebaseMoveStats } from './interfaces';
 
+export const MAX_ANALYSE_DEPTH = 50;
+
 export function winnerOf(fen: FEN, move: TablebaseMoveStats): Color | undefined {
   const stm = fenColor(fen);
   if (move.checkmate || move.variant_loss || (move.dtz && move.dtz < 0) || (move.dtc && move.dtc < 0))

--- a/ui/analyse/src/explorer/explorerView.ts
+++ b/ui/analyse/src/explorer/explorerView.ts
@@ -7,8 +7,8 @@ import { bind, dataIcon, type MaybeVNode, type LooseVNodes, hl } from 'lib/view'
 
 import type AnalyseCtrl from '../ctrl';
 import { view as renderConfig } from './explorerConfig';
-import ExplorerCtrl, { MAX_DEPTH } from './explorerCtrl';
-import { moveArrowAttributes, ucfirst } from './explorerUtil';
+import type ExplorerCtrl from './explorerCtrl';
+import { MAX_ANALYSE_DEPTH, moveArrowAttributes, ucfirst } from './explorerUtil';
 import {
   isOpening,
   isTablebase,
@@ -208,7 +208,7 @@ const closeButton = (ctrl: AnalyseCtrl): VNode =>
   );
 
 const showEmpty = (ctrl: AnalyseCtrl, data?: OpeningData): VNode => {
-  const isTooDeep = ctrl.explorer.root.node.ply >= MAX_DEPTH;
+  const isTooDeep = ctrl.explorer.root.node.ply >= MAX_ANALYSE_DEPTH;
   return hl('div.data.empty', [
     explorerTitle(ctrl.explorer),
     openingTitle(ctrl, data),

--- a/ui/analyse/src/nvuiUtil.ts
+++ b/ui/analyse/src/nvuiUtil.ts
@@ -1,0 +1,62 @@
+import { plyToTurn } from 'lib/game/chess';
+import { renderComments, renderSan } from 'lib/nvui/render';
+import { path as treePath } from 'lib/tree/tree';
+import { type VNode, enter } from 'lib/view';
+
+import type { AnalyseNvuiContext } from '@/analyse.nvui';
+import type AnalyseCtrl from '@/ctrl';
+
+export function clickHook(main?: (el: HTMLElement) => void, post?: () => void) {
+  return {
+    // put unique identifying props on the button container (such as class)
+    // because snabbdom WILL mix plain adjacent buttons up.
+    hook: {
+      insert: (vnode: VNode) => {
+        const el = vnode.elm as HTMLElement;
+        el.addEventListener('click', () => {
+          main?.(el);
+          post?.();
+        });
+        el.addEventListener(
+          'keydown',
+          enter(() => {
+            main?.(el);
+            post?.();
+          }),
+        );
+      },
+    },
+  };
+}
+
+export function currentLineIndex(ctrl: AnalyseCtrl): { i: number; of: number } {
+  if (ctrl.path === treePath.root) return { i: 1, of: 1 };
+  const prevNode = ctrl.tree.parentNode(ctrl.path);
+  return {
+    i: prevNode.children.findIndex(node => node.id === ctrl.node.id),
+    of: prevNode.children.length,
+  };
+}
+
+function renderLineIndex(ctrl: AnalyseCtrl): string {
+  const { i, of } = currentLineIndex(ctrl);
+  return of > 1 ? `, line ${i + 1} of ${of} ,` : '';
+}
+
+export function renderCurrentNode({
+  ctrl,
+  moveStyle,
+}: Pick<AnalyseNvuiContext, 'ctrl' | 'moveStyle'>): string {
+  const node = ctrl.node;
+  if (!node.san || !node.uci) return i18n.nvui.gameStart;
+  return [
+    plyToTurn(node.ply),
+    node.ply % 2 === 1 ? i18n.site.white : i18n.site.black,
+    renderSan(node.san, node.uci, moveStyle.get()),
+    renderLineIndex(ctrl),
+    !ctrl.retro && renderComments(node, moveStyle.get()),
+  ]
+    .filter(x => x)
+    .join(' ')
+    .trim();
+}

--- a/ui/analyse/src/retrospect/nvuiRetroView.ts
+++ b/ui/analyse/src/retrospect/nvuiRetroView.ts
@@ -4,10 +4,10 @@ import { renderSan } from 'lib/nvui/chess';
 import { liveText } from 'lib/nvui/notify';
 import { type LooseVNodes, hl } from 'lib/view';
 
-import type { AnalyseNvuiContext } from '../analyse.nvui';
-import type AnalyseCtrl from '../ctrl';
-import type { RetroCtrl } from '../retrospect/retroCtrl';
-import { clickHook, renderCurrentNode } from '../view/nvuiView';
+import type { AnalyseNvuiContext } from '@/analyse.nvui';
+import type AnalyseCtrl from '@/ctrl';
+import { clickHook, renderCurrentNode } from '@/nvuiUtil';
+import type { RetroCtrl } from '@/retrospect/retroCtrl';
 
 export function renderRetro(nvuiCtx: AnalyseNvuiContext): LooseVNodes {
   const ctx = makeContext(nvuiCtx);

--- a/ui/analyse/src/study/multiBoard.ts
+++ b/ui/analyse/src/study/multiBoard.ts
@@ -13,9 +13,10 @@ import { type MaybeVNode, type VNode, bind, dataIcon, onInsert, hl } from 'lib/v
 import { cmnToggleWrapProp } from 'lib/view/cmn-toggle';
 import { userTitle } from 'lib/view/userLink';
 
+import { playerFedFlag } from '@/view/util';
+
 import type { ChapterId, ChapterPreview, StudyPlayer } from './interfaces';
 import { type CloudEval, type MultiCloudEval, renderScore } from './multiCloudEval';
-import { playerFedFlag } from './playerBars';
 import { playerColoredResult } from './relay/customScoreStatus';
 import type { RelayRound } from './relay/interfaces';
 import { type StudyChapters, gameLinkAttrs, gameLinksListener } from './studyChapters';

--- a/ui/analyse/src/study/playerBars.ts
+++ b/ui/analyse/src/study/playerBars.ts
@@ -7,16 +7,18 @@ import type { TreePath } from 'lib/tree/types';
 import { hl } from 'lib/view';
 import { userTitle } from 'lib/view/userLink';
 
-import type AnalyseCtrl from '../ctrl';
-import renderClocks from '../view/clocks';
-import { renderMaterialDiffs } from '../view/components';
-import type { StudyPlayers, Federation, StudyPlayer, StatusStr, TagMap } from './interfaces';
+import type AnalyseCtrl from '@/ctrl';
+import renderClocks from '@/view/clocks';
+import { renderMaterialDiffs } from '@/view/materialDiffs';
+import { playerFedFlag } from '@/view/util';
+
+import type { StudyPlayers, StudyPlayer, StatusStr, TagMap } from './interfaces';
 import { playerColoredResult } from './relay/customScoreStatus';
 import type { RelayRound } from './relay/interfaces';
 import RelayPlayers, { fidePageLinkAttrs, playerId, playerPhotoOrFallback } from './relay/relayPlayers';
 import RelayTeamLeaderboard from './relay/relayTeamLeaderboard';
 import { looksLikeLichessGame } from './studyChapters';
-import { StudyCtrl } from './studyDeps';
+import type { StudyCtrl } from './studyDeps';
 import { tagsToMap } from './studyTags';
 import { resultTag } from './studyView';
 
@@ -158,12 +160,3 @@ function resultOf(tags: TagMap, isWhite: boolean): string | undefined {
   const mine = both?.length === 2 ? both[isWhite ? 0 : 1] : undefined;
   return mine === '1/2' ? '½' : mine;
 }
-
-export const playerFedFlag = (fed?: Federation): VNode | undefined =>
-  fed &&
-  hl('img.mini-game__flag', {
-    attrs: {
-      src: site.asset.fideFedSrc(fed.id),
-      title: `Federation: ${fed.i18nName}`,
-    },
-  });

--- a/ui/analyse/src/study/relay/deepLink.ts
+++ b/ui/analyse/src/study/relay/deepLink.ts
@@ -1,4 +1,14 @@
+import type { VNodeData } from 'lib/view';
+
+import type { RelayTeamName } from './interfaces';
+
 export const broadcasterDeepLink = (url: string): string => {
   const parsed = new URL(url);
   return 'lichess-broadcaster:/' + parsed.pathname;
 };
+
+export const teamLinkData = (teamName: RelayTeamName): VNodeData => ({
+  attrs: {
+    href: `#team-results/${encodeURIComponent(teamName)}`,
+  },
+});

--- a/ui/analyse/src/study/relay/relayGames.ts
+++ b/ui/analyse/src/study/relay/relayGames.ts
@@ -4,9 +4,10 @@ import { defined, scrollToInnerSelector } from 'lib';
 import { hl } from 'lib/view';
 import { userTitle } from 'lib/view/userLink';
 
+import { playerFedFlag } from '@/view/util';
+
 import type { ChapterPreview } from '../interfaces';
 import { renderClock, verticalEvalGauge } from '../multiBoard';
-import { playerFedFlag } from '../playerBars';
 import { gameLinkAttrs } from '../studyChapters';
 import type { StudyCtrl } from '../studyDeps';
 import { playerColoredResult } from './customScoreStatus';

--- a/ui/analyse/src/study/relay/relayPlayers.ts
+++ b/ui/analyse/src/study/relay/relayPlayers.ts
@@ -11,10 +11,12 @@ import { type VNode, dataIcon, hl, onInsert, spinnerVdom as spinner, type LooseV
 import { userLink, userTitle } from 'lib/view/userLink';
 import { json as xhrJson } from 'lib/xhr';
 
+import { playerFedFlag } from '@/view/util';
+
 import type { ChapterId, FideId, PointsStr, StudyPlayer, StudyPlayerFromServer } from '../interfaces';
-import { playerFedFlag } from '../playerBars';
 import { convertPlayerFromServer } from '../studyChapters';
 import { playerColoredResult } from './customScoreStatus';
+import { teamLinkData } from './deepLink';
 import type {
   FideTC,
   Photo,
@@ -24,7 +26,6 @@ import type {
   RoundId,
   StatByFideTC,
 } from './interfaces';
-import { teamLinkData } from './relayTeamLeaderboard';
 
 export type RelayPlayerId = FideId | string;
 

--- a/ui/analyse/src/study/relay/relayTeamLeaderboard.ts
+++ b/ui/analyse/src/study/relay/relayTeamLeaderboard.ts
@@ -2,7 +2,7 @@ import type { Tablesort } from 'tablesort';
 
 import { throttle } from 'lib';
 import { Group, StudyBoard } from 'lib/licon';
-import { dataIcon, hl, onInsert, requiresI18n, spinnerVdom, type VNode, type VNodeData } from 'lib/view';
+import { dataIcon, hl, onInsert, requiresI18n, spinnerVdom, type VNode } from 'lib/view';
 import { json as xhrJson } from 'lib/xhr';
 
 import type { StudyPlayerFromServer } from '../interfaces';
@@ -187,9 +187,3 @@ export default class RelayTeamLeaderboard {
     this.setTeamToShow(team);
   };
 }
-
-export const teamLinkData = (teamName: RelayTeamName): VNodeData => ({
-  attrs: {
-    href: `#team-results/${encodeURIComponent(teamName)}`,
-  },
-});

--- a/ui/analyse/src/study/relay/relayTeams.ts
+++ b/ui/analyse/src/study/relay/relayTeams.ts
@@ -2,14 +2,15 @@ import { type MaybeVNodes, type VNode, onInsert, hl, spinnerVdom as spinner } fr
 import { userTitle } from 'lib/view/userLink';
 import { json as xhrJson } from 'lib/xhr';
 
+import { playerFedFlag } from '@/view/util';
+
 import type { ChapterId, ChapterPreview, StudyPlayer, ChapterSelect } from '../interfaces';
 import { type MultiCloudEval, renderScore } from '../multiCloudEval';
-import { playerFedFlag } from '../playerBars';
 import { gameLinkAttrs, gameLinksListener, StudyChapters } from '../studyChapters';
 import { coloredStatusStr } from './customScoreStatus';
+import { teamLinkData } from './deepLink';
 import type { RelayRound, RelayTour } from './interfaces';
 import type RelayPlayers from './relayPlayers';
-import { teamLinkData } from './relayTeamLeaderboard';
 
 interface TeamWithPoints {
   name: string;

--- a/ui/analyse/src/study/relay/relayTourView.ts
+++ b/ui/analyse/src/study/relay/relayTourView.ts
@@ -1,6 +1,6 @@
 import type { VNode } from 'snabbdom';
 
-import { defined, memoize } from 'lib';
+import { defined, memoize, onClickAway } from 'lib';
 import { renderChat } from 'lib/chat/renderChat';
 import { displayColumns } from 'lib/device';
 import { commonDateFormat, timeago } from 'lib/i18n';
@@ -34,7 +34,6 @@ import { gamesList } from './relayGames';
 import { playersView } from './relayPlayers';
 import { statsView } from './relayStats';
 import { teamsView } from './relayTeams';
-import { renderStreamerMenu } from './relayView';
 
 export function renderRelayTour(ctx: RelayViewContext): VNode | undefined {
   const tab = ctx.relay.tab();
@@ -601,3 +600,31 @@ const broadcastImageOrStream = (ctx: RelayViewContext) => {
           : undefined,
   );
 };
+
+function renderStreamerMenu(relay: RelayCtrl): VNode {
+  const makeUrl = (id: string) => {
+    const url = new URL(location.href);
+    url.searchParams.set('embed', id);
+    return url.toString();
+  };
+  return hl(
+    'div.streamer-menu-anchor',
+    hl(
+      'div.streamer-menu',
+      {
+        hook: onInsert(
+          onClickAway(() => {
+            relay.showStreamerMenu(false);
+            relay.redraw();
+          }),
+        ),
+      },
+      relay.streams.map(([id, info]) =>
+        hl('a.streamer.text', { attrs: { 'data-icon': licon.Mic, href: makeUrl(id) } }, [
+          info.name,
+          hl('i', info.lang),
+        ]),
+      ),
+    ),
+  );
+}

--- a/ui/analyse/src/study/relay/relayView.ts
+++ b/ui/analyse/src/study/relay/relayView.ts
@@ -1,8 +1,7 @@
-import { onClickAway } from 'lib';
 import { view as cevalView } from 'lib/ceval';
 import { displayColumns, isTouchDevice } from 'lib/device';
 import * as licon from 'lib/licon';
-import { bind, dataIcon, hl, onInsert, type VNode } from 'lib/view';
+import { bind, dataIcon, hl, type VNode } from 'lib/view';
 
 import type AnalyseCtrl from '@/ctrl';
 import { view as keyboardView } from '@/keyboard';
@@ -11,14 +10,15 @@ import {
   viewContext,
   renderBoard,
   renderMain,
-  renderTools,
   renderUnderboard,
 } from '@/view/components';
 import { renderControls } from '@/view/controls';
+import { renderTools } from '@/view/tools';
 
 import type * as studyDeps from '../studyDeps';
 import type RelayCtrl from './relayCtrl';
 import { tourSide, renderRelayTour } from './relayTourView';
+import { allowVideo } from './videoPlayer';
 
 export function relayView(
   ctrl: AnalyseCtrl,
@@ -64,37 +64,6 @@ export const backToLiveView = (ctrl: AnalyseCtrl) =>
         i18n.broadcast.backToLiveMove,
       )
     : undefined;
-
-export function renderStreamerMenu(relay: RelayCtrl): VNode {
-  const makeUrl = (id: string) => {
-    const url = new URL(location.href);
-    url.searchParams.set('embed', id);
-    return url.toString();
-  };
-  return hl(
-    'div.streamer-menu-anchor',
-    hl(
-      'div.streamer-menu',
-      {
-        hook: onInsert(
-          onClickAway(() => {
-            relay.showStreamerMenu(false);
-            relay.redraw();
-          }),
-        ),
-      },
-      relay.streams.map(([id, info]) =>
-        hl('a.streamer.text', { attrs: { 'data-icon': licon.Mic, href: makeUrl(id) } }, [
-          info.name,
-          hl('i', info.lang),
-        ]),
-      ),
-    ),
-  );
-}
-
-export const allowVideo = (): boolean =>
-  window.getComputedStyle(document.body).getPropertyValue('---allow-video') === 'true';
 
 function renderBoardView(ctx: RelayViewContext) {
   const { ctrl, deps, study, gaugeOn, relay } = ctx;

--- a/ui/analyse/src/study/relay/videoPlayer.ts
+++ b/ui/analyse/src/study/relay/videoPlayer.ts
@@ -1,7 +1,5 @@
 import { hl, type VNode, onInsert } from 'lib/view';
 
-import { allowVideo } from './relayView';
-
 export class VideoPlayer {
   private iframe: HTMLIFrameElement;
   private close: HTMLImageElement;
@@ -122,3 +120,6 @@ export class VideoPlayer {
     window.location.href = urlWithEmbed.toString();
   };
 }
+
+export const allowVideo = (): boolean =>
+  window.getComputedStyle(document.body).getPropertyValue('---allow-video') === 'true';

--- a/ui/analyse/src/study/studyView.ts
+++ b/ui/analyse/src/study/studyView.ts
@@ -10,14 +10,16 @@ import { type VNode, iconTag, bind, dataIcon, type LooseVNodes, onInsert, hl } f
 import { verticalResize } from 'lib/view/verticalResize';
 import { watchers } from 'lib/view/watchers';
 
+import { viewContext, renderBoard, renderMain, renderUnderboard } from '@/view/components';
+import { renderControls } from '@/view/controls';
+import { renderTools } from '@/view/tools';
+import { wikiToggleBox } from '@/wiki';
+
 import crazyView from '../crazy/crazyView';
 import type AnalyseCtrl from '../ctrl';
 import { view as keyboardView } from '../keyboard';
 import type * as studyDeps from '../study/studyDeps';
-import { viewContext, renderBoard, renderMain, renderTools, renderUnderboard } from '../view/components';
-import { renderControls } from '../view/controls';
 import { render as trainingView } from '../view/roundTraining';
-import { wikiToggleBox } from '../wiki';
 import { view as chapterEditFormView } from './chapterEditForm';
 import { view as chapterNewFormView } from './chapterNewForm';
 import * as commentForm from './commentForm';

--- a/ui/analyse/src/view/components.ts
+++ b/ui/analyse/src/view/components.ts
@@ -2,12 +2,11 @@ import { parseFen } from 'chessops/fen';
 import { h } from 'snabbdom';
 
 import { defined } from 'lib';
-import { view as cevalView, renderEval as normalizeEval } from 'lib/ceval';
+import { renderEval as normalizeEval } from 'lib/ceval';
 import { dispatchChessgroundResize } from 'lib/chessgroundResize';
 import { isMobile } from 'lib/device';
 import { playable } from 'lib/game';
 import { fixCrazySan, plyToTurn } from 'lib/game/chess';
-import * as materialView from 'lib/game/view/material';
 import statusView from 'lib/game/view/status';
 import * as licon from 'lib/licon';
 import * as Prefs from 'lib/prefs';
@@ -16,7 +15,6 @@ import { path as treePath } from 'lib/tree/tree';
 import type { ClientEval, ServerEval, TreeNode, TreePath } from 'lib/tree/types';
 import {
   type VNode,
-  type LooseVNode,
   type LooseVNodes,
   bind,
   bindNonPassive,
@@ -29,23 +27,17 @@ import {
 
 import * as control from '../control';
 import type AnalyseCtrl from '../ctrl';
-import explorerView from '../explorer/explorerView';
-import { view as forkView } from '../fork';
 import * as chessground from '../ground';
 import type { ConcealOf } from '../interfaces';
 import * as pgnExport from '../pgnExport';
 import { renderPgnError } from '../pgnImport';
-import practiceView from '../practice/practiceView';
-import retroView from '../retrospect/retroView';
 import serverSideUnderboard from '../serverSideUnderboard';
-import { renderNextChapter } from '../study/nextChapter';
 import type RelayCtrl from '../study/relay/relayCtrl';
-import { backToLiveView } from '../study/relay/relayView';
 import { findTag } from '../study/studyChapters';
 import type StudyCtrl from '../study/studyCtrl';
 import type * as studyDeps from '../study/studyDeps';
-import { view as actionMenu } from './actionMenu';
 import renderClocks from './clocks';
+import { renderMaterialDiffs } from './materialDiffs';
 
 export interface ViewContext {
   ctrl: AnalyseCtrl;
@@ -129,21 +121,6 @@ export function renderMain(ctx: ViewContext, ...kids: LooseVNodes[]): VNode {
     },
     kids,
   );
-}
-
-export function renderTools({ ctrl, deps, concealOf, allowVideo }: ViewContext, embeddedVideo?: LooseVNode) {
-  const showCeval = ctrl.isCevalAllowed() && ctrl.showCeval();
-  return hl(addChapterId(ctrl.study, 'div.analyse__tools'), [
-    allowVideo && embeddedVideo,
-    showCeval && cevalView.renderCeval(ctrl),
-    showCeval && !ctrl.retro?.isSolving() && !ctrl.practice && cevalView.renderPvs(ctrl),
-    renderMoveList(ctrl, deps, concealOf),
-    deps?.gbEdit.running(ctrl) ? deps?.gbEdit.render(ctrl) : undefined,
-    backToLiveView(ctrl),
-    forkView(ctrl, concealOf),
-    retroView(ctrl) || explorerView(ctrl) || practiceView(ctrl),
-    ctrl.actionMenu() && actionMenu(ctrl),
-  ]);
 }
 
 export const renderBoard = ({ ctrl, study, playerBars, playerStrips }: ViewContext): VNode =>
@@ -316,22 +293,6 @@ export function renderMoveNodes(
   if (withEval && evalText) nodes.push(h('eval', evalText.replace('-', '−')));
   return nodes;
 }
-
-const renderMoveList = (ctrl: AnalyseCtrl, deps?: typeof studyDeps, concealOf?: ConcealOf): VNode =>
-  hl('div.analyse__moves.areplay', { hook: ctrl.treeView.hook() }, [
-    hl('div', [ctrl.treeView.render(concealOf), renderResult(ctrl)]),
-    !ctrl.practice && !deps?.gbEdit.running(ctrl) && renderNextChapter(ctrl),
-  ]);
-
-export const renderMaterialDiffs = (ctrl: AnalyseCtrl): [VNode, VNode] =>
-  materialView.renderMaterialDiffs(
-    !!ctrl.data.pref.showCaptured,
-    ctrl.bottomColor(),
-    ctrl.node.fen,
-    !!(ctrl.data.player.checks || ctrl.data.opponent.checks), // showChecks
-    ctrl.nodeList,
-    ctrl.node.ply,
-  );
 
 export const addChapterId = (study: StudyCtrl | undefined, cssClass: string) =>
   cssClass + (study && study.data.chapter ? '.' + study.data.chapter.id : '');

--- a/ui/analyse/src/view/main.ts
+++ b/ui/analyse/src/view/main.ts
@@ -9,17 +9,19 @@ import * as licon from 'lib/licon';
 import { type VNode, onInsert, hl } from 'lib/view';
 import { watchers } from 'lib/view/watchers';
 
-import crazyView from '../crazy/crazyView';
-import type AnalyseCtrl from '../ctrl';
-import forecastView from '../forecast/forecastView';
-import { view as keyboardView } from '../keyboard';
-import { relayView } from '../study/relay/relayView';
-import type * as studyDeps from '../study/studyDeps';
-import { studyView } from '../study/studyView';
-import { wikiToggleBox } from '../wiki';
-import { viewContext, renderBoard, renderMain, renderTools, renderUnderboard } from './components';
+import crazyView from '@/crazy/crazyView';
+import type AnalyseCtrl from '@/ctrl';
+import forecastView from '@/forecast/forecastView';
+import { view as keyboardView } from '@/keyboard';
+import { relayView } from '@/study/relay/relayView';
+import type * as studyDeps from '@/study/studyDeps';
+import { studyView } from '@/study/studyView';
+import { wikiToggleBox } from '@/wiki';
+
+import { viewContext, renderBoard, renderMain, renderUnderboard } from './components';
 import { renderControls } from './controls';
 import { render as trainingView } from './roundTraining';
+import { renderTools } from './tools';
 
 let resizeCache: {
   columns: number;

--- a/ui/analyse/src/view/materialDiffs.ts
+++ b/ui/analyse/src/view/materialDiffs.ts
@@ -1,0 +1,15 @@
+import type { VNode } from 'snabbdom';
+
+import * as materialView from 'lib/game/view/material';
+
+import type AnalyseCtrl from '@/ctrl';
+
+export const renderMaterialDiffs = (ctrl: AnalyseCtrl): [VNode, VNode] =>
+  materialView.renderMaterialDiffs(
+    !!ctrl.data.pref.showCaptured,
+    ctrl.bottomColor(),
+    ctrl.node.fen,
+    !!(ctrl.data.player.checks || ctrl.data.opponent.checks), // showChecks
+    ctrl.nodeList,
+    ctrl.node.ply,
+  );

--- a/ui/analyse/src/view/nvuiView.ts
+++ b/ui/analyse/src/view/nvuiView.ts
@@ -39,7 +39,7 @@ import { renderSetting } from 'lib/nvui/setting';
 import { pubsub } from 'lib/pubsub';
 import { ops, path as treePath } from 'lib/tree/tree';
 import type { ClientEval, PvData } from 'lib/tree/types';
-import { type VNode, type LooseVNodes, type VNodeChildren, hl, bind, noTrans, enter } from 'lib/view';
+import { type VNode, type LooseVNodes, type VNodeChildren, hl, bind, noTrans } from 'lib/view';
 import { text as xhrText } from 'lib/xhr';
 
 import type { AnalyseNvuiContext } from '../analyse.nvui';
@@ -48,6 +48,7 @@ import type AnalyseCtrl from '../ctrl';
 import explorerView from '../explorer/explorerView';
 import { makeConfig as makeCgConfig } from '../ground';
 import type { AnalyseData } from '../interfaces';
+import { clickHook, currentLineIndex, renderCurrentNode } from '../nvuiUtil';
 import { renderRetro } from '../retrospect/nvuiRetroView';
 import { view as chapterEditFormView } from '../study/chapterEditForm';
 import { view as chapterNewFormView } from '../study/chapterNewForm';
@@ -216,29 +217,6 @@ export function renderNvui(ctx: AnalyseNvuiContext): VNode {
       deps && ctrl.study?.relay && tourDetails(ctx),
     ]),
   ]);
-}
-
-export function clickHook(main?: (el: HTMLElement) => void, post?: () => void) {
-  return {
-    // put unique identifying props on the button container (such as class)
-    // because snabbdom WILL mix plain adjacent buttons up.
-    hook: {
-      insert: (vnode: VNode) => {
-        const el = vnode.elm as HTMLElement;
-        el.addEventListener('click', () => {
-          main?.(el);
-          post?.();
-        });
-        el.addEventListener(
-          'keydown',
-          enter(() => {
-            main?.(el);
-            post?.();
-          }),
-        );
-      },
-    },
-  };
 }
 
 function boardEventsHook(
@@ -513,38 +491,6 @@ const requestAnalysisBtn = ({ ctrl, notify, analysisInProgress }: AnalyseNvuiCon
         i18n.site.requestAComputerAnalysis,
       );
 };
-
-function currentLineIndex(ctrl: AnalyseCtrl): { i: number; of: number } {
-  if (ctrl.path === treePath.root) return { i: 1, of: 1 };
-  const prevNode = ctrl.tree.parentNode(ctrl.path);
-  return {
-    i: prevNode.children.findIndex(node => node.id === ctrl.node.id),
-    of: prevNode.children.length,
-  };
-}
-
-function renderLineIndex(ctrl: AnalyseCtrl): string {
-  const { i, of } = currentLineIndex(ctrl);
-  return of > 1 ? `, line ${i + 1} of ${of} ,` : '';
-}
-
-export function renderCurrentNode({
-  ctrl,
-  moveStyle,
-}: Pick<AnalyseNvuiContext, 'ctrl' | 'moveStyle'>): string {
-  const node = ctrl.node;
-  if (!node.san || !node.uci) return i18n.nvui.gameStart;
-  return [
-    plyToTurn(node.ply),
-    node.ply % 2 === 1 ? i18n.site.white : i18n.site.black,
-    renderSan(node.san, node.uci, moveStyle.get()),
-    renderLineIndex(ctrl),
-    !ctrl.retro && renderComments(node, moveStyle.get()),
-  ]
-    .filter(x => x)
-    .join(' ')
-    .trim();
-}
 
 const renderPlayer = (ctrl: AnalyseCtrl, player: Player): LooseVNodes =>
   player.ai ? i18n.site.aiNameLevelAiLevel('Stockfish', player.ai) : userHtml(ctrl, player);

--- a/ui/analyse/src/view/tools.ts
+++ b/ui/analyse/src/view/tools.ts
@@ -1,0 +1,36 @@
+import { view as cevalView } from 'lib/ceval';
+import { hl, type LooseVNode, type VNode } from 'lib/view';
+
+import type AnalyseCtrl from '@/ctrl';
+import type { ConcealOf } from '@/interfaces';
+import { renderNextChapter } from '@/study/nextChapter';
+import { backToLiveView } from '@/study/relay/relayView';
+import type * as studyDeps from '@/study/studyDeps';
+import { addChapterId, renderResult, type ViewContext } from '@/view/components';
+
+import explorerView from '../explorer/explorerView';
+import { view as forkView } from '../fork';
+import practiceView from '../practice/practiceView';
+import retroView from '../retrospect/retroView';
+import { view as actionMenu } from './actionMenu';
+
+export function renderTools({ ctrl, deps, concealOf, allowVideo }: ViewContext, embeddedVideo?: LooseVNode) {
+  const showCeval = ctrl.isCevalAllowed() && ctrl.showCeval();
+  return hl(addChapterId(ctrl.study, 'div.analyse__tools'), [
+    allowVideo && embeddedVideo,
+    showCeval && cevalView.renderCeval(ctrl),
+    showCeval && !ctrl.retro?.isSolving() && !ctrl.practice && cevalView.renderPvs(ctrl),
+    renderMoveList(ctrl, deps, concealOf),
+    deps?.gbEdit.running(ctrl) ? deps?.gbEdit.render(ctrl) : undefined,
+    backToLiveView(ctrl),
+    forkView(ctrl, concealOf),
+    retroView(ctrl) || explorerView(ctrl) || practiceView(ctrl),
+    ctrl.actionMenu() && actionMenu(ctrl),
+  ]);
+}
+
+const renderMoveList = (ctrl: AnalyseCtrl, deps?: typeof studyDeps, concealOf?: ConcealOf): VNode =>
+  hl('div.analyse__moves.areplay', { hook: ctrl.treeView.hook() }, [
+    hl('div', [ctrl.treeView.render(concealOf), renderResult(ctrl)]),
+    !ctrl.practice && !deps?.gbEdit.running(ctrl) && renderNextChapter(ctrl),
+  ]);

--- a/ui/analyse/src/view/util.ts
+++ b/ui/analyse/src/view/util.ts
@@ -4,12 +4,14 @@ import {
   propsModule,
   eventListenersModule,
   init,
-  h,
   type VNodeData,
 } from 'snabbdom';
 
 import { fixCrazySan, plyToTurn } from 'lib/game/chess';
 import type { TreeNode } from 'lib/tree/types';
+import { hl } from 'lib/view';
+
+import type { Federation } from '@/study/interfaces';
 
 export const patch = init([classModule, attributesModule, propsModule, eventListenersModule]);
 
@@ -30,4 +32,13 @@ export function titleNameToId(titleName: string): string {
 }
 
 export const option = (value: string, current: string | undefined, name: string, data?: VNodeData) =>
-  h('option', { attrs: { value: value, selected: value === current }, ...data }, name);
+  hl('option', { attrs: { value: value, selected: value === current }, ...data }, name);
+
+export const playerFedFlag = (fed?: Federation) =>
+  fed &&
+  hl('img.mini-game__flag', {
+    attrs: {
+      src: site.asset.fideFedSrc(fed.id),
+      title: `Federation: ${fed.i18nName}`,
+    },
+  });

--- a/ui/botPlay/src/play/keyboard.ts
+++ b/ui/botPlay/src/play/keyboard.ts
@@ -1,6 +1,6 @@
 import { pubsub } from 'lib/pubsub';
 
-import PlayCtrl from './playCtrl';
+import type PlayCtrl from './playCtrl';
 
 export default function keyboard(ctrl: PlayCtrl): void {
   site.mousetrap

--- a/ui/botPlay/src/play/sound.ts
+++ b/ui/botPlay/src/play/sound.ts
@@ -2,7 +2,7 @@ import { type SoundEvent } from 'lib/bot/types';
 
 import type { Move } from '@/interfaces';
 
-import PlayCtrl from './playCtrl';
+import type PlayCtrl from './playCtrl';
 
 export const playMoveSounds = async (ctrl: PlayCtrl, move: Move) => {
   const san = move.san;

--- a/ui/dasher/src/background.ts
+++ b/ui/dasher/src/background.ts
@@ -7,7 +7,9 @@ import { pubsub } from 'lib/pubsub';
 import { bind } from 'lib/view';
 import { text as xhrText, form as xhrForm, textRaw as xhrTextRaw } from 'lib/xhr';
 
-import { type DasherCtrl, PaneCtrl } from './interfaces';
+import type { DasherCtrl } from '@/ctrl';
+
+import { PaneCtrl } from './interfaces';
 import { elementScrollBarWidthSlowGuess, header } from './util';
 
 export interface BackgroundData {

--- a/ui/dasher/src/board.ts
+++ b/ui/dasher/src/board.ts
@@ -5,7 +5,9 @@ import { pubsub } from 'lib/pubsub';
 import { bind, hl, type VNode } from 'lib/view';
 import { text as xhrText, form as xhrForm } from 'lib/xhr';
 
-import { type DasherCtrl, type Dimension, PaneCtrl } from './interfaces';
+import type { DasherCtrl } from '@/ctrl';
+
+import { type Dimension, PaneCtrl } from './interfaces';
 import { header, moreButton } from './util';
 
 type Range = { min: number; max: number; step: number };

--- a/ui/dasher/src/interfaces.ts
+++ b/ui/dasher/src/interfaces.ts
@@ -1,10 +1,8 @@
 import type { VNode } from 'lib/view';
 
-import type { BackgroundData } from './background';
-import { DasherCtrl } from './ctrl';
-import type { LangsData } from './langs';
-
-export { DasherCtrl };
+import type { BackgroundData } from '@/background';
+import type { DasherCtrl } from '@/ctrl';
+import type { LangsData } from '@/langs';
 
 export type Dimension = 'd2' | 'd3';
 

--- a/ui/dasher/src/piece.ts
+++ b/ui/dasher/src/piece.ts
@@ -5,7 +5,9 @@ import { pubsub } from 'lib/pubsub';
 import { bind } from 'lib/view';
 import { text as xhrText, form as xhrForm } from 'lib/xhr';
 
-import { type DasherCtrl, type Dimension, PaneCtrl } from './interfaces';
+import type { DasherCtrl } from '@/ctrl';
+
+import { type Dimension, PaneCtrl } from './interfaces';
 import { header, elementScrollBarWidthSlowGuess, moreButton } from './util';
 
 export class PieceCtrl extends PaneCtrl {

--- a/ui/dasher/src/ping.ts
+++ b/ui/dasher/src/ping.ts
@@ -3,7 +3,7 @@ import { h, type VNode } from 'snabbdom';
 import { defined } from 'lib';
 import { pubsub } from 'lib/pubsub';
 
-import type { DasherCtrl } from './interfaces';
+import type { DasherCtrl } from '@/ctrl';
 
 export class PingCtrl {
   ping: number | undefined;

--- a/ui/dasher/src/sound.ts
+++ b/ui/dasher/src/sound.ts
@@ -6,7 +6,9 @@ import * as licon from 'lib/licon';
 import { bind, dataIcon, snabDialog } from 'lib/view';
 import { text as xhrText, form as xhrForm } from 'lib/xhr';
 
-import { type DasherCtrl, PaneCtrl } from './interfaces';
+import type { DasherCtrl } from '@/ctrl';
+
+import { PaneCtrl } from './interfaces';
 import { header } from './util';
 
 type Key = string;

--- a/ui/insight/src/ctrl.ts
+++ b/ui/insight/src/ctrl.ts
@@ -13,7 +13,7 @@ import type {
   Filters,
   ViewTab,
 } from './interfaces';
-import { isLandscapeLayout } from './view';
+import { isLandscapeLayout } from './util';
 
 export default class {
   env: Env;

--- a/ui/insight/src/info.ts
+++ b/ui/insight/src/info.ts
@@ -5,7 +5,7 @@ import { onInsert, spinnerHtml } from 'lib/view';
 import { userLink } from 'lib/view/userLink';
 
 import type Ctrl from './ctrl';
-import { registerFormHandler } from './insight';
+import { registerFormHandler } from './insight.refresh';
 
 const shareStates = ['nobody', 'friends only', 'everybody'];
 

--- a/ui/insight/src/insight.refresh.ts
+++ b/ui/insight/src/insight.refresh.ts
@@ -1,3 +1,14 @@
-import { registerFormHandler } from './insight';
+export function registerFormHandler() {
+  $('form.insight-refresh').on('submit', function (this: HTMLFormElement) {
+    fetch(this.action, {
+      method: 'post',
+      credentials: 'same-origin',
+    }).then(site.reload);
+
+    $(this).replaceWith($(this).find('.crunching').removeClass('none'));
+
+    return false;
+  });
+}
 
 site.load.then(registerFormHandler);

--- a/ui/insight/src/insight.ts
+++ b/ui/insight/src/insight.ts
@@ -26,16 +26,3 @@ export function initModule(opts: Env) {
 
   return ctrl;
 }
-
-export function registerFormHandler() {
-  $('form.insight-refresh').on('submit', function (this: HTMLFormElement) {
-    fetch(this.action, {
-      method: 'post',
-      credentials: 'same-origin',
-    }).then(site.reload);
-
-    $(this).replaceWith($(this).find('.crunching').removeClass('none'));
-
-    return false;
-  });
-}

--- a/ui/insight/src/util.ts
+++ b/ui/insight/src/util.ts
@@ -1,0 +1,7 @@
+export function isLandscapeLayout() {
+  return isAtLeastXSmall() || window.innerWidth > window.innerHeight;
+}
+
+export const isAtLeastXXSmall = (w = window.innerWidth) => w >= 500; // $mq-xx-small
+export const isAtLeastXSmall = (w = window.innerWidth) => w >= 650; // $mq-x-small
+export const isAtLeastSmall = (w = window.innerWidth) => w >= 800; // $mq-small

--- a/ui/insight/src/view.ts
+++ b/ui/insight/src/view.ts
@@ -14,6 +14,7 @@ import { info, tutor } from './info';
 import type { ViewTab } from './interfaces';
 import presets from './presets';
 import { vert } from './table';
+import { isAtLeastSmall, isAtLeastXSmall, isAtLeastXXSmall, isLandscapeLayout } from './util';
 
 let forceRender = false;
 
@@ -30,10 +31,6 @@ export function view(ctrl: Ctrl) {
     ctrl.vm.view = 'insights';
   }
   return portraitView(ctrl);
-}
-
-export function isLandscapeLayout() {
-  return isAtLeastXSmall() || window.innerWidth > window.innerHeight;
 }
 
 // Key that determines whether or not renderMain needs to get rerendered
@@ -177,7 +174,3 @@ const containerStyle = () => ({
       ` ---chart-height: ${Math.max(300, Math.min(600, window.innerHeight - 100))}px;`,
   },
 });
-
-const isAtLeastXXSmall = (w = window.innerWidth) => w >= 500; // $mq-xx-small
-const isAtLeastXSmall = (w = window.innerWidth) => w >= 650; // $mq-x-small
-const isAtLeastSmall = (w = window.innerWidth) => w >= 800; // $mq-small

--- a/ui/learn/src/sideCtrl.ts
+++ b/ui/learn/src/sideCtrl.ts
@@ -1,6 +1,6 @@
 import { type Prop, propWithEffect } from 'lib';
 
-import { LearnCtrl } from './ctrl';
+import type { LearnCtrl } from './ctrl';
 import type { LearnProgress, LearnOpts } from './learn';
 import * as scoring from './score';
 import { stageIdToCategId, byKey as stageByKey, list as stageList } from './stage/list';

--- a/ui/lib/src/richText.ts
+++ b/ui/lib/src/richText.ts
@@ -4,7 +4,7 @@
 // Refactored for https://github.com/lichess-org/lila/issues/7342 request
 import type { VNode, Hooks } from 'snabbdom';
 
-import { escapeHtml } from './index';
+import { escapeHtml } from './common';
 
 // from https://github.com/bryanwoods/autolink-js/blob/master/autolink.js
 export const linkRegex: RegExp =

--- a/ui/round/src/view/clock.ts
+++ b/ui/round/src/view/clock.ts
@@ -12,7 +12,7 @@ import * as licon from 'lib/licon';
 import { type LooseVNode, hl, bind } from 'lib/view';
 
 import renderCorresClock from '../corresClock/corresClockView';
-import RoundController from '../ctrl';
+import type RoundController from '../ctrl';
 import { justIcon } from '../util';
 import { moretime } from './button';
 

--- a/ui/voice/src/languages.ts
+++ b/ui/voice/src/languages.ts
@@ -1,0 +1,15 @@
+export const supportedLangs: [string, string][] = [
+  ['en', 'English'],
+  ['fr', 'Français'],
+  ['pl', 'Polski'],
+];
+
+if (site.debug)
+  supportedLangs.push(
+    ['de', 'Deutsch'],
+    ['tr', 'Türkçe'],
+    ['vi', 'Tiếng Việt'],
+    ['ru', 'Русский'],
+    ['it', 'Italiano'],
+    ['sv', 'Svenska'],
+  );

--- a/ui/voice/src/util.ts
+++ b/ui/voice/src/util.ts
@@ -123,3 +123,9 @@ export function dest(uci: Uci) {
 }
 
 export const promo = (uci: Uci): Role | undefined => charToRole(uci.slice(4, 5));
+
+export function flash(): void {
+  const div = document.querySelector<HTMLElement>('#voice-status-row')!;
+  div.classList.add('flash');
+  div.onanimationend = () => div.classList.remove('flash');
+}

--- a/ui/voice/src/view.ts
+++ b/ui/voice/src/view.ts
@@ -5,7 +5,7 @@ import { cmnToggleProp } from 'lib/view/cmn-toggle';
 import { jsonSimple } from 'lib/xhr';
 
 import type { Entry, VoiceCtrl, MsgType } from './interfaces';
-import { supportedLangs } from './voice';
+import { supportedLangs } from './languages';
 
 export function renderVoiceBar(ctrl: VoiceCtrl, redraw: () => void, cls?: string): VNode {
   return hl(`div#voice-bar${cls ? '.' + cls : ''}`, [
@@ -35,12 +35,6 @@ export function renderVoiceBar(ctrl: VoiceCtrl, redraw: () => void, cls?: string
       ]),
     ctrl.showHelp() && renderHelpModal(ctrl),
   ]);
-}
-
-export function flash(): void {
-  const div = document.querySelector<HTMLElement>('#voice-status-row')!;
-  div.classList.add('flash');
-  div.onanimationend = () => div.classList.remove('flash');
 }
 
 function voiceBarUpdater(ctrl: VoiceCtrl, el: HTMLElement) {

--- a/ui/voice/src/voice.ts
+++ b/ui/voice/src/voice.ts
@@ -10,27 +10,11 @@ import {
 import type { VoiceCtrl, VoiceModule } from './interfaces';
 import { Mic } from './mic';
 import type { VoiceMove } from './move/interfaces';
-import { flash } from './view';
+import { flash } from './util';
 
 export * from './interfaces';
 export * from './move/interfaces';
 export { renderVoiceBar } from './view';
-
-export const supportedLangs: [string, string][] = [
-  ['en', 'English'],
-  ['fr', 'Français'],
-  ['pl', 'Polski'],
-];
-
-if (site.debug)
-  supportedLangs.push(
-    ['de', 'Deutsch'],
-    ['tr', 'Türkçe'],
-    ['vi', 'Tiếng Việt'],
-    ['ru', 'Русский'],
-    ['it', 'Italiano'],
-    ['sv', 'Svenska'],
-  );
 
 export function makeVoice(opts: {
   redraw: () => void;


### PR DESCRIPTION
# Why

Import cycles can lead to symbols that are unexpectedly `undefined` and are generally considered as an indicator of not great code architecture.

There were 60+ import cycles reported in the codebase, for now I have disabled the rule for `ui/.build` code, since resolving issues there would require a bigger refactor. Example of detected cycle:

<img width="1936" height="858" alt="Screenshot 2026-03-06 at 15 32 55" src="https://github.com/user-attachments/assets/f7b02bd0-f3bb-4ae9-88fa-af35c8641b1e" />

# How

Enable [`import/no-cycles` lint rule](https://oxc.rs/docs/guide/usage/linter/rules/import/no-cycle), refactor code to avoid import cycles.