### PR TITLE
ui: visual and a11y tweaks for lobby filters

### DIFF
--- a/ui/lobby/css/app/_hook-filters.scss
+++ b/ui/lobby/css/app/_hook-filters.scss
@@ -19,17 +19,48 @@
   .checkable {
     @extend %nowrap-ellipsis;
 
-    padding: 4.3px 2px 4.3px 0;
+    padding: 4px 2px 4px 0;
 
-    label,
+    label {
+      display: inline-flex;
+      align-items: center;
+      gap: 2px;
+      cursor: pointer;
+    }
+
     input {
-      vertical-align: middle;
       cursor: pointer;
     }
   }
 
   .regular-checkbox {
     @extend %checkbox;
+
+    position: relative;
+    border-radius: calc($box-radius-size / 2);
+
+    &:hover {
+      border-color: $c-border-light;
+    }
+
+    &:checked {
+      &:hover {
+        border-color: $c-good;
+      }
+
+      &::after {
+        border: 1.5px solid #fff;
+        border-top: none;
+        border-right: none;
+        content: '';
+        width: 8px;
+        height: 4.5px;
+        left: 50%;
+        top: 50%;
+        position: absolute;
+        transform: translate(-50%, -62%) rotate(-45deg);
+      }
+    }
   }
 
   tr.variant td:last-child {
@@ -43,7 +74,7 @@
 
   tr.inline .checkable {
     display: inline-block;
-    padding: 4.3px 20px 4.3px 2px;
+    padding: 4px 20px 4px 2px;
   }
 
   input {
@@ -51,13 +82,31 @@
   }
 
   .range {
-    display: block;
-    text-align: center;
+    display: grid;
+    grid-template-columns: 1fr 20px 1fr;
+    gap: 2px;
+    justify-content: center;
+
+    span {
+      color: $c-font-dim;
+      text-align: center;
+
+      &:first-child {
+        color: unset;
+        text-align: right;
+      }
+
+      &:last-child {
+        color: unset;
+        text-align: left;
+      }
+    }
   }
 
   .rating-range {
     @extend %flex-center-nowrap;
 
+    color: $c-font-dim;
     justify-content: center;
 
     input {
@@ -71,12 +120,10 @@
   }
 
   .actions {
+    display: flex;
+    gap: 6px;
     margin-top: 1.5em;
-    text-align: end;
-
-    button {
-      margin-inline-start: 0.3em;
-    }
+    justify-content: end;
   }
 
   @media (max-width: at-most($xx-small)) {

--- a/ui/lobby/css/app/_hook-filters.scss
+++ b/ui/lobby/css/app/_hook-filters.scss
@@ -74,7 +74,7 @@
 
   tr.inline .checkable {
     display: inline-block;
-    padding: 4px 20px 4px 2px;
+    padding: 6px 20px 2px 0;
   }
 
   input {

--- a/ui/lobby/src/view/realTime/filter.ts
+++ b/ui/lobby/src/view/realTime/filter.ts
@@ -59,12 +59,12 @@ function initialize(ctrl: LobbyController, el: FilterNode) {
 
   const minValue = rangeValues[0] || $minInput.attr('min')!;
   $minInput
-    .attr({ step: '50', value: minValue, 'aria-label': `Max rating of ${minValue}` })
+    .attr({ step: '50', value: minValue, 'aria-label': `Minimum rating of ${minValue}` })
     .on('input', changeRatingRange);
 
   const maxValue = rangeValues[1] || $minInput.attr('max')!;
   $maxInput
-    .attr({ step: '50', value: maxValue, 'aria-label': `Max rating of ${maxValue}` })
+    .attr({ step: '50', value: maxValue, 'aria-label': `Maximum rating of ${maxValue}` })
     .on('input', changeRatingRange);
 
   changeRatingRange();

--- a/ui/lobby/src/view/realTime/filter.ts
+++ b/ui/lobby/src/view/realTime/filter.ts
@@ -41,12 +41,18 @@ function initialize(ctrl: LobbyController, el: FilterNode) {
     });
 
   function changeRatingRange(e?: Event) {
-    $minInput.attr('max', $maxInput.val() as string);
-    $maxInput.attr('min', $minInput.val() as string);
-    $rangeInput.val($minInput.val() + '-' + $maxInput.val());
-    $ratingRange
-      .siblings('.range')
-      .html(`<span>${$minInput.val()}</span><span>–</span><span>${$maxInput.val()}</span>`);
+    const minVal = $minInput.val() as string;
+    const maxVal = $maxInput.val() as string;
+
+    $minInput.attr('max', maxVal);
+    $maxInput.attr('min', minVal);
+    $rangeInput.val(minVal + '-' + maxVal);
+
+    const $range = $ratingRange.siblings('.range').empty();
+    $('<span>').text(minVal).appendTo($range);
+    $('<span>').text('–').appendTo($range);
+    $('<span>').text(maxVal).appendTo($range);
+
     if (e) save();
   }
   const rangeValues = $rangeInput.val() ? ($rangeInput.val() as string).split('-') : [];

--- a/ui/lobby/src/view/realTime/filter.ts
+++ b/ui/lobby/src/view/realTime/filter.ts
@@ -43,19 +43,22 @@ function initialize(ctrl: LobbyController, el: FilterNode) {
   function changeRatingRange(e?: Event) {
     $minInput.attr('max', $maxInput.val() as string);
     $maxInput.attr('min', $minInput.val() as string);
-    const txt = $minInput.val() + '-' + $maxInput.val();
-    $rangeInput.val(txt);
-    $ratingRange.siblings('.range').text(txt);
+    $rangeInput.val($minInput.val() + '-' + $maxInput.val());
+    $ratingRange
+      .siblings('.range')
+      .html(`<span>${$minInput.val()}</span><span>–</span><span>${$maxInput.val()}</span>`);
     if (e) save();
   }
   const rangeValues = $rangeInput.val() ? ($rangeInput.val() as string).split('-') : [];
 
+  const minValue = rangeValues[0] || $minInput.attr('min')!;
   $minInput
-    .attr({ step: '50', value: rangeValues[0] || $minInput.attr('min')! })
+    .attr({ step: '50', value: minValue, 'aria-label': `Max rating of ${minValue}` })
     .on('input', changeRatingRange);
 
+  const maxValue = rangeValues[1] || $minInput.attr('max')!;
   $maxInput
-    .attr({ step: '50', value: rangeValues[1] || $maxInput.attr('max')! })
+    .attr({ step: '50', value: maxValue, 'aria-label': `Max rating of ${maxValue}` })
     .on('input', changeRatingRange);
 
   changeRatingRange();
@@ -65,7 +68,10 @@ export function toggle({ filter, redraw }: LobbyController, nbFiltered: number) 
   return h('button.toggle.toggle-filter', {
     class: { gamesFiltered: nbFiltered > 0, active: filter.open },
     hook: bind('click', filter.toggle, redraw),
-    attrs: { 'data-icon': filter.open ? licon.X : licon.Gear, title: i18n.site.filterGames },
+    attrs: {
+      'data-icon': filter.open ? licon.X : licon.Gear,
+      title: filter.open ? 'Close filters' : i18n.site.filterGames,
+    },
   });
 }
 


### PR DESCRIPTION
# Why

Recently spotted some slight misalignment between checkboxes and labels in lobby filter UI. When working on the tweaks I have caught and. fixed few more minor issues.

# How

Summary of changes:
* fix alignment of checkboxes and their labels
* add slight interaction (hover) effect
* add check icon to checkboxes (based on existing, large/regular-sized checkboxes)
* add a11y labels to the rating sliders
* adjust spacing between rating values, make sure that contend does not move when rating digits count changes
* fix incorrect title for filters close button

As a follow up, I plan to introduce few i18n strings which can used for rating filters here and in correspondence game setup.

# Preview

https://github.com/user-attachments/assets/34c46d91-c62f-4a87-979d-23b6f5a2bb7a