### PR TITLE
Add select search to Tiebreaks

### DIFF
--- a/ui/bits/src/bits.relayForm.ts
+++ b/ui/bits/src/bits.relayForm.ts
@@ -12,6 +12,10 @@ site.load.then(() => {
       createSelectSearch(this);
     });
 
+    $('select[id^="form3-tiebreaks_"]').each(function (this: HTMLSelectElement) {
+      createSelectSearch(this);
+    });
+
     wireCropDialog({
       aspectRatio: 2 / 1,
       post: { url: $('.relay-image-edit').attr('data-post-url')!, field: 'image' },


### PR DESCRIPTION
<img width="961" height="493" alt="imagem" src="https://github.com/user-attachments/assets/d63d1784-186c-4737-9d0f-0c175948bc10" />

IA assit: copilot only just simplfy (`#form3-tiebreaks_0, #form3-tiebreaks_1, #form3-tiebreaks_2, #form3-tiebreaks_3, #form3-tiebreaks_4` -> `select[id^="form3-tiebreaks_"]`)