### PR TITLE
ui: fix in-stage Learn/Practice progress overflow

### DIFF
--- a/ui/bits/css/build/bits.practice.index.scss
+++ b/ui/bits/css/build/bits.practice.index.scss
@@ -1,5 +1,4 @@
 @import '../../../lib/css/plugin';
-@import '../learn/progress';
 @import '../learn/ribbon';
 @import '../animated-border';
 @import '../practice/index';

--- a/ui/bits/css/practice/_side.scss
+++ b/ui/bits/css/practice/_side.scss
@@ -1,4 +1,5 @@
 .practice-side {
+  @import '../learn/progress';
   @extend %box-radius, %flex-column;
   @include backdrop-blur-if-transparent;
 

--- a/ui/learn/css/_side-home.scss
+++ b/ui/learn/css/_side-home.scss
@@ -1,4 +1,5 @@
 .learn__side-home {
+  @import '../../bits/css/learn/progress';
   @extend %box-radius, %flex-column;
   @include backdrop-blur-if-transparent;
 

--- a/ui/learn/css/build/learn.scss
+++ b/ui/learn/css/build/learn.scss
@@ -2,7 +2,6 @@
 @import '../../../lib/css/theme/board/coords';
 @import '../../../lib/css/layout/uniboard';
 @import '../../../lib/css/chess/promotion';
-@import '../../../bits/css/learn/progress';
 @import '../../../bits/css/learn/ribbon';
 @import '../../../bits/css/animated-border';
 @import '../learn';


### PR DESCRIPTION
# Why

This regression has been mention on the Learn/Practice discussion thread:
* https://hq.lichess.ovh/#narrow/channel/8-dev/topic/learn.2Fpractice.20UI.20refresh.20exploration/near/4157226

The root cause is the fact that we inject progress bit for whole module, but the in-stage indicator also uses `.progress` element which is different from the bar at the Learn/Practice home page.

# How

Import progres bit inside home page side sheet instead of root level, to avoiding applying styles to the wrong element.

# Preview

### Before

<img width="722" height="458" alt="Screenshot 2026-04-26 at 10 47 02" src="https://github.com/user-attachments/assets/6fa179a6-82e0-4611-8f74-d66fd19e518e" />

### After

<img width="722" height="458" alt="Screenshot 2026-04-26 at 10 42 09" src="https://github.com/user-attachments/assets/e25c3e1c-4a5d-4b4e-b11c-090497255eea" />
