### PR TITLE
Fix temporary accuracy spikes during game review computation

### DIFF
--- a/modules/analyse/src/main/AccuracyPercent.scala
+++ b/modules/analyse/src/main/AccuracyPercent.scala
@@ -91,12 +91,13 @@ for x in xs:
       .zipWithIndex
       .collect { case ((List(prev, next), weight), i) =>
         val color = Color.fromWhite((i % 2 == 0) == startColor.white)
-        if prev.isDefined && next.isDefined && weight.isDefined then
-          val accuracy = AccuracyPercent
-            .fromWinPercents(color.fold(prev.get, next.get), color.fold(next.get, prev.get))
-            .value
-          (Some((accuracy, weight.get)), color)
-        else (None, color)
+        val weighted = for
+          p <- prev
+          n <- next
+          w <- weight
+          accuracy = AccuracyPercent.fromWinPercents(color.fold(p, n), color.fold(n, p))
+        yield (accuracy.value, w)
+        (weighted, color)
       }
       .to(Iterable)
 

--- a/modules/analyse/src/main/AccuracyPercent.scala
+++ b/modules/analyse/src/main/AccuracyPercent.scala
@@ -74,27 +74,34 @@ for x in xs:
     fromEvalsAndPov(pov, analysis.infos.map(_.eval))
 
   def gameAccuracy(startColor: Color, analysis: Analysis): Option[ByColor[AccuracyPercent]] =
-    gameAccuracy(startColor, analysis.infos.map(_.eval).flatMap(_.forceAsCp))
+    gameAccuracy(startColor, analysis.infos.map(_.eval.forceAsCp))
 
   // a mean of volatility-weighted mean and harmonic mean
-  def gameAccuracy(startColor: Color, cps: List[Cp]): Option[ByColor[AccuracyPercent]] =
-    val allWinPercents = (Cp.initial :: cps).map(WinPercent.fromCentiPawns)
+  def gameAccuracy(startColor: Color, cps: List[Option[Cp]]): Option[ByColor[AccuracyPercent]] =
+    val allWinPercents = (Some(Cp.initial) :: cps).map(_.map(WinPercent.fromCentiPawns))
     val windowSize = (cps.size / 10).atLeast(2).atMost(8)
-    val allWinPercentValues = WinPercent.raw(allWinPercents)
+    val allWinPercentValues = allWinPercents.map(_.map(_.value))
+
     val windows =
       List
         .fill(windowSize.atMost(allWinPercentValues.size) - 2)(allWinPercentValues.take(windowSize))
         ::: allWinPercentValues.sliding(windowSize).toList
-    val weights = windows.map { xs => Maths.standardDeviation(xs).orZero.atLeast(0.5).atMost(12) }
-    val weightedAccuracies: Iterable[((Double, Double), Color)] = allWinPercents
+    val weights = windows.map { xs =>
+      if xs.forall(_.isDefined) then Some(Maths.standardDeviation(xs.flatten).orZero.atLeast(0.5).atMost(12))
+      else None
+    }
+    val weightedAccuracies: Iterable[(Option[(Double, Double)], Color)] = allWinPercents
       .sliding(2)
       .zip(weights)
       .zipWithIndex
       .collect { case ((List(prev, next), weight), i) =>
         val color = Color.fromWhite((i % 2 == 0) == startColor.white)
-        val accuracy =
-          AccuracyPercent.fromWinPercents(color.fold(prev, next), color.fold(next, prev)).value
-        ((accuracy, weight), color)
+        if prev.isDefined && next.isDefined && weight.isDefined then
+          val accuracy = AccuracyPercent
+            .fromWinPercents(color.fold(prev.get, next.get), color.fold(next.get, prev.get))
+            .value
+          (Some((accuracy, weight.get)), color)
+        else (None, color)
       }
       .to(Iterable)
 
@@ -105,10 +112,10 @@ for x in xs:
     def colorAccuracy(color: Color) = for
       weighted <- Maths.weightedMean:
         weightedAccuracies.collect:
-          case (weightedAccuracy, c) if c == color => weightedAccuracy
+          case (Some(weightedAccuracy), c) if c == color => weightedAccuracy
       harmonic <- Maths.harmonicMean:
         weightedAccuracies.collect:
-          case ((accuracy, _), c) if c == color => accuracy
+          case (Some((accuracy, _)), c) if c == color => accuracy
     yield AccuracyPercent((weighted + harmonic) / 2)
 
     ByColor(colorAccuracy)

--- a/modules/analyse/src/main/AccuracyPercent.scala
+++ b/modules/analyse/src/main/AccuracyPercent.scala
@@ -79,17 +79,12 @@ for x in xs:
   // a mean of volatility-weighted mean and harmonic mean
   def gameAccuracy(startColor: Color, cps: List[Option[Cp]]): Option[ByColor[AccuracyPercent]] =
     val allWinPercents = (Some(Cp.initial) :: cps).map(_.map(WinPercent.fromCentiPawns))
-    val windowSize = (cps.size / 10).atLeast(2).atMost(8)
-    val allWinPercentValues = allWinPercents.map(_.map(_.value))
+    val windowSize = (cps.size / 10).squeeze(2, 8)
 
-    val windows =
-      List
-        .fill(windowSize.atMost(allWinPercentValues.size) - 2)(allWinPercentValues.take(windowSize))
-        ::: allWinPercentValues.sliding(windowSize).toList
-    val weights = windows.map { xs =>
-      if xs.forall(_.isDefined) then Some(Maths.standardDeviation(xs.flatten).orZero.atLeast(0.5).atMost(12))
-      else None
-    }
+    val windows = List.fill(windowSize.atMost(allWinPercents.size) - 2)(allWinPercents.take(windowSize))
+      ::: allWinPercents.sliding(windowSize).toList
+    val weights = windows.map:
+      _.sequence.map(wp => Maths.standardDeviation(WinPercent.raw(wp)).so(_.squeeze(0.5, 12)))
     val weightedAccuracies: Iterable[(Option[(Double, Double)], Color)] = allWinPercents
       .sliding(2)
       .zip(weights)

--- a/modules/analyse/src/main/AccuracyPercent.scala
+++ b/modules/analyse/src/main/AccuracyPercent.scala
@@ -100,10 +100,6 @@ for x in xs:
       }
       .to(Iterable)
 
-    // cps.zip(weightedAccuracies) foreach { case (eval, ((acc, weight), color)) =>
-    //   println(s"$eval $color ${weight.toInt} ${acc.toInt}")
-    // }
-
     def colorAccuracy(color: Color) = for
       weighted <- Maths.weightedMean:
         weightedAccuracies.collect:

--- a/modules/analyse/src/main/AccuracyPercent.scala
+++ b/modules/analyse/src/main/AccuracyPercent.scala
@@ -85,7 +85,7 @@ for x in xs:
       ::: allWinPercents.sliding(windowSize).toList
     val weights = windows.map:
       _.sequence.map(wp => Maths.standardDeviation(WinPercent.raw(wp)).so(_.squeeze(0.5, 12)))
-    val weightedAccuracies: Iterable[(Option[(Double, Double)], Color)] = allWinPercents
+    val weightedAccuracies: Iterable[(Option[PairOf[AccuracyPercent]], Color)] = allWinPercents
       .sliding(2)
       .zip(weights)
       .zipWithIndex
@@ -96,7 +96,7 @@ for x in xs:
           n <- next
           w <- weight
           accuracy = AccuracyPercent.fromWinPercents(color.fold(p, n), color.fold(n, p))
-        yield (accuracy.value, w)
+        yield (accuracy, w)
         (weighted, color)
       }
       .to(Iterable)

--- a/modules/analyse/src/test/AccuracyPercentTest.scala
+++ b/modules/analyse/src/test/AccuracyPercentTest.scala
@@ -10,7 +10,7 @@ class AccuracyPercentTest extends munit.FunSuite:
   type AccMap = ByColor[AccuracyPercent]
 
   def compute(cps: List[Int]): Option[AccMap] =
-    gameAccuracy(Color.white, cps.map(Cp(_)))
+    gameAccuracy(Color.white, cps.map(Cp(_)).map(Some(_)))
 
   test("empty game"):
     assertEquals(compute(Nil), None)
@@ -61,7 +61,7 @@ class AccuracyPercentTest extends munit.FunSuite:
     assert(isCloseTo(a.white.value, 20d, 8d))
     assert(isCloseTo(a.black.value, 20d, 8d))
 
-  def computeBlack(cps: List[Int]) = gameAccuracy(Color.black, cps.map(Cp(_)))
+  def computeBlack(cps: List[Int]) = gameAccuracy(Color.black, cps.map(Cp(_)).map(Some(_)))
 
   test("black moves first, empty game"):
     assertEquals(computeBlack(Nil), None)


### PR DESCRIPTION
For the majority of games I review, the accuracy tends to temporarily jump very high at points (like 99% or 100%) while the computer is reviewing. This is because the flatmap in `def gameAccuracy(startColor: Color, analysis: Analysis)` removes `None` values, which leads to situations like:

+1.0, None, None, None, +2.0
turning into
+1.0, +2.0

This makes it seem like a move was played that somehow increased the eval from +1.0 to +2.0. Removing the Nones also prevents us from knowing which plies were played by White/Black, since the `i % 2 == 0` no longer has meaning.

So this PR keeps any `None` vals, and waits to compute the accuracy for any two plies p1 and p2 until the entire window for them (used to compute the weight) has no `None` val. This should only change the behaviour while the game is being reviewed.