### PR TITLE
fix: game search analysed filter silently drops all other filters

### DIFF
--- a/modules/api/src/main/GameApiV2.scala
+++ b/modules/api/src/main/GameApiV2.scala
@@ -419,7 +419,7 @@ object GameApiV2:
           white = color.exists(_.white).option(user.id.into(UserStr)),
           black = color.exists(_.black).option(user.id.into(UserStr))
         ),
-        analysed = analysed.map(_.so(1)),
+        analysed = analysed,
         sort = toSorting.some
       ).query.copy(
         date = DateRange(since.map(ts), until.map(ts)),

--- a/modules/gameSearch/src/main/GameSearchForm.scala
+++ b/modules/gameSearch/src/main/GameSearchForm.scala
@@ -41,7 +41,7 @@ final private[gameSearch] class GameSearchForm:
       "dateMin" -> GameSearchForm.dateField,
       "dateMax" -> GameSearchForm.dateField,
       "status" -> optional(numberIn(FormHelpers.statuses)),
-      "analysed" -> optional(number),
+      "analysed" -> optional(tolerantBoolean),
       "sort" -> optional(
         mapping(
           "field" -> stringIn(Sorting.fields),
@@ -74,7 +74,7 @@ case class SearchData(
     dateMin: Option[LocalDate] = None,
     dateMax: Option[LocalDate] = None,
     status: Option[Int] = None,
-    analysed: Option[Int] = None,
+    analysed: Option[Boolean] = None,
     sort: Option[SearchSort] = None
 ):
 
@@ -98,7 +98,7 @@ case class SearchData(
     aiLevel = IntRange(aiLevelMin, aiLevelMax),
     date = DateRange(dateMin.map(transform), dateMax.map(transform)),
     duration = IntRange(durationMin, durationMax),
-    analysed = analysed.map(_ == 1),
+    analysed = analysed,
     whiteUser = players.cleanWhite.map(_.value),
     blackUser = players.cleanBlack.map(_.value),
     sorting = SpecSorting(sortOrDefault.field, sortOrDefault.order),


### PR DESCRIPTION
Fixes #20252  
## What was wrong

  The \"Analysed games only\" checkbox on \`/@/:user/search\` submits the value \"true\" (a string), but the form field was declared as \`optional(number)\`. Play's \`number\` binder rejects \"true\" as invalid, so the entire form binding fails silently.

  When binding fails, lila falls back to a default \`SearchData\` with no filters at all, meaning every other selected filter (perf, time control, opponent, rating range, etc.) is discarded, and the result set contains all of the user's games instead of the filtered subset.

  ## Fix

  **\`modules/gameSearch/src/main/GameSearchForm.scala\`**

  - \`optional(number)\` → \`optional(tolerantBoolean)\`
  - Field type \`Option[Int]\` → \`Option[Boolean]\`
  - Remove the now-unnecessary \`analysed.map(_ == 1)\` conversion

  **\`modules/api/src/main/GameApiV2.scala\`**

  - Remove \`analysed.map(_.so(1))\` — this was a \`Boolean → Int → Boolean\` round-trip that always returned the identity value

  ## Testing

  Created 40 local test games for a test user (20 bullet, 20 rapid of which 5 rapid + computer-analysed). Searched at \`/@/user/search\`:

  | Filters applied | Expected | Before fix | After fix |
  |---|---|---|---|
  | Rapid only | 20 | 20 ✓ | 20 ✓ |
  | Rapid + Analysed | 5 | 40 ✗ | 5 ✓ |
  | Bullet + Analysed | 0 | 40 ✗ | 0 ✓ |
  | Analysed only (no perf filter) | 5 | 40 ✗ | 5 ✓ |

  ## AI disclosure

  This fix was developed with Claude Code (claude-sonnet-4-6). I traced the form submission path from the checkbox HTML through \`GameSearchForm.scala → UserGameSearch → GameSearchApi → PaginatorBuilder\`, identified the `optional(number)\` / \`\"true\"\` mismatch, and verified the fix with local test data against a running lila + lila-search instance.

<img width="1064" height="941" alt="image" src="https://github.com/user-attachments/assets/612782f5-e310-4e93-9e0d-f3957f02b31a" />

Toggling the \"Analysed games only\" checkbox now limits the total number of games.
<img width="1072" height="942" alt="image" src="https://github.com/user-attachments/assets/8cf7b738-ccc6-4501-b6c1-315ccf498c1a" />

