### PR TITLE
fix: missing extraCgConfig when no showResults

### DIFF
--- a/ui/analyse/src/study/multiBoard.ts
+++ b/ui/analyse/src/study/multiBoard.ts
@@ -233,7 +233,7 @@ export const previewContent = (
   extraCgConfig?: () => Partial<CgConfig>,
 ) => {
   const makeCgConfig = () => ({
-    ...previewToCgConfig(preview),
+    ...(showResults ? previewToCgConfig(preview) : { fen: EMPTY_BOARD_FEN }),
     ...(extraCgConfig ? extraCgConfig() : {}),
   });
   return [
@@ -251,7 +251,7 @@ export const previewContent = (
                 viewOnly: true,
                 orientation,
                 drawable: { enabled: false, visible: false },
-                ...(showResults ? makeCgConfig() : { fen: EMPTY_BOARD_FEN }),
+                ...makeCgConfig(),
               });
               vnode.data!.fen = preview.fen;
             },


### PR DESCRIPTION
### Exact URL of where the bug happened

https://lichess.org/broadcast/grenke-chess-festival-2026--freestyle-open-a/round-4/giZiVGrt/zTsrEaZM

### Steps to reproduce the bug

1. Go to the URL provided above
2. Disable results
3. Refresh the page

### Before

<img width="1392" height="806" alt="image" src="https://github.com/user-attachments/assets/64f4dd77-d80f-4a57-9a63-067edaf4cd79" />

### After

<img width="1384" height="760" alt="image" src="https://github.com/user-attachments/assets/9a240a31-4262-4545-a7c2-8d23813372cf" />
