### PR TITLE
enhance error handling in turnstile: include troubleshooting information for captcha errors

### DIFF
--- a/ui/lib/src/view/turnstile.ts
+++ b/ui/lib/src/view/turnstile.ts
@@ -22,7 +22,7 @@ export default function turnstile($form: Cash): void {
           showError(false);
         },
         'error-callback': (errorCode: string) => {
-          showError('Captcha error: ' + errorCode);
+          showError(`Captcha error: ${errorCode} - ${troubleshooting(errorCode)}`);
         },
         'expired-callback': () => {
           showError('Captcha expired, please try again');
@@ -33,4 +33,23 @@ export default function turnstile($form: Cash): void {
       });
     });
   });
+}
+
+// https://developers.cloudflare.com/turnstile/troubleshooting/client-side-errors/error-codes/
+function troubleshooting(code: string): string {
+  switch (code) {
+    case '110600': // Challenge timed out
+    case '200100': // Clock or cache problem
+      return 'Please check your system clock and clear your browser cache.';
+    case '200500': // Iframe load error
+      return 'Failed to load the captcha. Check if "challenges.cloudflare.com" is blocked.';
+    case '110100': // Invalid sitekey
+    case '110110': // Sitekey not found
+    case '110200': // Domain not authorized
+    case '400020': // Invalid sitekey
+    case '400070': // Sitekey disabled
+      return 'Please report this issue to the site administrator.';
+    default:
+      return 'An unknown error occurred. Please access https://browser-compat.turnstile.workers.dev/ for more information.';
+  }
 }


### PR DESCRIPTION
Better show a quick troubleshooting guide so the user knows what to do without needing support