### PR TITLE
add mon for clients on api board seek endpoint

### DIFF
--- a/app/controllers/Setup.scala
+++ b/app/controllers/Setup.scala
@@ -151,6 +151,13 @@ final class Setup(
             me <- ctx.me.so(env.user.api.withPerfs)
             blocking <- ctx.me.so(env.relation.api.fetchBlocking(_))
             sri = orUserSri(author)
+            _ = lila.mon.lobby.hook
+              .apiCreate:
+                if ctx.isMobileOauth then env.oAuth.signedClients.mobile.clientId.value
+                else if ctx.isPolygon then env.oAuth.signedClients.polygon.clientId.value
+                else if HTTPRequest.isLichobile(ctx.req) then "lichobile"
+                else "other"
+              .increment()
             forcedColor <- env.lobby.boardApiHookStream.mustPlayAsColor(config.color)
             res <- forcedColor.match
               case Some(forced) => fuccess(JsonBadRequest(s"You must also play some games as $forced"))

--- a/modules/common/src/main/mon.scala
+++ b/modules/common/src/main/mon.scala
@@ -99,6 +99,7 @@ object mon:
       val create = counter("lobby.hook.create").withoutTags()
       val join = counter("lobby.hook.join").withoutTags()
       val size = histogram("lobby.hook.size").withoutTags()
+      def apiCreate(client: String) = counter("lobby.hook.apiCreate").withTag("client", client)
     object seek:
       val create = counter("lobby.seek.create").withoutTags()
       val join = counter("lobby.seek.join").withoutTags()


### PR DESCRIPTION
Note this restores monitoring previously deleted in https://github.com/lichess-org/lila/commit/a9733eb3227db0d84da548ff0e5eddd189c029d5, but now without the high cardinality of tagging with user agent

## tested locally

```bash
http -A bearer -a lip_bobby post http://localhost:8080/api/board/seek
```

metric shows up in local influxdb:

```bash
http http://localhost:8086/query \
  'Authorization: Token secret' \
  db==kamon \
  q=='show tag values from "lobby.hook.apiCreate" with key = "client"'

# > see "other" value is present
```