### PR TITLE
ui: move history hover state tweak for light mode

### DIFF
--- a/ui/analyse/css/study/_list-widget.scss
+++ b/ui/analyse/css/study/_list-widget.scss
@@ -102,6 +102,7 @@
     top: 0.5em;
     right: 0.5em;
     z-index: 3;
+
     .button {
       padding: 0.3em 0.5em;
     }

--- a/ui/puzzle/css/_tools.scss
+++ b/ui/puzzle/css/_tools.scss
@@ -41,7 +41,7 @@
     }
 
     &:hover glyph {
-      color: #fff;
+      color: $c-font-dim;
     }
   }
 }


### PR DESCRIPTION
# Why

Addresses the small UI issue in light mode mentioned here:
* https://github.com/lichess-org/lila/issues/20164#issuecomment-4369430099

# How

Use `$c-font-dim` instead of hardcoded white color. I have also fixed the stylelint error from one of earlier commits, see:
* https://github.com/lichess-org/lila/actions/runs/25290724284/job/74142029222

# Preview

<img width="734" height="338" alt="Screenshot 2026-05-04 at 11 07 04" src="https://github.com/user-attachments/assets/ad0b123d-9355-45dc-ac03-a4bdb62368b7" />
<img width="734" height="338" alt="Screenshot 2026-05-04 at 11 06 49" src="https://github.com/user-attachments/assets/519776f7-35d9-4345-9c83-ae865bd8fbe7" />
