### PR TITLE
Some tweaks to `isShouting`

### DIFF
--- a/modules/common/src/main/String.scala
+++ b/modules/common/src/main/String.scala
@@ -40,7 +40,7 @@ object String:
           then word.toLowerCase
           else word
         )
-        .mkString(" ")
+        .mkString
         .take(80)
         .foldLeft(0) { (i, c) =>
           getType(c) match

--- a/modules/common/src/main/String.scala
+++ b/modules/common/src/main/String.scala
@@ -34,7 +34,8 @@ object String:
         .filter(_.nonEmpty)
         .map(word =>
           if Set("O-O", "O-O-O").contains(word.filter(c => c.isLetter || c == '-')) || (
-              Set(8, 9).contains(word.split('/').filter(_.nonEmpty).length) &&
+              word.length < 100 &&
+                Set(8, 9).contains(word.split('/').filter(_.nonEmpty).length) &&
                 Fen.makeBoard(Crazyhouse, word).isDefined
             )
           then word.toLowerCase

--- a/modules/common/src/main/String.scala
+++ b/modules/common/src/main/String.scala
@@ -35,7 +35,7 @@ object String:
         .map(word =>
           if Set("O-O", "O-O-O").contains(word.filter(c => c.isLetter || c == '-')) || (
               word.length < 100 &&
-                Set(8, 9).contains(word.split('/').filter(_.nonEmpty).length) &&
+                Set(8, 9).contains(word.split('/').count(_.nonEmpty)) &&
                 Fen.makeBoard(Crazyhouse, word).isDefined
             )
           then word.toLowerCase

--- a/modules/common/src/main/String.scala
+++ b/modules/common/src/main/String.scala
@@ -33,8 +33,8 @@ object String:
         .filter(_.nonEmpty)
         .map(word =>
           if Set("O-O", "O-O-O").contains(word.filter(c => c.isLetter || c == '-')) || {
-              val rowCount = word.split('/').filter(_.nonEmpty).length
-              (rowCount == 8 || rowCount == 9) &&
+              word.length < 100 &&
+              Set(8, 9).contains(word.split('/').filter(_.nonEmpty).length) &&
               Fen.makeBoard(Crazyhouse, word).isDefined
             }
           then word.toLowerCase

--- a/modules/common/src/main/String.scala
+++ b/modules/common/src/main/String.scala
@@ -23,20 +23,20 @@ object String:
     catch case _: play.utils.InvalidUriEncodingException => None
 
   def isShouting(text: String) =
-    import chess.format.Fen
-    import chess.variant.Crazyhouse
     text.lengthIs >= 5 && {
       import java.lang.Character.*
+      import chess.format.Fen
+      import chess.variant.Crazyhouse
       // true if >1/2 of the latin letters are uppercase (or castling notation / fen board field)
       text
+        .take(1000)
         .split("\\s+")
         .filter(_.nonEmpty)
         .map(word =>
-          if Set("O-O", "O-O-O").contains(word.filter(c => c.isLetter || c == '-')) || {
-              word.length < 100 &&
+          if Set("O-O", "O-O-O").contains(word.filter(c => c.isLetter || c == '-')) || (
               Set(8, 9).contains(word.split('/').filter(_.nonEmpty).length) &&
-              Fen.makeBoard(Crazyhouse, word).isDefined
-            }
+                Fen.makeBoard(Crazyhouse, word).isDefined
+            )
           then word.toLowerCase
           else word
         )

--- a/modules/common/src/main/String.scala
+++ b/modules/common/src/main/String.scala
@@ -23,16 +23,33 @@ object String:
     catch case _: play.utils.InvalidUriEncodingException => None
 
   def isShouting(text: String) =
+    import chess.format.Fen
+    import chess.variant.Crazyhouse
     text.lengthIs >= 5 && {
       import java.lang.Character.*
-      // true if >1/2 of the latin letters are uppercase
-      text.take(80).replace("O-O", "o-o").foldLeft(0) { (i, c) =>
-        getType(c) match
-          case UPPERCASE_LETTER => i + 1
-          case LOWERCASE_LETTER => i - 1
-          case _ => i
-      } > 0
+      // true if >1/2 of the latin letters are uppercase (or castling notation / fen board field)
+      text
+        .split("\\s+")
+        .filter(_.nonEmpty)
+        .map(word =>
+          if Set("O-O", "O-O-O").contains(word.filter(c => c.isLetter || c == '-')) || {
+              val rowCount = word.split('/').filter(_.nonEmpty).length
+              (rowCount == 8 || rowCount == 9) &&
+              Fen.makeBoard(Crazyhouse, word).isDefined
+            }
+          then word.toLowerCase
+          else word
+        )
+        .mkString(" ")
+        .take(80)
+        .foldLeft(0) { (i, c) =>
+          getType(c) match
+            case UPPERCASE_LETTER => i + 1
+            case LOWERCASE_LETTER => i - 1
+            case _ => i
+        } > 0
     }
+
   def noShouting(str: String): String = if isShouting(str) then str.toLowerCase else str
 
   val atUsernameRegex = RawHtml.atUsernameRegex

--- a/modules/web/src/test/common/StringTest.scala
+++ b/modules/web/src/test/common/StringTest.scala
@@ -55,6 +55,25 @@ class StringTest extends munit.FunSuite:
     assertEquals(extractPosts("go/to/some/very/long/path"), Nil)
     assertEquals(extractPosts("Answer me yes/no?"), Nil)
 
-  test("noShouting"):
-    assertEquals(String.noShouting("HELLO SIR"), "hello sir")
-    assertEquals(String.noShouting("1. Nf3 O-O-O#"), "1. Nf3 O-O-O#")
+  test("shouting"):
+    List(
+      "HELLO SIR",
+      "4k3/8/8/8/8/8/PPPPPPPP/RNBQKBNR/8/8 w KQ - 0 1",
+      "4k3/8/8/8/8/8/HI/RNBQKBNR w KQ - 0 1",
+      "Hello" + " " * 90 + "HELLO" * 5,
+      "O-O-O-O",
+      "O-OHI-O",
+      "O-O-OO"
+    ).foreach: testCase =>
+      assert(String.isShouting(testCase))
+      assertEquals(String.noShouting(testCase), testCase.toLowerCase)
+
+  test("not shouting"):
+    List(
+      "1. Nf3 O-O-O#",
+      "4k3/8/8/8/8/8/PPPPPPPP/RNBQKBNR w KQ - 0 1",
+      "FEN: 4k3/8/8/8/8/8/PPPPPPPP/RNBQKBNR w KQ - 0 1.",
+      "FEN: 4k3/8/8/8/8/8/PPPPPPPP/RNBQKBNR/Pp w KQ - 0 1."
+    ).foreach: testCase =>
+      assert(!String.isShouting(testCase))
+      assertEquals(String.noShouting(testCase), testCase)


### PR DESCRIPTION
- Do not treat uppercase chars in FENs as shouting.
- 'O' and '-' repeating past long castling (e.g., 'O-O-O-O') will now be judged as shouting.
- Trim excess whitespace before taking the 80 chars to judge a text.