### PR TITLE
Prevent player from resigning when they cannot lose

### DIFF
--- a/modules/core/src/main/game/Pov.scala
+++ b/modules/core/src/main/game/Pov.scala
@@ -48,12 +48,6 @@ case class Pov(game: Game, color: Color):
 
   def sideAndStart = SideAndStart(color, game.chess.startedAtPly)
 
-  // We are always the player in the pov. However for a scalachess Position, the "player" and "opponent"
-  // are based on whose turn it is.
-  def cannotLose =
-    (isMyTurn && game.position.opponentHasInsufficientMaterial) ||
-      (!isMyTurn && game.position.playerHasInsufficientMaterial)
-
   override def toString = ref.toString
 
 object Pov:

--- a/modules/round/src/main/Drawer.scala
+++ b/modules/round/src/main/Drawer.scala
@@ -52,7 +52,7 @@ final private[round] class Drawer(
           Messenger.SystemMessage.Persistent(trans.site.drawOfferAccepted.txt()).some
         )
       case Pov(g, color) if g.playerCanOfferDraw(color) =>
-        if pov.cannotLose then finisher.other(pov.game, _.InsufficientMaterialClaim, None)
+        if RoundGame.cannotLose(pov) then finisher.other(pov.game, _.InsufficientMaterialClaim, None)
         else
           val progress = Progress(g).map(offerDraw(color))
           messenger.system(g, color.fold(trans.site.whiteOffersDraw, trans.site.blackOffersDraw).txt())

--- a/modules/round/src/main/RoundAsyncActor.scala
+++ b/modules/round/src/main/RoundAsyncActor.scala
@@ -204,7 +204,7 @@ final private class RoundAsyncActor(
     case RoundBus.Resign(playerId) =>
       handle(playerId): pov =>
         pov.game.resignable.so(
-          if pov.cannotLose then finisher.other(pov.game, _.InsufficientMaterialClaim, None)
+          if RoundGame.cannotLose(pov) then finisher.other(pov.game, _.InsufficientMaterialClaim, None)
           else finisher.other(pov.game, _.Resign, Some(!pov.color))
         )
 

--- a/modules/round/src/main/RoundGame.scala
+++ b/modules/round/src/main/RoundGame.scala
@@ -32,3 +32,9 @@ object RoundGame:
 
     def timeBeforeExpiration: Option[Centis] = g.expirable.option:
       Centis.ofMillis(g.movedAt.toMillis - nowMillis + g.timeForFirstMove.millis).nonNeg
+
+  // We are always the player in the pov. However for a scalachess Position, the "player" and "opponent"
+  // are based on whose turn it is.
+  def cannotLose(p: Pov) =
+    (p.isMyTurn && p.game.position.opponentHasInsufficientMaterial) ||
+      (!p.isMyTurn && p.game.position.playerHasInsufficientMaterial)


### PR DESCRIPTION
If a player tries to resign when it's impossible for them to lose, have a draw be claimed due to insufficient mating material.
Caveat: currently if an account gets terminated (e.g. for cheating), all in-progress games are resigned. This PR will make it so that any games where the opponent can't win are drawn instead.