### PR TITLE
Don't hide lobby in blind mode

### DIFF
--- a/ui/bits/css/_blind.scss
+++ b/ui/bits/css/_blind.scss
@@ -31,10 +31,6 @@ body.blind-mode {
   margin-top: 170px;
 }
 
-.lobby__app {
-  display: none !important;
-}
-
 #clinput {
   .link {
     display: none;


### PR DESCRIPTION
fixes #20107
fixes #17958


The visual lobby is now accessible (I did not realise that ... big thanks to whoever did it)

We can now show it verbatim for blind users to try it.
It will be found in heading 2 'Ongoing games'
(Note that filter is visible when you use the screen reader)

<img width="1123" height="579" alt="image" src="https://github.com/user-attachments/assets/5f5a9fd4-334e-4dee-b921-e419fef80ffa" />

Notes for later:
- Invert the time controls in nvui (slow games first)
- Hide the graph which purely visual
- 'Ongoing games' and 'games in play' are now redundant (I would hide the tab as blind users rely on the the heading)
- Listen to users' feedback