### PR TITLE
ui: fix shield icon position in tournament header

### DIFF
--- a/ui/tournament/css/_app-header.scss
+++ b/ui/tournament/css/_app-header.scss
@@ -129,11 +129,10 @@
       letter-spacing: 2px;
 
       .shield-trophy {
+        @include inline-start(24px);
+
         position: absolute;
-        top: -8px;
-
-        @include inline-start(12px);
-
+        top: 16px;
         display: block;
         width: 67px;
         height: 80px;
@@ -145,6 +144,10 @@
         text-align: center;
         color: #333 !important;
         text-shadow: 0 0 6px #fff;
+
+        @media (width <= $small) {
+          top: 10px;
+        }
       }
     }
   }


### PR DESCRIPTION
# Why

Spotted that tournament shield icons are slightly wrong positioned in the tournament header.

<img width="1880" height="710" alt="Screenshot 2026-03-07 at 12 25 27" src="https://github.com/user-attachments/assets/9bbdd606-0b67-4e40-a954-10e25a1bccc6" />

# How

Update base position, adjust position on mobile viewports.

# Preview

<img width="1880" height="710" alt="Screenshot 2026-03-07 at 12 22 56" src="https://github.com/user-attachments/assets/955ba61f-c4de-42b5-8b59-36026b2bfa43" />

<img width="780" height="598" alt="Screenshot 2026-03-07 at 12 22 39" src="https://github.com/user-attachments/assets/8e8722aa-7e4a-44ef-b9a3-e8be148fda67" />
