### PR TITLE
Fix #17563: NVUI - board becomes unresponsive after layout change

### DIFF
--- a/ui/round/src/view/nvuiView.ts
+++ b/ui/round/src/view/nvuiView.ts
@@ -246,7 +246,12 @@ function renderBoard(ctx: RoundNvuiContext): LooseVNodes {
     hl('h2', i18n.site.board),
     hl(
       'div.board',
-      { hook: { insert: el => boardEventsHook(ctx, el.elm as HTMLElement) } },
+      {
+        hook: {
+          insert: el => boardEventsHook(ctx, el.elm as HTMLElement),
+          update: (_, vnode) => boardEventsHook(ctx, vnode.elm as HTMLElement),
+        },
+      },
       nv.renderBoard(
         ctrl.chessground.state.pieces,
         ctrl.data.game.variant.key === 'racingKings'
@@ -279,17 +284,24 @@ function boardEventsHook(ctx: RoundNvuiContext, el: HTMLElement): void {
   const { ctrl, prefixStyle, pieceStyle, moveStyle, deviceType } = ctx;
 
   const $board = $(el);
-  const $buttons = $board.find('button');
-  $buttons.on('blur', nv.leaveSquareHandler($buttons));
-  $buttons.on(
-    'click',
+  // Remove old handlers before rebinding (important on re-render)
+  $board.off('.nvui');
+  // NVUI re-renders the board, recreating <button> elements.
+  // Avoid binding events directly to buttons, as references
+  // become stale. Use delegation on $board instead.
+  $board.on('blur.nvui', 'button', e => {
+    nv.leaveSquareHandler($board.find('button'))(e);
+  });
+
+  $board.on('click.nvui', 'button', e => {
     nv.selectionHandler(
       () => ctrl.data.opponent.color,
       deviceType.get() === 'touchscreen',
       ctrl.data.game.variant.key === 'antichess',
-    ),
-  );
-  $buttons.on('keydown', (e: KeyboardEvent) => {
+    )(e);
+  });
+
+  $board.on('keydown.nvui', 'button', (e: KeyboardEvent) => {
     if (e.shiftKey && e.key.match(/^[ad]$/i)) nextOrPrev(ctrl)(e);
     else if (e.key.match(/^x$/i))
       scanDirectionsHandler(


### PR DESCRIPTION
### Fix #17563: NVUI board becomes unresponsive after layout change

The board stopped responding to clicks and keyboard input after changing the layout in NVUI mode. This happened because event listeners were bound directly to button elements, which were destroyed and recreated during re-render, causing the listeners to be lost.

### Fix

Replaced direct event binding with delegated events attached to the board container to ensure handlers persist across DOM updates.

Added namespaced event cleanup using `$board.off('.nvui')` to prevent duplicate bindings when the hook runs multiple times.

Updated the render hook to call `boardEventsHook` on both `insert` and `update`, ensuring events are consistently reattached after every re-render.

### Testing

Manually tested by:
- Playing a game in NVUI mode
- Changing the board layout multiple times
- Verifying that click and keyboard interactions continue to work correctly

Also ran all frontend tests and confirmed they pass.

### Demo / Video

A short video demonstrating the bug and explaining the changes:

[Watch the video](https://www.youtube.com/watch?v=ywQrf0eVyzE)