### PR TITLE
Fix: check whether variant is 960 when computing dests in analysis

### DIFF
--- a/ui/lib/src/tree/node.ts
+++ b/ui/lib/src/tree/node.ts
@@ -17,7 +17,7 @@ export const completeNode =
     node.pos ||= memoize(() =>
       parseFen(node.fen).chain(setup => setupPosition(lichessRules(variant), setup)),
     );
-    node.dests = memoize(() => computeDests(node.pos()));
+    node.dests = memoize(() => computeDests(node.pos(), variant === 'chess960'));
     node.drops = memoize(() => computeDrops(variant, node.pos()));
     node.check = memoize(() => computeCheck(node.pos()));
     node.outcome ||= memoize(() => computeOutcome(node.pos()));
@@ -25,7 +25,8 @@ export const completeNode =
     return node;
   };
 
-const computeDests = (position: PositionResult) => withPosition(position, new Map(), chessgroundDests);
+const computeDests = (position: PositionResult, chess960: boolean) =>
+  withPosition<Dests>(position, new Map(), p => chessgroundDests(p, { chess960 }));
 
 const computeDrops = (variant: VariantKey, position: PositionResult): Key[] | undefined =>
   variant === 'crazyhouse'


### PR DESCRIPTION
Fixes  #20268

Chessops already had the compat to check if the variant is 960 we just never specified it.
Allows only king on rook castling for 960 positions.