### PR TITLE
ui: fix relay tour horizontal overflow on mobile

### DIFF
--- a/ui/analyse/css/study/relay/_tour.scss
+++ b/ui/analyse/css/study/relay/_tour.scss
@@ -9,6 +9,7 @@
   gap: 3vh;
   background: $c-bg-box;
   overflow: visible;
+  max-width: 100vw;
 
   &__side {
     @extend %flex-column;


### PR DESCRIPTION
# Why

Fixes #19819

* #19819

# How

Add max width to relay tour box set to device viewport width.

# Preview

https://github.com/user-attachments/assets/36e47832-bf97-40cc-bd44-8cd3cf44ab7f

<img width="1426" height="1150" alt="Screenshot 2026-03-20 at 12 15 35" src="https://github.com/user-attachments/assets/df83a977-3148-4658-9e25-4fe3847ec47f" />
