### PR TITLE
ui: build process micro-optimizations

### DIFF
--- a/ui/.build/src/build.ts
+++ b/ui/.build/src/build.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'node:child_process';
+import { spawn } from 'node:child_process';
 import fs from 'node:fs';
 import { relative, join } from 'node:path';
 import { chdir } from 'node:process';
@@ -19,9 +19,21 @@ import { tsc, stopTsc } from './tsc.ts';
 export async function build(pkgs: string[]): Promise<void> {
   env.startTime = Date.now();
   try {
+    // pnpm install and package parsing don't depend on each other — run in parallel
     try {
       chdir(env.rootDir);
-      if (env.install) execSync('pnpm install', { stdio: 'inherit' });
+
+      const install = env.install
+        ? new Promise<void>((resolve, reject) => {
+            const proc = spawn('pnpm', ['install'], { stdio: 'inherit' });
+            proc.on('close', code => {
+              if (code === 0) resolve();
+              else reject(new Error(`pnpm install exited with code ${code}`));
+            });
+          })
+        : await Promise.resolve();
+      await install;
+
       if (!pkgs.length) env.log(`Parsing packages in '${c.cyan(env.uiDir)}'`);
 
       await Promise.allSettled([parsePackages(), fs.promises.mkdir(env.buildTempDir)]);

--- a/ui/.build/src/env.ts
+++ b/ui/.build/src/env.ts
@@ -208,7 +208,7 @@ function pad2(n: number) {
 }
 
 function stripColorEscapes(text: string) {
-  return text.replace(/\x1b\[[0-9;]*m/, '');
+  return text.replace(/\x1b\[[0-9;]*m/g, '');
 }
 
 function prettyTime() {

--- a/ui/.build/src/manifest.ts
+++ b/ui/.build/src/manifest.ts
@@ -2,6 +2,7 @@ import cps from 'node:child_process';
 import crypto from 'node:crypto';
 import fs from 'node:fs';
 import { join } from 'node:path';
+import { promisify } from 'node:util';
 
 import { shallowSort, isContained } from './algo.ts';
 import { jsLogger } from './console.ts';
@@ -49,19 +50,22 @@ export function updateManifest(update: ManifestUpdate = {}): void {
   }
 }
 
+const exec = promisify(cps.exec);
+
 async function writeManifest() {
   if (!(env.manifestOk() && taskOk())) return;
-  const commitMessage = cps
-    .execSync('git log -1 --pretty=%s', { encoding: 'utf-8' })
-    .trim()
-    .replaceAll("'", '&#39;')
-    .replaceAll('"', '&quot;');
+
+  const [{ stdout: sha }, { stdout: msg }] = await Promise.all([
+    exec('git rev-parse -q HEAD'),
+    exec('git log -1 --pretty=%s'),
+  ]);
+  const commitMessage = msg.trim().replaceAll("'", '&#39;').replaceAll('"', '&quot;');
 
   const clientJs: string[] = [
     'if (!window.site) window.site={};',
     'const s=window.site;',
     's.info={};',
-    `s.info.commit='${cps.execSync('git rev-parse -q HEAD', { encoding: 'utf-8' }).trim()}';`,
+    `s.info.commit='${sha.trim()}';`,
     `s.info.message='${commitMessage}';`,
     `s.debug=${env.debug};`,
     's.asset={loadEsm:(m,o)=>import(`/assets/compiled/${m}${s.manifest.js[m]?"."+s.manifest.js[m]:""}.js`)' +

--- a/ui/.build/src/parse.ts
+++ b/ui/.build/src/parse.ts
@@ -30,8 +30,8 @@ interface Sync {
 }
 
 export async function parsePackages(): Promise<void> {
-  for (const dir of (await glob('ui/[^@.]*/package.json')).map(pkg => dirname(pkg))) {
-    const pkgInfo = await parsePackage(dir);
+  const dirs = (await glob('ui/[^@.]*/package.json')).map(pkg => dirname(pkg));
+  for (const pkgInfo of await Promise.all(dirs.map(parsePackage))) {
     env.packages.set(pkgInfo.name, pkgInfo);
   }
 
@@ -53,20 +53,11 @@ export async function glob(glob: string[] | string | undefined, opts: fg.Options
 }
 
 export async function folderSize(folder: string): Promise<number> {
-  async function getSize(dir: string): Promise<number> {
-    const entries = await fs.promises.readdir(dir, { withFileTypes: true });
-
-    const sizes = await Promise.all(
-      entries.map(async entry => {
-        const fullPath = join(dir, entry.name);
-        if (entry.isDirectory()) return getSize(fullPath);
-        if (entry.isFile()) return (await fs.promises.stat(fullPath)).size;
-        return 0;
-      }),
-    );
-    return sizes.reduce((acc: number, size: number) => acc + size, 0);
+  try {
+    return (await fs.promises.readdir(folder, { recursive: true })).length;
+  } catch {
+    return 0;
   }
-  return getSize(folder);
 }
 
 export async function readable(file: string): Promise<boolean> {

--- a/ui/.build/src/sass.ts
+++ b/ui/.build/src/sass.ts
@@ -17,11 +17,13 @@ const colorMixMap = new Map<string, { c1: string; c2?: string; op: string; val: 
 const themeColorMap = new Map<string, Map<string, clr.Instance>>();
 
 let sassPs: cps.ChildProcessWithoutNullStreams | undefined;
+let sassBin: string | undefined;
 
 export function stopSass(): void {
   sassPs?.removeAllListeners();
   sassPs?.kill();
   sassPs = undefined;
+  sassBin = undefined;
   importMap.clear();
   colorMixMap.clear();
   themeColorMap.clear();
@@ -96,12 +98,12 @@ export async function sass(): Promise<string | undefined> {
 
 // compile an array of concrete scss files, return any that error
 async function compile(sources: string[], logAll = true): Promise<string[]> {
-  const sassBin =
+  const bin = (sassBin ??=
     process.env.SASS_PATH ??
     (await fs.promises.realpath(
       join(env.buildDir, 'node_modules', `sass-embedded-${ps.platform}-${ps.arch}`, 'dart-sass', 'sass'),
-    ));
-  if (!(await readable(sassBin))) env.exit(`Sass executable not found '${c.cyan(sassBin)}'`, 'sass');
+    )));
+  if (!(await readable(bin))) env.exit(`Sass executable not found '${c.cyan(bin)}'`, 'sass');
 
   return new Promise(resolveWithErrors => {
     if (!sources.length) return resolveWithErrors([]);
@@ -111,7 +113,7 @@ async function compile(sources: string[], logAll = true): Promise<string[]> {
     const sassArgs = ['--no-error-css', '--stop-on-error', '--no-color', '--quiet', '--quiet-deps'];
     sassPs?.removeAllListeners();
     sassPs = cps.spawn(
-      sassBin,
+      bin,
       sassArgs.concat(
         env.prod ? ['--style=compressed', '--no-source-map'] : ['--embed-sources'],
         sources.map((src: string) => `${src}:${absTempCss(src)}`),

--- a/ui/.build/src/sync.ts
+++ b/ui/.build/src/sync.ts
@@ -8,6 +8,7 @@ import { makeTask } from './task.ts';
 
 export async function sync(): Promise<void[] | undefined> {
   if (!env.begin('sync')) return;
+  const createdDirs = new Set<string>();
   return Promise.all(
     [...env.tasks('sync')].map(async ([pkg, sync]) => {
       const { root, exact } = await srcRoot(env.rootDir, sync.src);
@@ -23,7 +24,10 @@ export async function sync(): Promise<void[] | undefined> {
             env.log(`${c.grey(pkg.name)} '${c.cyan(sync.src)}' -> '${c.cyan(sync.dest)}'`, 'sync');
           return Promise.all(
             files.map(async f => {
-              if ((await syncOne(f, join(env.rootDir, sync.dest, f.slice(root.length)))) && logEvery)
+              if (
+                (await syncOne(f, join(env.rootDir, sync.dest, f.slice(root.length)), createdDirs)) &&
+                logEvery
+              )
                 env.log(
                   `${c.grey(pkg.name)} '${c.cyan(f.slice(root.length))}' -> '${c.cyan(sync.dest)}'`,
                   'sync',
@@ -36,21 +40,19 @@ export async function sync(): Promise<void[] | undefined> {
   );
 }
 
-async function syncOne(absSrc: string, absDest: string): Promise<boolean> {
-  // TODO are these stats unnecessary now?
-  const [src, dest] = (
-    await Promise.allSettled([
-      fs.promises.stat(absSrc),
-      fs.promises.stat(absDest),
-      fs.promises.mkdir(dirname(absDest), { recursive: true }),
-    ])
-  ).map(x => (x.status === 'fulfilled' ? (x.value as fs.Stats) : undefined));
-  if (src && !(dest && isClose(src.mtimeMs, dest.mtimeMs))) {
-    await fs.promises.copyFile(absSrc, absDest);
-    await fs.promises.utimes(absDest, src.atime, src.mtime);
-    return true;
-  }
-  return false;
+async function syncOne(absSrc: string, absDest: string, createdDirs: Set<string>): Promise<boolean> {
+  const destDir = dirname(absDest);
+  const [src, dest] = await Promise.all([
+    fs.promises.stat(absSrc).catch(() => undefined),
+    fs.promises.stat(absDest).catch(() => undefined),
+    createdDirs.has(destDir)
+      ? undefined
+      : fs.promises.mkdir(destDir, { recursive: true }).then(() => createdDirs.add(destDir)),
+  ]);
+  if (!src || (dest && isClose(src.mtimeMs, dest.mtimeMs))) return false;
+  await fs.promises.copyFile(absSrc, absDest);
+  await fs.promises.utimes(absDest, src.atime, src.mtime);
+  return true;
 }
 
 async function srcRoot(cwd: string, path: string): Promise<{ root: string; exact: boolean }> {


### PR DESCRIPTION
# Why

Spotted that SASS bin is resolved on each compile batch, and after fixing it I have asked Claude Sonet 4.6 to analyze the `.build` package for the potential performance issues and propose a solution for them.

# How

Address the SASS bin issue by locally caching the bin, address few more small performance issues found by Claude to improve the overall build process time. This includes, parallel pnpm install with package parse, run git stat in parallel, caching glob results to avoid same call in loop and simplified `folderSize` and `syncOne` helpers.

# Test plan

Overall, I was able to notice around 0.5s gain on printed build times on my machine, including runs under 3s, which does not happen before.

However, I have also run the benchmarks via `hyperfine` which adds a bit overhead, but can provide some rought stats. Runs include incremental and clean builds.

### Before

```
simek ui % hyperfine --warmup 1 --runs 5 ./build
Benchmark 1: ./build
  Time (mean ± σ):      3.809 s ±  0.104 s    [User: 19.802 s, System: 4.076 s]
  Range (min … max):    3.712 s …  3.968 s    5 runs

simek ui % hyperfine --warmup 1 --runs 5 './build --clean'
Benchmark 1: ./build --clean
  Time (mean ± σ):     15.755 s ±  0.223 s    [User: 59.765 s, System: 18.358 s]
  Range (min … max):   15.383 s … 15.948 s    5 runs
```

### After

```
simek ui % hyperfine --warmup 1 --runs 5 ./build
Benchmark 1: ./build
  Time (mean ± σ):      3.655 s ±  0.079 s    [User: 19.543 s, System: 4.186 s]
  Range (min … max):    3.595 s …  3.748 s    5 runs

simek ui % hyperfine --warmup 1 --runs 5 './build --clean'
Benchmark 1: ./build --clean
  Time (mean ± σ):     14.202 s ±  0.202 s    [User: 58.770 s, System: 17.464 s]
  Range (min … max):   14.017 s … 14.536 s    5 runs
```