### PR TITLE
ui: fix forum message content overflow

### DIFF
--- a/ui/bits/css/forum/_post.scss
+++ b/ui/bits/css/forum/_post.scss
@@ -122,6 +122,7 @@
 
   p {
     margin-block: 0;
+    overflow-wrap: anywhere;
   }
 
   margin-top: 1em;


### PR DESCRIPTION
# Why

Very long character chain can cause forum message content overflow, i.e.:
```
⸻⸻⸻⸻⸻⸻⸻⸻⸻⸻⸻⸻⸻⸻⸻⸻⸻⸻
```


Fixes #20064
* #20064

# How

Add `overflow-wrap: anywhere` property to the post message content paragraphs. It should not break the regular words unless their width spans over device viewport, but will correctly break long chains of characters.

# Preview (before/after)

<img width="380" height="1352" alt="Screenshot 2026-03-22 at 11 57 45" src="https://github.com/user-attachments/assets/26fa1fe0-5e77-4c0f-9f4e-fc180e3549a7" />

<img width="380" height="1474" alt="Screenshot 2026-03-22 at 11 58 51" src="https://github.com/user-attachments/assets/fcca0dca-248e-4f8f-a1cd-9373da80e9a5" />
