### PR TITLE
fix: loading when another tab started ceval

### DIFF
--- a/ui/lib/src/ceval/ctrl.ts
+++ b/ui/lib/src/ceval/ctrl.ts
@@ -102,7 +102,7 @@ export default class CevalCtrl {
   });
 
   available(): boolean {
-    return !document.hidden && this.analysable;
+    return this.analysable;
   }
 
   private readonly doStart = (
@@ -111,7 +111,7 @@ export default class CevalCtrl {
     gameId: string | undefined,
     threatMode: boolean,
   ) => {
-    if (!this.available()) {
+    if (document.hidden) {
       this.lastStarted = { path, steps, gameId, threatMode };
       return;
     }
@@ -187,7 +187,7 @@ export default class CevalCtrl {
   };
 
   start = (path: string, steps: Step[], gameId: string | undefined, threatMode?: boolean): void => {
-    if (this.isPaused) return;
+    if (!this.available() || this.isPaused) return;
     this.isDeeper(false);
     this.doStart(path, steps, gameId, !!threatMode);
   };


### PR DESCRIPTION
### Steps to reproduce the bug

command + click a link to a lichess game
https://lichess.org/broadcast/reykjavik-open-2026/round-6/UHMy3Lh9/oCN5AjFN

### What did you expect to happen?

Either the ceval to be disabled or enabled and calculate the moves

### What happened instead?

The ceval was constantly Calculating moves...

<img width="414" height="66" src="https://github.com/user-attachments/assets/d58de5e0-92d5-47f0-9817-9d44dc6b651a" />