### PR TITLE
Fix mobile logo visibility on auth pages (#20206)

### DIFF
--- a/ui/lib/css/header/_title.scss
+++ b/ui/lib/css/header/_title.scss
@@ -77,3 +77,11 @@
     margin-inline-end: 0.5em;
   }
 }
+
+body.auth {
+  .site-title {
+    @media (max-width: at-least($xx-small)) {
+      display: flex;
+    }
+  }
+}


### PR DESCRIPTION
Fixes #20206

### **Description**
This PR addresses issue #20206, where the Lichess logo and "lichess.org" text were completely hidden on mobile views for the sign-in and registration pages. This made the authentication context unclear, especially during OAuth flows in internal mobile browsers where the URL is partially obscured.

### **Changes Made**
* Modified `ui/lib/css/header/_title.scss`.
* Added a scoped SCSS rule for `body.auth` that overrides the default mobile `display: none` on the `.site-title` class, setting it to `display: flex` for screens smaller than the `$xx-small` breakpoint. This ensures the logo appears on auth pages without breaking the header layout on the rest of the site.

### **AI-Assisted Contribution Disclosure**
This code and the Git workflow were completed with the assistance of an AI tool, as per Lichess guidelines.
* **Tool used:** Google Gemini
* **Prompts used:** * *[Uploaded screenshot of issue #20206]*
    * *"insomma dimme che deo fa cazzo tutti i passaaggi cazzo"* (Requested step-by-step Git and terminal instructions)
    * Shared terminal outputs to debug Git initialization errors.
    * Shared contents of `_title.scss` to locate the exact `@media (max-width: at-least($xx-small))` query hiding the logo and to formulate the non-destructive SCSS override.

### **Proof of Testing**
The changes were compiled using `./ui/build -w` and tested locally using `sbt run`. The logo correctly appears on mobile views without overlapping the hamburger menu or other UI elements.

<img width="381" height="681" alt="image" src="https://github.com/user-attachments/assets/3c73eb99-f10b-4e92-ab26-9d1dc85aa087" />