### PR TITLE
forum: exclude erased posts from user post count on profile

### DIFF
--- a/modules/forum/src/main/ForumPostApi.scala
+++ b/modules/forum/src/main/ForumPostApi.scala
@@ -189,7 +189,7 @@ final class ForumPostApi(
 
   def allUserIds(topicId: ForumTopicId) = postRepo.allUserIdsByTopicId(topicId)
 
-  def nbByUser(userId: UserId) = postRepo.coll.secondary.countSel($doc("userId" -> userId))
+  def nbByUser(userId: UserId) = postRepo.coll.secondary.countSel($doc("userId" -> userId) ++ postRepo.selectNotErased)
 
   def categsForUser(teams: Iterable[TeamId], forUser: Option[User]): Fu[List[CategView]] =
     val isMod = forUser.fold(false)(MasterGranter.of(_.ModerateForum))


### PR DESCRIPTION
Currently, nbByUser counts all forum posts including those erased by the user (erasedAt is set). This causes the profile page to display a higher count than the forum search page, which already filters out erased posts via selectNotErased.

Fix: add selectNotErased filter to nbByUser so both views show the same count of active, non-erased posts.

Changed: 1 line in modules/forum/src/main/ForumPostApi.scala