### PR TITLE
Unexpected enter behaviour in new chapter form

### DIFF
--- a/ui/analyse/src/study/chapterNewForm.ts
+++ b/ui/analyse/src/study/chapterNewForm.ts
@@ -127,7 +127,7 @@ export function view(ctrl: StudyChapterNewForm): VNode {
       'button.' + key,
       {
         class: { active: activeTab === key },
-        attrs: { role: 'tab', title, tabindex: '0' },
+        attrs: { type: 'button', role: 'tab', title, tabindex: '0' },
         hook: onInsert(el => {
           el.addEventListener('click', (e: Event) => {
             ctrl.setTab(key);

--- a/ui/editor/src/view.ts
+++ b/ui/editor/src/view.ts
@@ -88,7 +88,7 @@ function controls(ctrl: EditorCtrl, state: EditorState): VNode {
             ctrl.startPosition();
           },
         },
-        attrs: icon ? dataIcon(icon) : {},
+        attrs: { type: 'button', ...(icon ? dataIcon(icon) : {}) },
       },
       i18n.site.startPosition,
     );
@@ -102,7 +102,7 @@ function controls(ctrl: EditorCtrl, state: EditorState): VNode {
             ctrl.clearBoard();
           },
         },
-        attrs: icon ? dataIcon(icon) : {},
+        attrs: { type: 'button', ...(icon ? dataIcon(icon) : {}) },
       },
       i18n.site.clearBoard,
     );


### PR DESCRIPTION
Closes #20100.

The buttons in this PR didn't have an explicit type, so by default they were treated as buttons with type `submit`. Thus when pressing enter in a submittable field of a form, the nearest submit button was triggered, causing the unexpected behaviour.