### PR TITLE
Add FEN field to puzzle API responses

### DIFF
--- a/modules/puzzle/src/main/JsonView.scala
+++ b/modules/puzzle/src/main/JsonView.scala
@@ -227,7 +227,6 @@ object JsonView:
 
   def puzzleJsonStandalone(puzzle: Puzzle): JsObject =
     puzzleJsonBase(puzzle) ++ Json.obj(
-      "fen" -> puzzle.fenAfterInitialMove,
       "lastMove" -> puzzle.line.head.uci
     )
 
@@ -236,7 +235,8 @@ object JsonView:
     "rating" -> puzzle.glicko.intRating,
     "plays" -> puzzle.plays,
     "solution" -> puzzle.line.tail.map(_.uci),
-    "themes" -> simplifyThemes(puzzle.themes)
+    "themes" -> simplifyThemes(puzzle.themes),
+    "fen" -> puzzle.fenAfterInitialMove
   )
   private def simplifyThemes(themes: Set[PuzzleTheme.Key]) =
     themes.filterNot(_ == PuzzleTheme.mate.key)


### PR DESCRIPTION

The `GET /api/puzzle/daily` and `GET /api/puzzle/:id` endpoints did not include the FEN of the puzzle starting position. This makes it impossible to implement lightweight clients — such as an iOS home screen widget — that need to render the board without access to a chess engine to replay the PGN.

The fix moves "`fen" -> puzzle.fenAfterInitialMove` from `puzzleJsonStandalone` into `puzzleJsonBase`, so the field is now present in all puzzle API responses. `fenAfterInitialMove` is the board position after the opponent's last move (i.e. the position the solver starts from), which is exactly what a rendering client needs.

### Motivation 

Enables implementing a native iOS home screen widget for daily/random puzzles, as described in https://github.com/lichess-org/mobile/issues/2839. The widget process is isolated from the main app, cannot use Flutter, and cannot run a chess engine — so the FEN must come from the API directly.
