### PR TITLE
ui: only highlight active filters icon in lobby view

### DIFF
--- a/ui/lobby/css/app/_app.scss
+++ b/ui/lobby/css/app/_app.scss
@@ -66,7 +66,7 @@
     }
   }
 
-  .gamesFiltered {
+  .gamesFiltered:not(.active) {
     color: $c-accent;
 
     @include transition;


### PR DESCRIPTION
# Why

Fixes #18631

# How

Currently, we were applying the icon highlight color if any games were filtered out also when filter settings view has been active, which seems to confuse users. I have made a small tweak to only apply icon color when user is in lobby view.

# Preview

https://github.com/user-attachments/assets/594f1229-24fe-4352-bc99-97b10dc73597

