### PR TITLE
fix PGN export for force variations

### DIFF
--- a/modules/study/src/test/PgnDumpTest.scala
+++ b/modules/study/src/test/PgnDumpTest.scala
@@ -12,7 +12,13 @@ class PgnDumpTest extends munit.FunSuite:
 
   val P = PgnDump
 
-  def node(ply: Ply, uci: String, san: String, children: Branches = Branches.empty) =
+  def node(
+      ply: Ply,
+      uci: String,
+      san: String,
+      children: Branches = Branches.empty,
+      forceVariation: Boolean = false
+  ) =
     Branch(
       ply = ply,
       move = Uci.WithSan(Uci(uci).get, SanStr(san)),
@@ -20,7 +26,7 @@ class PgnDumpTest extends munit.FunSuite:
       clock = None,
       crazyData = None,
       children = children,
-      forceVariation = false
+      forceVariation = forceVariation
     )
 
   def children(nodes: Branch*) = Branches(nodes.toList)
@@ -127,3 +133,23 @@ class PgnDumpTest extends munit.FunSuite:
       rootToPgn(tree).value,
       "1. e4 (1. Nf3 a6 (1... b6 2. c4)) 1... d5 (1... Nf6 2. h4) 2. a3 (2. b3)"
     )
+
+  test("force variation after last mainline move should render in brackets"):
+    val tree = root.copy(children =
+      children(
+        node(
+          1,
+          "e2e4",
+          "e4",
+          children(
+            node(
+              2,
+              "c7c5",
+              "c5"
+            )
+          )
+        ),
+        node(1, "c7c5", "c5", forceVariation = true)
+      )
+    )
+    assertEquals(rootToPgn(tree).value, "1. e4 c5 (1. c5)")

--- a/modules/tree/src/main/tree.scala
+++ b/modules/tree/src/main/tree.scala
@@ -30,6 +30,8 @@ object Branches:
     def mainlineFirst = nodes.collectFirst:
       case node if !node.forceVariation => node
     def variations = nodes.drop(1)
+    def forceVariations = nodes.filter(_.forceVariation)
+    def others = nodes.drop(1)
     def isEmpty = nodes.isEmpty
     def nonEmpty = !isEmpty
 
@@ -172,7 +174,7 @@ case class Root(
 
   def addChild(child: Branch): Root = copy(children = children.addNode(child))
   def prependChildUnchecked(branch: Branch) = copy(children = children.prependUnchecked(branch))
-  def dropFirstChild = copy(children = if children.isEmpty then children else Branches(children.variations))
+  def dropFirstChild = copy(children = if children.isEmpty then children else Branches(children.others))
 
   def withChildren(f: Branches => Option[Branches]): Option[Root] =
     f(children).map: newChildren =>
@@ -357,7 +359,7 @@ case class Branch(
     )
 
   def prependChildUnchecked(branch: Branch) = copy(children = children.prependUnchecked(branch))
-  def dropFirstChild = copy(children = if children.isEmpty then children else Branches(children.variations))
+  def dropFirstChild = copy(children = if children.isEmpty then children else Branches(children.others))
 
   def setComp = copy(comp = true)
 


### PR DESCRIPTION
Fixes #20081

Force variations (created via 'Force variation' context menu action) were not being rendered in PGN brackets. This bug affected both Analysis and Studies pages.

The issue was that Branches.variations only returned nodes.drop(1) which doesn't account for the forceVariation flag. This fix adds a new forceVariations method that properly filters nodes by their forceVariation flag.

Example before fix: 1. e4 c5 1. c5
Example after fix: 1. e4 c5 (1. c5)