### PR TITLE
persist explorer player-tab color across refresh

### DIFF
--- a/ui/analyse/src/explorer/explorerConfig.ts
+++ b/ui/analyse/src/explorer/explorerConfig.ts
@@ -36,7 +36,7 @@ export interface ExplorerConfigData {
     value: StoredProp<string>;
     previous: Prop<string[]>;
   };
-  color: Prop<Color>;
+  color: StoredProp<Color>;
   byDb(): ByDbSetting;
 }
 
@@ -77,7 +77,7 @@ export class ExplorerConfigCtrl {
         value: storedStringProp('analyse.explorer.player.name', this.myName || ''),
         previous: storedJsonProp<string[]>('explorer.player.name.previous', () => []),
       },
-      color: prevData?.color || prop(root.bottomColor()),
+      color: storedProp<Color>('analyse.explorer.color', root.bottomColor(), str => str as Color),
       byDb() {
         return this.byDbData[this.db()] || this.byDbData.lichess;
       },

--- a/ui/analyse/src/explorer/explorerConfig.ts
+++ b/ui/analyse/src/explorer/explorerConfig.ts
@@ -77,7 +77,7 @@ export class ExplorerConfigCtrl {
         value: storedStringProp('analyse.explorer.player.name', this.myName || ''),
         previous: storedJsonProp<string[]>('explorer.player.name.previous', () => []),
       },
-      color: storedProp<Color>('analyse.explorer.color', root.bottomColor(), str => str as Color),
+      color: storedProp<Color>('analyse.explorer.player.color', root.bottomColor(), str => str as Color),
       byDb() {
         return this.byDbData[this.db()] || this.byDbData.lichess;
       },


### PR DESCRIPTION
Closes #18107.

## Problem
On the analysis Explorer, setting the Player tab side to Black and refreshing reverts it back to White. The tab and player name are preserved because they use `storedProp`, but `color` was a plain in-memory `prop`.

## Fix
One field change in `ui/analyse/src/explorer/explorerConfig.ts`:
- `color: Prop<Color>` → `color: StoredProp<Color>`
- `prop(root.bottomColor())` → `storedProp<Color>('analyse.explorer.color', root.bottomColor(), str => str as Color)`

Matches the pattern used by the `db` field two lines above.

## Testing
Verified end-to-end locally against lila-docker running my branch:

1. Opened Explorer config → Player tab → toggled to "as black"
2. Hard-refreshed the page
3. Reopened Explorer config → Player tab
4. Side was still "as black"

Also compared against production lichess.org in the same session, where the same flow reverts to "as white" on refresh.

Screen recording demonstrating both the production bug and the localhost fix attached below.

https://github.com/user-attachments/assets/6cf29e59-e082-4273-ba46-84a409cca846


## AI disclosure
Parts of this change were drafted with help from Claude (Anthropic). Prompt intent: locate the one-line field in the explorer config that isn't persisted and make it match the pattern used by the other persisted fields in the same object. All code reviewed by me and verified locally.