### PR TITLE
ui: small tweaks and fixes for storm puzzle

### DIFF
--- a/ui/storm/css/_end.scss
+++ b/ui/storm/css/_end.scss
@@ -77,7 +77,7 @@
       width: 100%;
 
       td {
-        padding: 0.5em 1em;
+        padding: 0.5em 1em 0.5em 2em;
         text-align: right;
 
         number {

--- a/ui/storm/css/_high.scss
+++ b/ui/storm/css/_high.scss
@@ -2,6 +2,7 @@
   &__periods {
     display: flex;
     flex-flow: row wrap;
+    gap: 4%;
 
     @media (min-width: at-least($xx-small)) {
       flex-flow: row nowrap;
@@ -14,7 +15,7 @@
     align-items: center;
     justify-content: center;
     flex: 1 1 auto;
-    margin-inline-end: 4%;
+    min-width: calc(88% / 4);
     background: $c-bg-box;
     padding: 3em 1em 1.5em 1em;
 

--- a/ui/storm/css/_storm.scss
+++ b/ui/storm/css/_storm.scss
@@ -21,16 +21,13 @@
   }
 
   &-dashboard__high__periods {
-    @media (max-width: at-most($xx-small)) {
-      display: none;
-    }
-
     @extend %zen;
   }
 
   &--reload {
     @extend %flex-column;
 
+    min-width: min(100vw, $x-small);
     justify-content: stretch;
     text-align: center;
 

--- a/ui/storm/src/view/end.ts
+++ b/ui/storm/src/view/end.ts
@@ -44,13 +44,16 @@ const renderSummary = (ctrl: StormCtrl): LooseVNodes => {
           hl('tr', [hl('th', i18n.storm.moves), hl('td', hl('number', `${run.moves}`))]),
           hl('tr', [
             hl('th', i18n.storm.accuracy),
-            hl('td', [hl('number', Number(accuracy).toFixed(1)), '%']),
+            hl('td', [hl('number', accuracy ? `${Number(accuracy).toFixed(1)}%` : '-')]),
           ]),
           hl('tr', [hl('th', i18n.storm.combo), hl('td', hl('number', `${ctrl.run.combo.best}`))]),
-          hl('tr', [hl('th', i18n.storm.time), hl('td', [hl('number', `${Math.round(run.time)}`), 's'])]),
+          hl('tr', [
+            hl('th', i18n.storm.time),
+            hl('td', [hl('number', run.time ? `${Math.round(run.time)}` : 0), 's']),
+          ]),
           hl('tr', [
             hl('th', i18n.storm.timePerMove),
-            hl('td', [hl('number', Number(run.time / run.moves).toFixed(2)), 's']),
+            hl('td', [hl('number', run.time ? Number(run.time / run.moves).toFixed(2) : 0), 's']),
           ]),
           hl('tr', [hl('th', i18n.storm.highestSolved), hl('td', hl('number', `${run.highest}`))]),
         ]),


### PR DESCRIPTION
# Why

Fixes #20223 + tweaks for storm puzzle UI.

* #20223

# How

Summary of changes:
* do not attempt to manipulate values with Number utils, when they are not set (avoid `NaN`)
* distribute high scores tiles evenly
* do not hide high score tiles on mobile, tweak mobile display
* set min width to expired storm puzzle container to avoid content cramping
* adjust spacing between stats labels and values

# Preview

<img width="1586" height="2362" alt="Screenshot 2026-04-13 at 11 51 39" src="https://github.com/user-attachments/assets/4ec57164-874f-4984-bec4-96add416c225" />

<img width="854" height="738" alt="Screenshot 2026-04-13 at 11 51 22" src="https://github.com/user-attachments/assets/42fa6267-ffa2-4cc5-a629-739e48cd2e44" />

<img width="1434" height="1640" alt="Screenshot 2026-04-13 at 11 57 58" src="https://github.com/user-attachments/assets/267a3415-05b6-4c61-b788-2743a82016ee" />
