### PR TITLE
ui: fix players photo size in the tooltips on Safari

### DIFF
--- a/ui/analyse/css/study/relay/_player-tip.scss
+++ b/ui/analyse/css/study/relay/_player-tip.scss
@@ -23,7 +23,7 @@
 
     .fide-players__photo {
       width: 150px;
-      height: fit-content;
+      height: auto;
     }
 
     &__info {


### PR DESCRIPTION
# Why

@SergioGlorias reported that players photo in tooltips have incorrect size on Safari, while it was fine on Chrome and FF.

See WPT test-case:
* https://wpt.fyi/results/css/css-sizing/replaced-max-width-with-height-fit-content.html?label=master&label=experimental&aligned&q=fit-content

<img width="1508" height="1264" alt="Screenshot 2026-03-15 at 10 37 31" src="https://github.com/user-attachments/assets/ca4a3106-47f5-4eb5-8845-0224f4c442e1" />

# How

Change players photo height from `fit-content` to `auto`. It fixes the stretch issue on Safari, and retains correct presentation on other browsers. 

# Preview

<img width="1102" height="618" alt="Screenshot 2026-03-15 at 10 37 04" src="https://github.com/user-attachments/assets/5b9a7ab1-3a74-42d3-ace0-c6622ca13ec7" />
