### PR TITLE
ui: Fix string student.releaseDesc1 so HTML element is not escaped

### DIFF
--- a/bin/i18n-file-gen.ts
+++ b/bin/i18n-file-gen.ts
@@ -86,12 +86,15 @@ object I18nKey:
       trans.translator.txt.literal(key, args, trans.lang)
     def pluralTxt(count: Count, args: Any*)(using trans: Translate): String =
       trans.translator.txt.plural(key, count, args, trans.lang)
-    def pluralSameTxt(count: Long)(using trans: Translate): String = pluralTxt(count, count)
+    def pluralSameTxt(count: Long)(using Translate): String = pluralTxt(count, count)
     def apply(args: Matchable*)(using trans: Translate): RawFrag =
       trans.translator.frag.literal(key, args, trans.lang)
     def plural(count: Count, args: Matchable*)(using trans: Translate): RawFrag =
       trans.translator.frag.plural(key, count, args, trans.lang)
-    def pluralSame(count: Int)(using trans: Translate): RawFrag = plural(count, count)
+    def pluralSame(count: Int)(using Translate): RawFrag = plural(count, count)
+    // the translated message contains HTML tags
+    def rawHtml(args: Any*)(using Translate): RawFrag = RawFrag(txt(args*))
+    def pluralRawHtml(count: Count, args: Any*)(using Translate): RawFrag = RawFrag(pluralTxt(count, args*))
 
   // format: OFF
 ${objs.map(dbCode).join('\n')}

--- a/modules/clas/src/main/ui/StudentFormUi.scala
+++ b/modules/clas/src/main/ui/StudentFormUi.scala
@@ -235,7 +235,7 @@ final class StudentFormUi(helpers: Helpers, clasUi: ClasUi, studentUi: StudentUi
         div(cls := "box__pad")(
           h2(trans.clas.releaseTheAccount()),
           p(
-            trans.clas.releaseDesc1(),
+            raw(trans.clas.releaseDesc1.txt()),
             br,
             trans.clas.releaseDesc2()
           ),

--- a/modules/clas/src/main/ui/StudentFormUi.scala
+++ b/modules/clas/src/main/ui/StudentFormUi.scala
@@ -235,7 +235,7 @@ final class StudentFormUi(helpers: Helpers, clasUi: ClasUi, studentUi: StudentUi
         div(cls := "box__pad")(
           h2(trans.clas.releaseTheAccount()),
           p(
-            raw(trans.clas.releaseDesc1.txt()),
+            trans.clas.releaseDesc1.rawHtml(),
             br,
             trans.clas.releaseDesc2()
           ),

--- a/modules/coreI18n/src/main/key.scala
+++ b/modules/coreI18n/src/main/key.scala
@@ -11,12 +11,15 @@ object I18nKey:
       trans.translator.txt.literal(key, args, trans.lang)
     def pluralTxt(count: Count, args: Any*)(using trans: Translate): String =
       trans.translator.txt.plural(key, count, args, trans.lang)
-    def pluralSameTxt(count: Long)(using trans: Translate): String = pluralTxt(count, count)
+    def pluralSameTxt(count: Long)(using Translate): String = pluralTxt(count, count)
     def apply(args: Matchable*)(using trans: Translate): RawFrag =
       trans.translator.frag.literal(key, args, trans.lang)
     def plural(count: Count, args: Matchable*)(using trans: Translate): RawFrag =
       trans.translator.frag.plural(key, count, args, trans.lang)
-    def pluralSame(count: Int)(using trans: Translate): RawFrag = plural(count, count)
+    def pluralSame(count: Int)(using Translate): RawFrag = plural(count, count)
+    // the translated message contains HTML tags
+    def rawHtml(args: Any*)(using Translate): RawFrag = RawFrag(txt(args*))
+    def pluralRawHtml(count: Count, args: Any*)(using Translate): RawFrag = RawFrag(pluralTxt(count, args*))
 
   // format: OFF
   object activity:

--- a/modules/ui/src/main/helper/I18nHelper.scala
+++ b/modules/ui/src/main/helper/I18nHelper.scala
@@ -42,7 +42,7 @@ trait I18nHelper:
 
   export lila.core.i18n.Translate
   export lila.core.i18n.I18nKey as trans
-  export I18nKey.{ txt, pluralTxt, pluralSameTxt, apply, plural, pluralSame }
+  export I18nKey.{ txt, pluralTxt, pluralSameTxt, apply, plural, pluralSame, rawHtml, pluralRawHtml }
 
   given (using ctx: Context): Translate = Translate(translator, ctx.lang)
   given (using trans: Translate): Lang = trans.lang

--- a/translation/source/class.xml
+++ b/translation/source/class.xml
@@ -66,7 +66,7 @@ Here is the link to access the class.</string>
   <string name="upgradeFromManaged">Upgrade from managed to autonomous</string>
   <string name="release">Graduate</string>
   <string name="releaseTheAccount">Graduate the account so the student can manage it autonomously.</string>
-  <string name="releaseDesc1">A graduated account cannot be set to &amp;lt;i&amp;gt;managed&amp;lt;/i&amp;gt; again. The student will be able to disable kid mode and reset password themselves.</string>
+  <string name="releaseDesc1">A graduated account cannot be set to &lt;i&gt;managed&lt;/i&gt; again. The student will be able to disable kid mode and reset password themselves.</string>
   <string name="releaseDesc2">The student will remain in the class after their account is graduated.</string>
   <string name="realUniqueEmail">Real, unique email address of the student. We will send a confirmation email to it, with a link to graduate the account.</string>
   <string name="closeStudent">Close account</string>

--- a/ui/@types/lichess/i18n.d.ts
+++ b/ui/@types/lichess/i18n.d.ts
@@ -639,7 +639,7 @@ interface I18n {
     realUniqueEmail: string;
     /** Graduate */
     release: string;
-    /** A graduated account cannot be set to &lt;i&gt;managed&lt;/i&gt; again. The student will be able to disable kid mode and reset password themselves. */
+    /** A graduated account cannot be set to <i>managed</i> again. The student will be able to disable kid mode and reset password themselves. */
     releaseDesc1: string;
     /** The student will remain in the class after their account is graduated. */
     releaseDesc2: string;


### PR DESCRIPTION
_This PR follows #20126._

The way I did the HTML element there did not render previously, with the codes escaped by Scala.

Passing it raw fixed it now:

![Screenshot_20260403_173644](https://github.com/user-attachments/assets/9a28e8f7-36d6-41e5-8d78-0bf8ac872d4c)

However, it's not visually obvious that we are now using `<i>` (as it's [idiomatic text](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/i)).

It appears that a rule has been in place [since 2019](https://github.com/lichess-org/lila/commit/84f9710e3137410a9194607552ad1c7df6f84ced#diff-da7f8f6d66d60e6843622766655bf57789961587f34136b0c50c64bb65033771), which overrides the element's default behaviour of italicising the text. It now looks like this:

https://github.com/lichess-org/lila/blob/59c71fdef1c8a5a40668ff0a4ae4bd3d44de7a05/ui/lib/css/base/_elements.scss#L66-L69

I would like to please ask for a **decision** on whether it would now be appropriate to remove this override rule.
Such a change would enable us to using this element for other idiomatic text in strings, where it'd be appropriate.

If you would prefer to keep the CSS rule in place, we might as well take the HTML element out of this string and replace `<i></i>` with quote marks.