### PR TITLE
ui: use `fenColor` helper instead of inline checks

### DIFF
--- a/ui/analyse/src/autoShape.ts
+++ b/ui/analyse/src/autoShape.ts
@@ -6,6 +6,7 @@ import { isDrop, type Square } from 'chessops/types';
 import { parseUci, makeSquare } from 'chessops/util';
 
 import { winningChances } from 'lib/ceval';
+import { fenColor } from 'lib/game';
 import { isUci } from 'lib/game/chess';
 import { annotationShapes, analysisGlyphs } from 'lib/game/glyphs';
 import type { ServerEval } from 'lib/tree/types';
@@ -92,7 +93,7 @@ export function makeShapesFromUci(
 }
 
 export function compute(ctrl: AnalyseCtrl): DrawShape[] {
-  const color = ctrl.node.fen.includes(' w ') ? 'white' : 'black';
+  const color = fenColor(ctrl.node.fen);
   const rcolor = opposite(color);
   if (ctrl.practice) {
     const hovering = ctrl.practice.hovering();

--- a/ui/learn/src/util.ts
+++ b/ui/learn/src/util.ts
@@ -3,6 +3,8 @@ import type { BrushColor } from '@lichess-org/chessground/types';
 import type { SquareName } from 'chessops';
 import { h } from 'snabbdom';
 
+import { fenColor } from 'lib/game';
+
 import type { Level, LevelPartial } from './stage/list';
 
 export function toLevel(l: LevelPartial, it: number): Level {
@@ -11,7 +13,7 @@ export function toLevel(l: LevelPartial, it: number): Level {
   return {
     id: it + 1,
     apples: [],
-    color: l.fen.includes(' w ') ? 'white' : 'black',
+    color: fenColor(l.fen),
     detectCapture: l.apples ? false : 'unprotected',
     ...l,
   };

--- a/ui/puzzle/src/autoShape.ts
+++ b/ui/puzzle/src/autoShape.ts
@@ -3,6 +3,7 @@ import type { NormalMove } from 'chessops/types';
 import { opposite, parseUci, makeSquare } from 'chessops/util';
 
 import { winningChances } from 'lib/ceval';
+import { fenColor } from 'lib/game';
 import { annotationShapes } from 'lib/game/glyphs';
 import type { Glyph, TreeNode } from 'lib/tree/types';
 
@@ -26,9 +27,9 @@ function makeAutoShapesFromUci(
 }
 
 export default function (ctrl: PuzzleCtrl): DrawShape[] {
-  const n = ctrl.node,
-    hovering = ctrl.ceval.hovering(),
-    color = n.fen.includes(' w ') ? 'white' : 'black';
+  const n = ctrl.node;
+  const hovering = ctrl.ceval.hovering();
+  const color = fenColor(n.fen);
   let shapes: DrawShape[] = [];
   if (hovering && hovering.fen === n.fen)
     shapes = shapes.concat(makeAutoShapesFromUci(color, hovering.uci, 'paleBlue'));

--- a/ui/puzzle/src/report.ts
+++ b/ui/puzzle/src/report.ts
@@ -1,4 +1,5 @@
 import { winningChances } from 'lib/ceval';
+import { fenColor } from 'lib/game';
 import { plyToTurn, pieceCount } from 'lib/game/chess';
 import * as licon from 'lib/licon';
 import { type StoredProp, storedIntProp } from 'lib/storage';
@@ -50,7 +51,7 @@ export default class Report {
       return;
     const node = ctrl.node;
     // more resilient than checking the turn directly, if eventually puzzles get generated from 'from position' games
-    const nodeTurn = node.fen.includes(' w ') ? 'white' : 'black';
+    const nodeTurn = fenColor(node.fen);
     if (
       nextMoveInSolution(node) &&
       nodeTurn === ctrl.pov &&


### PR DESCRIPTION
# Why

While reading thro some UI code spotted that we sometimes extract color from FEN directly, while there is a helper defined for that.

# How

Use `fenColor` helper instead of inline checks in few files.