### PR TITLE
ui: assorted changes/code cleanup in `lib`

### DIFF
--- a/ui/lib/src/algo.ts
+++ b/ui/lib/src/algo.ts
@@ -2,7 +2,7 @@ export const randomToken = (): string => {
   try {
     const data = globalThis.crypto.getRandomValues(new Uint8Array(9));
     return btoa(String.fromCharCode(...data)).replace(/[/+]/g, '_');
-  } catch (_) {
+  } catch {
     return Math.random().toString(36).slice(2, 12);
   }
 };

--- a/ui/lib/src/api.ts
+++ b/ui/lib/src/api.ts
@@ -1,6 +1,6 @@
+import { domDialog, alert, confirm, prompt } from '@/view';
+
 import { type PubsubEventKey, type PubsubEvents, pubsub } from './pubsub';
-import { domDialog } from './view/dialog';
-import { alert, confirm, prompt } from './view/dialogs';
 
 // #TODO document these somewhere
 const publicEvents = ['ply', 'analysis.change', 'chat.resize', 'analysis.closeAll'] as const;

--- a/ui/lib/src/async.ts
+++ b/ui/lib/src/async.ts
@@ -33,7 +33,7 @@ export function throttlePromiseWithResult<R, T extends (...args: any) => Promise
     if (!current) return runCurrent();
 
     pending?.reject();
-    const next = new Promise<R>((resolve, reject) => {
+    return new Promise<R>((resolve, reject) => {
       pending = {
         run: () =>
           runCurrent().then(
@@ -49,7 +49,6 @@ export function throttlePromiseWithResult<R, T extends (...args: any) => Promise
         reject: () => reject(new Error('Throttled')),
       };
     });
-    return next;
   };
 }
 

--- a/ui/lib/src/bot/bot.ts
+++ b/ui/lib/src/bot/bot.ts
@@ -1,10 +1,10 @@
 import type { SearchResult } from '@lichess-org/zerofish';
 import * as co from 'chessops';
 
+import { zip } from '@/algo';
 import { clockToSpeed } from '@/game';
+import type { OpeningBook } from '@/game/polyglot';
 
-import { zip } from '../algo';
-import type { OpeningBook } from '../game/polyglot';
 import type { BotLoader } from './botLoader';
 import {
   type FilterFacetValue,

--- a/ui/lib/src/bot/botLoader.ts
+++ b/ui/lib/src/bot/botLoader.ts
@@ -1,8 +1,9 @@
 import './filters';
 import makeZerofish, { type Zerofish } from '@lichess-org/zerofish';
 
-import { definedMap } from '../algo';
-import { type OpeningBook, makeBookFromPolyglot } from '../game/polyglot';
+import { definedMap } from '@/algo';
+import { type OpeningBook, makeBookFromPolyglot } from '@/game/polyglot';
+
 import { myUserId, myUsername } from '../index';
 import * as xhr from '../xhr';
 import { Bot } from './bot';

--- a/ui/lib/src/bot/filter.ts
+++ b/ui/lib/src/bot/filter.ts
@@ -1,4 +1,5 @@
-import { clamp, quantize } from '../algo';
+import { clamp, quantize } from '@/algo';
+
 import type { SearchMove, MoveArgs } from './types';
 
 type Point = [number, number];

--- a/ui/lib/src/bot/lichessBook.ts
+++ b/ui/lib/src/bot/lichessBook.ts
@@ -1,7 +1,7 @@
 import * as co from 'chessops';
 
-import { clamp } from '../algo';
-import type { OpeningBook } from '../game/polyglot';
+import { clamp } from '@/algo';
+import type { OpeningBook } from '@/game/polyglot';
 
 export function makeLichessBook(): OpeningBook {
   // todo, timeout cancel and probably don't even bother below bullet

--- a/ui/lib/src/ceval/ctrl.ts
+++ b/ui/lib/src/ceval/ctrl.ts
@@ -5,12 +5,12 @@ import { lichessRules } from 'chessops/compat';
 import { parseFen } from 'chessops/fen';
 import { setupPosition } from 'chessops/variant';
 
+import { clamp } from '@/algo';
+import { throttle } from '@/async';
+import { storedIntProp, storage } from '@/storage';
 import type { LocalEval, PvData, TreePath } from '@/tree/types';
 
-import { clamp } from '../algo';
-import { throttle } from '../async';
 import { prop, type Prop, type Toggle, toggle } from '../index';
-import { storedIntProp, storage } from '../storage';
 import { Engines } from './engines/engines';
 import {
   type CevalOpts,

--- a/ui/lib/src/ceval/engines/engines.ts
+++ b/ui/lib/src/ceval/engines/engines.ts
@@ -1,12 +1,12 @@
 import { lichessRules } from 'chessops/compat';
 
+import type { BrowserEngineInfo, ExternalEngineInfo, EngineInfo, CevalEngine } from '@/ceval';
 import { isAndroid, isIos, isIPad, features as browserSupport } from '@/device';
 import { log } from '@/permalog';
 import { storedStringProp, type StoredProp } from '@/storage';
 import { xhrHeader } from '@/xhr';
 
 import type CevalCtrl from '../ctrl';
-import type { BrowserEngineInfo, ExternalEngineInfo, EngineInfo, CevalEngine } from '../types';
 import { ExternalEngine } from './externalEngine';
 import { SimpleEngine } from './simpleEngine';
 import { StockfishWebEngine } from './stockfishWebEngine';

--- a/ui/lib/src/ceval/types.ts
+++ b/ui/lib/src/ceval/types.ts
@@ -1,8 +1,9 @@
 import type { VNode } from 'snabbdom';
 
+import type { Feature } from '@/device';
 import type { ClientEval, LocalEval, ServerEval, TreeNode } from '@/tree/types';
+import type { MaybeVNode } from '@/view';
 
-import type { Feature } from '../device';
 import type { Prop } from '../index';
 import type CevalCtrl from './ctrl';
 
@@ -14,8 +15,8 @@ export type Millis = number;
 export interface Work {
   variant: VariantKey;
   threads: number;
-  hashSize: number | undefined;
-  gameId: string | undefined; // send ucinewgame when changed
+  hashSize?: number;
+  gameId?: string; // send ucinewgame when changed
   stopRequested: boolean;
 
   path: string;
@@ -99,12 +100,12 @@ export type Progress = (p?: { bytes: number; total: number }) => void;
 export interface CustomCeval {
   search?: () => Search | Millis; // pass number as millis to cap user defined search
   pearlNode?: () => VNode | undefined;
-  statusNode?: () => VNode | string | undefined;
+  statusNode?: () => MaybeVNode;
 }
 
 export interface CevalOpts {
   variant: Variant;
-  initialFen: string | undefined;
+  initialFen?: string;
   emit: (ev: LocalEval, meta: EvalMeta) => void;
   onUciHover: (hovering: Hovering | null) => void;
   redraw: Redraw;
@@ -126,7 +127,7 @@ export interface PvBoard {
 export interface Started {
   path: string;
   steps: Step[];
-  gameId: string | undefined;
+  gameId?: string;
   threatMode: boolean;
 }
 

--- a/ui/lib/src/ceval/util.ts
+++ b/ui/lib/src/ceval/util.ts
@@ -1,10 +1,10 @@
 // no side effects allowed due to re-export by index.ts
 
+import { isMobile } from '@/device';
 import type { ClientEval } from '@/tree/types';
+import { domDialog } from '@/view';
 
-import { isMobile } from '../device';
 import { memoize, escapeHtml } from '../index';
-import { domDialog } from '../view/dialog';
 
 export function isEvalBetter(a: ClientEval, b: ClientEval, desiredPvs: number): boolean {
   return (

--- a/ui/lib/src/ceval/view/main.ts
+++ b/ui/lib/src/ceval/view/main.ts
@@ -86,7 +86,7 @@ const threatButton = (ctrl: CevalHandler): VNode | null =>
   ctrl.ceval.download
     ? null
     : hl('button.show-threat', {
-        class: { active: ctrl.threatMode(), hidden: !!ctrl.getNode().check() },
+        class: { active: ctrl.threatMode(), hidden: ctrl.getNode().check() },
         attrs: { 'data-icon': licon.Target, title: i18n.site.showThreat + ' (x)' },
         hook: bind('click', e => {
           ctrl.toggleThreatMode();

--- a/ui/lib/src/chat/chatCtrl.ts
+++ b/ui/lib/src/chat/chatCtrl.ts
@@ -1,10 +1,10 @@
 import { isContained } from '@/algo';
 import { isMobile } from '@/device';
+import { pubsub, type PubsubEvents } from '@/pubsub';
+import { storedStringProp, storedBooleanProp } from '@/storage';
+import { alert } from '@/view';
 
 import { prop, type Prop } from '../index';
-import { pubsub, type PubsubEvents } from '../pubsub';
-import { storedStringProp, storedBooleanProp } from '../storage';
-import { alert } from '../view/dialogs';
 import type {
   ChatOpts,
   Line,
@@ -55,7 +55,7 @@ export class ChatCtrl {
     this.voiceChat = {
       instance: undefined,
       loaded: false,
-      enabled: prop(!opts.kidMode && !!this.data.voiceChat),
+      enabled: prop(!opts.kidMode && this.data.voiceChat),
     };
     this.vm = {
       loading: false,

--- a/ui/lib/src/chat/discussion.ts
+++ b/ui/lib/src/chat/discussion.ts
@@ -1,13 +1,12 @@
 import { h, thunk, type VNode, type VNodeData } from 'snabbdom';
 
-import { enter } from '@/view';
+import { pubsub } from '@/pubsub';
+import { tempStorage } from '@/storage';
+import { enter, alert } from '@/view';
+import { userLink } from '@/view/userLink';
 
 import * as licon from '../licon';
-import { pubsub } from '../pubsub';
 import * as enhance from '../richText';
-import { tempStorage } from '../storage';
-import { alert } from '../view/dialogs';
-import { userLink } from '../view/userLink';
 import type { ChatCtrl } from './chatCtrl';
 import type { Line } from './interfaces';
 import { lineAction as modLineAction, flagReport } from './moderation';

--- a/ui/lib/src/chat/moderation.ts
+++ b/ui/lib/src/chat/moderation.ts
@@ -1,11 +1,11 @@
 import { h, type VNode } from 'snabbdom';
 
+import { numberFormat } from '@/i18n';
+import { pubsub } from '@/pubsub';
 import { bind, confirm } from '@/view';
+import { userLink } from '@/view/userLink';
 
-import { numberFormat } from '../i18n';
 import * as licon from '../licon';
-import { pubsub } from '../pubsub';
-import { userLink } from '../view/userLink';
 import type {
   ModerationCtrl,
   ModerationOpts,

--- a/ui/lib/src/chat/note.ts
+++ b/ui/lib/src/chat/note.ts
@@ -1,6 +1,7 @@
 import { h, type VNode } from 'snabbdom';
 
-import { debounce } from '../async';
+import { debounce } from '@/async';
+
 import type { NoteCtrl, NoteOpts } from './interfaces';
 import * as xhr from './xhr';
 

--- a/ui/lib/src/chat/xhr.ts
+++ b/ui/lib/src/chat/xhr.ts
@@ -1,4 +1,4 @@
-import { json, text, form } from '../xhr';
+import { json, text, form } from '@/xhr';
 
 export const userModInfo = (username: string): Promise<any> => json('/mod/chat-user/' + username);
 

--- a/ui/lib/src/game/chess.ts
+++ b/ui/lib/src/game/chess.ts
@@ -3,14 +3,12 @@
 import { type Chess, type NormalMove, parseUci, makeUci } from 'chessops';
 import { normalizeMove } from 'chessops/chess';
 
-import { shuffle } from '../algo';
+import { shuffle } from '@/algo';
 
 export const fixCrazySan = (san: San): San => (san[0] === 'P' ? san.slice(1) : san);
 
 export const destsToUcis = (destMap: Dests): Uci[] =>
   Array.from(destMap).reduce<Uci[]>((acc, [orig, dests]) => acc.concat(dests.map(dest => orig + dest)), []);
-
-export { uciToMove } from '@lichess-org/chessground/util';
 
 export const fenColor = (fen: string): Color => (fen.includes(' w') ? 'white' : 'black');
 

--- a/ui/lib/src/game/clock/clockView.ts
+++ b/ui/lib/src/game/clock/clockView.ts
@@ -1,7 +1,7 @@
 import { displayColumns } from '@/device';
+import type { TopOrBottom } from '@/game';
 import { hl, type VNode, type LooseVNodes, type Hooks } from '@/view';
 
-import type { TopOrBottom } from '../index';
 import type { ClockElements, ClockCtrl } from './clockCtrl';
 
 export function renderClock(

--- a/ui/lib/src/game/polyglot.ts
+++ b/ui/lib/src/game/polyglot.ts
@@ -1,9 +1,9 @@
-import * as co from 'chessops';
+import type { Chess, pgn } from 'chessops';
 
 export type OpeningMove = { uci: string; weight: number };
-export type OpeningBook = (pos: co.Chess, ...args: any[]) => Promise<OpeningMove[]>;
+export type OpeningBook = (pos: Chess, ...args: any[]) => Promise<OpeningMove[]>;
 export type PgnProgress = (processed: number, total: number) => boolean | undefined; // return false to stop
-export type PgnFilter = (game: co.pgn.Game<co.pgn.PgnNodeData>) => boolean;
+export type PgnFilter = (game: pgn.Game<pgn.PgnNodeData>) => boolean;
 export type PolyglotResult = { getMoves: OpeningBook; positions?: number; polyglot?: Blob; cover?: Blob };
 
 export type PolyglotOpts = { cover?: boolean | { boardSize: number } } & (

--- a/ui/lib/src/game/promotion.ts
+++ b/ui/lib/src/game/promotion.ts
@@ -3,9 +3,9 @@ import type { MoveMetadata } from '@lichess-org/chessground/types';
 import { opposite, key2pos } from '@lichess-org/chessground/util';
 import { h } from 'snabbdom';
 
+import { AutoQueen } from '@/prefs';
 import { type MaybeVNode, bind, onInsert } from '@/view';
 
-import { AutoQueen } from '../prefs';
 import type { WithGround } from './ground';
 
 export type Hooks = {

--- a/ui/lib/src/game/sanWriter.ts
+++ b/ui/lib/src/game/sanWriter.ts
@@ -189,7 +189,7 @@ const transRole = (role: Role): string =>
   (i18n.nvui[role as keyof typeof i18n.nvui] as string) || (role as string);
 
 export function speakable(san?: San): string {
-  const text = !san
+  return !san
     ? i18n.nvui.gameStart
     : sanToWords(san)
         .replace(/^A /, '"A"') // "A takes" & "A 3" are mispronounced
@@ -198,5 +198,4 @@ export function speakable(san?: San): string {
         .replace(/F /, 'f ') // Capital F is pronounced as "degrees fahrenheit" when it comes after a number (e.g. R8f3)
         .replace(/(\d) H (\d)/, '$1H$2') // "H" is pronounced as "hour" when it comes after a number with a space (e.g. Rook 5 H 3)
         .replace(/(\d) H (\d)/, '$1H$2');
-  return text;
 }

--- a/ui/lib/src/game/view/material.ts
+++ b/ui/lib/src/game/view/material.ts
@@ -2,7 +2,8 @@ import { opposite } from '@lichess-org/chessground/util';
 import { type Board } from 'chessops';
 import { h, type VNode } from 'snabbdom';
 
-import type { CheckCount, CheckState, MaterialDiffSide } from '../interfaces';
+import type { CheckCount, CheckState, MaterialDiffSide } from '@/game';
+
 import { countChecks, getMaterialDiff, getScore, NO_CHECKS } from '../material';
 
 function renderMaterialDiff(

--- a/ui/lib/src/game/view/status.ts
+++ b/ui/lib/src/game/view/status.ts
@@ -1,4 +1,4 @@
-import type { GameData, Source, StatusName } from '../index';
+import type { GameData, Source, StatusName } from '@/game';
 
 export function bishopOnColor(expandedFen: string, offset: 0 | 1): boolean {
   if (expandedFen.length !== 64) throw new Error('Expanded FEN expected to be 64 characters');

--- a/ui/lib/src/poolRangeStorage.ts
+++ b/ui/lib/src/poolRangeStorage.ts
@@ -1,4 +1,5 @@
-import type { GameData } from './game/interfaces';
+import type { GameData } from '@/game';
+
 import { defined } from './index';
 import { storage } from './storage';
 

--- a/ui/lib/src/puz/clock.ts
+++ b/ui/lib/src/puz/clock.ts
@@ -7,9 +7,9 @@ export class Clock {
 
   public constructor(
     readonly config: Config,
-    startedMillisAgo: number | undefined = 0,
+    startedMillisAgo: number = 0,
   ) {
-    this.initialMillis = config.clock.initial * 1000 - (startedMillisAgo || 0);
+    this.initialMillis = config.clock.initial * 1000 - startedMillisAgo;
   }
 
   start = (): void => {

--- a/ui/lib/src/puz/run.ts
+++ b/ui/lib/src/puz/run.ts
@@ -15,7 +15,7 @@ export const makeCgOpts = (run: Run, canMove: boolean, flipped: boolean): CgConf
       color: run.pov,
       dests: canMove ? chessgroundDests(pos) : undefined,
     },
-    check: !!pos.isCheck(),
+    check: pos.isCheck(),
     lastMove: uciToMove(cur.lastMove()),
     animation: {
       enabled: cur.moveIndex >= 0,

--- a/ui/lib/src/puz/sign.ts
+++ b/ui/lib/src/puz/sign.ts
@@ -1,5 +1,5 @@
-import { pubsub } from '../pubsub';
-import { wsSend } from '../socket';
+import { pubsub } from '@/pubsub';
+import { wsSend } from '@/socket';
 
 export default function (serverKey: string): Promise<string> {
   const otp = randomAscii(64);

--- a/ui/lib/src/puz/view/history.ts
+++ b/ui/lib/src/puz/view/history.ts
@@ -1,9 +1,9 @@
+import { uciToMove } from '@lichess-org/chessground/util';
 import { Chess } from 'chessops/chess';
 import { parseFen, makeFen } from 'chessops/fen';
 import { parseUci } from 'chessops/util';
 import { h, type VNode } from 'snabbdom';
 
-import { uciToMove } from '@/game/chess';
 import type { Toggle } from '@/index';
 import type { PuzCtrl } from '@/puz/interfaces';
 import { initMiniBoardWith, onInsert } from '@/view';

--- a/ui/lib/src/richText.ts
+++ b/ui/lib/src/richText.ts
@@ -2,7 +2,7 @@
 
 // Rich Text helper functions
 // Refactored for https://github.com/lichess-org/lila/issues/7342 request
-import type { VNode, Hooks } from 'snabbdom';
+import type { Hooks, VNode } from 'snabbdom';
 
 import { escapeHtml } from './common';
 
@@ -92,6 +92,5 @@ export function enhance(text: string, opts?: EnhanceOpts): string {
   const escaped = escapeHtml(text);
   const linked = escaped.replace(userPattern, userLinkReplacePawn).replace(linkPattern, linkReplace);
   const plied = opts?.plies && linked === escaped ? addPlies(linked) : linked;
-  const boarded = opts?.boards && linked === escaped ? addBoards(plied) : linked;
-  return boarded;
+  return opts?.boards && linked === escaped ? addBoards(plied) : linked;
 }

--- a/ui/lib/src/setup/view/timeControl.ts
+++ b/ui/lib/src/setup/view/timeControl.ts
@@ -1,5 +1,5 @@
 import type { Prop } from '@/index';
-import { hl, type VNode } from '@/view';
+import { hl, type MaybeVNode, type VNode } from '@/view';
 
 import type { InputValue } from '../interfaces';
 import { option } from '../option';
@@ -135,7 +135,7 @@ export const timePickerAndSliders = (tc: TimeControl, minimumTimeRequiredIfReal:
       )
     : null;
 
-  let panelContent: VNode | null = null;
+  let panelContent: MaybeVNode = null;
 
   if (activeMode === 'realTime') {
     const [tcTime, tcIncrement] = [tc.time(), tc.increment()];

--- a/ui/lib/src/view/controls.ts
+++ b/ui/lib/src/view/controls.ts
@@ -109,13 +109,7 @@ export const spinnerHtml: string = $html`
       <g mask="url(#mask)" fill="none">
         ${pathAttrs.map(
           (a, i) =>
-            '<path id="' +
-            String.fromCharCode(97 + i) +
-            '" stroke-width="' +
-            a['stroke-width'] +
-            '" d="' +
-            a.d +
-            '"/>',
+            `<path id="${String.fromCharCode(97 + i)}" stroke-width="${a['stroke-width']}" d="${a.d}"/>`,
         )}
       </g>
     </svg>

--- a/ui/lib/src/view/dialogs.ts
+++ b/ui/lib/src/view/dialogs.ts
@@ -36,25 +36,22 @@ export async function confirm(
   ok: string = i18n.site.ok,
   cancel: string = i18n.site.cancel,
 ): Promise<boolean> {
-  return (
-    (
-      await domDialog({
-        htmlText: $html`<div>${escapeHtmlAddBreaks(msg)}</div>
-          <span><button class="button button-empty cancel">${cancel}</button>
-          <button class="button ok">${ok}</button></span>`,
-        class: 'alert',
-        noCloseButton: true,
-        noClickAway: true,
-        modal: true,
-        show: true,
-        focus: '.ok',
-        actions: [
-          { selector: '.cancel', result: 'cancel' },
-          { selector: '.ok', result: 'ok' },
-        ],
-      })
-    ).returnValue === 'ok'
-  );
+  const confirmDialog = await domDialog({
+    htmlText: $html`<div>${escapeHtmlAddBreaks(msg)}</div>
+      <span><button class="button button-empty cancel">${cancel}</button>
+      <button class="button ok">${ok}</button></span>`,
+    class: 'alert',
+    noCloseButton: true,
+    noClickAway: true,
+    modal: true,
+    show: true,
+    focus: '.ok',
+    actions: [
+      { selector: '.cancel', result: 'cancel' },
+      { selector: '.ok', result: 'ok' },
+    ],
+  });
+  return confirmDialog.returnValue === 'ok';
 }
 
 // non-blocking window.prompt-alike

--- a/ui/lib/src/view/miniBoard.ts
+++ b/ui/lib/src/view/miniBoard.ts
@@ -1,11 +1,12 @@
 // no side effects allowed due to re-export by index.ts
 
 import { Chessground as makeChessground } from '@lichess-org/chessground';
+import { uciToMove } from '@lichess-org/chessground/util';
 import { COLORS } from 'chessops';
 import { h, type VNode } from 'snabbdom';
 
 import * as domData from '@/data';
-import { uciToMove, fenColor } from '@/game/chess';
+import { fenColor } from '@/game/chess';
 import { lichessClockIsRunning, setClockWidget } from '@/game/clock/clockWidget';
 import { pubsub } from '@/pubsub';
 import { wsSend } from '@/socket';

--- a/ui/lib/src/view/userLink.ts
+++ b/ui/lib/src/view/userLink.ts
@@ -2,35 +2,20 @@ import { type Attrs, h, type VNode, type VNodeData } from 'snabbdom';
 
 import { type MaybeVNodes } from './snabbdom';
 
-export interface HasRating {
-  rating?: number;
-  provisional?: boolean;
-  brackets?: boolean; // display the rating in brackets/parentheses, true by default
-}
-
-export interface HasRatingDiff {
-  ratingDiff?: number;
-}
-
-export interface HasFlair {
-  flair?: Flair;
-}
-
-export interface HasTitle {
-  title?: string;
-}
-
-export interface HasLine {
-  line?: boolean; // display i.line, true by default
-  patronColor?: PatronColor; // turn i.line into a patron wing
-  moderator?: boolean; // turn i.line into a mod icon
-}
-
-export interface AnyUser extends HasRating, HasFlair, HasTitle, HasLine {
+export type AnyUser = {
   name: string;
   online?: boolean; // light up .line
   attrs?: Attrs;
-}
+  title?: string;
+  flair?: Flair;
+  ratingDiff?: number;
+  line?: boolean; // display i.line, true by default
+  patronColor?: PatronColor; // turn i.line into a patron wing
+  moderator?: boolean; // turn i.line into a mod icon
+  rating?: number;
+  provisional?: boolean;
+  brackets?: boolean; // display the rating in brackets/parentheses, true by default
+};
 
 export const userLink = (u: AnyUser): VNode =>
   h('a', userLinkData(u), [userLine(u), ...fullName(u), u.rating && ` ${userRating(u)} `]);
@@ -41,10 +26,10 @@ export const userLinkData = (u: AnyUser): VNodeData => ({
   attrs: { href: `/@/${u.name}`, ...u.attrs },
 });
 
-export const userFlair = (u: HasFlair): VNode | undefined =>
+export const userFlair = (u: Pick<AnyUser, 'flair'>): VNode | undefined =>
   u.flair ? h('img.uflair', { attrs: { src: site.asset.flairSrc(u.flair) } }) : undefined;
 
-export const userLine = (u: HasLine): VNode | undefined =>
+export const userLine = (u: Pick<AnyUser, 'line' | 'patronColor' | 'moderator'>): VNode | undefined =>
   u.line !== false
     ? h('i.line', {
         class: {
@@ -56,14 +41,14 @@ export const userLine = (u: HasLine): VNode | undefined =>
       })
     : undefined;
 
-export const userTitle = (u: HasTitle): VNode | undefined =>
-  u.title
-    ? h('span.utitle', u.title === 'BOT' ? { attrs: { 'data-bot': true } } : {}, [u.title, '\xa0'])
+export const userTitle = ({ title }: Pick<AnyUser, 'title'>): VNode | undefined =>
+  title
+    ? h('span.utitle', title === 'BOT' ? { attrs: { 'data-bot': true } } : {}, [title, '\xa0'])
     : undefined;
 
 export const fullName = (u: AnyUser): MaybeVNodes => [userTitle(u), u.name, userFlair(u)];
 
-export const userRating = (u: HasRating): string | undefined => {
+export const userRating = (u: Pick<AnyUser, 'rating' | 'provisional' | 'brackets'>): string | undefined => {
   if (u.rating) {
     const rating = `${u.rating}${u.provisional ? '?' : ''}`;
     return u.brackets !== false ? `(${rating})` : rating;
@@ -71,11 +56,11 @@ export const userRating = (u: HasRating): string | undefined => {
   return undefined;
 };
 
-export const ratingDiff = (u: HasRatingDiff): VNode | undefined =>
-  u.ratingDiff === 0
+export const ratingDiff = ({ ratingDiff }: Pick<AnyUser, 'ratingDiff'>): VNode | undefined =>
+  ratingDiff === 0
     ? h('span', '±0')
-    : u.ratingDiff && u.ratingDiff > 0
-      ? h('good', '+' + u.ratingDiff)
-      : u.ratingDiff && u.ratingDiff < 0
-        ? h('bad', '−' + -u.ratingDiff)
+    : ratingDiff && ratingDiff > 0
+      ? h('good', '+' + ratingDiff)
+      : ratingDiff && ratingDiff < 0
+        ? h('bad', '−' + -ratingDiff)
         : undefined;

--- a/ui/lib/src/view/util.ts
+++ b/ui/lib/src/view/util.ts
@@ -1,6 +1,6 @@
 import { h, type VNode, type VNodeChildren } from 'snabbdom';
 
-import { numberFormat } from '../i18n';
+import { numberFormat } from '@/i18n';
 
 const ratio2percent = (r: number): string => Math.round(100 * r) + '%';
 


### PR DESCRIPTION
# Why

A set of assorted changes and small cleanup/tweaks for the UI `lib` code created when I was going through the module content to familiarize myself more with base/shared code which is available for the UIs.

# How

Update imports, avoid assignments if they are immediately returned, simplify types, avoid local re-exports and don't use double negation for boolean values.