### PR TITLE
Immediately update the chess 960 position id in `onChange`

### DIFF
--- a/ui/editor/src/chess960.ts
+++ b/ui/editor/src/chess960.ts
@@ -55,10 +55,10 @@ export const randomPositionId = (): number => Math.floor(Math.random() * 960);
 
 export const isValidPositionId = (id: number): boolean => Number.isInteger(id) && id >= 0 && id <= 959;
 
-export function fenToChess960Id(fen: FEN): number | undefined {
-  const parts = fen.split(' ');
-  if (parts.length < 1) return undefined;
-  const ranks = parts[0].split('/');
+export function firstFenFieldToChess960Id(firstFenField: string): number | undefined {
+  if (firstFenField.includes(' '))
+    throw new Error('`firstFenField` should only be the piece placement portion');
+  const ranks = firstFenField.split('/');
   if (ranks.length !== 8) return undefined;
   const rank = ranks[7];
   if (rank.toLowerCase() !== ranks[0] || rank.length !== 8 || rank !== rank.toUpperCase()) return undefined;
@@ -97,6 +97,11 @@ export function fenToChess960Id(fen: FEN): number | undefined {
   return krnIndex === -1
     ? undefined
     : lightBishopIndex + 4 * darkBishopIndex + 16 * queenIndex + 96 * krnIndex;
+}
+
+export function fenToChess960Id(fen: FEN): number | undefined {
+  const parts = fen.split(' ');
+  return parts.length < 1 ? undefined : firstFenFieldToChess960Id(parts[0]);
 }
 
 function chess960IdToRank(id: number): string {

--- a/ui/editor/src/chess960.ts
+++ b/ui/editor/src/chess960.ts
@@ -55,10 +55,9 @@ export const randomPositionId = (): number => Math.floor(Math.random() * 960);
 
 export const isValidPositionId = (id: number): boolean => Number.isInteger(id) && id >= 0 && id <= 959;
 
-export function firstFenFieldToChess960Id(firstFenField: string): number | undefined {
-  if (firstFenField.includes(' '))
-    throw new Error('`firstFenField` should only be the piece placement portion');
-  const ranks = firstFenField.split('/');
+export function boardFenToChess960Id(boardFen: string): number | undefined {
+  if (boardFen.includes(' ')) throw new Error('`boardFen` should only be the piece placement portion');
+  const ranks = boardFen.split('/');
   if (ranks.length !== 8) return undefined;
   const rank = ranks[7];
   if (rank.toLowerCase() !== ranks[0] || rank.length !== 8 || rank !== rank.toUpperCase()) return undefined;
@@ -101,7 +100,7 @@ export function firstFenFieldToChess960Id(firstFenField: string): number | undef
 
 export function fenToChess960Id(fen: FEN): number | undefined {
   const parts = fen.split(' ');
-  return parts.length < 1 ? undefined : firstFenFieldToChess960Id(parts[0]);
+  return parts.length < 1 ? undefined : boardFenToChess960Id(parts[0]);
 }
 
 function chess960IdToRank(id: number): string {

--- a/ui/editor/src/ctrl.ts
+++ b/ui/editor/src/ctrl.ts
@@ -16,7 +16,7 @@ import {
   chess960CastlingSquares,
   chess960IdToFEN,
   fenToChess960Id,
-  firstFenFieldToChess960Id,
+  boardFenToChess960Id,
   randomPositionId,
 } from './chess960';
 import {
@@ -120,8 +120,7 @@ export default class EditorCtrl {
 
   onChange(): void {
     // We can use the first field of the fen now; it's the ep and castle fields that may be inaccurate at the moment.
-    this.chess960PositionId =
-      firstFenFieldToChess960Id(this.getFen().split(' ')[0]) ?? this.chess960PositionId;
+    this.chess960PositionId = boardFenToChess960Id(this.getFen().split(' ')[0]) ?? this.chess960PositionId;
     // The id will be used for computing castling toggles, which will in turn be used in the later `this.getFen()` call.
     this.enabledCastlingToggles = this.computeCastlingToggles();
     if (this.guessCastlingToggles) {

--- a/ui/editor/src/ctrl.ts
+++ b/ui/editor/src/ctrl.ts
@@ -12,7 +12,13 @@ import { Castles, defaultPosition, Position, setupPosition } from 'chessops/vari
 import { defined, prop, type Prop } from 'lib';
 import { prompt } from 'lib/view';
 
-import { chess960CastlingSquares, chess960IdToFEN, fenToChess960Id, randomPositionId } from './chess960';
+import {
+  chess960CastlingSquares,
+  chess960IdToFEN,
+  fenToChess960Id,
+  firstFenFieldToChess960Id,
+  randomPositionId,
+} from './chess960';
 import {
   type EditorState,
   type Selected,
@@ -113,17 +119,19 @@ export default class EditorCtrl {
   }
 
   onChange(): void {
+    // We can use the first field of the fen now; it's the ep and castle fields that may be inaccurate at the moment.
+    this.chess960PositionId =
+      firstFenFieldToChess960Id(this.getFen().split(' ')[0]) ?? this.chess960PositionId;
+    // The id will be used for computing castling toggles, which will in turn be used in the later `this.getFen()` call.
     this.enabledCastlingToggles = this.computeCastlingToggles();
     if (this.guessCastlingToggles) {
       this.castlingToggles = { ...this.enabledCastlingToggles };
     }
-
     const fen = this.fenFixedEp(this.getFen());
     if (!this.cfg.embed) {
       window.history.replaceState(null, '', this.makeEditorUrl(fen, this.bottomColor()));
     }
     this.options.onChange?.(fen);
-    this.chess960PositionId = fenToChess960Id(fen) ?? this.chess960PositionId;
     this.redraw();
   }
 


### PR DESCRIPTION
Closes #20260.

Since the 960 id is used for computing castling toggles, we need to make sure it's updated as needed beforehand.

I also broke up `fenToChess960Id` into two functions, so that the new one (that just accepts the first field of the fen) can be used in `onChange`. This is to mitigate code smell, since sending a full FEN that's potentially wrong for ep and castling could lead to bugs in the future.