### PR TITLE
lint: add no-inferrable-types rule

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -46,6 +46,7 @@
     "typescript/no-empty-object-type": "error",
     "typescript/no-confusing-non-null-assertion": "error",
     "typescript/no-extra-non-null-assertion": "error",
+    "typescript/no-inferrable-types": "error",
     "typescript/no-unnecessary-template-expression": "error",
     "typescript/no-unnecessary-type-arguments": "error",
     "typescript/no-unnecessary-type-assertion": "error",

--- a/ui/analyse/src/pgnImport.ts
+++ b/ui/analyse/src/pgnImport.ts
@@ -86,7 +86,7 @@ const rulesToVariantKey: Record<string, VariantKey> = {
   racingkings: 'racingKings',
 };
 
-export const renderPgnError = (error: string = '') =>
+export const renderPgnError = (error = '') =>
   `PGN error: ${
     {
       [IllegalSetup.Empty]: 'empty board',

--- a/ui/analyse/src/study/multiBoard.ts
+++ b/ui/analyse/src/study/multiBoard.ts
@@ -26,7 +26,7 @@ export class MultiBoardCtrl {
   playing: Toggle = toggle(false);
   showResults: Prop<boolean>;
   teamSelect: Prop<string> = prop('');
-  page: number = 1;
+  page = 1;
   maxPerPageStorage = storage.make('study.multiBoard.maxPerPage');
 
   constructor(

--- a/ui/analyse/src/study/relay/relayPlayers.ts
+++ b/ui/analyse/src/study/relay/relayPlayers.ts
@@ -526,7 +526,7 @@ const fideTCOrder: FideTC[] = ['standard', 'rapid', 'blitz'];
 const statByFideTCSort = (a: [FideTC, number], b: [FideTC, number]) =>
   fideTCOrder.indexOf(a[0]) - fideTCOrder.indexOf(b[0]);
 
-const ratingDiff = (p: RelayPlayer | RelayPlayerGame, showIcons: boolean = false) => {
+const ratingDiff = (p: RelayPlayer | RelayPlayerGame, showIcons = false) => {
   if (isRelayPlayerGame(p)) return hl('div.diff', showIcons && fideTCAttrs(p.fideTC), diffNode(p.ratingDiff));
   if (!p.ratingDiffs) return p.rating;
   const rds = Object.entries(p.ratingDiffs).sort(statByFideTCSort);

--- a/ui/analyse/src/study/studyCtrl.ts
+++ b/ui/analyse/src/study/studyCtrl.ts
@@ -416,7 +416,7 @@ export default class StudyCtrl {
   xhrReload = throttlePromiseDelay(
     () => 400,
     /* `callback` runs immediately after the xhr, and is not affected by the delay */
-    (withChapters: boolean = false, immediateCallback: () => void = () => {}) => {
+    (withChapters = false, immediateCallback: () => void = () => {}) => {
       this.vm.loading = true;
       return xhr
         .reload(

--- a/ui/analyse/src/study/studyXhr.ts
+++ b/ui/analyse/src/study/studyXhr.ts
@@ -6,7 +6,7 @@ export const reload = (
   baseUrl: string,
   id: string,
   chapterId?: string,
-  withChapters: boolean = false,
+  withChapters = false,
 ): Promise<ReloadData> => {
   let url = `/${baseUrl}/${id}`;
   if (chapterId) url += '/' + chapterId;

--- a/ui/bits/src/bits.infiniteScroll.ts
+++ b/ui/bits/src/bits.infiniteScroll.ts
@@ -2,7 +2,7 @@ import { pubsub } from 'lib/pubsub';
 import { spinnerHtml } from 'lib/view';
 import * as xhr from 'lib/xhr';
 
-export function initModule(selector: string = '.infinite-scroll'): void {
+export function initModule(selector = '.infinite-scroll'): void {
   $(selector).each(function (this: HTMLElement) {
     register(this, selector);
   });

--- a/ui/bits/src/bits.passwordComplexity.ts
+++ b/ui/bits/src/bits.passwordComplexity.ts
@@ -1,6 +1,6 @@
 import zxcvbn from 'zxcvbn';
 
-export function initModule(id: string = 'form3-newPasswd1'): void {
+export function initModule(id = 'form3-newPasswd1'): void {
   const passwordInput = document.getElementById(id) as HTMLInputElement;
   passwordInput.addEventListener('input', () => {
     updatePasswordComplexityMeter(passwordInput.value);

--- a/ui/bits/src/bits.passwordGenerator.ts
+++ b/ui/bits/src/bits.passwordGenerator.ts
@@ -1,6 +1,6 @@
 import cryptoRandomString from 'crypto-random-string';
 
-export function initModule(id: string = 'form3-newPasswd1'): void {
+export function initModule(id = 'form3-newPasswd1'): void {
   const password = cryptoRandomString({ length: 20, type: 'ascii-printable' });
   $('#' + id)
     .val(password)

--- a/ui/bits/src/toastEditor.ts
+++ b/ui/bits/src/toastEditor.ts
@@ -8,7 +8,7 @@ import { enter } from 'lib/view';
 import { wireMarkdownImgResizers, wrapImg, naturalSize } from 'lib/view/markdownImgResizer';
 import { json as xhrJson } from 'lib/xhr';
 
-export function makeToastEditor(el: HTMLTextAreaElement, text: string = '', height: string = '60vh'): Editor {
+export function makeToastEditor(el: HTMLTextAreaElement, text = '', height = '60vh'): Editor {
   const rewire = () =>
     wireMarkdownImgResizers({
       root: document.querySelector<HTMLElement>('.toastui-editor-ww-container .ProseMirror')!,

--- a/ui/bits/src/youtubeLinkProcessor.ts
+++ b/ui/bits/src/youtubeLinkProcessor.ts
@@ -8,7 +8,7 @@ type DomainType = 'youtube.com' | 'youtu.be';
 
 const supportedVideoTypes: string[] = ['watch', 'embed', 'shorts', 'live', 'playlist'] as const;
 const videoIdValidLength = 11;
-const videoIdRegex: RegExp = /^[a-zA-Z0-9_-]{11}$/;
+const videoIdRegex = /^[a-zA-Z0-9_-]{11}$/;
 
 export function parseYoutubeUrl(url: string): YoutubeMatch | undefined {
   const youtubeUrl = toURL(url);

--- a/ui/botDev/src/devCtrl.ts
+++ b/ui/botDev/src/devCtrl.ts
@@ -57,7 +57,7 @@ export class DevCtrl implements GameObserver {
     return this.hurryProp() || (this.gameInProgress && env.bot.playing.some(x => 'level' in x));
   }
 
-  run(test?: Test, iterations: number = 1): boolean {
+  run(test?: Test, iterations = 1): boolean {
     if (test) {
       this.resetScript(test);
       this.script.games.push(...this.matchups(test, iterations));

--- a/ui/botDev/src/devUtil.ts
+++ b/ui/botDev/src/devUtil.ts
@@ -80,7 +80,7 @@ export function playersWithResults(results: Result[]): string[] {
   return [...new Set(results.flatMap(r => [r.white ?? '', r.black ?? ''].filter(x => x)))];
 }
 
-export function renderRemoveButton(cls: string = ''): Node {
+export function renderRemoveButton(cls = ''): Node {
   return frag(
     `<button class="button button-empty button-red icon-btn ${cls}" tabindex="0" data-icon="${licon.Cancel}" data-action="remove">`,
   );

--- a/ui/botDev/src/schema.ts
+++ b/ui/botDev/src/schema.ts
@@ -26,6 +26,7 @@ export const infoKeys: InfoKey[] = [
   'toggle',
 ]; // InfoKey in file://./devTypes.ts
 
+// oxlint-disable-next-line no-inferrable-types This collides with out TS config.
 export const requiresOpRe: RegExp = /==|>=|>|<<=|<=|<|!=/; // <<= means startsWith
 
 const base: Schema = {

--- a/ui/lib/src/common.ts
+++ b/ui/lib/src/common.ts
@@ -78,14 +78,14 @@ export const memoize = <A>(compute: () => A): (() => A) => {
 export const scrollToInnerSelector = (
   el: HTMLElement,
   selector: string,
-  horiz: boolean = false,
+  horiz = false,
   behavior: ScrollBehavior = 'instant',
 ): void => scrollTo(el, el.querySelector(selector), horiz, behavior);
 
 export const scrollTo = (
   el: HTMLElement,
   target: HTMLElement | null,
-  horiz: boolean = false,
+  horiz = false,
   behavior: ScrollBehavior = 'instant',
 ): void => {
   if (!target) return;

--- a/ui/lib/src/nvui/notify.ts
+++ b/ui/lib/src/nvui/notify.ts
@@ -22,7 +22,7 @@ export class Notify {
 export function liveText(
   text: string,
   live: 'assertive' | 'polite' = 'polite',
-  sel: string = 'p',
+  sel = 'p',
   forceKey?: Date,
 ): VNode {
   const data: VNodeData = isMac()

--- a/ui/lib/src/puz/clock.ts
+++ b/ui/lib/src/puz/clock.ts
@@ -7,7 +7,7 @@ export class Clock {
 
   public constructor(
     readonly config: Config,
-    startedMillisAgo: number = 0,
+    startedMillisAgo = 0,
   ) {
     this.initialMillis = config.clock.initial * 1000 - startedMillisAgo;
   }

--- a/ui/lib/src/richText.ts
+++ b/ui/lib/src/richText.ts
@@ -7,15 +7,21 @@ import type { Hooks, VNode } from 'snabbdom';
 import { escapeHtml } from './common';
 
 // from https://github.com/bryanwoods/autolink-js/blob/master/autolink.js
+
+/* oxlint-disable no-inferrable-types */
+// Our TS config require explicit type annotation on exported code due to `isolatedDeclarations` flag.
 export const linkRegex: RegExp =
   /(^|[\s\n]|<[A-Za-z]*\/?>)((?:(?:https?|ftp):\/\/|lichess\.org)[\-A-Z0-9+\u0026\u2019@#\/%?=()~_|!:,.;]*[\-A-Z0-9+\u0026@#\/%=~()_|])/gi;
 export const newLineRegex: RegExp = /\n/g;
 export const userPattern: RegExp = /(^|[^\w@#/])@([a-z0-9_-]{2,30})/gi;
+export const movePattern: RegExp =
+  /\b(\d+)\s*(\.+)\s*(?:[o0-]+[o0]|[NBRQKP\u2654\u2655\u2656\u2657\u2658\u2659]?[a-h]?[1-8]?[x@]?[a-h][1-8](?:=[NBRQK\u2654\u2655\u2656\u2657\u2658\u2659])?)\+?#?[!\?=]{0,5}/gi;
+/* oxlint-enable no-inferrable-types */
 
 // looks like it has a @mention or #gameid or a url.tld
 export const isMoreThanText = (str: string): boolean => /(\n|(@|#|\.)\w{2,}|(board|game) \d)/i.test(str);
 
-const linkHtml = (href: string, content: string, expandable: boolean = true): string =>
+const linkHtml = (href: string, content: string, expandable = true): string =>
   `<a${expandable ? '' : ' class="text"'} target="_blank" rel="nofollow noreferrer" href="${href}">${content}</a>`;
 
 export function toLink(url: string): string {
@@ -37,7 +43,7 @@ export const innerHTML = <A>(a: A, toHtml: (a: A) => string): Hooks => ({
   },
 });
 
-export function linkReplace(href: string, body?: string, expandable: boolean = true): string {
+export function linkReplace(href: string, body?: string, expandable = true): string {
   if (href.includes('&quot;')) return href;
   return linkHtml(
     href.startsWith('/') || href.includes('://') ? href : '//' + href,
@@ -63,8 +69,6 @@ export function richHTML(text: string, newLines = true): Hooks {
 
 const linkPattern = /\b\b(?:https?:\/\/)?(lichess\.org\/[-–—\w+&'@#\/%?=()~|!:,.;]+[\w+&@#\/%=~|])/gi;
 const pawnDropPattern = /^[a-h][2-7]$/;
-export const movePattern: RegExp =
-  /\b(\d+)\s*(\.+)\s*(?:[o0-]+[o0]|[NBRQKP\u2654\u2655\u2656\u2657\u2658\u2659]?[a-h]?[1-8]?[x@]?[a-h][1-8](?:=[NBRQK\u2654\u2655\u2656\u2657\u2658\u2659])?)\+?#?[!\?=]{0,5}/gi;
 const boardPattern = /\b(?:board|game)\s(\d+)/gi;
 
 function moveReplacer(match: string, turn: number, dots: string) {

--- a/ui/lib/src/setup/timeControl.ts
+++ b/ui/lib/src/setup/timeControl.ts
@@ -24,11 +24,10 @@ export class TimeControl {
 
   isRealTime = (): boolean => this.mode() === 'realTime';
 
-  realTimeValid = (minimumTime: number = 0): boolean =>
+  realTimeValid = (minimumTime = 0): boolean =>
     this.time() >= minimumTime && (this.time() > 0 || this.increment() > 0);
 
-  valid = (minimumTimeIfReal: number = 0): boolean =>
-    !this.isRealTime() || this.realTimeValid(minimumTimeIfReal);
+  valid = (minimumTimeIfReal = 0): boolean => !this.isRealTime() || this.realTimeValid(minimumTimeIfReal);
 
   initialSeconds = (): Seconds => this.time() * 60;
 

--- a/ui/lib/src/setup/view/timeControl.ts
+++ b/ui/lib/src/setup/view/timeControl.ts
@@ -107,7 +107,7 @@ const inputRange = (min: number, max: number, prop: Prop<InputValue>, classes?: 
     on: { input: (e: Event) => prop(parseFloat((e.target as HTMLInputElement).value)) },
   });
 
-export const timePickerAndSliders = (tc: TimeControl, minimumTimeRequiredIfReal: number = 0): VNode => {
+export const timePickerAndSliders = (tc: TimeControl, minimumTimeRequiredIfReal = 0): VNode => {
   if (site.blindMode) return hl('div.config-group', blindModeTimePickers(tc));
 
   const activeMode = tc.mode();

--- a/ui/lib/src/socket.ts
+++ b/ui/lib/src/socket.ts
@@ -268,7 +268,7 @@ class WsSocket {
     pubsub.emit('socket.lag', this.averageLag);
   };
 
-  private readonly handle = (m: MsgIn, retries: number = 10): void => {
+  private readonly handle = (m: MsgIn, retries = 10): void => {
     if (m.v && this.version !== false) {
       if (m.v <= this.version) {
         this.debug('already has event ' + m.v);

--- a/ui/lib/src/tree/tree.ts
+++ b/ui/lib/src/tree/tree.ts
@@ -190,7 +190,7 @@ export function makeTree(root: TreeNode): TreeWrapper {
   function walkUntilTrue(
     fn: (node: TreeNode, isMainline: boolean) => boolean,
     from: TreePath = '',
-    branchOnly: boolean = false,
+    branchOnly = false,
   ) {
     function traverse(node: TreeNode, isMainline: boolean): boolean {
       if (fn(node, isMainline)) return true;

--- a/ui/lib/src/view/boardMenu.ts
+++ b/ui/lib/src/view/boardMenu.ts
@@ -38,7 +38,7 @@ export const boardMenu = (
     : undefined;
 
 export class BoardMenu {
-  anonymous: boolean = !myUserId();
+  anonymous: boolean = !myUserId(); // oxlint-disable-line no-inferrable-types The simplification collides with our TS config.
 
   constructor(readonly redraw: Redraw) {}
 

--- a/ui/lib/src/view/dialogs.ts
+++ b/ui/lib/src/view/dialogs.ts
@@ -57,7 +57,7 @@ export async function confirm(
 // non-blocking window.prompt-alike
 export async function prompt(
   msg: string,
-  def: string = '',
+  def = '',
   valid: (text: string) => boolean = () => true,
 ): Promise<string | null> {
   const res = await domDialog({

--- a/ui/lib/src/view/markdownImgResizer.ts
+++ b/ui/lib/src/view/markdownImgResizer.ts
@@ -124,7 +124,7 @@ export async function naturalSize(image: Blob): Promise<{ width: number; height:
   }
 }
 
-export function markdownPicfitRegex(origin: string = ''): RegExp {
+export function markdownPicfitRegex(origin = ''): RegExp {
   return new RegExp(
     String.raw`!\[([^\n\]]*)\]\((${regexQuote(
       origin,

--- a/ui/lib/src/view/userComplete.ts
+++ b/ui/lib/src/view/userComplete.ts
@@ -55,7 +55,7 @@ export const checkDebouncedResultAgainstTerm =
   (got: ResultOfTerm): Promise<LightUserOnline[]> =>
     term === got.term ? Promise.resolve(got.result) : Promise.reject(new Error('Debounced ' + term));
 
-export const renderUserEntry = (o: LightUserOnline, tag: string = 'a'): string => {
+export const renderUserEntry = (o: LightUserOnline, tag = 'a'): string => {
   const patronClass = o.patronColor ? ` paco${o.patronColor}` : '';
   return (
     '<' +

--- a/ui/lobby/src/filter.ts
+++ b/ui/lobby/src/filter.ts
@@ -25,7 +25,7 @@ export default class Filter {
   store: FormStore;
   data: FilterData | null;
   open = false;
-  uiCacheBuster: number = 1; // used to force re-init of filter UI
+  uiCacheBuster = 1; // used to force re-init of filter UI
 
   constructor(
     storage: LichessStorage,

--- a/ui/puzzle/src/report.ts
+++ b/ui/puzzle/src/report.ts
@@ -14,7 +14,7 @@ const version = 11;
 
 export default class Report {
   // if local eval suspect multiple solutions, report the puzzle, once at most
-  private reported: boolean = false;
+  private reported = false;
   // timestamp (ms) of the last time the user clicked on the hide report dialog toggle
   private readonly tsHideReportDialog: StoredProp<number>;
   // number of evals that have triggered the `winningChances.hasMultipleSolutions` method

--- a/ui/recap/src/slides.ts
+++ b/ui/recap/src/slides.ts
@@ -374,7 +374,7 @@ export const shareable = (r: Recap): VNode =>
   ]);
 
 const slideTag =
-  (key: string, millis: number = 5000) =>
+  (key: string, millis = 5000) =>
   (content: LooseVNodes) =>
     hl(
       `div.swiper-slide.recap__slide--${key}`,

--- a/ui/site/src/asset.ts
+++ b/ui/site/src/asset.ts
@@ -54,7 +54,7 @@ export const removeCss = (href: string) => $(`head > link[href="${href}"]`).remo
 
 export const removeCssPath = (key: string) => $(`head > link[data-css-key="${key}"]`).remove();
 
-export const jsModule = (name: string, prefix: string = 'compiled/') => {
+export const jsModule = (name: string, prefix = 'compiled/') => {
   if (name.endsWith('.js')) name = name.slice(0, -3);
   const hash = site.manifest.js[name];
   return `${prefix}${name}${hash ? `.${hash}` : ''}.js`;


### PR DESCRIPTION
# Why

Spotted that sometimes we add types where they can be easily inferred from context or default values.

# How

Add `no-inferrable-types` rule:
* https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-inferrable-types.html

Fix reported warnings. In few case I had to disable the rule since it collides with our TypeScript setup which forces the declaration for exposed parts to be explicit. See [`isolatedDeclarations` doc](https://typescriptlang.org/tsconfig/isolatedDeclarations.html).