### PR TITLE
Fix toggling of the mobile analysis engine button when clicking the l…

### DIFF
--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -833,7 +833,7 @@ export default class AnalyseCtrl implements CevalHandler {
     if (show === undefined) return displayColumns() > 1 || barMode === 'ceval' || barMode === 'practice';
     this.ceval.showEnginePrefs(false);
     this.showCevalProp(show);
-    if (show) this.cevalEnabled(true);
+    this.cevalEnabled(show);
     return show;
   };
 

--- a/ui/analyse/src/view/controls.ts
+++ b/ui/analyse/src/view/controls.ts
@@ -144,7 +144,7 @@ function clickControl(ctrl: AnalyseCtrl, e: PointerEvent) {
   else if (action === 'opening-explorer') ctrl.toggleExplorer();
   else if (action === 'menu') ctrl.toggleActionMenu();
   else if (action === 'analysis') window.open(ctrl.study?.practice?.analysisUrl(), '_blank');
-  else if (action === 'engine-mode' && !e.target.closest<HTMLElement>('.cmn-toggle')) {
+  else if (action === 'engine-mode' && !e.target.closest<HTMLElement>('input, label')) {
     const mode = e.target.dataset.mode as EngineMode;
     if (ctrl.activeControlBarTool()) {
       ctrl.explorer.enabled(false);


### PR DESCRIPTION
This PR fixes two problems with the mobile analysis button.

1. inconsistent behavior when clicking the label as detailed in https://github.com/lichess-org/lila/issues/20096
2. A dead area in-between the toggle and the engine icon that doesnt respond to taps
<img width="490" height="594" alt="image" src="https://github.com/user-attachments/assets/f0f61a5a-02d6-40bf-b8ec-7a39147a9161" />

Fixes https://github.com/lichess-org/lila/issues/20096
