### PR TITLE
reduce orangeness in transparent theme button hovers

### DIFF
--- a/ui/lib/css/theme/_theme.transp.scss
+++ b/ui/lib/css/theme/_theme.transp.scss
@@ -21,8 +21,8 @@ html.transp {
   --c-font-page: #{change-color($c-font, $lightness: 97%)};
   --c-metal-top: hsla(37, 7%, 19%, 0.56);
   --c-metal-bottom: hsla(37, 7%, 19%, 0.66);
-  --c-metal-top-hover: hsla(22, 100%, 42%, 0.4);
-  --c-metal-bottom-hover: hsla(22, 100%, 42%, 0.3);
+  --c-metal-top-hover: hsla(210, 5%, 42%, 0.3);
+  --c-metal-bottom-hover: hsla(210, 5%, 42%, 0.3);
 
   @include transp-mix;
 }


### PR DESCRIPTION
# Before:
<img width="362" height="284" alt="image" src="https://github.com/user-attachments/assets/3ec10d95-2e54-4f84-960a-88fe770a7a58" />

<img width="362" height="122" alt="image" src="https://github.com/user-attachments/assets/ead4b95a-c946-45ab-9f0c-15a0051d9d7e" />

# After:
<img width="362" height="284" alt="image" src="https://github.com/user-attachments/assets/f94faff2-3896-4e3c-9442-2e30961c7dc8" />

<img width="362" height="122" alt="image" src="https://github.com/user-attachments/assets/d962ce21-ed5a-4aca-b7f9-5c1d418c7628" />
