### PR TITLE
centre lobby sort-column values and stop sort-triangle shift

### DIFF
--- a/ui/lobby/css/app/_hook-list.scss
+++ b/ui/lobby/css/app/_hook-list.scss
@@ -42,6 +42,13 @@
 
     &.sortable {
       cursor: pointer;
+      text-align: center;
+
+      .is::before {
+        content: $licon-DownTriangle;
+        margin-inline-end: 3px;
+        opacity: 0;
+      }
     }
 
     &.sortable:hover,
@@ -51,8 +58,6 @@
 
     &.sort .is::before {
       opacity: 0.7;
-      margin-inline-end: 3px;
-      content: $licon-DownTriangle;
     }
 
     &.player {
@@ -68,6 +73,11 @@
         text-align: left;
       }
     }
+  }
+
+  &:has(th.sortable) td:nth-child(2),
+  &:has(th.sortable) td:nth-child(3) {
+    text-align: center;
   }
 
   td {


### PR DESCRIPTION
Closes #18744.

## Problem
The sort triangle (▼) is only rendered inside the currently-active sortable column header. Clicking Rating vs Time moves the triangle between columns, reflowing:
- the header text (pushed right by the triangle's inline width + margin)
- the values in the two columns below (since column widths change)

Result: clicking a different sort option makes the whole table shift horizontally.

## Fix
`ui/lobby/css/app/_hook-list.scss`:
- Render the triangle on every sortable header, toggle it via `opacity` instead of swapping `content`. Column widths stay identical regardless of which column is currently the sort.
- Centre sortable headers and their matching cells (`:has(th.sortable) td:nth-child(2|3)`) so values sit under the header text instead of left-aligning against the triangle.

No markup change. Only affects the lobby's realtime hook list.

## Testing
Verified locally against lila-docker running my branch. Clicked between Rating and Time repeatedly:
- Triangle moves between columns
- Cell positions stay identical (sub-pixel jitter only, measured via `getBoundingClientRect`)
- Non-sortable Mode column unchanged

Screen recording attached below.

## AI disclosure
Parts of this change were drafted with help from Claude (Anthropic). Prompt intent: find why the lobby columns shift on sort change (`_hook-list.scss`), reserve the triangle's space on all sortable headers, and centre sort-column data so values sit under the header text. All code reviewed by me and verified locally.