### PR TITLE
fix missing GDPR button for forever closed accounts

### DIFF
--- a/modules/mod/src/main/ui/ModUserUi.scala
+++ b/modules/mod/src/main/ui/ModUserUi.scala
@@ -217,7 +217,8 @@ final class ModUserUi(helpers: Helpers, modUi: ModUi):
                     action := routes.Mod.reopenAccount(u.username),
                     title := "Re-activates this account.",
                     cls := "xhr"
-                  )(submitButton(cls := "btn-rack__btn active")("Closed")),
+                  )(submitButton(cls := "btn-rack__btn active")("Closed"))
+                ,
                 Granter.opt(_.GdprErase).option(gdprEraseForm(u))
               )
           )


### PR DESCRIPTION
GDPR button was missing when account was forever closed due to logic nesting.

Moved GDPR button to a separate logic block, so now it shows for closed or forever closed accounts, but not deleted accounts.
Viewed as GDPR eraser permission:
  Forever closed:
  <img width="242" height="78" alt="image" src="https://github.com/user-attachments/assets/82e6e940-3103-444a-b6ca-03ebf90ed265" />
  Normal closed:
  <img width="207" height="75" alt="image" src="https://github.com/user-attachments/assets/aec20a19-8e9d-423a-8c80-e974c3c7c564" />
Other permission views unchanged:
<img width="176" height="63" alt="image" src="https://github.com/user-attachments/assets/c345d0c7-d8a9-40c5-8cfe-b4ecc6cba527" />


