### PR TITLE
ui: Move clock hint to top of fieldset as it's a general instruction

### DIFF
--- a/modules/simul/src/main/ui/SimulFormUi.scala
+++ b/modules/simul/src/main/ui/SimulFormUi.scala
@@ -108,11 +108,11 @@ final class SimulFormUi(helpers: Helpers)(
         ),
       form.toOption.map: form =>
         form3.fieldset("Clock")(
+          p(trans.site.simulClockHint()),
           form3.split(
             form3.group(
               form("clockTime"),
               trans.site.clockInitialTime(),
-              help = trans.site.simulClockHint().some,
               half = true
             )(form3.select(_, clockTimeChoices)),
             form3.group(form("clockIncrement"), trans.site.clockIncrement(), half = true)(


### PR DESCRIPTION
Repositioned the clock hint for simuls on the new simul form (`/simul/new`) to the top of its fieldset. The text is a general instruction which applies to all inputs in that set, not  just 'clock initial time'.

|Before|After|
|----------|-------|
|![Clock before](https://github.com/user-attachments/assets/a27d0b9b-20ec-47c7-8ceb-508e5fce6d94)|![Clock after](https://github.com/user-attachments/assets/85a72e05-833b-4775-b1fb-26a7c845dd58)|

The formatter sequence (<kbd>lila-docker format</kbd>) kept it as-is so I hope this is okay, but I will note that the next label,
```scala
form3.group(form("clockIncrement"), trans.site.clockIncrement(), half = true)
```
seems to be all on one line.