### PR TITLE
ui: use regular buttons in learn popups, small display tweaks

### DIFF
--- a/ui/learn/css/_screen.scss
+++ b/ui/learn/css/_screen.scss
@@ -136,6 +136,7 @@
   }
 
   .round-svg {
+    display: flex;
     width: 240px;
     height: 240px;
     padding: 0;
@@ -145,14 +146,14 @@
   }
 
   .round-svg img {
-    width: 240px;
-    height: 240px;
-    padding: 20px;
+    width: 180px;
+    height: 180px;
+    margin: auto;
   }
 
   .score {
     text-transform: uppercase;
-    color: #0288d1;
+    color: $c-brag;
     font-size: 0.85em;
     display: block;
     letter-spacing: 1px;
@@ -172,35 +173,17 @@
   }
 
   .buttons {
-    width: 100%;
-    text-align: center;
-    margin-bottom: 23px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin: 8px 10% 24px 10%;
 
-    a {
-      @extend %box-radius;
-
-      display: block;
-      text-decoration: none;
-      text-transform: uppercase;
-      line-height: 48px;
-      margin: 8px 10% 0 10%;
+    button {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 4px;
       height: 48px;
-      color: #fff;
-      transition: all 0.3s;
-    }
-
-    .next {
-      font-size: 0.9em;
-      background: #3692e7;
-    }
-
-    .back {
-      font-size: 0.85em;
-      background: #e53935f0;
-    }
-
-    a:hover {
-      filter: brightness(0.9);
     }
   }
 

--- a/ui/learn/src/run/stageComplete.ts
+++ b/ui/learn/src/run/stageComplete.ts
@@ -50,16 +50,15 @@ export default function (ctrl: RunCtrl) {
       h('p', withLinebreaks(stage.complete)),
       h('div.buttons', [
         next
-          ? h('a.next', { hook: bind('click', () => hashNavigate(next.id)) }, [
-              i18n.learn.nextX(next.title) + ' ',
+          ? h('button.button', { hook: bind('click', () => hashNavigate(next.id)) }, [
+              i18n.learn.nextX(next.title),
               h('i', { attrs: { 'data-icon': licon.GreaterThan } }),
             ])
           : null,
-        h(
-          `a.back.text[data-icon=${licon.LessThan}]`,
-          { hook: bind('click', () => hashNavigate()) },
+        h(`button.button.button-empty`, { hook: bind('click', () => hashNavigate()) }, [
+          h('i', { attrs: { 'data-icon': licon.LessThan } }),
           i18n.learn.backToMenu,
-        ),
+        ]),
       ]),
     ]),
   );

--- a/ui/learn/src/run/stageStarting.ts
+++ b/ui/learn/src/run/stageStarting.ts
@@ -16,7 +16,7 @@ export default function (ctrl: RunCtrl) {
       h(
         'div.buttons',
         h(
-          'a.next',
+          'button.button',
           {
             key: ctrl.stage.id,
             hook: bind('click', ctrl.hideStartingPane),


### PR DESCRIPTION
# Why

Spotted that Learn popups use the custom button style reassembling default buttons style.

<img width="816" height="868" alt="Screenshot 2026-03-19 at 21 41 57" src="https://github.com/user-attachments/assets/ced1d173-dc1e-4cdc-809f-fc64f89fbbbc" />

# How

Summary of changes:
* use regular/default buttons in Learn popovers (also improves a11y)
* change "Back" button from red one to "empty" variant (it emphasizes the next lesson button, and red was a bit too much since the action is non-destructive and reversible)
* fix "Back" button icon, it was added in JS code incorrectly, and do not displayed in the UI
* change score color to our yellow one, since blue is usually used for links (interactive text)
* make sure that every icon fits within chapter circle background

# Preview

https://github.com/user-attachments/assets/ddea59fa-58c4-4276-8171-c9f4c9011b1e

<img width="816" height="868" alt="Screenshot 2026-03-19 at 21 41 23" src="https://github.com/user-attachments/assets/588c6f09-2424-41f0-875b-6fc654e863e4" />

<img width="816" height="1038" alt="Screenshot 2026-03-19 at 21 47 49" src="https://github.com/user-attachments/assets/dd1cb7d1-b7e7-47e9-9b44-33cd859b0066" />
