### PR TITLE
revert mousetrap binding change

### DIFF
--- a/ui/site/src/mousetrap.ts
+++ b/ui/site/src/mousetrap.ts
@@ -80,6 +80,9 @@ const SPECIAL_ALIASES: Record<string, string> = {
 };
 
 const keyFromEvent = (e: KeyboardEvent): string => {
+  if (e.type === 'keypress') {
+    return e.shiftKey ? e.key : e.key?.toLowerCase();
+  }
   return KEY_MAP[e.key] ?? KEY_MAP[e.code] ?? e.key?.toLowerCase();
 };
 


### PR DESCRIPTION
revert 1fc880583d67c83a82d4b86a1ee2fee856ad6081

From the forum: https://lichess.org/forum/lichess-feedback/shift-key-keyboard-shortcuts-do-not-work-anymore

 "$" doesn't work