### PR TITLE
ui: refresh and align appearance of Learn and Practice pages

### DIFF
--- a/modules/practice/src/main/PracticeUi.scala
+++ b/modules/practice/src/main/PracticeUi.scala
@@ -11,6 +11,7 @@ final class PracticeUi(helpers: Helpers)(
     explorerAndCevalConfig: Context ?=> JsObject
 ):
   import helpers.{ *, given }
+  import trans.learn as trl
 
   def show(us: UserStudy, data: JsonView.JsData)(using ctx: Context) =
     Page(us.practiceStudy.name.value)
@@ -47,16 +48,16 @@ final class PracticeUi(helpers: Helpers)(
             h1("Practice"),
             h2("makes your chess perfect"),
             div(cls := "progress")(
-              div(cls := "text")("Progress: ", data.progressPercent, "%"),
+              div(cls := "text")(trl.progressX(s"${data.progressPercent}%")),
               div(cls := "bar", style := s"width: ${data.progressPercent}%")
             ),
             postForm(action := routes.Practice.reset)(
               if ctx.isAuth then
                 (data.nbDoneChapters > 0).option(
                   submitButton(
-                    cls := "button ok-cancel-confirm",
-                    title := "You will lose your practice progress!"
-                  )("Reset my progress")
+                    cls := "ok-cancel-confirm",
+                    title := trl.youWillLoseAllYourProgress.txt()
+                  )(trl.resetMyProgress.txt())
                 )
               else a(href := routes.Auth.signup)("Sign up to save your progress")
             )
@@ -74,7 +75,11 @@ final class PracticeUi(helpers: Helpers)(
                     )(
                       ctx.isAuth.option(
                         span(cls := "ribbon-wrapper")(
-                          span(cls := "ribbon")(prog.done, " / ", prog.total)
+                          span(cls := s"ribbon ${if prog.complete then "done" else "ongoing"}")(
+                            prog.done,
+                            " / ",
+                            prog.total
+                          )
                         )
                       ),
                       i(cls := s"${stud.id}"),

--- a/modules/practice/src/main/PracticeUi.scala
+++ b/modules/practice/src/main/PracticeUi.scala
@@ -69,7 +69,8 @@ final class PracticeUi(helpers: Helpers)(
                 div(cls := "studies")(
                   section.studies.map: stud =>
                     val prog = data.progressOn(stud.id)
-                    val stateClas = if prog.complete then "done" else "ongoing";
+                    val stateClas =
+                      if prog.complete then "done" else if prog.done > 0 then "ongoing" else "future";
                     a(
                       cls := s"study ${stateClas}",
                       href := routes.Practice.show(section.id, stud.slug, stud.id)

--- a/modules/practice/src/main/PracticeUi.scala
+++ b/modules/practice/src/main/PracticeUi.scala
@@ -85,7 +85,7 @@ final class PracticeUi(helpers: Helpers)(
                       i(cls := s"${stud.id}"),
                       span(cls := "text")(
                         h3(stud.name),
-                        em(stud.desc)
+                        p(stud.desc)
                       )
                     )
                 )

--- a/modules/practice/src/main/PracticeUi.scala
+++ b/modules/practice/src/main/PracticeUi.scala
@@ -69,13 +69,14 @@ final class PracticeUi(helpers: Helpers)(
                 div(cls := "studies")(
                   section.studies.map: stud =>
                     val prog = data.progressOn(stud.id)
+                    val stateClas = if prog.complete then "done" else "ongoing";
                     a(
-                      cls := s"study ${if prog.complete then "done" else "ongoing"}",
+                      cls := s"study ${stateClas}",
                       href := routes.Practice.show(section.id, stud.slug, stud.id)
                     )(
                       ctx.isAuth.option(
                         span(cls := "ribbon-wrapper")(
-                          span(cls := s"ribbon ${if prog.complete then "done" else "ongoing"}")(
+                          span(cls := s"ribbon ${stateClas}")(
                             prog.done,
                             " / ",
                             prog.total
@@ -86,7 +87,8 @@ final class PracticeUi(helpers: Helpers)(
                       span(cls := "text")(
                         h3(stud.name),
                         p(stud.desc)
-                      )
+                      ),
+                      (!prog.complete).option(div(cls := "attention-effect"))
                     )
                 )
               )

--- a/modules/practice/src/main/PracticeUi.scala
+++ b/modules/practice/src/main/PracticeUi.scala
@@ -50,8 +50,10 @@ final class PracticeUi(helpers: Helpers)(
                 alt := "Decorative image of a robotic golem",
                 src := assetUrl("images/practice/robot-golem.svg")
               ),
-              h1("Practice"),
-              h2("makes your chess perfect")
+              div(cls := "practice-side__title")(
+                h1("Practice"),
+                h2("makes your chess perfect")
+              )
             ),
             div(cls := "progress")(
               div(cls := "text")(trl.progressX(s"${data.progressPercent}%")),

--- a/modules/practice/src/main/PracticeUi.scala
+++ b/modules/practice/src/main/PracticeUi.scala
@@ -44,9 +44,15 @@ final class PracticeUi(helpers: Helpers)(
       ):
         main(cls := "page-menu force-ltr")(
           st.aside(cls := "page-menu__menu practice-side")(
-            i(cls := "fat"),
-            h1("Practice"),
-            h2("makes your chess perfect"),
+            div(cls := "practice-side__header")(
+              img(
+                cls := "practice-side__decoration",
+                alt := "Decorative image of a robotic golem",
+                src := assetUrl("images/practice/robot-golem.svg")
+              ),
+              h1("Practice"),
+              h2("makes your chess perfect")
+            ),
             div(cls := "progress")(
               div(cls := "text")(trl.progressX(s"${data.progressPercent}%")),
               div(cls := "bar", style := s"width: ${data.progressPercent}%")

--- a/ui/bits/css/_animated-border.scss
+++ b/ui/bits/css/_animated-border.scss
@@ -1,0 +1,36 @@
+@mixin animated-border($head-color, $tail-color) {
+  --border-angle: 0turn;
+  --gradient-border: conic-gradient(
+    from var(--border-angle),
+    transparent 25%,
+    #{$head-color},
+    #{$tail-color}
+  );
+
+  position: absolute;
+  inset: -1px;
+  z-index: -1;
+  border: 1px solid transparent;
+  border-radius: $box-radius-size;
+  background:
+    var(--gradient-border) border-box,
+    transparent border-box;
+  background-position: center center;
+  animation: bg-spin 4s linear infinite;
+  mask:
+    linear-gradient(#fff 0 0) content-box,
+    linear-gradient(#fff 0 0);
+  mask-composite: exclude;
+
+  @keyframes bg-spin {
+    to {
+      --border-angle: 1turn;
+    }
+  }
+}
+
+@property --border-angle {
+  syntax: '<angle>';
+  inherits: true;
+  initial-value: 0turn;
+}

--- a/ui/bits/css/_animated-border.scss
+++ b/ui/bits/css/_animated-border.scss
@@ -10,7 +10,7 @@
   position: absolute;
   inset: -1px;
   z-index: -1;
-  border: 1px solid transparent;
+  border: 3px solid transparent;
   border-radius: $box-radius-size;
   background:
     var(--gradient-border) border-box,

--- a/ui/bits/css/_animated-border.scss
+++ b/ui/bits/css/_animated-border.scss
@@ -16,7 +16,7 @@
     var(--gradient-border) border-box,
     transparent border-box;
   background-position: center center;
-  animation: bg-spin 4s linear infinite;
+  animation: bg-spin 3.5s linear infinite;
   mask:
     linear-gradient(#fff 0 0) content-box,
     linear-gradient(#fff 0 0);

--- a/ui/bits/css/build/bits.practice.index.scss
+++ b/ui/bits/css/build/bits.practice.index.scss
@@ -1,4 +1,5 @@
 @import '../../../lib/css/plugin';
 @import '../learn/progress';
 @import '../learn/ribbon';
+@import '../animated-border';
 @import '../practice/index';

--- a/ui/bits/css/build/bits.practice.index.scss
+++ b/ui/bits/css/build/bits.practice.index.scss
@@ -1,2 +1,4 @@
 @import '../../../lib/css/plugin';
+@import '../learn/progress';
+@import '../learn/ribbon';
 @import '../practice/index';

--- a/ui/bits/css/learn/_progress.scss
+++ b/ui/bits/css/learn/_progress.scss
@@ -1,0 +1,52 @@
+.progress {
+  @include box-radius;
+
+  position: relative;
+  height: 30px;
+  color: $c-over;
+  background: #1a7edb;
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.1);
+  overflow: hidden;
+}
+
+.progress .bar {
+  @extend %box-radius-right;
+
+  height: 100%;
+  background: #1566b2;
+  background-image: url('../images/grain.png');
+  transform: translateX(-100px);
+  animation:
+    animated-background 50s linear infinite,
+    animated-bar 1s forwards;
+}
+
+.progress .text {
+  @include inline-start(0);
+
+  position: absolute;
+  top: 0;
+  width: 100%;
+  line-height: 30px;
+  z-index: 3;
+}
+
+@keyframes animated-background {
+  from {
+    background-position: 0 0;
+  }
+
+  to {
+    background-position: 0 1000%;
+  }
+}
+
+@keyframes animated-bar {
+  from {
+    transform: translateX(-100px);
+  }
+
+  to {
+    transform: translateX(0);
+  }
+}

--- a/ui/bits/css/learn/_ribbon.scss
+++ b/ui/bits/css/learn/_ribbon.scss
@@ -1,0 +1,79 @@
+.ribbon-wrapper {
+  @include inline-end(-3px);
+
+  display: block;
+  width: 88px;
+  height: 88px;
+  overflow: hidden;
+  position: absolute;
+  top: -4px;
+
+  @media (width < $xx-small) {
+    @include inline-end(-13px);
+
+    scale: 0.75;
+    top: -14px;
+  }
+}
+
+.ribbon {
+  @include inline-start(-4px);
+
+  display: block;
+  font-size: 15px;
+  font-weight: bold;
+  text-align: center;
+  text-shadow: rgba(255, 255, 255, 0.5) 0 1px 0;
+  position: relative;
+  padding: 7px 0;
+  top: 15px;
+  width: 120px;
+  color: #6a6340;
+  box-shadow: 1px 0 3px rgba(0, 0, 0, 0.3);
+  transform: rotate(45deg);
+
+  @include if-rtl {
+    transform: rotate(-45deg);
+  }
+
+  i {
+    color: $c-brag;
+    animation: 0.6s soft-hue ease-in-out infinite;
+    text-shadow: 0 -0.5px 1px rgba(0, 0, 0, 0.5);
+  }
+
+  i:nth-child(2) {
+    animation-delay: 0.2s;
+  }
+
+  i:nth-child(3) {
+    animation-delay: 0.4s;
+  }
+
+  &::before,
+  &::after {
+    content: '';
+    border-left: 3px solid $c-border;
+    border-right: 3px solid $c-border;
+    position: absolute;
+    bottom: -3px;
+  }
+
+  &::before {
+    @include inline-start(0);
+  }
+
+  &::after {
+    @include inline-end(0);
+  }
+
+  &.done {
+    background-color: #bfdc7a;
+    box-shadow: 1px 0 3px $m-secondary--fade-50;
+  }
+
+  &.ongoing {
+    background-color: #b3e5fc;
+    box-shadow: 1px 0 3px $m-primary--fade-50;
+  }
+}

--- a/ui/bits/css/learn/_ribbon.scss
+++ b/ui/bits/css/learn/_ribbon.scss
@@ -17,6 +17,12 @@
 }
 
 .ribbon {
+  --ribbon-fade: #1111115a;
+
+  @include if-light {
+    --ribbon-fade: #1111113a;
+  }
+
   @include inline-start(-4px);
 
   display: block;
@@ -28,7 +34,7 @@
   padding: 7px 0;
   top: 15px;
   width: 120px;
-  color: #6a6340;
+  color: #5c5c5c;
   box-shadow: 1px 0 3px rgba(0, 0, 0, 0.3);
   transform: rotate(45deg);
 
@@ -53,18 +59,23 @@
   &::before,
   &::after {
     content: '';
-    border-left: 3px solid $c-border;
-    border-right: 3px solid $c-border;
+    width: 32px;
+    height: 100%;
     position: absolute;
-    bottom: -3px;
+    top: 0;
+    mix-blend-mode: overlay;
   }
 
   &::before {
     @include inline-start(0);
+
+    background: linear-gradient(90deg, var(--ribbon-fade), transparent);
   }
 
   &::after {
     @include inline-end(0);
+
+    background: linear-gradient(270deg, var(--ribbon-fade), transparent);
   }
 
   &.done {
@@ -75,5 +86,10 @@
   &.ongoing {
     background-color: #b3e5fc;
     box-shadow: 1px 0 3px $m-primary--fade-50;
+  }
+
+  &.future {
+    background-color: $m-future--lighten-22;
+    box-shadow: 1px 0 3px $m-future--fade-50;
   }
 }

--- a/ui/bits/css/learn/_ribbon.scss
+++ b/ui/bits/css/learn/_ribbon.scss
@@ -17,10 +17,10 @@
 }
 
 .ribbon {
-  --ribbon-fade: #1111115a;
+  --ribbon-fade: #1111116e;
 
   @include if-light {
-    --ribbon-fade: #1111113a;
+    --ribbon-fade: #1111113e;
   }
 
   @include inline-start(-4px);
@@ -79,12 +79,12 @@
   }
 
   &.done {
-    background-color: #bfdc7a;
+    background-color: #c5e791;
     box-shadow: 1px 0 3px $m-secondary--fade-50;
   }
 
   &.ongoing {
-    background-color: #b3e5fc;
+    background-color: #bddffa;
     box-shadow: 1px 0 3px $m-primary--fade-50;
   }
 

--- a/ui/bits/css/practice/_app.scss
+++ b/ui/bits/css/practice/_app.scss
@@ -83,20 +83,24 @@
     }
 
     &.ongoing {
-      border-color: $m-primary--fade-30;
+      border-color: $m-primary--fade-50;
       background: linear-gradient(0deg, $m-primary--fade-60, $m-primary--fade-80 100px);
+
+      .attention-effect {
+        @include animated-border($m-primary--lighten-30, $m-primary--fade-80);
+      }
 
       @include if-light {
         background: linear-gradient(180deg, $m-primary--fade-60, $m-primary--fade-80 100px);
+
+        .attention-effect {
+          @include animated-border($m-primary--darken-25, $m-primary--fade-80);
+        }
       }
     }
 
-    &.ongoing:hover {
-      filter: saturate(1.2);
-    }
-
     &.done {
-      border-color: $m-secondary--fade-30;
+      border-color: $m-secondary--fade-35;
       background: linear-gradient(0deg, $m-secondary--fade-60, $m-secondary--fade-80 100px);
 
       @include if-light {

--- a/ui/bits/css/practice/_app.scss
+++ b/ui/bits/css/practice/_app.scss
@@ -80,6 +80,7 @@
     p {
       margin: 4px 0 0 0;
       line-height: 1.2;
+      opacity: 0.8;
     }
 
     &.ongoing {
@@ -105,6 +106,15 @@
 
       @include if-light {
         background: linear-gradient(180deg, $m-secondary--fade-60, $m-secondary--fade-80 100px);
+      }
+    }
+
+    &.future {
+      border-color: $m-future--fade-35;
+      background: linear-gradient(0deg, $m-future--fade-60, $m-future--fade-80 100px);
+
+      @include if-light {
+        background: linear-gradient(180deg, $m-future--fade-60, $m-future--fade-80 100px);
       }
     }
 

--- a/ui/bits/css/practice/_app.scss
+++ b/ui/bits/css/practice/_app.scss
@@ -61,7 +61,7 @@
       width: 70px;
       height: 70px;
       margin: 0 1em;
-      opacity: 0.75;
+      opacity: 0.6;
       background-repeat: no-repeat;
       background-position: center;
       flex-shrink: 0;

--- a/ui/bits/css/practice/_app.scss
+++ b/ui/bits/css/practice/_app.scss
@@ -1,147 +1,100 @@
 .practice-app {
   section {
     > h2 {
-      @extend %roboto;
+      @extend %roboto, %page-text-shadow;
 
-      color: $c-font-dim;
       font-size: 2em;
-      letter-spacing: 0.3em;
+      letter-spacing: 8px;
       text-transform: uppercase;
+      color: #999;
       text-align: center;
     }
   }
 
   .studies {
-    ---min-width: 100vw;
+    ---min-width: 400px;
 
-    @media (min-width: at-least($xx-small)) {
-      ---min-width: 400px;
+    @media (width < $xx-small) {
+      ---min-width: calc(100vw - 2em);
+
+      padding: 0 0.5em;
     }
 
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(var(---min-width), 1fr));
     gap: 1em;
-    margin: 0.8em 0 3em 0;
+    margin: 1.5em 0 3em 0;
   }
 
   .study {
-    @extend %flex-center, %box-neat;
+    @extend %box-radius, %flex-center-nowrap;
+    @include transition;
+    @include backdrop-blur-if-transparent;
 
     position: relative;
-    height: 110px;
-    min-width: 300px;
+    height: 90px;
     color: #fff;
-
-    @include transition;
-
-    white-space: nowrap;
+    box-shadow: 0 3px 5px 0 rgba(0, 0, 0, 0.07);
     font-size: 1.2em;
-    overflow-x: hidden;
+    border: 1px solid $c-border;
+    background: $c-bg-box;
+    padding-right: 3em;
 
-    @media (min-width: at-least($small)) {
-      overflow-x: visible;
+    @include if-light {
+      color: $c-font;
 
-      /* ribbon */
+      i {
+        filter: brightness(0.15);
+      }
+    }
+
+    @media (width < $xx-small) {
+      height: fit-content;
     }
 
     i {
-      flex: 0 0 80px;
-      height: 80px;
-      margin: 0 0.9em;
-      opacity: 0.9;
+      width: 70px;
+      height: 70px;
+      margin: 0 1em;
+      opacity: 0.75;
+      background-repeat: no-repeat;
+      background-position: center;
+
+      @media (width < $xx-small) {
+        width: 50px;
+        height: 64px;
+      }
     }
 
     h3 {
       font-size: 1.4em;
     }
 
-    @keyframes soft-bright {
-      50% {
-        filter: brightness(1.2);
+    &.ongoing {
+      border-color: $m-primary--fade-30;
+      background: linear-gradient(0deg, $m-primary--fade-60, $m-primary--fade-80 100px);
+
+      @include if-light {
+        background: linear-gradient(180deg, $m-primary--fade-60, $m-primary--fade-80 100px);
       }
     }
 
-    &.ongoing {
-      background: $c-primary;
-
-      &:hover {
-        animation: 1.7s soft-bright ease-in-out infinite;
-      }
+    &.ongoing:hover {
+      filter: saturate(1.2);
     }
 
     &.done {
-      background: #4caf50 !important;
-    }
+      border-color: $m-secondary--fade-30;
+      background: linear-gradient(0deg, $m-secondary--fade-60, $m-secondary--fade-80 100px);
 
-    &.future {
-      opacity: 0.7;
-      background: #f57c00;
-    }
-
-    &.future .icon {
-      opacity: 0.7;
+      @include if-light {
+        background: linear-gradient(180deg, $m-secondary--fade-60, $m-secondary--fade-80 100px);
+      }
     }
 
     &.active,
     &:hover {
-      filter: brightness(1.08);
-      transform: scale(1.02);
-      opacity: 1;
-    }
-  }
-
-  .ribbon-wrapper {
-    display: block;
-    width: 85px;
-    height: 88px;
-    overflow: hidden;
-    position: absolute;
-    top: -3px;
-    right: -3px;
-  }
-
-  .ribbon {
-    display: block;
-    font-size: 15px;
-    font-weight: bold;
-    text-align: center;
-    text-shadow: rgba(255, 255, 255, 0.5) 0 1px 0;
-    transform: rotate(45deg);
-    position: relative;
-    padding: 7px 0;
-    left: -5px;
-    top: 15px;
-    width: 120px;
-    color: #6a6340;
-    box-shadow: 0 0 3px rgba(0, 0, 0, 0.3);
-
-    &::before,
-    &::after {
-      content: '';
-      border-left: 3px solid transparent;
-      border-right: 3px solid transparent;
-      border-top: 3px solid #536dfe;
-      position: absolute;
-      bottom: -3px;
-    }
-
-    &::before {
-      left: 0;
-    }
-
-    &::after {
-      right: 0;
-    }
-
-    background-color: #b3e5fc;
-  }
-
-  .done .ribbon {
-    background-color: #bfdc7a;
-
-    &::before,
-    &::after {
-      border-top: 3px solid #6e8900;
+      transform: scale(1.025);
     }
   }
 

--- a/ui/bits/css/practice/_app.scss
+++ b/ui/bits/css/practice/_app.scss
@@ -50,7 +50,11 @@
 
     @media (width < $xx-small) {
       min-height: fit-content;
-      padding: 4px 2.5em 4px 0;
+      padding: 6px 3em 6px 0;
+
+      p {
+        margin-top: 2px;
+      }
     }
 
     i {
@@ -69,13 +73,12 @@
     }
 
     h3 {
-      font-size: 1.4em;
+      font-size: 1.5em;
       line-height: 1;
     }
 
-    em {
-      display: inline-block;
-      margin: 2px 0 0 0;
+    p {
+      margin: 4px 0 0 0;
       line-height: 1.2;
     }
 

--- a/ui/bits/css/practice/_app.scss
+++ b/ui/bits/css/practice/_app.scss
@@ -32,7 +32,7 @@
     @include backdrop-blur-if-transparent;
 
     position: relative;
-    height: 90px;
+    min-height: 90px;
     color: #fff;
     box-shadow: 0 3px 5px 0 rgba(0, 0, 0, 0.07);
     font-size: 1.2em;
@@ -49,7 +49,8 @@
     }
 
     @media (width < $xx-small) {
-      height: fit-content;
+      min-height: fit-content;
+      padding: 4px 2.5em 4px 0;
     }
 
     i {
@@ -59,6 +60,7 @@
       opacity: 0.75;
       background-repeat: no-repeat;
       background-position: center;
+      flex-shrink: 0;
 
       @media (width < $xx-small) {
         width: 50px;
@@ -68,6 +70,13 @@
 
     h3 {
       font-size: 1.4em;
+      line-height: 1;
+    }
+
+    em {
+      display: inline-block;
+      margin: 2px 0 0 0;
+      line-height: 1.2;
     }
 
     &.ongoing {
@@ -99,6 +108,8 @@
   }
 
   .what_next > p {
+    @extend %page-text-shadow !optional;
+
     width: 100%;
     text-align: center;
     margin: 20px 0;

--- a/ui/bits/css/practice/_index.scss
+++ b/ui/bits/css/practice/_index.scss
@@ -3,9 +3,9 @@
 @import 'icons';
 
 .page-menu__menu {
-  margin: 0 0 3rem 0;
+  margin: 0 0 2rem 0;
 
   @include mq-subnav-side {
-    margin: 0 3rem 0 0;
+    margin: 0 2rem 0 0;
   }
 }

--- a/ui/bits/css/practice/_side.scss
+++ b/ui/bits/css/practice/_side.scss
@@ -32,6 +32,21 @@
     }
   }
 
+  &__header {
+    @extend %flex-column;
+
+    @media (width < $small) {
+      flex-flow: row nowrap;
+      gap: $block-gap;
+      text-align: left;
+
+      .practice-side__decoration {
+        width: min(100px, 30vw);
+        margin: 0;
+      }
+    }
+  }
+
   &__decoration {
     display: block;
     width: 160px;

--- a/ui/bits/css/practice/_side.scss
+++ b/ui/bits/css/practice/_side.scss
@@ -1,15 +1,24 @@
 .practice-side {
   @extend %box-radius;
+  @include backdrop-blur-if-transparent;
 
-  background: $c-primary;
-  color: $c-over;
+  background: $c-bg-box;
+  border: $border;
   text-align: center;
-  padding: 1.2em;
   align-self: start;
+  padding: 1em 1.25em;
+
+  @include if-light {
+    color: $c-font;
+
+    i.fat {
+      filter: brightness(0.15);
+    }
+  }
 
   h1 {
     font-size: 3.3em;
-    margin: 0.2em;
+    margin-top: 0.2em;
   }
 
   h2 {
@@ -19,80 +28,34 @@
 
   @keyframes fat-glide {
     50% {
-      opacity: 1;
+      transform: translateY(-4px);
     }
   }
 
   .fat {
     display: block;
-    width: 16em;
-    height: 16em;
+    width: 160px;
+    height: 160px;
     background: url('../images/practice/robot-golem.svg');
     margin: auto;
     opacity: 0.8;
-    animation: 1.2s fat-glide ease-in-out infinite;
   }
 
-  .progress {
-    @extend %box-radius-force;
-
-    position: relative;
-    width: 100%;
-    height: 2em;
-    background: #ccc3; // better
-    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.1);
-  }
-
-  @keyframes animated-background {
-    from {
-      background-position: 0 0;
-    }
-
-    to {
-      background-position: 0 1000%;
-    }
-  }
-
-  @keyframes animated-bar {
-    from {
-      transform: translateX(-100px);
-    }
-
-    to {
-      transform: translateX(0);
-    }
-  }
-
-  .progress .bar {
-    @extend %box-radius-right;
-
-    height: 100%;
-    background: #ccc3; // better
-    background-image: url('../images/grain.png');
-    transform: translateX(-100px);
-    animation:
-      animated-background 50s linear infinite,
-      animated-bar 1s forwards;
-  }
-
-  .progress .text {
-    @extend %abs-100;
-
-    line-height: 2em;
-    z-index: 1;
+  &:hover i.fat {
+    animation: 1.5s fat-glide ease-in-out infinite;
   }
 
   form {
-    padding-top: 1em;
-    text-align: left;
-  }
+    padding: 16px 10px 8px;
+    text-align: center;
 
-  a {
-    opacity: 0.6;
-    color: #fff;
-  }
+    button {
+      opacity: 0.6;
+      color: $c-font;
 
-  a:hover {
-    opacity: 1;
+      &:hover {
+        opacity: 1;
+      }
+    }
   }
 }

--- a/ui/bits/css/practice/_side.scss
+++ b/ui/bits/css/practice/_side.scss
@@ -1,49 +1,17 @@
 .practice-side {
-  @extend %box-radius;
+  @extend %box-radius, %flex-column;
   @include backdrop-blur-if-transparent;
 
+  gap: 1em;
   background: $c-bg-box;
   border: $border;
   text-align: center;
   align-self: start;
   padding: 1em 1.25em;
 
-  @include if-light {
-    color: $c-font;
-
-    i.fat {
-      filter: brightness(0.15);
-    }
-  }
-
-  h1 {
-    font-size: 3.3em;
-    margin-top: 0.2em;
-  }
-
-  h2 {
-    font-size: 1.3em;
-    margin-bottom: 1em;
-  }
-
   @keyframes fat-glide {
     50% {
       transform: translateY(-4px);
-    }
-  }
-
-  &__header {
-    @extend %flex-column;
-
-    @media (width < $small) {
-      flex-flow: row nowrap;
-      gap: $block-gap;
-      text-align: left;
-
-      .practice-side__decoration {
-        width: min(100px, 30vw);
-        margin: 0;
-      }
     }
   }
 
@@ -59,9 +27,40 @@
     animation: 1.5s fat-glide ease-in-out infinite;
   }
 
+  &__header {
+    @extend %flex-column;
+
+    gap: 1em;
+
+    .practice-side__title {
+      @extend %flex-column;
+
+      justify-content: center;
+    }
+
+    h1 {
+      font-size: 3.3em;
+    }
+
+    h2 {
+      font-size: 1.3em;
+    }
+
+    @media (width < $small) {
+      flex-flow: row nowrap;
+      gap: $block-gap;
+      text-align: left;
+
+      .practice-side__decoration {
+        width: min(100px, 30vw);
+        margin: 0;
+      }
+    }
+  }
+
   form {
-    padding: 16px 10px 8px;
     text-align: center;
+    font-size: 0.9em;
 
     button {
       opacity: 0.6;

--- a/ui/bits/css/practice/_side.scss
+++ b/ui/bits/css/practice/_side.scss
@@ -32,16 +32,15 @@
     }
   }
 
-  .fat {
+  &__decoration {
     display: block;
     width: 160px;
-    height: 160px;
-    background: url('../images/practice/robot-golem.svg');
+    aspect-ratio: 1;
     margin: auto;
-    opacity: 0.8;
+    opacity: 0.7;
   }
 
-  &:hover i.fat {
+  &:hover .practice-side__decoration {
     animation: 1.5s fat-glide ease-in-out infinite;
   }
 

--- a/ui/bits/css/practice/_side.scss
+++ b/ui/bits/css/practice/_side.scss
@@ -21,6 +21,10 @@
     aspect-ratio: 1;
     margin: auto;
     opacity: 0.7;
+
+    @include if-light {
+      filter: brightness(0.15);
+    }
   }
 
   &:hover .practice-side__decoration {

--- a/ui/learn/css/_layout.scss
+++ b/ui/learn/css/_layout.scss
@@ -30,7 +30,7 @@
     grid-template-areas: 'side' 'main';
   }
 
-  gap: $block-gap;
+  gap: 2rem;
 
   @include mq-at-least-col2 {
     &--run {

--- a/ui/learn/css/_map.scss
+++ b/ui/learn/css/_map.scss
@@ -30,7 +30,7 @@
     @include backdrop-blur-if-transparent;
 
     position: relative;
-    height: 90px;
+    min-height: 90px;
     color: #fff;
     box-shadow: 0 3px 5px 0 rgba(0, 0, 0, 0.07);
     font-size: 1.2em;
@@ -47,7 +47,8 @@
     }
 
     @media (width < $xx-small) {
-      height: fit-content;
+      min-height: fit-content;
+      padding: 4px 2.5em 4px 0;
     }
 
     img {
@@ -64,17 +65,12 @@
 
     h3 {
       font-size: 1.6em;
-      letter-spacing: 1px;
-      margin: 0 0 1px -1px;
-    }
-
-    &.vvv h3 {
-      font-size: 1.4em;
-      letter-spacing: 1px;
+      line-height: 1;
     }
 
     p {
-      margin: 0;
+      margin: 2px 0 0 0;
+      line-height: 1.2;
     }
 
     @keyframes soft-bright {

--- a/ui/learn/css/_map.scss
+++ b/ui/learn/css/_map.scss
@@ -48,7 +48,11 @@
 
     @media (width < $xx-small) {
       min-height: fit-content;
-      padding: 4px 2.5em 4px 0;
+      padding: 6px 3em 6px 0;
+
+      p {
+        margin-top: 2px;
+      }
     }
 
     img {
@@ -69,7 +73,7 @@
     }
 
     p {
-      margin: 2px 0 0 0;
+      margin: 4px 0 0 0;
       line-height: 1.2;
     }
 

--- a/ui/learn/css/_map.scss
+++ b/ui/learn/css/_map.scss
@@ -59,7 +59,7 @@
       width: 70px;
       height: 70px;
       margin: 0 1em;
-      opacity: 0.75;
+      opacity: 0.6;
 
       @media (width < $xx-small) {
         width: 50px;

--- a/ui/learn/css/_map.scss
+++ b/ui/learn/css/_map.scss
@@ -1,6 +1,4 @@
 .learn-stages {
-  padding-top: 10px;
-
   .categ > h2 {
     @extend %roboto, %page-text-shadow;
 
@@ -12,10 +10,12 @@
   }
 
   .categ_stages {
-    ---min-width: 100vw;
+    ---min-width: 400px;
 
-    @media (width >= $xx-small) {
-      ---min-width: 400px;
+    @media (width < $xx-small) {
+      ---min-width: calc(100vw - 2em);
+
+      padding: 0 0.5em;
     }
 
     display: grid;
@@ -27,24 +27,34 @@
   .stage {
     @extend %box-radius, %flex-center-nowrap;
     @include transition;
+    @include backdrop-blur-if-transparent;
 
     position: relative;
     height: 90px;
     color: #fff;
-    box-shadow:
-      0 3px 5px 0 rgba(0, 0, 0, 0.3),
-      0 1px 1px 0 rgba(0, 0, 0, 0.2);
+    box-shadow: 0 3px 5px 0 rgba(0, 0, 0, 0.07);
     font-size: 1.2em;
+    border: 1px solid $c-border;
+    background: $c-bg-box;
+    padding-right: 3em;
+
+    @include if-light {
+      color: $c-font;
+
+      img {
+        filter: brightness(0.15);
+      }
+    }
 
     @media (width < $xx-small) {
       height: fit-content;
     }
 
     img {
-      width: 80px;
-      height: 80px;
+      width: 70px;
+      height: 70px;
       margin: 0 1em;
-      opacity: 0.9;
+      opacity: 0.75;
 
       @media (width < $xx-small) {
         width: 50px;
@@ -54,7 +64,7 @@
 
     h3 {
       font-size: 1.6em;
-      letter-spacing: 2px;
+      letter-spacing: 1px;
       margin: 0 0 1px -1px;
     }
 
@@ -69,121 +79,46 @@
 
     @keyframes soft-bright {
       50% {
-        filter: brightness(0.97);
+        filter: saturate(1.4);
+        transform: scale(1.0075);
       }
     }
 
     &.ongoing {
-      background: $c-primary;
-      filter: brightness(0.9);
+      border-color: $m-primary--fade-30;
+      background: linear-gradient(0deg, $m-primary--fade-60, $m-primary--fade-80 100px);
       animation: 1.7s soft-bright ease-in-out infinite;
+
+      @include if-light {
+        background: linear-gradient(180deg, $m-primary--fade-60, $m-primary--fade-80 100px);
+      }
     }
 
     &.ongoing:hover {
-      filter: brightness(1.2);
+      filter: saturate(1.2);
     }
 
     &.done {
-      background: $c-secondary;
+      border-color: $m-secondary--fade-30;
+      background: linear-gradient(0deg, $m-secondary--fade-60, $m-secondary--fade-80 100px);
+
+      @include if-light {
+        background: linear-gradient(180deg, $m-secondary--fade-60, $m-secondary--fade-80 100px);
+      }
     }
 
     &.future {
-      opacity: 0.8;
-      background: $c-accent;
-    }
+      border-color: $m-future--fade-30;
+      background: linear-gradient(0deg, $m-future--fade-60, $m-future--fade-80 100px);
 
-    &.future img {
-      opacity: 0.8;
+      @include if-light {
+        background: linear-gradient(180deg, $m-future--fade-60, $m-future--fade-80 100px);
+      }
     }
 
     &.active,
     &:hover {
-      filter: brightness(1.08);
-      transform: scale(1.02);
-      opacity: 1;
-    }
-
-    .ribbon-wrapper {
-      display: block;
-      width: 85px;
-      height: 88px;
-      overflow: hidden;
-      position: absolute;
-      top: -3px;
-
-      @include inline-end(-3px);
-    }
-  }
-
-  .ribbon {
-    display: block;
-    font-size: 15px;
-    font-weight: bold;
-    text-align: center;
-    text-shadow: rgba(255, 255, 255, 0.5) 0 1px 0;
-    transform: rotate(45deg);
-
-    @include if-rtl {
-      transform: rotate(-45deg);
-    }
-
-    position: relative;
-    padding: 7px 0;
-
-    @include inline-start(-5px);
-
-    top: 15px;
-    width: 120px;
-    color: #6a6340;
-    box-shadow: 0 0 3px rgba(0, 0, 0, 0.3);
-
-    i {
-      color: $c-brag;
-      animation: 0.6s soft-hue ease-in-out infinite;
-      text-shadow: 0 -0.5px 1px rgba(0, 0, 0, 0.5);
-    }
-
-    i:nth-child(2) {
-      animation-delay: 0.2s;
-    }
-
-    i:nth-child(3) {
-      animation-delay: 0.4s;
-    }
-
-    &::before,
-    &::after {
-      content: '';
-      border-left: 3px solid transparent;
-      border-right: 3px solid transparent;
-      position: absolute;
-      bottom: -3px;
-    }
-
-    &::before {
-      @include inline-start(0);
-    }
-
-    &::after {
-      @include inline-end(0);
-    }
-
-    &.done {
-      background-color: #bfdc7a;
-    }
-
-    &.done::before,
-    &.done::after {
-      border-top: 3px solid #6e8900;
-    }
-
-    &.ongoing {
-      background-color: #b3e5fc;
-    }
-
-    &.ongoing::before,
-    &.ongoing::after {
-      border-top: 3px solid #536dfe;
+      transform: scale(1.025);
     }
   }
 

--- a/ui/learn/css/_map.scss
+++ b/ui/learn/css/_map.scss
@@ -75,6 +75,7 @@
     p {
       margin: 4px 0 0 0;
       line-height: 1.2;
+      opacity: 0.8;
     }
 
     &.ongoing {

--- a/ui/learn/css/_map.scss
+++ b/ui/learn/css/_map.scss
@@ -77,29 +77,25 @@
       line-height: 1.2;
     }
 
-    @keyframes soft-bright {
-      50% {
-        filter: saturate(1.4);
-        transform: scale(1.0075);
-      }
-    }
-
     &.ongoing {
-      border-color: $m-primary--fade-30;
+      border-color: $m-primary--fade-50;
       background: linear-gradient(0deg, $m-primary--fade-60, $m-primary--fade-80 100px);
-      animation: 1.7s soft-bright ease-in-out infinite;
+
+      .attention-effect {
+        @include animated-border($m-primary--lighten-30, $m-primary--fade-80);
+      }
 
       @include if-light {
         background: linear-gradient(180deg, $m-primary--fade-60, $m-primary--fade-80 100px);
+
+        .attention-effect {
+          @include animated-border($m-primary--darken-25, $m-primary--fade-80);
+        }
       }
     }
 
-    &.ongoing:hover {
-      filter: saturate(1.2);
-    }
-
     &.done {
-      border-color: $m-secondary--fade-30;
+      border-color: $m-secondary--fade-35;
       background: linear-gradient(0deg, $m-secondary--fade-60, $m-secondary--fade-80 100px);
 
       @include if-light {
@@ -108,7 +104,7 @@
     }
 
     &.future {
-      border-color: $m-future--fade-30;
+      border-color: $m-future--fade-35;
       background: linear-gradient(0deg, $m-future--fade-60, $m-future--fade-80 100px);
 
       @include if-light {

--- a/ui/learn/css/_side-home.scss
+++ b/ui/learn/css/_side-home.scss
@@ -20,6 +20,10 @@
     aspect-ratio: 1;
     margin: auto;
     opacity: 0.7;
+
+    @include if-light {
+      filter: brightness(0.15);
+    }
   }
 
   &:hover img.decoration {

--- a/ui/learn/css/_side-home.scss
+++ b/ui/learn/css/_side-home.scss
@@ -1,10 +1,19 @@
 .learn__side-home {
-  @extend %box-neat;
+  @extend %box-radius;
+  @include backdrop-blur-if-transparent;
 
-  background: $c-primary;
-  color: $c-over;
+  background: $c-bg-box;
+  border: $border;
   text-align: center;
-  padding: 1em 0;
+  padding: 1.25em 1.25em 1em;
+
+  @include if-light {
+    color: $c-font;
+
+    i.fat {
+      filter: brightness(0.15);
+    }
+  }
 
   h1 {
     font-size: 2.5em;
@@ -13,7 +22,7 @@
 
   h2 {
     font-size: 1.8em;
-    margin: 0.4em 0 1em 0;
+    margin-bottom: 1em;
   }
 
   @keyframes fat-glide {
@@ -24,77 +33,24 @@
 
   i.fat {
     display: block;
-    width: 200px;
-    height: 200px;
+    width: 160px;
+    height: 160px;
     background: url('../images/learn/brutal-helm.svg');
     margin: auto;
     opacity: 0.8;
   }
 
   &:hover i.fat {
-    animation: 1.2s fat-glide ease-in-out infinite;
-  }
-
-  .progress {
-    position: relative;
-    width: 100%;
-    height: 30px;
-
-    /* border-top: 3px solid #1566b2; */
-    background: #1a7edb;
-    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.1);
-    overflow: hidden;
-  }
-
-  @keyframes animated-background {
-    from {
-      background-position: 0 0;
-    }
-
-    to {
-      background-position: 0 1000%;
-    }
-  }
-
-  @keyframes animated-bar {
-    from {
-      transform: translateX(-100px);
-    }
-
-    to {
-      transform: translateX(0);
-    }
-  }
-
-  .progress .bar {
-    height: 100%;
-    background: #1566b2;
-    border-radius: 0 5px 5px 0;
-    background-image: url('../images/grain.png');
-    transform: translateX(-100px);
-    animation:
-      animated-background 50s linear infinite,
-      animated-bar 1s forwards;
-  }
-
-  .progress .text {
-    position: absolute;
-    top: 0;
-
-    @include inline-start(0);
-
-    width: 100%;
-    line-height: 30px;
-    z-index: 3;
+    animation: 1.5s fat-glide ease-in-out infinite;
   }
 
   .actions {
-    padding: 20px 10px;
+    padding: 16px 10px 8px;
   }
 
   a {
     opacity: 0.6;
-    color: #fff;
+    color: $c-font;
 
     &:hover {
       opacity: 1;

--- a/ui/learn/css/_side-home.scss
+++ b/ui/learn/css/_side-home.scss
@@ -1,29 +1,12 @@
 .learn__side-home {
-  @extend %box-radius;
+  @extend %box-radius, %flex-column;
   @include backdrop-blur-if-transparent;
 
+  gap: 1em;
   background: $c-bg-box;
   border: $border;
   text-align: center;
   padding: 1.25em 1.25em 1em;
-
-  @include if-light {
-    color: $c-font;
-
-    i.fat {
-      filter: brightness(0.15);
-    }
-  }
-
-  h1 {
-    font-size: 2.5em;
-    margin: 0;
-  }
-
-  h2 {
-    font-size: 1.8em;
-    margin-bottom: 1em;
-  }
 
   @keyframes fat-glide {
     50% {
@@ -31,21 +14,47 @@
     }
   }
 
-  i.fat {
+  img.decoration {
     display: block;
     width: 160px;
-    height: 160px;
-    background: url('../images/learn/brutal-helm.svg');
+    aspect-ratio: 1;
     margin: auto;
-    opacity: 0.8;
+    opacity: 0.7;
   }
 
-  &:hover i.fat {
+  &:hover img.decoration {
     animation: 1.5s fat-glide ease-in-out infinite;
   }
 
-  .actions {
-    padding: 16px 10px 8px;
+  &__header {
+    @extend %flex-column;
+
+    gap: 1em;
+
+    .learn__side-home__title {
+      @extend %flex-column;
+
+      justify-content: center;
+    }
+
+    h1 {
+      font-size: 2.5em;
+    }
+
+    h2 {
+      font-size: 1.8em;
+    }
+
+    @media (width < $small) {
+      flex-flow: row nowrap;
+      gap: $block-gap;
+      text-align: left;
+
+      img.decoration {
+        width: min(100px, 30vw);
+        margin: 0;
+      }
+    }
   }
 
   a {

--- a/ui/learn/css/build/learn.scss
+++ b/ui/learn/css/build/learn.scss
@@ -4,4 +4,5 @@
 @import '../../../lib/css/chess/promotion';
 @import '../../../bits/css/learn/progress';
 @import '../../../bits/css/learn/ribbon';
+@import '../../../bits/css/animated-border';
 @import '../learn';

--- a/ui/learn/css/build/learn.scss
+++ b/ui/learn/css/build/learn.scss
@@ -2,4 +2,6 @@
 @import '../../../lib/css/theme/board/coords';
 @import '../../../lib/css/layout/uniboard';
 @import '../../../lib/css/chess/promotion';
+@import '../../../bits/css/learn/progress';
+@import '../../../bits/css/learn/ribbon';
 @import '../learn';

--- a/ui/learn/src/mapSideView.ts
+++ b/ui/learn/src/mapSideView.ts
@@ -21,7 +21,7 @@ function renderInStage(ctrl: SideCtrl) {
         {
           attrs: { href: BASE_LEARN_PATH },
         },
-        [h('img', { attrs: { src: assetUrl + 'images/learn/brutal-helm.svg' } }), i18n.site.menu],
+        [h('img', { attrs: { alt: '', src: assetUrl + 'images/learn/brutal-helm.svg' } }), i18n.site.menu],
       ),
       ...categs.map((categ, categId) =>
         h(
@@ -55,9 +55,10 @@ function renderInStage(ctrl: SideCtrl) {
 function renderHome(ctrl: SideCtrl) {
   const progress = ctrl.progress();
   return h('div.learn__side-home', [
-    h('i.fat'),
-    h('h1', i18n.learn.learnChess),
-    h('h2', i18n.learn.byPlaying),
+    h('div.learn__side-home__header', [
+      h('img.decoration', { attrs: { alt: '', src: assetUrl + 'images/learn/brutal-helm.svg' } }),
+      h('div.learn__side-home__title', [h('h1', i18n.learn.learnChess), h('h2', i18n.learn.byPlaying)]),
+    ]),
     h('div.progress', [
       h('div.text', i18n.learn.progressX(progress + '%')),
       h('div.bar', {

--- a/ui/learn/src/view.ts
+++ b/ui/learn/src/view.ts
@@ -30,15 +30,11 @@ const mapView = (ctrl: LearnCtrl) =>
               const prevComplete = ctrl.isStageIdComplete(stage.id - 1);
               const status: Status = complete ? 'done' : prevComplete || stageProgress ? 'ongoing' : 'future';
               const title = stage.title;
-              return h(
-                `a.stage.${status}.${titleVerbosityClass(title)}`,
-                { attrs: { href: hashHref(stage.id) } },
-                [
-                  status !== 'future' ? ribbon(ctrl, stage, status, stageProgress) : undefined,
-                  h('img', { attrs: { src: stage.image } }),
-                  h('div.text', [h('h3', title), h('p.subtitle', stage.subtitle)]),
-                ],
-              );
+              return h(`a.stage.${status}`, { attrs: { href: hashHref(stage.id) } }, [
+                status !== 'future' ? ribbon(ctrl, stage, status, stageProgress) : undefined,
+                h('img', { attrs: { src: stage.image } }),
+                h('div.text', [h('h3', title), h('p.subtitle', stage.subtitle)]),
+              ]);
             }),
           ),
         ]),
@@ -46,8 +42,6 @@ const mapView = (ctrl: LearnCtrl) =>
       whatNext(ctrl),
     ]),
   ]);
-
-const titleVerbosityClass = (title: string) => (title.length > 13 ? (title.length > 18 ? 'vvv' : 'vv') : '');
 
 const makeStars = (rank: scoring.Rank): VNode[] =>
   Array(4 - rank).fill(h('i', { attrs: { 'data-icon': licon.Star } }));
@@ -68,11 +62,10 @@ const ribbon = (ctrl: LearnCtrl, s: Stage, status: Exclude<Status, 'future'>, st
 
 function whatNext(ctrl: LearnCtrl) {
   const makeStage = (href: string, img: string, title: string, subtitle: string, done?: boolean) => {
-    const transTitle = title;
-    return h(`a.stage.done.${titleVerbosityClass(transTitle)}`, { attrs: { href: href } }, [
+    return h(`a.stage.done`, { attrs: { href: href } }, [
       done ? h('span.ribbon-wrapper', h('span.ribbon.done', makeStars(1))) : null,
       h('img', { attrs: { src: assetUrl + 'images/learn/' + img + '.svg' } }),
-      h('div.text', [h('h3', transTitle), h('p.subtitle', subtitle)]),
+      h('div.text', [h('h3', title), h('p.subtitle', subtitle)]),
     ]);
   };
   const userId = ctrl.data._id;

--- a/ui/learn/src/view.ts
+++ b/ui/learn/src/view.ts
@@ -34,6 +34,7 @@ const mapView = (ctrl: LearnCtrl) =>
                 status !== 'future' ? ribbon(ctrl, stage, status, stageProgress) : undefined,
                 h('img', { attrs: { src: stage.image } }),
                 h('div.text', [h('h3', title), h('p.subtitle', stage.subtitle)]),
+                status === 'ongoing' ? h('div.attention-effect') : undefined,
               ]);
             }),
           ),

--- a/ui/lib/css/theme/_theme.default.scss
+++ b/ui/lib/css/theme/_theme.default.scss
@@ -37,6 +37,7 @@ $c-mistake: hsl(41, 100%, 45%);
 $c-blunder: hsl(0, 69%, 60%);
 $c-brilliant: hsl(129, 71%, 45%);
 $c-interesting: hsl(307, 80%, 70%);
+$c-future: hsl(274, 48%, 60%);
 $c-paper: hsl(60, 56%, 91%);
 $c-dark: #333;
 $c-dimmer: #000;

--- a/ui/lib/css/theme/_theme.light.scss
+++ b/ui/lib/css/theme/_theme.light.scss
@@ -26,6 +26,7 @@ $c-mistake: hsl(41, 100%, 35%);
 $c-blunder: hsl(0, 68%, 50%);
 $c-brilliant: hsl(129, 71%, 30%);
 $c-interesting: hsl(307, 80%, 59%);
+$c-future: hsl(274, 65%, 70%);
 $c-paper: hsl(60, 56%, 86%);
 $c-border: hsl(0, 0%, 85%);
 $c-dimmer: #fff;


### PR DESCRIPTION
# Why

Lately I have been experimenting a bit locally with learn/practice UI slight refresh, mainly driven by the contrast/readability issues in light mode, brought up not that long ago. Here is a result proposition of those efforts.

Any feedback is appreciated! 

Discussion thread in Zulip:
* https://hq.lichess.ovh/#narrow/channel/8-dev/topic/learn.2Fpractice.20UI.20refresh.20exploration

# How

Refresh and align appearance of Learn and Practice pages, change the "future" lesson state color to new violet shade (to avoid negative connotations with red/orange color and improve a11y), extract shearable SCSS code to new bits, re-use few Learn translation on the Practice page where possible.

# Preview

### Recording

https://github.com/user-attachments/assets/3efd6d63-5a03-4904-94ed-0d277ee297a7

### Screenshots

<img width="2728" height="1670" alt="Screenshot 2026-04-22 at 12 10 13" src="https://github.com/user-attachments/assets/739a92c2-32d1-41ab-86fc-3cba5e972a83" />

<img width="2728" height="1640" alt="Screenshot 2026-04-22 at 12 10 27" src="https://github.com/user-attachments/assets/63423376-fd75-4a26-a43e-c97ec190409a" />
