### PR TITLE
fix: engine sometimes fails to load after puzzle finished

### DIFF
--- a/ui/lib/src/ceval/ctrl.ts
+++ b/ui/lib/src/ceval/ctrl.ts
@@ -172,7 +172,7 @@ export default class CevalCtrl {
   };
 
   start = (path: string, steps: Step[], gameId: string | undefined, threatMode?: boolean): void => {
-    if (!this.available() || this.isPaused) return;
+    if (!this.available()) return;
     this.isDeeper(false);
     this.doStart({ path, steps, gameId, threatMode: !!threatMode });
   };


### PR DESCRIPTION
### Exact URL of where the bug happened

https://lichess.org/training

### Steps to reproduce the bug

1. Solve a puzzle
2. Use the "play from here against the computer" button (a new tab will open)
3. Go back to the original tab, click "continue training"
4. Solve the puzzle
5. The engine will not start

### What did you expect to happen?

The engine starts

### What happened instead?

The engine did not start

### Additional information

from the forum: https://lichess.org/forum/lichess-feedback/engine-sometimes-fails-to-load-after-puzzle-finished#coZlt0MZ

The new tab pauses the original tab ceval. For some reason the start function had a check to not start if was paused... And the view rendered a pearl with an empty i tag:

https://github.com/lichess-org/lila/blob/95c337c4acf6b51364449e5f7199cadc95cf808d/ui/lib/src/ceval/view/main.ts#L173