### PR TITLE
ui: tweaks for opening wiki data render

### DIFF
--- a/ui/analyse/css/_side.scss
+++ b/ui/analyse/css/_side.scss
@@ -42,7 +42,22 @@
 
     p {
       text-align: justify;
-      line-height: 1.5;
+      line-height: 1.4;
+    }
+
+    ul,
+    ol {
+      line-height: 1.4;
+      margin-bottom: 1rem;
+      padding-left: 1rem;
+    }
+
+    ul li {
+      list-style: disc;
+    }
+
+    ol li {
+      list-style: decimal;
     }
 
     h1,


### PR DESCRIPTION
# Why

Spotted that lists rendered within analyse wiki books sidebar does not have any style set, resulting in lack of markers and different line height than the regular text.

# How

Add basic styles for lists rendered in analysis side section, adjust spacing and default line-height slightly.

# Preview (before/after)

<img width="380" height="1290" alt="Screenshot 2026-04-01 at 10 17 39" src="https://github.com/user-attachments/assets/7d22ab25-2882-4f3d-a58e-57bac80858b9" />


<img width="380" height="1290" alt="Screenshot 2026-04-01 at 10 17 10" src="https://github.com/user-attachments/assets/d66c4d46-6200-4ebb-9470-64a2b2df9a62" />
