### PR TITLE
nvui - Add a toggle eval button below the board

### DIFF
--- a/ui/analyse/src/view/nvuiView.ts
+++ b/ui/analyse/src/view/nvuiView.ts
@@ -257,6 +257,11 @@ function renderTouchDeviceCommands(ctx: AnalyseNvuiContext): LooseVNodes {
       ),
       hl('button', { hook: bind('click', ctrl.navigate.first) }, 'first move'),
       hl('button', { hook: bind('click', ctrl.navigate.last) }, 'last move'),
+      hl(
+        'button',
+        { hook: bind('click', () => toggleLocalEvaluation(ctrl)) },
+        noEvalStr(ctrl) ? noEvalStr(ctrl) : 'local evaluation is enabled',
+      ),
     ]),
   ];
 }
@@ -321,6 +326,10 @@ const noEvalStr = (ctrl: AnalyseCtrl) =>
     : !ctrl.cevalEnabled()
       ? 'local evaluation not enabled'
       : '';
+
+function toggleLocalEvaluation(ctrl: AnalyseCtrl): void {
+  if (ctrl.isCevalAllowed() && ctrl.ceval.analysable) ctrl.cevalEnabled(!ctrl.cevalEnabled());
+}
 
 function renderBestMove({ ctrl, moveStyle }: AnalyseNvuiContext): string {
   const noEvalMsg = noEvalStr(ctrl);


### PR DESCRIPTION
Try to solve this [issue](https://lichess.org/forum/team-the-blind-mode-team/android-problem) by adding a button under the board

When touched, the button announces the state of local evaluation:
- Not allowed
- Not enabled
- Enabled

When double tapped, it toggles the local evaluation state if local evaluation is allowed

Works fine on Iphone - VoiceOver