### PR TITLE
ui: small cleanups in mousetrap code

### DIFF
--- a/ui/site/src/mousetrap.ts
+++ b/ui/site/src/mousetrap.ts
@@ -80,9 +80,6 @@ const SPECIAL_ALIASES: Record<string, string> = {
 };
 
 const keyFromEvent = (e: KeyboardEvent): string => {
-  if (e.type === 'keypress') {
-    return e.shiftKey ? e.key : e.key?.toLowerCase();
-  }
   return KEY_MAP[e.key] ?? KEY_MAP[e.code] ?? e.key?.toLowerCase();
 };
 
@@ -128,11 +125,10 @@ const getKeyInfo = (combination: string, action?: Action): KeyInfo => {
 export default class Mousetrap {
   private readonly bindings: Record<string, Binding[]> = {};
 
-  constructor(targetElement?: HTMLElement | Document) {
-    targetElement = targetElement || document;
-    targetElement.addEventListener('keypress', e => this.handleKeyEvent(e as KeyboardEvent));
-    targetElement.addEventListener('keydown', e => this.handleKeyEvent(e as KeyboardEvent));
-    targetElement.addEventListener('keyup', e => this.handleKeyEvent(e as KeyboardEvent));
+  constructor(targetElement: HTMLElement | Document = document) {
+    targetElement.addEventListener('keypress', this.handleKeyEvent);
+    targetElement.addEventListener('keydown', this.handleKeyEvent);
+    targetElement.addEventListener('keyup', this.handleKeyEvent);
   }
 
   /**


### PR DESCRIPTION
# Why

While trying to reproduce one of the reported issues was debug the mousetrap logic and find out that we can cleanup the code a bit.

# How

Summary:
* do not handle separately ketrokes with "Shift", it becomes redundant after adding `e.code` fallback to the generic case.
* avoid casting events by altering how `targetElement` is set