### PR TITLE
Fix spacing on user_tag button

### DIFF
--- a/ui/lib/css/header/_buttons.scss
+++ b/ui/lib/css/header/_buttons.scss
@@ -126,7 +126,6 @@
 #user_tag {
   @extend %flex-center-nowrap, %nowrap-ellipsis;
 
-  gap: 0.5rem;
   max-width: 40vw;
   display: inline-block;
 
@@ -137,6 +136,7 @@
     color: $m-font_dimmer--mix-85;
     content: $licon-AccountCircle;
     font-size: 2rem;
+    margin-left: 0.5rem;
   }
 
   &:hover::after {


### PR DESCRIPTION
# Context

Spacing between username and the icon is a little weird. `css` specifies a `gap:0.5rem` but that doesn't do anything since display isn't `flex`. 

This diff fixes that.

## Before

<img width="228" height="59" alt="image" src="https://github.com/user-attachments/assets/95e63c21-47d6-4f04-901e-2f80431ab45d" />

## After

<img width="206" height="62" alt="image" src="https://github.com/user-attachments/assets/f4cf5bee-8715-4e42-98e2-b024321d8dd9" />


## Overflow
<img width="279" height="69" alt="image" src="https://github.com/user-attachments/assets/3eee148b-d428-413e-a3db-a6691a92b8e4" />
