### PR TITLE
Add live move annotations using local eval

### DIFF
--- a/ui/analyse/src/autoShape.ts
+++ b/ui/analyse/src/autoShape.ts
@@ -177,7 +177,7 @@ export function compute(ctrl: AnalyseCtrl): DrawShape[] {
     });
   }
   if (ctrl.showMoveAnnotationsOnBoard()) {
-    const liveGlyph = ctrl.liveGlyphs.get(ctrl.path);
+    const liveGlyph = ctrl.liveAnnotate.get(ctrl.path);
     shapes = shapes.concat(
       // Override server analysis glyphs as local eval also overrides the eval score
       annotationShapes(liveGlyph ? { ...ctrl.node, glyphs: [liveGlyph] } : ctrl.node),

--- a/ui/analyse/src/autoShape.ts
+++ b/ui/analyse/src/autoShape.ts
@@ -177,11 +177,10 @@ export function compute(ctrl: AnalyseCtrl): DrawShape[] {
     });
   }
   if (ctrl.showMoveAnnotationsOnBoard()) {
-    const liveGlyphs = ctrl.liveGlyphs.get(ctrl.path);
-    const glyphs = liveGlyphs ?? ctrl.node.glyphs;
+    const liveGlyph = ctrl.liveGlyphs.get(ctrl.path);
     shapes = shapes.concat(
       // Override server analysis glyphs as local eval also overrides the eval score
-      annotationShapes(liveGlyphs ? { ...ctrl.node, glyphs } : ctrl.node),
+      annotationShapes(liveGlyph ? { ...ctrl.node, glyphs: [liveGlyph] } : ctrl.node),
     );
   }
   if (ctrl.showVariationArrows()) hiliteVariations(ctrl, shapes);

--- a/ui/analyse/src/autoShape.ts
+++ b/ui/analyse/src/autoShape.ts
@@ -176,7 +176,14 @@ export function compute(ctrl: AnalyseCtrl): DrawShape[] {
       }
     });
   }
-  if (ctrl.showMoveAnnotationsOnBoard()) shapes = shapes.concat(annotationShapes(ctrl.node));
+  if (ctrl.showMoveAnnotationsOnBoard()) {
+    const liveGlyphs = ctrl.liveGlyphsOf(ctrl.path);
+    const glyphs = liveGlyphs ?? ctrl.node.glyphs;
+    shapes = shapes.concat(
+      // Override server analysis glyphs as local eval also overrides the eval score
+      annotationShapes(liveGlyphs ? { ...ctrl.node, glyphs } : ctrl.node),
+    );
+  }
   if (ctrl.showVariationArrows()) hiliteVariations(ctrl, shapes);
 
   if (ctrl.isCevalAllowed()) {

--- a/ui/analyse/src/autoShape.ts
+++ b/ui/analyse/src/autoShape.ts
@@ -177,7 +177,7 @@ export function compute(ctrl: AnalyseCtrl): DrawShape[] {
     });
   }
   if (ctrl.showMoveAnnotationsOnBoard()) {
-    const liveGlyphs = ctrl.liveGlyphsOf(ctrl.path);
+    const liveGlyphs = ctrl.liveGlyphs.get(ctrl.path);
     const glyphs = liveGlyphs ?? ctrl.node.glyphs;
     shapes = shapes.concat(
       // Override server analysis glyphs as local eval also overrides the eval score

--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -39,7 +39,7 @@ import { pubsub } from 'lib/pubsub';
 import { storedBooleanProp, storedBooleanPropWithEffect } from 'lib/storage';
 import { makeTree, treePath, treeOps, type TreeWrapper } from 'lib/tree';
 import { completeNode } from 'lib/tree/node';
-import type { ClientEval, Glyph, LocalEval, ServerEval, TreeNode, TreePath } from 'lib/tree/types';
+import type { ClientEval, LocalEval, ServerEval, TreeNode, TreePath } from 'lib/tree/types';
 import { confirm } from 'lib/view';
 
 import { Autoplay, type AutoplayDelay } from './autoplay';
@@ -52,7 +52,7 @@ import { ForkCtrl } from './fork';
 import { IdbTree } from './idbTree';
 import type { AnalyseOpts, AnalyseData, ServerEvalData, JustCaptured, NvuiPlugin } from './interfaces';
 import * as keyboard from './keyboard';
-import { liveNodeGlyph } from './liveAnnotate';
+import LiveAnnotate from './liveAnnotate';
 import MotifCtrl from './motif/motifCtrl';
 import Navigate from './navigate';
 import { nextGlyphSymbol, add3or5FoldGlyphs } from './nodeFinder';
@@ -76,6 +76,7 @@ export default class AnalyseCtrl implements CevalHandler {
   chessground: ChessgroundApi;
   ceval: CevalCtrl;
   evalCache: EvalCache;
+  liveAnnotate: LiveAnnotate;
   navigate: Navigate;
   idbTree: IdbTree = new IdbTree(this);
   actionMenu: Toggle = toggle(false);
@@ -123,7 +124,6 @@ export default class AnalyseCtrl implements CevalHandler {
   );
   showFishnetAnalysis = storedBooleanProp('analyse.show-computer', true);
   possiblyShowMoveAnnotationsOnBoard = storedBooleanProp('analyse.show-move-annotation', true);
-  liveGlyphs = new Map<TreePath, Glyph | undefined>();
   keyboardHelp: boolean = location.hash === '#keyboard';
   threatMode: Prop<boolean> = prop(false);
   disclosureMode = storedBooleanProp('analyse.disclosure.enabled', false);
@@ -179,6 +179,7 @@ export default class AnalyseCtrl implements CevalHandler {
       });
 
     this.instanciateEvalCache();
+    this.liveAnnotate = new LiveAnnotate();
 
     if (opts.inlinePgn) this.data = this.changePgn(opts.inlinePgn, false) || this.data;
 
@@ -740,10 +741,7 @@ export default class AnalyseCtrl implements CevalHandler {
         if (node.ceval?.cloud && this.ceval.isDeeper()) node.ceval = ev;
       }
 
-      if (!isThreat && ev) {
-        this.annotateLivePath(path);
-        this.annotateLiveChildren(path, node);
-      }
+      if (!isThreat) this.liveAnnotate.onNewCeval(path, node, this.tree);
 
       if (path === this.path) {
         this.setAutoShapes();
@@ -758,23 +756,6 @@ export default class AnalyseCtrl implements CevalHandler {
       }
     });
   };
-
-  private annotateLivePath(path: TreePath): void {
-    if (path.length)
-      this.liveGlyphs.set(path, liveNodeGlyph(this.tree.nodeAtPath(path), this.tree.parentNode(path)));
-  }
-
-  private annotateLiveChildren(path: TreePath, node: TreeNode): void {
-    node.children.forEach(child => this.annotateLivePath(path + child.id));
-  }
-
-  private rebuildLiveGlyphs(node = this.tree.root, path: TreePath = treePath.root): void {
-    node.children.forEach(child => {
-      const childPath = path + child.id;
-      this.annotateLivePath(childPath);
-      this.rebuildLiveGlyphs(child, childPath);
-    });
-  }
 
   private initCeval(): void {
     const opts: CevalOpts = {

--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -123,7 +123,6 @@ export default class AnalyseCtrl implements CevalHandler {
   );
   showFishnetAnalysis = storedBooleanProp('analyse.show-computer', true);
   possiblyShowMoveAnnotationsOnBoard = storedBooleanProp('analyse.show-move-annotation', true);
-  liveAnnotationsProp = storedBooleanProp('analyse.live-annotations', false);
   liveGlyphs = new Map<TreePath, Glyph[]>();
   keyboardHelp: boolean = location.hash === '#keyboard';
   threatMode: Prop<boolean> = prop(false);
@@ -741,7 +740,7 @@ export default class AnalyseCtrl implements CevalHandler {
         if (node.ceval?.cloud && this.ceval.isDeeper()) node.ceval = ev;
       }
 
-      if (this.liveAnnotationsProp() && !isThreat && isLocalEval(ev)) {
+      if (!isThreat && isLocalEval(ev)) {
         this.annotateLivePath(path);
         this.annotateLiveChildren(path, node);
       }
@@ -778,9 +777,6 @@ export default class AnalyseCtrl implements CevalHandler {
       this.rebuildLiveGlyphs(child, childPath);
     });
   }
-
-  liveGlyphsOf = (path: TreePath): Glyph[] | undefined =>
-    this.liveAnnotationsProp() ? this.liveGlyphs.get(path) : undefined;
 
   private initCeval(): void {
     const opts: CevalOpts = {
@@ -855,8 +851,7 @@ export default class AnalyseCtrl implements CevalHandler {
     return this.showFishnetAnalysis() || (this.cevalEnabled() && this.isCevalAllowed());
   }
 
-  showMoveGlyphs = (): boolean =>
-    (this.study && !this.study.relay) || this.showFishnetAnalysis() || this.liveAnnotationsProp();
+  showMoveGlyphs = (): boolean => (this.study && !this.study.relay) || this.showFishnetAnalysis();
 
   showMoveAnnotationsOnBoard = (): boolean =>
     this.possiblyShowMoveAnnotationsOnBoard() && this.showMoveGlyphs();
@@ -929,14 +924,6 @@ export default class AnalyseCtrl implements CevalHandler {
     this.showFishnetAnalysis(!this.showFishnetAnalysis());
     this.resetAutoShapes();
     pubsub.emit('analysis.comp.toggle', this.showFishnetAnalysis());
-  };
-
-  toggleLiveAnnotations = () => {
-    this.liveAnnotationsProp(!this.liveAnnotationsProp());
-    this.liveGlyphs.clear();
-    if (this.liveAnnotationsProp()) this.rebuildLiveGlyphs();
-    this.resetAutoShapes();
-    this.redraw();
   };
 
   toggleActionMenu = () => {

--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -39,7 +39,7 @@ import { pubsub } from 'lib/pubsub';
 import { storedBooleanProp, storedBooleanPropWithEffect } from 'lib/storage';
 import { makeTree, treePath, treeOps, type TreeWrapper } from 'lib/tree';
 import { completeNode } from 'lib/tree/node';
-import type { ClientEval, LocalEval, ServerEval, TreeNode, TreePath } from 'lib/tree/types';
+import type { ClientEval, Glyph, LocalEval, ServerEval, TreeNode, TreePath } from 'lib/tree/types';
 import { confirm } from 'lib/view';
 
 import { Autoplay, type AutoplayDelay } from './autoplay';
@@ -52,6 +52,7 @@ import { ForkCtrl } from './fork';
 import { IdbTree } from './idbTree';
 import type { AnalyseOpts, AnalyseData, ServerEvalData, JustCaptured, NvuiPlugin } from './interfaces';
 import * as keyboard from './keyboard';
+import { isLocalEval, liveNodeGlyphs } from './liveAnnotate';
 import MotifCtrl from './motif/motifCtrl';
 import Navigate from './navigate';
 import { nextGlyphSymbol, add3or5FoldGlyphs } from './nodeFinder';
@@ -122,6 +123,8 @@ export default class AnalyseCtrl implements CevalHandler {
   );
   showFishnetAnalysis = storedBooleanProp('analyse.show-computer', true);
   possiblyShowMoveAnnotationsOnBoard = storedBooleanProp('analyse.show-move-annotation', true);
+  liveAnnotationsProp = storedBooleanProp('analyse.live-annotations', false);
+  liveGlyphs = new Map<TreePath, Glyph[]>();
   keyboardHelp: boolean = location.hash === '#keyboard';
   threatMode: Prop<boolean> = prop(false);
   disclosureMode = storedBooleanProp('analyse.disclosure.enabled', false);
@@ -738,6 +741,11 @@ export default class AnalyseCtrl implements CevalHandler {
         if (node.ceval?.cloud && this.ceval.isDeeper()) node.ceval = ev;
       }
 
+      if (this.liveAnnotationsProp() && !isThreat && isLocalEval(ev)) {
+        this.annotateLivePath(path);
+        this.annotateLiveChildren(path, node);
+      }
+
       if (path === this.path) {
         this.setAutoShapes();
         if (!isThreat) {
@@ -751,6 +759,28 @@ export default class AnalyseCtrl implements CevalHandler {
       }
     });
   };
+
+  private annotateLivePath(path: TreePath): void {
+    if (path.length < 2) return;
+    const glyphs = liveNodeGlyphs(this.tree.nodeAtPath(path), this.tree.parentNode(path));
+    if (glyphs) this.liveGlyphs.set(path, glyphs);
+    else this.liveGlyphs.delete(path);
+  }
+
+  private annotateLiveChildren(path: TreePath, node: TreeNode): void {
+    node.children.forEach(child => this.annotateLivePath(path + child.id));
+  }
+
+  private rebuildLiveGlyphs(node = this.tree.root, path: TreePath = treePath.root): void {
+    node.children.forEach(child => {
+      const childPath = path + child.id;
+      this.annotateLivePath(childPath);
+      this.rebuildLiveGlyphs(child, childPath);
+    });
+  }
+
+  liveGlyphsOf = (path: TreePath): Glyph[] | undefined =>
+    this.liveAnnotationsProp() ? this.liveGlyphs.get(path) : undefined;
 
   private initCeval(): void {
     const opts: CevalOpts = {
@@ -825,7 +855,8 @@ export default class AnalyseCtrl implements CevalHandler {
     return this.showFishnetAnalysis() || (this.cevalEnabled() && this.isCevalAllowed());
   }
 
-  showMoveGlyphs = (): boolean => (this.study && !this.study.relay) || this.showFishnetAnalysis();
+  showMoveGlyphs = (): boolean =>
+    (this.study && !this.study.relay) || this.showFishnetAnalysis() || this.liveAnnotationsProp();
 
   showMoveAnnotationsOnBoard = (): boolean =>
     this.possiblyShowMoveAnnotationsOnBoard() && this.showMoveGlyphs();
@@ -898,6 +929,14 @@ export default class AnalyseCtrl implements CevalHandler {
     this.showFishnetAnalysis(!this.showFishnetAnalysis());
     this.resetAutoShapes();
     pubsub.emit('analysis.comp.toggle', this.showFishnetAnalysis());
+  };
+
+  toggleLiveAnnotations = () => {
+    this.liveAnnotationsProp(!this.liveAnnotationsProp());
+    this.liveGlyphs.clear();
+    if (this.liveAnnotationsProp()) this.rebuildLiveGlyphs();
+    this.resetAutoShapes();
+    this.redraw();
   };
 
   toggleActionMenu = () => {

--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -52,7 +52,7 @@ import { ForkCtrl } from './fork';
 import { IdbTree } from './idbTree';
 import type { AnalyseOpts, AnalyseData, ServerEvalData, JustCaptured, NvuiPlugin } from './interfaces';
 import * as keyboard from './keyboard';
-import { isLocalEval, liveNodeGlyphs } from './liveAnnotate';
+import { isLocalEval, liveNodeGlyph } from './liveAnnotate';
 import MotifCtrl from './motif/motifCtrl';
 import Navigate from './navigate';
 import { nextGlyphSymbol, add3or5FoldGlyphs } from './nodeFinder';
@@ -123,7 +123,7 @@ export default class AnalyseCtrl implements CevalHandler {
   );
   showFishnetAnalysis = storedBooleanProp('analyse.show-computer', true);
   possiblyShowMoveAnnotationsOnBoard = storedBooleanProp('analyse.show-move-annotation', true);
-  liveGlyphs = new Map<TreePath, Glyph[]>();
+  liveGlyphs = new Map<TreePath, Glyph | undefined>();
   keyboardHelp: boolean = location.hash === '#keyboard';
   threatMode: Prop<boolean> = prop(false);
   disclosureMode = storedBooleanProp('analyse.disclosure.enabled', false);
@@ -760,10 +760,8 @@ export default class AnalyseCtrl implements CevalHandler {
   };
 
   private annotateLivePath(path: TreePath): void {
-    if (path.length < 2) return;
-    const glyphs = liveNodeGlyphs(this.tree.nodeAtPath(path), this.tree.parentNode(path));
-    if (glyphs) this.liveGlyphs.set(path, glyphs);
-    else this.liveGlyphs.delete(path);
+    if (path.length)
+      this.liveGlyphs.set(path, liveNodeGlyph(this.tree.nodeAtPath(path), this.tree.parentNode(path)));
   }
 
   private annotateLiveChildren(path: TreePath, node: TreeNode): void {

--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -52,7 +52,7 @@ import { ForkCtrl } from './fork';
 import { IdbTree } from './idbTree';
 import type { AnalyseOpts, AnalyseData, ServerEvalData, JustCaptured, NvuiPlugin } from './interfaces';
 import * as keyboard from './keyboard';
-import { isLocalEval, liveNodeGlyph } from './liveAnnotate';
+import { liveNodeGlyph } from './liveAnnotate';
 import MotifCtrl from './motif/motifCtrl';
 import Navigate from './navigate';
 import { nextGlyphSymbol, add3or5FoldGlyphs } from './nodeFinder';
@@ -740,7 +740,7 @@ export default class AnalyseCtrl implements CevalHandler {
         if (node.ceval?.cloud && this.ceval.isDeeper()) node.ceval = ev;
       }
 
-      if (!isThreat && isLocalEval(ev)) {
+      if (!isThreat && ev) {
         this.annotateLivePath(path);
         this.annotateLiveChildren(path, node);
       }

--- a/ui/analyse/src/liveAnnotate.ts
+++ b/ui/analyse/src/liveAnnotate.ts
@@ -1,5 +1,6 @@
 import { povChances } from 'lib/ceval/winningChances';
-import type { Glyph, TreeNode } from 'lib/tree/types';
+import type { TreeWrapper } from 'lib/tree';
+import type { Glyph, TreeNode, TreePath } from 'lib/tree/types';
 
 const glyphs = {
   inaccuracy: { id: 6, symbol: '?!', name: 'Inaccuracy' } as Glyph,
@@ -7,15 +8,34 @@ const glyphs = {
   blunder: { id: 4, symbol: '??', name: 'Blunder' } as Glyph,
 };
 
-export function liveGlyph(parentEval: EvalScore, currentEval: EvalScore, ply: Ply): Glyph | undefined {
-  const color: Color = ply % 2 === 1 ? 'white' : 'black';
-  const loss = povChances(color, parentEval) - povChances(color, currentEval);
-  if (loss > 0.3) return glyphs.blunder;
-  if (loss > 0.2) return glyphs.mistake;
-  if (loss > 0.1) return glyphs.inaccuracy;
-  return undefined;
-}
+export default class LiveAnnotate {
+  private readonly glyphs = new Map<TreePath, Glyph>();
 
-export function liveNodeGlyph(node: TreeNode, parentNode: TreeNode): Glyph | undefined {
-  return parentNode.ceval && node.ceval && liveGlyph(parentNode.ceval, node.ceval, node.ply);
+  readonly get = this.glyphs.get.bind(this.glyphs);
+
+  readonly onNewCeval = (path: TreePath, node: TreeNode, tree: TreeWrapper): void => {
+    const parent = tree.parentNode(path);
+    this.update(path, node, parent);
+    node.children.forEach(child => this.update(path + child.id, child, node));
+  };
+
+  private readonly liveGlyph = (
+    parentEval: EvalScore,
+    currentEval: EvalScore,
+    ply: Ply,
+  ): Glyph | undefined => {
+    const color: Color = ply % 2 === 1 ? 'white' : 'black';
+    const loss = povChances(color, parentEval) - povChances(color, currentEval);
+    if (loss > 0.3) return glyphs.blunder;
+    if (loss > 0.2) return glyphs.mistake;
+    if (loss > 0.1) return glyphs.inaccuracy;
+    return undefined;
+  };
+
+  private readonly update = (path: TreePath, node: TreeNode, parent: TreeNode): void => {
+    if (!path.length) return;
+    const glyph = parent.ceval && node.ceval && this.liveGlyph(parent.ceval, node.ceval, node.ply);
+    if (glyph) this.glyphs.set(path, glyph);
+    else this.glyphs.delete(path);
+  };
 }

--- a/ui/analyse/src/liveAnnotate.ts
+++ b/ui/analyse/src/liveAnnotate.ts
@@ -18,8 +18,7 @@ export function liveGlyph(parentEval: EvalScore, currentEval: EvalScore, ply: Pl
   return undefined;
 }
 
-export function liveNodeGlyphs(node: TreeNode, parentNode: TreeNode): Glyph[] | undefined {
+export function liveNodeGlyph(node: TreeNode, parentNode: TreeNode): Glyph | undefined {
   if (!isLocalEval(parentNode.ceval) || !isLocalEval(node.ceval)) return;
-  const glyph = liveGlyph(parentNode.ceval, node.ceval, node.ply);
-  return glyph ? [glyph] : [];
+  return liveGlyph(parentNode.ceval, node.ceval, node.ply);
 }

--- a/ui/analyse/src/liveAnnotate.ts
+++ b/ui/analyse/src/liveAnnotate.ts
@@ -1,0 +1,25 @@
+import { povChances } from 'lib/ceval/winningChances';
+import type { ClientEval, Glyph, LocalEval, TreeNode } from 'lib/tree/types';
+
+const glyphs = {
+  inaccuracy: { id: 6, symbol: '?!', name: 'Inaccuracy' } as Glyph,
+  mistake: { id: 2, symbol: '?', name: 'Mistake' } as Glyph,
+  blunder: { id: 4, symbol: '??', name: 'Blunder' } as Glyph,
+};
+
+export const isLocalEval = (ev?: ClientEval): ev is LocalEval => !!ev && !ev.cloud;
+
+export function liveGlyph(parentEval: EvalScore, currentEval: EvalScore, ply: Ply): Glyph | undefined {
+  const color: Color = ply % 2 === 1 ? 'white' : 'black';
+  const loss = povChances(color, parentEval) - povChances(color, currentEval);
+  if (loss > 0.3) return glyphs.blunder;
+  if (loss > 0.2) return glyphs.mistake;
+  if (loss > 0.1) return glyphs.inaccuracy;
+  return undefined;
+}
+
+export function liveNodeGlyphs(node: TreeNode, parentNode: TreeNode): Glyph[] | undefined {
+  if (!isLocalEval(parentNode.ceval) || !isLocalEval(node.ceval)) return;
+  const glyph = liveGlyph(parentNode.ceval, node.ceval, node.ply);
+  return glyph ? [glyph] : [];
+}

--- a/ui/analyse/src/liveAnnotate.ts
+++ b/ui/analyse/src/liveAnnotate.ts
@@ -1,13 +1,11 @@
 import { povChances } from 'lib/ceval/winningChances';
-import type { ClientEval, Glyph, LocalEval, TreeNode } from 'lib/tree/types';
+import type { Glyph, TreeNode } from 'lib/tree/types';
 
 const glyphs = {
   inaccuracy: { id: 6, symbol: '?!', name: 'Inaccuracy' } as Glyph,
   mistake: { id: 2, symbol: '?', name: 'Mistake' } as Glyph,
   blunder: { id: 4, symbol: '??', name: 'Blunder' } as Glyph,
 };
-
-export const isLocalEval = (ev?: ClientEval): ev is LocalEval => !!ev && !ev.cloud;
 
 export function liveGlyph(parentEval: EvalScore, currentEval: EvalScore, ply: Ply): Glyph | undefined {
   const color: Color = ply % 2 === 1 ? 'white' : 'black';
@@ -19,6 +17,5 @@ export function liveGlyph(parentEval: EvalScore, currentEval: EvalScore, ply: Pl
 }
 
 export function liveNodeGlyph(node: TreeNode, parentNode: TreeNode): Glyph | undefined {
-  if (!isLocalEval(parentNode.ceval) || !isLocalEval(node.ceval)) return;
-  return liveGlyph(parentNode.ceval, node.ceval, node.ply);
+  return parentNode.ceval && node.ceval && liveGlyph(parentNode.ceval, node.ceval, node.ply);
 }

--- a/ui/analyse/src/treeView/inlineView.ts
+++ b/ui/analyse/src/treeView/inlineView.ts
@@ -164,7 +164,7 @@ export class InlineView {
       'pending-deletion': path.startsWith(ctrl.pendingDeletionPath() || ' '),
       'pending-copy': !!ctrl.pendingCopyPath()?.startsWith(path),
     };
-    const liveGlyph = ctrl.liveGlyphs.get(path);
+    const liveGlyph = ctrl.liveAnnotate.get(path);
     const glyphs = liveGlyph ? [liveGlyph] : node.glyphs;
     if (ctrl.showMoveGlyphs()) {
       glyphs

--- a/ui/analyse/src/treeView/inlineView.ts
+++ b/ui/analyse/src/treeView/inlineView.ts
@@ -164,7 +164,8 @@ export class InlineView {
       'pending-deletion': path.startsWith(ctrl.pendingDeletionPath() || ' '),
       'pending-copy': !!ctrl.pendingCopyPath()?.startsWith(path),
     };
-    const glyphs = ctrl.liveGlyphs.get(path) ?? node.glyphs;
+    const liveGlyph = ctrl.liveGlyphs.get(path);
+    const glyphs = liveGlyph ? [liveGlyph] : node.glyphs;
     if (ctrl.showMoveGlyphs()) {
       glyphs
         ?.map(g => this.glyphs[g.id - 1])

--- a/ui/analyse/src/treeView/inlineView.ts
+++ b/ui/analyse/src/treeView/inlineView.ts
@@ -164,7 +164,7 @@ export class InlineView {
       'pending-deletion': path.startsWith(ctrl.pendingDeletionPath() || ' '),
       'pending-copy': !!ctrl.pendingCopyPath()?.startsWith(path),
     };
-    const glyphs = ctrl.liveGlyphsOf(path) ?? node.glyphs;
+    const glyphs = ctrl.liveGlyphs.get(path) ?? node.glyphs;
     if (ctrl.showMoveGlyphs()) {
       glyphs
         ?.map(g => this.glyphs[g.id - 1])

--- a/ui/analyse/src/treeView/inlineView.ts
+++ b/ui/analyse/src/treeView/inlineView.ts
@@ -164,11 +164,13 @@ export class InlineView {
       'pending-deletion': path.startsWith(ctrl.pendingDeletionPath() || ' '),
       'pending-copy': !!ctrl.pendingCopyPath()?.startsWith(path),
     };
-    if (ctrl.showMoveGlyphs())
-      node.glyphs
+    const glyphs = ctrl.liveGlyphsOf(path) ?? node.glyphs;
+    if (ctrl.showMoveGlyphs()) {
+      glyphs
         ?.map(g => this.glyphs[g.id - 1])
         .filter(Boolean)
         .forEach(cls => (classes[cls] = true));
+    }
     return hl('move', { attrs: { p: path }, class: classes }, [
       parentDisclose && this.disclosureBtn(parentNode, parentPath),
       withIndex && renderIndex(node.ply, true),
@@ -177,6 +179,7 @@ export class InlineView {
         isMainline && !this.inline,
         ctrl.showMoveGlyphs(),
         ctrl.allowedEval(node) || false,
+        glyphs,
       ),
     ]);
   }

--- a/ui/analyse/src/view/actionMenu.ts
+++ b/ui/analyse/src/view/actionMenu.ts
@@ -184,14 +184,6 @@ export function view(ctrl: AnalyseCtrl): VNode {
         prop: ctrl.showManeuverMoveArrowsProp,
         redraw: ctrl.redraw,
       }),
-    cmnToggleWrap({
-      id: 'live-annotations',
-      name: 'Live move annotations',
-      title: 'Show inaccuracy/mistake/blunder from local engine eval',
-      checked: ctrl.liveAnnotationsProp(),
-      change: ctrl.toggleLiveAnnotations,
-      redraw: ctrl.redraw,
-    }),
     displayColumns() > 1 &&
       cmnToggleWrapProp({
         id: 'gauge',

--- a/ui/analyse/src/view/actionMenu.ts
+++ b/ui/analyse/src/view/actionMenu.ts
@@ -184,6 +184,14 @@ export function view(ctrl: AnalyseCtrl): VNode {
         prop: ctrl.showManeuverMoveArrowsProp,
         redraw: ctrl.redraw,
       }),
+    cmnToggleWrap({
+      id: 'live-annotations',
+      name: 'Live move annotations',
+      title: 'Show inaccuracy/mistake/blunder from local engine eval',
+      checked: ctrl.liveAnnotationsProp(),
+      change: ctrl.toggleLiveAnnotations,
+      redraw: ctrl.redraw,
+    }),
     displayColumns() > 1 &&
       cmnToggleWrapProp({
         id: 'gauge',

--- a/ui/analyse/src/view/components.ts
+++ b/ui/analyse/src/view/components.ts
@@ -12,7 +12,7 @@ import * as licon from 'lib/licon';
 import * as Prefs from 'lib/prefs';
 import { storage } from 'lib/storage';
 import { path as treePath } from 'lib/tree/tree';
-import type { ClientEval, ServerEval, TreeNode, TreePath } from 'lib/tree/types';
+import type { ClientEval, Glyph, ServerEval, TreeNode, TreePath } from 'lib/tree/types';
 import {
   type VNode,
   type LooseVNodes,
@@ -276,6 +276,7 @@ export function renderMoveNodes(
   withEval: boolean,
   withGlyphs: boolean,
   ev?: ClientEval | ServerEval | false,
+  glyphs?: Glyph[],
 ): VNode[] {
   ev ??= node.ceval ?? node.eval; // ev = false will override withEval
   const evalText = !ev
@@ -286,8 +287,9 @@ export function renderMoveNodes(
         ? `#${ev.mate}`
         : '';
   const nodes = [h('san', fixCrazySan(node.san!))];
-  if (withGlyphs && node.glyphs)
-    node.glyphs.forEach(g => nodes.push(h('glyph', { attrs: { title: g.name } }, g.symbol)));
+  const relevantGlyphs = glyphs ?? node.glyphs;
+  if (withGlyphs && relevantGlyphs)
+    relevantGlyphs.forEach(g => nodes.push(h('glyph', { attrs: { title: g.name } }, g.symbol)));
   if (withEval && node.shapes?.length) nodes.push(h('shapes'));
   if (withEval && evalText) nodes.push(h('eval', evalText.replace('-', '−')));
   return nodes;


### PR DESCRIPTION

Changes:

- Adds live annotations derived from local engine eval
- Adds a UI toggle to enable/disable live annotations
- Renders live glyphs on the board and in the move list
- Rebuilds and caches glyphs when toggling or navigating

Reason for this feature is to allow some highlights of big evaluation
changes even when using just the local evaluation mode.

This also allows running the local mode with high settings to double check
server eval with updating glyphs.

It does not provide "alternate lines" like the server eval does.

AI was used for navigating and generating some of the code, Model GPT5.5 
via Opencode.

Video of the feature in action: https://www.youtube.com/watch?v=_5tlPyKsdQk

