### PR TITLE
Broadcast form grouping ease of life features

### DIFF
--- a/app/controllers/RelayTour.scala
+++ b/app/controllers/RelayTour.scala
@@ -209,7 +209,7 @@ final class RelayTour(env: Env, apiC: => Api, roundC: => RelayRound) extends Lil
       then Redirect(routes.RelayTour.show(group.name.toSlug, id.into(RelayTourId)))
       else
         for
-          allTours <- env.relay.api.toursByIds(group.tours)
+          allTours <- env.relay.api.toursByIds(group.tours.toList)
           tours = if isGrantedOpt(_.StudyAdmin) then allTours else allTours.filter(_.canView)
           page <- Ok.page(views.relay.group.show(group, tours))
         yield page

--- a/modules/clas/src/main/ClasForm.scala
+++ b/modules/clas/src/main/ClasForm.scala
@@ -66,7 +66,7 @@ final class ClasForm(
       mapping(
         "username" -> lila.common.Form.username.historicalField
           .verifying("Unknown username", { blockingFetchUser(_).exists(!_.isBot) })
-          .verifying("This is a teacher", u => !c.teachers.toList.contains(u.id)),
+          .verifying("This is a teacher", u => !c.teachers.contains(u.id)),
         "realName" -> cleanNonEmptyText.into[RealName]
       )(InviteStudent.apply)(unapply)
 

--- a/modules/core/src/main/lilaism/LilaLibraryExtensions.scala
+++ b/modules/core/src/main/lilaism/LilaLibraryExtensions.scala
@@ -149,6 +149,8 @@ trait LilaLibraryExtensions extends CoreExports:
       list.iterator
         .foldLeft(funit)((fr, fa) => fr.zipWith(fa)((_, _) => ()))
 
+  extension [A](nel: NonEmptyList[A]) def contains(a: A): Boolean = nel.head == a || nel.tail.contains(a)
+
   extension [A](fua: Fu[A])
 
     infix def >>[B](fub: => Fu[B])(using Executor): Fu[B] =

--- a/modules/game/src/main/CaptchaApi.scala
+++ b/modules/game/src/main/CaptchaApi.scala
@@ -20,7 +20,7 @@ final private class CaptchaApi(gameRepo: GameRepo)(using Executor) extends ICapt
     case Some(c) => fuccess(c)
 
   def validate(gameId: GameId, move: String): Fu[Boolean] =
-    get(gameId).map(_.solutions.toList contains move)
+    get(gameId).map(_.solutions.contains(move))
 
   def validateSync(data: WithCaptcha): Boolean =
     validate(data.gameId, data.move).await(2.seconds, "CaptchaApi.validateSync")

--- a/modules/relay/src/main/RelayApi.scala
+++ b/modules/relay/src/main/RelayApi.scala
@@ -241,7 +241,7 @@ final class RelayApi(
           "orphanWarn" -> tour.orphanWarn.some
         )
       )
-      _ <- data.grouping.so(updateGrouping(tour, _))
+      _ <- updateGrouping(tour, data.grouping)
       _ <- playerEnrich.onPlayerTextareaUpdate(tour, prev)
       _ <- (tour.visibility != prev.visibility).so(studyPropagation.onVisibilityChange(tour))
       _ <- tour.markup.so:
@@ -251,7 +251,7 @@ final class RelayApi(
       players.invalidate(tour.id)
       teamLeaderboard.invalidate(tour.id)
       studyIds.foreach(preview.invalidate)
-      (tour.id :: data.grouping.so(_.tourIds)).foreach(withTours.invalidate)
+      (tour.id :: data.grouping.tourIds).foreach(withTours.invalidate)
 
   private def updateGrouping(tour: RelayTour, data: RelayGroupData)(using me: Me): Funit =
     for

--- a/modules/relay/src/main/RelayApi.scala
+++ b/modules/relay/src/main/RelayApi.scala
@@ -155,9 +155,9 @@ final class RelayApi(
     private val cache = cacheApi[RelayTourId, Option[RelayGroup.WithTours]](256, "relay.groupWithTours"):
       _.expireAfterWrite(1.minute).buildAsyncFuture: id =>
         for
-          group <- groupRepo.byTour(id)
-          tours <- tourRepo.previews(group.so(_.tours))
-        yield group.map(RelayGroup.WithTours(_, tours))
+          groupOpt <- groupRepo.byTour(id)
+          toursList <- tourRepo.previews(groupOpt.so(_.tours.toList))
+        yield (groupOpt, toursList.toNel).mapN(RelayGroup.WithTours.apply)
     export cache.get
     def addTo(tour: RelayTour): Fu[RelayTour.WithGroupTours] =
       get(tour.id).map(RelayTour.WithGroupTours(tour, _))

--- a/modules/relay/src/main/RelayDefaults.scala
+++ b/modules/relay/src/main/RelayDefaults.scala
@@ -18,7 +18,7 @@ final class RelayDefaults(
       groupRepo
         .byId(groupId)
         .flatMapz: group =>
-          tourRepo.byIds(group.tours).map(RelayDefaults.defaultTourOfGroup)
+          tourRepo.byIds(group.tours.toList).map(RelayDefaults.defaultTourOfGroup)
 
   private def tourWithRounds(id: RelayTourId): Fu[Option[RelayTour.WithRounds]] =
     tourRepo.coll

--- a/modules/relay/src/main/RelayGroup.scala
+++ b/modules/relay/src/main/RelayGroup.scala
@@ -8,11 +8,11 @@ import lila.common.Form.cleanNonEmptyText
 case class RelayGroup(
     @Key("_id") id: RelayGroupId,
     name: RelayGroup.Name,
-    tours: List[RelayTourId],
+    tours: NonEmptyList[RelayTourId],
     scoreGroups: Option[List[ScoreGroup]]
 ):
   def scoreGroupOf(tourId: RelayTourId): Option[ScoreGroup] =
-    scoreGroups.flatMap(_.find(_.toList.contains(tourId)))
+    scoreGroups.flatMap(_.find(_.contains(tourId)))
 
 object RelayGroup:
 
@@ -31,25 +31,27 @@ object RelayGroup:
         val s = scalalib.StringOps.slug(name.value)
         if s.isEmpty then "-" else s
 
-  case class WithTours(group: RelayGroup, tours: List[RelayTour.TourPreview]):
+  case class WithTours(group: RelayGroup, tours: NonEmptyList[RelayTour.TourPreview]):
     def withShorterTourNames = copy(
       tours = tours.map: tour =>
         tour.copy(name = group.name.shortTourName(tour.name))
     )
 
 private case class RelayGroupData(
-    info: RelayGroupData.Info,
+    info: Option[RelayGroupData.Info],
     scoreGroups: Option[List[ScoreGroup]]
 ):
-  def tourIds = info.tours.map(_.id)
-  def update(group: RelayGroup): RelayGroup =
-    group.copy(name = info.name, tours = tourIds, scoreGroups = scoreGroups)
-  def make: RelayGroup = RelayGroup(RelayGroup.makeId, info.name, tourIds, scoreGroups)
+  def tourIds: List[RelayTourId] = info.so(_.tours.toList.map(_.id))
+  def update(group: RelayGroup): Option[RelayGroup] =
+    info.map: i =>
+      group.copy(name = i.name, tours = i.tours.map(_.id), scoreGroups = scoreGroups)
+  def make: Option[RelayGroup] = info.map: i =>
+    RelayGroup(RelayGroup.makeId, i.name, i.tours.map(_.id), scoreGroups)
 
 object RelayGroupData:
   case class Info(
       name: RelayGroup.Name,
-      tours: List[RelayTour.TourPreview]
+      tours: NonEmptyList[RelayTour.TourPreview]
   )
 
 private final class RelayGroupForm:
@@ -59,7 +61,7 @@ private final class RelayGroupForm:
 
   def data(group: RelayGroup.WithTours) =
     RelayGroupData(
-      RelayGroupData.Info(group.group.name, group.tours),
+      RelayGroupData.Info(group.group.name, group.tours).some,
       group.group.scoreGroups
     )
 
@@ -79,16 +81,11 @@ private final class RelayGroupForm:
     scoreGroup.toList.map(_.value).mkString(",")
 
   private def scoreGroupParse(value: String): Option[ScoreGroup] =
-    value
-      .split(",")
-      .toList
-      .map(_.trim)
-      .flatMap(parseId)
-      .toNel
+    value.split(",").toList.map(_.trim).flatMap(parseId).toNel
 
   private def allIdsFromGroup(tourIds: List[RelayTourId], scoreGroups: List[ScoreGroup]): Boolean =
     val groupTourIds = tourIds.toSet
-    scoreGroups.flatMap(_.toList).forall(id => groupTourIds.contains(id))
+    scoreGroups.flatMap(_.toList).forall(groupTourIds.contains)
 
   private def noOverlappingScoreGroups(scoreGroups: List[ScoreGroup]): Boolean =
     val ids = scoreGroups.flatMap(_.toList)
@@ -104,13 +101,13 @@ private final class RelayGroupForm:
       .toNel
       .map(_.map(RelayTour.TourPreview(_, RelayTour.Name(""), active = false, live = none)))
 
-  private def toursAsText(tours: List[TourPreview]): String =
-    tours.map(t => s"${t.name},${t.id}").mkString("\n")
+  private def toursAsText(tours: NonEmptyList[TourPreview]): String =
+    tours.toList.map(t => s"${t.name},${t.id}").mkString("\n")
 
   val infoMapping: Mapping[RelayGroupData.Info] =
     Forms.mapping(
       "name" -> cleanNonEmptyText,
-      "tours" -> of(using formatter.stringOptionFormatter(toursAsText, txt => toursParse(txt).map(_.toList)))
+      "tours" -> of(using formatter.stringOptionFormatter(toursAsText, toursParse))
     )((name, tours) => RelayGroupData.Info(RelayGroup.Name(name), tours))(info =>
       Some((info.name.value, info.tours))
     )
@@ -126,9 +123,7 @@ private final class RelayGroupForm:
     .mapping(
       "info" -> optional(infoMapping),
       "scoreGroups" -> scoreGroupsMapping
-    )((info, scoreGroups) =>
-      RelayGroupData(info.getOrElse(RelayGroupData.Info(RelayGroup.Name(""), List())), scoreGroups)
-    )(data => Some(data.info.some, data.scoreGroups))
+    )(RelayGroupData.apply)(unapply)
     .verifying(
       "Score groups cannot contain broadcasts not present in this group",
       data => data.scoreGroups.forall(allIdsFromGroup(data.tourIds, _))
@@ -149,23 +144,24 @@ final private class RelayGroupRepo(coll: Coll)(using Executor):
   def byTours(tourIds: Seq[RelayTourId]): Fu[List[RelayGroup]] =
     coll.find($doc("tours".$in(tourIds))).cursor[RelayGroup]().listAll()
 
-  def allTourIdsOfGroup(tourId: RelayTourId): Fu[List[RelayTourId]] =
-    byTour(tourId).map(_.fold(List(tourId))(_.tours))
+  def allTourIdsOfGroup(tourId: RelayTourId): Fu[NonEmptyList[RelayTourId]] =
+    byTour(tourId).map(_.fold(NonEmptyList.one(tourId))(_.tours))
 
   def update(tourId: RelayTourId, data: RelayGroupData): Funit =
     for
       prev <- byTour(tourId)
-      curId <- prev match
-        case Some(prev) if data.info.tours.isEmpty => coll.delete.one($id(prev.id)).inject(none)
-        case Some(prev) => coll.update.one($id(prev.id), data.update(prev)).inject(prev.id.some)
+      current <- prev match
+        case Some(prev) =>
+          data.update(prev) match
+            case None => coll.delete.one($id(prev.id)).inject(none)
+            case Some(next) => coll.update.one($id(prev.id), next).inject(prev.some)
         case None =>
-          val newGroup = data.make
-          coll.insert.one(newGroup).inject(newGroup.id.some)
+          data.make.so: group =>
+            coll.insert.one(group).inject(group.some)
       // make sure the tours of this group are not in other groups
-      _ <- curId.so: id =>
-        data.tourIds.sequentiallyVoid { tourId =>
-          coll.update.one($doc("_id".$ne(id), "tours" -> tourId), $pull("tours" -> tourId), multi = true)
-        }
+      _ <- current.so: cur =>
+        cur.tours.toList.traverseVoid: tour =>
+          coll.update.one($doc("_id".$ne(cur.id), "tours" -> tour), $pull("tours" -> tour), multi = true)
     yield ()
 
 final class RelayGroupCrowdSumCache(
@@ -184,7 +180,7 @@ final class RelayGroupCrowdSumCache(
       tourIds <- groupRepo.allTourIdsOfGroup(tourId)
       res <- colls.round.aggregateOne(_.sec): framework =>
         import framework.*
-        Match($doc("tourId".$in(tourIds), "crowdAt".$gt(nowInstant.minus(1.hours)))) ->
+        Match($doc("tourId".$in(tourIds.toList), "crowdAt".$gt(nowInstant.minus(1.hours)))) ->
           List(Group(BSONNull)("sum" -> SumField("crowd")))
     yield res.headOption.flatMap(_.int("sum")).orZero
 

--- a/modules/relay/src/main/RelayGroup.scala
+++ b/modules/relay/src/main/RelayGroup.scala
@@ -3,7 +3,7 @@ package lila.relay
 import reactivemongo.api.bson.Macros.Annotations.Key
 import lila.relay.RelayGroup.ScoreGroup
 import lila.relay.RelayTour.TourPreview
-import lila.common.Form.cleanNonEmptyText
+import lila.common.Form.{ into, cleanNonEmptyText }
 
 case class RelayGroup(
     @Key("_id") id: RelayGroupId,
@@ -106,11 +106,9 @@ private final class RelayGroupForm:
 
   val infoMapping: Mapping[RelayGroupData.Info] =
     Forms.mapping(
-      "name" -> cleanNonEmptyText,
+      "name" -> cleanNonEmptyText.into[RelayGroup.Name],
       "tours" -> of(using formatter.stringOptionFormatter(toursAsText, toursParse))
-    )((name, tours) => RelayGroupData.Info(RelayGroup.Name(name), tours))(info =>
-      Some((info.name.value, info.tours))
-    )
+    )(RelayGroupData.Info.apply)(unapply)
 
   val scoreGroupsMapping: Mapping[Option[List[ScoreGroup]]] = optional(
     list(optional(of(using formatter.stringOptionFormatter(scoreGroupAsText, scoreGroupParse))))

--- a/modules/relay/src/main/RelayGroup.scala
+++ b/modules/relay/src/main/RelayGroup.scala
@@ -75,15 +75,16 @@ private final class RelayGroupForm:
           case _ => none
       yield RelayTourId(id)
 
-  private val scoreGroupsMapping = nonEmptyText.transform[List[ScoreGroup]](
-    _.split("\n").toList
+  private def scoreGroupAsText(scoreGroup: ScoreGroup): String =
+    scoreGroup.toList.map(_.value).mkString(",")
+
+  private def scoreGroupParse(value: String): Option[ScoreGroup] =
+    value
+      .split(",")
+      .toList
       .map(_.trim)
-      .filter(_.nonEmpty)
-      .flatMap:
-        _.split(",").take(50).map(_.trim).filter(_.nonEmpty).flatMap(parseId).distinct.toList.toNel
-    ,
-    _.map(_.toList.mkString(",")).mkString("\n")
-  )
+      .flatMap(parseId)
+      .toNel
 
   private def allIdsFromGroup(tourIds: List[RelayTourId], scoreGroups: List[ScoreGroup]): Boolean =
     val groupTourIds = tourIds.toSet
@@ -119,7 +120,9 @@ private final class RelayGroupForm:
   val mapping = Forms
     .mapping(
       "info" -> optional(infoMapping),
-      "scoreGroups" -> optional(scoreGroupsMapping)
+      "scoreGroups" -> optional(
+        list(of(using formatter.stringOptionFormatter(scoreGroupAsText, scoreGroupParse)))
+      )
     )((info, scoreGroups) =>
       RelayGroupData(info.getOrElse(RelayGroupData.Info(RelayGroup.Name(""), List())), scoreGroups)
     )(data => Some(data.info.some, data.scoreGroups))

--- a/modules/relay/src/main/RelayGroup.scala
+++ b/modules/relay/src/main/RelayGroup.scala
@@ -9,7 +9,7 @@ case class RelayGroup(
     @Key("_id") id: RelayGroupId,
     name: RelayGroup.Name,
     tours: NonEmptyList[RelayTourId],
-    scoreGroups: Option[List[ScoreGroup]]
+    scoreGroups: Option[NonEmptyList[ScoreGroup]]
 ):
   def scoreGroupOf(tourId: RelayTourId): Option[ScoreGroup] =
     scoreGroups.flatMap(_.find(_.contains(tourId)))
@@ -39,7 +39,7 @@ object RelayGroup:
 
 private case class RelayGroupData(
     info: Option[RelayGroupData.Info],
-    scoreGroups: Option[List[ScoreGroup]]
+    scoreGroups: Option[NonEmptyList[ScoreGroup]]
 ):
   def tourIds: List[RelayTourId] = info.so(_.tours.toList.map(_.id))
   def update(group: RelayGroup): Option[RelayGroup] =
@@ -76,18 +76,12 @@ private final class RelayGroupForm:
           case _ => none
       yield RelayTourId(id)
 
-  private def scoreGroupAsText(scoreGroup: ScoreGroup): String =
-    scoreGroup.toList.map(_.value).mkString(",")
-
-  private def scoreGroupParse(value: String): Option[ScoreGroup] =
-    value.split(",").toList.map(_.trim).flatMap(parseId).toNel
-
-  private def allIdsFromGroup(tourIds: List[RelayTourId], scoreGroups: List[ScoreGroup]): Boolean =
+  private def allIdsFromGroup(tourIds: List[RelayTourId], scoreGroups: NonEmptyList[ScoreGroup]): Boolean =
     val groupTourIds = tourIds.toSet
-    scoreGroups.flatMap(_.toList).forall(groupTourIds.contains)
+    scoreGroups.toList.flatMap(_.toList).forall(groupTourIds.contains)
 
-  private def noOverlappingScoreGroups(scoreGroups: List[ScoreGroup]): Boolean =
-    val ids = scoreGroups.flatMap(_.toList)
+  private def noOverlappingScoreGroups(scoreGroups: NonEmptyList[ScoreGroup]): Boolean =
+    val ids = scoreGroups.toList.flatMap(_.toList)
     ids.distinct.size == ids.size
 
   private def toursParse(value: String): Option[NonEmptyList[TourPreview]] =
@@ -109,16 +103,23 @@ private final class RelayGroupForm:
       "tours" -> of(using formatter.stringOptionFormatter(toursAsText, toursParse))
     )(RelayGroupData.Info.apply)(unapply)
 
-  val scoreGroupsMapping: Mapping[List[ScoreGroup]] =
-    list(optional(of(using formatter.stringOptionFormatter(scoreGroupAsText, scoreGroupParse))))
+  val scoreGroupsMapping: Mapping[Option[NonEmptyList[ScoreGroup]]] =
+    def scoreGroupAsText(scoreGroup: ScoreGroup): String =
+      scoreGroup.toList.map(_.value).mkString(",")
+    def scoreGroupParse(value: String): Option[ScoreGroup] =
+      value.split(",").toList.map(_.trim).flatMap(parseId).toNel
+    val scoreGroupMapping: FieldMapping[NonEmptyList[RelayTourId]] =
+      of(using formatter.stringOptionFormatter(scoreGroupAsText, scoreGroupParse))
+    list(optional(scoreGroupMapping))
       .transform(_.flatten, _.map(some))
-      .verifying("Too many score groups (max 10)", _.sizeIs <= 10)
-      .verifying("Score groups cannot have overlapping broadcasts", noOverlappingScoreGroups)
+      .transform(_.toNel, _.so(_.toList))
+      .verifying("Too many score groups (max 10)", _.forall(_.size <= 10))
+      .verifying("Score groups cannot have overlapping broadcasts", _.forall(noOverlappingScoreGroups))
 
   val mapping = Forms
     .mapping(
       "info" -> optional(infoMapping),
-      "scoreGroups" -> optional(scoreGroupsMapping)
+      "scoreGroups" -> scoreGroupsMapping
     )(RelayGroupData.apply)(unapply)
     .verifying(
       "Score groups cannot contain broadcasts not present in this group",

--- a/modules/relay/src/main/RelayGroup.scala
+++ b/modules/relay/src/main/RelayGroup.scala
@@ -117,22 +117,23 @@ private final class RelayGroupForm:
       Some((info.name.value, info.tours))
     )
 
+  val scoreGroupsMapping: Mapping[Option[List[ScoreGroup]]] = optional(
+    list(optional(of(using formatter.stringOptionFormatter(scoreGroupAsText, scoreGroupParse))))
+      .transform(_.flatten, _.map(some))
+  )
+    .verifying("Too many score groups (max 10)", _.forall(_.sizeIs <= 10))
+    .verifying("Score groups cannot have overlapping broadcasts", _.forall(noOverlappingScoreGroups))
+
   val mapping = Forms
     .mapping(
       "info" -> optional(infoMapping),
-      "scoreGroups" -> optional(
-        list(of(using formatter.stringOptionFormatter(scoreGroupAsText, scoreGroupParse)))
-      )
+      "scoreGroups" -> scoreGroupsMapping
     )((info, scoreGroups) =>
       RelayGroupData(info.getOrElse(RelayGroupData.Info(RelayGroup.Name(""), List())), scoreGroups)
     )(data => Some(data.info.some, data.scoreGroups))
     .verifying(
-      "score groups cannot contain broadcasts not present in this group",
+      "Score groups cannot contain broadcasts not present in this group",
       data => data.scoreGroups.forall(allIdsFromGroup(data.tourIds, _))
-    )
-    .verifying(
-      "score groups cannot have overlapping broadcasts",
-      data => data.scoreGroups.forall(noOverlappingScoreGroups)
     )
 
 import lila.db.dsl.{ *, given }

--- a/modules/relay/src/main/RelayGroup.scala
+++ b/modules/relay/src/main/RelayGroup.scala
@@ -94,17 +94,15 @@ private final class RelayGroupForm:
     val ids = scoreGroups.flatMap(_.toList)
     ids.distinct.size == ids.size
 
-  private def toursParse(value: String): Option[List[TourPreview]] =
+  private def toursParse(value: String): Option[NonEmptyList[TourPreview]] =
     value
       .split("\n")
       .toList
-      .nonEmptyOption
-      .map: lines =>
-        lines
-          .take(50)
-          .map(_.trim.takeWhile(' ' != _))
-          .flatMap(parseId)
-          .map(RelayTour.TourPreview(_, RelayTour.Name(""), active = false, live = none))
+      .take(50)
+      .map(_.trim.takeWhile(' ' != _))
+      .flatMap(parseId)
+      .toNel
+      .map(_.map(RelayTour.TourPreview(_, RelayTour.Name(""), active = false, live = none)))
 
   private def toursAsText(tours: List[TourPreview]): String =
     tours.map(t => s"${t.name},${t.id}").mkString("\n")
@@ -112,7 +110,7 @@ private final class RelayGroupForm:
   val infoMapping: Mapping[RelayGroupData.Info] =
     Forms.mapping(
       "name" -> cleanNonEmptyText,
-      "tours" -> of(using formatter.stringOptionFormatter(toursAsText, toursParse))
+      "tours" -> of(using formatter.stringOptionFormatter(toursAsText, txt => toursParse(txt).map(_.toList)))
     )((name, tours) => RelayGroupData.Info(RelayGroup.Name(name), tours))(info =>
       Some((info.name.value, info.tours))
     )

--- a/modules/relay/src/main/RelayGroup.scala
+++ b/modules/relay/src/main/RelayGroup.scala
@@ -49,21 +49,20 @@ private case class RelayGroupData(
     RelayGroup(RelayGroup.makeId, i.name, i.tours.map(_.id), scoreGroups)
 
 object RelayGroupData:
-  case class Info(
-      name: RelayGroup.Name,
-      tours: NonEmptyList[RelayTour.TourPreview]
-  )
+  def empty = RelayGroupData(none, none)
+  case class Info(name: RelayGroup.Name, tours: NonEmptyList[RelayTour.TourPreview])
 
 private final class RelayGroupForm:
   import play.api.data.*
   import play.api.data.Forms.*
   import lila.common.Form.formatter
 
-  def data(group: RelayGroup.WithTours) =
-    RelayGroupData(
-      RelayGroupData.Info(group.group.name, group.tours).some,
-      group.group.scoreGroups
-    )
+  def data(group: Option[RelayGroup.WithTours]) =
+    group.fold(RelayGroupData.empty): group =>
+      RelayGroupData(
+        RelayGroupData.Info(group.group.name, group.tours).some,
+        group.group.scoreGroups
+      )
 
   private def parseId(str: String): Option[RelayTourId] =
     def looksLikeId(id: String): Boolean = id.size == 8 && id.forall(_.isLetterOrDigit)
@@ -110,17 +109,16 @@ private final class RelayGroupForm:
       "tours" -> of(using formatter.stringOptionFormatter(toursAsText, toursParse))
     )(RelayGroupData.Info.apply)(unapply)
 
-  val scoreGroupsMapping: Mapping[Option[List[ScoreGroup]]] = optional(
+  val scoreGroupsMapping: Mapping[List[ScoreGroup]] =
     list(optional(of(using formatter.stringOptionFormatter(scoreGroupAsText, scoreGroupParse))))
       .transform(_.flatten, _.map(some))
-  )
-    .verifying("Too many score groups (max 10)", _.forall(_.sizeIs <= 10))
-    .verifying("Score groups cannot have overlapping broadcasts", _.forall(noOverlappingScoreGroups))
+      .verifying("Too many score groups (max 10)", _.sizeIs <= 10)
+      .verifying("Score groups cannot have overlapping broadcasts", noOverlappingScoreGroups)
 
   val mapping = Forms
     .mapping(
       "info" -> optional(infoMapping),
-      "scoreGroups" -> scoreGroupsMapping
+      "scoreGroups" -> optional(scoreGroupsMapping)
     )(RelayGroupData.apply)(unapply)
     .verifying(
       "Score groups cannot contain broadcasts not present in this group",

--- a/modules/relay/src/main/RelayGroup.scala
+++ b/modules/relay/src/main/RelayGroup.scala
@@ -1,8 +1,9 @@
 package lila.relay
 
 import reactivemongo.api.bson.Macros.Annotations.Key
-import lila.core.config.RouteUrl
 import lila.relay.RelayGroup.ScoreGroup
+import lila.relay.RelayTour.TourPreview
+import lila.common.Form.cleanNonEmptyText
 
 case class RelayGroup(
     @Key("_id") id: RelayGroupId,
@@ -51,10 +52,9 @@ object RelayGroupData:
       tours: List[RelayTour.TourPreview]
   )
 
-private final class RelayGroupForm(routeUrl: RouteUrl):
+private final class RelayGroupForm:
   import play.api.data.*
   import play.api.data.Forms.*
-  import play.api.data.format.Formatter
   import lila.common.Form.formatter
 
   def data(group: RelayGroup.WithTours) =
@@ -93,28 +93,32 @@ private final class RelayGroupForm(routeUrl: RouteUrl):
     val ids = scoreGroups.flatMap(_.toList)
     ids.distinct.size == ids.size
 
-  private def infoParse(value: String): Option[RelayGroupData.Info] =
-    value.split("\n").toList match
-      case Nil => none
-      case name :: tourIds =>
-        val tours = tourIds
+  private def toursParse(value: String): Option[List[TourPreview]] =
+    value
+      .split("\n")
+      .toList
+      .nonEmptyOption
+      .map: lines =>
+        lines
           .take(50)
           .map(_.trim.takeWhile(' ' != _))
           .flatMap(parseId)
           .map(RelayTour.TourPreview(_, RelayTour.Name(""), active = false, live = none))
-        RelayGroupData.Info(RelayGroup.Name(name.linesIterator.next().trim), tours).some
 
-  private def infoAsText(info: RelayGroupData.Info): String =
-    val name = info.name.value
-    val tourUrls = info.tours.map(t => s"${routeUrl(routes.RelayTour.show(t.name.toSlug, t.id))}")
-    (name :: tourUrls).mkString("\n")
+  private def toursAsText(tours: List[TourPreview]): String =
+    tours.map(t => s"${t.name},${t.id}").mkString("\n")
 
-  given Formatter[RelayGroupData.Info] = formatter.stringOptionFormatter(infoAsText, infoParse)
-  val infoMapping: Mapping[Option[RelayGroupData.Info]] = optional(of[RelayGroupData.Info])
+  val infoMapping: Mapping[RelayGroupData.Info] =
+    Forms.mapping(
+      "name" -> cleanNonEmptyText,
+      "tours" -> of(using formatter.stringOptionFormatter(toursAsText, toursParse))
+    )((name, tours) => RelayGroupData.Info(RelayGroup.Name(name), tours))(info =>
+      Some((info.name.value, info.tours))
+    )
 
   val mapping = Forms
     .mapping(
-      "info" -> infoMapping,
+      "info" -> optional(infoMapping),
       "scoreGroups" -> optional(scoreGroupsMapping)
     )((info, scoreGroups) =>
       RelayGroupData(info.getOrElse(RelayGroupData.Info(RelayGroup.Name(""), List())), scoreGroups)

--- a/modules/relay/src/main/RelayListing.scala
+++ b/modules/relay/src/main/RelayListing.scala
@@ -120,7 +120,7 @@ private final class RelayListing(
       .filter(t => !groups.exists(_.tours.contains(t.tour.id)))
       .map(Spot.UngroupedTour.apply)
     val groupedTours: List[Spot] = groups.flatMap: group =>
-      group.tours.flatMap(toursById.get).toNel.map(Spot.GroupWithTours(group, _))
+      group.tours.toList.flatMap(toursById.get).toNel.map(Spot.GroupWithTours(group, _))
     ungroupedTours ::: groupedTours
 
   private def toursWithRounds: Fu[List[RelayTour.WithRounds]] =

--- a/modules/relay/src/main/RelayStudyPropagation.scala
+++ b/modules/relay/src/main/RelayStudyPropagation.scala
@@ -30,7 +30,7 @@ private final class RelayStudyPropagation(
               groupRepo
                 .allTourIdsOfGroup(tourId)
                 .flatMap:
-                  _.sequentiallyVoid: tourId =>
+                  _.toList.sequentiallyVoid: tourId =>
                     roundRepo
                       .studyIdsOf(tourId)
                       .flatMap:

--- a/modules/relay/src/main/RelayTour.scala
+++ b/modules/relay/src/main/RelayTour.scala
@@ -43,7 +43,7 @@ case class RelayTour(
 
   def official = tier.isDefined
 
-  def isOwnedBy[U: UserIdOf](u: U): Boolean = ownerIds.toList.contains(u.id)
+  def isOwnedBy[U: UserIdOf](u: U): Boolean = ownerIds.contains(u.id)
 
   def communityOwner: Option[UserId] = tier.isEmpty.option(ownerIds.head)
 

--- a/modules/relay/src/main/RelayTourForm.scala
+++ b/modules/relay/src/main/RelayTourForm.scala
@@ -69,7 +69,7 @@ final class RelayTourForm(langList: lila.core.i18n.LangList, groupForm: RelayGro
       ),
       "showTeamScores" -> boolean,
       "spotlight" -> optional(spotlightMapping),
-      "grouping" -> optional(groupForm.mapping),
+      "grouping" -> groupForm.mapping,
       "pinnedStream" -> optional(pinnedStreamMapping),
       "note" -> optional(nonEmptyText(maxLength = 20_000)),
       "orphanWarn" -> boolean
@@ -107,7 +107,7 @@ final class RelayTourForm(langList: lila.core.i18n.LangList, groupForm: RelayGro
       teams = tour.teams,
       showTeamScores = tour.showTeamScores,
       spotlight = tour.spotlight,
-      grouping = group.map(groupForm.data),
+      grouping = groupForm.data(group),
       pinnedStream = tour.pinnedStream,
       note = tour.note,
       orphanWarn = tour.orphanWarn
@@ -133,7 +133,7 @@ object RelayTourForm:
       teams: Option[RelayTeamsTextarea] = none,
       showTeamScores: Boolean = false,
       spotlight: Option[RelayTour.Spotlight] = none,
-      grouping: Option[RelayGroupData] = none,
+      grouping: RelayGroupData = RelayGroupData.empty,
       pinnedStream: Option[RelayPinnedStream] = none,
       note: Option[String] = none,
       orphanWarn: Boolean = true

--- a/modules/relay/src/main/ui/RelayFormUi.scala
+++ b/modules/relay/src/main/ui/RelayFormUi.scala
@@ -73,7 +73,7 @@ final class RelayFormUi(helpers: Helpers, ui: RelayUi, pageMenu: RelayMenuUi):
         case Some(g) =>
           frag(
             span(cls := "relay-form__subnav__group")(g.group.name),
-            g.withShorterTourNames.tours.map: t =>
+            g.withShorterTourNames.tours.toList.map: t =>
               if nav.tour.id == t.id then tourAndRounds(t.name.some)
               else a(href := routes.RelayTour.edit(t.id), cls := List("subnav__item" -> true))(t.name)
           )

--- a/modules/relay/src/main/ui/RelayFormUi.scala
+++ b/modules/relay/src/main/ui/RelayFormUi.scala
@@ -752,7 +752,7 @@ Team Dogs ; Scooby Doo"""),
           )
         ,
         tg.map: t =>
-          form3.fieldset("Grouping", toggle = false.some):
+          form3.fieldset("Grouping", toggle = form.errors("grouping").nonEmpty.some):
             grouping(form, t)
         ,
         if Granter.opt(_.Relay) then
@@ -878,7 +878,6 @@ Team Dogs ; Scooby Doo"""),
 
   private def grouping(form: Form[RelayTourForm.Data], twg: RelayTour.WithGroupTours)(using Context) =
     val tour = twg.tour
-    val group = twg.group
     val disabledGroup = (tour.tier.isDefined && !Granter.opt(_.Relay)).option(disabled)
     def scoreGroupInput(sgIndex: Int) =
       form3.group(form(s"grouping.scoreGroups[$sgIndex]"), s"Score Group ${sgIndex + 1}")(
@@ -927,9 +926,11 @@ Team Dogs ; Scooby Doo"""),
           br,
           "A score group combines players and games between two or more broadcasts.",
           br,
-          "Each input defines a new score group with comma-separated tournament IDs.",
+          "Each input defines a new score group.",
           br,
           "Only tournaments that are part of this group can be used in score groups.",
+          br,
+          "Score groups cannot overlap.",
           br,
           "Settings for scores, rating diffs and tiebreaks are taken from the first tournament in each score group.",
           br,
@@ -944,9 +945,10 @@ Team Dogs ; Scooby Doo"""),
           br,
           "2) Combines the women's section"
         ).some
-      )(_ =>
-        group
-          .flatMap(_.group.scoreGroups)
-          .fold(scoreGroupInput(0))(sgs => sgs.zipWithIndex.map((_, i) => scoreGroupInput(i)))
+      )(field =>
+        frag(
+          errMsg(form("grouping")),
+          (field.indexes.toList.nonEmptyOption.fold(scoreGroupInput(0))(_.map(scoreGroupInput)))
+        )
       )
     )

--- a/modules/relay/src/main/ui/RelayFormUi.scala
+++ b/modules/relay/src/main/ui/RelayFormUi.scala
@@ -753,7 +753,7 @@ Team Dogs ; Scooby Doo"""),
         ,
         tg.map: t =>
           form3.fieldset("Grouping", toggle = false.some):
-            grouping(form, t.tour)
+            grouping(form, t)
         ,
         if Granter.opt(_.Relay) then
           frag(
@@ -876,8 +876,14 @@ Team Dogs ; Scooby Doo"""),
         )
       )
 
-  private def grouping(form: Form[RelayTourForm.Data], tour: RelayTour)(using Context) =
+  private def grouping(form: Form[RelayTourForm.Data], twg: RelayTour.WithGroupTours)(using Context) =
+    val tour = twg.tour
+    val group = twg.group
     val disabledGroup = (tour.tier.isDefined && !Granter.opt(_.Relay)).option(disabled)
+    def scoreGroupInput(sgIndex: Int) =
+      form3.group(form(s"grouping.scoreGroups[$sgIndex]"), s"Score Group ${sgIndex + 1}")(
+        form3.textarea(_)(rows := 1, spellcheck := "false", cls := "monospace", disabledGroup)
+      )
     div(cls := "relay-form__grouping")(
       form3.group(
         form("grouping.info.name"),
@@ -903,6 +909,7 @@ Team Dogs ; Scooby Doo"""),
   https://lichess.org/broadcast/dutch-championships-2025--open--first-stage/ISdmqct3
   https://lichess.org/broadcast/dutch-championships-2025--women--first-stage/PGFBkEha
   https://lichess.org/broadcast/dutch-championships-2025--open--quarterfinals/Zi12QchK
+  https://lichess.org/broadcast/dutch-championships-2025--women--quarterfinals/xfLp6UlH
   """)
         ).some
       )(
@@ -917,20 +924,29 @@ Team Dogs ; Scooby Doo"""),
         form("grouping.scoreGroups"),
         "Optional: Divide the group into score groups",
         help = frag(
-          "Each line defines a new score group with comma-separated tournament IDs.",
+          br,
+          "A score group combines players and games between two or more broadcasts.",
+          br,
+          "Each input defines a new score group with comma-separated tournament IDs.",
           br,
           "Only tournaments that are part of this group can be used in score groups.",
           br,
           "Settings for scores, rating diffs and tiebreaks are taken from the first tournament in each score group.",
           br,
-          "Example:",
-          pre("""ISdmqct3,Zi12QchK
-PGFBkEha"""),
+          "Example: " +
+            "Score group 1",
+          pre("""ISdmqct3,Zi12QchK"""),
+          "Score group 2",
+          pre("""PGFBkEha, xfLp6UlH"""),
           "Using the same example as above, this will create 2 score groups:",
           br,
           "1) Combines the open sections",
           br,
-          "2) Is the lone women's section"
+          "2) Combines the women's section"
         ).some
-      )(form3.textarea(_)(rows := 3, spellcheck := "false", cls := "monospace", disabledGroup))
+      )(_ =>
+        group
+          .flatMap(_.group.scoreGroups)
+          .fold(scoreGroupInput(0))(sgs => sgs.zipWithIndex.map((_, i) => scoreGroupInput(i)))
+      )
     )

--- a/modules/relay/src/main/ui/RelayFormUi.scala
+++ b/modules/relay/src/main/ui/RelayFormUi.scala
@@ -480,7 +480,7 @@ Hanna Marie ; Kozul, Zdenko"""),
             esmInit("bits.broadcastForm.i18nCheck"),
             esmInitObj(
               "bits.broadcastGroup",
-              Json.obj("studyadmin" -> Granter.opt(_.StudyAdmin), "broadcaster" -> Granter.opt(_.Relay))
+              Json.obj("studyAdmin" -> Granter.opt(_.StudyAdmin), "broadcaster" -> Granter.opt(_.Relay))
             )
           )
             .map(some)

--- a/modules/relay/src/main/ui/RelayFormUi.scala
+++ b/modules/relay/src/main/ui/RelayFormUi.scala
@@ -904,15 +904,7 @@ Team Dogs ; Scooby Doo"""),
           br,
           "You can also re-order tournaments by dragging.",
           br,
-          "If the tournament you want is not listed in the dropdown you can paste the link to the tournament.",
-          br,
-          "Example:",
-          pre("""
-  https://lichess.org/broadcast/dutch-championships-2025--open--first-stage/ISdmqct3
-  https://lichess.org/broadcast/dutch-championships-2025--women--first-stage/PGFBkEha
-  https://lichess.org/broadcast/dutch-championships-2025--open--quarterfinals/Zi12QchK
-  https://lichess.org/broadcast/dutch-championships-2025--women--quarterfinals/xfLp6UlH
-  """)
+          "If the tournament you want is not listed in the dropdown you can paste the link to the tournament."
         ).some
       )(
         form3.textarea(_)(

--- a/modules/relay/src/main/ui/RelayFormUi.scala
+++ b/modules/relay/src/main/ui/RelayFormUi.scala
@@ -752,7 +752,10 @@ Team Dogs ; Scooby Doo"""),
           )
         ,
         tg.map: t =>
-          form3.fieldset("Grouping", toggle = form.errors("grouping").nonEmpty.some):
+          form3.fieldset(
+            "Grouping",
+            toggle = form.errors.exists(_.key.contains("grouping")).some
+          ):
             grouping(form, t)
         ,
         if Granter.opt(_.Relay) then

--- a/modules/relay/src/main/ui/RelayFormUi.scala
+++ b/modules/relay/src/main/ui/RelayFormUi.scala
@@ -6,6 +6,7 @@ import lila.ui.*
 import lila.ui.ScalatagsTemplate.{ given, * }
 import lila.core.study.Visibility
 import chess.tiebreak.Tiebreak
+import play.api.libs.json.Json
 
 case class FormNavigation(
     group: Option[RelayGroup.WithTours],
@@ -96,8 +97,13 @@ final class RelayFormUi(helpers: Helpers, ui: RelayUi, pageMenu: RelayMenuUi):
     private def page(title: String, nav: FormNavigation)(using Context) =
       Page(title)
         .css("bits.relay.form")
-        .js(List(Esm("bits.flatpickr"), Esm("bits.relayForm")).map(some))
-        .js(esmInit("bits.broadcastForm.i18nCheck"))
+        .js(
+          List(
+            Esm("bits.flatpickr"),
+            Esm("bits.relayForm"),
+            esmInit("bits.broadcastForm.i18nCheck")
+          ).map(some)
+        )
         .i18n(_.broadcast)
         .wrap: body =>
           main(cls := "page page-menu")(
@@ -467,9 +473,18 @@ Hanna Marie ; Kozul, Zdenko"""),
 
     private def page(title: String, menu: Either[String, FormNavigation])(using Context) =
       Page(title)
-        .css("bits.relay.form")
-        .js(Esm("bits.relayForm"))
-        .js(esmInit("bits.broadcastForm.i18nCheck"))
+        .css("bits.relay.form", "bits.tagify")
+        .js(
+          List(
+            Esm("bits.relayForm"),
+            esmInit("bits.broadcastForm.i18nCheck"),
+            esmInitObj(
+              "bits.broadcastGroup",
+              Json.obj("studyadmin" -> Granter.opt(_.StudyAdmin), "broadcaster" -> Granter.opt(_.Relay))
+            )
+          )
+            .map(some)
+        )
         .i18n(_.broadcast)
         .wrap: body =>
           main(cls := "page page-menu")(
@@ -862,30 +877,40 @@ Team Dogs ; Scooby Doo"""),
       )
 
   private def grouping(form: Form[RelayTourForm.Data], tour: RelayTour)(using Context) =
+    val disabledGroup = (tour.tier.isDefined && !Granter.opt(_.Relay)).option(disabled)
     div(cls := "relay-form__grouping")(
       form3.group(
-        form("grouping.info"),
-        "Optional: assign tournaments to a group",
+        form("grouping.info.name"),
+        "Optional: Group name",
+        help = frag("Name of the overall group. Example: Dutch Championships 2025").some
+      )(
+        form3.input(_)(disabledGroup)
+      ),
+      form3.group(
+        form("grouping.info.tours"),
+        "Optional: Broadcasts part of this group",
         help = frag( // do not translate
-          "First line is the group name.",
+          "Select tournaments from your 20 most recent broadcasts.",
           br,
-          "Subsequent lines are URLs of tournaments that will be part of the group.",
+          "You can add and remove tournaments.",
           br,
-          "You can add, remove, and re-order tournaments; and you can rename the group.",
+          "You can also re-order tournaments by dragging.",
+          br,
+          "If the tournament you want is not listed in the dropdown you can paste the link to the tournament.",
           br,
           "Example:",
-          pre("""Dutch Championships 2025
-https://lichess.org/broadcast/dutch-championships-2025--open--first-stage/ISdmqct3
-https://lichess.org/broadcast/dutch-championships-2025--women--first-stage/PGFBkEha
-https://lichess.org/broadcast/dutch-championships-2025--open--quarterfinals/Zi12QchK
-""")
+          pre("""
+  https://lichess.org/broadcast/dutch-championships-2025--open--first-stage/ISdmqct3
+  https://lichess.org/broadcast/dutch-championships-2025--women--first-stage/PGFBkEha
+  https://lichess.org/broadcast/dutch-championships-2025--open--quarterfinals/Zi12QchK
+  """)
         ).some
       )(
         form3.textarea(_)(
           rows := 5,
           spellcheck := "false",
           cls := "monospace",
-          (tour.tier.isDefined && !Granter.opt(_.Relay)).option(disabled)
+          disabledGroup
         )
       ),
       form3.group(
@@ -907,5 +932,5 @@ PGFBkEha"""),
           br,
           "2) Is the lone women's section"
         ).some
-      )(form3.textarea(_)(rows := 3, spellcheck := "false", cls := "monospace"))
+      )(form3.textarea(_)(rows := 3, spellcheck := "false", cls := "monospace", disabledGroup))
     )

--- a/modules/relay/src/main/ui/RelayFormUi.scala
+++ b/modules/relay/src/main/ui/RelayFormUi.scala
@@ -927,18 +927,7 @@ Team Dogs ; Scooby Doo"""),
           br,
           "Score groups cannot overlap.",
           br,
-          "Settings for scores, rating diffs and tiebreaks are taken from the first tournament in each score group.",
-          br,
-          "Example: " +
-            "Score group 1",
-          pre("""ISdmqct3,Zi12QchK"""),
-          "Score group 2",
-          pre("""PGFBkEha, xfLp6UlH"""),
-          "Using the same example as above, this will create 2 score groups:",
-          br,
-          "1) Combines the open sections",
-          br,
-          "2) Combines the women's section"
+          "Settings for scores, rating diffs and tiebreaks are taken from the first tournament in each score group."
         ).some
       )(field =>
         frag(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -157,6 +157,9 @@ importers:
       '@types/qrcode':
         specifier: ^1.5.6
         version: 1.5.6
+      '@types/sortablejs':
+        specifier: ^1.15.9
+        version: 1.15.9
       '@types/yaireo__tagify':
         specifier: 4.27.0
         version: 4.27.0
@@ -211,6 +214,9 @@ importers:
       shepherd.js:
         specifier: 11.2.0
         version: 11.2.0
+      sortablejs:
+        specifier: ^1.15.6
+        version: 1.15.6
       zxcvbn:
         specifier: ^4.4.2
         version: 4.4.2

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -56,7 +56,7 @@ object Dependencies {
   }
 
   object scalalib {
-    val version = "11.10.5"
+    val version = "11.10.6"
     val org = "com.github.lichess-org.scalalib"
     // val org = "org.lichess" // for publishLocal
     val core = org %% "scalalib-core" % version

--- a/ui/bits/css/relay/_form.scss
+++ b/ui/bits/css/relay/_form.scss
@@ -80,6 +80,11 @@
   display: block;
 }
 
+.relay-score-group-plus {
+  margin-top: -1em;
+  text-align: center;
+}
+
 @include mq-subnav-side {
   .relay-form__subnav__group {
     display: block;

--- a/ui/bits/package.json
+++ b/ui/bits/package.json
@@ -11,6 +11,7 @@
     "@types/debounce-promise": "^3.1.9",
     "@types/fnando__sparkline": "^0.3.7",
     "@types/qrcode": "^1.5.6",
+    "@types/sortablejs": "^1.15.9",
     "@types/yaireo__tagify": "4.27.0",
     "@types/zxcvbn": "^4.4.5",
     "@yaireo/tagify": "4.17.9",
@@ -29,6 +30,7 @@
     "prosemirror-view": "1.41.3",
     "qrcode": "^1.5.4",
     "shepherd.js": "11.2.0",
+    "sortablejs": "^1.15.6",
     "zxcvbn": "^4.4.2"
   },
   "build": {

--- a/ui/bits/src/bits.broadcastGroup.ts
+++ b/ui/bits/src/bits.broadcastGroup.ts
@@ -122,9 +122,11 @@ export default function initModule(opts: { studyAdmin: boolean; broadcaster: boo
 
   const plusButton = document.createElement('button');
   plusButton.type = 'button';
-  plusButton.className = 'button';
-  plusButton.textContent = '+';
-  plusButton.style.marginInlineStart = '45%';
+  plusButton.className = 'button button-thin';
+  plusButton.textContent = 'Add another score group';
+  const plusWrap = document.createElement('div');
+  plusWrap.className = 'relay-score-group-plus';
+  plusWrap.appendChild(plusButton);
 
   const inputWithoutTagify = $('[id*="_scoreGroups_"]').last().parent().clone();
   plusButton.addEventListener('mousedown', () => {
@@ -143,7 +145,7 @@ export default function initModule(opts: { studyAdmin: boolean; broadcaster: boo
     newLast.insertAfter(lastEl);
   });
 
-  $('[id*="_scoreGroups_"]').last().parent()[0]?.insertAdjacentElement('afterend', plusButton);
+  $('[id*="_scoreGroups_"]').last().parent()[0]?.insertAdjacentElement('afterend', plusWrap);
 
   const makeSgTagify = (el: HTMLTextAreaElement) => {
     const sgTagify = makeTourTagify(el);

--- a/ui/bits/src/bits.broadcastGroup.ts
+++ b/ui/bits/src/bits.broadcastGroup.ts
@@ -11,7 +11,7 @@ type CurrentPageResults = {
 type BroadcastByUser = { id: string; name: string; tier?: number; communityOwner?: LightUser };
 type BroadcastTag = { value: string; name: string };
 
-export default function initModule(opts: { studyadmin: boolean; broadcaster: boolean }): void {
+export default function initModule(opts: { studyAdmin: boolean; broadcaster: boolean }): void {
   const textArea = document.querySelector<HTMLTextAreaElement>('#form3-grouping_info_tours');
   if (!textArea) return;
   let myBroadcasts: BroadcastByUser[] | null = null;
@@ -89,7 +89,7 @@ export default function initModule(opts: { studyadmin: boolean; broadcaster: boo
         .then(
           tour => {
             if (
-              !opts.studyadmin ||
+              !opts.studyAdmin ||
               (!opts.broadcaster && !tour.tier && tour.communityOwner?.id !== myUserId())
             )
               replaceErrTag('Insufficient permissions to group this broadcast');

--- a/ui/bits/src/bits.broadcastGroup.ts
+++ b/ui/bits/src/bits.broadcastGroup.ts
@@ -21,7 +21,7 @@ export default function initModule(opts: { studyadmin: boolean; broadcaster: boo
     .map(t => t.trim())
     .filter(t => t.length > 0);
 
-  const tagify = new Tagify<BroadcastTag>(textArea, {
+  const groups = new Tagify<BroadcastTag>(textArea, {
     enforceWhitelist: true,
     keepInvalidTags: true, // Persist bad tags so that users can hover and see the reason why it was rejected
     duplicates: false,
@@ -34,37 +34,36 @@ export default function initModule(opts: { studyadmin: boolean; broadcaster: boo
     maxTags: 50,
     originalInputValueFormat: tags => tags.map(t => t.value).join('\n'),
     readonly: textArea.disabled,
-    texts: { notAllowed: 'Invalid broadcast ID or insufficient permissions' },
   });
 
-  tagify.removeAllTags();
+  groups.removeAllTags();
   const preExisting = fromServer.map<BroadcastTag>(t => ({ value: t.slice(-8), name: t.slice(0, -9) }));
   if (preExisting.length) {
-    tagify.whitelist = preExisting;
-    tagify.addTags(preExisting);
+    groups.whitelist = preExisting;
+    groups.addTags(preExisting);
   }
 
-  Sortable.create(tagify.DOM.scope, {
+  Sortable.create(groups.DOM.scope, {
     filter: '.tagify__input',
     onEnd: () => {
-      tagify.updateValueByDOMTags();
+      groups.updateValueByDOMTags();
     },
   });
 
   const fetchMyBroadcasts = async () => {
     if (myBroadcasts === null) {
-      tagify.loading(true);
+      groups.loading(true);
       const resp = await xhrJson(`/api/broadcast/by/${myUserId()}`);
       const results = resp['currentPageResults'] as CurrentPageResults;
       myBroadcasts = results.map(t => t.tour).filter(t => opts.broadcaster || !t.tier);
-      tagify.whitelist = tagify.whitelist.map(t => (typeof t === 'string' ? { value: t, name: t } : t));
-      tagify.whitelist = tagify.whitelist.concat(
+      groups.whitelist = groups.whitelist.map(t => (typeof t === 'string' ? { value: t, name: t } : t));
+      groups.whitelist = groups.whitelist.concat(
         myBroadcasts
           .map(b => ({ value: b.id, name: b.name }))
-          .filter(b => !tagify.whitelist.some(t => typeof t !== 'string' && t.value === b.value)),
+          .filter(b => !groups.whitelist.some(t => typeof t !== 'string' && t.value === b.value)),
       );
-      tagify.loading(false);
-      tagify.dropdown.show();
+      groups.loading(false);
+      groups.dropdown.show();
     }
   };
 
@@ -73,9 +72,9 @@ export default function initModule(opts: { studyadmin: boolean; broadcaster: boo
   const fetchBroadcastAndVerify = throttle(
     3000,
     async (invalidData: InvalidTagEventData<BroadcastTag>, broadcastId: string) => {
-      tagify.loading(true);
+      groups.loading(true);
       const replaceErrTag = (msg: string) =>
-        tagify.replaceTag(invalidData.tag, {
+        groups.replaceTag(invalidData.tag, {
           ...invalidData.data,
           // @ts-ignore
           __isValid: msg,
@@ -90,11 +89,11 @@ export default function initModule(opts: { studyadmin: boolean; broadcaster: boo
               replaceErrTag('Insufficient permissions to group this broadcast');
             else {
               const newTag = { value: tour.id, name: tour.name };
-              tagify.whitelist = [
-                ...(tagify.whitelist as BroadcastTag[]).filter(t => t.value !== tour.id),
+              groups.whitelist = [
+                ...(groups.whitelist as BroadcastTag[]).filter(t => t.value !== tour.id),
                 newTag,
               ];
-              tagify.replaceTag(invalidData.tag, newTag);
+              groups.replaceTag(invalidData.tag, newTag);
             }
           },
           () => {
@@ -102,16 +101,64 @@ export default function initModule(opts: { studyadmin: boolean; broadcaster: boo
           },
         )
         .finally(() => {
-          tagify.loading(false);
+          groups.loading(false);
         });
     },
   );
 
-  tagify.on('focus', fetchMyBroadcasts);
-  tagify.on('invalid', e => {
+  groups.on('focus', fetchMyBroadcasts);
+  groups.on('invalid', e => {
     const data = e.detail.data;
     const validIDRegex = /(?:^|(?:broadcast(?:\/.*)?\/))(\w{8})(?:\/edit)?$/; // 8 character ID OR Tour URL OR edit URL
     const match = data?.name.match(validIDRegex);
     if (data?.name && match) fetchBroadcastAndVerify(e.detail, match[1]);
   });
+
+  const plusButton = document.createElement('button');
+  plusButton.type = 'button';
+  plusButton.className = 'button';
+  plusButton.textContent = '+';
+  plusButton.style.marginInlineStart = '45%';
+
+  const inputWithoutTagify = $('[id*="_scoreGroups_"]').last().parent().clone();
+  plusButton.addEventListener('mousedown', () => {
+    const lastEl = $('[id*="_scoreGroups_"]').last().parent();
+    const newLast = inputWithoutTagify.clone();
+    const textArea = newLast.find('textarea');
+    const newIndex = $('[id*="_scoreGroups_"]').length;
+    if (newIndex >= 10) return;
+    textArea.attr('id', `form3-grouping_scoreGroups_${newIndex}`);
+    textArea.attr('name', `grouping.scoreGroups[${newIndex}]`);
+    textArea.val('');
+    const label = newLast.find('label');
+    label.attr('for', `form3-grouping_scoreGroups_${newIndex}`);
+    label.text(`Score Group ${newIndex + 1}`);
+    makeSgTagify(textArea[0] as HTMLTextAreaElement);
+    newLast.insertAfter(lastEl);
+  });
+
+  $('[id*="_scoreGroups_"]').last().parent()[0]?.insertAdjacentElement('afterend', plusButton);
+
+  const makeSgTagify = (el: HTMLTextAreaElement) => {
+    const sgTagify = new Tagify<BroadcastTag>(el, {
+      enforceWhitelist: true,
+      whitelist: groups.whitelist,
+      dropdown: {
+        enabled: 0,
+        mapValueTo: 'name',
+        searchKeys: ['name'],
+      },
+      tagTextProp: 'name',
+      originalInputValueFormat: tags => tags.map(t => t.value).join(','),
+    });
+    const preExisting = el.value
+      .split(',')
+      .map(id => groups.whitelist.find(t => typeof t !== 'string' && t.value === id))
+      .filter(t => typeof t === 'object');
+    sgTagify.removeAllTags();
+    sgTagify.addTags(preExisting);
+    groups.on('edit:updated', () => (sgTagify.whitelist = groups.whitelist));
+  };
+
+  $('[id*="_scoreGroups_"]').each((_, el) => makeSgTagify(el as HTMLTextAreaElement));
 }

--- a/ui/bits/src/bits.broadcastGroup.ts
+++ b/ui/bits/src/bits.broadcastGroup.ts
@@ -21,49 +21,55 @@ export default function initModule(opts: { studyadmin: boolean; broadcaster: boo
     .map(t => t.trim())
     .filter(t => t.length > 0);
 
-  const groups = new Tagify<BroadcastTag>(textArea, {
-    enforceWhitelist: true,
-    keepInvalidTags: true, // Persist bad tags so that users can hover and see the reason why it was rejected
-    duplicates: false,
-    dropdown: {
-      enabled: 0,
-      mapValueTo: 'name',
-      searchKeys: ['name'],
-    },
-    tagTextProp: 'name',
-    maxTags: 50,
-    originalInputValueFormat: tags => tags.map(t => t.value).join('\n'),
-    readonly: textArea.disabled,
-  });
+  const makeTourTagify = (el: HTMLTextAreaElement) =>
+    new Tagify<BroadcastTag>(el, {
+      enforceWhitelist: true,
+      keepInvalidTags: true, // Persist bad tags so that users can hover and see the reason why it was rejected
+      duplicates: false,
+      dropdown: {
+        enabled: 0,
+        mapValueTo: 'name',
+        searchKeys: ['name'],
+      },
+      tagTextProp: 'name',
+      maxTags: 50,
+      originalInputValueFormat: tags => tags.map(t => t.value).join('\n'),
+      readonly: textArea.disabled,
+    });
 
-  groups.removeAllTags();
+  const group = makeTourTagify(textArea);
+
+  group.removeAllTags();
   const preExisting = fromServer.map<BroadcastTag>(t => ({ value: t.slice(-8), name: t.slice(0, -9) }));
-  if (preExisting.length) {
-    groups.whitelist = preExisting;
-    groups.addTags(preExisting);
-  }
+  group.whitelist = preExisting;
+  group.addTags(preExisting);
 
-  Sortable.create(groups.DOM.scope, {
+  Sortable.create(group.DOM.scope, {
     filter: '.tagify__input',
     onEnd: () => {
-      groups.updateValueByDOMTags();
+      group.updateValueByDOMTags();
     },
   });
 
   const fetchMyBroadcasts = async () => {
     if (myBroadcasts === null) {
-      groups.loading(true);
+      group.loading(true);
       const resp = await xhrJson(`/api/broadcast/by/${myUserId()}`);
       const results = resp['currentPageResults'] as CurrentPageResults;
-      myBroadcasts = results.map(t => t.tour).filter(t => opts.broadcaster || !t.tier);
-      groups.whitelist = groups.whitelist.map(t => (typeof t === 'string' ? { value: t, name: t } : t));
-      groups.whitelist = groups.whitelist.concat(
+      myBroadcasts = results.map(t => t.tour).filter(t => opts.broadcaster || !t.tier); // Fetching our own broadcasts so no need to check for communityOwner
+      group.whitelist = group.whitelist.map(t => (typeof t === 'string' ? { value: t, name: t } : t));
+      group.whitelist = group.whitelist.concat(
         myBroadcasts
           .map(b => ({ value: b.id, name: b.name }))
-          .filter(b => !groups.whitelist.some(t => typeof t !== 'string' && t.value === b.value)),
+          .filter(
+            fetched =>
+              !group.whitelist.some(
+                existing => typeof existing !== 'string' && existing.value === fetched.value,
+              ),
+          ),
       );
-      groups.loading(false);
-      groups.dropdown.show();
+      group.loading(false);
+      group.dropdown.show();
     }
   };
 
@@ -72,9 +78,9 @@ export default function initModule(opts: { studyadmin: boolean; broadcaster: boo
   const fetchBroadcastAndVerify = throttle(
     3000,
     async (invalidData: InvalidTagEventData<BroadcastTag>, broadcastId: string) => {
-      groups.loading(true);
+      group.loading(true);
       const replaceErrTag = (msg: string) =>
-        groups.replaceTag(invalidData.tag, {
+        group.replaceTag(invalidData.tag, {
           ...invalidData.data,
           // @ts-ignore
           __isValid: msg,
@@ -89,11 +95,11 @@ export default function initModule(opts: { studyadmin: boolean; broadcaster: boo
               replaceErrTag('Insufficient permissions to group this broadcast');
             else {
               const newTag = { value: tour.id, name: tour.name };
-              groups.whitelist = [
-                ...(groups.whitelist as BroadcastTag[]).filter(t => t.value !== tour.id),
+              group.whitelist = [
+                ...(group.whitelist as BroadcastTag[]).filter(t => t.value !== tour.id),
                 newTag,
               ];
-              groups.replaceTag(invalidData.tag, newTag);
+              group.replaceTag(invalidData.tag, newTag);
             }
           },
           () => {
@@ -101,13 +107,13 @@ export default function initModule(opts: { studyadmin: boolean; broadcaster: boo
           },
         )
         .finally(() => {
-          groups.loading(false);
+          group.loading(false);
         });
     },
   );
 
-  groups.on('focus', fetchMyBroadcasts);
-  groups.on('invalid', e => {
+  group.on('focus', fetchMyBroadcasts);
+  group.on('invalid', e => {
     const data = e.detail.data;
     const validIDRegex = /(?:^|(?:broadcast(?:\/.*)?\/))(\w{8})(?:\/edit)?$/; // 8 character ID OR Tour URL OR edit URL
     const match = data?.name.match(validIDRegex);
@@ -140,24 +146,26 @@ export default function initModule(opts: { studyadmin: boolean; broadcaster: boo
   $('[id*="_scoreGroups_"]').last().parent()[0]?.insertAdjacentElement('afterend', plusButton);
 
   const makeSgTagify = (el: HTMLTextAreaElement) => {
-    const sgTagify = new Tagify<BroadcastTag>(el, {
+    const sgTagify = makeTourTagify(el);
+    sgTagify.settings = {
+      ...sgTagify.settings,
       enforceWhitelist: true,
-      whitelist: groups.whitelist,
-      dropdown: {
-        enabled: 0,
-        mapValueTo: 'name',
-        searchKeys: ['name'],
-      },
-      tagTextProp: 'name',
+      keepInvalidTags: false,
+      whitelist: group.value,
       originalInputValueFormat: tags => tags.map(t => t.value).join(','),
-    });
+    };
     const preExisting = el.value
       .split(',')
-      .map(id => groups.whitelist.find(t => typeof t !== 'string' && t.value === id))
+      .map(id => group.whitelist.find(t => typeof t !== 'string' && t.value === id))
       .filter(t => typeof t === 'object');
     sgTagify.removeAllTags();
     sgTagify.addTags(preExisting);
-    groups.on('edit:updated', () => (sgTagify.whitelist = groups.whitelist));
+    group.on('add', () => {
+      sgTagify.whitelist = group.value;
+    });
+    group.on('remove', tag => {
+      if (tag.detail.data?.value) sgTagify.removeTags(tag.detail.data.value);
+    });
   };
 
   $('[id*="_scoreGroups_"]').each((_, el) => makeSgTagify(el as HTMLTextAreaElement));

--- a/ui/bits/src/bits.broadcastGroup.ts
+++ b/ui/bits/src/bits.broadcastGroup.ts
@@ -1,0 +1,117 @@
+import Tagify, { type InvalidTagEventData } from '@yaireo/tagify';
+import Sortable from 'sortablejs';
+
+import { myUserId, throttle } from 'lib';
+import { json as xhrJson } from 'lib/xhr';
+
+type CurrentPageResults = {
+  tour: BroadcastByUser;
+}[];
+
+type BroadcastByUser = { id: string; name: string; tier?: number; communityOwner?: LightUser };
+type BroadcastTag = { value: string; name: string };
+
+export default function initModule(opts: { studyadmin: boolean; broadcaster: boolean }): void {
+  const textArea = document.querySelector<HTMLTextAreaElement>('#form3-grouping_info_tours');
+  if (!textArea) return;
+  let myBroadcasts: BroadcastByUser[] | null = null;
+  const fromServer = textArea.value
+    .trim()
+    .split(/\n/)
+    .map(t => t.trim())
+    .filter(t => t.length > 0);
+
+  const tagify = new Tagify<BroadcastTag>(textArea, {
+    enforceWhitelist: true,
+    keepInvalidTags: true, // Persist bad tags so that users can hover and see the reason why it was rejected
+    duplicates: false,
+    dropdown: {
+      enabled: 0,
+      mapValueTo: 'name',
+      searchKeys: ['name'],
+    },
+    tagTextProp: 'name',
+    maxTags: 50,
+    originalInputValueFormat: tags => tags.map(t => t.value).join('\n'),
+    readonly: textArea.disabled,
+    texts: { notAllowed: 'Invalid broadcast ID or insufficient permissions' },
+  });
+
+  tagify.removeAllTags();
+  const preExisting = fromServer.map<BroadcastTag>(t => ({ value: t.slice(-8), name: t.slice(0, -9) }));
+  if (preExisting.length) {
+    tagify.whitelist = preExisting;
+    tagify.addTags(preExisting);
+  }
+
+  Sortable.create(tagify.DOM.scope, {
+    filter: '.tagify__input',
+    onEnd: () => {
+      tagify.updateValueByDOMTags();
+    },
+  });
+
+  const fetchMyBroadcasts = async () => {
+    if (myBroadcasts === null) {
+      tagify.loading(true);
+      const resp = await xhrJson(`/api/broadcast/by/${myUserId()}`);
+      const results = resp['currentPageResults'] as CurrentPageResults;
+      myBroadcasts = results.map(t => t.tour).filter(t => opts.broadcaster || !t.tier);
+      tagify.whitelist = tagify.whitelist.map(t => (typeof t === 'string' ? { value: t, name: t } : t));
+      tagify.whitelist = tagify.whitelist.concat(
+        myBroadcasts
+          .map(b => ({ value: b.id, name: b.name }))
+          .filter(b => !tagify.whitelist.some(t => typeof t !== 'string' && t.value === b.value)),
+      );
+      tagify.loading(false);
+      tagify.dropdown.show();
+    }
+  };
+
+  const doFetchBroadcast = async (id: string) =>
+    (await xhrJson(`/api/broadcast/${id}`))?.tour as BroadcastByUser;
+  const fetchBroadcastAndVerify = throttle(
+    3000,
+    async (invalidData: InvalidTagEventData<BroadcastTag>, broadcastId: string) => {
+      tagify.loading(true);
+      const replaceErrTag = (msg: string) =>
+        tagify.replaceTag(invalidData.tag, {
+          ...invalidData.data,
+          // @ts-ignore
+          __isValid: msg,
+        });
+      doFetchBroadcast(broadcastId)
+        .then(
+          tour => {
+            if (
+              !opts.studyadmin ||
+              (!opts.broadcaster && !tour.tier && tour.communityOwner?.id !== myUserId())
+            )
+              replaceErrTag('Insufficient permissions to group this broadcast');
+            else {
+              const newTag = { value: tour.id, name: tour.name };
+              tagify.whitelist = [
+                ...(tagify.whitelist as BroadcastTag[]).filter(t => t.value !== tour.id),
+                newTag,
+              ];
+              tagify.replaceTag(invalidData.tag, newTag);
+            }
+          },
+          () => {
+            replaceErrTag('Failed to fetch broadcast details.');
+          },
+        )
+        .finally(() => {
+          tagify.loading(false);
+        });
+    },
+  );
+
+  tagify.on('focus', fetchMyBroadcasts);
+  tagify.on('invalid', e => {
+    const data = e.detail.data;
+    const validIDRegex = /(?:^|(?:broadcast(?:\/.*)?\/))(\w{8})(?:\/edit)?$/; // 8 character ID OR Tour URL OR edit URL
+    const match = data?.name.match(validIDRegex);
+    if (data?.name && match) fetchBroadcastAndVerify(e.detail, match[1]);
+  });
+}

--- a/ui/lib/css/component/_tagify.scss
+++ b/ui/lib/css/component/_tagify.scss
@@ -471,13 +471,19 @@
     white-space: pre-wrap;
     color: $input-color;
     color: var(--input-color, $input-color);
-    box-sizing: inherit;
+    box-sizing: border-box;
+
+    // Firefox-specific fixes for stability and caret positioning
+    @include firefox {
+      display: block;
+      vertical-align: middle;
+    }
 
     &:empty {
       @include firefox {
         // clicking twice on the input (not fast) disallows typing (bug) only when the input has "display:flex".
         // https://bugzilla.mozilla.org/show_bug.cgi?id=904846#c45
-        display: flex;
+        display: block;
       }
 
       &::before {
@@ -518,7 +524,10 @@
           @include firefox {
             // remove ":after" pseudo element: https://bugzilla.mozilla.org/show_bug.cgi?id=904846#c45
             content: unset;
-            display: inline-block;
+            display: block;
+            position: static;
+            height: auto;
+            line-height: inherit;
           }
 
           color: $placeholder-color-focus;
@@ -696,19 +705,17 @@
       @extend %box-radius-bottom;
 
       max-height: 300px;
-      overflow: hidden;
+      overflow-y: auto;
+      overflow-x: hidden;
       background: $c-bg-popup;
       border: 1px solid $tags-focus-border-color;
+      border-top: none;
 
       // fixes - https://bugs.chromium.org/p/chromium/issues/detail?id=1147523
       border-width: 1.1px;
       border-top-width: 0;
       box-shadow: 0 2px 4px -2px rgba(black, 0.2);
       transition: $trans;
-
-      &:hover {
-        overflow: auto;
-      }
     }
 
     // initial state, pre-rendered
@@ -726,13 +733,18 @@
     }
 
     &__item {
-      box-sizing: inherit;
+      box-sizing: border-box;
       padding: $tag-pad;
-      margin: 1px;
+      margin: 0;
       cursor: pointer;
-      border-radius: 2px;
+      border-radius: 0;
       position: relative;
       outline: none;
+      width: 100%;
+      display: block;
+      text-overflow: ellipsis;
+      overflow: hidden;
+      white-space: nowrap;
 
       &--active {
         background: $tags-focus-border-color;


### PR DESCRIPTION
Re-do the broadcast form for grouping:

### Groups
1. Split the groups form from one single textArea into individual fields for name and tours. This is an API change from
```typescript
{ info: string }
```
to 
```typescript
{ info: { name: string, tours: string } }
```
<img width="1317" height="473" alt="image" src="https://github.com/user-attachments/assets/95708f0a-c014-4b27-8de6-ba477b16894c" />

2. Use tagify on the tours field. When the user focuses on the field, use [/api/broadcast/by/{username}](https://lichess.org/api#tag/broadcasts/GET/api/broadcast/by/{username}) to fetch the user's 20 most recent broadcasts.
3. Filter the broadcasts for tournaments they can actually group depending on if they have `StudyAdmin` or `Broadcaster` perms. Set the tagify whitelist accordingly.
4. Users can fuzzy search the whitelist by tournament name and select broadcasts to add to the group.
5. If they want to add a broadcast that is not in the whitelist, they can still paste a link. On pasting the link, use [/api/broadcast/{broadcastTournamentId}](https://lichess.org/api#tag/broadcasts/GET/api/broadcast/{broadcastTournamentId}) to fetch tournament details.  If they fulfil the same criteria to group the broadcast, add it as a valid tag. Failing the check means the tag goes red and they can hover over to see the error. (Either insufficient perms or bad link/broadcast ID). <img width="1319" height="214" alt="image" src="https://github.com/user-attachments/assets/1a1fdb84-be50-440b-8e80-0e426050b357" />
6. Use sortableJS to allow dragging tags around to re-order groups.

### ScoreGroups
1. Split the form from one single textArea into an array of textArea. This is an API change from
```typescript
{ scoreGroups: string }
```
to
```typescript
{ scoreGroups[]: string }
```
where every element in the array is a new scoreGroup. This is to avoid the confusing comma delimited tourIds and the newline delimited scoreGroups.
2. Use this to show each scoreGroup as its own textArea input. Users can add more scoreGroups by clicking the plus button.
3. Use tagify on these inputs to dynamically set their whitelist to the groups input.
<img width="1339" height="1002" alt="image" src="https://github.com/user-attachments/assets/704347e7-a94d-46bd-bfdb-cceec699841f" />


### AI use disclosure:
Used to fix tagify styling on firefox.