### PR TITLE
remove slack puzzle app, no longer supported

### DIFF
--- a/app/controllers/Main.scala
+++ b/app/controllers/Main.scala
@@ -46,9 +46,6 @@ final class Main(env: Env, assetsC: ExternalAssets) extends LilaController(env):
     pageHit
     FoundPage(env.cms.renderKey("mobile"))(views.mobile)
 
-  def dailyPuzzleSlackApp = Open:
-    Ok.page(views.site.ui.dailyPuzzleSlackApp)
-
   def jslog(id: GameFullId) = Open:
     env.round.selfReport(
       userId = ctx.userId,

--- a/conf/routes
+++ b/conf/routes
@@ -911,7 +911,6 @@ GET   /lag                             controllers.Main.lag
 GET   /get-fishnet                     controllers.Main.getFishnet
 GET   /costs                           controllers.Main.costs
 GET   /InstantChess.com                controllers.Main.instantChess
-GET   /daily-puzzle-slack              controllers.Main.dailyPuzzleSlackApp
 POST  /upload/image/user/:rel          controllers.Main.uploadImage(rel)
 GET   /image-url/:id                   controllers.Main.imageUrl(id: ImageId, width: Int)
 POST  /github/secret-scanning          controllers.Github.secretScanning

--- a/modules/web/src/main/ui/SitePages.scala
+++ b/modules/web/src/main/ui/SitePages.scala
@@ -105,12 +105,7 @@ final class SitePages(helpers: Helpers):
                   s"""<iframe src="$netBaseUrl/training/frame?theme=brown&bg=dark" $args></iframe>"""
                 ),
                 parameters(),
-                p("The text is automatically translated to your visitor's language."),
-                p(
-                  "Alternatively, you can ",
-                  a(href := routes.Main.dailyPuzzleSlackApp)("post the puzzle in your slack workspace"),
-                  "."
-                )
+                p("The text is automatically translated to your visitor's language.")
               )
             )
           },
@@ -285,69 +280,6 @@ final class SitePages(helpers: Helpers):
             p(trl.youCanFindTheseValuesAtAnyTimeByClickingOnYourUsername()),
             h2(trl.lagCompensation()),
             p(trl.lagCompensationExplanation())
-          )
-        )
-
-  def dailyPuzzleSlackApp =
-    Page("Daily Chess Puzzle by Lichess (Slack App)")
-      .css("bits.page"):
-        main(cls := "page page-small box box-pad")(
-          h1(cls := "box__top")("Daily Chess Puzzle by Lichess (Slack App)"),
-          div(cls := "body")(
-            p(
-              "Spice up your Slack workspace with a daily chess puzzle from ",
-              a(href := "/")("lichess.org"),
-              "."
-            ),
-            a(
-              href := "https://slack.com/oauth/v2/authorize?client_id=17688987239.964622027363&scope=commands,incoming-webhook"
-            )(
-              img(
-                alt := "Add to Slack",
-                heightA := 40,
-                widthA := 139,
-                src := assetUrl("images/add-to-slack.png")
-              )
-            ),
-            h2("Summary"),
-            p(
-              "By default, the app will post the ",
-              a(href := routes.Puzzle.daily)("daily chess puzzle"),
-              " from Lichess to the channel in which it was installed every day (at the same time of day it was installed). Use the ",
-              code("/puzzletime"),
-              " command to change this setting, e.g. ",
-              code("/puzzletime 14:45"),
-              ". To post the daily puzzle on demand, use the ",
-              code("/puzzle"),
-              " command."
-            ),
-            h2("Commands"),
-            ul(
-              li(code("/puzzlehelp"), " - Displays helpful instructions"),
-              li(
-                code("/puzzletime HH:MM"),
-                " - Sets the time of day the daily puzzle should be posted (per channel)"
-              ),
-              li(code("/puzzle"), " - Posts the daily puzzle")
-            ),
-            h2("Privacy Policy"),
-            p(
-              "The app only collects and stores information necessary to deliver the service, which is limited to OAuth authentication information, Slack workspace/channel identifiers and app configuration settings. No personal information is processed except for the username of users invoking slash commands. No personal information is stored."
-            ),
-            h2("Support and feedback"),
-            p(
-              // Contact email, because Slack requires a support channel without
-              // mandatory registration.
-              "Give us feedback or ask questions ",
-              a(href := routes.ForumCateg.show(ForumCategId("lichess-feedback")))(
-                "in the forum"
-              ),
-              ". The source code is available at ",
-              a(href := "https://github.com/arex1337/lichess-daily-puzzle-slack-app")(
-                "github.com/arex1337/lichess-daily-puzzle-slack-app"
-              ),
-              "."
-            )
           )
         )
 


### PR DESCRIPTION
Removes page: https://lichess.org/daily-puzzle-slack

https://lichess.org/forum/lichess-feedback/lichess-slack-app-cant-install-into-slack-workspace