### PR TITLE
RelayPlayers: Delete API BC

### DIFF
--- a/modules/relay/src/main/RelayPlayer.scala
+++ b/modules/relay/src/main/RelayPlayer.scala
@@ -123,10 +123,8 @@ object RelayPlayer:
       Json.toJsObject(p.player) ++ Json
         .obj("played" -> p.games.count(_.points.isDefined))
         .add("score" -> p.score)
-        .add("ratingDiff" -> p.ratingDiffs.headOption._2F) // API BC grace
         .add("ratingsMap" -> p.ratingsMap.nonEmptyOption)
         .add("ratingDiffs" -> p.ratingDiffs.nonEmptyOption)
-        .add("performance" -> p.performances.headOption._2F) // API BC grace
         .add("performances" -> p.performances.nonEmptyOption)
         .add("tiebreaks" -> p.tiebreaks)
         .add("rank" -> p.rank)


### PR DESCRIPTION
"ratingsDiffs" and "performances" supercede it

The mobile app has been updated and doesn't use these values for the past month. 