### PR TITLE
enable few less impactful lint rules, fix new warnings

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -6,6 +6,7 @@
   },
   "ignorePatterns": ["**/dist/", "**/public"],
   "rules": {
+    "default-param-last": "error",
     "no-var": "warn",
     "no-constant-condition": [
       "warn",
@@ -14,6 +15,7 @@
       }
     ],
     "no-duplicate-imports": "error",
+    "no-useless-call": "error",
     "no-useless-computed-key": "error",
     "no-useless-concat": "error",
     "no-useless-constructor": "error",
@@ -30,6 +32,7 @@
     "prefer-promise-reject-errors": "error",
     "promise/no-callback-in-promise": "error",
     "promise/no-multiple-resolved": "error",
+    "promise/no-return-wrap": "error",
     "typescript/consistent-indexed-object-style": "error",
     "typescript/no-empty-interface": "error",
     "typescript/no-empty-object-type": "error",
@@ -40,7 +43,9 @@
     "typescript/no-unnecessary-type-assertion": "error",
     "typescript/no-unnecessary-type-constraint": "error",
     "unicorn/no-immediate-mutation": "error",
+    "unicorn/no-unnecessary-array-flat-depth": "error",
     "unicorn/no-useless-collection-argument": "error",
+    "unicorn/prefer-array-find": "error",
     "unicorn/prefer-array-flat": "error",
     "unicorn/prefer-array-flat-map": "error",
     "unicorn/prefer-array-some": "error",
@@ -225,6 +230,7 @@
     "no-unused-expressions": "off",
     "typescript/no-base-to-string": "off",
     "typescript/no-duplicate-type-constituents": "off",
+    "typescript/no-explicit-any": "off",
     "typescript/no-floating-promises": "off",
     "typescript/no-misused-spread": "off",
     "typescript/no-redundant-type-constituents": "off",

--- a/ui/lib/src/objectStorage.ts
+++ b/ui/lib/src/objectStorage.ts
@@ -75,10 +75,10 @@ export async function objectStorage<V, K extends IDBValidKey = IDBValidKey>(
     txn: (mode: IDBTransactionMode) => db.transaction(dbInfo.store, mode),
     cursor,
     readCursor: async (opts: CursorOpts, it: (v: V) => any): Promise<void> => {
-      for await (const c of cursor(opts, 'readonly')) await it(c.value);
+      for await (const c of cursor('readonly', opts)) await it(c.value);
     },
     writeCursor: async (opts: CursorOpts, it: WriteCursorCallback<V>): Promise<void> => {
-      for await (const c of cursor(opts, 'readwrite')) {
+      for await (const c of cursor('readwrite', opts)) {
         await it({
           value: c.value,
           update: (v: V) => promise(() => c.update(v)),
@@ -102,11 +102,12 @@ export async function objectStorage<V, K extends IDBValidKey = IDBValidKey>(
     });
   }
 
-  function cursor(opts: CursorOpts = {}, mode: IDBTransactionMode): AsyncGenerator<IDBCursorWithValue> {
+  function cursor(
+    mode: IDBTransactionMode,
+    { index, query, dir }: CursorOpts = {},
+  ): AsyncGenerator<IDBCursorWithValue> {
     const store = objectStore(mode);
-    const req = opts.index
-      ? store.index(opts.index).openCursor(opts.query, opts.dir)
-      : store.openCursor(opts.query, opts.dir);
+    const req = index ? store.index(index).openCursor(query, dir) : store.openCursor(query, dir);
     return (async function* () {
       while (true) {
         const cursor = await promise<IDBCursorWithValue | null>(() => req);
@@ -227,7 +228,7 @@ export interface ObjectStorage<V, K extends IDBValidKey = IDBValidKey> {
   /** initiate a database transaction */
   txn(mode: IDBTransactionMode): IDBTransaction;
   /** create a raw cursor to iterate over an index or store's records */
-  cursor(opts: CursorOpts, mode: IDBTransactionMode): AsyncGenerator<IDBCursorWithValue>;
+  cursor(mode: IDBTransactionMode, opts?: CursorOpts): AsyncGenerator<IDBCursorWithValue>;
   /** read records using an idb cursor via simple value callback. resolves when iteration completes */
   readCursor(o: CursorOpts, it: (v: V) => any): Promise<void>;
   /** read, write, or delete records via cursor callback. promise resolves when iteration is done */

--- a/ui/voice/makeGrammar.mts
+++ b/ui/voice/makeGrammar.mts
@@ -124,10 +124,10 @@ function writeGrammar(out: string) {
   fs.writeFileSync(out, JSON.stringify(builder.lexicon, null, 2));
 }
 
-function getArg(arg: string): string | undefined {
+function getArg(arg: string) {
   return ps.argv
-    .filter(v => v.startsWith(`--${arg}`))
-    .pop()
+    .reverse()
+    .find(value => value.startsWith(`--${arg}`))
     ?.slice(3 + arg.length);
 }
 

--- a/ui/voice/src/mic.ts
+++ b/ui/voice/src/mic.ts
@@ -195,7 +195,7 @@ export class Mic implements Microphone {
   }
 
   private broadcast(text: string, msgType: MsgType = 'status', forMs = 0) {
-    this.ctrl?.call(this, text, msgType);
+    this.ctrl(text, msgType);
     if (msgType === 'status' || msgType === 'full') window.clearTimeout(this.broadcastTimeout);
     this.voskStatus = text;
     for (const li of this.recs.items.get(this.recId)?.listeners ?? []) {


### PR DESCRIPTION
# Why

Enable few new and less impactful lint rules, which most of does not produce warnings, but will help us to kepp codebase in check.

# How

Enable:
* `default-param-last`
* `no-useless-call`
* `promise/no-return-wrap`
* `unicorn/no-unnecessary-array-flat-depth`
* `unicorn/prefer-array-find`

Fix related new warnings which there is not many of.

Also, I have added `typescript/no-explicit-any`, but in disabled mode, to indicate that we want to have it enabled in the future, but it still requires some refactor an more broad code changes.