### PR TITLE
Fix type comparison

### DIFF
--- a/modules/relation/src/main/RelationApi.scala
+++ b/modules/relation/src/main/RelationApi.scala
@@ -119,7 +119,7 @@ final class RelationApi(
       sort = $empty
     ).map(_.userId)
 
-  def follow(u1: User, u2: UserId): Funit = (u1 != u2).so:
+  def follow(u1: User, u2: UserId): Funit = (u1.id != u2).so:
     prefApi.followable(u2).flatMapz {
       userApi.isEnabled(u2).flatMapz {
         fetchRelation(u1, u2).zip(fetchRelation(u2, u1)).flatMap {


### PR DESCRIPTION
Compare `UserId` with `UserId`,
instead of `User` with `UserId`

Before this fix it was possible to follow oneself via the API.
(The API to unfollow oneself is correct though, so it is not possible to unfollow oneself) 

https://lichess.org/forum/lichess-feedback/how-to-unfriend-yourself-1btf

After the fix, it is no longer possible to follow oneself.

(Sidenote,
the API returns status code 200, even when follow/unfollow fails)