### PR TITLE
ui: bold game score in the player tooltip

### DIFF
--- a/ui/analyse/css/study/relay/_player-tip.scss
+++ b/ui/analyse/css/study/relay/_player-tip.scss
@@ -80,7 +80,8 @@
     max-height: 40vh;
     overflow-y: auto;
 
-    &__status, .game-point {
+    &__status,
+    .game-point {
       font-weight: bold;
     }
 


### PR DESCRIPTION
# Why

Fixes #19811
* #19811

# How

Apply bold font weight to the game score in the player tooltip.

# Preview

<img width="1080" height="562" alt="Screenshot 2026-03-17 at 15 19 08" src="https://github.com/user-attachments/assets/f3612b71-70bd-48cd-bb4b-acdf55843402" />
