### PR TITLE
Fix #18267: Study board shows wrong orientation after manual flip

### DIFF
--- a/ui/analyse/src/study/studyCtrl.ts
+++ b/ui/analyse/src/study/studyCtrl.ts
@@ -372,8 +372,8 @@ export default class StudyCtrl {
     document.title = this.relay?.fullRoundName() ?? this.data.name;
     this.members.dict(s.members);
     if (s.chapters) this.chapters.loadFromServer(s.chapters);
-    this.ctrl.flipped = changeInChapterOrientation ? false : this.chapterFlipMapProp(this.data.chapter.id);
     if (changeInChapterOrientation) this.chapterFlipMapProp(this.data.chapter.id, false);
+    this.ctrl.flipped = this.chapterFlipMapProp(this.data.chapter.id);
 
     const merge = !this.vm.mode.write && sameChapter;
     this.ctrl.reloadData(d.analysis, merge);


### PR DESCRIPTION
### Fix #18267: Study board shows wrong orientation after manual flip
When editing a study chapter’s orientation, the board could display the opposite orientation of what was saved if the user had previously flipped the board. The flip state was always restored on reload, even when the chapter’s saved orientation had changed, causing an unintended “double‑flip” and resulting in the wrong side being shown.

This created confusing behavior, especially for users unfamiliar with the flip feature, since the board could appear to contradict the newly saved chapter orientation.

### Fix
- Added logic to detect when the chapter’s saved orientation changes between reloads, using the new `changeInChapterOrientation` constant.
- When an orientation change is detected **within the same chapter**, the flip state is reset and the stored flip preference for that chapter is cleared via `chapterFlipMapProp.`
- When switching to a different chapter, or when the orientation has not changed, the previously stored flip preference is preserved as before.

This ensures that chapter orientation updates are always reflected correctly, while still maintaining user‑defined flips when appropriate.

### Testing
Manually tested by:

- Editing chapter orientation in both directions (white ↔ black).
- Editing other chapter settings.
- Flipping the board before and after editing.
- Navigating between different chapters.
- Reloading the page to confirm persistence and correct restoration of flip state.

All frontend tests were also run and passed successfully.

### Demo / Video

A short video demonstrating the bug, explaining the changes and showing some of the new behavior:
[Watch video on Youtube](https://www.youtube.com/watch?v=wYcwH_tAz9I)

### Notes
If the board already matches the newly saved orientation (e.g., due to a previous flip), saving may not produce a visible change. This is expected and consistent with current behavior.