### PR TITLE
Fix iOS Safari auto-zoom on auth form inputs

### DIFF
--- a/ui/bits/css/_auth.scss
+++ b/ui/bits/css/_auth.scss
@@ -93,6 +93,7 @@ $auth-input-bg: rgba(26, 22, 16, 1);
 
   .form-group input {
     height: 50px;
+    font-size: 16px;
     border: none;
     border-radius: $auth-input-radius;
     background: $auth-input-bg;


### PR DESCRIPTION
Set font-size to 16px on auth form inputs. iOS Safari auto-zooms when focusing inputs with font-size below 16px.

A recording that shows the auto-zoom:


https://github.com/user-attachments/assets/e206fc4b-4eca-4ac3-b822-3283e759566d

With the fix:


https://github.com/user-attachments/assets/74e0495c-d054-40d6-84f1-a2c74b95ae4e



