### PR TITLE
Broadcasts: use player's standard FIDE rating if they're unrated in rapid or blitz

### DIFF
--- a/modules/core/src/main/fide.scala
+++ b/modules/core/src/main/fide.scala
@@ -24,6 +24,7 @@ trait Player:
   def title: Option[PlayerTitle]
   def year: Option[Int]
   def ratingOf(tc: FideTC): Option[Elo]
+  def ratingOfOrStandard(tc: FideTC): Option[Elo]
   def kFactorOf(tc: FideTC): KFactor
   def ratingsMap: Map[FideTC, Elo]
 

--- a/modules/fide/src/main/FidePlayer.scala
+++ b/modules/fide/src/main/FidePlayer.scala
@@ -32,6 +32,8 @@ case class FidePlayer(
     case FideTC.rapid => rapid
     case FideTC.blitz => blitz
 
+  def ratingOfOrStandard(tc: FideTC): Option[Elo] = ratingOf(tc).orElse(standard)
+
   def kFactorOf(tc: FideTC): KFactor = tc
     .match
       case FideTC.standard => standardK

--- a/modules/relay/src/main/RelayFidePlayerApi.scala
+++ b/modules/relay/src/main/RelayFidePlayerApi.scala
@@ -38,7 +38,7 @@ final private class RelayFidePlayerApi(guessPlayer: lila.core.fide.GuessPlayer)(
             Tag(_.fideIds(color), fide.id.toString).some,
             Tag(_.names(color), fide.name).some,
             fide.title.map { title => Tag(_.titles(color), title.value) },
-            fide.ratingOf(tc).map { rating => Tag(_.elos(color), rating.toString) }
+            fide.ratingOfOrStandard(tc).map(rating => Tag(_.elos(color), rating.toString))
           ).flatten
       removeEmptyFieldTags(tags) ++ fideTags
 

--- a/modules/relay/src/main/RelayPlayer.scala
+++ b/modules/relay/src/main/RelayPlayer.scala
@@ -322,7 +322,7 @@ private final class RelayPlayerApi(
                       player.ratingsMap
                         .get(gameTC)
                         .map(_.into(Elo))
-                        .orElse(fidePlayer.ratingOf(gameTC))
+                        .orElse(fidePlayer.ratingOfOrStandard(gameTC))
                         .fold(diffs): rating =>
                           val p = Elo.Player(rating, fidePlayer.kFactorOf(gameTC))
                           val newDiff = Elo.computeRatingDiff(gameTC)(p, tcGames.flatMap(_.eloGame))


### PR DESCRIPTION
https://handbook.fide.com/chapter/B02RBRegulations2024

> 7.2.1      If an unrated player has a standard rating at the beginning of a rapid or blitz tournament, their standard rating is used for rating calculation.

* Adds a new function `ratingOfOrStandard` in FIDE player trait exclusively for use in broadcasts.
* Because the player is still technically unrated, continue using the old `ratingOf` function for /fide related ops. Note in the screenshot their rapid rating should be and still is blank.
* `KFactorOf` was already correctly set up to use the default of 40 if no KFactor is present so ratingDiffs worked correctly without any changes 😄 

|[Before](https://lichess.org/broadcast/british-rapidplay-championship-2026--boards-1-100/round-11/hFTdUahE#players/343455433)|After|
|------|-----|
|<img width="1087" height="474" alt="image" src="https://github.com/user-attachments/assets/3432ed6e-0532-48c4-a7f0-a240b6cf6721" />|<img width="1087" height="474" alt="image" src="https://github.com/user-attachments/assets/6eed0e2a-f81c-4814-835a-3335d2531bdf" />|