### PR TITLE
chore: few new lint rules, apply fixes

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -39,9 +39,12 @@
     "typescript/no-unnecessary-type-arguments": "error",
     "typescript/no-unnecessary-type-assertion": "error",
     "typescript/no-unnecessary-type-constraint": "error",
+    "unicorn/no-immediate-mutation": "error",
+    "unicorn/no-useless-collection-argument": "error",
     "unicorn/prefer-array-flat": "error",
     "unicorn/prefer-array-flat-map": "error",
     "unicorn/prefer-array-some": "error",
+    "unicorn/prefer-keyboard-event-key": "error",
     "no-restricted-globals": [
       "error",
       "addEventListener",
@@ -231,8 +234,7 @@
     {
       "files": ["bin/**", "cron/**"],
       "rules": {
-        "no-unused-vars": "off",
-        "unicorn/prefer-array-some": "off"
+        "no-unused-vars": "off"
       }
     },
     {

--- a/bin/mongodb/msg_import.js
+++ b/bin/mongodb/msg_import.js
@@ -60,7 +60,7 @@ db.m_thread_sorted
 
     o.threads.forEach(t => {
       t.posts.forEach(p => {
-        if (o.creatorId == 'lichess' && isOld(p.createdAt)) return;
+        if (o.creatorId === 'lichess' && isOld(p.createdAt)) return;
         msgs.push({
           _id: p.id,
           tid: threadId,
@@ -84,7 +84,7 @@ db.m_thread_sorted
         text: last.text.slice(0, 60),
         user: last.user,
         date: last.date,
-        read: !o.threads.find(t => t.posts.find(p => p.isRead)) || isOld(last.date),
+        read: !o.threads.some(t => t.posts.find(p => p.isRead)) || isOld(last.date),
       },
     };
 

--- a/bin/mongodb/play21.js
+++ b/bin/mongodb/play21.js
@@ -69,11 +69,13 @@ db.f_topic.ensureIndex({ categId: 1, updatedAt: -1, troll: 1 });
 print('user.settings.{chat,sound} should be a string');
 ['settings.chat', 'settings.sound'].forEach(function (name) {
   [true, false].forEach(function (value) {
-    const sel = {};
-    sel[name] = value;
+    const sel = {
+      [name]: value,
+    };
     db.user2.find(sel).forEach(function (user) {
-      const up = {};
-      up[name] = value.toString();
+      const up = {
+        [name]: value.toString(),
+      };
       db.user2.update({ _id: user['_id'] }, { $set: up });
     });
   });

--- a/bin/mongodb/study-clone-track.js
+++ b/bin/mongodb/study-clone-track.js
@@ -2,7 +2,7 @@ const user = 'Amazing_Tactics'.toLowerCase();
 
 db.study.find({ ownerId: user, visibility: 'public' }).forEach(function (study) {
   const line = computeLine(study);
-  if (line.find(l => l.ownerId != user)) {
+  if (line.some(l => l.ownerId !== user)) {
     console.log('--------------------------');
     line.forEach((study, i) => {
       console.log(`${i} ${studyUrl(study)} @${study.ownerId} ${study.likes} ${study.name}`);
@@ -13,7 +13,7 @@ db.study.find({ ownerId: user, visibility: 'public' }).forEach(function (study) 
 function computeLine(study) {
   const parts = (study.from || '').split(' ');
   let source;
-  if (parts[0] == 'study') source = db.study.findOne({ _id: parts[1] });
+  if (parts[0] === 'study') source = db.study.findOne({ _id: parts[1] });
   if (source) return [study, ...computeLine(source)];
   return [study];
 }

--- a/bin/mongodb/study-remove-bad-nodes.js
+++ b/bin/mongodb/study-remove-bad-nodes.js
@@ -5,8 +5,9 @@ function dig(chapId, node, path) {
     const c = node.n[i];
     const newPath = `${path}.n.${i}`;
     if (!c || !c.i) {
-      const set = {};
-      set[`${path}.n`] = [];
+      const set = {
+        [`${path}.n`]: [],
+      };
       printjson(set);
       db.study_chapter.update({ _id: chapId }, { $set: set });
     } else {

--- a/bin/mongodb/user-data-request.js
+++ b/bin/mongodb/user-data-request.js
@@ -7,7 +7,7 @@ db.security
   })
   .map(o => `${o.ip} ${o.ua}`)
   .forEach(conn => {
-    if (!connections.find(c => c === conn)) connections.push(conn);
+    if (!connections.some(c => c === conn)) connections.push(conn);
   });
 
 print(`\n${user.username} ${user.email}`);

--- a/cron/mongodb-puzzle-denormalize-themes.js
+++ b/cron/mongodb-puzzle-denormalize-themes.js
@@ -39,7 +39,7 @@ db.puzzle2_puzzle
     const themeMap = {};
 
     p.rounds.forEach(x => {
-      const signum = x._id[0] == '+' ? 1 : -1;
+      const signum = x._id[0] === '+' ? 1 : -1;
       const theme = x._id.substring(1);
       themeMap[theme] = x.v * signum + (themeMap[theme] || 0);
     });
@@ -50,7 +50,7 @@ db.puzzle2_puzzle
     });
 
     const update = { $unset: { dirty: true } };
-    if (oldThemes.length !== newThemes.size || oldThemes.find(t => !newThemes.has(t))) {
+    if (oldThemes.length !== newThemes.size || oldThemes.some(t => !newThemes.has(t))) {
       update['$set'] = { themes: Array.from(newThemes) };
     }
     playColl.updateOne({ _id: p._id }, update);

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "check-format": "oxfmt --check",
     "lint": "oxlint --type-aware --tsconfig=ui/tsconfig.base.json && stylelint \"**/*.scss\"",
     "lint:fix": "oxlint --type-aware --tsconfig=ui/tsconfig.base.json --fix && stylelint \"**/*.scss\" --fix",
+    "test": "node ui/test",
     "journal": "journalctl --user -fu lila -o cat",
     "metals": "tail -F .metals/metals.log | stdbuf -oL cut -c 21- | rg -v '(notification for request|handleCancellation)'",
     "serverlog": "pnpm journal & pnpm metals",

--- a/ui/learn/src/promotionCtrl.ts
+++ b/ui/learn/src/promotionCtrl.ts
@@ -56,8 +56,7 @@ export class PromotionCtrl {
     this.withGround(ground => {
       const piece = ground.state.pieces.get(key);
       if (piece && piece.role === 'pawn') {
-        const pieces: PiecesDiff = new Map();
-        pieces.set(key, { color: piece.color, role, promoted: true });
+        const pieces: PiecesDiff = new Map([[key, { color: piece.color, role, promoted: true }]]);
         ground.setPieces(pieces);
       }
     });

--- a/ui/lib/tests/command.test.ts
+++ b/ui/lib/tests/command.test.ts
@@ -4,11 +4,12 @@ import { test } from 'node:test';
 
 import { commands } from '../src/nvui/command';
 
-const pieces: Pieces = new Map();
-pieces.set('a1', { color: 'white', role: 'king' });
-pieces.set('a2', { color: 'white', role: 'queen' });
-pieces.set('b1', { color: 'white', role: 'knight' });
-pieces.set('b2', { color: 'white', role: 'knight' });
+const pieces: Pieces = new Map([
+  ['a1', { color: 'white', role: 'king' }],
+  ['a2', { color: 'white', role: 'queen' }],
+  ['b1', { color: 'white', role: 'knight' }],
+  ['b2', { color: 'white', role: 'knight' }],
+]);
 
 test('piece command', () => {
   assert.strictEqual(commands().piece.apply('p Q', pieces, 'anna'), 'nvui.whiteQueen: anna 2');

--- a/ui/msg/src/view/interact.ts
+++ b/ui/msg/src/view/interact.ts
@@ -83,7 +83,7 @@ function setupTextarea(area: HTMLTextAreaElement, contact: string, ctrl: MsgCtrl
 
   // send the content on <enter.
   area.addEventListener('keypress', (e: KeyboardEvent) => {
-    if ((e.which === 10 || e.which === 13) && !e.shiftKey) {
+    if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
       setTimeout(send);
     }

--- a/ui/round/tests/premove.test.ts
+++ b/ui/round/tests/premove.test.ts
@@ -122,7 +122,7 @@ describe('premoves', () => {
       ['g7', new Set(['g6', 'f6'])],
       ['e5', new Set(['e4', 'd4'])],
       ['b5', new Set(['b4'])],
-      ['a3', new Set([])],
+      ['a3', new Set()],
     ]);
     testPosition(
       fen.read('k1n2r1r/2bP2p1/3r3p/Ppq1pPr1/qP4n1/p3r1P1/PbnP2KP/R4r1q w - - 0 1'),
@@ -141,7 +141,7 @@ describe('premoves', () => {
       ['h3', new Set(['g3', 'f3', 'e3', 'd3', 'h4', 'h5'])],
       ['f5', new Set(['e5', 'd5', 'c5', 'b5', 'a5', 'f6', 'f7', 'f8', 'f4', 'f3'])],
       ['c4', new Set(['c5'])],
-      ['f4', new Set([])],
+      ['f4', new Set()],
       ['g5', new Set(['g6'])],
       ['d3', new Set(['d4', 'e4'])],
     ]);


### PR DESCRIPTION
# Why

Some chores and few new lint rules.

# How

Add the following lint rules:
* https://oxc.rs/docs/guide/usage/linter/rules/unicorn/no-immediate-mutation.html
* https://oxc.rs/docs/guide/usage/linter/rules/unicorn/no-useless-collection-argument.html
* https://oxc.rs/docs/guide/usage/linter/rules/unicorn/prefer-keyboard-event-key.html
  > The `keyCode`, `which`, and `charCode` KeyboardEvent properties are deprecated and should be avoided in favor of the key property.  

Fix `unicorn/prefer-array-some` warning in `bin` code, add `pnpm test` script shorthand to run UI unit test.
