### PR TITLE
ui: low-contrast tweaks mainly for a light theme

### DIFF
--- a/ui/learn/css/_map.scss
+++ b/ui/learn/css/_map.scss
@@ -88,12 +88,12 @@
     }
 
     &.future {
-      opacity: 0.7;
+      opacity: 0.8;
       background: $c-accent;
     }
 
     &.future img {
-      opacity: 0.7;
+      opacity: 0.8;
     }
 
     &.active,

--- a/ui/lib/css/component/_ublog-card.scss
+++ b/ui/lib/css/component/_ublog-card.scss
@@ -61,12 +61,14 @@
   time {
     @include inline-start(0);
 
+    backdrop-filter: blur(6px);
     border-radius: 0 0 $box-radius-size 0;
   }
 
   .user-link {
     @include inline-end(0);
 
+    backdrop-filter: blur(6px);
     border-radius: 0 0 0 $box-radius-size;
   }
 

--- a/ui/tournament/css/_calendar.scss
+++ b/ui/tournament/css/_calendar.scss
@@ -109,7 +109,7 @@
     }
 
     &.max-rating {
-      background-color: #8572ff;
+      background-color: #6b55fc;
     }
 
     &.yesterday {

--- a/ui/tournament/css/schedule/_schedule.scss
+++ b/ui/tournament/css/schedule/_schedule.scss
@@ -8,7 +8,7 @@ $c-tour-yearly: $c-brag;
 $c-tour-weekend: $c-brag;
 $c-tour-marathon: #66558c;
 $c-tour-unique: $c-brag;
-$c-tour-max-rating: #8572ff;
+$c-tour-max-rating: #6b55fc;
 $c-tour-variant: #7c5133;
 
 .tour-chart {


### PR DESCRIPTION
# Why

Not yet fully fixing the reported issues, but a step forward, addressing the leftover cases which does not require larger code refactors, refs:
* #20164

# How

Summary of changes:
* reduce the opacity of `future` learn tiles which increases contrast ratio for text over 3.0
* alter slightly the violet shade used for scheduled tournaments to increase the contrast a bit more
* add backdrop blur to ublog time/author nodes which improves the readability, but still the low contract, especially for `brag` text is a problem

# Preview

<img width="768" height="568" alt="Screenshot 2026-04-20 at 18 05 26" src="https://github.com/user-attachments/assets/8b1dcbbe-1bbc-4807-8579-cc07b1d125e0" />

<img width="1990" height="780" alt="Screenshot 2026-04-20 at 18 12 32" src="https://github.com/user-attachments/assets/64650c0f-b1f4-4e0e-aac7-1d7f6b0dfe0a" />

<img width="1310" height="446" alt="Screenshot 2026-04-20 at 18 20 37" src="https://github.com/user-attachments/assets/d744f26f-9791-43d1-a56d-ba0ff1855e97" />
