### PR TITLE
ui: remove debug logs and guard download API path in gamesDownload

### DIFF
--- a/ui/user/src/user.gamesDownload.ts
+++ b/ui/user/src/user.gamesDownload.ts
@@ -35,11 +35,10 @@ function generateSearchParams(): string {
 function update() {
   const params = generateSearchParams();
   const apiUrl = $('#dl-api-url');
-  console.log(params);
-  console.log(apiUrl.find('input'));
-  apiUrl
-    .find('input')
-    .val(`${window.location.protocol}//${window.location.host}${apiUrl.data('apiPath')}?${params}`);
+  const apiPath = apiUrl.data('apiPath');
+  if (apiPath) {
+    apiUrl.find('input').val(`${window.location.protocol}//${window.location.host}${apiPath}?${params}`);
+  }
   const btn = $('#dl-button');
   btn.prop('href', btn.prop('href').split('?')[0] + '?' + params);
 }


### PR DESCRIPTION
Removes two leftover `console.log` statements that were logging `params` and the jQuery input element on every update call.

Also adds a null-check on `apiPath` before setting the input value to prevent a broken URL like `.../undefined?params` if `apiUrl.data('apiPath')` is undefined.

No linked issue, cleanup of leftover debug code.

Assisted with Claude Code (sonnet 4.6)