### PR TITLE
fix piece disappearing when using keyboardSubmit - closes #20310

### DIFF
--- a/ui/keyboardMove/src/keyboardMove.ts
+++ b/ui/keyboardMove/src/keyboardMove.ts
@@ -17,10 +17,12 @@ export function initModule(opts: Opts): KeyboardMoveHandler | undefined {
     // update legal SAN moves
     opts.ctrl.legalSans = dests && dests.size > 0 ? sanWriter(fen, destsToUcis(dests)) : null;
     // play a premove if it is available in the input
-    submit(opts.input.value, {
-      isTrusted: true,
-      yourMove: yourMove,
-    });
+    setTimeout(() => {
+      submit(opts.input.value, {
+        isTrusted: true,
+        yourMove: yourMove,
+      });
+    }, 1);
   };
 }
 


### PR DESCRIPTION
closes https://github.com/lichess-org/lila/issues/20310

This solution might look a little crazy, but it does fix the issue with very little code.

With the timeout:

1. We receive the move that the opponenet made, `pluginUpdate` gets called
2. The opponents move get's scheduled by chessground (1ms)
3. premove gets scheduled by keyboardMove (1ms)
4. onMove gets called with the opponents move
5. onMove gets called with our premove

Without the timeout:

1. We receive the move that the opponenet made, `pluginUpdate` gets called
2. The opponents move get's scheduled by chessground (1ms)
3. premove gets called by keyboardMove  <-- diff
4. chessground updates its internal state (state.pieces)
5. onMove gets called with the opponents move but with the state after the premove!

https://github.com/lichess-org/lila/blob/38c207e669bff0c45f8130e0888cd0200c741bad/ui/round/src/ctrl.ts#L211-L215

The `enpassant` function was the one getting the `stale` move with the `fresh` state.

And here you can see how chessground updates its internal state immidiately but schedules the move callback.

https://github.com/lichess-org/chessground/blob/e47565c8d1b356bd3d1a30f92e7e96e4ae04d4b1/src/board.ts#L110-L125

### Before

https://github.com/user-attachments/assets/396bddb5-2478-4fe9-a56c-3c41bc8aee4b

### After

https://github.com/user-attachments/assets/e8b5f4f9-435a-45be-9438-f64be00473f3




 