### PR TITLE
don't show disable blind mode on mobile

### DIFF
--- a/ui/bits/css/_blind.scss
+++ b/ui/bits/css/_blind.scss
@@ -14,12 +14,14 @@ body.blind-mode {
   }
 }
 
-#blind-mode {
-  position: static;
-  text-align: center;
-  padding: 5px 0;
-  background: #888;
-  height: auto;
+@media (min-width: $small) {
+  #blind-mode {
+    position: static;
+    text-align: center;
+    padding: 5px 0;
+    background: #888;
+    height: auto;
+  }
 }
 
 #topnav div {


### PR DESCRIPTION
fixes #20160 

A sighted user has no chance to trigger blind mode on a mobile by mistake ... we can safely leave the button out of the screen.