### PR TITLE
ui: show provisional rating message directly in lobby dialog

### DIFF
--- a/ui/lobby/src/view/setup/components/ratingDifferenceSliders.ts
+++ b/ui/lobby/src/view/setup/components/ratingDifferenceSliders.ts
@@ -7,10 +7,6 @@ export const ratingDifferenceSliders = ({ setupCtrl, me, data }: LobbyController
 
   const isProvisional = setupCtrl.isProvisional();
 
-  // Get current rating values or use default values if isProvisional
-  const currentRatingMin = isProvisional ? -500 : setupCtrl.ratingMin();
-  const currentRatingMax = isProvisional ? 500 : setupCtrl.ratingMax();
-
   const ratingInput = (type: 'min' | 'max') => {
     const isMin = type === 'min';
     return hl(`input.range.rating-range__${type}`, {
@@ -23,7 +19,7 @@ export const ratingDifferenceSliders = ({ setupCtrl, me, data }: LobbyController
         disabled: isProvisional,
       },
       props: {
-        value: isMin ? currentRatingMin : currentRatingMax,
+        value: isMin ? setupCtrl.ratingMin() : setupCtrl.ratingMax(),
       },
       on: {
         input: (e: Event) => {
@@ -41,25 +37,20 @@ export const ratingDifferenceSliders = ({ setupCtrl, me, data }: LobbyController
     'div',
     {
       class: { disabled: isProvisional },
-      attrs: isProvisional
-        ? {
-            title: i18n.site.ratingRangeIsDisabledBecauseYourRatingIsProvisional,
-            'aria-disabled': 'true',
-            tabindex: -1,
-          }
-        : undefined,
     },
-    [
-      i18n.site.ratingFilter,
-      hl('div.rating-range', [
-        ratingInput('min'),
-        !site.blindMode && [
-          hl('span.rating-min', '-' + Math.abs(currentRatingMin)),
-          '/',
-          hl('span.rating-max', '+' + currentRatingMax),
+    isProvisional
+      ? hl('span', i18n.site.ratingRangeIsDisabledBecauseYourRatingIsProvisional)
+      : [
+          i18n.site.ratingFilter,
+          hl('div.rating-range', [
+            ratingInput('min'),
+            !site.blindMode && [
+              hl('span.rating-min', '-' + Math.abs(setupCtrl.ratingMin())),
+              '/',
+              hl('span.rating-max', '+' + setupCtrl.ratingMax()),
+            ],
+            ratingInput('max'),
+          ]),
         ],
-        ratingInput('max'),
-      ]),
-    ],
   );
 };


### PR DESCRIPTION
# Why

Showing disabled rating sliders can be confusing, and without a proper tooltip UI getting information can be cumbersome, since `title` message appears with delay.

# How

When rating is provisional, show message directly in lobby dialog and hide rating inputs.

# Preview

### Before

<img width="1428" height="488" alt="Screenshot 2026-03-07 at 09 53 12" src="https://github.com/user-attachments/assets/51f5068c-cced-4292-b6db-36fa02e1afd0" />

### After

<img width="1254" height="488" alt="Screenshot 2026-03-07 at 10 04 46" src="https://github.com/user-attachments/assets/24313a24-26c1-4970-8c87-5ed04e445219" />
