### PR TITLE
puzzle vote buttons: apply background to active buttons immediately upon clicking

### DIFF
--- a/ui/puzzle/css/_after.scss
+++ b/ui/puzzle/css/_after.scss
@@ -96,8 +96,10 @@
     &.vote-down {
       color: $c-bad;
 
-      &.active {
+      &.active,
+      &.active:hover {
         background: $m-bad_bg--mix-50;
+        text-shadow: none !important;
       }
 
       &::before {
@@ -106,8 +108,10 @@
     }
 
     &.vote-up {
-      &.active {
+      &.active,
+      &.active:hover {
         background: $m-good_bg--mix-50;
+        text-shadow: none !important;
       }
 
       &:hover {


### PR DESCRIPTION
| before | after |
| - | - |
| <img width="204" height="80" alt="image" src="https://github.com/user-attachments/assets/ce94d3eb-faf5-40ee-9e15-f9d1ebd84968" /> | <img width="196" height="83" alt="image" src="https://github.com/user-attachments/assets/01f9a88f-59c0-400f-9174-afd2aa7fb83c" /> |
| <img width="201" height="77" alt="image" src="https://github.com/user-attachments/assets/e4e558c8-fc33-44de-a65b-f7354facc6aa" /> | <img width="197" height="75" alt="image" src="https://github.com/user-attachments/assets/99d56617-f3ea-4173-8e11-f5401619521b" /> |