### PR TITLE
ui: small visual tweaks for round table and child elements

### DIFF
--- a/ui/round/css/_control.scss
+++ b/ui/round/css/_control.scss
@@ -6,6 +6,17 @@
     margin: 0;
   }
 
+  button {
+    @extend %box-radius;
+
+    &.resign,
+    &.abort {
+      &:hover {
+        background: $c-bad;
+      }
+    }
+  }
+
   .disabled {
     opacity: 0.5;
     cursor: not-allowed;

--- a/ui/round/css/_control.scss
+++ b/ui/round/css/_control.scss
@@ -1,6 +1,7 @@
 .rcontrols {
   text-align: center;
   width: 100%;
+  z-index: 1;
 
   p {
     margin: 0;
@@ -11,7 +12,7 @@
 
     &.resign,
     &.abort {
-      &:hover {
+      &:not(.disabled):hover {
         background: $c-bad;
       }
     }

--- a/ui/round/css/_table.scss
+++ b/ui/round/css/_table.scss
@@ -1,5 +1,6 @@
 .round__app__table {
   @extend %box-radius, %box-shadow;
+  @include backdrop-blur-if-transparent;
 
   background: $c-bg-box;
 }

--- a/ui/round/css/_table.scss
+++ b/ui/round/css/_table.scss
@@ -1,5 +1,5 @@
 .round__app__table {
-  @extend %box-radius-right, %box-shadow;
+  @extend %box-radius, %box-shadow;
 
   background: $c-bg-box;
 }

--- a/ui/round/css/_user.scss
+++ b/ui/round/css/_user.scss
@@ -7,6 +7,7 @@
   align-items: center;
   font-size: 1.2em;
   padding: 0 0.3em;
+  z-index: 1;
 
   &:hover {
     color: $c-font;


### PR DESCRIPTION
# Why

When working on nudge for user powertip I have spotted small UI things which can be improved in round table component.

# How

Summary:
* apply even rounding for the table, since it does not touch any element on the left, lack of rounded corner there felt a bit off
* apply round borders to the round control buttons
* use red background on hover for actions finishing the game (abort/retire)
* add backdrop blur to the round table in transparent theme mode

# Preview

https://github.com/user-attachments/assets/acd4564a-a0c5-4b28-97f8-db2b7419794d

<img width="358" height="336" alt="Screenshot 2026-05-21 at 14 05 40" src="https://github.com/user-attachments/assets/ec7fd0b6-87b9-4d10-af7f-6b0debb7c255" />

<img width="438" height="325" alt="Screenshot 2026-05-21 at 14 13 01" src="https://github.com/user-attachments/assets/86652318-c7c7-4b21-9839-4d713d9a1ee6" />
