### PR TITLE
workspace: fix lint-staged config

### DIFF
--- a/ui/lint-staged.config.mjs
+++ b/ui/lint-staged.config.mjs
@@ -6,13 +6,13 @@ function filterSymbolicLinks(files) {
 
 export default {
   // NOTE: these patterns must stay in sync with bin/git-hooks/pre-commit!
-  'ui/*.{json,ts,mts,mjs}': files => {
+  '*.{json,ts,mts,mjs}': files => {
     const regularFiles = filterSymbolicLinks(files);
     return regularFiles.length
-      ? `oxlint --type-aware --config=.oxlintrc.json --tsconfig=./ui/tsconfig.base.json --fix ${regularFiles.join(' ')} && oxfmt`
+      ? `oxlint --type-aware --config=../.oxlintrc.json --tsconfig=tsconfig.base.json --fix ${regularFiles.join(' ')} && oxfmt`
       : 'true';
   },
-  'ui/*.scss': files => {
+  '*.scss': files => {
     const regularFiles = filterSymbolicLinks(files);
     return regularFiles.length ? `stylelint ${regularFiles.join(' ')} --fix && oxfmt` : 'true';
   },


### PR DESCRIPTION
# Why

Fixes #20056 
* #20056 

# How

Lint Staged config does not use default `glob` for matching, but `picomatch` (https://github.com/lint-staged/lint-staged?tab=readme-ov-file#filtering-files), which lead to issues with path resolve. Switching to just file name match should be fine and do not affect performance since those filters run on the list of modified/added files in changeset only.

Also, I have updated the Oxlint config paths, since Lint Staged have issues resolving correct path.

# Test plan

Make whitespace change suggested in the issue, stage file, run `pnpm lint-staged` with `--debug` flag to ensure that file is registered and matched correctly.

# Preview

https://github.com/user-attachments/assets/e76aab73-fa3c-4f0d-af30-651bdfb6edc2
