### PR TITLE
ui: avoid image and meta tags overflow in blogs card

### DIFF
--- a/ui/lib/css/component/_ublog-card.scss
+++ b/ui/lib/css/component/_ublog-card.scss
@@ -62,19 +62,20 @@
     @include inline-start(0);
 
     backdrop-filter: blur(6px);
-    border-radius: 0 0 $box-radius-size 0;
+    border-radius: $box-radius-size 0 $box-radius-size 0;
   }
 
   .user-link {
     @include inline-end(0);
 
     backdrop-filter: blur(6px);
-    border-radius: 0 0 0 $box-radius-size;
+    border-radius: 0 $box-radius-size 0 $box-radius-size;
   }
 
   &__image {
     width: 100%;
     height: auto;
+    border-radius: calc($box-radius-size - 1px) calc($box-radius-size - 1px) 0 0;
 
     &.ublog-post-image-default {
       background-image: url('../images/placeholder-margin.png');
@@ -107,7 +108,7 @@
   }
 
   &--by-lichess {
-    border: 1px solid $c-brag;
+    border: 2px solid $c-brag;
 
     .user-link {
       color: $c-brag;


### PR DESCRIPTION
# Why

Spotted a small overflow on the blog posts cards.

# How

Adjust the roundness of certain elements inside of the blog card since it seems that we cannot rely on `overflow: hidden` there. 

Increase the thickness of the official Lichess post decoration border to make it easier to spot the posts.

# Preview

### Before

<img width="2216" height="2074" alt="Screenshot 2026-04-25 at 17 50 56" src="https://github.com/user-attachments/assets/a7678b04-c7dc-451a-9448-25e28574e06e" />

### After

<img width="2216" height="2034" alt="Screenshot 2026-04-25 at 17 50 02" src="https://github.com/user-attachments/assets/f24177e9-875f-40a0-9a4a-7206d761c828" />

