### PR TITLE
fixes `can't access property "compute", this.protocol is undefined`

### DIFF
--- a/ui/lib/src/ceval/engines/threadedEngine.ts
+++ b/ui/lib/src/ceval/engines/threadedEngine.ts
@@ -130,6 +130,7 @@ export class ThreadedEngine implements CevalEngine {
   }
 
   stop(): void {
+    if (!this.protocol) return;
     this.protocol.compute(undefined);
   }
 


### PR DESCRIPTION
Not sure how to reproduce, But here's the stack from https://lichess.org/#debug
```
2026-04-26 17:25:20.825 #83c4d0b - /SeYxiwAV/black#34 - TypeError: can't access property "compute", this.protocol is undefined - (https://lichess1.org/assets/compiled/lib.5SYWJHH7.js:1:14030)
stop@https://lichess1.org/assets/compiled/lib.5SYWJHH7.js:1:14030
Y/this.stop@https://lichess1.org/assets/compiled/lib.5SYWJHH7.js:1:21935
at/this.startCeval@https://lichess1.org/assets/compiled/lib.J5TFXFEG.js:1:102853
at/<@https://lichess1.org/assets/compiled/lib.J5TFXFEG.js:1:109558
```

Looks like this is the code that the stack points to:

https://github.com/lichess-org/lila/blob/9a0f5abcb9e54070f02a146396533d1875a69342/ui/analyse/src/ctrl.ts#L800-L805

edit - same here:
```
2026-04-29 18:38:34.547 #e2865ea - /lk87I3Uc/black#11 - TypeError: can't access property "compute", this.protocol is undefined - (https://lichess1.org/assets/compiled/lib.I3SECCHF.js:1:14030)
stop@https://lichess1.org/assets/compiled/lib.I3SECCHF.js:1:14030
Y/this.stop@https://lichess1.org/assets/compiled/lib.I3SECCHF.js:1:21935
jump@https://lichess1.org/assets/compiled/lib.RDHHWTL4.js:1:111827
at/this.userJump@https://lichess1.org/assets/compiled/lib.RDHHWTL4.js:1:99724
userJumpIfCan@https://lichess1.org/assets/compiled/lib.RDHHWTL4.js:1:112421
et/this.next@https://lichess1.org/assets/compiled/lib.RDHHWTL4.js:1:27426
yn/<@https://lichess1.org/assets/compiled/lib.RDHHWTL4.js:1:21242
S/this.handleKeyEvent@https://lichess1.org/assets/compiled/site.A6OHST5B.js:4:3430
S/<@https://lichess1.org/assets/compiled/site.A6OHST5B.js:4:3778
```