### PR TITLE
Break ties on leaderboards by comparing whose position will stay longer.

### DIFF
--- a/bin/mongodb/indexes.js
+++ b/bin/mongodb/indexes.js
@@ -348,3 +348,4 @@ db.puzzle2_path.createIndex({ min: 1, max: -1 });
 db.relay_delay.createIndex({ at: 1 }, { expireAfterSeconds: 7200 });
 db.ranking.createIndex({ expiresAt: 1 }, { expireAfterSeconds: 0 });
 db.ranking.createIndex({ perf: 1, rating: -1 }, { partialFilterExpression: { stable: true } });
+db.ranking.createIndex({ perf: 1, rating: -1, expiresAt: -1 }, { partialFilterExpression: { stable: true } });

--- a/modules/user/src/main/RankingApi.scala
+++ b/modules/user/src/main/RankingApi.scala
@@ -69,7 +69,7 @@ final class RankingApi(
         .so:
           coll:
             _.find($doc("perf" -> perf.id, "stable" -> true))
-              .sort($doc("rating" -> -1))
+              .sort($doc("rating" -> -1, "expiresAt" -> -1))
               .skip(skip)
               .cursor[Ranking](ReadPref.sec)
               .list(nb)
@@ -139,7 +139,7 @@ final class RankingApi(
       _.aggregateOne(_.sec): framework =>
         import framework.*
         Match($doc("perf" -> pt.id, "stable" -> true)) -> List(
-          Sort(Descending("rating")),
+          Sort(Descending("rating"), Descending("expiresAt")),
           Group(BSONNull)("all" -> Push($doc("$first" -> $doc("$split" -> $arr("$_id", ":")))))
         )
       .map:


### PR DESCRIPTION
Note that if this PR is merged, I think an index should be made in prod; e.g.: `db.ranking.createIndex({ rating: -1, expiresAt: -1 })`.

This PR adds a tiebreaker between players with the same rating, by seeing whose leaderboard expiry date is further away (i.e., who played more recently).

This also fixes a bug where occasionally at the border between pages (ranks x and x+1, where x is a multiple of 100), the same player would appear twice. E.g., ranks 1200 and 1201:

<img width="750" height="1334" alt="image" src="https://github.com/user-attachments/assets/988d86a2-bcf0-4495-81db-11ef540bfba6" />

The reason is possibly because the sort is non-deterministic(?), since atm it only uses ratings. However, why this doesn't happen more often at the borders between pages is unclear.