### PR TITLE
Create /account/permissions redirect

### DIFF
--- a/app/controllers/Account.scala
+++ b/app/controllers/Account.scala
@@ -418,3 +418,7 @@ final class Account(
             Ok.chunked(source.map(_ + "\n")).asAttachmentStream(s"lichess_${user.username}.txt")
         else Ok.page(pages.data(user))
   }
+
+  def permissionsRedirect = Auth { _ ?=> me ?=>
+    Redirect(routes.Mod.permissions(me.username))
+  }

--- a/conf/routes
+++ b/conf/routes
@@ -851,6 +851,7 @@ POST  /account/reopen/send             controllers.Account.reopenApply
 GET   /account/reopen/sent             controllers.Account.reopenSent
 GET   /account/reopen/login/:token     controllers.Account.reopenLogin(token)
 GET   /account/personal-data           controllers.Account.data
+GET   /account/permissions             controllers.Account.permissionsRedirect
 
 # App BC
 GET   /account/security                controllers.Account.security


### PR DESCRIPTION
Just wanted an easier URL for listing in documentation rather than instructions on how to find the "permissions" menu item in the profile. Now we can just say e.g. "check lichess.org/account/permissions for GDPR erase account" 