### PR TITLE
fix PGN export for force variations

### DIFF
--- a/modules/study/src/test/PgnDumpTest.scala
+++ b/modules/study/src/test/PgnDumpTest.scala
@@ -12,7 +12,13 @@ class PgnDumpTest extends munit.FunSuite:
 
   val P = PgnDump
 
-  def node(ply: Ply, uci: String, san: String, children: Branches = Branches.empty) =
+  def node(
+      ply: Ply,
+      uci: String,
+      san: String,
+      children: Branches = Branches.empty,
+      forceVariation: Boolean = false
+  ) =
     Branch(
       ply = ply,
       move = Uci.WithSan(Uci(uci).get, SanStr(san)),
@@ -20,7 +26,7 @@ class PgnDumpTest extends munit.FunSuite:
       clock = None,
       crazyData = None,
       children = children,
-      forceVariation = false
+      forceVariation = forceVariation
     )
 
   def children(nodes: Branch*) = Branches(nodes.toList)
@@ -127,3 +133,19 @@ class PgnDumpTest extends munit.FunSuite:
       rootToPgn(tree).value,
       "1. e4 (1. Nf3 a6 (1... b6 2. c4)) 1... d5 (1... Nf6 2. h4) 2. a3 (2. b3)"
     )
+
+  test("force variation after last mainline move should render in brackets"):
+    val tree = root.copy(children =
+      children(
+        node(
+          1,
+          "e2e4",
+          "e4",
+          children(
+            node(2, "c7c5", "c5")
+          )
+        ),
+        node(1, "d2d4", "d4", forceVariation = true)
+      )
+    )
+    assertEquals(rootToPgn(tree).value, "1. e4 c5 (1. d4)")

--- a/modules/tree/src/main/newTree.scala
+++ b/modules/tree/src/main/newTree.scala
@@ -102,7 +102,7 @@ object NewTree:
       NewTree(
         value = fromBranch(first),
         child = first.children.first.map(fromBranch(_, first.children.variations)),
-        variations = root.children.variations.map(toVariation)
+        variations = (root.children.variations ::: root.children.forceVariations).map(toVariation)
       )
 
   def toVariation(branch: Branch): Variation[NewBranch] =

--- a/modules/tree/src/main/tree.scala
+++ b/modules/tree/src/main/tree.scala
@@ -30,6 +30,8 @@ object Branches:
     def mainlineFirst = nodes.collectFirst:
       case node if !node.forceVariation => node
     def variations = nodes.drop(1)
+    def forceVariations = nodes.filter(_.forceVariation)
+    def others = nodes.drop(1)
     def isEmpty = nodes.isEmpty
     def nonEmpty = !isEmpty
 
@@ -172,7 +174,7 @@ case class Root(
 
   def addChild(child: Branch): Root = copy(children = children.addNode(child))
   def prependChildUnchecked(branch: Branch) = copy(children = children.prependUnchecked(branch))
-  def dropFirstChild = copy(children = if children.isEmpty then children else Branches(children.variations))
+  def dropFirstChild = copy(children = if children.isEmpty then children else Branches(children.others))
 
   def withChildren(f: Branches => Option[Branches]): Option[Root] =
     f(children).map: newChildren =>
@@ -357,7 +359,7 @@ case class Branch(
     )
 
   def prependChildUnchecked(branch: Branch) = copy(children = children.prependUnchecked(branch))
-  def dropFirstChild = copy(children = if children.isEmpty then children else Branches(children.variations))
+  def dropFirstChild = copy(children = if children.isEmpty then children else Branches(children.others))
 
   def setComp = copy(comp = true)
 


### PR DESCRIPTION
Fixes #20081

Force variations (created via 'Force variation' context menu action) were not being rendered in PGN brackets. This bug affected both Analysis and Studies pages.

The issue was that Branches.variations and NewTree were not accounting for the forceVariation flag when building trees for PGN export. This fix modifies both Branches.variations and NewTree to use forceVariations.