### PR TITLE
allow use of an explorer config endpoint with a path

### DIFF
--- a/ui/analyse/src/explorer/explorerXhr.ts
+++ b/ui/analyse/src/explorer/explorerXhr.ts
@@ -22,7 +22,7 @@ export async function opening(
 ): Promise<void> {
   const conf = opts.config;
   const confByDb = conf.byDb();
-  const url = new URL(`/${opts.db}`, opts.endpoint);
+  const url = new URL(`./${opts.db}`, opts.endpoint);
   const params = url.searchParams;
   params.set('variant', opts.variant || 'standard');
   params.set('fen', opts.rootFen);


### PR DESCRIPTION
For local dev setup of openingexplorer through an existing reverse proxy. I setup the handler but the path was being dropped.

### Before
Path is lost:
```js
(new URL("/players", "http://localhost:8080/explorer/")).toString()
// -> http://localhost:8080/players
```

### After
```js
(new URL("./players", "http://localhost:8080/explorer/")).toString()
// -> http://localhost:8080/explorer/players
```