### PR TITLE
ui: hide empty wiki box in studies

### DIFF
--- a/ui/analyse/css/study/panel/_comment.scss
+++ b/ui/analyse/css/study/panel/_comment.scss
@@ -24,7 +24,8 @@
     padding: 0.8em 1em;
     margin-top: 1vh;
 
-    &.empty {
+    &.empty,
+    &:empty {
       display: none;
     }
   }


### PR DESCRIPTION
# Why

Fixes #20195

* #20195

# How

Add CSS `:empty` selector to existing manual set `.empty` class to make the styling more robust.

# Preview

<img width="2108" height="1892" alt="Screenshot 2026-04-13 at 12 10 37" src="https://github.com/user-attachments/assets/591165c0-fd44-48b5-90a0-55f2e97f3870" />
