### PR TITLE
chore: try to autofix issues in lint-staged runs

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "remove-hooks": "git config unset --value=bin/git-hooks core.hooksPath || true"
   },
   "lint-staged": {
-    "*.{json,scss,ts,mts,mjs}": "pnpm lint:code --fix && pnpm format",
+    "*.{json,ts,mts,mjs}": "pnpm lint:code --fix && pnpm format",
     "*.{scss}": "pnpm lint:style --fix && pnpm format"
   },
   "browserslist": [


### PR DESCRIPTION
# Why

We can try to autofix issues in `lint-staged` runs, forgot about the `--fix` flag while suggesting recent changes.

# How

Add `--fix` flag to `lint-staged` scripts.