### PR TITLE
email confirmation help page tweaks

### DIFF
--- a/modules/security/src/main/ui/AccountSecurity.scala
+++ b/modules/security/src/main/ui/AccountSecurity.scala
@@ -171,21 +171,22 @@ final class AccountSecurity(helpers: Helpers)(
                   )
                 )
               case Status.EmailSent(name, email, sendTo) =>
-                frag(
-                  p(trans.site.emailSent(email.conceal)),
-                  p(
-                    trans.site.emailCanTakeSomeTime(),
-                    br,
-                    strong(trans.site.refreshInboxAfterFiveMinutes())
+                val mailto = s"mailto:${email.value}?subject=Confirm+account+$name"
+                ol(
+                  li(
+                    p(trans.site.emailSent(strong(email.conceal))),
+                    p(
+                      trans.site.emailCanTakeSomeTime(),
+                      br,
+                      strong(trans.site.refreshInboxAfterFiveMinutes())
+                    )
                   ),
-                  p(trans.site.checkSpamFolder()),
-                  hr,
-                  p:
-                    trans.site.sendEmailForAccountVerification(sendTo)
-                  ,
-                  p:
-                    a(cls := "button", href := s"mailto:${sendTo}?subject=Confirm account $name"):
+                  li(trans.site.checkSpamFolder()),
+                  li(
+                    p(trans.site.sendEmailForAccountVerification(strong(a(href := mailto)(sendTo)))),
+                    a(cls := "button", href := mailto):
                       trans.site.send()
+                  )
                 )
               case Status.Confirmed(name) =>
                 frag(

--- a/modules/security/src/main/ui/AccountSecurity.scala
+++ b/modules/security/src/main/ui/AccountSecurity.scala
@@ -171,7 +171,7 @@ final class AccountSecurity(helpers: Helpers)(
                   )
                 )
               case Status.EmailSent(name, email, sendTo) =>
-                val mailto = s"mailto:${email.value}?subject=Confirm+account+$name"
+                val mailto = s"mailto:$sendTo?subject=Confirm+account+$name"
                 ol(
                   li(
                     p(trans.site.emailSent(strong(email.conceal))),

--- a/ui/bits/css/_email-confirm.scss
+++ b/ui/bits/css/_email-confirm.scss
@@ -120,10 +120,17 @@ body:has(.email-confirm, .signup-confirm) .signin-or-signup {
 
   .replies {
     font-size: 1.2em;
-  }
 
-  .replies p {
-    margin-bottom: 1em;
+    ol {
+      li {
+        list-style: decimal;
+        margin-bottom: 2em;
+      }
+    }
+
+    p {
+      margin-bottom: 0.5em;
+    }
   }
 }
 


### PR DESCRIPTION
before+after:

<img width="3831" height="2105" alt="image" src="https://github.com/user-attachments/assets/09602e2f-79aa-4b00-95d0-71fccf0d675d" />
