### PR TITLE
ui: do not use deprecated `e.which`, replace with modern equivalents

### DIFF
--- a/ui/coordinateTrainer/src/ctrl.ts
+++ b/ui/coordinateTrainer/src/ctrl.ts
@@ -334,7 +334,7 @@ export default class CoordinateTrainerCtrl {
   onRadioInputKeyUp = (e: KeyboardEvent) => {
     // Mousetrap by default ignores key presses on inputs
     // when enter is pressed on a radio input, start training
-    if (!this.playing && e.which === 13) this.start();
+    if (!this.playing && e.key === 'Enter') this.start();
   };
 
   onVoice = (txt: string) => {
@@ -355,7 +355,7 @@ export default class CoordinateTrainerCtrl {
 
     if (!e.isTrusted || !this.playing) {
       input.value = '';
-      if (e.which === 13) this.start();
+      if (e.key === 'Enter') this.start();
     } else this.checkKeyboardInput();
   };
 

--- a/ui/insight/src/multipleSelect.ts
+++ b/ui/insight/src/multipleSelect.ts
@@ -210,17 +210,15 @@ export const registerMultipleSelect = () => {
           .off('mouseout')
           .multipleSelectHover(that.open.bind(that), that.close.bind(that));
       this.$parent.off('keydown').on('keydown', function (e) {
-        switch (e.which) {
-          case 27:
-            that.close();
-            that.$choice[0]?.focus();
-            break;
+        if (e.key === 'Escape') {
+          that.close();
+          that.$choice[0]?.focus();
         }
       });
       this.$searchInput
         .off('keydown')
         .on('keydown', function (e) {
-          if (e.keyCode === 9 && e.shiftKey) {
+          if (e.key === 'Tab' && e.shiftKey) {
             that.close();
           }
         })
@@ -228,7 +226,7 @@ export const registerMultipleSelect = () => {
         .on('keyup', function (e) {
           if (
             that.options.filterAcceptOnEnter &&
-            (e.which === 13 || e.which === 32) &&
+            (e.key === 'Enter' || e.code === 'Space') &&
             that.$searchInput.val()
           ) {
             that.$selectAll[0]?.click();

--- a/ui/site/src/mousetrap.ts
+++ b/ui/site/src/mousetrap.ts
@@ -34,51 +34,31 @@ interface Binding {
   action: Action;
 }
 
-const MAP: Record<string, string> = {
-  8: 'backspace',
-  9: 'tab',
-  13: 'enter',
-  16: 'shift',
-  17: 'ctrl',
-  18: 'alt',
-  20: 'capslock',
-  27: 'esc',
-  32: 'space',
-  33: 'pageup',
-  34: 'pagedown',
-  35: 'end',
-  36: 'home',
-  37: 'left',
-  38: 'up',
-  39: 'right',
-  40: 'down',
-  45: 'ins',
-  46: 'del',
-  91: 'meta',
-  93: 'meta',
-  224: 'meta',
+const KEY_MAP: Record<string, string> = {
+  Backspace: 'backspace',
+  Tab: 'tab',
+  Enter: 'enter',
+  Shift: 'shift',
+  Control: 'ctrl',
+  Alt: 'alt',
+  CapsLock: 'capslock',
+  Escape: 'esc',
+  ' ': 'space',
+  PageUp: 'pageup',
+  PageDown: 'pagedown',
+  End: 'end',
+  Home: 'home',
+  ArrowLeft: 'left',
+  ArrowUp: 'up',
+  ArrowRight: 'right',
+  ArrowDown: 'down',
+  Insert: 'ins',
+  Delete: 'del',
+  Meta: 'meta',
 };
-for (let i = 1; i < 20; ++i) MAP[111 + i] = 'f' + i;
-for (let i = 0; i <= 9; ++i) MAP[i + 96] = i.toString();
 
-const KEYCODE_MAP: Record<string, string> = {
-  106: '*',
-  107: '+',
-  109: '-',
-  110: '.',
-  111: '/',
-  186: ';',
-  187: '=',
-  188: ',',
-  189: '-',
-  190: '.',
-  191: '/',
-  192: '`',
-  219: '[',
-  220: '\\',
-  221: ']',
-  222: "'",
-};
+const SPECIAL_KEYS: Set<string> = new Set(Object.values(KEY_MAP));
+for (let i = 1; i < 20; ++i) SPECIAL_KEYS.add('f' + i);
 
 const SPECIAL_ALIASES: Record<string, string> = {
   option: 'alt',
@@ -91,10 +71,9 @@ const SPECIAL_ALIASES: Record<string, string> = {
 
 const keyFromEvent = (e: KeyboardEvent): string => {
   if (e.type === 'keypress') {
-    const character = String.fromCharCode(e.which);
-    return e.shiftKey ? character : character.toLowerCase(); // ignore caps lock
+    return e.shiftKey ? e.key : e.key.toLowerCase();
   }
-  return MAP[e.which] || KEYCODE_MAP[e.which] || String.fromCharCode(e.which).toLowerCase();
+  return KEY_MAP[e.key] || e.key.toLowerCase();
 };
 
 const modifiersMatch = (a: string[], b: string[]): boolean => a.sort().join(',') === b.sort().join(',');
@@ -111,24 +90,8 @@ const eventModifiers = (e: KeyboardEvent): string[] => {
 const isModifier = (key: string): boolean =>
   key === 'shift' || key === 'ctrl' || key === 'alt' || key === 'meta';
 
-const getReverseMap = (() => {
-  let REVERSE_MAP: Record<string, string> | undefined;
-  return () => {
-    if (!REVERSE_MAP) {
-      REVERSE_MAP = {};
-      for (const key in MAP) {
-        if (parseInt(key, 10) > 95 && parseInt(key, 10) < 112) continue; // skip numeric keypad
-        if (Object.prototype.hasOwnProperty.call(MAP, key)) {
-          REVERSE_MAP[MAP[key]] = key;
-        }
-      }
-    }
-    return REVERSE_MAP;
-  };
-})();
-
 const pickBestAction = (key: string, modifiers: string[], action?: Action): Action => {
-  action = action || (getReverseMap()[key] ? 'keydown' : 'keypress');
+  action = action || (SPECIAL_KEYS.has(key) ? 'keydown' : 'keypress');
   if (action === 'keypress' && modifiers.length) return 'keydown'; // modifiers incompatible with keypress
   return action;
 };
@@ -197,8 +160,6 @@ export default class Mousetrap {
   };
 
   private readonly handleKeyEvent = (e: KeyboardEvent) => {
-    if (typeof e.which !== 'number') (e as any).which = e.keyCode; // normalize
-
     const el = e.target as HTMLElement;
 
     for (const binding of this.getMatches(e)) {


### PR DESCRIPTION
# Why

Using `e.which` to match pressed key is deprecated and discouraged:
* https://developer.mozilla.org/en-US/docs/Web/API/UIEvent/which

# How

Refactor few files still using `e.which` to be based on modern equivalents, simplify `mousetrap` code in the process.

# Test plan

I have confirmed locally that mostrap shortcut still works on the Puzzle page. 