### PR TITLE
fix subscription toggle after cmn-toggle refactor

### DIFF
--- a/modules/streamer/src/main/ui/StreamerBits.scala
+++ b/modules/streamer/src/main/ui/StreamerBits.scala
@@ -192,6 +192,7 @@ final class StreamerBits(helpers: Helpers)(picfitUrl: lila.memo.PicfitUrl):
     (ctx.isAuth && ctx.isnt(s.user)).option:
       val id = s"streamer-subscribe-${s.streamer.userId}"
       form3.cmnToggleWrap(
+        cls := "streamer-subscribe",
         form3.cmnToggle(
           id,
           id,

--- a/ui/bits/src/bits.ts
+++ b/ui/bits/src/bits.ts
@@ -221,18 +221,16 @@ function setAssetInfo() {
 }
 
 function streamerSubscribe() {
-  $('.streamer-show, .streamer-list').on('change', '.streamer-subscribe input', (e: Event) => {
+  $('.streamer-show').on('change', '.streamer-subscribe input', (e: Event) => {
     const target = e.target as HTMLInputElement;
-    $(target)
-      .parents('.streamer-subscribe')
-      .each(function (this: HTMLElement) {
-        text(
-          $(this)
-            .data('action')
-            .replace(/set=[^&]+/, `set=${target.checked}`),
-          { method: 'post' },
-        );
-      });
+    const action = target.dataset.action;
+    if (action) {
+      const url = new URL(action, location.href);
+      url.searchParams.set('set', String(target.checked));
+      text(url.pathname + url.search, { method: 'post' });
+      url.searchParams.set('set', String(!target.checked));
+      target.dataset.action = url.pathname + url.search;
+    }
   });
 }
 


### PR DESCRIPTION
https://github.com/lichess-org/lila/commit/499912c99d1e63dea6a026ea4d9d2e27aad9ce30

Adds the required class `streamer-subscribe` back
Refactors the logic to work with the location of `data-action`
Uses the modern `URL` API instead of `replace`
Removes `.streamer-list` because the code no longer runs in the streamer list