### PR TITLE
fix: show lichess logo on auth pages

### DIFF
--- a/modules/web/src/main/ui/AuthUi.scala
+++ b/modules/web/src/main/ui/AuthUi.scala
@@ -25,7 +25,10 @@ final class AuthUi(helpers: Helpers):
       .csp(_.withTurnstile)
       .hrefLangs(lila.ui.LangPath(routes.Auth.login)):
         main(cls := "auth auth-login box box-pad")(
-          span(cls := "auth__logo", aria.label := "Lichess"),
+          div(cls := "auth__brand")(
+            span(cls := "auth__logo", aria.hidden := "true"),
+            span(cls := "auth__brand-name")("lichess.org")
+          ),
           authTabs("login"),
           postForm(
             cls := "form3",
@@ -100,7 +103,10 @@ final class AuthUi(helpers: Helpers):
             "auth-signup--simple" -> simple
           )
         )(
-          span(cls := "auth__logo", aria.label := "Lichess"),
+          div(cls := "auth__brand")(
+            span(cls := "auth__logo", aria.hidden := "true"),
+            span(cls := "auth__brand-name")("lichess.org")
+          ),
           authTabs("signup"),
           postForm(
             id := "signup-form",

--- a/modules/web/src/main/ui/AuthUi.scala
+++ b/modules/web/src/main/ui/AuthUi.scala
@@ -14,6 +14,12 @@ final class AuthUi(helpers: Helpers):
   private def addReferrer(url: String)(using referrer: Option[ValidReferrer]): String =
     referrer.fold(url)(ref => addQueryParam(url, "referrer", ref.value))
 
+  private def logoAndName =
+    div(cls := "auth__brand")(
+      span(cls := "auth__logo", aria.hidden := "true"),
+      span(cls := "auth__brand-name")("lichess.org")
+    )
+
   def login(form: Form[?], isRememberMe: Boolean = true)(using
       TurnstilePublicConfig,
       Option[ValidReferrer]
@@ -25,10 +31,7 @@ final class AuthUi(helpers: Helpers):
       .csp(_.withTurnstile)
       .hrefLangs(lila.ui.LangPath(routes.Auth.login)):
         main(cls := "auth auth-login box box-pad")(
-          div(cls := "auth__brand")(
-            span(cls := "auth__logo", aria.hidden := "true"),
-            span(cls := "auth__brand-name")("lichess.org")
-          ),
+          logoAndName,
           authTabs("login"),
           postForm(
             cls := "form3",
@@ -103,10 +106,7 @@ final class AuthUi(helpers: Helpers):
             "auth-signup--simple" -> simple
           )
         )(
-          div(cls := "auth__brand")(
-            span(cls := "auth__logo", aria.hidden := "true"),
-            span(cls := "auth__brand-name")("lichess.org")
-          ),
+          logoAndName,
           authTabs("signup"),
           postForm(
             id := "signup-form",

--- a/modules/web/src/main/ui/AuthUi.scala
+++ b/modules/web/src/main/ui/AuthUi.scala
@@ -25,6 +25,7 @@ final class AuthUi(helpers: Helpers):
       .csp(_.withTurnstile)
       .hrefLangs(lila.ui.LangPath(routes.Auth.login)):
         main(cls := "auth auth-login box box-pad")(
+          span(cls := "auth__logo", aria.label := "Lichess"),
           authTabs("login"),
           postForm(
             cls := "form3",
@@ -99,6 +100,7 @@ final class AuthUi(helpers: Helpers):
             "auth-signup--simple" -> simple
           )
         )(
+          span(cls := "auth__logo", aria.label := "Lichess"),
           authTabs("signup"),
           postForm(
             id := "signup-form",

--- a/modules/web/src/main/ui/AuthUi.scala
+++ b/modules/web/src/main/ui/AuthUi.scala
@@ -16,8 +16,8 @@ final class AuthUi(helpers: Helpers):
 
   private def logoAndName =
     div(cls := "auth__brand")(
-      span(cls := "auth__logo", aria.hidden := "true"),
-      span(cls := "auth__brand-name")("lichess.org")
+      span(cls := "auth__brand__logo", aria.hidden := "true"),
+      span(cls := "auth__brand__name")("lichess.org")
     )
 
   def login(form: Form[?], isRememberMe: Boolean = true)(using

--- a/ui/bits/css/_auth.scss
+++ b/ui/bits/css/_auth.scss
@@ -26,17 +26,29 @@ $auth-input-bg: rgba(26, 22, 16, 1);
   border-radius: $auth-input-radius;
   border: $border;
 
+  .auth__brand {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 1.5rem;
+  }
+
   .auth__logo {
     display: block;
     width: 64px;
     height: 64px;
-    margin: 0 auto 1.5rem;
     background: center no-repeat url('../logo/lichess-white.svg');
     background-size: contain;
 
     @include if-light {
       background-image: url('../logo/lichess.svg');
     }
+  }
+
+  .auth__brand-name {
+    font-size: 1.5rem;
+    font-weight: bold;
   }
 
   .auth-tabs {

--- a/ui/bits/css/_auth.scss
+++ b/ui/bits/css/_auth.scss
@@ -26,29 +26,29 @@ $auth-input-bg: rgba(26, 22, 16, 1);
   border-radius: $auth-input-radius;
   border: $border;
 
-  .auth__brand {
+  &__brand {
     display: flex;
     flex-direction: column;
     align-items: center;
     gap: 0.5rem;
     margin-bottom: 1.5rem;
-  }
 
-  .auth__logo {
-    display: block;
-    width: 64px;
-    height: 64px;
-    background: center no-repeat url('../logo/lichess-white.svg');
-    background-size: contain;
+    &__logo {
+      display: block;
+      width: 64px;
+      height: 64px;
+      background: center no-repeat url('../logo/lichess-white.svg');
+      background-size: contain;
 
-    @include if-light {
-      background-image: url('../logo/lichess.svg');
+      @include if-light {
+        background-image: url('../logo/lichess.svg');
+      }
     }
-  }
 
-  .auth__brand-name {
-    font-size: 1.5rem;
-    font-weight: bold;
+    &__name {
+      font-size: 1.5rem;
+      font-weight: bold;
+    }
   }
 
   .auth-tabs {
@@ -289,23 +289,28 @@ $auth-input-bg: rgba(26, 22, 16, 1);
   .cf-turnstile {
     margin: 1em 0;
   }
+
   .button.submit {
     .button__loader .spinner {
       width: 1.3em;
       height: 1.3em;
     }
+
     .button__ready {
       display: block;
     }
+
     .button__verifying {
       justify-content: center;
       gap: 1ch;
       display: none;
     }
+
     &:disabled {
       .button__ready {
         display: none;
       }
+
       .button__verifying {
         display: flex;
       }

--- a/ui/bits/css/_auth.scss
+++ b/ui/bits/css/_auth.scss
@@ -26,6 +26,19 @@ $auth-input-bg: rgba(26, 22, 16, 1);
   border-radius: $auth-input-radius;
   border: $border;
 
+  .auth__logo {
+    display: block;
+    width: 64px;
+    height: 64px;
+    margin: 0 auto 1.5rem;
+    background: center no-repeat url('../logo/lichess-white.svg');
+    background-size: contain;
+
+    @include if-light {
+      background-image: url('../logo/lichess.svg');
+    }
+  }
+
   .auth-tabs {
     @extend %flex-center-nowrap;
 

--- a/ui/bits/css/_auth.scss
+++ b/ui/bits/css/_auth.scss
@@ -7,6 +7,13 @@
   display: none;
 }
 
+@media (max-width: at-most($medium)) {
+  .site-title,
+  .site-title-nav__donate {
+    display: none;
+  }
+}
+
 .checklist {
   font-size: 1.5em;
   font-weight: 700;
@@ -27,11 +34,15 @@ $auth-input-bg: rgba(26, 22, 16, 1);
   border: $border;
 
   &__brand {
-    display: flex;
-    flex-direction: column;
+    @extend %flex-column;
+
     align-items: center;
     gap: 0.5rem;
-    margin-bottom: 1.5rem;
+    margin: -0.5em 0 2em 0;
+
+    @media (width >= $large) {
+      display: none;
+    }
 
     &__logo {
       display: block;
@@ -47,7 +58,6 @@ $auth-input-bg: rgba(26, 22, 16, 1);
 
     &__name {
       font-size: 1.5rem;
-      font-weight: bold;
     }
   }
 

--- a/ui/lib/css/header/_title.scss
+++ b/ui/lib/css/header/_title.scss
@@ -51,7 +51,7 @@
     }
   }
 
-  @media (min-width: at-least(1180px)) {
+  @media (min-width: at-least($large)) {
     .site-name {
       display: block;
     }


### PR DESCRIPTION
closes #20206 

adds lichess logo on auth pages for both desktop and mobile 

### Desktop light & dark mode
<img width="1920" height="1055" alt="image" src="https://github.com/user-attachments/assets/009426ab-94ad-4d93-8ac9-e302f74edbaa" />
<img width="1920" height="1054" alt="image" src="https://github.com/user-attachments/assets/9e316134-16f7-4d02-a08a-f417095e455d" />



### Mobile light & dark mode
<img width="1919" height="1058" alt="image" src="https://github.com/user-attachments/assets/15e287c1-19d8-4950-8732-d10dc2ce295e" />
<img width="1920" height="1054" alt="image" src="https://github.com/user-attachments/assets/7fea7218-1a4a-405a-8f84-78e08ab75257" />


