### PR TITLE
ui: add shadow to chessground dragged pieces

### DIFF
--- a/ui/lib/css/theme/board/_chessground.scss
+++ b/ui/lib/css/theme/board/_chessground.scss
@@ -1,5 +1,12 @@
 @import 'board-2d';
 
+@mixin withPieceFilterShadowWhileDragging($extraFilters: ()) {
+  &.dragging {
+    filter: drop-shadow(3px 4px 4px rgba(0 0 0 / 0.5)) $extraFilters;
+    @content;
+  }
+}
+
 cg-board {
   @extend %box-shadow, %abs-100;
   @include prevent-select;
@@ -136,7 +143,7 @@ piece {
   will-change: transform;
   pointer-events: none;
 
-  &.dragging {
+  @include withPieceFilterShadowWhileDragging {
     cursor: move;
     z-index: $z-cg__piece_dragging-204 !important;
   }
@@ -211,19 +218,30 @@ cg-auto-pieces {
 }
 
 html:not(.transp) body:not(.simple-board) {
+  $brightness-filter: brightness(calc(0.35 + 0.0065 * min(120, var(---board-brightness))));
+
   &.coords-in coord,
   cg-board piece,
   cg-board square,
   .cg-custom-svgs,
   .cg-custom-below {
-    filter: brightness(calc(0.35 + 0.0065 * min(120, var(---board-brightness))));
+    filter: $brightness-filter;
+  }
+
+  cg-board piece {
+    @include withPieceFilterShadowWhileDragging($brightness-filter);
   }
 }
 
 html.transp body:not(.simple-board) cg-board {
+  $opacity-filter: calc(min(1, 0.5 + var(---board-opacity) / 100));
+
   piece,
   square {
-    opacity: calc(min(1, 0.5 + var(---board-opacity) / 100));
+    opacity: $opacity-filter;
+  }
+  piece {
+    @include withPieceFilterShadowWhileDragging($opacity-filter);
   }
 }
 

--- a/ui/lib/css/theme/board/_chessground.scss
+++ b/ui/lib/css/theme/board/_chessground.scss
@@ -1,8 +1,8 @@
 @import 'board-2d';
 
-@mixin withPieceFilterShadowWhileDragging($extraFilters: ()) {
+@mixin with-filter-shadow-while-dragging($extraFilters: ()) {
   &.dragging {
-    filter: drop-shadow(3px 4px 4px rgba(0 0 0 / 0.5)) $extraFilters;
+    filter: drop-shadow(3px 4px 4px rgba(0, 0, 0, 0.5)) $extraFilters;
     @content;
   }
 }
@@ -143,7 +143,7 @@ piece {
   will-change: transform;
   pointer-events: none;
 
-  @include withPieceFilterShadowWhileDragging {
+  @include with-filter-shadow-while-dragging {
     cursor: move;
     z-index: $z-cg__piece_dragging-204 !important;
   }
@@ -229,7 +229,7 @@ html:not(.transp) body:not(.simple-board) {
   }
 
   cg-board piece {
-    @include withPieceFilterShadowWhileDragging($brightness-filter);
+    @include with-filter-shadow-while-dragging($brightness-filter);
   }
 }
 
@@ -240,8 +240,9 @@ html.transp body:not(.simple-board) cg-board {
   square {
     opacity: $opacity-filter;
   }
+
   piece {
-    @include withPieceFilterShadowWhileDragging($opacity-filter);
+    @include with-filter-shadow-while-dragging($opacity-filter);
   }
 }
 


### PR DESCRIPTION
# Why

An experiment to add a bit more visual feedback to pieces while dragging them.

> [!note]
> Since this is an experiment, some tweaks to the shadow values are welcome, we can also decide not to go that way and close the PR.

# How

Add `drop-shadow` filter to piece which is in dragging state, mix filters with user board ones if needed.

# Preview

https://github.com/user-attachments/assets/cd78e676-01c7-4cea-a03e-e6c7a924054c

