### PR TITLE
ui: small style tweaks and lint fix

### DIFF
--- a/ui/bits/css/_email-confirm.scss
+++ b/ui/bits/css/_email-confirm.scss
@@ -12,7 +12,7 @@
   bottom: 0;
   left: 0;
   right: 0;
-  z-index: 107;
+  z-index: $z-above-site-header-107;
 
   &.error {
     background: $c-error;
@@ -150,6 +150,7 @@ body:has(.email-confirm, .signup-confirm) .signin-or-signup {
 
     .button-fat {
       @extend %box-radius;
+
       border: 10px solid $m-primary_bg--mix-30;
     }
   }

--- a/ui/lib/css/game/_row.scss
+++ b/ui/lib/css/game/_row.scss
@@ -8,7 +8,7 @@
 
   @include transition(background);
 
-  &:nth-child(odd) {
+  &:nth-child(even) {
     background: $c-bg-zebra;
   }
 

--- a/ui/mod/css/_impersonate.scss
+++ b/ui/mod/css/_impersonate.scss
@@ -25,7 +25,7 @@ body {
   top: 0;
   left: 0;
   right: 0;
-  z-index: 110;
+  z-index: $z-topnav-111;
   backdrop-filter: blur(6px);
 
   form {

--- a/ui/racer/css/_countdown.scss
+++ b/ui/racer/css/_countdown.scss
@@ -3,7 +3,7 @@
     @extend %box-radius, %popup-shadow, %flex-center-nowrap;
 
     background: $c-bg-zebra;
-    z-index: 100;
+    z-index: $z-cg__board_overlay-100;
     position: absolute;
     top: 50%;
     left: 50%;


### PR DESCRIPTION
# Why

In the previous PR I have spotted that style lint checks are failing. Also had few small style tweaks stashed locally, so let's put those out together.

# How

Summary of changes:
* fix style lint
* use `z-index` variable where applicable for bit more context on the chosen value
* alter coloring of even game rows on user profile so first row match tab background

# Preview

<img width="2172" height="1372" alt="Screenshot 2026-03-19 at 15 14 12" src="https://github.com/user-attachments/assets/ab6ae3f0-c917-4c41-9b00-0c2352adc7e7" />
