### PR TITLE
ui: home lobby layout tweaks

### DIFF
--- a/ui/lobby/css/_layout.scss
+++ b/ui/lobby/css/_layout.scss
@@ -38,7 +38,12 @@
     }
 
     &__start {
+      margin-inline-start: 0;
       margin-inline-end: $block-gap;
+
+      &__button {
+        padding-inline: 1em;
+      }
     }
   }
 
@@ -68,11 +73,11 @@
     }
 
     &__blog {
-      padding: 1.2em 0;
+      margin-top: 1.65em;
     }
 
     &__support {
-      margin-bottom: 1.2em;
+      margin-bottom: 1.65em;
     }
 
     &__side,

--- a/ui/lobby/css/_lobby.scss
+++ b/ui/lobby/css/_lobby.scss
@@ -81,6 +81,10 @@ body {
 
 .lobby__tv .mini-game {
   overflow: visible;
+
+  &__player {
+    padding-top: 0;
+  }
 }
 
 .lobby__puzzle .text {
@@ -90,6 +94,14 @@ body {
   display: block;
   text-align: right;
   margin-inline-end: 1ch;
+
+  @include mq-at-least-col2 {
+    min-height: 19px;
+  }
+
+  @include mq-at-least-col3 {
+    min-height: 21px;
+  }
 }
 
 .lobby__blog {


### PR DESCRIPTION
# Why

Spotted that on two column layout setup buttons can cause an uneven column size leading to mini boards size difference.

<img width="420" height="1502" alt="Screenshot 2026-03-19 at 22 27 08" src="https://github.com/user-attachments/assets/9eddbbce-2fb2-49bb-9916-7f02617c64b3" />

# How

* Adjust setup game buttons padding and spacing in two columns mode. 
* Adjust blog carousel and support button spacing to match mini boards.
* Adjust tv mini board bottom player spacing, and puzzle board captions to make sure both boards size matches.

# Preview

<img width="420" height="1502" alt="Screenshot 2026-03-19 at 22 42 13" src="https://github.com/user-attachments/assets/33f7445c-a6b2-4692-858c-55303ba8acca" />

<img width="2970" height="1010" alt="Screenshot 2026-03-19 at 22 19 57" src="https://github.com/user-attachments/assets/345cdcf5-f402-4743-8d73-40c5087c0d86" />
