### PR TITLE
ui: few more legacy icon tag replacements

### DIFF
--- a/ui/analyse/src/explorer/explorerView.ts
+++ b/ui/analyse/src/explorer/explorerView.ts
@@ -141,11 +141,7 @@ function showGameTable(ctrl: AnalyseCtrl, fen: FEN, title: string, games: Openin
               hl('td', showResult(game.winner)),
               hl('td', game.month || game.year),
               !isMasters &&
-                hl(
-                  'td',
-                  game.speed &&
-                    hl('icon', { attrs: { title: ucfirst(game.speed), ...dataIcon(perfIcons[game.speed]) } }),
-                ),
+                hl('td', game.speed && iconTag(perfIcons[game.speed], { title: ucfirst(game.speed) })),
             ]);
       }),
     ),

--- a/ui/analyse/src/study/analyse.study.tour.ts
+++ b/ui/analyse/src/study/analyse.study.tour.ts
@@ -13,7 +13,7 @@ export function initModule(): StudyTour {
   };
 
   function iconTag(i: string) {
-    return `<i data-icon='${i}'></i>`;
+    return `<icon data-icon='${i}'></icon>`;
   }
 
   function study(ctrl: AnalyseCtrl) {

--- a/ui/bits/src/bits.clas.ts
+++ b/ui/bits/src/bits.clas.ts
@@ -44,9 +44,9 @@ site.load.then(() => {
           '" data-href="/@/' +
           o.name +
           '">' +
-          '<i class="line' +
+          '<icon class="line' +
           (o.patron ? ' patron' : '') +
-          '"></i>' +
+          '"></icon>' +
           (o.title ? '<span class="utitle">' + o.title + '</span>&nbsp;' : '') +
           o.name +
           '</span>',

--- a/ui/botDev/src/booksPane.ts
+++ b/ui/botDev/src/booksPane.ts
@@ -15,7 +15,7 @@ export class BooksPane extends Pane {
   constructor(p: PaneArgs) {
     super(p);
     this.label?.prepend(
-      frag(`<i role="button" tabindex="0" data-icon="${licon.PlusButton}" data-action="add">`),
+      frag(`<icon role="button" tabindex="0" data-icon="${licon.PlusButton}" data-action="add">`),
     );
     this.template = {
       type: 'range',

--- a/ui/botDev/src/historyDialog.ts
+++ b/ui/botDev/src/historyDialog.ts
@@ -81,7 +81,7 @@ class HistoryDialog {
       );
       const versionStr = typeof version === 'number' ? `#${version}` : version;
       const span = frag(`<span class="author">${bot.author}</span>`);
-      if (isLive) span.appendChild(frag(`<i data-icon="${licon.Checkmark}" class="live">`));
+      if (isLive) span.appendChild(frag(`<icon data-icon="${licon.Checkmark}" class="live">`));
       div.append(frag(`<span class="version-number">${versionStr}</span>`), span);
       versionsEl.append(div);
     }

--- a/ui/botDev/src/soundEventPane.ts
+++ b/ui/botDev/src/soundEventPane.ts
@@ -15,7 +15,7 @@ export class SoundEventPane extends Pane {
     super(p);
     this.template = (p.parent!.info as SoundsInfo).template!;
     this.label.prepend(
-      frag(`<i role="button" tabindex="0" data-icon="${licon.PlusButton}" data-action="add">`),
+      frag(`<icon role="button" tabindex="0" data-icon="${licon.PlusButton}" data-action="add">`),
     );
     this.label.append(frag(`<span class="hide-disabled"><hr><span class="total-chance dim"></span></span>`));
     this.value?.forEach((_, index) => this.makeSound(index));

--- a/ui/lib/src/view/userComplete.ts
+++ b/ui/lib/src/view/userComplete.ts
@@ -67,10 +67,10 @@ export const renderUserEntry = (o: LightUserOnline, tag = 'a'): string => {
     'href="/@/' +
     o.name +
     '">' +
-    '<i class="line' +
+    '<icon class="line' +
     (o.patron ? ' patron' : '') +
     patronClass +
-    '"></i>' +
+    '"></icon>' +
     (o.title
       ? '<span class="utitle"' +
         (o.title === 'BOT' ? ' data-bot="data-bot" ' : '') +

--- a/ui/lobby/src/view/realTime/chart.ts
+++ b/ui/lobby/src/view/realTime/chart.ts
@@ -79,7 +79,8 @@ function renderHook(ctrl: LobbyController, hook: Hook): string {
   }
   html += '<div class="inner-clickable">';
   html += `<div>${hook.clock}</div>`;
-  html += '<i data-icon="' + perfIcons[hook.perf] + '"> ' + i18n.site[hook.ra ? 'rated' : 'casual'] + '</i>';
+  html +=
+    '<icon data-icon="' + perfIcons[hook.perf] + '"> ' + i18n.site[hook.ra ? 'rated' : 'casual'] + '</icon>';
   html += '</div></div>';
   return html;
 }

--- a/ui/lobby/src/view/setup/components/ratingView.ts
+++ b/ui/lobby/src/view/setup/components/ratingView.ts
@@ -1,6 +1,6 @@
 import { h } from 'snabbdom';
 
-import { dataIcon, type MaybeVNode } from 'lib/view';
+import { dataIcon, iconTag, type MaybeVNode } from 'lib/view';
 
 import type LobbyController from '@/ctrl';
 import { speeds, variants } from '@/options';
@@ -14,14 +14,17 @@ export const ratingView = ({ opts, data, setupCtrl }: LobbyController): MaybeVNo
 
   if (!perfOrSpeed) return undefined;
 
-  const perfIconAttrs = { attrs: dataIcon(perfOrSpeed.icon) };
   return h(
     'div.ratings',
     !opts.showRatings
-      ? [h('icon', perfIconAttrs), perfOrSpeed.name]
+      ? [iconTag(perfOrSpeed.icon), perfOrSpeed.name]
       : [
           ...i18n.site.yourRatingIsX.asArray(
-            h('strong', perfIconAttrs, setupCtrl.myRating() + (setupCtrl.isProvisional() ? '?' : '')),
+            h(
+              'strong',
+              { attrs: dataIcon(perfOrSpeed.icon) },
+              setupCtrl.myRating() + (setupCtrl.isProvisional() ? '?' : ''),
+            ),
           ),
           perfOrSpeed.name,
         ],

--- a/ui/round/src/ctrl.ts
+++ b/ui/round/src/ctrl.ts
@@ -745,7 +745,7 @@ export default class RoundController implements MoveRootCtrl {
     this.goneBerserk[color] = true;
     if (color !== this.data.player.color) site.sound.play('berserk');
     this.redraw();
-    $(`<i data-icon="${licon.Berserk}">`).appendTo($(`.game__meta .player.${color} .user-link`));
+    $(`<icon data-icon="${licon.Berserk}">`).appendTo($(`.game__meta .player.${color} .user-link`));
   };
 
   setLoading = (v: boolean, duration = 1500): void => {

--- a/ui/round/src/util.ts
+++ b/ui/round/src/util.ts
@@ -1,10 +1,4 @@
-import type { VNodeData } from 'snabbdom';
-
 import type { EncodedDests, RoundData, Step } from './interfaces';
-
-export const justIcon = (icon: string): VNodeData => ({
-  attrs: { 'data-icon': icon },
-});
 
 export function parsePossibleMoves(dests?: EncodedDests): Dests {
   const dec = new Map();

--- a/ui/round/src/view/button.ts
+++ b/ui/round/src/view/button.ts
@@ -5,11 +5,18 @@ import type { ClockData } from 'lib/game/clock/clockCtrl';
 import { game as gameRoute } from 'lib/game/router';
 import * as licon from 'lib/licon';
 import { pubsub } from 'lib/pubsub';
-import { spinnerVdom as spinner, type LooseVNodes, type LooseVNode, hl, bind, onInsert } from 'lib/view';
+import {
+  spinnerVdom as spinner,
+  type LooseVNodes,
+  type LooseVNode,
+  hl,
+  bind,
+  onInsert,
+  dataIcon,
+} from 'lib/view';
 
 import type RoundController from '../ctrl';
 import type { EventsWithoutPayload, RoundData } from '../interfaces';
-import { justIcon } from '../util';
 
 export interface ButtonState {
   enabled: boolean;
@@ -105,7 +112,7 @@ function rematchButtons(ctrl: RoundController): LooseVNodes {
 export function standard(
   ctrl: RoundController,
   condition: ((d: RoundData) => ButtonState) | undefined,
-  icon: string,
+  icon: LiconType,
   hint: string,
   socketMsg: EventsWithoutPayload,
   onclick?: () => void,
@@ -121,7 +128,7 @@ export function standard(
         if (enabled()) onclick ? onclick() : ctrl.socket.sendLoading(socketMsg);
       }),
     },
-    ctrl.nvui ? [hintFn()] : [hl('span', justIcon(icon))],
+    ctrl.nvui ? [hintFn()] : [hl('span', { attrs: dataIcon(icon) })],
   );
 }
 
@@ -210,7 +217,7 @@ export function backToTournament(ctrl: RoundController): LooseVNode {
         i18n.site.backToTournament,
       ),
       hl('form', { attrs: { method: 'post', action: '/tournament/' + d.tournament.id + '/withdraw' } }, [
-        hl('button.text.fbt.weak', justIcon(licon.Pause), i18n.site.pause),
+        hl('button.text.fbt.weak', { attrs: dataIcon(licon.Pause) }, i18n.site.pause),
       ]),
       analysisButton(ctrl),
     ])

--- a/ui/round/src/view/clock.ts
+++ b/ui/round/src/view/clock.ts
@@ -9,11 +9,10 @@ import {
 } from 'lib/game';
 import { renderClock } from 'lib/game/clock/clockView';
 import * as licon from 'lib/licon';
-import { type LooseVNode, hl, bind } from 'lib/view';
+import { type LooseVNode, hl, bind, dataIcon } from 'lib/view';
 
 import renderCorresClock from '../corresClock/corresClockView';
 import type RoundController from '../ctrl';
-import { justIcon } from '../util';
 import { moretime } from './button';
 
 export const anyClockView = (ctrl: RoundController, position: TopOrBottom): LooseVNode => {
@@ -52,13 +51,13 @@ const showBerserk = (ctrl: RoundController, color: Color): boolean =>
   ctrl.hasGoneBerserk(color) && !bothPlayersHavePlayed(ctrl.data) && playable(ctrl.data);
 
 const renderBerserk = (ctrl: RoundController, color: Color, position: TopOrBottom) =>
-  showBerserk(ctrl, color) ? hl('div.berserked.' + position, justIcon(licon.Berserk)) : null;
+  showBerserk(ctrl, color) ? hl('div.berserked.' + position, { attrs: dataIcon(licon.Berserk) }) : null;
 
 const goBerserk = (ctrl: RoundController, color: Color) =>
   berserkableBy(ctrl.data) &&
   !ctrl.hasGoneBerserk(color) &&
   hl('button.fbt.go-berserk', {
-    attrs: { title: 'GO BERSERK! Half the time, no increment, bonus point', 'data-icon': licon.Berserk },
+    attrs: { title: 'GO BERSERK! Half the time, no increment, bonus point', ...dataIcon(licon.Berserk) },
     hook: bind('click', ctrl.goBerserk),
   });
 

--- a/ui/round/src/view/replay.ts
+++ b/ui/round/src/view/replay.ts
@@ -13,6 +13,7 @@ import {
   type LooseVNode,
   hl,
   onInsert,
+  dataIcon,
 } from 'lib/view';
 
 import type RoundController from '../ctrl';
@@ -189,7 +190,7 @@ function initMessage(ctrl: RoundController) {
     playable(d) &&
     d.game.turns === 0 &&
     !d.player.spectator &&
-    hl('div.message', util.justIcon(licon.InfoCircle), [
+    hl('div.message', { attrs: dataIcon(licon.InfoCircle) }, [
       hl('div', [
         i18n.site[d.player.color === 'white' ? 'youPlayTheWhitePieces' : 'youPlayTheBlackPieces'],
         d.player.color === 'white' && [hl('br'), hl('strong', i18n.site.itsYourTurn)],

--- a/ui/round/src/view/user.ts
+++ b/ui/round/src/view/user.ts
@@ -2,7 +2,7 @@ import { defined } from 'lib';
 import type { Player, TopOrBottom } from 'lib/game';
 import * as licon from 'lib/licon';
 import { wsAverageLag } from 'lib/socket';
-import { hl, type VNode } from 'lib/view';
+import { dataIcon, hl, type VNode } from 'lib/view';
 import { ratingDiff, userLink } from 'lib/view/userLink';
 
 import type RoundController from '../ctrl';
@@ -61,7 +61,7 @@ export function userHtml(ctrl: RoundController, player: Player, position: TopOrB
         !!rating && ratingDiff(player),
         player.engine &&
           hl('span', {
-            attrs: { 'data-icon': licon.CautionCircle, title: i18n.site.thisAccountViolatedTos },
+            attrs: { ...dataIcon(licon.CautionCircle), title: i18n.site.thisAccountViolatedTos },
           }),
       ],
     );

--- a/ui/simul/src/view/created.ts
+++ b/ui/simul/src/view/created.ts
@@ -35,7 +35,7 @@ export default function (showText: (ctrl: SimulCtrl) => VNode | false) {
                 : hl(
                     'a.button.text' + (canJoin ? '' : '.disabled'),
                     {
-                      attrs: { disabled: !canJoin, 'data-icon': licon.PlayTriangle },
+                      attrs: { disabled: !canJoin, ...dataIcon(licon.PlayTriangle) },
                       hook: canJoin
                         ? bind('click', () => {
                             if (ctrl.data.variants.length === 1)
@@ -60,7 +60,7 @@ export default function (showText: (ctrl: SimulCtrl) => VNode | false) {
                 'a.button.text',
                 {
                   attrs: {
-                    'data-icon': licon.PlayTriangle,
+                    ...dataIcon(licon.PlayTriangle),
                     href: '/login?referrer=' + window.location.pathname,
                   },
                 },
@@ -105,7 +105,7 @@ export default function (showText: (ctrl: SimulCtrl) => VNode | false) {
                         'td.action',
                         isHost &&
                           hl('a.button', {
-                            attrs: { 'data-icon': licon.Checkmark, title: 'Accept' },
+                            attrs: { ...dataIcon(licon.Checkmark), title: 'Accept' },
                             hook: bind('click', () => xhr.accept(applicant.player.id)(ctrl.data.id)),
                           }),
                       ),

--- a/ui/site/src/friends.ts
+++ b/ui/site/src/friends.ts
@@ -58,7 +58,7 @@ export default class OnlineFriends {
   };
   renderFriend = (friend: Friend) => {
     const patronCls = friend.patronColor ? ` patron paco${friend.patronColor}` : '';
-    const icon = `<i class="line${patronCls}"></i>`,
+    const icon = `<icon class="line${patronCls}"></icon>`,
       titleTag = friend.title
         ? `<span class="utitle"${friend.title === 'BOT' ? ' data-bot' : ''}>${friend.title}</span>&nbsp;`
         : '',

--- a/ui/swiss/src/view/standing.ts
+++ b/ui/swiss/src/view/standing.ts
@@ -1,7 +1,7 @@
 import { h, type VNode } from 'snabbdom';
 
 import * as licon from 'lib/licon';
-import { bind, type MaybeVNodes, onInsert } from 'lib/view';
+import { bind, iconTag, type MaybeVNodes, onInsert } from 'lib/view';
 
 import type SwissCtrl from '../ctrl';
 import type { Player } from '../interfaces';
@@ -20,7 +20,7 @@ function playerTr(ctrl: SwissCtrl, player: Player) {
       h(
         'td.rank',
         player.absent && ctrl.data.status !== 'finished'
-          ? h('icon', { attrs: { 'data-icon': licon.Pause, title: 'Absent' } })
+          ? iconTag(licon.Pause, { title: 'Absent' })
           : [player.rank],
       ),
       h('td.player', renderPlayer(player, false, ctrl.opts.showRatings)),

--- a/ui/tournament/src/view/arena.ts
+++ b/ui/tournament/src/view/arena.ts
@@ -2,7 +2,7 @@ import { h, type VNode } from 'snabbdom';
 
 import { defined } from 'lib';
 import * as licon from 'lib/licon';
-import { bind, dataIcon, type MaybeVNodes } from 'lib/view';
+import { bind, dataIcon, iconTag, type MaybeVNodes } from 'lib/view';
 import { renderPager, searchButton, searchInput } from 'lib/view/pagination';
 import { userLink } from 'lib/view/userLink';
 import { numberRow } from 'lib/view/util';
@@ -49,12 +49,7 @@ function playerTr(ctrl: TournamentController, player: StandingPlayer) {
       hook: bind('click', _ => ctrl.showPlayerInfo(player), ctrl.redraw),
     },
     [
-      h(
-        'td.rank',
-        player.withdraw
-          ? h('i', { attrs: { 'data-icon': licon.Pause, title: i18n.site.pause } })
-          : player.rank,
-      ),
+      h('td.rank', player.withdraw ? iconTag(licon.Pause, { title: i18n.site.pause }) : player.rank),
       h('td.player', [
         renderPlayer(player, false, ctrl.opts.showRatings, userId === ctrl.data.defender),
         ...(battle && player.team ? [' ', teamName(battle, player.team)] : []),

--- a/ui/tournament/src/view/header.ts
+++ b/ui/tournament/src/view/header.ts
@@ -3,7 +3,7 @@ import { h, type Hooks, type VNode } from 'snabbdom';
 import { setClockWidget } from 'lib/game/clock/clockWidget';
 import perfIcons from 'lib/game/perfIcons';
 import * as licon from 'lib/licon';
-import { dataIcon, iconCls } from 'lib/view';
+import { dataIcon, iconCls, iconTag } from 'lib/view';
 import { userTitle } from 'lib/view/userLink';
 
 import type TournamentController from '../ctrl';
@@ -57,7 +57,7 @@ function image(d: TournamentData): VNode | undefined {
 
 function title(ctrl: TournamentController) {
   const d = ctrl.data;
-  if (hasFreq('marathon', d)) return h('h1', [h('icon.fire-trophy', licon.Globe), d.fullName]);
+  if (hasFreq('marathon', d)) return h('h1', [iconTag(licon.Globe, { cls: 'fire-trophy' }), d.fullName]);
   if (hasFreq('shield', d))
     return h('h1', [
       h('a.shield-trophy', { attrs: { href: '/tournament/shields' } }, perfIcons[d.perf.key]),

--- a/ui/tournament/src/view/playerInfo.ts
+++ b/ui/tournament/src/view/playerInfo.ts
@@ -94,4 +94,4 @@ export default function (ctrl: TournamentController): VNode {
 }
 
 const berserkTd = (b: boolean) =>
-  b ? hl('td.berserk', { attrs: { 'data-icon': licon.Berserk, title: 'Berserk' } }) : hl('td.berserk');
+  b ? hl('td.berserk', { attrs: { ...dataIcon(licon.Berserk), title: 'Berserk' } }) : hl('td.berserk');

--- a/ui/voice/src/view.ts
+++ b/ui/voice/src/view.ts
@@ -1,6 +1,6 @@
 import { onClickAway } from 'lib';
 import * as licon from 'lib/licon';
-import { onInsert, bind, hl, type VNode, snabDialog, type Dialog } from 'lib/view';
+import { onInsert, bind, hl, type VNode, snabDialog, type Dialog, dataIcon } from 'lib/view';
 import { cmnToggleProp } from 'lib/view/cmn-toggle';
 import { jsonSimple } from 'lib/xhr';
 
@@ -17,11 +17,11 @@ export function renderVoiceBar(ctrl: VoiceCtrl, redraw: () => void, cls?: string
         hook: onInsert(el => ctrl.mic.setController(voiceBarUpdater(ctrl, el))),
       }),
       hl('button#voice-help-button', {
-        attrs: { 'data-icon': licon.InfoCircle, title: 'Voice help' },
+        attrs: { ...dataIcon(licon.InfoCircle), title: 'Voice help' },
         hook: bind('click', () => ctrl.showHelp(true), undefined, false),
       }),
       hl('button#voice-settings-button', {
-        attrs: { 'data-icon': licon.Gear, title: 'Voice settings' },
+        attrs: { ...dataIcon(licon.Gear), title: 'Voice settings' },
         class: { active: ctrl.showPrefs() },
         hook: bind('click', () => ctrl.showPrefs.toggle(), redraw, false),
       }),


### PR DESCRIPTION
# Why

Follow up to:
* 50f1a607dad71f5d5ffeafe9099a8190c3e46f0f

# How

Few more legacy icon tag replacements in HTML partials/fragments, usage of icon tag helpers in few more places, and removal of duplicated `justIcon` helper.

# Preview

<img width="1019" height="721" alt="Screenshot 2026-05-10 at 12 54 15" src="https://github.com/user-attachments/assets/74e33f7c-cac4-4a2f-a6e4-a0e286402431" />

