### PR TITLE
ui: fix PGN viewer menu background in transparent theme

### DIFF
--- a/ui/lib/css/component/_pgn-viewer.scss
+++ b/ui/lib/css/component/_pgn-viewer.scss
@@ -34,14 +34,14 @@
   --c-lpv-bg-brilliant-hover: #{$m-brilliant_bg--mix-30};
   --c-lpv-bg-interesting-hover: #{$m-interesting_bg--mix-30};
 
+  @include if-transp {
+    --c-lpv-bg-pane: #{$m-body-gradient--fade-15};
+  }
+
   @extend %box-neat-force;
 
   &__player__title {
     color: $c-brag;
-  }
-
-  @include if-transp {
-    --c-lpv-bg-pane: #{$m-body-gradient--fade-15};
   }
 
   &__pane {


### PR DESCRIPTION
# Why

Fixes #20086

* #20086

# How

Overwrite the `lpv-bg-pane` variable in transparent theme to less transparent color since `bg-zebra2` is set to `0.1` alpha leading to the reported issue.

Also added a default backdrop blur for the menu container and made the default menu color bit more faded, so the effect is slightly visible in dark and light themes. We might consider moving the `backdrop-filter` to `pgn-viewer` default styles, but since I was not sure if this is a good idea and will match other usages I added the style on the lila side for now.

# Preview

https://github.com/user-attachments/assets/78c5e876-1c96-4221-9c0c-476e47e84963

