### PR TITLE
Different default orders for different study groups

### DIFF
--- a/app/views/study.scala
+++ b/app/views/study.scala
@@ -7,7 +7,7 @@ import play.api.data.Form
 import lila.app.UiEnv.{ *, given }
 import lila.common.Json.given
 import lila.core.socket.SocketVersion
-import lila.core.study.{ IdName, StudyGroup }
+import lila.core.study.IdName
 
 lazy val bits = lila.study.ui.StudyBits(helpers)
 lazy val ui = lila.study.ui.StudyUi(helpers)
@@ -18,7 +18,7 @@ def staffPicks(p: lila.cms.CmsPage.Render, featuredForm: Option[Form[?]])(using 
     .css("analyse.study.index", "bits.page")
     .css(featuredForm.isDefined.option("bits.form3")):
       main(cls := "page-menu")(
-        list.menu(StudyGroup.staffPicks, None, Nil),
+        list.menu(lila.study.StudyGroup.staffPicks, None, Nil),
         div(cls := "page-menu__content box box-pad")(
           featuredForm.map: form =>
             postForm(action := routes.Study.staffPicks)(

--- a/app/views/study.scala
+++ b/app/views/study.scala
@@ -7,7 +7,7 @@ import play.api.data.Form
 import lila.app.UiEnv.{ *, given }
 import lila.common.Json.given
 import lila.core.socket.SocketVersion
-import lila.core.study.{ IdName, StudyOrder }
+import lila.core.study.{ IdName, StudyGroup }
 
 lazy val bits = lila.study.ui.StudyBits(helpers)
 lazy val ui = lila.study.ui.StudyUi(helpers)
@@ -18,7 +18,7 @@ def staffPicks(p: lila.cms.CmsPage.Render, featuredForm: Option[Form[?]])(using 
     .css("analyse.study.index", "bits.page")
     .css(featuredForm.isDefined.option("bits.form3")):
       main(cls := "page-menu")(
-        list.menu("staffPicks", StudyOrder.mine, Nil),
+        list.menu(StudyGroup.staffPicks, None, Nil),
         div(cls := "page-menu__content box box-pad")(
           featuredForm.map: form =>
             postForm(action := routes.Study.staffPicks)(

--- a/modules/core/src/main/study.scala
+++ b/modules/core/src/main/study.scala
@@ -44,13 +44,3 @@ enum StudyOrder:
 object StudyOrder:
   def all: List[StudyOrder] = values.toList
   val byKey = values.mapBy(_.key)
-
-enum StudyGroup:
-  case all, mine, mineMember, minePublic, minePrivate, mineLikes, byOwner, staffPicks, search
-  case topic(topicName: Option[String])
-  def isTopic: Boolean = this match
-    case StudyGroup.topic(_) => true
-    case _ => false
-  def isPersonal: Boolean = this match
-    case StudyGroup.mine | StudyGroup.mineMember | StudyGroup.minePublic | StudyGroup.minePrivate => true
-    case _ => false

--- a/modules/core/src/main/study.scala
+++ b/modules/core/src/main/study.scala
@@ -44,3 +44,13 @@ enum StudyOrder:
 object StudyOrder:
   def all: List[StudyOrder] = values.toList
   val byKey = values.mapBy(_.key)
+
+enum StudyGroup:
+  case all, mine, mineMember, minePublic, minePrivate, mineLikes, byOwner, staffPicks, search
+  case topic(topicName: Option[String])
+  def isTopic: Boolean = this match
+    case StudyGroup.topic(_) => true
+    case _ => false
+  def isPersonal: Boolean = this match
+    case StudyGroup.mine | StudyGroup.mineMember | StudyGroup.minePublic | StudyGroup.minePrivate => true
+    case _ => false

--- a/modules/study/src/main/model.scala
+++ b/modules/study/src/main/model.scala
@@ -24,7 +24,7 @@ case class AddNode(
 
 enum StudyGroup:
   case all, mine, mineMember, minePublic, minePrivate, mineLikes, byOwner, staffPicks, search
-  case topic(topicName: Option[String])
+  case topic(name: Option[StudyTopic])
   def isTopic: Boolean = this match
     case StudyGroup.topic(_) => true
     case _ => false

--- a/modules/study/src/main/model.scala
+++ b/modules/study/src/main/model.scala
@@ -21,3 +21,13 @@ case class AddNode(
     opts: MoveOpts,
     relay: Option[Chapter.Relay] = None
 )(using val who: Who)
+
+enum StudyGroup:
+  case all, mine, mineMember, minePublic, minePrivate, mineLikes, byOwner, staffPicks, search
+  case topic(topicName: Option[String])
+  def isTopic: Boolean = this match
+    case StudyGroup.topic(_) => true
+    case _ => false
+  def isPersonal: Boolean = this match
+    case StudyGroup.mine | StudyGroup.mineMember | StudyGroup.minePublic | StudyGroup.minePrivate => true
+    case _ => false

--- a/modules/study/src/main/ui/StudyBits.scala
+++ b/modules/study/src/main/ui/StudyBits.scala
@@ -6,15 +6,16 @@ import lila.core.study.StudyOrder
 import lila.ui.*
 
 import ScalatagsTemplate.{ *, given }
+import lila.core.study.StudyGroup
 
 final class StudyBits(helpers: Helpers):
   import helpers.{ *, given }
 
-  def orderSelect(order: StudyOrder, active: String, url: StudyOrder => Call)(using Context) =
+  def orderSelect(order: StudyOrder, active: StudyGroup, url: StudyOrder => Call)(using Context) =
     val orders =
-      if active == "search" then Orders.search
-      else if active == "all" then Orders.withoutSelector
-      else if active.startsWith("topic") then Orders.list
+      if active == StudyGroup.search then Orders.search
+      else if active == StudyGroup.all then Orders.withoutSelector
+      else if active.isTopic then Orders.list
       else Orders.withoutMine
     lila.ui.bits.mselect(
       "orders",
@@ -32,18 +33,26 @@ final class StudyBits(helpers: Helpers):
       )
     )
 
-  def authLinks(active: String, order: StudyOrder)(using Context) =
-    def activeCls(c: String) = cls := (c == active).option("active")
+  def authLinks(
+      activeCls: StudyGroup => AttrPair,
+      order: StudyGroup => StudyOrder
+  )(using Context) =
     frag(
-      a(activeCls("mine"), href := routes.Study.mine(order))(trans.study.myStudies()),
-      a(activeCls("mineMember"), href := routes.Study.mineMember(order))(
+      a(activeCls(StudyGroup.mine), href := routes.Study.mine(order(StudyGroup.mine)))(
+        trans.study.myStudies()
+      ),
+      a(activeCls(StudyGroup.mineMember), href := routes.Study.mineMember(order(StudyGroup.mineMember)))(
         trans.study.studiesIContributeTo()
       ),
-      a(activeCls("minePublic"), href := routes.Study.minePublic(order))(trans.study.myPublicStudies()),
-      a(activeCls("minePrivate"), href := routes.Study.minePrivate(order))(
+      a(activeCls(StudyGroup.minePublic), href := routes.Study.minePublic(order(StudyGroup.minePublic)))(
+        trans.study.myPublicStudies()
+      ),
+      a(activeCls(StudyGroup.minePrivate), href := routes.Study.minePrivate(order(StudyGroup.minePrivate)))(
         trans.study.myPrivateStudies()
       ),
-      a(activeCls("mineLikes"), href := routes.Study.mineLikes(order))(trans.study.myFavoriteStudies())
+      a(activeCls(StudyGroup.mineLikes), href := routes.Study.mineLikes(order(StudyGroup.mineLikes)))(
+        trans.study.myFavoriteStudies()
+      )
     )
 
   def widget(s: Study.WithChaptersAndLiked, tag: Tag = h2)(using ctx: Context) =

--- a/modules/study/src/main/ui/StudyBits.scala
+++ b/modules/study/src/main/ui/StudyBits.scala
@@ -6,7 +6,6 @@ import lila.core.study.StudyOrder
 import lila.ui.*
 
 import ScalatagsTemplate.{ *, given }
-import lila.core.study.StudyGroup
 
 final class StudyBits(helpers: Helpers):
   import helpers.{ *, given }

--- a/modules/study/src/main/ui/StudyListUi.scala
+++ b/modules/study/src/main/ui/StudyListUi.scala
@@ -9,7 +9,6 @@ import lila.study.Study.WithChaptersAndLiked
 import lila.ui.*
 
 import ScalatagsTemplate.{ *, given }
-import lila.core.study.StudyGroup
 
 final class StudyListUi(helpers: Helpers, bits: StudyBits):
   import helpers.{ *, given }

--- a/modules/study/src/main/ui/StudyListUi.scala
+++ b/modules/study/src/main/ui/StudyListUi.scala
@@ -173,7 +173,7 @@ final class StudyListUi(helpers: Helpers, bits: StudyBits):
       ctx.isAuth.option(bits.authLinks(activeCls, newOrder)),
       a(activeCls(StudyGroup.topic(None)), href := routes.Study.topics)(trs.topics()),
       topics.map: topic =>
-        val group = StudyGroup.topic(Some(topic.value))
+        val group = StudyGroup.topic(topic.some)
         a(activeCls(group), href := routes.Study.byTopic(topic.value, newOrder(group)))(
           topic.value
         )
@@ -228,7 +228,7 @@ final class StudyListUi(helpers: Helpers, bits: StudyBits):
         order: StudyOrder,
         myTopics: Option[StudyTopics]
     )(using Context) =
-      val active = StudyGroup.topic(Some(topic.value))
+      val active = StudyGroup.topic(topic.some)
       val url = (o: StudyOrder) => routes.Study.byTopic(topic.value, o)
       Page(topic.value)
         .css("analyse.study.index")

--- a/modules/study/src/main/ui/StudyListUi.scala
+++ b/modules/study/src/main/ui/StudyListUi.scala
@@ -9,6 +9,7 @@ import lila.study.Study.WithChaptersAndLiked
 import lila.ui.*
 
 import ScalatagsTemplate.{ *, given }
+import lila.core.study.StudyGroup
 
 final class StudyListUi(helpers: Helpers, bits: StudyBits):
   import helpers.{ *, given }
@@ -17,7 +18,7 @@ final class StudyListUi(helpers: Helpers, bits: StudyBits):
   def all(pag: Paginator[WithChaptersAndLiked], order: StudyOrder)(using Context) =
     page(
       title = trs.allStudies.txt(),
-      active = "all",
+      active = StudyGroup.all,
       order = order,
       pag = pag,
       searchFilter = "",
@@ -28,7 +29,7 @@ final class StudyListUi(helpers: Helpers, bits: StudyBits):
   def byOwner(pag: Paginator[WithChaptersAndLiked], order: StudyOrder, owner: User)(using Context) =
     page(
       title = trs.studiesCreatedByX.txt(owner.titleUsername),
-      active = "owner",
+      active = StudyGroup.byOwner,
       order = order,
       pag = pag,
       searchFilter = s"owner:${owner.username}",
@@ -41,7 +42,7 @@ final class StudyListUi(helpers: Helpers, bits: StudyBits):
   ) =
     page(
       title = trs.myStudies.txt(),
-      active = "mine",
+      active = StudyGroup.mine,
       order = order,
       pag = pag,
       searchFilter = s"owner:${me.username}",
@@ -55,7 +56,7 @@ final class StudyListUi(helpers: Helpers, bits: StudyBits):
   )(using Context) =
     page(
       title = trs.myFavoriteStudies.txt(),
-      active = "mineLikes",
+      active = StudyGroup.mineLikes,
       order = order,
       pag = pag,
       searchFilter = "",
@@ -68,7 +69,7 @@ final class StudyListUi(helpers: Helpers, bits: StudyBits):
   ) =
     page(
       title = trs.studiesIContributeTo.txt(),
-      active = "mineMember",
+      active = StudyGroup.mineMember,
       order = order,
       pag = pag,
       searchFilter = s"member:${me.username}",
@@ -79,7 +80,7 @@ final class StudyListUi(helpers: Helpers, bits: StudyBits):
   def minePublic(pag: Paginator[WithChaptersAndLiked], order: StudyOrder)(using Context)(using me: Me) =
     page(
       title = trs.myPublicStudies.txt(),
-      active = "minePublic",
+      active = StudyGroup.minePublic,
       order = order,
       pag = pag,
       searchFilter = s"owner:${me.username}",
@@ -89,7 +90,7 @@ final class StudyListUi(helpers: Helpers, bits: StudyBits):
   def minePrivate(pag: Paginator[WithChaptersAndLiked], order: StudyOrder)(using Context)(using me: Me) =
     page(
       title = trs.myPrivateStudies.txt(),
-      active = "minePrivate",
+      active = StudyGroup.minePrivate,
       order = order,
       pag = pag,
       searchFilter = s"owner:${me.username}",
@@ -101,11 +102,11 @@ final class StudyListUi(helpers: Helpers, bits: StudyBits):
       .css("analyse.study.index")
       .js(infiniteScrollEsmInit):
         main(cls := "page-menu")(
-          menu("search", Orders.default),
+          menu(StudyGroup.search, Some(order)),
           main(cls := "page-menu__content study-index box")(
             div(cls := "box__top")(
               searchForm(trans.search.search.txt(), text, order),
-              bits.orderSelect(order, "search", url = o => routes.Study.search(text, 1, o.some)),
+              bits.orderSelect(order, StudyGroup.search, url = o => routes.Study.search(text, 1, o.some)),
               bits.newForm()
             ),
             paginate(pag, routes.Study.search(text, 1, order.some))
@@ -114,7 +115,7 @@ final class StudyListUi(helpers: Helpers, bits: StudyBits):
 
   private def page(
       title: String,
-      active: String,
+      active: StudyGroup,
       order: StudyOrder,
       pag: Paginator[WithChaptersAndLiked],
       url: StudyOrder => Call,
@@ -125,7 +126,7 @@ final class StudyListUi(helpers: Helpers, bits: StudyBits):
       .css("analyse.study.index")
       .js(infiniteScrollEsmInit):
         main(cls := "page-menu")(
-          menu(active, order, topics.so(_.value)),
+          menu(active, Some(order), topics.so(_.value)),
           main(cls := "page-menu__content study-index box")(
             div(cls := "box__top")(
               searchForm(title, s"$searchFilter${searchFilter.nonEmpty.so(" ")}", order),
@@ -152,19 +153,33 @@ final class StudyListUi(helpers: Helpers, bits: StudyBits):
         pagerNext(pager, np => addQueryParam(url.url, "page", np.toString))
       )
 
-  def menu(active: String, order: StudyOrder, topics: List[StudyTopic] = Nil)(using ctx: Context) =
-    val nonMineOrder = if order == StudyOrder.mine then StudyOrder.hot else order
+  def menu(active: StudyGroup, order: Option[StudyOrder], topics: List[StudyTopic] = Nil)(using
+      ctx: Context
+  ) =
+    def defaultOrder(group: StudyGroup): Option[StudyOrder] =
+      if group == StudyGroup.search || group == StudyGroup.staffPicks then None
+      else if group.isTopic then Some(StudyOrder.mine)
+      else if group.isPersonal then Some(StudyOrder.updated)
+      else Some(StudyOrder.hot)
+    def newOrder(newGroup: StudyGroup): StudyOrder =
+      (if defaultOrder(active).forall(order.contains) then defaultOrder(newGroup) else order)
+        .getOrElse(Orders.default)
+    def activeCls(group: StudyGroup) = cls := (
+      group match
+        case StudyGroup.topic(None) => active.isTopic
+        case _ => group == active
+    ).option("active")
     lila.ui.bits.pageMenuSubnav(
-      a(cls := active.active("all"), href := routes.Study.all(nonMineOrder))(trs.allStudies()),
-      ctx.isAuth.option(bits.authLinks(active, nonMineOrder)),
-      a(cls := List("active" -> active.startsWith("topic")), href := routes.Study.topics):
-        trs.topics()
-      ,
+      a(activeCls(StudyGroup.all), href := routes.Study.all(newOrder(StudyGroup.all)))(trs.allStudies()),
+      ctx.isAuth.option(bits.authLinks(activeCls, newOrder)),
+      a(activeCls(StudyGroup.topic(None)), href := routes.Study.topics)(trs.topics()),
       topics.map: topic =>
-        a(cls := active.active(s"topic:$topic"), href := routes.Study.byTopic(topic.value, order))(
+        val group = StudyGroup.topic(Some(topic.value))
+        a(activeCls(group), href := routes.Study.byTopic(topic.value, newOrder(group)))(
           topic.value
-        ),
-      a(cls := active.active("staffPicks"), href := routes.Study.staffPicks)("Staff picks"),
+        )
+      ,
+      a(activeCls(StudyGroup.staffPicks), href := routes.Study.staffPicks)("Staff picks"),
       a(
         dataIcon := Icon.InfoCircle,
         href := "/@/lichess/blog/study-chess-the-lichess-way/V0KrLSkA"
@@ -191,7 +206,7 @@ final class StudyListUi(helpers: Helpers, bits: StudyBits):
         .css("analyse.study.index", "bits.form3", "bits.tagify")
         .js(Esm("analyse.study.topic.form")):
           main(cls := "page-menu")(
-            menu("topic", StudyOrder.mine, mine.so(_.value)),
+            menu(StudyGroup.topic(None), Some(StudyOrder.mine), mine.so(_.value)),
             main(cls := "page-menu__content study-topics box box-pad")(
               h1(cls := "box__top")(trans.study.topics()),
               myForm.map { form =>
@@ -214,13 +229,13 @@ final class StudyListUi(helpers: Helpers, bits: StudyBits):
         order: StudyOrder,
         myTopics: Option[StudyTopics]
     )(using Context) =
-      val active = s"topic:$topic"
+      val active = StudyGroup.topic(Some(topic.value))
       val url = (o: StudyOrder) => routes.Study.byTopic(topic.value, o)
       Page(topic.value)
         .css("analyse.study.index")
         .js(infiniteScrollEsmInit):
           main(cls := "page-menu")(
-            menu(active, order, myTopics.so(_.value)),
+            menu(active, Some(order), myTopics.so(_.value)),
             main(cls := "page-menu__content study-index box")(
               boxTop(
                 h1(topic.value),


### PR DESCRIPTION
Motivation: to open a study, my process is usually clicking on "My studies", and then changing the order from "Hot" to "Recently updated". I'm usually opening studies I've worked on fairly recently (such as for chess lessons, opening analysis, etc), so sorting this way is the most useful. I think this would apply to almost all users as well (most don't have a big following that like their public studies, for example).

The PR does the following:

- Use different default orders depending on the type of the study group. E.g., for public ones (like `all`), use `hot`. But for personal ones (like `mine`), use `updated`.
- When clicking on a menu button, only carry over the current order if it's not the default one. E.g., if the user changed from hot to newest on `all`, it's reasonable to assume they'd want this order for personal studies as well.
- Another case where we won't carry over the current order is if we're on `staffPicks` or `search`. The former group doesn't use an order; for the latter, lichess already doesn't carry over the current order.
- Adds a `StudyGroup` enum to make the new code (and some current code) cleaner.