### PR TITLE
study: dynamic last move highlight color based on glyph

### DIFF
--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -374,7 +374,6 @@ export default class AnalyseCtrl implements CevalHandler {
     });
     this.pluginUpdate(this.node.fen);
     this.onChange();
-    
     const glyphColors: Record<string, string> = {
       '!!': 'rgba(22, 130, 38, 0.41)',
       '!': 'rgba(34, 172, 56, 0.41)',

--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -374,6 +374,20 @@ export default class AnalyseCtrl implements CevalHandler {
     });
     this.pluginUpdate(this.node.fen);
     this.onChange();
+    
+    const glyphColors: Record<string, string> = {
+      '!!': 'rgba(22, 130, 38, 0.41)',
+      '!': 'rgba(34, 172, 56, 0.41)',
+      '??': 'rgba(223, 83, 83, 0.41)',
+      '?': 'rgba(230, 159, 0, 0.41)',
+      '!?': 'rgba(234, 69, 216, 0.41)',
+      '?!': 'rgba(86, 180, 233, 0.41)',
+    };
+    const symbol = this.node.glyphs?.[0]?.symbol;
+    document.body.style.setProperty(
+      '--last-move-color',
+      (symbol && glyphColors[symbol]) || 'rgba(155, 199, 0, 0.41)',
+    );
   }
 
   serverMainline = () => this.mainline.slice(0, playedTurns(this.data) + 1);

--- a/ui/lib/css/theme/board/_chessground.scss
+++ b/ui/lib/css/theme/board/_chessground.scss
@@ -67,7 +67,7 @@ square {
 
   &.last-move {
     will-change: transform;
-    background-color: rgba(155, 199, 0, 0.41);
+    background-color: var(--last-move-color, rgba(155, 199, 0, 0.41));
 
     body[data-board='horsey'] .is2d &:not(.move-dest) {
       background: url('../images/board/horsey.last-move.png');


### PR DESCRIPTION
When a move has a glyph annotation in a study, the last move highlight
color on the board now reflects the glyph type:

- Brilliant (!!) → dark green
- Good (!) → green
- Blunder (??) → red
- Mistake (?) → orange
- Interesting (!?) → pink
- Inaccuracy (?!) → light blue
- No glyph → default green (rgba(155, 199, 0, 0.41))

The color is set via a CSS custom property (--last-move-color) on the body,
which is read by the chessground last-move square style.