### PR TITLE
Fix search field stealing focus when clicking Register on top bar.

### DIFF
--- a/ui/site/src/topBar.ts
+++ b/ui/site/src/topBar.ts
@@ -191,7 +191,10 @@ export default function () {
         if (mouseInside === undefined) {
           const rect = $wrap[0]!.getBoundingClientRect();
           mouseInside =
-            e.clientX >= rect.left && e.clientX <= rect.right && e.clientY >= rect.top && e.clientY <= rect.bottom;
+            e.clientX >= rect.left &&
+            e.clientX <= rect.right &&
+            e.clientY >= rect.top &&
+            e.clientY <= rect.bottom;
         }
       },
       { once: true },


### PR DESCRIPTION
This change stops the search bar from stealing focus after clicking the Register button on the top bar. After clicking the Register button, the cursor would end up over the search bar, triggering it to extend and focus. This stole focus from the auto-focused "User name" field.
<img width="1320" height="50" alt="image" src="https://github.com/user-attachments/assets/38390578-ea19-493d-bc4a-42deba7631e9" />
<img width="1315" height="592" alt="image" src="https://github.com/user-attachments/assets/f69c3cbb-2e1f-4ab0-bfec-f9b100b2445b" />


In this PR we detect if the search bar has loaded in under the cursor, and if it has we wait until the mouse is removed before we accept mouse-enter triggers.

Fixes #20080 
https://github.com/lichess-org/lila/issues/20080

This is my first time contributing, please let me know if I got anything wrong or if changes are needed.
