### PR TITLE
fix: handle focus-within of the forum reactions in Safari

### DIFF
--- a/modules/forum/src/main/ui/PostUi.scala
+++ b/modules/forum/src/main/ui/PostUi.scala
@@ -157,7 +157,7 @@ final class PostUi(helpers: Helpers, bits: ForumBits):
     val canActuallyReact = canReact && ctx.me.exists(me => !me.isBot && !post.isBy(me))
     val allReactionsVisible =
       ForumPost.Reaction.list.forall(r => (~post.reactions.flatMap(_.get(r))).nonEmpty)
-    div(cls := List("reactions" -> true, "reactions-auth" -> canActuallyReact))(
+    div(cls := List("reactions" -> true, "reactions-auth" -> canActuallyReact), tabindex := -1)(
       (canActuallyReact && !allReactionsVisible).option(
         button(cls := "reactions-toggle", tpe := "button", dataIcon := Icon.PlusButton)
       ),


### PR DESCRIPTION
closes https://github.com/lichess-org/lila/issues/20483

Safari, once again...

https://github.com/user-attachments/assets/f7058707-802b-4037-8c3f-73ede649d15e



