### PR TITLE
ui: Remove redundant body prefix from scrollbar selectors

### DIFF
--- a/ui/lib/css/base/_scrollbar.scss
+++ b/ui/lib/css/base/_scrollbar.scss
@@ -1,14 +1,14 @@
-body ::-webkit-scrollbar,
-body ::-webkit-scrollbar-corner {
+::-webkit-scrollbar,
+::-webkit-scrollbar-corner {
   width: 0.5rem;
   background: $c-bg-box;
 }
 
-body ::-webkit-scrollbar-thumb {
+::-webkit-scrollbar-thumb {
   background: $c-shade;
 }
 
-body ::-webkit-scrollbar-thumb:hover,
-body ::-webkit-scrollbar-thumb:active {
+::-webkit-scrollbar-thumb:hover,
+::-webkit-scrollbar-thumb:active {
   background: $c-font-dimmer;
 }


### PR DESCRIPTION
Fixes #20187

Remove the `body ` prefix from all selectors in `_scrollbar.scss`. It adds a redundant ancestor check (everything scrollable is inside `body` anyway) and misses the viewport scrollbar which Chromium puts on `<html>`.

**AI disclosure:** This change was made with the help of Claude. The prompt was the issue description from #20187 plus a discussion about whether the `body` prefix was actually problematic. I went over all the code myself and it was alright.

**Testing:** Verified via DevTools that `::-webkit-scrollbar` now matches the `<html>` viewport scrollbar (previously missed by `body ::-webkit-scrollbar`). Inner scrollbars remain correctly styled. Screenshots to be attached below.
