### PR TITLE
Only replace fishnet comments with 'Learn from this mistake'.

### DIFF
--- a/ui/analyse/src/treeView/inlineView.ts
+++ b/ui/analyse/src/treeView/inlineView.ts
@@ -66,7 +66,7 @@ export class InlineView {
     if (!this.ctrl.showComments || !node.comments) return [];
     return node.comments
       .map(comment =>
-        this.ctrl.retro?.hideComputerLine(node)
+        this.ctrl.retro?.hideComputerLine(node) && this.isFishnetComment(comment)
           ? hl('comment', i18n.site.learnFromThisMistake)
           : (!this.isFishnetComment(comment) || this.ctrl.showFishnetAnalysis()) &&
             hl('comment', {


### PR DESCRIPTION
If a user offers a draw on the same move they make a mistake, current retro behaviour will show two 'Learn from this mistake' comments.