### PR TITLE
Increase onlineBotVisible limit from 200 to 500

### DIFF
--- a/modules/user/src/main/package.scala
+++ b/modules/user/src/main/package.scala
@@ -6,6 +6,6 @@ export lila.rating.UserWithPerfs
 
 private val logger = lila.log("user")
 
-val onlineBotVisible = Max(200)
+val onlineBotVisible = Max(500)
 
 case class LightCount(user: lila.core.LightUser, count: Int)


### PR DESCRIPTION
Reasoning: The current limit does not allow retrieval of all online bots on the bot page or the api.
