### PR TITLE
ui: small visual tweaks for the bots page

### DIFF
--- a/modules/user/src/main/ui/UserList.scala
+++ b/modules/user/src/main/ui/UserList.scala
@@ -146,18 +146,18 @@ final class UserList(helpers: Helpers, bits: UserBits):
           div(cls := "bots page-menu__content")(
             div(cls := "box box-pad bots__categ")(
               boxTop(h1("Featured bots")),
-              div("Try playing these innovative chess engines! These are our favourites.")
-            ),
-            div(cls := "bots__featured")(
-              botGrid(featured, bestPerfs)
+              h3("Try playing these innovative chess engines! These are our favourites."),
+              div(cls := "bots__featured")(
+                botGrid(featured, bestPerfs)
+              ),
             ),
             div(cls := "box box-pad bots__categ")(
               boxTop(h1("Community bots"), aboutLink),
-              div(
+              h3(
                 "More chess engines created by the Lichess community. They are hosted by their creators, and as such might not always be online."
-              )
-            ),
-            botGrid(community, bestPerfs)
+              ),
+              botGrid(community, bestPerfs)
+            )
           )
         )
 

--- a/modules/user/src/main/ui/UserList.scala
+++ b/modules/user/src/main/ui/UserList.scala
@@ -149,7 +149,7 @@ final class UserList(helpers: Helpers, bits: UserBits):
               h3("Try playing these innovative chess engines! These are our favourites."),
               div(cls := "bots__featured")(
                 botGrid(featured, bestPerfs)
-              ),
+              )
             ),
             div(cls := "box box-pad bots__categ")(
               boxTop(h1("Community bots"), aboutLink),

--- a/ui/user/css/_list-bot.scss
+++ b/ui/user/css/_list-bot.scss
@@ -9,14 +9,26 @@
     }
 
     .box__top {
-      padding-bottom: 1.5em;
+      padding-bottom: 0.5em;
+    }
+
+    h3 {
+      margin-bottom: 2em;
     }
   }
 
-  --c-bot: #{$c-primary};
-
   &__featured {
-    --c-bot: #{$c-brag};
+    .bots__list__entry {
+      border-color: $c-brag;
+
+      &__play {
+        color: $c-brag;
+
+        &:hover {
+          background-color: $c-brag;
+        }
+      }
+    }
   }
 
   &__list {
@@ -32,19 +44,19 @@
     user-select: none;
 
     &__entry {
-      @extend %box-neat, %flex-column;
+      @extend %flex-column, %box-radius;
+      @include backdrop-blur-if-transparent;
 
       justify-content: space-between;
       gap: 1em;
-      background: $c-bg-box;
-      border: 1px solid var(--c-bot);
-      cursor: pointer;
+      background: $c-bg-zebra;
+      border: $border;
+      overflow: hidden;
 
       &__head {
         @extend %flex-column;
 
         padding: 1em 1.5em 0 1.5em;
-        gap: 0.5em;
 
         .user-link {
           font-size: 1.7em;
@@ -68,13 +80,14 @@
       }
 
       &__play {
-        @extend %flex-center-center, %box-radius-bottom;
+        @extend %flex-center-center;
 
-        padding: 1.5em 0;
-        color: $c-bot;
+        padding: 1em 0;
+        font-size: 1.1em;
+        color: $c-primary;
 
         &:hover {
-          background: var(--c-bot);
+          background: $c-primary;
           color: $c-over;
         }
       }


### PR DESCRIPTION
# Why

Spotted that bots page uses a bit different appearance to the other pages from the same section, where bots grid is rendered outside container.

# How

Move bots into relevant box containers, adjust spacing to display more bots on the viewport at the same time, apply regular border color to community bots boxes, remove shadow.

# Preview

<img width="4104" height="2134" alt="Screenshot 2026-05-02 at 22 48 58" src="https://github.com/user-attachments/assets/4a685fdd-61ee-45e5-9cee-3850387fc548" />
<img width="4104" height="2134" alt="Screenshot 2026-05-02 at 22 49 02" src="https://github.com/user-attachments/assets/b8fcb47a-6077-44c4-8f06-30295f8c1cfa" />
<img width="4104" height="2134" alt="Screenshot 2026-05-02 at 22 48 46" src="https://github.com/user-attachments/assets/4820fd8c-0011-43b4-9262-611eee213a75" />
