### PR TITLE
refactor broadcaster zulip notification

### DIFF
--- a/modules/msg/src/main/MsgApi.scala
+++ b/modules/msg/src/main/MsgApi.scala
@@ -21,7 +21,8 @@ final class MsgApi(
     notifier: MsgNotify,
     security: MsgSecurity,
     shutupApi: lila.core.shutup.ShutupApi,
-    spam: lila.core.security.SpamApi
+    spam: lila.core.security.SpamApi,
+    ircApi: lila.core.irc.IrcApi
 )(using Executor, akka.stream.Materializer)
     extends lila.core.msg.MsgApi:
 
@@ -176,7 +177,11 @@ final class MsgApi(
               if send == Ok || send == TrollFriend then
                 notifier.onPost(threadId)
                 Bus.pub(SendTo(dest, makeMessage("msgNew", json.renderMsg(msg))))
-              if send == Ok && !multi then shutupApi.privateMessage(orig, dest, text)
+              if send == Ok && !multi then
+                shutupApi.privateMessage(orig, dest, text)
+                if orig == UserId.broadcaster || dest == UserId.broadcaster then
+                  val topicUser = if orig == UserId.broadcaster then dest else orig
+                  ircApi.broadcasterDm(topicUser, orig, msg.text)
               PostResult.Success
       yield res
     }

--- a/modules/msg/src/main/MsgNotify.scala
+++ b/modules/msg/src/main/MsgNotify.scala
@@ -8,8 +8,7 @@ import lila.db.dsl.{ *, given }
 
 final private class MsgNotify(
     colls: MsgColls,
-    notifyApi: NotifyApi,
-    ircApi: lila.core.irc.IrcApi
+    notifyApi: NotifyApi
 )(using ec: Executor, scheduler: Scheduler):
 
   import BsonHandlers.given
@@ -53,13 +52,9 @@ final private class MsgNotify(
     colls.thread.byId[MsgThread](threadId.value).flatMapz { thread =>
       val msg = thread.lastMsg
       (!thread.delBy(thread.other(msg.user))).so:
-        for
-          _ <- notifyApi.notifyOne(
+        for _ <- notifyApi.notifyOne(
             thread.other(msg.user),
             NotificationContent.PrivateMessage(msg.user, text = shorten(msg.text, 40))
           )
-          _ <- thread.users
-            .has(UserId.broadcaster)
-            .so(ircApi.broadcasterDm(thread.other(UserId.broadcaster), msg.user, msg.text))
         yield ()
     }


### PR DESCRIPTION
refactors away from using `MsgNotify`
1. prevent truncating of text to 60 chars
2. prevent only sending the most recent message, if 2 are sent quickly