### PR TITLE
enable `no-useless-return` lint rule, fix new warnings

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -17,6 +17,7 @@
     "no-useless-computed-key": "error",
     "no-useless-concat": "error",
     "no-useless-constructor": "error",
+    "no-useless-return": "error",
     "no-useless-spread": "error",
     "no-unused-vars": [
       "warn",

--- a/ui/.build/src/tsc.ts
+++ b/ui/.build/src/tsc.ts
@@ -69,9 +69,10 @@ function assignWork(buckets: SplitConfig[][], key: 'noCheck' | 'noEmit'): Promis
       case 'busy':
         return env.done('tsc', undefined);
       case 'ok':
-        if (status.some(s => s !== 'ok')) return;
-        if (key === 'noEmit') env.done('tsc', 0);
-        okResolve();
+        if (!status.some(s => s !== 'ok')) {
+          if (key === 'noEmit') env.done('tsc', 0);
+          okResolve();
+        }
     }
   };
 

--- a/ui/analyse/src/keyboard.ts
+++ b/ui/analyse/src/keyboard.ts
@@ -47,7 +47,7 @@ export const bind = (ctrl: AnalyseCtrl) => {
   kbd.bind('space', () => {
     const gb = ctrl.gamebookPlay();
     if (gb) gb.onSpace();
-    else if (ctrl.practice || ctrl.study?.practice) return;
+    else if (ctrl.practice || ctrl.study?.practice) return undefined;
     else if (ctrl.cevalEnabled()) ctrl.playBestMove();
     else if (ctrl.isCevalAllowed() && ctrl.ceval.analysable) ctrl.cevalEnabled(!ctrl.cevalEnabled());
   });

--- a/ui/analyse/src/study/multiBoard.ts
+++ b/ui/analyse/src/study/multiBoard.ts
@@ -331,14 +331,14 @@ export const renderClock = (chapter: ChapterPreview, color: Color) => {
     : undefined;
 };
 
-const computeTimeLeft = (preview: ChapterPreview, color: Color): number | undefined => {
+const computeTimeLeft = (preview: ChapterPreview, color: Color) => {
   const clock = preview.players?.[color]?.clock;
   if (notNull(clock)) {
     if (defined(preview.lastMoveAt) && defined(preview.lastMove) && fenColor(preview.fen) === color) {
       const spent = (Date.now() - preview.lastMoveAt) / 1000;
       return Math.max(0, clock / 100 - spent);
     } else return clock / 100;
-  } else return;
+  } else return undefined;
 };
 
 const boardPlayer = (preview: ChapterPreview, color: Color, showResults?: boolean, round?: RelayRound) => {

--- a/ui/analyse/src/view/components.ts
+++ b/ui/analyse/src/view/components.ts
@@ -208,7 +208,7 @@ export function renderInputs(ctrl: AnalyseCtrl): VNode | undefined {
 
               el.addEventListener('keypress', (e: KeyboardEvent) => {
                 if (e.key !== 'Enter' || e.shiftKey || e.ctrlKey || e.altKey || e.metaKey || isMobile())
-                  return;
+                  return undefined;
                 else if (changePgnIfDifferent()) e.preventDefault();
               });
               if (isMobile()) el.addEventListener('focusout', changePgnIfDifferent);

--- a/ui/bits/src/bits.cropDialog.ts
+++ b/ui/bits/src/bits.cropDialog.ts
@@ -36,7 +36,6 @@ export async function initModule(o?: CropOpts): Promise<void> {
   }).catch(e => {
     URL.revokeObjectURL(url);
     opts.onCropped?.(false, `Image load failed: ${url} ${e.toString()}`);
-    return;
   });
 
   const viewBounds = constrain(image.naturalWidth / image.naturalHeight, {

--- a/ui/bits/src/youtubeLinkProcessor.ts
+++ b/ui/bits/src/youtubeLinkProcessor.ts
@@ -168,10 +168,10 @@ function extractStartTime(value: string): number {
   return start;
 }
 
-function toURL(url: string): URL | undefined {
+function toURL(url: string) {
   try {
     return new URL(url);
   } catch {
-    return;
+    return undefined;
   }
 }

--- a/ui/botPlay/src/botCtrl.ts
+++ b/ui/botPlay/src/botCtrl.ts
@@ -40,7 +40,6 @@ export class BotCtrl {
       if (game && (game.worthResuming() || evenIfEnded)) this.resumeGame(game);
     } catch (e) {
       this.onResumeFail(e);
-      return;
     }
   };
 
@@ -76,7 +75,6 @@ export class BotCtrl {
       });
     } catch (e) {
       this.onResumeFail(e);
-      return;
     }
   };
 

--- a/ui/insight/src/multipleSelect.ts
+++ b/ui/insight/src/multipleSelect.ts
@@ -140,7 +140,7 @@ export const registerMultipleSelect = () => {
           optionalStyle = this.options.styler?.(value),
           style = optionalStyle ? `style="${optionalStyle}"` : '';
         disabled = groupDisabled || $elm.prop('disabled');
-        const $el = $(
+        return $(
           [
             `<li class="${multiple} ${classes}" ${style}>`,
             `<label class="${disabled ? 'disabled' : ''}">`,
@@ -152,7 +152,6 @@ export const registerMultipleSelect = () => {
             '</li>',
           ].join(''),
         );
-        return $el;
       }
       if ($elm.is('optgroup')) {
         const label = that.options.labelTemplate?.($elm),
@@ -176,7 +175,7 @@ export const registerMultipleSelect = () => {
         });
         return $group.html();
       }
-      return;
+      return undefined;
     }
 
     events() {

--- a/ui/learn/src/scenario.ts
+++ b/ui/learn/src/scenario.ts
@@ -45,7 +45,7 @@ export default function (blueprint: ScenarioLevel | undefined, opts: ScenarioOpt
     it++;
     opts.setFen(opts.chess.fen(), opts.chess.getColor(), opts.makeChessDests(), [move[0], move[1]]);
     if (step.shapes) timeouts.setTimeout(() => opts.setShapes(step.shapes), 500);
-    return;
+    return undefined;
   };
 
   return {

--- a/ui/lib/src/ceval/protocol.ts
+++ b/ui/lib/src/ceval/protocol.ts
@@ -73,7 +73,6 @@ export class Protocol {
         work.emit(ceval);
       }
       this.swapWork();
-      return;
     } else if (this.work && !this.work.stopRequested && parts[0] === 'info') {
       let depth = 0,
         nodes,

--- a/ui/lib/src/chat/discussion.ts
+++ b/ui/lib/src/chat/discussion.ts
@@ -123,7 +123,7 @@ let mouchListener: EventListener;
 const setupHooks = (ctrl: ChatCtrl, chatEl: HTMLInputElement) => {
   const inner = tempStorage.make(`chat.input`);
   const storage = {
-    get: (): string | undefined => {
+    get: () => {
       const v = inner.get();
       if (v) {
         try {
@@ -135,7 +135,7 @@ const setupHooks = (ctrl: ChatCtrl, chatEl: HTMLInputElement) => {
           console.log(`Could not parse "chat.input" value ${v}`);
         }
       }
-      return;
+      return undefined;
     },
     set: (txt: string) => {
       inner.set(JSON.stringify([ctrl.data.opponentId || '', txt]));

--- a/ui/lib/src/chessgroundResize.ts
+++ b/ui/lib/src/chessgroundResize.ts
@@ -82,8 +82,8 @@ export default function resizeHandle(
   }
 }
 
-function eventPosition(e: MouchEvent): [number, number] | undefined {
+function eventPosition(e: MouchEvent) {
   if (e.clientX || e.clientX === 0) return [e.clientX, e.clientY!];
   if (e.targetTouches?.[0]) return [e.targetTouches[0].clientX, e.targetTouches[0].clientY];
-  return;
+  return undefined;
 }

--- a/ui/lib/src/game/sanWriter.ts
+++ b/ui/lib/src/game/sanWriter.ts
@@ -163,7 +163,7 @@ export function sanToUci(san: string, legalSans: SanToUci): Uci | undefined {
   if (san in legalSans) return legalSans[san];
   const lowered = san.toLowerCase();
   for (const i in legalSans) if (i.toLowerCase() === lowered) return legalSans[i];
-  return;
+  return undefined;
 }
 
 export const sanToWords = (san: string): string =>

--- a/ui/lib/src/menuKeyboardInteractions.ts
+++ b/ui/lib/src/menuKeyboardInteractions.ts
@@ -10,9 +10,7 @@ export default function menuKeyboardInteractions(): void {
     if (ev.code === 'Tab') {
       if (ev.shiftKey ? $target.is(':first-child') : $target.is(':last-child')) {
         $section.removeClass('active');
-        return;
       } else if ($section.hasClass('active')) {
-        return;
       }
     } else if (ev.code === 'Space') {
       $section.toggleClass('active');

--- a/ui/lib/src/puz/combo.ts
+++ b/ui/lib/src/puz/combo.ts
@@ -43,6 +43,6 @@ export class Combo {
           at: getNow(),
         };
     }
-    return;
+    return undefined;
   };
 }

--- a/ui/lib/src/view/complete.ts
+++ b/ui/lib/src/view/complete.ts
@@ -90,7 +90,7 @@ export function complete<Result>(opts: CompleteOpts<Result>): void {
           return false;
         }
       }
-      return;
+      return undefined;
     },
   });
 

--- a/ui/lib/src/view/markdownImgResizer.ts
+++ b/ui/lib/src/view/markdownImgResizer.ts
@@ -142,7 +142,6 @@ async function urlUpdate(img: HTMLImageElement, update: Extract<UpdateImageHook,
   preloadImg.src = imageUrl;
   await preloadImg.decode();
   update.url(img, imageUrl, Number(img.dataset.widthRatio));
-  return;
 }
 
 function dragHandles(img: HTMLImageElement): HTMLElement[] {

--- a/ui/lobby/src/view/correspondence.ts
+++ b/ui/lobby/src/view/correspondence.ts
@@ -1,4 +1,4 @@
-import { h, type VNode } from 'snabbdom';
+import { h } from 'snabbdom';
 
 import perfIcons from 'lib/game/perfIcons';
 import { bind, type MaybeVNodes, confirm } from 'lib/view';
@@ -8,7 +8,7 @@ import type { Seek } from '@/interfaces';
 
 import { tds, perfNames } from './util';
 
-function renderSeek(ctrl: LobbyController, seek: Seek): VNode {
+function renderSeek(ctrl: LobbyController, seek: Seek) {
   const klass = seek.action === 'joinSeek' ? 'join' : 'cancel';
   return h(
     'tr.seek.' + klass,
@@ -37,7 +37,7 @@ function renderSeek(ctrl: LobbyController, seek: Seek): VNode {
   );
 }
 
-function createSeek(ctrl: LobbyController): VNode | undefined {
+function createSeek(ctrl: LobbyController) {
   if (ctrl.me && ctrl.data.seeks.length < 8)
     return h('div.create', [
       h(
@@ -52,7 +52,7 @@ function createSeek(ctrl: LobbyController): VNode | undefined {
         i18n.site.createAGame,
       ),
     ]);
-  return;
+  return undefined;
 }
 
 export default function (ctrl: LobbyController): MaybeVNodes {
@@ -65,7 +65,6 @@ export default function (ctrl: LobbyController): MaybeVNodes {
           (['player', 'rating', 'time', 'mode'] as const).map(k => h('th', i18n.site[k])),
         ),
       ),
-
       h(
         'tbody',
         {

--- a/ui/opening/src/wiki.ts
+++ b/ui/opening/src/wiki.ts
@@ -20,19 +20,17 @@ async function fetchAndRender(data: OpeningPage, render: (html: string) => void)
     if (res.ok) {
       const json = await res.json();
       const page = json.query.pages[0];
-      if (page.missing) return;
-      else if (page.invalid) {
-        console.warn('invalid request: ' + page.invalidreason);
-        return;
-      } else if (!page.extract) {
-        console.warn('error: unexpected API response:<br><pre>' + JSON.stringify(page) + '</pre>');
-        return;
-      } else {
-        return render(transformWikiHtml(page.extract, title));
+      if (!page.missing) {
+        if (page.invalid) {
+          console.warn('invalid request: ' + page.invalidreason);
+        } else if (!page.extract) {
+          console.warn('error: unexpected API response:<br><pre>' + JSON.stringify(page) + '</pre>');
+        } else {
+          return render(transformWikiHtml(page.extract, title));
+        }
       }
-    } else return;
+    }
   } catch (err) {
     console.warn(err);
-    return;
   }
 }

--- a/ui/puzzle/src/view/feedback.ts
+++ b/ui/puzzle/src/view/feedback.ts
@@ -71,5 +71,5 @@ export default function (ctrl: PuzzleCtrl): MaybeVNode {
     case 'fail':
       return fail(ctrl);
   }
-  return;
+  return undefined;
 }

--- a/ui/puzzle/src/view/tree.ts
+++ b/ui/puzzle/src/view/tree.ts
@@ -111,7 +111,7 @@ function puzzleGlyph(node: TreeNode): MaybeVNode {
     case 'retry':
       return renderGlyph({ name: i18n.puzzle.goodMove, symbol: '?!' });
     default:
-      return;
+      return undefined;
   }
 }
 

--- a/ui/round/src/round.ts
+++ b/ui/round/src/round.ts
@@ -108,10 +108,10 @@ async function boot(
       });
   };
   const getPresetGroup = (d: RoundData) => {
-    if (d.player.spectator) return;
+    if (d.player.spectator) return undefined;
     if (finished(d)) return 'end';
     if (d.steps.length < 6) return 'start';
-    return;
+    return undefined;
   };
   const ctrl = await roundMain(opts);
   const round: RoundApi = { socketReceive: ctrl.socket.receive, moveOn: ctrl.moveOn };

--- a/ui/round/src/view/replay.ts
+++ b/ui/round/src/view/replay.ts
@@ -88,7 +88,7 @@ export function renderResult(ctrl: RoundController): VNode | undefined {
       ),
     ]);
   }
-  return;
+  return undefined;
 }
 
 function renderMoves(ctrl: RoundController): LooseVNodes {

--- a/ui/swiss/src/view/main.ts
+++ b/ui/swiss/src/view/main.ts
@@ -179,7 +179,7 @@ function joinButton(ctrl: SwissCtrl): VNode | undefined {
             i18n.site.withdraw,
           );
 
-  return;
+  return undefined;
 }
 
 function joinTheGame(ctrl: SwissCtrl) {

--- a/ui/tournament/src/ctrl.ts
+++ b/ui/tournament/src/ctrl.ts
@@ -176,7 +176,7 @@ export default class TournamentController {
           return;
         }
       }
-      await xhr.join(this, password, team);
+      xhr.join(this, password, team);
       this.joinSpinner = true;
       this.focusOnMe = true;
     }

--- a/ui/tournament/src/ctrl.ts
+++ b/ui/tournament/src/ctrl.ts
@@ -176,11 +176,10 @@ export default class TournamentController {
           return;
         }
       }
-      xhr.join(this, password, team);
+      await xhr.join(this, password, team);
       this.joinSpinner = true;
       this.focusOnMe = true;
     }
-    return;
   };
 
   scrollToMe = () => this.setPage(myPage(this));


### PR DESCRIPTION
# Why

Enable `no-useless-return` lint rule, to detect redundant `return`s or force to specify returned value directly for the core readability:
* https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-useless-return.html#eslint-no-useless-return

# How

Update Oxlint config to enable rule, address new warnings, simplify types in altered code chunks if possible.