### PR TITLE
analyse: play explosion sound on atomic variant captures

### DIFF
--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -445,10 +445,11 @@ export default class AnalyseCtrl implements CevalHandler {
     if (pathChanged) {
       if (this.study) this.study.setPath(path, this.node);
       if (this.retro) this.retro.onJump();
-      if (isForwardStep)
-        this.data.game.variant.key === 'atomic' && this.node.san?.includes('x')
-          ? site.sound.play('explosion')
-          : site.sound.move(this.node);
+      if (isForwardStep) {
+        if (this.data.game.variant.key === 'atomic' && this.node.san?.includes('x'))
+          site.sound.play('explosion');
+        else site.sound.move(this.node);
+      }
       this.threatMode(false);
       this.ceval?.stop();
       this.startCeval();

--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -446,8 +446,8 @@ export default class AnalyseCtrl implements CevalHandler {
       if (this.study) this.study.setPath(path, this.node);
       if (this.retro) this.retro.onJump();
       if (isForwardStep) {
-        const isAtomicCapture = this.data.game.variant.key === 'atomic' && !!this.node.san?.includes('x');
-        if (isAtomicCapture) site.sound.play('explosion');
+        if (this.data.game.variant.key === 'atomic' && this.node.san?.includes('x'))
+          site.sound.play('explosion');
         else site.sound.move(this.node);
       }
       this.threatMode(false);

--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -445,7 +445,10 @@ export default class AnalyseCtrl implements CevalHandler {
     if (pathChanged) {
       if (this.study) this.study.setPath(path, this.node);
       if (this.retro) this.retro.onJump();
-      if (isForwardStep) site.sound.move(this.node);
+      if (isForwardStep)
+        this.data.game.variant.key === 'atomic' && this.node.san?.includes('x')
+          ? site.sound.play('explosion')
+          : site.sound.move(this.node);
       this.threatMode(false);
       this.ceval?.stop();
       this.startCeval();

--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -446,8 +446,8 @@ export default class AnalyseCtrl implements CevalHandler {
       if (this.study) this.study.setPath(path, this.node);
       if (this.retro) this.retro.onJump();
       if (isForwardStep) {
-        if (this.data.game.variant.key === 'atomic' && this.node.san?.includes('x'))
-          site.sound.play('explosion');
+        const isAtomicCapture = this.data.game.variant.key === 'atomic' && !!this.node.san?.includes('x');
+        if (isAtomicCapture) site.sound.play('explosion');
         else site.sound.move(this.node);
       }
       this.threatMode(false);


### PR DESCRIPTION
When stepping through moves in the analysis board, captures in atomic variant
games were playing the regular capture sound instead of the explosion sound.

This brings the analysis board in line with the behaviour already present
in the round (game) page.