### PR TITLE
fix: disable mobile tap highlight on chessboard

### DIFF
--- a/ui/lib/css/component/_board.scss
+++ b/ui/lib/css/component/_board.scss
@@ -14,7 +14,7 @@
 
 cg-board {
   @extend %box-radius;
-  
+
   -webkit-tap-highlight-color: transparent;
 }
 


### PR DESCRIPTION
Remove the distracting and unnecessary highlight when tapping the board on mobile browsers using -webkit-tap-highlight-color: transparent

This is a very small change that only affects touch devices and does not interfere with other board interactions. 


https://github.com/user-attachments/assets/6bee2fc1-4d8c-49ab-952f-7b7acacc00b2



 
