### PR TITLE
ui: refactor FAQ page, use semantic tags, visual improvements

### DIFF
--- a/app/controllers/Main.scala
+++ b/app/controllers/Main.scala
@@ -83,7 +83,7 @@ final class Main(env: Env, assetsC: ExternalAssets) extends LilaController(env):
 
   def faq = Open:
     pageHit
-    Ok.page(views.site.page.faq.apply)
+    Ok.page(views.site.page.faq)
 
   def temporarilyDisabled(@annotation.nowarn path: String) = Open:
     pageHit

--- a/app/views/site.scala
+++ b/app/views/site.scala
@@ -8,10 +8,12 @@ val ui = lila.web.ui.SitePages(helpers)
 
 object page:
 
-  val faq = lila.web.ui.FaqUi(helpers, ui)(
+  private val faqUi = lila.web.ui.FaqUi(helpers, ui)(
     standardRankableDeviation = lila.rating.Glicko.standardRankableDeviation,
     variantRankableDeviation = lila.rating.Glicko.variantRankableDeviation
   )
+
+  def faq(using Context) = faqUi.apply.js(esmInitBit("faq"))
 
   def withMenu(active: String, p: CmsPage.Render)(using Context) =
     ui.SitePage(

--- a/modules/web/src/main/ui/FaqUi.scala
+++ b/modules/web/src/main/ui/FaqUi.scala
@@ -17,11 +17,12 @@ final class FaqUi(helpers: Helpers, sitePages: SitePages)(
   private def cmsPageUrl(key: String) = routes.Cms.lonePage(lila.core.id.CmsPageKey(key))
 
   private def question(id: String, title: String, answer: Frag*) =
-    div(
+    details(
       st.id := id,
-      cls := "question"
+      cls := "question",
+      name := "faq"
     )(
-      h3(a(href := s"#$id")(title)),
+      summary(span(title)),
       div(cls := "answer")(answer)
     )
 

--- a/ui/bits/css/_faq.scss
+++ b/ui/bits/css/_faq.scss
@@ -1,38 +1,68 @@
+@supports (interpolate-size: allow-keywords) {
+  :root {
+    interpolate-size: allow-keywords;
+  }
+
+  ::details-content {
+    transition:
+      height 0.3s ease,
+      content-visibility 0.3s ease allow-discrete;
+    height: 0;
+    overflow: clip;
+  }
+
+  [open]::details-content {
+    height: auto;
+  }
+}
+
 .faq {
   .question {
-    .answer {
-      display: none;
+    @extend %box-radius;
+    @include backdrop-blur-if-transparent;
+
+    border: $border;
+    background: $c-bg-zebra;
+    padding: 1em 2em;
+    margin-top: 1em;
+
+    & + h2 {
+      margin-top: 1.3em;
     }
 
-    &:target {
-      @extend %box-neat;
+    &:open {
+      summary,
+      summary::marker {
+        color: $c-accent;
+      }
+    }
 
-      background: $c-bg-zebra;
-      padding: 2em 3em 1em 3em;
-      margin-top: 1em;
+    summary {
+      font-size: 1.3em;
+      padding-top: 0;
+      cursor: pointer;
+      font-weight: bold;
 
-      .answer {
-        display: block;
+      &::marker {
+        color: $c-font-dim;
       }
 
-      h3 {
-        padding-top: 0;
-        font-weight: bold;
+      span {
+        margin-left: 0.25em;
+      }
+    }
 
-        a {
-          color: $c-accent;
-        }
+    .answer {
+      padding-top: 0.5em;
+
+      & *:last-child {
+        margin-bottom: 0.25em;
       }
     }
   }
 
   h2 {
-    margin: 1.3em 0 0.3em 0;
-  }
-
-  h3 {
-    font-size: 1.3em;
-    padding: 1em 0;
+    margin-bottom: 0.3em;
   }
 
   h4 {

--- a/ui/bits/src/bits.ts
+++ b/ui/bits/src/bits.ts
@@ -23,6 +23,8 @@ export function initModule(args: { fn: string } & any): void {
       return embedReasonToggle();
     case 'eventCountdown':
       return eventCountdown();
+    case 'faq':
+      return faq();
     case 'hcaptcha':
       return hcaptcha();
     case 'importer':
@@ -145,6 +147,24 @@ function eventCountdown() {
     const interval = setInterval(redraw, second);
 
     redraw();
+  });
+}
+
+function faq() {
+  if (location.hash) {
+    const target = document.querySelector(location.hash);
+    const details = target?.closest('details');
+    if (details) {
+      details.open = true;
+    }
+  }
+
+  document.querySelectorAll('details > summary').forEach(summary => {
+    summary.addEventListener('click', () => {
+      const details = summary.closest('details');
+      if (!details?.id) return;
+      history.replaceState(null, '', `#${details.id}`);
+    });
   });
 }
 


### PR DESCRIPTION
# Why

Currently, the FAQ user experience felt a bit off and the open state was driven by hash presence leading to weird scroll position and content jumps.

# How

Refactor FAQ page:
* use semantic elements - `details` and `summary`
* add pure CSS based expand/collapse animations (if browser supports them)
  > Unfortunately only V8 based browsers supports animations fully - https://wpt.fyi/results/css/css-values/calc-size?label=master&label=experimental&aligned&q=interpolate-size - on other browser content just appears instantly.
* use `name` to group details to retain previously behaviour - only one open question at the time
* inject small JS bit to allow hash injection and open given question if hash matches (`a` elements cannot be used with or within `summary`)

# Preview

https://github.com/user-attachments/assets/af10a248-ac4c-4c09-b300-ea26b0dd6bab