### PR TITLE
ui: restore `c-clas` theme color, rename other SCSS vars

### DIFF
--- a/ui/bits/css/_clas.scss
+++ b/ui/bits/css/_clas.scss
@@ -1,7 +1,7 @@
-$c-clas: hsl(274, 48%, 60%);
+$c-clas-light: hsl(274, 48%, 60%);
+$c-clas-lighter: mix($c-clas-light, #fff, 86%);
 $c-bg-clas-over: white;
 $c-bg-clas-over-dim: $m-clas_white--mix-20;
-$c-clas-light: mix($c-clas, #fff, 86%);
 
 @mixin button-with-clas-shadow {
   @include with-button-shadow(
@@ -25,7 +25,7 @@ body {
 .button-empty {
   &.button-clas,
   &.button-clas:hover {
-    color: $c-clas;
+    color: $c-clas-light;
   }
 }
 
@@ -49,11 +49,11 @@ body {
   }
 
   &.active {
-    color: $c-clas;
+    color: $c-clas-light;
   }
 
   &::after {
-    background: $c-clas;
+    background: $c-clas-light;
   }
 
   &.student {
@@ -74,7 +74,7 @@ h1 {
 }
 
 .page .body h2 {
-  border-bottom-color: $c-clas;
+  border-bottom-color: $c-clas-light;
 }
 
 .clas-index {
@@ -95,7 +95,7 @@ h1 {
       @include button-with-clas-shadow;
 
       color: $c-over;
-      background: $c-clas-light !important;
+      background: $c-clas-lighter !important;
     }
 
     &::before {
@@ -119,7 +119,7 @@ h1 {
       &::before {
         @include transition;
 
-        color: $c-clas-light;
+        color: $c-clas-lighter;
         font-size: 5em;
         margin-inline-end: 0.4em;
 
@@ -132,7 +132,7 @@ h1 {
         background: $m-clas_bg--mix-10;
 
         &::before {
-          color: $c-clas;
+          color: $c-clas-light;
         }
       }
 
@@ -143,7 +143,7 @@ h1 {
       h3 {
         @include fluid-size('font-size', 23px, 35px);
 
-        color: $c-clas;
+        color: $c-clas-light;
       }
 
       p {
@@ -316,7 +316,7 @@ h1 {
 
       &.active {
         background: $c-bg-box;
-        color: $c-clas;
+        color: $c-clas-light;
         font-weight: bold;
 
         .dashboard-teacher-overview &,
@@ -396,7 +396,7 @@ h1 {
         text-align: center;
         font-weight: bold;
         padding: 0.7em;
-        color: $c-clas;
+        color: $c-clas-light;
 
         &:hover {
           background: $m-clas_bg--mix-30;
@@ -686,10 +686,10 @@ h1 {
 
       margin-bottom: 2em;
       display: inline-block;
-      background: $c-clas-light;
+      background: $c-clas-lighter;
 
       &:hover {
-        background: $c-clas;
+        background: $c-clas-light;
       }
     }
   }
@@ -712,7 +712,7 @@ h1 {
       .button {
         @extend %box-radius-inline-end;
 
-        background: $c-clas-light;
+        background: $c-clas-lighter;
         padding: 0 1.5em;
         border-inline-start: 0;
       }

--- a/ui/lib/css/theme/_theme.default.scss
+++ b/ui/lib/css/theme/_theme.default.scss
@@ -30,6 +30,7 @@ $c-good: hsl(88, 62%, 37%);
 $c-accent: hsl(22, 100%, 42%);
 $c-bad: hsl(0, 60%, 50%);
 $c-brag: hsl(37, 74%, 43%);
+$c-clas: rgb(88, 28, 135);
 $c-shade: hsl(0, 0%, 30%);
 $c-inaccuracy: hsl(202, 78%, 62%);
 $c-mistake: hsl(41, 100%, 45%);


### PR DESCRIPTION
# Why

Build assets step fails:
* https://github.com/lichess-org/lila/actions/runs/24774515960/job/72489194250

Refs https://github.com/lichess-org/lila/commit/fdc8a5f086ebd7ba3267af1327c7dac1755f7b04

# How

Restore `c-clas` theme color to allow generating mixed values, rename other SCSS vars in `_clas` bit to avoid confusion.

# Test plan

Rebuilded the UI code locally, made sure that classes pages still display correctly and use correct shades.

<img width="3138" height="978" alt="Screenshot 2026-04-22 at 15 50 11" src="https://github.com/user-attachments/assets/7db8ed12-d71a-4daf-85c1-9bde444f157c" />
