### PR TITLE
ui: add wrap for profile games tabs

### DIFF
--- a/ui/user/css/_show.scss
+++ b/ui/user/css/_show.scss
@@ -210,6 +210,7 @@
   .number-menu .to-games.active,
   #games.number-menu {
     background: $c-bg-low !important;
+    flex-wrap: wrap;
   }
 
   .angles {


### PR DESCRIPTION
# Why

Fixes #19750

# How

Add wrap for profile games tabs. Not an ideal solution, but feels like a better way to hotfix than enabling horizontal overflow.

# Preview

<img width="712" height="490" alt="Screenshot 2026-03-08 at 10 27 53" src="https://github.com/user-attachments/assets/166b6064-15e5-4488-8d03-f6d0e4b7c4c1" />
