### PR TITLE
Only apply the 'packed' class to trophies when an overflow is close to happening

### DIFF
--- a/app/views/user/show/header.scala
+++ b/app/views/user/show/header.scala
@@ -64,12 +64,7 @@ object header:
               userDom(u)
             )
           case None => h1(userDom(u)),
-        div(
-          cls := List(
-            "trophies" -> true,
-            "packed" -> (info.trophies.countTrophiesAndPerfCups > 7)
-          )
-        )(
+        div(cls := "trophies")(
           views.user.bits.perfTrophies(u, info.ranks),
           otherTrophies(info),
           u.plan.active.option(

--- a/ui/user/src/user.ts
+++ b/ui/user/src/user.ts
@@ -12,6 +12,8 @@ export async function initModule(): Promise<void> {
   makeLinkPopups($('.user-infos .bio'));
 
   tmpRandomTutorLink();
+  updatePackedTrophies();
+  window.addEventListener('resize', updatePackedTrophies);
 
   const loadNoteZone = () => {
     const $zone = $('.user-show .note-zone');
@@ -95,4 +97,15 @@ function tmpRandomTutorLink() {
     <span><strong>Try out Tutor</strong><em>Compare to your peers!</em></span>
   </a>`;
   $(buttonHtml).insertBefore('.profile-side .insight');
+}
+
+function updatePackedTrophies() {
+  const header = document.querySelector<HTMLElement>('.user-show__header');
+  const trophies = header?.querySelector<HTMLElement>('.trophies');
+  const title = header?.querySelector<HTMLElement>('h1');
+  if (!trophies || !title) return;
+  trophies.classList.remove('packed');
+  // see if there's an overflow (or close to one) without 'packed':
+  if (trophies.getBoundingClientRect().left < title.getBoundingClientRect().right + 8)
+    trophies.classList.add('packed');
 }


### PR DESCRIPTION
E.g., the packed class is applied on my profile:

<img width="2096" height="318" alt="image" src="https://github.com/user-attachments/assets/af1f3302-3bbb-4b82-a1a4-fd2361423feb" />

But without it there'd still be more than enough room:

<img width="2062" height="304" alt="image" src="https://github.com/user-attachments/assets/5df62036-ce25-4701-91a3-dd8e494a9861" />

Note that for this PR, when `packed` is needed, the trophies will initially be shown unpacked for a split second on page load.