### PR TITLE
ui: small lib code tweaks

### DIFF
--- a/ui/lib/src/i18n.ts
+++ b/ui/lib/src/i18n.ts
@@ -83,7 +83,7 @@ const getCurrencyDigits = (currency: string): number => {
     const digits = nf.resolvedOptions().maximumFractionDigits ?? 2;
     currencyDigitsCache.set(currency, digits);
     return digits;
-  } catch (_) {
+  } catch {
     return 2;
   }
 };

--- a/ui/lib/src/view/controls.ts
+++ b/ui/lib/src/view/controls.ts
@@ -24,8 +24,8 @@ export function rangeConfig(read: () => number, write: (value: number) => void):
     insert: (v: VNode) => {
       const el = v.elm as HTMLInputElement;
       el.value = '' + read();
-      el.addEventListener('input', _ => write(parseInt(el.value)));
-      el.addEventListener('mouseout', _ => el.blur());
+      el.addEventListener('input', () => write(parseInt(el.value)));
+      el.addEventListener('mouseout', () => el.blur());
     },
     update: (_, v: VNode) => {
       (v.elm as HTMLInputElement).value = `${read()}`; // force redraw on external value change
@@ -54,7 +54,7 @@ export const addPasswordVisibilityToggleListener = (): void => {
   $('.password-wrapper').each(function (this: HTMLElement) {
     const $wrapper = $(this);
     const $button = $wrapper.find('.password-reveal');
-    $button.on('click', function (e: Event) {
+    $button.on('click', (e: PointerEvent) => {
       e.preventDefault();
       const $input = $wrapper.find('input');
       const type = $input.attr('type') === 'password' ? 'text' : 'password';

--- a/ui/lib/src/view/userComplete.ts
+++ b/ui/lib/src/view/userComplete.ts
@@ -36,14 +36,18 @@ export function userComplete(opts: UserCompleteOpts): void {
 }
 
 type ResultOfTerm = { term: string } & UserCompleteResult;
-export const fetchUsers = async (term: string, opts: Partial<UserCompleteOpts>): Promise<ResultOfTerm> => {
+
+export const fetchUsers = async (
+  term: string,
+  { friend, tour, swiss, team }: Partial<UserCompleteOpts>,
+): Promise<ResultOfTerm> => {
   const result = await xhr.json(
     xhr.url('/api/player/autocomplete', {
       term,
-      friend: opts.friend ? 1 : 0,
-      tour: opts.tour,
-      swiss: opts.swiss,
-      team: opts.team,
+      friend: friend ? 1 : 0,
+      tour,
+      swiss,
+      team,
       object: 1,
     }),
   );
@@ -57,31 +61,10 @@ export const checkDebouncedResultAgainstTerm =
 
 export const renderUserEntry = (o: LightUserOnline, tag = 'a'): string => {
   const patronClass = o.patronColor ? ` paco${o.patronColor}` : '';
-  return (
-    '<' +
-    tag +
-    ' class="complete-result ulpt user-link' +
-    (o.online ? ' online' : '') +
-    '" ' +
-    (tag === 'a' ? '' : 'data-') +
-    'href="/@/' +
-    o.name +
-    '">' +
-    '<icon class="line' +
-    (o.patron ? ' patron' : '') +
-    patronClass +
-    '"></icon>' +
-    (o.title
-      ? '<span class="utitle"' +
-        (o.title === 'BOT' ? ' data-bot="data-bot" ' : '') +
-        '>' +
-        o.title +
-        '</span>&nbsp;'
-      : '') +
-    o.name +
-    (o.flair ? '<img class="uflair" src="' + site.asset.flairSrc(o.flair) + '"/>' : '') +
-    '</' +
-    tag +
-    '>'
-  );
+  const hrefAttr = tag === 'a' ? 'href' : 'data-href';
+  const title = o.title
+    ? `<span class="utitle"${o.title === 'BOT' ? ' data-bot="data-bot"' : ''}>${o.title}</span>&nbsp;`
+    : '';
+  const flair = o.flair ? `<img class="uflair" src="${site.asset.flairSrc(o.flair)}" alt="" />` : '';
+  return `<${tag} class="complete-result ulpt user-link${o.online ? ' online' : ''}" ${hrefAttr}="/@/${o.name}"><icon class="line${o.patron ? ' patron' : ''}${patronClass}"></icon>${title}${o.name}${flair}</${tag}>`;
 };

--- a/ui/lib/src/view/verticalResize.ts
+++ b/ui/lib/src/view/verticalResize.ts
@@ -25,10 +25,15 @@ export function verticalResize(o: Opts): VNode {
       hook: {
         insert: vn => {
           const divider = vn.elm as ResizerElement;
-          const onDomChange = () => {
-            const el = o.selector
+
+          function getSelectorElement(o: Opts) {
+            return o.selector
               ? document.querySelector<HTMLElement>(o.selector)!
               : (divider.previousElementSibling as HTMLElement);
+          }
+
+          const onDomChange = () => {
+            const el = getSelectorElement(o);
             if (el.style.height) return;
             let height = o.id && heightStore(`${o.key}.${o.id}`);
             if (typeof height !== 'number') height = heightStore(o.key) ?? o.initialMaxHeight?.();
@@ -45,9 +50,7 @@ export function verticalResize(o: Opts): VNode {
             safariHack(true);
             divider.classList.add('is-dragging');
 
-            const el = o.selector
-              ? document.querySelector<HTMLElement>(o.selector)!
-              : (divider.previousElementSibling as HTMLElement);
+            const el = getSelectorElement(o);
             const beginFrom = el.getBoundingClientRect().height - down.clientY;
             divider.setPointerCapture(down.pointerId);
 

--- a/ui/round/src/round.ts
+++ b/ui/round/src/round.ts
@@ -31,6 +31,10 @@ async function app(opts: RoundOpts): Promise<RoundController> {
 
   let vnode = patch(el, blueprint);
 
+  function redraw() {
+    vnode = patch(vnode, view(ctrl));
+  }
+
   window.addEventListener('resize', () => {
     redraw(); // col1 / col2+ transition
     ctrl.autoScroll();
@@ -41,21 +45,19 @@ async function app(opts: RoundOpts): Promise<RoundController> {
   site.sound.preloadBoardSounds();
 
   return ctrl;
-
-  function redraw() {
-    vnode = patch(vnode, view(ctrl));
-  }
 }
 
 async function boot(
   opts: RoundOpts,
   roundMain: (opts: RoundOpts) => Promise<RoundController>,
 ): Promise<RoundController> {
-  const data = opts.data;
+  const { data, chat } = opts;
+
   if (data.tournament) document.body.dataset.tournamentId = data.tournament.id;
-  const socketUrl = opts.data.player.spectator
+  const socketUrl = data.player.spectator
     ? `/watch/${data.game.id}/${data.player.color}/v6`
     : `/play/${data.game.id}${data.player.id}/v6`;
+
   opts.socketSend = wsConnect(socketUrl, data.player.version, {
     options: { reloadOnResume: true },
     params: { userTv: data.userTv && data.userTv.id },
@@ -63,17 +65,12 @@ async function boot(
       round.socketReceive(t, d);
     },
     events: {
-      tvSelect(o: {
-        channel: string;
-        gameId: string;
-        color: Color;
-        player?: { title?: string; name: string; rating?: number };
-      }) {
-        if (data.tv && data.tv.channel === o.channel) site.reload();
+      tvSelect({ channel, player }: TVOptions) {
+        if (data.tv && data.tv.channel === channel) site.reload();
         else
-          $('.tv-channels .' + o.channel + ' .champion').html(
-            o.player
-              ? [o.player.title, o.player.name, data.pref.ratings ? o.player.rating : '']
+          $(`.tv-channels .${channel} .champion`).html(
+            player
+              ? [player.title, player.name, data.pref.ratings ? player.rating : '']
                   .filter(x => x)
                   .join('&nbsp')
               : 'Anonymous',
@@ -90,10 +87,10 @@ async function boot(
         });
       },
       tourStanding(s: TourPlayer[]) {
-        const chat = opts.chat?.plugin && opts.chat?.instance;
-        if (chat) {
-          (opts.chat!.plugin as TourStandingCtrl).set(s);
-          chat.redraw();
+        const chatInstance = chat?.plugin && chat?.instance;
+        if (chatInstance) {
+          (chat.plugin as TourStandingCtrl).set(s);
+          chatInstance.redraw();
         }
       },
     },
@@ -107,28 +104,30 @@ async function boot(
         });
       });
   };
+
   const getPresetGroup = (d: RoundData) => {
     if (d.player.spectator) return undefined;
     if (finished(d)) return 'end';
     if (d.steps.length < 6) return 'start';
     return undefined;
   };
+
   const ctrl = await roundMain(opts);
   const round: RoundApi = { socketReceive: ctrl.socket.receive, moveOn: ctrl.moveOn };
-  const chatOpts = opts.chat;
-  if (chatOpts) {
+
+  if (chat) {
     if (data.tournament?.top) {
-      chatOpts.plugin = tourStandingCtrl(data.tournament.top, data.tournament.team, i18n.site.standings);
+      chat.plugin = tourStandingCtrl(data.tournament.top, data.tournament.team, i18n.site.standings);
     } else if (!data.simul && !data.swiss) {
-      chatOpts.preset = getPresetGroup(data);
-      chatOpts.enhance = { plies: true };
+      chat.preset = getPresetGroup(data);
+      chat.enhance = { plies: true };
     }
-    if (chatOpts.noteId && (chatOpts.noteAge || 0) < 10) chatOpts.noteText = '';
-    chatOpts.instance = standaloneChat(chatOpts);
+    if (chat.noteId && (chat.noteAge || 0) < 10) chat.noteText = '';
+    chat.instance = standaloneChat(chat);
     if (!data.tournament && !data.simul && !data.swiss) {
-      opts.onChange = (d: RoundData) => chatOpts.instance!.preset.setGroup(getPresetGroup(d));
+      opts.onChange = (d: RoundData) => chat.instance!.preset.setGroup(getPresetGroup(d));
       if (myUserId())
-        chatOpts.instance.listenToIncoming(line => {
+        chat.instance.listenToIncoming(line => {
           if (
             line.u === 'lichess' &&
             (startsWithPrefix(line.t, 'warning') || startsWithPrefix(line.t, 'reminder'))
@@ -137,6 +136,7 @@ async function boot(
         });
     }
   }
+
   startTournamentClock();
   $('#round-toggle-autoswitch')
     .on('change', round.moveOn.toggle)
@@ -145,8 +145,11 @@ async function boot(
       site.unload.expected = true;
       return true;
     });
-  if (location.pathname.lastIndexOf('/round-next/', 0) === 0)
+
+  if (location.pathname.lastIndexOf('/round-next/', 0) === 0) {
     history.replaceState(null, '', '/' + data.game.id);
+  }
+
   $('#zentog').on('click', () => pubsub.emit('zen'));
   storage.make('reload-round-tabs').listen(site.reload);
 
@@ -160,7 +163,14 @@ async function boot(
 const startsWithPrefix = (t: string, prefix: string) =>
   t.toLowerCase().startsWith(`${prefix}, ${myUserId()}`);
 
-interface RoundApi {
-  socketReceive(typ: string, data: any): boolean;
+type RoundApi = {
+  socketReceive: (typ: string, data: any) => boolean;
   moveOn: MoveOn;
-}
+};
+
+type TVOptions = {
+  channel: string;
+  gameId: string;
+  color: Color;
+  player?: { title?: string; name: string; rating?: number };
+};


### PR DESCRIPTION
# Why

A few small `lib` code tweaks which I have stored locally when working on other code changes. Pushing them to clear local stash.

# How

Summary of changes:
* improve redability of `renderUserEntry`
* define selector helper for verticalResize to avoid code duplication
* destruct round opts in one place to easier catch access via non destructed consts, extract `TVOptions` type
* small types/syntax tweaks here and there