### PR TITLE
improve relay (broadcast) search

### DIFF
--- a/modules/relay/src/main/RelayPager.scala
+++ b/modules/relay/src/main/RelayPager.scala
@@ -1,5 +1,7 @@
 package lila.relay
 
+import java.util.regex.Pattern
+
 import scalalib.paginator.{ AdapterLike, Paginator }
 
 import lila.db.dsl.{ *, given }
@@ -129,25 +131,29 @@ final class RelayPager(
 
     val day = 1000L * 3600 * 24
 
-    val (textSearch, nameFilter) = query match
-      case RelayPager.yearRegex(pre, year, post) =>
-        val remaining = s"$pre $post".trim
-        (if remaining.isEmpty then query else remaining, $doc("name".$regex(s"\\b$year\\b")))
-      case q => (q, $empty)
+    def partialNameSelector(query: String): Bdoc =
+      query.trim
+        .split("\\s+")
+        .toList
+        .filter(_.nonEmpty)
+        .map: term =>
+          $doc("name".$regex(Pattern.quote(term), "i"))
+        .match
+          case Nil => $empty
+          case head :: Nil => head
+          case filters => $and(filters*)
 
-    // We add quotes to the query to perform an exact match even when the query contains whitespaces
-    val textSelector = $text(s"\"$textSearch\"") ++ nameFilter ++ selectors.officialPublic
+    val selector = partialNameSelector(query) ++ selectors.officialPublic
 
     forSelector(
-      selector = textSelector,
+      selector = selector,
       page = page,
       onlyKeepGroupFirst = false,
       addFields = $doc(
         "searchDate" -> $doc(
           "$add" -> $arr(
             $doc("$ifNull" -> $arr("$syncedAt", "$createdAt")),
-            $doc("$multiply" -> $arr($doc("$add" -> $arr("$tier", -RelayTour.Tier.normal.v)), 60 * day)),
-            $doc("$multiply" -> $arr($doc("$meta" -> "textScore"), 30 * day))
+            $doc("$multiply" -> $arr($doc("$add" -> $arr("$tier", -RelayTour.Tier.normal.v)), 60 * day))
           )
         )
       ).some,
@@ -203,6 +209,3 @@ final class RelayPager(
     round = rounds.headOption
     group = RelayTourRepo.group.readFrom(doc)
   yield round.fold(tour)(WithLastRound(tour, _, group))
-
-private object RelayPager:
-  val yearRegex = """(.*)\b(20\d{2})\b(.*)""".r


### PR DESCRIPTION
# Why

Spotted that relay (broadcast) search did not return result for partials queries. Then, I have found that we have an open issue about that.

Fixes #18408
* #18408

# How

Switch off base text search in favour of regex match on the broadcast name.  It has been tested on the partial snapshot of the existing broadcasts, and seems to work fine.

I'm not sure if this is an ideal approach, especially that it removes `textScore` meta param used for additional weighting of the results. I was thinking about splitting and additional weighting results based on if for given query match happens at the beginning (starts with) vs match in the middle on the name, but it might be a bit overkill since quality of the result is not that bad, they seems logical, but please let me know what's your take. I would iterate on the approach further, if needed.

# Preview

https://github.com/user-attachments/assets/9c8fe1d2-e462-4ef2-a940-cbe871e3fde6

