### PR TITLE
Support crazyhouse drop moves in conditional premoves

### DIFF
--- a/modules/core/src/main/round.scala
+++ b/modules/core/src/main/round.scala
@@ -2,7 +2,7 @@ package lila.core
 package round
 
 import _root_.chess.format.{ Fen, Uci }
-import _root_.chess.{ Color, Move }
+import _root_.chess.{ Color, MoveOrDrop }
 import play.api.libs.json.{ JsArray, JsObject }
 import scalalib.bus.NotBuseable
 
@@ -67,7 +67,7 @@ case class Moretime(
 )
 case class ClientFlag(color: Color, fromPlayerId: Option[GamePlayerId])
 case object Abandon
-case class ForecastPlay(lastMove: Move)
+case class ForecastPlay(lastMove: MoveOrDrop)
 case class Cheat(color: Color)
 case class HoldAlert(playerId: GamePlayerId, mean: Int, sd: Int, ip: IpAddress)
 case class GoBerserk(color: Color, promise: Promise[Boolean])

--- a/modules/round/src/main/Forecast.scala
+++ b/modules/round/src/main/Forecast.scala
@@ -2,14 +2,14 @@ package lila.round
 
 import chess.format.pgn.SanStr
 import chess.format.{ Fen, Uci }
-import chess.{ Move, Ply }
+import chess.{ MoveOrDrop, Ply }
 import play.api.libs.json.*
 
 import lila.common.Json.given
 
 case class Forecast(_id: GameFullId, steps: Forecast.Steps, date: Instant):
 
-  def apply(g: Game, lastMove: Move): Option[(Forecast, Uci.Move)] =
+  def apply(g: Game, lastMove: MoveOrDrop): Option[(Forecast, Uci)] =
     nextMove(g, lastMove).map { move =>
       copy(
         steps = steps.collect {
@@ -23,7 +23,7 @@ case class Forecast(_id: GameFullId, steps: Forecast.Steps, date: Instant):
   // accept up to 30 lines of 30 moves each
   def truncate = copy(steps = steps.take(30).map(_.take(30)))
 
-  private def nextMove(g: Game, last: Move) =
+  private def nextMove(g: Game, last: MoveOrDrop) =
     steps.collectFirstSome:
       case fst :: snd :: _ if g.ply == fst.ply && fst.is(last) => snd.uciMove
       case _ => none
@@ -42,10 +42,10 @@ object Forecast:
       check: Option[Boolean]
   ):
 
-    def is(move: Move) = move.toUci.uci == uci
-    def is(move: Uci.Move) = move.uci == uci
+    def is(move: MoveOrDrop) = move.toUci.uci == uci
+    def is(move: Uci) = move.uci == uci
 
-    def uciMove = Uci.Move(uci)
+    def uciMove = Uci(uci)
 
   given Format[Step] = Json.format
   given Writes[Forecast] = Json.writes

--- a/modules/round/src/main/ForecastApi.scala
+++ b/modules/round/src/main/ForecastApi.scala
@@ -70,7 +70,7 @@ final class ForecastApi(coll: Coll, roundApi: lila.core.round.RoundApi)(using Ex
           if firstStep(fc.steps).exists(_.ply != pov.game.ply) then clearPov(pov).inject(none)
           else fuccess(fc.some)
 
-  def nextMove(g: Game, last: chess.Move): Fu[Option[Uci.Move]] =
+  def nextMove(g: Game, last: chess.MoveOrDrop): Fu[Option[Uci]] =
     g.forecastable.so:
       val pov = Pov(g, g.turnColor)
       loadForPlay(pov).flatMapz: fc =>

--- a/modules/round/src/main/MovePlayer.scala
+++ b/modules/round/src/main/MovePlayer.scala
@@ -79,10 +79,7 @@ final private class MovePlayer(
       if progress.game.playableByAi then requestFishnet(progress.game, round)
       if pov.opponent.isOfferingDraw then round ! RoundBus.Draw(pov.player.id, false)
       if pov.opponent.isProposingTakeback then round ! RoundBus.Takeback(pov.player.id, false)
-      if progress.game.forecastable then
-        moveOrDrop.move.foreach { move =>
-          round ! ForecastPlay(move)
-        }
+      if progress.game.forecastable then round ! ForecastPlay(moveOrDrop)
       scheduleExpiration.exec(progress.game)
       fuccess(progress.events)
 


### PR DESCRIPTION
This PR teaches `Forecast` to play and respond to `DropMove`s, closing #19802. Removes the downcast from `MoveOrDrop` to `Drop` and adapts `Forecast.scala` and `ForecastApi.scala` accordingly.

Used the following DeepWiki prompt https://deepwiki.com/search/there-is-a-bug-when-adding-con_d2fd3d01-86bc-4591-80f2-fff84c5ada5f

Here's a video of the change in action:

[output.webm](https://github.com/user-attachments/assets/21342446-0162-4497-903c-df11c6c46664)

Closes #19802