### PR TITLE
fix-login-username-tabindex

### DIFF
--- a/modules/web/src/main/ui/AuthUi.scala
+++ b/modules/web/src/main/ui/AuthUi.scala
@@ -413,5 +413,6 @@ final class AuthUi(helpers: Helpers):
       tpe := "button",
       dataIcon := Icon.Cancel,
       title := trans.site.clearField.txt(),
-      aria.label := trans.site.clearField.txt()
+      aria.label := trans.site.clearField.txt(),
+      tabindex := -1
     )


### PR DESCRIPTION
For the login the user wants to type username TAB password. In order to not land on the username removal button X, the tabindex is set to -1 to exclude it from the tablist.