### PR TITLE
ui: improve explorer config selectors appearance

### DIFF
--- a/ui/analyse/css/explorer/_config.scss
+++ b/ui/analyse/css/explorer/_config.scss
@@ -28,6 +28,7 @@
       border: $border;
       border-width: 1px 0 1px 1px;
       text-transform: capitalize;
+      text-shadow: 0 1px 0 $c-font-shadow;
 
       &:first-child {
         @extend %box-radius-left;
@@ -43,12 +44,12 @@
       &.active {
         background: $c-secondary;
         color: $c-over;
-        text-shadow: 1px 0 0 rgba(0, 0, 0, 0.5);
         font-weight: bold;
-      }
+        box-shadow: 0 3px 5px rgba(0, 0, 0, 0.2) inset !important;
 
-      &[aria-pressed='true'] {
-        box-shadow: 0 3px 5px rgba(0, 0, 0, 0.2) inset;
+        &:hover {
+          background: $m-secondary--lighten-5;
+        }
       }
     }
   }

--- a/ui/analyse/css/explorer/_config.scss
+++ b/ui/analyse/css/explorer/_config.scss
@@ -47,6 +47,10 @@
         font-weight: bold;
         box-shadow: 0 3px 5px rgba(0, 0, 0, 0.2) inset !important;
 
+        @include if-light {
+          text-shadow: 0 1px 0 $c-font !important;
+        }
+
         &:hover {
           background: $m-secondary--lighten-5;
         }


### PR DESCRIPTION
# Why

Refs:
* https://github.com/lichess-org/lila/issues/20164#issuecomment-4415645762

# How

Improve explorer config selectors appearance, mainly in light mode.

# Preview

https://github.com/user-attachments/assets/206dbb53-2a31-4759-9631-61f49954524a


