### PR TITLE
fix: include game division in game analysis progress events

### DIFF
--- a/modules/analyse/src/main/Analyser.scala
+++ b/modules/analyse/src/main/Analyser.scala
@@ -4,11 +4,13 @@ import monocle.syntax.all.*
 import play.api.libs.json.*
 
 import lila.common.Bus
+import lila.common.Json.given
 import lila.tree.Analysis
 
 final class Analyser(
     gameRepo: lila.core.game.GameRepo,
-    analysisRepo: AnalysisRepo
+    analysisRepo: AnalysisRepo,
+    divider: lila.core.game.Divider
 )(using Executor)
     extends lila.tree.Analyser:
 
@@ -53,7 +55,9 @@ final class Analyser(
   ): JsObject =
     import lila.tree.{ TreeBuilder, ExportOptions, Node }
     val tree = TreeBuilder(game, analysis.some, initialFen, ExportOptions.default, lila.log("analyser").warn)
+    val division = divider(game.id, game.sans, game.variant, initialFen.some)
     Json.obj(
       "analysis" -> JsonView.bothPlayers(game.startedAtPly, analysis),
-      "tree" -> Node.lichobileNodeJsonWriter.writes(tree)
+      "tree" -> Node.lichobileNodeJsonWriter.writes(tree),
+      "division" -> division
     )

--- a/modules/analyse/src/main/Env.scala
+++ b/modules/analyse/src/main/Env.scala
@@ -10,7 +10,8 @@ final class Env(
     db: lila.db.Db,
     gameRepo: lila.core.game.GameRepo,
     cacheApi: lila.memo.CacheApi,
-    net: NetConfig
+    net: NetConfig,
+    divider: lila.core.game.Divider
 )(using Executor):
 
   lazy val repo = AnalysisRepo(db(CollName("analysis2")))


### PR DESCRIPTION
## Problem

While analysis is running, the app listens to `analysisProgress` events on the websocket.

When analyzing a study chapter, these events inlude a `division` field, which the app uses to update the game summary chart. However, for game analysis this field is missing.

## Solution

Add the `division` field to game analysis progress events as well.

## AI

Assisted by DeepWiki: https://deepwiki.com/search/when-requesting-a-game-analysi_9b8dcaa5-de97-4dee-8eec-80b241aa0ad6?mode=fast