### PR TITLE
Remove backdrop filter on header

### DIFF
--- a/app/views/base/page.scala
+++ b/app/views/base/page.scala
@@ -126,8 +126,8 @@ object page:
           dataTheme := pref.currentBg,
           dataBoard := pref.currentTheme.name,
           dataPieceSet := pref.currentPieceSet.name,
-          dataBoard3d := pref.currentTheme3d.name,
-          dataPieceSet3d := pref.currentPieceSet3d.name,
+          dataBoard3d := pref.is3d.option(pref.currentTheme3d.name),
+          dataPieceSet3d := pref.is3d.option(pref.currentPieceSet3d.name),
           dataAnnounce := lila.web.AnnounceApi.get.map(a => safeJsonValue(a.json)),
           attr("data-i18n-catalog") := assetHelper.manifest
             .js(s"i18n/${ctx.lang.code}")

--- a/ui/lib/css/header/_header.scss
+++ b/ui/lib/css/header/_header.scss
@@ -34,6 +34,8 @@ body > header {
     }
 
     @include if-transp {
+      @include back-blur(6px);
+
       border: none;
       background: hsla(0, 0, 20%, 0.15);
     }
@@ -131,4 +133,8 @@ body.zen {
       display: none;
     }
   }
+}
+
+html.transp body[data-board3d] #top::before {
+  display: none;
 }

--- a/ui/lib/css/header/_header.scss
+++ b/ui/lib/css/header/_header.scss
@@ -34,8 +34,6 @@ body > header {
     }
 
     @include if-transp {
-      @include back-blur(6px);
-
       border: none;
       background: hsla(0, 0, 60%, 0.14);
     }

--- a/ui/lib/css/header/_header.scss
+++ b/ui/lib/css/header/_header.scss
@@ -35,7 +35,7 @@ body > header {
 
     @include if-transp {
       border: none;
-      background: hsla(0, 0, 60%, 0.14);
+      background: hsla(0, 0, 20%, 0.15);
     }
 
     .dropdown {


### PR DESCRIPTION
fixes #19843

When theme is transparent, header blurs the top of 3D pieces

This backdrop filter on header seems redundant as the underlying picture is already blurred


Before fixing
<img width="899" height="282" alt="Capture d&#39;écran 2026-03-21 050425" src="https://github.com/user-attachments/assets/ea30dabc-dcb4-4b4f-b4a2-b6219e817ac6" />

After fixing
<img width="904" height="253" alt="Capture d&#39;écran 2026-03-21 052108" src="https://github.com/user-attachments/assets/f419f0b7-73cd-4593-bf5e-e7166df6d690" />
