### PR TITLE
enable `eqeqeq` lint rule, fix new warnings

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -6,6 +6,13 @@
   },
   "ignorePatterns": ["**/dist/", "**/public"],
   "rules": {
+    "eqeqeq": [
+      "error",
+      "always",
+      {
+        "null": "ignore"
+      }
+    ],
     "no-var": "warn",
     "no-constant-condition": [
       "warn",

--- a/bin/mongodb/analysis2.js
+++ b/bin/mongodb/analysis2.js
@@ -71,11 +71,11 @@ const piotr = {
 };
 
 function decodePiotr(pp) {
-  return pp == '_' ? null : (piotr[pp[0]] + piotr[pp[1]]).toLowerCase();
+  return pp === '_' ? null : (piotr[pp[0]] + piotr[pp[1]]).toLowerCase();
 }
 
 function decodeScore(pp) {
-  return pp == '_' ? null : parseInt(pp);
+  return pp === '_' ? null : parseInt(pp);
 }
 
 print('Migrating ' + max + ' analysis');
@@ -87,7 +87,7 @@ let nb = 0,
 gamesToMigrate.forEach(function (a) {
   const encoded = a.encoded;
   if (!encoded) return;
-  if (typeof encoded == 'undefined') return;
+  if (typeof encoded === 'undefined') return;
   try {
     const splitted = encoded.split(' ');
     const data = [];
@@ -98,7 +98,7 @@ gamesToMigrate.forEach(function (a) {
         best = decodePiotr(cur[1]),
         score = decodeScore(next[2]),
         mate = decodeScore(next[3]);
-      data.push([score, mate == null ? null : it % 2 == 1 ? mate : -mate].join(','));
+      data.push([score, mate == null ? null : it % 2 === 1 ? mate : -mate].join(','));
     }
     a.data = data.join(';');
     delete a.encoded;
@@ -112,7 +112,7 @@ gamesToMigrate.forEach(function (a) {
     print(e);
   }
   ++nb;
-  if (nb % batchSize == 0) {
+  if (nb % batchSize === 0) {
     const percent = Math.round((nb / max) * 100);
     const dat2 = Date.now() / 1000;
     const perSec = Math.round(batchSize / (dat2 - dat));

--- a/bin/mongodb/chat-cleanup.js
+++ b/bin/mongodb/chat-cleanup.js
@@ -17,10 +17,10 @@ const isChatGarbage = chat =>
 
 // system, anon, bots
 const isAuthorGarbage = author =>
-  author == 'lichess' || author == 'w' || author == 'b' || author.indexOf('BOT~') == 0;
+  author === 'lichess' || author === 'w' || author === 'b' || author.indexOf('BOT~') === 0;
 
 // shadowbanned and deleted
-const isFlagGarbage = flag => flag == '!' || flag == '?';
+const isFlagGarbage = flag => flag === '!' || flag === '?';
 
 const presets = new Set([
   'good luck',
@@ -56,7 +56,7 @@ const flushBuffer = () => {
   }
   idBuffer = [];
   deleted += flushEvery;
-  if (deleted % 100000 == 0)
+  if (deleted % 100000 === 0)
     print(`${numberFormat(deleted)} / ${numberFormat(read)} - ${Math.round((deleted * 100) / read)}%`);
 };
 
@@ -67,7 +67,7 @@ db.chat
     ++read;
     if (isChatGarbage(chat)) {
       deleteChat(chat);
-      if (read % 10000 == 0) printjson(chat);
+      if (read % 10000 === 0) printjson(chat);
     }
   });
 

--- a/bin/mongodb/config-int.js
+++ b/bin/mongodb/config-int.js
@@ -1,6 +1,6 @@
 function toInt(obj) {
   return function (prop) {
-    if (typeof obj[prop] != 'undefined' && isNumber(obj[prop])) obj[prop] = NumberInt(obj[prop]);
+    if (typeof obj[prop] !== 'undefined' && isNumber(obj[prop])) obj[prop] = NumberInt(obj[prop]);
   };
 }
 // db.config.find({_id:'thibault'}).forEach(function(config) {
@@ -11,7 +11,7 @@ db.config.find().forEach(function (config) {
   });
   const filter = config.filter;
   ['m', 's', 'v'].forEach(function (prop) {
-    if (typeof filter[prop] != 'undefined')
+    if (typeof filter[prop] !== 'undefined')
       filter[prop] = filter[prop].map(function (n) {
         return NumberInt(n);
       });

--- a/bin/mongodb/denormalize-game-uids.js
+++ b/bin/mongodb/denormalize-game-uids.js
@@ -16,20 +16,20 @@ gamesToMigrate.forEach(function (game) {
   let prev = '',
     uids = [];
   game.p.forEach(function (p) {
-    if (p.uid && p.uid != prev) {
+    if (p.uid && p.uid !== prev) {
       uids.push(p.uid);
       prev = p.uid;
     }
   });
 
   const gameSris = game.uids || [];
-  if (gameSris.length != uids.length) {
+  if (gameSris.length !== uids.length) {
     ++j;
     db.game4.update({ _id: game['_id'] }, { $set: { uids: uids } });
   }
 
   ++it;
-  if (it % batchSize == 0) {
+  if (it % batchSize === 0) {
     const percent = Math.round((it / max) * 100);
     const dat2 = Date.now() / 1000;
     const perSec = Math.round(batchSize / (dat2 - dat));

--- a/bin/mongodb/fix-normalized-emails.js
+++ b/bin/mongodb/fix-normalized-emails.js
@@ -29,10 +29,10 @@ db.user4
     print(user.username, ': ', verbatim, '->', normalized);
 
     const updates = {};
-    if (normalized != user.email) updates.email = normalized;
-    if (verbatim != user.email) updates.verbatimEmail = verbatim;
+    if (normalized !== user.email) updates.email = normalized;
+    if (verbatim !== user.email) updates.verbatimEmail = verbatim;
 
-    if (Object.keys(updates).length == 0) return;
+    if (Object.keys(updates).length === 0) return;
     if (dry) nbSkips++;
     else
       try {
@@ -44,7 +44,7 @@ db.user4
         );
         nbUpdates++;
       } catch (e) {
-        if (e.code == 11000) nbDups++;
+        if (e.code === 11000) nbDups++;
       }
   });
 

--- a/bin/mongodb/game-search-test.js
+++ b/bin/mongodb/game-search-test.js
@@ -61,7 +61,7 @@ for (let i = 0; i < nbGames; i++) {
     date: new Date(Date.now() - intRandom(118719488)),
     analysed: !!intRandom(2),
   });
-  if (i % 1000 == 0) print(`${i} / ${nbGames}`);
+  if (i % 1000 === 0) print(`${i} / ${nbGames}`);
 }
 
 const indexes = [

--- a/bin/mongodb/game3.js
+++ b/bin/mongodb/game3.js
@@ -77,10 +77,10 @@ gamesToMigrate.forEach(function (g) {
   cleanOrRename(g, 'updatedAt', 'ua');
   cleanOrRename(g, 'winId', 'wid');
   delete g.r960;
-  if (typeof g.v !== 'undefined' && g.v != 2) {
+  if (typeof g.v !== 'undefined' && g.v !== 2) {
     delete g.v;
   }
-  if (typeof g.isRated != 'undefined' && g.isRated !== true) {
+  if (typeof g.isRated !== 'undefined' && g.isRated !== true) {
     delete g.isRated;
   } else {
     cleanOrRename(g, 'isRated', 'ra');
@@ -126,7 +126,7 @@ gamesToMigrate.forEach(function (g) {
     pgnCollection.insert({ _id: g._id, p: pgn });
   }
   ++it;
-  if (it % batchSize == 0) {
+  if (it % batchSize === 0) {
     const percent = Math.round((it / max) * 100);
     const dat2 = Date.now() / 1000;
     const perSec = Math.round(batchSize / (dat2 - dat));

--- a/bin/mongodb/game4.js
+++ b/bin/mongodb/game4.js
@@ -19,7 +19,7 @@ let i,
 let dat = Date.now() / 1000;
 gamesToMigrate.forEach(function (g) {
   g.p.forEach(function (p) {
-    if (typeof p.mts != 'undefined') {
+    if (typeof p.mts !== 'undefined') {
       if (p.mts === null || p.mts.length === 0) {
         delete p.mts;
       } else {
@@ -40,7 +40,7 @@ gamesToMigrate.forEach(function (g) {
   });
   collection.insert(g);
   ++it;
-  if (it % batchSize == 0) {
+  if (it % batchSize === 0) {
     const percent = Math.round((it / max) * 100);
     const dat2 = Date.now() / 1000;
     const perSec = Math.round(batchSize / (dat2 - dat));

--- a/bin/mongodb/history.js
+++ b/bin/mongodb/history.js
@@ -19,7 +19,7 @@ historyToMigrate.forEach(function (h) {
     if (e.g) {
       game = games.findOne({ _id: e.g }, { 'p.elo': true, 'p.uid': true });
       if (game) {
-        if (game.p[0].uid != h._id) e2.push(game.p[0].elo);
+        if (game.p[0].uid !== h._id) e2.push(game.p[0].elo);
         else e2.push(game.p[1].elo);
       }
     }
@@ -27,7 +27,7 @@ historyToMigrate.forEach(function (h) {
   }
   collection.update({ _id: h2._id }, { $set: h2 }, { upsert: true });
   ++it;
-  if (it % batchSize == 0) {
+  if (it % batchSize === 0) {
     const percent = Math.round((it / max) * 100);
     const dat2 = Date.now() / 1000;
     const perSec = Math.round(batchSize / (dat2 - dat));

--- a/bin/mongodb/history2.js
+++ b/bin/mongodb/history2.js
@@ -25,15 +25,15 @@ games.forEach(function (game) {
       const p = game.p[pi],
         op = game.p[1 - pi];
       const entry = [parseInt(game.ca.getTime() / 1000), parseInt(p.elo + p.ed), parseInt(op.elo)];
-      if (typeof cache[p.uid] == 'undefined') cache[p.uid] = [entry];
+      if (typeof cache[p.uid] === 'undefined') cache[p.uid] = [entry];
       else cache[p.uid].push(entry);
     } catch (e) {
       print('game ' + game._id + ' => ' + e);
     }
   }
   ++it;
-  if (it % batchSize == 0) {
-    if (it % (batchSize * 7) == 0) {
+  if (it % batchSize === 0) {
+    if (it % (batchSize * 7) === 0) {
       print('FLUSH');
       flush(cache);
       cache = {};

--- a/bin/mongodb/marathon-trophies.js
+++ b/bin/mongodb/marathon-trophies.js
@@ -1,7 +1,7 @@
 const users = ['blitzstream-twitch', 'legend', 'admirala', 'hellball'];
 
 for (let i of users) {
-  const kind = i == 0 ? 'marathonWinner' : 'marathonTopTen';
+  const kind = i === 0 ? 'marathonWinner' : 'marathonTopTen';
   const user = users[i];
   db.trophy.insert({
     _id: kind + '/' + user,

--- a/bin/mongodb/msg_import.js
+++ b/bin/mongodb/msg_import.js
@@ -42,7 +42,7 @@ if (!db.m_thread_sorted.count()) {
       ],
     })
     .forEach(t => {
-      if (t.creatorId == t.invitedId) return;
+      if (t.creatorId === t.invitedId) return;
       t.visibleByUserIds.sort();
       db.m_thread_sorted.insert(t);
     });

--- a/bin/mongodb/practice-fen-fix.js
+++ b/bin/mongodb/practice-fen-fix.js
@@ -23,7 +23,7 @@ const chapters = db.study_chapter
   .forEach(function (chapter) {
     const fen = chapter.root.f;
     const fixed = fixFen(fen);
-    if (fixed != fen) {
+    if (fixed !== fen) {
       print('Fix chapter FEN ' + chapter._id + ': ' + fixed);
       db.study_chapter.update(
         {
@@ -38,7 +38,7 @@ const chapters = db.study_chapter
     }
 
     const ply = makePly(fixed);
-    if (chapter.root.p != ply) {
+    if (chapter.root.p !== ply) {
       print('Fix chapter root ply ' + chapter._id);
       db.study_chapter.update(
         {

--- a/bin/mongodb/pref-submitMove.js
+++ b/bin/mongodb/pref-submitMove.js
@@ -1,4 +1,4 @@
-const convert = s => (s == 1 ? 3 : s == 2 ? 31 : s == 4 ? 2 : 0);
+const convert = s => (s === 1 ? 3 : s === 2 ? 31 : s === 4 ? 2 : 0);
 
 const updateSubmitMove = pref =>
   db.pref.updateOne({ _id: pref._id }, { $set: { submitMove: convert(pref.submitMove) } });

--- a/bin/mongodb/puzzle-salvage-old-good.js
+++ b/bin/mongodb/puzzle-salvage-old-good.js
@@ -3,7 +3,7 @@ coll
   .find({ _id: { $lt: 60120 }, 'vote.sum': { $gte: 100 } })
   .sort({ _id: 1 })
   .forEach(function (p) {
-    if (coll.count({ fen: p.fen }) == 1) {
+    if (coll.count({ fen: p.fen }) === 1) {
       const nextId = coll.find({}, { _id: 1 }).sort({ _id: -1 }).limit(1)[0]._id + 1;
       p.salvaged = NumberInt(p._id);
       p._id = NumberInt(nextId);

--- a/bin/mongodb/rapid-init-all.js
+++ b/bin/mongodb/rapid-init-all.js
@@ -86,7 +86,7 @@ db.user4.find(query).forEach(u => {
     },
   };
 
-  if (classicalPerf.nb == 0) update['$unset'] = { 'perfs.classical': true };
+  if (classicalPerf.nb === 0) update['$unset'] = { 'perfs.classical': true };
   else update['$set']['perfs.classical'] = classicalPerf;
   if (rapidPerf.nb > 0) update['$set']['perfs.rapid'] = rapidPerf;
 

--- a/bin/mongodb/rapid-init-online.js
+++ b/bin/mongodb/rapid-init-online.js
@@ -88,7 +88,7 @@ db.user4.find(query).forEach(u => {
     },
   };
 
-  if (classicalPerf.nb == 0) update['$unset'] = { 'perfs.classical': true };
+  if (classicalPerf.nb === 0) update['$unset'] = { 'perfs.classical': true };
   else update['$set']['perfs.classical'] = classicalPerf;
   if (rapidPerf.nb > 0) update['$set']['perfs.rapid'] = rapidPerf;
 

--- a/bin/mongodb/recap-notif.js
+++ b/bin/mongodb/recap-notif.js
@@ -72,7 +72,7 @@ function sendToRandomOfflinePlayers() {
     if (batch) {
       const newUsers = filterNewUsers(batch);
       newUsers.forEach(sendToUser);
-      if (countAll % 1000 == 0) {
+      if (countAll % 1000 === 0) {
         print(
           `+ ${countSent - lastPrinted} = ${countSent} / ${countAll} | ${user.createdAt.toLocaleDateString('fr')}`,
         );

--- a/bin/mongodb/relay-dates-migrate.js
+++ b/bin/mongodb/relay-dates-migrate.js
@@ -11,7 +11,7 @@ const fetchDates = tourId =>
     ])
     .next();
 
-const cmp = (a, b) => (a ? a.getTime() : 0) == (b ? b.getTime() : 0);
+const cmp = (a, b) => (a ? a.getTime() : 0) === (b ? b.getTime() : 0);
 
 db.relay_tour
   .find()

--- a/bin/mongodb/relay-order.js
+++ b/bin/mongodb/relay-order.js
@@ -11,7 +11,7 @@ db.relay_tour
       for (k of ['startedAt', 'startsAt', 'createdAt']) {
         const aVal = sortWith(a);
         const bVal = sortWith(b);
-        if (aVal && bVal && aVal != 'afterPrevious' && bVal != 'afterPrevious') return aVal - bVal;
+        if (aVal && bVal && aVal !== 'afterPrevious' && bVal !== 'afterPrevious') return aVal - bVal;
       }
     });
     const res = db.relay.bulkWrite(

--- a/bin/mongodb/relay-round-finishedAt.js
+++ b/bin/mongodb/relay-round-finishedAt.js
@@ -1,6 +1,6 @@
 db.relay.find({ finished: true, finishedAt: { $exists: false } }).forEach(function (relay) {
   print(relay.tourId + '/' + relay._id + ' ' + relay.name);
-  const actualStartsAt = relay.startsAt && relay.startsAt != 'afterPrevious' ? relay.startsAt : undefined;
+  const actualStartsAt = relay.startsAt && relay.startsAt !== 'afterPrevious' ? relay.startsAt : undefined;
   const startAt = relay.startedAt || actualStartsAt || relay.createdAt;
   const duration = 1000 * 60 * 60 * 3; // 3 hours
   const finishAt = new Date(startAt.getTime() + duration);

--- a/bin/mongodb/study-chapter-castling-notation.js
+++ b/bin/mongodb/study-chapter-castling-notation.js
@@ -29,7 +29,7 @@ const repairChapter = idOrDiag => {
   if (debug) console.log('https://lichess.org/study/' + chapter.studyId + '/' + chapter._id);
   const moves = chapter.root;
   const moveList = Object.entries(moves);
-  const moveIndexes = diag.root.map(d => moveList.findIndex(([k, _]) => k == d.k));
+  const moveIndexes = diag.root.map(d => moveList.findIndex(([k, _]) => k === d.k));
   diag.root.forEach((d, index) => {
     const move = moveList[moveIndexes[index]];
     if (!move) {
@@ -137,7 +137,7 @@ const repairAll = nb => {
       const [c, r] = repairChapter(diag);
       if (c && r) updateChapterRoot(c, r);
       nb--;
-      if (nb % 100 == 0) {
+      if (nb % 100 === 0) {
         console.log(nb + ' remaining');
       }
     });

--- a/bin/mongodb/study-flat-chapter-migrate.js
+++ b/bin/mongodb/study-flat-chapter-migrate.js
@@ -73,7 +73,7 @@ db.study_chapter_backup
     else batch.push(c);
     i++;
     sumMoves += nbMoves;
-    if (i % batchSize == 0) {
+    if (i % batchSize === 0) {
       coll.insertMany(batch, {
         ordered: false,
         writeConcern: { w: 0, j: false },

--- a/bin/mongodb/swiss-fix.js
+++ b/bin/mongodb/swiss-fix.js
@@ -24,7 +24,7 @@ db.swiss
 
 db.swiss.find({ nbOngoing: { $ne: 0 } }).forEach(s => {
   const count = db.swiss_pairing.count({ s: s._id, t: true });
-  if (count != s.nbOngoing) {
+  if (count !== s.nbOngoing) {
     print(`nbOngoing ${s._id} ${s.name} ${s.nbOngoing} -> ${count}`);
     const set = {
       nbOngoing: NumberInt(count),

--- a/bin/mongodb/swiss-remove-number.js
+++ b/bin/mongodb/swiss-remove-number.js
@@ -13,7 +13,7 @@ db.swiss.find().forEach(swiss => {
       {
         $set: {
           p: [index[p.p[0]], index[p.p[1]]],
-          t: p.t == p.p[0] ? NumberInt(0) : p.t == p.p[1] ? NumberInt(1) : p.t,
+          t: p.t === p.p[0] ? NumberInt(0) : p.t === p.p[1] ? NumberInt(1) : p.t,
         },
       },
     );

--- a/bin/mongodb/team-leaders.js
+++ b/bin/mongodb/team-leaders.js
@@ -1,7 +1,7 @@
 db.team.find().forEach(t => {
-  if (t.leaders.length == 1 && t.leaders[0] == t.createdBy) return;
+  if (t.leaders.length === 1 && t.leaders[0] === t.createdBy) return;
   const leaders = db.team_member.distinct('user', { team: t._id, user: { $in: t.leaders } });
-  if (leaders.length != t.leaders.length) {
+  if (leaders.length !== t.leaders.length) {
     if (!leaders.length) leaders.push(t.createdBy);
     print(`${t._id} ${t.name} ${t.leaders.join(',')} -> ${leaders.join(',')}`);
     db.team.update({ _id: t._id }, { $set: { leaders: leaders } });

--- a/bin/mongodb/tournament-int.js
+++ b/bin/mongodb/tournament-int.js
@@ -1,6 +1,6 @@
 function toInt(obj) {
   return function (prop) {
-    if (typeof obj[prop] != 'undefined') obj[prop] = NumberInt(obj[prop]);
+    if (typeof obj[prop] !== 'undefined') obj[prop] = NumberInt(obj[prop]);
   };
 }
 // db.tournament.find({_id:'fefNHKaL'}).forEach(function(tour) {

--- a/bin/mongodb/tournament-v2.js
+++ b/bin/mongodb/tournament-v2.js
@@ -64,7 +64,7 @@ cursor.forEach(function (o) {
   insertPairings(o);
 
   ++it;
-  if (it % batchSize == 0) {
+  if (it % batchSize === 0) {
     const percent = Math.round((it / max) * 100);
     const dat2 = Date.now() / 1000;
     const ms = Math.round(1000 * (dat2 - dat - pause / 1000));
@@ -106,7 +106,7 @@ function insertPairings(o) {
       u: p.u,
       t: int(p.t),
     };
-    if (p.w) n.w = p.w == p.u[0];
+    if (p.w) n.w = p.w === p.u[0];
     if (p.b1) n.b1 = int(p.b1);
     if (p.b2) n.b2 = int(p.b2);
     bulk.insert(n);
@@ -127,9 +127,9 @@ function mkTour(o) {
     createdBy: o.createdBy,
     startsAt: o.schedule ? o.schedule.at : o.createdAt,
   };
-  if (o.system && o.system != 1) n.system = int(o.system);
-  if (o.variant && o.variant != 1) n.variant = int(o.variant);
-  if (o.mode && o.mode != 1) n.mode = int(o.mode);
+  if (o.system && o.system !== 1) n.system = int(o.system);
+  if (o.variant && o.variant !== 1) n.variant = int(o.variant);
+  if (o.mode && o.mode !== 1) n.mode = int(o.mode);
   if (o.schedule)
     n.schedule = {
       freq: o.schedule.freq,

--- a/bin/mongodb/ublog-blog.js
+++ b/bin/mongodb/ublog-blog.js
@@ -54,7 +54,7 @@ db.ublog_post.find({ blog: { $exists: false } }).forEach(p => {
           at: p.createdAt,
         },
         updated:
-          p.createdAt != p.updatedAt
+          p.createdAt !== p.updatedAt
             ? {
                 by: p.user,
                 at: p.updatedAt,

--- a/bin/mongodb/ublog-similar-full.js
+++ b/bin/mongodb/ublog-similar-full.js
@@ -49,7 +49,7 @@ all.forEach(p => {
   const similar = new Map();
   p.likers.forEach(liker => {
     (likers.get(liker) || []).forEach(id => {
-      if (id != p._id) similar.set(id, (similar.get(id) || 0) + 1);
+      if (id !== p._id) similar.set(id, (similar.get(id) || 0) + 1);
     });
   });
   const sorted = Array.from(similar)

--- a/bin/mongodb/user-dedup-createdAt.js
+++ b/bin/mongodb/user-dedup-createdAt.js
@@ -31,7 +31,7 @@ db.user4
     );
 
     ++it;
-    if (it % batchSize == 0) {
+    if (it % batchSize === 0) {
       print(it);
       sleep(100);
     }

--- a/bin/mongodb/user-flag-to-flair.js
+++ b/bin/mongodb/user-flag-to-flair.js
@@ -7,6 +7,6 @@ map = [
 ];
 
 db.user4.find({ 'profile.country': { $in: map.map(e => e[0]) } }, { 'profile.country': 1 }).forEach(user => {
-  flair = map.find(e => e[0] == user.profile.country)[1];
+  flair = map.find(e => e[0] === user.profile.country)[1];
   db.user4.updateOne({ _id: user._id }, { $unset: { 'profile.country': 1 }, $set: { flair: flair } });
 });

--- a/bin/mongodb/wid.js
+++ b/bin/mongodb/wid.js
@@ -20,7 +20,7 @@ const gamesToMigrate = db.game5.find(
 );
 
 gamesToMigrate.forEach(function (g) {
-  if (g.w && typeof g.us[0] != 'undefined' && g.us[0]) {
+  if (g.w && typeof g.us[0] !== 'undefined' && g.us[0]) {
     db.game5.update(
       {
         _id: g._id,
@@ -31,7 +31,7 @@ gamesToMigrate.forEach(function (g) {
         },
       },
     );
-  } else if (!g.w && typeof g.us[1] != 'undefined' && g.us[1]) {
+  } else if (!g.w && typeof g.us[1] !== 'undefined' && g.us[1]) {
     db.game5.update(
       {
         _id: g._id,

--- a/cron/mongodb-puzzle-regen-paths.js
+++ b/cron/mongodb-puzzle-regen-paths.js
@@ -44,7 +44,7 @@ const mixBoundaries = [
   2100, 2200, 2350, 2500, 2650, 2800, 9999,
 ];
 
-const themes = puzzleColl.distinct('themes', {}).filter(t => t && t != 'checkFirst');
+const themes = puzzleColl.distinct('themes', {}).filter(t => t && t !== 'checkFirst');
 const openings = db.puzzle2_puzzle
   .aggregate([
     { $unwind: '$opening' },
@@ -86,9 +86,9 @@ let anyBuggy = false;
     ? { opening: theme }
     : {
         themes:
-          theme == 'mix'
+          theme === 'mix'
             ? { $ne: 'equality' }
-            : theme == 'equality'
+            : theme === 'equality'
               ? 'equality'
               : {
                   $eq: theme,
@@ -112,12 +112,12 @@ let anyBuggy = false;
 
   const themeMaxPathLength = Math.max(10, Math.min(maxPathLength, Math.round(nbPuzzles / 150)));
   const nbRatingBuckets =
-    theme == 'mix'
+    theme === 'mix'
       ? mixBoundaries.length - 1
       : Math.max(3, Math.min(maxRatingBuckets, Math.round(nbPuzzles / themeMaxPathLength / 15)));
 
   const bucketStages =
-    theme == 'mix'
+    theme === 'mix'
       ? [
           {
             $bucket: {
@@ -140,7 +140,7 @@ let anyBuggy = false;
     {
       $match: selector,
     },
-    ...(theme == 'mix' ? [{ $sample: { size: maxPuzzlesPerTheme } }] : []),
+    ...(theme === 'mix' ? [{ $sample: { size: maxPuzzlesPerTheme } }] : []),
     ...bucketStages,
     {
       $unwind: '$puzzle',
@@ -219,24 +219,24 @@ let anyBuggy = false;
       comment: 'regen-paths',
     })
     .forEach(bucket => {
-      if (prevTier == bucket.tier) indexInTier++;
+      if (prevTier === bucket.tier) indexInTier++;
       else {
         indexInTier = 0;
         prevTier = bucket.tier;
       }
-      const isFirstOfTier = indexInTier == 0;
-      const isLastOfTier = indexInTier == nbRatingBuckets - 1;
+      const isFirstOfTier = indexInTier === 0;
+      const isLastOfTier = indexInTier === nbRatingBuckets - 1;
       const pathLength = Math.max(10, Math.min(maxPathLength, Math.round(bucket.puzzles.length / 30)));
       const ratingMin = isFirstOfTier ? 100 : Math.ceil(bucket._id.min);
       const ratingMax = isLastOfTier
         ? 9999
-        : theme == 'mix'
+        : theme === 'mix'
           ? mixBoundaries[indexInTier + 1]
           : Math.floor(bucket._id.max);
       const nbPaths = Math.max(1, Math.floor(bucket.puzzles.length / pathLength));
       const allPaths = chunkify(bucket.puzzles, nbPaths);
       const paths = allPaths.slice(0, maxPathsPerGroup);
-      buggy = buggy || (ratingMin == 100 && ratingMax == 9999) || ratingMin > ratingMax;
+      buggy = buggy || (ratingMin === 100 && ratingMax === 9999) || ratingMin > ratingMax;
       anyBuggy = anyBuggy || buggy;
       if (verbose || buggy)
         print(

--- a/cron/mongodb-report-score-decay.js
+++ b/cron/mongodb-report-score-decay.js
@@ -22,7 +22,7 @@ db.report2
     };
 
     report.atoms.forEach((atom, index) => {
-      if (!atom.initScore || atom.initScore != NumberInt(atom.initScore)) {
+      if (!atom.initScore || atom.initScore !== NumberInt(atom.initScore)) {
         // save original score if not yet present
         atom.initScore = set[`atoms.${index}.initScore`] = NumberInt(atom.score);
       }
@@ -32,7 +32,7 @@ db.report2
 
     if (set.score <= 0) {
       db.report2.deleteOne({ _id: report._id });
-    } else if (set.score != report.score) {
+    } else if (set.score !== report.score) {
       db.report2.updateOne({ _id: report._id }, { $set: set });
     }
   });

--- a/cron/mongodb-ublog-similar-incremental.js
+++ b/cron/mongodb-ublog-similar-incremental.js
@@ -51,7 +51,7 @@ updatable.forEach(p => {
   const similar = new Map();
   p.likers.forEach(liker => {
     (likerToIds.get(liker) || []).forEach(id => {
-      if (id != p._id) similar.set(id, (similar.get(id) || 0) + 1);
+      if (id !== p._id) similar.set(id, (similar.get(id) || 0) + 1);
     });
   });
 

--- a/ui/analyse/src/study/relay/relayTeams.ts
+++ b/ui/analyse/src/study/relay/relayTeams.ts
@@ -182,7 +182,7 @@ const evalGauge = (
             const prevNodeCloud = old.data?.cloud;
             const fen = chapters.get(game.id)?.fen;
             const cev = (fen && cloudEval.getCloudEval(fen)) || prevNodeCloud;
-            if (cev?.chances != prevNodeCloud?.chances) {
+            if (cev?.chances !== prevNodeCloud?.chances) {
               const elm = vnode.elm as HTMLElement;
               const gauge = elm.parentNode as HTMLElement;
               elm.style.width = `${((1 - (cev?.chances || 0)) / 2) * 100}%`;

--- a/ui/analyse/src/wiki.ts
+++ b/ui/analyse/src/wiki.ts
@@ -55,7 +55,7 @@ export default function wikiTheory(): WikiTheory {
           if (res.ok) {
             const json = await res.json();
             const page = json.query.pages[0];
-            if (page.missing || page.extract.length == 0) saveAndShow('');
+            if (page.missing || page.extract.length === 0) saveAndShow('');
             else if (page.invalid) show('invalid request: ' + page.invalidreason);
             else if (!page.extract)
               show('error: unexpected API response:<br><pre>' + JSON.stringify(page) + '</pre>');

--- a/ui/bits/src/bits.auth.ts
+++ b/ui/bits/src/bits.auth.ts
@@ -93,8 +93,8 @@ function signupStart() {
     return false;
   });
   const showPasswordTools = () => {
-    $form.find('.password-generator').toggleClass('none', $password.val() != '');
-    $form.find('.password-complexity').toggleClass('none', $password.val() == '');
+    $form.find('.password-generator').toggleClass('none', $password.val() !== '');
+    $form.find('.password-complexity').toggleClass('none', $password.val() === '');
   };
   $password.on('input', showPasswordTools);
   showPasswordTools();

--- a/ui/bits/src/bits.coachForm.ts
+++ b/ui/bits/src/bits.coachForm.ts
@@ -80,7 +80,7 @@ site.load.then(() => {
       langInput
         .getAttribute('data-value')
         ?.split(',')
-        .map(code => whitelist?.find(l => l.code == code))
+        .map(code => whitelist?.find(l => l.code === code))
         .filter(notNull) as Tagify.TagData[],
     );
   }

--- a/ui/bits/src/bits.gameSearch.ts
+++ b/ui/bits/src/bits.gameSearch.ts
@@ -66,7 +66,7 @@ site.load.then(() => {
   function serialize() {
     const params = new URLSearchParams();
     for (const [k, v] of new FormData(form ?? undefined).entries()) {
-      if (v != '') params.set(k, v.toString());
+      if (v !== '') params.set(k, v.toString());
     }
     return params.toString();
   }

--- a/ui/bits/src/bits.voiceChat.ts
+++ b/ui/bits/src/bits.voiceChat.ts
@@ -157,7 +157,7 @@ export function initModule(opts: VoiceChatOpts): VoiceChat | undefined {
     if (!peer) return;
     for (const otherPeer in peer.connections) {
       peer.connections[otherPeer].forEach((c: any) => {
-        if (c.peerConnection && c.peerConnection.connectionState == 'disconnected') {
+        if (c.peerConnection && c.peerConnection.connectionState === 'disconnected') {
           log(`close disconnected call to ${c.peer}`);
           c.close();
           opts.redraw();

--- a/ui/cli/src/cli.ts
+++ b/ui/cli/src/cli.ts
@@ -10,7 +10,7 @@ type Entry = LightUserOnline | HTMLAnchorElement;
 
 export function initModule({ input }: { input: HTMLInputElement }) {
   const menuLinks = Array.from(document.querySelectorAll<HTMLAnchorElement>('#topnav a')).filter(
-    a => a.href != '/',
+    a => a.href !== '/',
   );
 
   const fetchLinks = (term: string): HTMLAnchorElement[] => {
@@ -59,7 +59,7 @@ export function initModule({ input }: { input: HTMLInputElement }) {
 
 function execute(e: string | Entry) {
   if (!e) return;
-  if (typeof e != 'string' && isLink(e)) location.href = e.href;
+  if (typeof e !== 'string' && isLink(e)) location.href = e.href;
   else if (isUser(e)) location.href = '/@/' + e.name;
   else if (e[0] === '/') command(e.replace(/\//g, ''));
   // 5kr1/p1p2p2/2b2Q2/3q2r1/2p4p/2P4P/P2P1PP1/1R1K3R b - - 1 23

--- a/ui/dgt/src/play.ts
+++ b/ui/dgt/src/play.ts
@@ -132,7 +132,7 @@ export default function (token: string): void {
           let output = '';
           for (let i = 0; i < arguments.length; i++) {
             const arg = arguments[i];
-            if (arg == '*' || arg == ':') {
+            if (arg === '*' || arg === ':') {
               output += arg;
             } else {
               output += '</br><span class="log-' + typeof arg + ' log-' + name + '">';
@@ -199,7 +199,7 @@ export default function (token: string): void {
         if (verbose) console.log('/api/account Response:' + JSON.stringify(data));
         //Display Title + UserName . Title may be undefined
         console.log('┌─────────────────────────────────────────────────────┐');
-        console.log('│ ' + (typeof data.title == 'undefined' ? '' : data.title) + ' ' + data.username);
+        console.log('│ ' + (typeof data.title === 'undefined' ? '' : data.title) + ' ' + data.username);
         //Display performance ratings
         console.table(data.perfs);
       })
@@ -251,7 +251,7 @@ export default function (token: string): void {
           try {
             const data = JSON.parse(jsonArray[i]);
             //JSON data found, let's check if this is a game that started. field type is mandatory except on http 4xx
-            if (data.type == 'gameStart') {
+            if (data.type === 'gameStart') {
               if (verbose)
                 console.log('connectToEventStream - gameStart event arrived. GameId: ' + data.game.id);
               try {
@@ -261,10 +261,10 @@ export default function (token: string): void {
                 //This will trigger if connectToGameStream fails
                 console.error('connectToEventStream - Failed to connect to game stream. ' + error);
               }
-            } else if (data.type == 'challenge') {
+            } else if (data.type === 'challenge') {
               //Challenge received
               //TODO
-            } else if (data.type == 'gameFinish') {
+            } else if (data.type === 'gameFinish') {
               //Game Finished
               //TODO Handle this event
             } else if (response.status >= 400) {
@@ -349,7 +349,7 @@ export default function (token: string): void {
           try {
             const data = JSON.parse(jsonArray[i]);
             //The first line is always of type gameFull.
-            if (data.type == 'gameFull') {
+            if (data.type === 'gameFull') {
               if (!verbose) console.clear();
               //Log game Summary
               //logGameSummary(data);
@@ -363,7 +363,7 @@ export default function (token: string): void {
               logGameState(gameId);
               //Call chooseCurrentGame to determine if this stream will be the new current game
               chooseCurrentGame();
-            } else if (data.type == 'gameState') {
+            } else if (data.type === 'gameState') {
               if (!verbose) console.clear();
               //Update the ChessBoard Map
               updateChessBoard(gameId, gameStateMap.get(gameId), data);
@@ -376,7 +376,7 @@ export default function (token: string): void {
               } else {
                 if (verbose) console.log('connectToGameStream - State received was not for current game.');
               }
-            } else if (data.type == 'chatLine') {
+            } else if (data.type === 'chatLine') {
               //Received chat line
               //TODO
             } else if (response.status >= 400) {
@@ -432,7 +432,7 @@ export default function (token: string): void {
         await sleep(5000);
         //Check if any started games are disconnected
         for (const [gameId, networkState] of gameConnectionMap) {
-          if (!networkState.connected && gameStateMap.get(gameId).status == 'started') {
+          if (!networkState.connected && gameStateMap.get(gameId).status === 'started') {
             //Game is not connected and has not finished, reconnect
             if (verbose)
               console.log(`Started game is disconnected. Attempting reconnection for gameId: ${gameId}`);
@@ -491,7 +491,7 @@ export default function (token: string): void {
         if (
           gameStateMap.has(currentGameId) &&
           gameConnectionMap.get(currentGameId)!.connected &&
-          gameStateMap.get(currentGameId).status == 'started'
+          gameStateMap.get(currentGameId).status === 'started'
         ) {
           //No match found but there is a valid currentGameId , so keep it
           if (verbose)
@@ -619,7 +619,7 @@ export default function (token: string): void {
     //Every times a new game is connected clear the console except on verbose
     if (!verbose) consoleOutput.innerHTML = '';
     //
-    if (me.id == gameInfoMap.get(currentGameId).white.id) currentGameColor = 'white';
+    if (me.id === gameInfoMap.get(currentGameId).white.id) currentGameColor = 'white';
     else currentGameColor = 'black';
     //Send the position to LiveChess for synchronization
     sendBoardToLiveChess(gameChessBoardMap.get(currentGameId)!);
@@ -647,18 +647,18 @@ export default function (token: string): void {
     }> = [];
     const keys = Array.from(gameConnectionMap.keys());
     for (let i = 0; i < keys.length; i++) {
-      if (gameConnectionMap.get(keys[i])?.connected && gameStateMap.get(keys[i])?.status == 'started') {
+      if (gameConnectionMap.get(keys[i])?.connected && gameStateMap.get(keys[i])?.status === 'started') {
         //Game is good for commands
         const gameInfo = gameInfoMap.get(keys[i]);
         const lastMove = getLastUCIMove(keys[i]);
         const versus =
-          gameInfo.black.id == me.id
+          gameInfo.black.id === me.id
             ? (gameInfo.white.title ? gameInfo.white.title : '@') + ' ' + gameInfo.white.name
             : (gameInfo.black.title ? gameInfo.black.title : '@') + ' ' + gameInfo.black.name;
         playableGames.push({
           gameId: gameInfo.id,
           versus: versus,
-          'vs rating': gameInfo.black.id == me.id ? gameInfo.white.rating : gameInfo.black.rating,
+          'vs rating': gameInfo.black.id === me.id ? gameInfo.white.rating : gameInfo.black.rating,
           'game rating': gameInfo.variant.short + ' ' + (gameInfo.rated ? 'rated' : 'unrated'),
           Timer:
             gameInfo.speed +
@@ -758,7 +758,7 @@ export default function (token: string): void {
           console.log(
             `getLastUCIMove - ${moves.length} moves detected. Last one: ${moves[moves.length - 1]}`,
           );
-        if (moves.length % 2 == 0)
+        if (moves.length % 2 === 0)
           return { player: 'black', move: moves[moves.length - 1], by: gameInfo.black.id };
         else return { player: 'white', move: moves[moves.length - 1], by: gameInfo.white.id };
       }
@@ -843,10 +843,10 @@ export default function (token: string): void {
       if (verbose) console.info('Websocket onmessage with data:' + e.data);
       const message = JSON.parse(e.data);
       //Store last board if received
-      if (message.response == 'feed' && !!message.param.board) {
+      if (message.response === 'feed' && !!message.param.board) {
         lastLiveChessBoard = message.param.board;
       }
-      if (message.response == 'call' && message.id == '1') {
+      if (message.response === 'call' && message.id === '1') {
         //Get the list of available boards on LiveChess
         boards = message.param;
         console.table(boards);
@@ -871,7 +871,7 @@ export default function (token: string): void {
         if (
           gameStateMap.has(currentGameId) &&
           gameConnectionMap.get(currentGameId)!.connected &&
-          gameStateMap.get(currentGameId).status == 'started'
+          gameStateMap.get(currentGameId).status === 'started'
         ) {
           //There is a game in progress, setup the board as per lichess board
           if (currentGameId !== DGTgameId) {
@@ -880,12 +880,12 @@ export default function (token: string): void {
             sendBoardToLiveChess(gameChessBoardMap.get(currentGameId)!);
           }
         }
-      } else if (message.response == 'feed' && !!message.param.san) {
+      } else if (message.response === 'feed' && !!message.param.san) {
         //Received move from board
         if (verbose) console.info('onmessage - san: ' + message.param.san);
         //get last move known to lichess and avoid calling multiple times this function
         const lastMove = getLastUCIMove(currentGameId);
-        if (message.param.san.length == 0) {
+        if (message.param.san.length === 0) {
           if (verbose) console.info('onmessage - san is empty');
         } else if (
           lastLegalParam !== undefined &&
@@ -999,7 +999,7 @@ export default function (token: string): void {
             }
           } //end for
         } //end else - move was received
-      } else if (message.response == 'feed') {
+      } else if (message.response === 'feed') {
         //feed received but not san
         //No moves received, this may be an out of snc problem or just the starting position
         if (verbose) console.info('onmessage - No move received on feed event.');
@@ -1084,7 +1084,7 @@ export default function (token: string): void {
       !(
         gameStateMap.has(currentGameId) &&
         gameConnectionMap.get(currentGameId)!.connected &&
-        gameStateMap.get(currentGameId).status == 'started'
+        gameStateMap.get(currentGameId).status === 'started'
       )
     ) {
       //Wait a few seconds to see if the games reconnects or starts and give some space to other code to run

--- a/ui/insight/src/chart.ts
+++ b/ui/insight/src/chart.ts
@@ -58,7 +58,7 @@ function insightChart(el: HTMLCanvasElement, data: InsightData) {
           position: 'bottom',
         },
         tooltip: {
-          filter: tooltipItem => (tooltipItem.raw as number) != 0,
+          filter: tooltipItem => (tooltipItem.raw as number) !== 0,
           itemSort: (a, b) => b.datasetIndex - a.datasetIndex,
           backgroundColor: tooltipBgColor,
           borderColor: gridColor,
@@ -123,7 +123,7 @@ function barBuilder(
             textStrokeWidth: 1.2,
             font: fontFamily(12, 'bold'),
             formatter: val =>
-              val == 0 && percent ? '' : formatNumber(serie.dataType, val * (percent ? 100 : 1)),
+              val === 0 && percent ? '' : formatNumber(serie.dataType, val * (percent ? 100 : 1)),
           },
   };
 }

--- a/ui/insight/src/multipleSelect.ts
+++ b/ui/insight/src/multipleSelect.ts
@@ -229,7 +229,7 @@ export const registerMultipleSelect = () => {
         .on('keyup', function (e) {
           if (
             that.options.filterAcceptOnEnter &&
-            (e.which === 13 || e.which == 32) &&
+            (e.which === 13 || e.which === 32) &&
             that.$searchInput.val()
           ) {
             that.$selectAll[0]?.click();

--- a/ui/lib/src/socket.ts
+++ b/ui/lib/src/socket.ts
@@ -169,7 +169,7 @@ class WsSocket {
         this.ackable.resend();
       };
       ws.onmessage = e => {
-        if (e.data == 0) return this.pong();
+        if (e.data === 0) return this.pong();
         const m = JSON.parse(e.data);
         if (m.t === 'n') this.pong();
         this.handle(m);

--- a/ui/lib/src/storage.ts
+++ b/ui/lib/src/storage.ts
@@ -23,7 +23,7 @@ export function storedProp<V>(
   const compatKey = 'analyse.' + key;
   let cached: V;
   return function (replacement?: V) {
-    if (defined(replacement) && replacement != cached) {
+    if (defined(replacement) && replacement !== cached) {
       cached = replacement;
       storage.set(key, toStr(replacement));
     } else if (!defined(cached)) {

--- a/ui/lib/src/view/complete.ts
+++ b/ui/lib/src/view/complete.ts
@@ -82,7 +82,7 @@ export function complete<Result>(opts: CompleteOpts<Result>): void {
         $container.addClass('none');
         const result =
           selectedResult() ||
-          (renderedResults[0] && opts.populate(renderedResults[0]) == opts.input.value
+          (renderedResults[0] && opts.populate(renderedResults[0]) === opts.input.value
             ? renderedResults[0]
             : undefined);
         if (result) {

--- a/ui/lobby/src/filter.ts
+++ b/ui/lobby/src/filter.ts
@@ -69,8 +69,8 @@ export default class Filter {
         if (
           !f.variant?.includes(variant) ||
           !f.speed?.includes((hook.s || 1).toString() /* ultrabullet = bullet */) ||
-          (f.mode?.length == 1 && f.mode[0] != (hook.ra || 0).toString()) ||
-          (f.increment?.length == 1 && f.increment[0] != hook.i.toString()) ||
+          (f.mode?.length === 1 && f.mode[0] !== (hook.ra || 0).toString()) ||
+          (f.increment?.length === 1 && f.increment[0] !== hook.i.toString()) ||
           (ratingRange && (!hook.rating || hook.rating < ratingRange[0] || hook.rating > ratingRange[1]))
         ) {
           hidden++;

--- a/ui/mod/src/checkBoxes.ts
+++ b/ui/mod/src/checkBoxes.ts
@@ -6,7 +6,7 @@ export const shiftClickCheckboxRange = (table: HTMLTableElement): OnSelect => {
   const checkIntermediateBoxes = (first: HTMLInputElement, last: HTMLInputElement) => {
     let started = false;
     for (const input of table.querySelectorAll('tbody tr:not(.none) input:not(:disabled)')) {
-      if (first == input || last == input) {
+      if (first === input || last === input) {
         if (started) return;
         started = true;
       } else if (started) (input as HTMLInputElement).checked = last.checked;
@@ -14,7 +14,7 @@ export const shiftClickCheckboxRange = (table: HTMLTableElement): OnSelect => {
   };
 
   return (input: HTMLInputElement, shift: boolean) => {
-    if (shift && lastChecked && input != lastChecked) checkIntermediateBoxes(lastChecked, input);
+    if (shift && lastChecked && input !== lastChecked) checkIntermediateBoxes(lastChecked, input);
     lastChecked = input;
   };
 };

--- a/ui/round/src/round.ts
+++ b/ui/round/src/round.ts
@@ -150,7 +150,7 @@ async function boot(
   $('#zentog').on('click', () => pubsub.emit('zen'));
   storage.make('reload-round-tabs').listen(site.reload);
 
-  if (!data.player.spectator && location.hostname != (document as any)['Location'.toLowerCase()].hostname) {
+  if (!data.player.spectator && location.hostname !== (document as any)['Location'.toLowerCase()].hostname) {
     alert(`Games cannot be played through a web proxy. Please use ${location.hostname} instead.`);
     wsDestroy();
   }

--- a/ui/site/src/site.tvEmbed.ts
+++ b/ui/site/src/site.tvEmbed.ts
@@ -19,10 +19,10 @@ window.onload = async () => {
       'message',
       e => {
         const msg = JSON.parse(e.data);
-        if (msg.t == 'featured') {
+        if (msg.t === 'featured') {
           document.getElementById('featured-game')!.innerHTML = msg.d.html;
           setup();
-        } else if (msg.t == 'fen') {
+        } else if (msg.t === 'fen') {
           updateMiniGame(findGame(), msg.d);
         }
       },

--- a/ui/swiss/src/util.ts
+++ b/ui/swiss/src/util.ts
@@ -1,3 +1,4 @@
 import type { Outcome, PairingExt } from './interfaces';
 
-export const isOutcome = (s: PairingExt | string): s is Outcome => s == 'absent' || s == 'late' || s == 'bye';
+export const isOutcome = (s: PairingExt | string): s is Outcome =>
+  s === 'absent' || s === 'late' || s === 'bye';

--- a/ui/swiss/src/view/standing.ts
+++ b/ui/swiss/src/view/standing.ts
@@ -30,11 +30,11 @@ function playerTr(ctrl: SwissCtrl, player: Player) {
           'div',
           player.sheet
             .map(p =>
-              p == 'absent'
+              p === 'absent'
                 ? h(p, title('Absent'), '-')
-                : p == 'bye'
+                : p === 'bye'
                   ? h(p, title('Bye'), '1')
-                  : p == 'late'
+                  : p === 'late'
                     ? h(p, title('Late'), '½')
                     : h(
                         'a.glpt.' + (p.o ? 'ongoing' : p.w ? 'win' : p.w === false ? 'loss' : 'draw'),

--- a/ui/user/src/user.ts
+++ b/ui/user/src/user.ts
@@ -80,7 +80,7 @@ export async function initModule(): Promise<void> {
 function tmpRandomTutorLink() {
   const me = myUserId(),
     userId = $('main.page-menu').data('username').toLowerCase();
-  if (!me || !userId || me != userId) return;
+  if (!me || !userId || me !== userId) return;
   const getNbGames = (icon: string) => {
     const text = $(`.sub-ratings a[data-icon=${icon}] rating span:last-child`).text();
     return Number.parseInt(text.replaceAll(/\D/g, ''));

--- a/ui/voice/makeGrammar.mts
+++ b/ui/voice/makeGrammar.mts
@@ -45,7 +45,7 @@ async function main() {
       ? ((await parseCrowdvData(lexicon.crowdv)).map(data => makeLexEntry(data)).filter(x => x) as LexEntry[])
       : [];
 
-    for (const e of entries.filter(e => e.h != e.x)) {
+    for (const e of entries.filter(e => e.h !== e.x)) {
       parseTransforms(findTransforms(e.h, e.x, buildMode), e, subMap, opThreshold);
     }
     subMap.forEach(v => (v.freq = v.count / v.all));


### PR DESCRIPTION
# Why

Avoiding type conversion in comparison is the way to avoid weird bugs and ensures code/types correctness.

# How

Enable `eqeqeq` lint rule:
* https://oxc.rs/docs/guide/usage/linter/rules/eslint/eqeqeq.html#eslint-eqeqeq

Fix all newly popped out warnings. Most issus comes from `bin`/`cron` scripts, but there were also several UI TypeScript files still using the loose comparison.