### PR TITLE
ui: color icons for done Learn/Practice tiles based on feedback

### DIFF
--- a/ui/learn/css/_map.scss
+++ b/ui/learn/css/_map.scss
@@ -99,8 +99,18 @@
       border-color: $m-secondary--fade-35;
       background: linear-gradient(0deg, $m-secondary--fade-60, $m-secondary--fade-80 100px);
 
+      img {
+        filter: brightness(0) saturate(100%) invert(81%) sepia(42%) saturate(529%) hue-rotate(38deg)
+          brightness(94%) contrast(90%);
+      }
+
       @include if-light {
         background: linear-gradient(180deg, $m-secondary--fade-60, $m-secondary--fade-80 100px);
+
+        img {
+          filter: brightness(0) saturate(100%) invert(41%) sepia(14%) saturate(1540%) hue-rotate(47deg)
+            brightness(97%) contrast(93%);
+        }
       }
     }
 


### PR DESCRIPTION
# Why

This was suggested in the thread about refreshed Learn/Practice pages appearance:
* https://hq.lichess.ovh/#narrow/channel/8-dev/topic/learn.2Fpractice.20UI.20refresh.20exploration/near/4157277

# How

Since we render SVGs via `img` tags we cannot control their attributes, thus I had to use the CSS filter approach to achieve the green tint over the white by default icons (similar approach to how we make icons darker in light mode, but with a bit more complex filters chain.

# Preview

<img width="2020" height="786" alt="Screenshot 2026-04-26 at 10 26 07" src="https://github.com/user-attachments/assets/2c0dd464-5e69-441e-b2cc-225e5910d944" />

<img width="2020" height="786" alt="Screenshot 2026-04-26 at 10 25 54" src="https://github.com/user-attachments/assets/59b39852-dbc6-4adf-aecc-44bb32276c5c" />
