### PR TITLE
Keep start of game chat buttons around for a move longer.

### DIFF
--- a/ui/lib/src/chat/preset.ts
+++ b/ui/lib/src/chat/preset.ts
@@ -67,6 +67,7 @@ export function presetView(ctrl: PresetCtrl): VNode | undefined {
   return sets && said.length < 2
     ? h(
         'div.mchat__presets',
+        { key: group },
         sets.map((p: Preset) => {
           const disabled = said.includes(p.key);
           return h(

--- a/ui/round/src/round.ts
+++ b/ui/round/src/round.ts
@@ -2,7 +2,7 @@ import { attributesModule, classModule, init } from 'snabbdom';
 
 import { myUserId } from 'lib';
 import standaloneChat from 'lib/chat/standalone';
-import type { TourPlayer } from 'lib/game';
+import { finished, type TourPlayer } from 'lib/game';
 import { setClockWidget } from 'lib/game/clock/clockWidget';
 import menuHover from 'lib/menuHover';
 import { pubsub } from 'lib/pubsub';
@@ -109,7 +109,7 @@ async function boot(
   };
   const getPresetGroup = (d: RoundData) => {
     if (d.player.spectator) return;
-    if (d.game.status.id >= 30) return 'end';
+    if (finished(d)) return 'end';
     if (d.steps.length < 6) return 'start';
     return;
   };

--- a/ui/round/src/round.ts
+++ b/ui/round/src/round.ts
@@ -109,8 +109,8 @@ async function boot(
   };
   const getPresetGroup = (d: RoundData) => {
     if (d.player.spectator) return;
-    if (d.steps.length < 4) return 'start';
-    else if (d.game.status.id >= 30) return 'end';
+    if (d.game.status.id >= 30) return 'end';
+    if (d.steps.length < 6) return 'start';
     return;
   };
   const ctrl = await roundMain(opts);


### PR DESCRIPTION
Changes:
- Start of game chat buttons (good luck, you too, etc) remain for first 4 ply, rather than first 2.
- If a game ends at ply 2, the chat buttons for end of game will show, rather than the start of game ones.
- Note that the `{ key: group },` addition in the code is needed, since buttons can now switch from start of game to end of game ones (if the game ends at ply 2, 3, or 4). Therefore, snabbdom needs to be forced to recreate the DOM, so that the hooks are updated to say the right messages.

First point motivated by personal use case:
- Playing Black on phone.
- Opponent makes a move, I reply.
- I scroll down and see they said something, like good luck.
- I want to reply you too, but by then they've made their second move and the button's gone.