### PR TITLE
ui: introduce `plyColor` and `plyOpponentColor` helpers

### DIFF
--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -33,6 +33,7 @@ import {
 import { ChatCtrl } from 'lib/chat/chatCtrl';
 import { displayColumns } from 'lib/device';
 import { playable, playedTurns, fenToEpd, validUci } from 'lib/game';
+import { plyColor } from 'lib/game/chess';
 import { PromotionCtrl } from 'lib/game/promotion';
 import { pubsub } from 'lib/pubsub';
 import { storedBooleanProp, storedBooleanPropWithEffect } from 'lib/storage';
@@ -355,7 +356,7 @@ export default class AnalyseCtrl implements CevalHandler {
   }
 
   turnColor(): Color {
-    return this.node.ply % 2 === 0 ? 'white' : 'black';
+    return plyColor(this.node.ply);
   }
 
   togglePlay(delay: AutoplayDelay): void {

--- a/ui/analyse/src/view/clocks.ts
+++ b/ui/analyse/src/view/clocks.ts
@@ -1,6 +1,7 @@
 import { h, type VNode } from 'snabbdom';
 
 import { defined, notNull } from 'lib';
+import { plyColor } from 'lib/game';
 import { formatClockTimeVerbal } from 'lib/game/clock/clockView';
 import * as licon from 'lib/licon';
 import type { TreePath } from 'lib/tree/types';
@@ -20,7 +21,7 @@ export default function renderClocks(ctrl: AnalyseCtrl, path: TreePath): [VNode,
   const node = ctrl.tree.nodeAtPath(path),
     whitePov = ctrl.bottomIsWhite(),
     parentClock = ctrl.tree.getParentClock(node, path),
-    isWhiteTurn = node.ply % 2 === 0,
+    isWhiteTurn = plyColor(node.ply) === 'white',
     centis: Array<number | undefined> = (
       isWhiteTurn ? [parentClock, node.clock] : [node.clock, parentClock]
     ).map(c => (defined(c) && c < 0 ? undefined : c));

--- a/ui/analyse/src/view/nvuiView.ts
+++ b/ui/analyse/src/view/nvuiView.ts
@@ -11,7 +11,7 @@ import { throttle } from 'lib/async';
 import { view as cevalView, renderEval } from 'lib/ceval';
 import { renderChat } from 'lib/chat/renderChat';
 import { isTouchDevice } from 'lib/device';
-import type { Player } from 'lib/game';
+import { type Player, plyOpponentColor } from 'lib/game';
 import { plyToTurn } from 'lib/game/chess';
 import {
   renderSan,
@@ -274,9 +274,11 @@ function boardEventsHook(
   const $buttons = $board.find('button');
   const steps = () => ctrl.tree.getNodeList(ctrl.path);
   const fenSteps = () => steps().map(step => step.fen);
-  const opponentColor = () => (ctrl.node.ply % 2 === 0 ? 'black' : 'white');
   $buttons.on('blur', leaveSquareHandler($buttons));
-  $buttons.on('click', selectionHandler(opponentColor));
+  $buttons.on(
+    'click',
+    selectionHandler(() => plyOpponentColor(ctrl.node.ply)),
+  );
   $buttons.on('keydown', (e: KeyboardEvent) => {
     if (e.shiftKey && e.key.match(/^[ad]$/i)) jumpMoveOrLine(ctrl)(e);
     else if (e.key.match(/^x$/i))

--- a/ui/lib/src/game/chess.ts
+++ b/ui/lib/src/game/chess.ts
@@ -17,6 +17,10 @@ export const fenToEpd = (fen: FEN): string => fen.split(' ').slice(0, 4).join(' 
 
 export const plyToTurn = (ply: number): number => Math.floor((ply - 1) / 2) + 1;
 
+export const plyColor = (ply: number): Color => (ply % 2 === 0 ? 'white' : 'black');
+
+export const plyOpponentColor = (ply: number): Color => (ply % 2 === 0 ? 'black' : 'white');
+
 export const pieceCount = (fen: FEN): number => fen.split(/\s/)[0].split(/[nbrqkp]/i).length - 1;
 
 export function fen960(): string {

--- a/ui/lib/src/game/chess.ts
+++ b/ui/lib/src/game/chess.ts
@@ -1,6 +1,6 @@
 // no side effects allowed due to re-export by index.ts
 
-import { type Chess, type NormalMove, parseUci, makeUci } from 'chessops';
+import { type Chess, type NormalMove, parseUci, makeUci, opposite } from 'chessops';
 import { normalizeMove } from 'chessops/chess';
 
 import { shuffle } from '@/algo';
@@ -19,7 +19,7 @@ export const plyToTurn = (ply: number): number => Math.floor((ply - 1) / 2) + 1;
 
 export const plyColor = (ply: number): Color => (ply % 2 === 0 ? 'white' : 'black');
 
-export const plyOpponentColor = (ply: number): Color => (ply % 2 === 0 ? 'black' : 'white');
+export const plyOpponentColor = (ply: number): Color => opposite(plyColor(ply));
 
 export const pieceCount = (fen: FEN): number => fen.split(/\s/)[0].split(/[nbrqkp]/i).length - 1;
 

--- a/ui/puzzle/src/ctrl.ts
+++ b/ui/puzzle/src/ctrl.ts
@@ -14,6 +14,7 @@ import { prop, type Prop, propWithEffect, type Toggle, toggle, requestIdleCallba
 import { type Deferred, defer, throttle } from 'lib/async';
 import { CevalCtrl } from 'lib/ceval';
 import type { CevalHandler } from 'lib/ceval/types';
+import { plyColor } from 'lib/game/chess';
 import { type WithGround } from 'lib/game/ground';
 import { PromotionCtrl } from 'lib/game/promotion';
 import { pubsub } from 'lib/pubsub';
@@ -250,7 +251,7 @@ export default class PuzzleCtrl implements CevalHandler {
     this.lastFeedback = 'init';
     this.initialPath = initialPath;
     this.initialNode = this.tree.nodeAtPath(initialPath);
-    this.pov = this.initialNode.ply % 2 === 1 ? 'black' : 'white';
+    this.pov = plyColor(this.initialNode.ply);
     this.isDaily = location.href.endsWith('/daily');
     this.hintHasBeenShown(false);
     this.canViewSolution(false);
@@ -290,7 +291,7 @@ export default class PuzzleCtrl implements CevalHandler {
 
   makeCgOpts = (): CgConfig => {
     const node = this.node;
-    const color: Color = node.ply % 2 === 0 ? 'white' : 'black';
+    const color = plyColor(node.ply);
     const dests = chessgroundDests(this.position());
     const nextNode = this.node.children[0];
     const canMove = this.mode === 'view' || (color === this.pov && (!nextNode || nextNode.puzzle === 'fail'));

--- a/ui/puzzle/src/moveTest.ts
+++ b/ui/puzzle/src/moveTest.ts
@@ -1,5 +1,6 @@
 import { parseUci } from 'chessops/util';
 
+import { plyOpponentColor } from 'lib/game';
 import { path as pathOps } from 'lib/tree/tree';
 
 import type PuzzleCtrl from './ctrl';
@@ -23,7 +24,7 @@ export default function moveTest(ctrl: PuzzleCtrl): MoveTestReturn {
   if (ctrl.mode === 'view') return;
   if (!pathOps.contains(ctrl.path, ctrl.initialPath)) return;
 
-  const playedByColor = ctrl.node.ply % 2 === 1 ? 'white' : 'black';
+  const playedByColor = plyOpponentColor(ctrl.node.ply);
   if (playedByColor !== ctrl.pov) return;
 
   const nodes = ctrl.nodeList.slice(pathOps.size(ctrl.initialPath) + 1).map(node => ({

--- a/ui/puzzle/src/moveTree.ts
+++ b/ui/puzzle/src/moveTree.ts
@@ -5,10 +5,11 @@ import { makeSanAndPlay, parseSan } from 'chessops/san';
 import { isNormal, type Move, type NormalMove } from 'chessops/types';
 import { makeUci, parseUci } from 'chessops/util';
 
+import { plyOpponentColor } from 'lib/game';
 import { completeNode } from 'lib/tree/node';
 import { type TreeWrapper, path as pathOps } from 'lib/tree/tree';
+import type { TreeNode, TreePath } from 'lib/tree/types';
 
-import type { TreeNode, TreePath } from '../../lib/src/tree/types';
 import type PuzzleCtrl from './ctrl';
 
 export function pgnToTree(pgn: San[]): TreeNode {
@@ -56,7 +57,7 @@ export function nextCorrectMove(ctrl: PuzzleCtrl): NormalMove | undefined {
   if (ctrl.mode === 'view') return;
   if (!pathOps.contains(ctrl.path, ctrl.initialPath)) return;
 
-  const playedByColor = ctrl.node.ply % 2 === 1 ? 'white' : 'black';
+  const playedByColor = plyOpponentColor(ctrl.node.ply);
   if (playedByColor === ctrl.pov) return;
 
   const nodes = ctrl.nodeList.slice(pathOps.size(ctrl.initialPath) + 1);

--- a/ui/round/src/ctrl.ts
+++ b/ui/round/src/ctrl.ts
@@ -8,7 +8,8 @@ import { makeVoiceMove, type VoiceMove } from 'voice';
 
 import { defined, type Toggle, type Prop, toggle, requestIdleCallbackSafe, memoize } from 'lib';
 import * as game from 'lib/game';
-import { plyToTurn } from 'lib/game/chess';
+import { plyOpponentColor } from 'lib/game';
+import { plyToTurn, plyColor } from 'lib/game/chess';
 import { ClockCtrl, type ClockOpts } from 'lib/game/clock/clockCtrl';
 import type { MoveRootCtrl } from 'lib/game/moveRootCtrl';
 import { PromotionCtrl, promote } from 'lib/game/promotion';
@@ -251,7 +252,7 @@ export default class RoundController implements MoveRootCtrl {
         fen: s.fen,
         lastMove: uciToMove(s.uci),
         check: !!s.check,
-        turnColor: this.ply % 2 === 0 ? 'white' : 'black',
+        turnColor: plyColor(this.ply),
       };
     if (this.replaying()) this.chessground.stop();
     else
@@ -397,12 +398,12 @@ export default class RoundController implements MoveRootCtrl {
   playerByColor = (c: Color): game.Player => this.data[c === this.data.player.color ? 'player' : 'opponent'];
 
   apiMove = (o: ApiMove): true => {
-    const d = this.data,
-      playing = this.isPlaying();
+    const d = this.data;
+    const playing = this.isPlaying();
     d.game.turns = o.ply;
-    d.game.player = o.ply % 2 === 0 ? 'white' : 'black';
-    const playedColor = o.ply % 2 === 0 ? 'black' : 'white',
-      activeColor = d.player.color === d.game.player;
+    d.game.player = plyColor(o.ply);
+    const playedColor = plyOpponentColor(o.ply);
+    const activeColor = d.player.color === d.game.player;
     if (o.status) d.game.status = o.status;
     if (o.winner) d.game.winner = o.winner;
     this.playerByColor('white').offeringDraw = o.wDraw;

--- a/ui/round/src/ground.ts
+++ b/ui/round/src/ground.ts
@@ -4,6 +4,7 @@ import { h, type VNode } from 'snabbdom';
 
 import resizeHandle from 'lib/chessgroundResize';
 import { isSafari } from 'lib/device';
+import { plyColor } from 'lib/game/chess';
 import { ShowResizeHandle, Coords, MoveEvent } from 'lib/prefs';
 import { storage } from 'lib/storage';
 import { onInsert } from 'lib/view';
@@ -23,7 +24,7 @@ export function makeConfig(ctrl: RoundController): CgConfig {
   return {
     fen: step.fen,
     orientation: boardOrientation(data, ctrl.flip),
-    turnColor: step.ply % 2 === 0 ? 'white' : 'black',
+    turnColor: plyColor(step.ply),
     lastMove: uciToMove(step.uci),
     check: !!step.check,
     coordinates: data.pref.coords !== Coords.Hidden,
@@ -41,7 +42,7 @@ export function makeConfig(ctrl: RoundController): CgConfig {
       dropNewPiece: hooks.onNewPiece,
       insert(elements) {
         const firstPly = util.firstPly(ctrl.data);
-        const isSecond = (firstPly % 2 === 0 ? 'white' : 'black') !== data.player.color;
+        const isSecond = plyColor(firstPly) !== data.player.color;
         const showUntil = firstPly + 2 + +isSecond;
         resizeHandle(
           elements,

--- a/ui/round/src/socket.ts
+++ b/ui/round/src/socket.ts
@@ -2,7 +2,7 @@ import { COLORS } from 'chessops';
 
 import { defined } from 'lib';
 import { throttle } from 'lib/async';
-import { type Simul, setOnGame, isPlayerTurn } from 'lib/game';
+import { type Simul, setOnGame, isPlayerTurn, plyColor } from 'lib/game';
 import { pubsub } from 'lib/pubsub';
 import { wsSign, wsVersion } from 'lib/socket';
 import { domDialog } from 'lib/view';
@@ -122,7 +122,7 @@ export function make(send: RoundSocketSend, ctrl: RoundController): RoundSocket 
       }
       if (by) {
         let ply = ctrl.lastPly();
-        if ((by === 'white') === (ply % 2 === 0)) ply++;
+        if (by === plyColor(ply)) ply++;
         ctrl.data.game.drawOffers = (ctrl.data.game.drawOffers || []).concat([ply]);
       }
       ctrl.redraw();


### PR DESCRIPTION
# Why

Spotted that we quite often use `ply % 2` checks to determine player or opponent color, it is not that obvious on the initial read and can lead to some logic mistakes since we compare it to `0` and `1` based on the case.

# How

Introduce `plyColor` and `plyOpponentColor` helpers to make it easier to reuse the logic with bit more confidence about the correctness due to verbose naming. There are probably few more places where we can utilize them, but don't want to make a lot of logic changes at once.