### PR TITLE
i18n: align "username" vs "user name" in login field description

### DIFF
--- a/translation/dest/site/en-US.xml
+++ b/translation/dest/site/en-US.xml
@@ -238,7 +238,7 @@
   <string name="rating">Rating</string>
   <string name="ratingStats">Rating stats</string>
   <string name="username">Username</string>
-  <string name="usernameOrEmail">User name or email</string>
+  <string name="usernameOrEmail">Username or email</string>
   <string name="changeUsername">Change username</string>
   <string name="changeUsernameNotSame">Only the case of the letters can change. For example \"johndoe\" to \"JohnDoe\".</string>
   <string name="changeUsernameDescription">Change your username. This can only be done once and you are only allowed to change the case of the letters in your username.</string>


### PR DESCRIPTION
# Why

Spotted that Login form uses "user name" phrase in the field label, while Sign Up and all other username related strings write it as a one word.

# How

Alter the Login label from "user name" to "username" to match the name used by the rest of the i18n strings.

# Preview

<img width="611" height="502" alt="Screenshot 2026-05-12 at 12 41 44" src="https://github.com/user-attachments/assets/c253474f-2cbd-475c-a84a-fc2793ce6952" />
