### PR TITLE
Send the same data to Unified Push than the one sent to firebase messaging

### DIFF
--- a/app/controllers/Account.scala
+++ b/app/controllers/Account.scala
@@ -160,7 +160,7 @@ final class Account(
 
   private def refreshSessionId(result: Result, pwned: IsPwned)(using ctx: Context, me: Me): Fu[Result] = for
     _ <- env.security.store.closeAllSessionsOf(me)
-    _ <- env.push.webSubscriptionApi.unsubscribeByUser(me)
+    _ <- env.push.browserSub.unsubscribeByUser(me)
     _ <- env.push.unregisterDevices(me)
     sessionId <- env.security.api.saveAuthentication(me, ctx.mobileApiVersion, pwned)
   yield result.withCookies(env.security.lilaCookie.session(env.security.api.sessionIdKey, sessionId.value))
@@ -356,7 +356,7 @@ final class Account(
     else
       for
         _ <- env.security.store.closeUserAndSessionId(me, SessionId(sessionId))
-        _ <- env.push.webSubscriptionApi.unsubscribeBySession(SessionId(sessionId))
+        _ <- env.push.browserSub.unsubscribeBySession(SessionId(sessionId))
       yield NoContent
   }
 

--- a/app/controllers/Auth.scala
+++ b/app/controllers/Auth.scala
@@ -201,7 +201,7 @@ final class Auth(env: Env, accountC: => Account) extends LilaController(env):
     val sid = env.security.api.reqSessionId(ctx.req)
     for
       _ <- sid.so(env.security.store.delete)
-      _ <- sid.so(env.push.webSubscriptionApi.unsubscribeBySession)
+      _ <- sid.so(env.push.browserSub.unsubscribeBySession)
       res <- negotiate(Redirect(routes.Auth.login), jsonOkResult)
     yield res.withCookies(env.security.lilaCookie.newSession)
 
@@ -452,7 +452,7 @@ final class Auth(env: Env, accountC: => Account) extends LilaController(env):
                   welcome(user, _, sendWelcomeEmail = false)
                 _ <- env.user.repo.disableTwoFactor(user.id)
                 _ <- env.security.store.closeAllSessionsOf(user.id)
-                _ <- env.push.webSubscriptionApi.unsubscribeByUser(user)
+                _ <- env.push.browserSub.unsubscribeByUser(user)
                 _ <- env.push.unregisterDevices(user)
                 res <- authenticateUser(user, remember = true, pwned = IsPwned.No)
               yield

--- a/app/controllers/Push.scala
+++ b/app/controllers/Push.scala
@@ -22,11 +22,12 @@ final class Push(env: Env) extends LilaController(env):
 
     currentSessionId match
       case Some(currentSessionId) =>
+        val api = if ctx.isMobileOauth then env.push.unifiedPushApi else env.push.webSubscriptionApi
         ctx.body.body
           .validate[WebSubscription]
           .fold(
             err => BadRequest(err.toString),
-            data => env.push.webSubscriptionApi.subscribe(me, data, currentSessionId).inject(NoContent)
+            data => api.subscribe(me, data, currentSessionId).inject(NoContent)
           )
       case None => BadRequest("Session ID is missing")
   }

--- a/app/controllers/Push.scala
+++ b/app/controllers/Push.scala
@@ -22,7 +22,7 @@ final class Push(env: Env) extends LilaController(env):
 
     currentSessionId match
       case Some(currentSessionId) =>
-        val api = if ctx.isMobileOauth then env.push.unifiedPushApi else env.push.webSubscriptionApi
+        val api = if ctx.isMobileOauth then env.push.unifiedSub else env.push.browserSub
         ctx.body.body
           .validate[WebSubscription]
           .fold(

--- a/bin/mongodb/unifiedpush-migrate.js
+++ b/bin/mongodb/unifiedpush-migrate.js
@@ -1,0 +1,7 @@
+const result = db.push_subscription.deleteMany({
+  $expr: {
+    $eq: [{ $strLenCP: '$_id' }, 64],
+  },
+});
+
+print(result.deletedCount + ' Unified Push subscriptions deleted');

--- a/conf/base.conf
+++ b/conf/base.conf
@@ -244,6 +244,7 @@ push {
   collection {
     device = push_device
     subscription = push_subscription
+    unifiedpush = push_unifiedpush
   }
   web {
     vapid_public_key = "BGr5CL0QlEYa7qW7HLqe7DFkCeTsYMLsi1Db-5Vwt1QBIs6-WxN8066AjtP8S9u-w-CbleE8xWY-qQaNEMs7sAs"

--- a/modules/api/src/main/AccountTermination.scala
+++ b/modules/api/src/main/AccountTermination.scala
@@ -82,7 +82,7 @@ final class AccountTermination(
     _ <- seekApi.removeByUser(u)
     _ <- securityStore.closeAllSessionsOf(u.id)
     _ <- selfClose.so(tokenApi.revokeAllByUser(u.id))
-    _ <- pushEnv.webSubscriptionApi.unsubscribeByUser(u)
+    _ <- pushEnv.browserSub.unsubscribeByUser(u)
     _ <- pushEnv.unregisterDevices(u)
     _ <- streamerApi.demote(u.id)
     reports <- reportApi.processAndGetBySuspect(lila.report.Suspect(u))

--- a/modules/push/src/main/Env.scala
+++ b/modules/push/src/main/Env.scala
@@ -2,6 +2,7 @@ package lila.push
 
 import akka.actor.*
 import com.softwaremill.macwire.*
+import com.softwaremill.tagging.*
 import play.api.Configuration
 import play.api.libs.ws.StandaloneWSClient
 
@@ -17,6 +18,9 @@ final private class PushConfig(
     val web: WebPush.Config,
     val firebase: FirebasePush.BothConfigs
 )
+
+trait BrowserSub
+trait UnifiedSub
 
 @Module
 final class Env(
@@ -37,26 +41,19 @@ final class Env(
   def vapidPublicKey = config.web.vapidPublicKey
 
   private val deviceApi = DeviceApi(db(config.deviceColl))
-  val webSubscriptionApi = WebSubscriptionApi(db(config.subscriptionColl))
-  val unifiedPushApi = WebSubscriptionApi(db(config.unifiedPushColl))
+
+  val browserSub = WebSubscriptionApi(db(config.subscriptionColl)).taggedWith[BrowserSub]
+  val unifiedSub = WebSubscriptionApi(db(config.unifiedPushColl)).taggedWith[UnifiedSub]
 
   export deviceApi.{ register as registerDevice, unregister as unregisterDevices }
 
-  private lazy val webPush = WebPush(webSubscriptionApi, config.web, ws, isUnifiedPush = false)
-
-  private lazy val unifiedPush = WebPush(unifiedPushApi, config.web, ws, isUnifiedPush = true)
-
-  private lazy val firebasePush = FirebasePush(unifiedPush, deviceApi, ws, config.firebase)
-
-  private lazy val pushApi: PushApi =
-    PushApi(firebasePush, webPush, gameProxy, roundJson, gameRepo, namer, notifyAllows, postApi, getLightUser)
-
-  private def logUnit(f: Fu[?]): Unit =
-    f.logFailure(logger)
-    ()
+  private lazy val browserPush = wire[BrowserWebPush]
+  private lazy val unifiedPush = wire[UnifiedWebPush]
+  private lazy val firebasePush = wire[FirebasePush]
+  private lazy val pushApi = wire[PushApi]
 
   Bus.sub[lila.core.misc.oauth.TokenRevoke]: token =>
-    unifiedPushApi.unsubscribeBySession(token.id)
+    unifiedSub.unsubscribeBySession(token.id)
 
   Bus.sub[lila.core.game.FinishGame]: f =>
     logUnit { pushApi.finish(f.game) }
@@ -85,3 +82,7 @@ final class Env(
 
   Bus.sub[lila.core.misc.push.TourSoon]: t =>
     logUnit { pushApi.tourSoon(t) }
+
+  private def logUnit(f: Fu[?]): Unit =
+    f.logFailure(logger)
+    ()

--- a/modules/push/src/main/Env.scala
+++ b/modules/push/src/main/Env.scala
@@ -13,6 +13,7 @@ import lila.core.config.*
 final private class PushConfig(
     @ConfigName("collection.device") val deviceColl: CollName,
     @ConfigName("collection.subscription") val subscriptionColl: CollName,
+    @ConfigName("collection.unifiedpush") val unifiedPushColl: CollName,
     val web: WebPush.Config,
     val firebase: FirebasePush.BothConfigs
 )
@@ -37,21 +38,25 @@ final class Env(
 
   private val deviceApi = DeviceApi(db(config.deviceColl))
   val webSubscriptionApi = WebSubscriptionApi(db(config.subscriptionColl))
+  val unifiedPushApi = WebSubscriptionApi(db(config.unifiedPushColl))
 
   export deviceApi.{ register as registerDevice, unregister as unregisterDevices }
 
-  private lazy val firebasePush = wire[FirebasePush]
+  private lazy val webPush = WebPush(webSubscriptionApi, config.web, ws, isUnifiedPush = false)
 
-  private lazy val webPush = wire[WebPush]
+  private lazy val unifiedPush = WebPush(unifiedPushApi, config.web, ws, isUnifiedPush = true)
 
-  private lazy val pushApi: PushApi = wire[PushApi]
+  private lazy val firebasePush = FirebasePush(unifiedPush, deviceApi, ws, config.firebase)
+
+  private lazy val pushApi: PushApi =
+    PushApi(firebasePush, webPush, gameProxy, roundJson, gameRepo, namer, notifyAllows, postApi, getLightUser)
 
   private def logUnit(f: Fu[?]): Unit =
     f.logFailure(logger)
     ()
 
   Bus.sub[lila.core.misc.oauth.TokenRevoke]: token =>
-    webSubscriptionApi.unsubscribeBySession(token.id)
+    unifiedPushApi.unsubscribeBySession(token.id)
 
   Bus.sub[lila.core.game.FinishGame]: f =>
     logUnit { pushApi.finish(f.game) }

--- a/modules/push/src/main/FirebasePush.scala
+++ b/modules/push/src/main/FirebasePush.scala
@@ -11,7 +11,7 @@ import scalalib.data.LazyFu
 import lila.mon.extensions.*
 
 final private class FirebasePush(
-    unifiedPush: WebPush,
+    unifiedPush: UnifiedWebPush,
     deviceApi: DeviceApi,
     ws: StandaloneWSClient,
     configs: FirebasePush.BothConfigs

--- a/modules/push/src/main/FirebasePush.scala
+++ b/modules/push/src/main/FirebasePush.scala
@@ -11,6 +11,7 @@ import scalalib.data.LazyFu
 import lila.mon.extensions.*
 
 final private class FirebasePush(
+    unifiedPush: WebPush,
     deviceApi: DeviceApi,
     ws: StandaloneWSClient,
     configs: FirebasePush.BothConfigs
@@ -30,6 +31,7 @@ final private class FirebasePush(
     )
 
   def apply(userId: UserId, data: LazyFu[PushApi.Data]): Funit =
+    unifiedPush(userId, data)
     deviceApi
       .findLastManyByUserId("firebase", 3)(userId)
       .flatMap:
@@ -81,28 +83,20 @@ final private class FirebasePush(
       )
       .post:
         Json.obj(
-          "message" -> Json
-            .obj(
-              "token" -> device._id,
-              "data" -> toDataKeyValue:
-                data.firebaseMod.match
-                  case Some(PushApi.Data.FirebaseMod.NotifOnly(mod)) => mod(data.payload.userData)
-                  case _ =>
-                    data.payload.userData ++ (data.iosBadge.map: number =>
-                      "iosBadge" -> number.toString),
-              "android" -> Json.obj("priority" -> "high")
-            )
-            .add:
-              "notification" -> data.firebaseMod.match
-                case Some(PushApi.Data.FirebaseMod.DataOnly) => none
-                case _ => Json.obj("body" -> data.body, "title" -> data.title).some
-            .add:
-              "apns" -> data.iosBadge.map: number =>
-                Json.obj(
-                  "headers" -> Json.obj("apns-priority" -> "10"),
-                  "payload" -> Json.obj:
-                    "aps" -> Json.obj("badge" -> number)
-                )
+          "message" ->
+            FirebasePush
+              .makeMobilePayload(data)
+              .add:
+                "token" -> device._id.some
+              .add:
+                "android" -> Json.obj("priority" -> "high").some
+              .add:
+                "apns" -> data.iosBadge.map: number =>
+                  Json.obj(
+                    "headers" -> Json.obj("apns-priority" -> "10"),
+                    "payload" -> Json.obj:
+                      "aps" -> Json.obj("badge" -> number)
+                  )
         )
       .flatMap: res =>
         val project = if device.isMobile then "mobileV2" else "lichobile"
@@ -117,12 +111,6 @@ final private class FirebasePush(
         else
           if errorCounter(res.status) then logger.warn(s"[push] firebase: ${res.status}")
           funit
-
-  private def toDataKeyValue(data: PushApi.Data.KeyValue): JsObject = JsObject:
-    data.view
-      .map: (k, v) =>
-        s"lichess.$k" -> JsString(v)
-      .toMap
 
 private object FirebasePush:
 
@@ -144,3 +132,24 @@ private object FirebasePush:
   import lila.common.config.given
   given ConfigLoader[Config] = AutoConfig.loader[Config]
   given ConfigLoader[BothConfigs] = AutoConfig.loader[BothConfigs]
+
+  def makeMobilePayload(data: PushApi.Data): JsObject =
+    Json
+      .obj(
+        "data" -> toDataKeyValue:
+          data.firebaseMod.match
+            case Some(PushApi.Data.FirebaseMod.NotifOnly(mod)) => mod(data.payload.userData)
+            case _ =>
+              data.payload.userData ++ (data.iosBadge.map: number =>
+                "iosBadge" -> number.toString)
+      )
+      .add:
+        "notification" -> data.firebaseMod.match
+          case Some(PushApi.Data.FirebaseMod.DataOnly) => none
+          case _ => Json.obj("body" -> data.body, "title" -> data.title).some
+
+  private def toDataKeyValue(data: PushApi.Data.KeyValue): JsObject = JsObject:
+    data.view
+      .map: (k, v) =>
+        s"lichess.$k" -> JsString(v)
+      .toMap

--- a/modules/push/src/main/PushApi.scala
+++ b/modules/push/src/main/PushApi.scala
@@ -434,7 +434,7 @@ private object PushApi:
       mobileCompatible: Option[LichessMobileVersion] = None,
       lichobileCompatible: Boolean = false,
       iosBadge: Option[Int] = None,
-      // https://firebase.google.com/docs/cloud-messaging/concept-options#data_messages
+      // https://firebase.google.com/docs/cloud-messaging/customize-messages/set-message-type
       firebaseMod: Option[Data.FirebaseMod] = None
   )
 

--- a/modules/push/src/main/PushApi.scala
+++ b/modules/push/src/main/PushApi.scala
@@ -16,7 +16,7 @@ import lila.core.net.LichessMobileVersion
 
 final private class PushApi(
     firebasePush: FirebasePush,
-    webPush: WebPush,
+    webPush: BrowserWebPush,
     gameProxy: lila.core.game.GameProxy,
     roundJson: lila.core.round.RoundJson,
     gameRepo: lila.core.game.GameRepo,

--- a/modules/push/src/main/WebPush.scala
+++ b/modules/push/src/main/WebPush.scala
@@ -1,5 +1,6 @@
 package lila.push
 
+import com.softwaremill.tagging.*
 import play.api.ConfigLoader
 import play.api.libs.json.*
 import play.api.libs.ws.JsonBodyReadables.*
@@ -11,24 +12,14 @@ import lila.common.Json.given
 import lila.common.autoconfig.*
 import lila.mon.extensions.*
 
-final private class WebPush(
-    webSubscriptionApi: WebSubscriptionApi,
+final private class BrowserWebPush(
+    webSub: WebSubscriptionApi @@ BrowserSub,
     config: WebPush.Config,
-    ws: StandaloneWSClient,
-    isUnifiedPush: Boolean
-)(using Executor):
+    ws: StandaloneWSClient
+)(using Executor)
+    extends WebPush(webSub, config, ws):
 
-  def apply(userId: UserId, data: LazyFu[PushApi.Data]): Funit =
-    webSubscriptionApi.getSubscriptions(5)(userId).flatMap(sendTo(data, List(userId)))
-
-  def apply(userIds: Iterable[UserId], data: LazyFu[PushApi.Data]): Funit =
-    webSubscriptionApi.getSubscriptions(userIds, 5).flatMap(sendTo(data, userIds))
-
-  private def sendTo(data: LazyFu[PushApi.Data], to: Iterable[UserId])(subs: List[WebSubscription]): Funit =
-    subs.toNel.so: subs =>
-      data.value.flatMap(send(subs, to))
-
-  private def makeWebPayload(data: PushApi.Data): JsObject =
+  protected def makeWebPayload(data: PushApi.Data) =
     Json.obj(
       "title" -> data.title,
       "body" -> data.body,
@@ -37,6 +28,33 @@ final private class WebPush(
         .obj("userData" -> data.payload.userData.toMap)
         .add("userId" -> data.payload.userId)
     )
+
+final private class UnifiedWebPush(
+    webSub: WebSubscriptionApi @@ UnifiedSub,
+    config: WebPush.Config,
+    ws: StandaloneWSClient
+)(using Executor)
+    extends WebPush(webSub, config, ws):
+
+  protected def makeWebPayload(data: PushApi.Data) = FirebasePush.makeMobilePayload(data)
+
+private abstract class WebPush(
+    browserSub: WebSubscriptionApi,
+    config: WebPush.Config,
+    ws: StandaloneWSClient
+)(using Executor):
+
+  protected def makeWebPayload(data: PushApi.Data): JsObject
+
+  def apply(userId: UserId, data: LazyFu[PushApi.Data]): Funit =
+    browserSub.getSubscriptions(5)(userId).flatMap(sendTo(data, List(userId)))
+
+  def apply(userIds: Iterable[UserId], data: LazyFu[PushApi.Data]): Funit =
+    browserSub.getSubscriptions(userIds, 5).flatMap(sendTo(data, userIds))
+
+  private def sendTo(data: LazyFu[PushApi.Data], to: Iterable[UserId])(subs: List[WebSubscription]): Funit =
+    subs.toNel.so: subs =>
+      data.value.flatMap(send(subs, to))
 
   private def send(allSubscriptions: NonEmptyList[WebSubscription], to: Iterable[UserId])(
       data: PushApi.Data
@@ -59,8 +77,7 @@ final private class WebPush(
                     )
                   )
                 }.toList),
-                "payload" -> (if isUnifiedPush then FirebasePush.makeMobilePayload(data)
-                              else makeWebPayload(data)).toString,
+                "payload" -> makeWebPayload(data).toString,
                 "topic" -> data.stacking.key,
                 "urgency" -> data.urgency.key,
                 "ttl" -> 43200
@@ -76,7 +93,7 @@ final private class WebPush(
                       case (endpoint, JsString("endpoint_not_valid" | "endpoint_not_found")) => endpoint
                   .filter(_.nonEmpty)
                   .so: staleEndpoints =>
-                    webSubscriptionApi
+                    browserSub
                       .unsubscribeByEndpoints(staleEndpoints, to)
                       .map: n =>
                         logger.info(s"[push] web: $n/${staleEndpoints.size} stale endpoints unsubscribed")

--- a/modules/push/src/main/WebPush.scala
+++ b/modules/push/src/main/WebPush.scala
@@ -14,7 +14,8 @@ import lila.mon.extensions.*
 final private class WebPush(
     webSubscriptionApi: WebSubscriptionApi,
     config: WebPush.Config,
-    ws: StandaloneWSClient
+    ws: StandaloneWSClient,
+    isUnifiedPush: Boolean
 )(using Executor):
 
   def apply(userId: UserId, data: LazyFu[PushApi.Data]): Funit =
@@ -26,6 +27,16 @@ final private class WebPush(
   private def sendTo(data: LazyFu[PushApi.Data], to: Iterable[UserId])(subs: List[WebSubscription]): Funit =
     subs.toNel.so: subs =>
       data.value.flatMap(send(subs, to))
+
+  private def makeWebPayload(data: PushApi.Data): JsObject =
+    Json.obj(
+      "title" -> data.title,
+      "body" -> data.body,
+      "tag" -> data.stacking.key,
+      "payload" -> Json
+        .obj("userData" -> data.payload.userData.toMap)
+        .add("userId" -> data.payload.userId)
+    )
 
   private def send(allSubscriptions: NonEmptyList[WebSubscription], to: Iterable[UserId])(
       data: PushApi.Data
@@ -48,16 +59,8 @@ final private class WebPush(
                     )
                   )
                 }.toList),
-                "payload" -> Json
-                  .obj(
-                    "title" -> data.title,
-                    "body" -> data.body,
-                    "tag" -> data.stacking.key,
-                    "payload" -> Json
-                      .obj("userData" -> data.payload.userData.toMap)
-                      .add("userId" -> data.payload.userId)
-                  )
-                  .toString,
+                "payload" -> (if isUnifiedPush then FirebasePush.makeMobilePayload(data)
+                              else makeWebPayload(data)).toString,
                 "topic" -> data.stacking.key,
                 "urgency" -> data.urgency.key,
                 "ttl" -> 43200


### PR DESCRIPTION
Before the data sent to the mobile app through Unified Push was the same as the web. Now it sends the same data as the one sent through firebase messaging.
    
The web push collection was split in 2 with a collection for web push subscriptions and one for the Unified Push subscriptions.