### PR TITLE
ui: a11y and visual tweaks for editor buttons, improve readability

### DIFF
--- a/ui/editor/css/_tools.scss
+++ b/ui/editor/css/_tools.scss
@@ -97,6 +97,7 @@
 
     .actions {
       @extend %flex-column;
+      @include backdrop-blur-if-transparent;
 
       justify-content: stretch;
 
@@ -105,6 +106,16 @@
 
         width: 100%;
         text-align: start;
+        display: flex;
+        align-items: center;
+
+        &.disabled {
+          cursor: default;
+        }
+
+        &::before {
+          color: var(--c-font);
+        }
       }
     }
   }

--- a/ui/editor/src/view.ts
+++ b/ui/editor/src/view.ts
@@ -80,13 +80,13 @@ function controls(ctrl: EditorCtrl, state: EditorState): VNode {
 
   const buttonStart = (icon?: string) =>
     h(
-      `a.button.button-empty${icon ? '.text' : ''}`,
+      `button.button.button-empty${icon ? '.text' : ''}`,
       { on: { click: ctrl.startPosition }, attrs: icon ? dataIcon(icon) : {} },
       i18n.site.startPosition,
     );
   const buttonClear = (icon?: string) =>
     h(
-      `a.button.button-empty${icon ? '.text' : ''}`,
+      `button.button.button-empty${icon ? '.text' : ''}`,
       { on: { click: ctrl.clearBoard }, attrs: icon ? dataIcon(icon) : {} },
       i18n.site.clearBoard,
     );
@@ -295,6 +295,9 @@ function controls(ctrl: EditorCtrl, state: EditorState): VNode {
               'button',
               {
                 class: { button: true, 'button-empty': true, disabled: !state.playable },
+                attrs: {
+                  disabled: !state.playable,
+                },
                 on: {
                   click: () => {
                     if (state.playable) domDialog({ cash: $('.continue-with'), modal: true, show: true });

--- a/ui/lib/css/component/_copy-me.scss
+++ b/ui/lib/css/component/_copy-me.scss
@@ -1,5 +1,6 @@
 .copy-me {
   @extend %box-radius, %flex-center-nowrap;
+  @include backdrop-blur-if-transparent;
 
   &__target {
     @extend %nowrap-ellipsis, %box-radius-left;


### PR DESCRIPTION
# Why

While working on screenshot improvements in editor I have spotted that some buttons are not focusable, disabled ones still use pointer cursor, and parts of UI is hard to read in picture bg mode.

# How

A11y and visual tweaks for action buttons, add backdrop blur for the whole `copy-me` input.

# Preview

https://github.com/user-attachments/assets/3c849814-fb80-42fc-8175-dc559e3aad95

<img width="3206" height="2284" alt="Screenshot 2026-03-11 at 11 10 58" src="https://github.com/user-attachments/assets/30f835a5-fb60-4463-9790-d8b3e140607b" />
