### PR TITLE
css: prevent material diff from blocking header dropdown hover

### DIFF
--- a/ui/lib/css/component/_material.scss
+++ b/ui/lib/css/component/_material.scss
@@ -1,5 +1,6 @@
 .material {
   pointer-events: none;
+
   @extend %flex-center-nowrap;
 
   div {

--- a/ui/lib/css/component/_material.scss
+++ b/ui/lib/css/component/_material.scss
@@ -1,6 +1,7 @@
 .material {
   @extend %flex-center-nowrap;
-
+  pointer-events: none;
+  
   div {
     display: inline-block;
     margin-inline-start: 10px;

--- a/ui/lib/css/component/_material.scss
+++ b/ui/lib/css/component/_material.scss
@@ -1,7 +1,7 @@
 .material {
   @extend %flex-center-nowrap;
   pointer-events: none;
-  
+
   div {
     display: inline-block;
     margin-inline-start: 10px;

--- a/ui/lib/css/component/_material.scss
+++ b/ui/lib/css/component/_material.scss
@@ -1,6 +1,6 @@
 .material {
-  @extend %flex-center-nowrap;
   pointer-events: none;
+  @extend %flex-center-nowrap;
 
   div {
     display: inline-block;


### PR DESCRIPTION
The material difference display (captured pieces and score) was intercepting mouse events, making it impossible to hover over the Tools dropdown menu when the material element overlapped with it.

Adding pointer-events: none fixes this without affecting any functionality, as the material display is purely visual and has no interactive elements.
