### PR TITLE
ui: fix lobby timeline time shift on hydration and overflow

### DIFF
--- a/modules/ui/src/main/helper/DateHelper.scala
+++ b/modules/ui/src/main/helper/DateHelper.scala
@@ -75,7 +75,7 @@ trait DateHelper:
   def momentFromNow(instant: Instant, alwaysRelative: Boolean = false, once: Boolean = false): Tag =
     if !alwaysRelative && (instant.toMillis - nowMillis) > oneDayMillis then
       absClientInstantEmpty(instant)(nbsp)
-    else timeTag(cls := s"timeago${once.so(" once")}", datetimeAttr := isoDateTime(instant))(nbsp)
+    else timeTag(cls := s"timeago${once.so(" once")}", datetimeAttr := isoDateTime(instant))
 
   def pastMomentWithPreload(instant: Instant)(using Translate): Frag =
     momentFromNow(instant)(pastMomentServerText(instant))

--- a/ui/lobby/css/_timeline.scss
+++ b/ui/lobby/css/_timeline.scss
@@ -7,7 +7,9 @@
   @include hoverflow;
 
   .entry {
-    @extend %roboto;
+    @extend %roboto, %break-word;
+
+    white-space: pre-wrap;
 
     a {
       @extend %base-font, %page-font;


### PR DESCRIPTION
# Why

Spotted that in some cases the lobby timeline entries can overflow horizontally and cause the container being scrollable and view hydration leads to the time node shift.

# How

Remove hardcoded `nbsp` from the server side relative `time` node content, adjust the styles to prevent line overflow.

# Preview

### Before

https://github.com/user-attachments/assets/b6edd0f9-52dd-494d-96df-260e00ab48e6

<img width="424" height="615" alt="Screenshot 2026-05-22 at 12 14 23" src="https://github.com/user-attachments/assets/ba3b7c17-9ae5-4c9d-9d86-5cb66922746a" />

### After

https://github.com/user-attachments/assets/58844c88-53da-4dd0-a940-c978ffa1117e

<img width="424" height="615" alt="Screenshot 2026-05-22 at 12 30 18" src="https://github.com/user-attachments/assets/b38a0b4d-df62-4f01-bbf4-ee540231089d" />
