### PR TITLE
ui: small tweaks and fixes for the impersonate mode

### DIFF
--- a/ui/mod/css/_impersonate.scss
+++ b/ui/mod/css/_impersonate.scss
@@ -1,24 +1,35 @@
 @include topnav-unsticky;
 
+$impersonate-bar-height: 40px;
+
 body {
-  margin-top: 45px;
+  margin-top: $impersonate-bar-height;
+
+  #main-wrap .msg-app {
+    height: calc(var(---app-height) - $site-header-height - $impersonate-bar-height);
+
+    @media (width >= $small) {
+      height: calc(var(---app-height) * 0.98 - $site-header-height - $impersonate-bar-height);
+    }
+  }
 }
 
 #impersonate {
   @extend %flex-center-center, %popup-shadow;
 
-  height: 40px;
-  background: #7f1010;
+  height: $impersonate-bar-height;
+  background: #7f1010df;
   color: #fff;
-  border-bottom: 1px solid #666;
+  border-bottom: 1px solid #912727;
   position: fixed;
   top: 0;
   left: 0;
   right: 0;
-  z-index: 100;
+  z-index: 110;
+  backdrop-filter: blur(6px);
 
   form {
-    height: 40px;
+    height: $impersonate-bar-height;
   }
 
   a,

--- a/ui/msg/css/_msg.scss
+++ b/ui/msg/css/_msg.scss
@@ -21,13 +21,12 @@ body {
 .msg-app {
   display: flex;
   flex-flow: row nowrap;
+  overflow: hidden;
   height: calc(var(---app-height) - $site-header-height);
 
   @media (min-width: at-least($small)) {
     height: calc(var(---app-height) * 0.98 - $site-header-height);
   }
-
-  overflow: hidden;
 
   &__search {
     h2 {


### PR DESCRIPTION
# Why

Fix inbox clipping and top bar options overflow in the impersonate mode.

# How

Account for impersonate bar when calculating `.msg-app` height, increase `z-index` to prevent top bar menu overflow, small visual tweaks.

# Preview

### Before

<img width="1913" height="944" alt="xx" src="https://github.com/user-attachments/assets/7ebd3e2c-a1bd-471d-9d14-21cd8131e0c3" />

<img width="4110" height="574" alt="Screenshot 2026-03-17 at 15 42 14" src="https://github.com/user-attachments/assets/59d82c1e-1614-478f-bf88-d44a10ab4bbb" />

### After

<img width="4110" height="2394" alt="Screenshot 2026-03-17 at 15 36 47" src="https://github.com/user-attachments/assets/8532c771-7ca8-4021-9ed5-1518efacd0d6" />

<img width="4110" height="574" alt="Screenshot 2026-03-17 at 15 38 13" src="https://github.com/user-attachments/assets/4d0a4678-51a3-4a71-8411-8d9dddbb17dd" />
