### PR TITLE
ui: fix meta + digit key strokes, avoid throwing on unset key

### DIFF
--- a/ui/site/src/mousetrap.ts
+++ b/ui/site/src/mousetrap.ts
@@ -55,6 +55,16 @@ const KEY_MAP: Record<string, string> = {
   Insert: 'ins',
   Delete: 'del',
   Meta: 'meta',
+  Digit1: '1',
+  Digit2: '2',
+  Digit3: '3',
+  Digit4: '4',
+  Digit5: '5',
+  Digit6: '6',
+  Digit7: '7',
+  Digit8: '8',
+  Digit9: '9',
+  Digit0: '0',
 };
 
 const SPECIAL_KEYS: Set<string> = new Set(Object.values(KEY_MAP));
@@ -71,9 +81,9 @@ const SPECIAL_ALIASES: Record<string, string> = {
 
 const keyFromEvent = (e: KeyboardEvent): string => {
   if (e.type === 'keypress') {
-    return e.shiftKey ? e.key : e.key.toLowerCase();
+    return e.shiftKey ? e.key : e.key?.toLowerCase();
   }
-  return KEY_MAP[e.key] || e.key.toLowerCase();
+  return KEY_MAP[e.key] ?? KEY_MAP[e.code] ?? e.key?.toLowerCase();
 };
 
 const modifiersMatch = (a: string[], b: string[]): boolean => a.sort().join(',') === b.sort().join(',');
@@ -161,7 +171,6 @@ export default class Mousetrap {
 
   private readonly handleKeyEvent = (e: KeyboardEvent) => {
     const el = e.target as HTMLElement;
-
     for (const binding of this.getMatches(e)) {
       if (
         binding.combination === 'esc' ||


### PR DESCRIPTION
# Why

Refs:
* https://github.com/lichess-org/lila/pull/20418#discussion_r3213641714

# How

Fix meta + digit key strokes (used in studies), avoid throwing on unset key. 

The Edge bug will be investigated separately in near future, since I need to do some re-setup work to be able to access local `lila` running from mac on my Windows machine.

# Preview

<img width="1976" height="1674" alt="Kapture 2026-05-10 at 12 09 54" src="https://github.com/user-attachments/assets/6bb47a8e-0c56-42a3-aca6-8485ed8edcc6" />
