### PR TITLE
ui: distribute evenly study edit panel buttons, improve a11y

### DIFF
--- a/ui/analyse/src/study/studyView.ts
+++ b/ui/analyse/src/study/studyView.ts
@@ -319,7 +319,7 @@ function buttons(root: AnalyseCtrl): VNode {
       }),
       !ctrl.relay &&
         !ctrl.data.chapter.gamebook &&
-        hl('span.help', {
+        hl('button.help', {
           attrs: { title: i18n.study.getTheTour, ...dataIcon(licon.InfoCircle) },
           hook: bind('click', ctrl.startTour),
         }),


### PR DESCRIPTION
# Why

While working on previous fix, spotted that tab buttons in study edit are not distributed evenly (tour button is wider than others).

# How

Convert tour tab button to use `button` element not `span` to inherit same styles, and allow focusing it by keyboard/focus.

# Preview

### Before

<img width="1214" height="404" alt="Screenshot 2026-04-13 at 12 23 06" src="https://github.com/user-attachments/assets/2c219938-764c-42d9-b446-8f4f0e884547" />

### After

<img width="1214" height="404" alt="Screenshot 2026-04-13 at 12 15 34" src="https://github.com/user-attachments/assets/72f25f91-f130-4e4e-b5ce-351d8f3c44a8" />
