### PR TITLE
lint: fix dependency cycle

### DIFF
--- a/ui/analyse/src/study/relay/relayView.ts
+++ b/ui/analyse/src/study/relay/relayView.ts
@@ -1,7 +1,6 @@
 import { view as cevalView } from 'lib/ceval';
 import { displayColumns, isTouchDevice } from 'lib/device';
-import * as licon from 'lib/licon';
-import { bind, dataIcon, hl, type VNode } from 'lib/view';
+import { type VNode } from 'lib/view';
 
 import type AnalyseCtrl from '@/ctrl';
 import { view as keyboardView } from '@/keyboard';
@@ -45,25 +44,6 @@ export function relayView(
     ctx.hasRelayTour ? renderTourView() : renderBoardView(ctx),
   );
 }
-
-export const backToLiveView = (ctrl: AnalyseCtrl) =>
-  ctrl.study?.isRelayAwayFromLive()
-    ? hl(
-        'button.fbt.relay-back-to-live.text',
-        {
-          attrs: dataIcon(licon.PlayTriangle),
-          hook: bind(
-            'click',
-            () => {
-              const p = ctrl.study?.data.chapter.relayPath;
-              if (p) ctrl.userJump(p);
-            },
-            ctrl.redraw,
-          ),
-        },
-        i18n.broadcast.backToLiveMove,
-      )
-    : undefined;
 
 function renderBoardView(ctx: RelayViewContext) {
   const { ctrl, deps, study, gaugeOn, relay } = ctx;

--- a/ui/analyse/src/view/tools.ts
+++ b/ui/analyse/src/view/tools.ts
@@ -1,10 +1,10 @@
 import { view as cevalView } from 'lib/ceval';
-import { hl, type LooseVNode, type VNode } from 'lib/view';
+import * as licon from 'lib/licon';
+import { bind, dataIcon, hl, type LooseVNode, type VNode } from 'lib/view';
 
 import type AnalyseCtrl from '@/ctrl';
 import type { ConcealOf } from '@/interfaces';
 import { renderNextChapter } from '@/study/nextChapter';
-import { backToLiveView } from '@/study/relay/relayView';
 import type * as studyDeps from '@/study/studyDeps';
 import { addChapterId, renderResult, type ViewContext } from '@/view/components';
 
@@ -22,7 +22,7 @@ export function renderTools({ ctrl, deps, concealOf, allowVideo }: ViewContext, 
     showCeval && !ctrl.retro?.isSolving() && !ctrl.practice && cevalView.renderPvs(ctrl),
     renderMoveList(ctrl, deps, concealOf),
     deps?.gbEdit.running(ctrl) ? deps?.gbEdit.render(ctrl) : undefined,
-    backToLiveView(ctrl),
+    renderBackToLiveButton(ctrl),
     forkView(ctrl, concealOf),
     retroView(ctrl) || explorerView(ctrl) || practiceView(ctrl),
     ctrl.actionMenu() && actionMenu(ctrl),
@@ -34,3 +34,22 @@ const renderMoveList = (ctrl: AnalyseCtrl, deps?: typeof studyDeps, concealOf?: 
     hl('div', [ctrl.treeView.render(concealOf), renderResult(ctrl)]),
     !ctrl.practice && !deps?.gbEdit.running(ctrl) && renderNextChapter(ctrl),
   ]);
+
+const renderBackToLiveButton = (ctrl: AnalyseCtrl) =>
+  ctrl.study?.isRelayAwayFromLive()
+    ? hl(
+        'button.fbt.relay-back-to-live.text',
+        {
+          attrs: dataIcon(licon.PlayTriangle),
+          hook: bind(
+            'click',
+            () => {
+              const p = ctrl.study?.data.chapter.relayPath;
+              if (p) ctrl.userJump(p);
+            },
+            ctrl.redraw,
+          ),
+        },
+        i18n.broadcast.backToLiveMove,
+      )
+    : undefined;

--- a/ui/lib/src/device.ts
+++ b/ui/lib/src/device.ts
@@ -1,6 +1,6 @@
 import { memoize } from './index';
 import * as licon from './licon';
-import { bind, type Hooks } from './view';
+import { bind, type Hooks } from './view/snabbdom';
 
 export const hookMobileMousedown = (f: (e: Event) => any): Hooks =>
   bind('ontouchstart' in window ? 'click' : 'mousedown', f);


### PR DESCRIPTION
### Before

```
pnpm oxlint
[...]
Found 0 warnings and 10 errors.
Finished in 312ms on 896 files with 110 rules using 10 threads.
```

### After

```
pnpm oxlint
Found 0 warnings and 0 errors.
Finished in 169ms on 896 files with 110 rules using 10 threads.
```

Its weird that `lint:code` does not idenity the dependency cycle. Maybe @Simek can help here