### PR TITLE
ui: use user board and pieces for editor screenshots

### DIFF
--- a/ui/editor/src/ctrl.ts
+++ b/ui/editor/src/ctrl.ts
@@ -84,6 +84,14 @@ export default class EditorCtrl {
       this.initialFen = INITIAL_FEN;
       this.setSetup(defaultSetup());
     });
+
+    new MutationObserver(mutations => {
+      for (const m of mutations) {
+        if (!m.attributeName || !(m.attributeName === 'data-board' || m.attributeName === 'data-piece-set'))
+          continue;
+        this.redraw();
+      }
+    }).observe(window.document.body, { attributes: true });
   }
 
   private indexOfNthOccurrence = (haystack: string, needle: string, n: number): number => {
@@ -231,7 +239,7 @@ export default class EditorCtrl {
     const variant = this.variant === 'standard' ? '' : this.variant + '/';
     const chess960PositionId =
       this.chess960PositionId === undefined ? '' : `&position=${this.chess960PositionId}`;
-    return `/analysis/${variant}${urlFen(legalFen)}?color=${orientation}${chess960PositionId}`;
+    return `/analysis/${variant}${this.urlFen(legalFen)}?color=${orientation}${chess960PositionId}`;
   }
 
   makeEditorUrl(fen: FEN, orientation: Color = 'white'): string {
@@ -241,11 +249,8 @@ export default class EditorCtrl {
     const chess960PositionId =
       this.chess960PositionId === undefined ? '' : `&position=${this.chess960PositionId}`;
     const orientationParam = variant ? `&color=${orientation}` : `?color=${orientation}`;
-    return `${this.cfg.baseUrl}/${urlFen(fen)}${variant}${orientationParam}${chess960PositionId}`;
+    return `${this.cfg.baseUrl}/${this.urlFen(fen)}${variant}${orientationParam}${chess960PositionId}`;
   }
-
-  makeImageUrl = (fen: FEN): string =>
-    `${site.asset.baseUrl()}/export/fen.gif?fen=${urlFen(fen)}&color=${this.bottomColor()}`;
 
   bottomColor = (): Color =>
     this.chessground ? this.chessground.state.orientation : this.options.orientation || 'white';
@@ -338,8 +343,8 @@ export default class EditorCtrl {
     const id = randomPositionId();
     id !== this.chess960PositionId ? this.set960Position(id) : this.setRandom960Position();
   }
-}
 
-function urlFen(fen: FEN): string {
-  return encodeURIComponent(fen).replace(/%20/g, '_').replace(/%2F/g, '/');
+  urlFen(fen: FEN): string {
+    return encodeURIComponent(fen).replace(/%20/g, '_').replace(/%2F/g, '/');
+  }
 }

--- a/ui/editor/src/view.ts
+++ b/ui/editor/src/view.ts
@@ -9,6 +9,7 @@ import { h, type VNode } from 'snabbdom';
 import { fenToEpd } from 'lib/game/chess';
 import * as licon from 'lib/licon';
 import { copyMeInput, dataIcon, domDialog, enter } from 'lib/view';
+import { url as xhrUrl } from 'lib/xhr';
 
 import { fenToChess960Id, isValidPositionId } from './chess960';
 import chessground from './chessground';
@@ -322,6 +323,7 @@ function controls(ctrl: EditorCtrl, state: EditorState): VNode {
 
 function inputs(ctrl: EditorCtrl, fen: FEN): VNode | undefined {
   if (ctrl.cfg.embed) return;
+
   return h('div.copyables', [
     h('p', [
       h('strong', 'FEN'),
@@ -355,7 +357,21 @@ function inputs(ctrl: EditorCtrl, fen: FEN): VNode | undefined {
       }),
     ]),
     h('p', [h('strong.name', 'URL'), copyMeInput(ctrl.makeEditorUrl(fen, ctrl.bottomColor()))]),
-    h('a', { attrs: { href: ctrl.makeImageUrl(fen) } }, 'SCREENSHOT'),
+    h(
+      'a',
+      {
+        attrs: {
+          href: xhrUrl(`${site.asset.baseUrl()}/export/fen.gif`, {
+            fen: ctrl.urlFen(fen),
+            color: ctrl.bottomColor(),
+            theme: document.body.dataset.board,
+            piece: document.body.dataset.pieceSet,
+          }),
+          download: true,
+        },
+      },
+      'SCREENSHOT',
+    ),
   ]);
 }
 


### PR DESCRIPTION
# Why

Spotted that editor screenshot always uses default board picture and pieces set.

# How

Pass user selected board and pieces set to the screenshot generator, add mutation observer for `body` attributes, so the link is updated immediately when user changes the preferences.

> [!note]
> While testing, spotted that changing board also always sets `data-piece-set`, not sure if this is intended, but if is, we can simplify mutation observer logic and just rerender on `data-piece-set` change (saving one rerender).
>
> An another approach would be adding `pubsub` event for user board preference changes, and then re-rendering the portion of view containing screenshot button, but was not sure if this would be useful anywhere else, and was a bit overkill solution for a quite simple case. Happy to go that route tho, if you think that it would be better.

# Preview

https://github.com/user-attachments/assets/ea59fa93-71ee-424a-9138-3e64e05e4962