### PR TITLE
Broadcasts: Check score group parallelism when computing team leaderboards

### DIFF
--- a/modules/relay/src/main/RelayGroup.scala
+++ b/modules/relay/src/main/RelayGroup.scala
@@ -20,7 +20,7 @@ object RelayGroup:
 
   type ScoreGroup = NonEmptyList[RelayTourId]
 
-  def sgIsParallel(tours: List[RelayTour]): Boolean =
+  private[relay] def sgIsParallel(tours: List[RelayTour]): Boolean =
     tours.headOption
       .flatMap(_.dates.map(_.start))
       .exists: firstStart =>

--- a/modules/relay/src/main/RelayGroup.scala
+++ b/modules/relay/src/main/RelayGroup.scala
@@ -20,6 +20,12 @@ object RelayGroup:
 
   type ScoreGroup = NonEmptyList[RelayTourId]
 
+  def sgIsParallel(tours: List[RelayTour]): Boolean =
+    tours.headOption
+      .flatMap(_.dates.map(_.start))
+      .exists: firstStart =>
+        tours.tailOption.exists(_.exists(_.dates.map(_.start).exists(_.isBefore(firstStart.plusMinutes(20)))))
+
   opaque type Name = String
   object Name extends OpaqueString[Name]:
     extension (name: Name)

--- a/modules/relay/src/main/RelayPlayer.scala
+++ b/modules/relay/src/main/RelayPlayer.scala
@@ -250,7 +250,10 @@ private final class RelayPlayerApi(
       tours <- tourRepo.byIds(tourIds)
       toursById = tours.mapBy(_.id)
       rounds <-
-        if RelayGroup.sgIsParallel(tours) then roundRepo.byToursOrdered(tourIds)
+        if RelayGroup.sgIsParallel(tours) then
+          roundRepo
+            .byToursOrdered(tourIds)
+            .map(_.sortBy(r => r.startsAt.collect({ case RelayRound.Starts.At(at) => at })))
         else tourIds.flatTraverse(roundRepo.byTourOrdered)
       roundsById = rounds.mapBy(_.id)
       chapters <- chapterRepo.tagsByStudyIds(rounds.map(_.studyId))

--- a/modules/relay/src/main/RelayPlayer.scala
+++ b/modules/relay/src/main/RelayPlayer.scala
@@ -245,18 +245,12 @@ private final class RelayPlayerApi(
             .to(SeqMap)
         yield withRank
 
-  private def sgIsParallel(tours: List[RelayTour]): Boolean =
-    tours.headOption
-      .flatMap(_.dates.map(_.start))
-      .exists: firstStart =>
-        tours.tailOption.exists(_.exists(_.dates.map(_.start).exists(_.isBefore(firstStart.plusMinutes(20)))))
-
   private def readGamesAndPlayers(tourIds: List[RelayTourId]): Fu[RelayPlayers] =
     for
       tours <- tourRepo.byIds(tourIds)
       toursById = tours.mapBy(_.id)
       rounds <-
-        if sgIsParallel(tours) then roundRepo.byToursOrdered(tourIds)
+        if RelayGroup.sgIsParallel(tours) then roundRepo.byToursOrdered(tourIds)
         else tourIds.flatTraverse(roundRepo.byTourOrdered)
       roundsById = rounds.mapBy(_.id)
       chapters <- chapterRepo.tagsByStudyIds(rounds.map(_.studyId))

--- a/modules/relay/src/main/RelayPlayer.scala
+++ b/modules/relay/src/main/RelayPlayer.scala
@@ -249,7 +249,7 @@ private final class RelayPlayerApi(
     tours.headOption
       .flatMap(_.dates.map(_.start))
       .exists: firstStart =>
-        tours.tailOption.exists(_.forall(_.dates.map(_.start).exists(_.isBefore(firstStart.plusMinutes(20)))))
+        tours.tailOption.exists(_.exists(_.dates.map(_.start).exists(_.isBefore(firstStart.plusMinutes(20)))))
 
   private def readGamesAndPlayers(tourIds: List[RelayTourId]): Fu[RelayPlayers] =
     for

--- a/modules/relay/src/main/RelayPlayer.scala
+++ b/modules/relay/src/main/RelayPlayer.scala
@@ -250,10 +250,8 @@ private final class RelayPlayerApi(
       tours <- tourRepo.byIds(tourIds)
       toursById = tours.mapBy(_.id)
       rounds <-
-        if RelayGroup.sgIsParallel(tours) then
-          roundRepo
-            .byToursOrdered(tourIds)
-            .map(_.sortBy(r => r.startsAt.collect({ case RelayRound.Starts.At(at) => at })))
+        if RelayGroup.sgIsParallel(tours)
+        then roundRepo.byToursOrdered(tourIds).map(_.sortBy(_.startsAtTime))
         else tourIds.flatTraverse(roundRepo.byTourOrdered)
       roundsById = rounds.mapBy(_.id)
       chapters <- chapterRepo.tagsByStudyIds(rounds.map(_.studyId))

--- a/modules/relay/src/main/RelayRoundRepo.scala
+++ b/modules/relay/src/main/RelayRoundRepo.scala
@@ -48,13 +48,6 @@ final private class RelayRoundRepo(val coll: Coll, tourRepo: RelayTourRepo)(usin
       field = "_id"
     )
 
-  def idsByToursOrdered(tours: Seq[RelayTourId]): Fu[List[RelayRoundId]] =
-    coll.primitive[RelayRoundId](
-      selector = $doc("tourId".$in(tours)),
-      sort = sort.asc,
-      field = "_id"
-    )
-
   def studyIdsOf(tourId: RelayTourId): Fu[List[StudyId]] =
     idsByTourOrdered(tourId).map(StudyId.from)
 

--- a/modules/relay/src/main/RelayRoundRepo.scala
+++ b/modules/relay/src/main/RelayRoundRepo.scala
@@ -48,6 +48,13 @@ final private class RelayRoundRepo(val coll: Coll, tourRepo: RelayTourRepo)(usin
       field = "_id"
     )
 
+  def idsByToursOrdered(tours: Seq[RelayTourId]): Fu[List[RelayRoundId]] =
+    coll.primitive[RelayRoundId](
+      selector = $doc("tourId".$in(tours)),
+      sort = sort.asc,
+      field = "_id"
+    )
+
   def studyIdsOf(tourId: RelayTourId): Fu[List[StudyId]] =
     idsByTourOrdered(tourId).map(StudyId.from)
 

--- a/modules/relay/src/main/RelayTeams.scala
+++ b/modules/relay/src/main/RelayTeams.scala
@@ -312,7 +312,11 @@ final class RelayTeamLeaderboard(
       .showTeamScores(scoreGroup.head)
       .flatMapz:
         for
-          rounds <- scoreGroup.toList.flatTraverse(roundRepo.idsByTourOrdered)
+          tourIds = scoreGroup.toList
+          tours <- tourRepo.byIds(tourIds)
+          rounds <-
+            if RelayGroup.sgIsParallel(tours) then roundRepo.idsByToursOrdered(tourIds)
+            else tourIds.flatTraverse(roundRepo.idsByTourOrdered)
           matches <- rounds.flatTraverse(teamTable.table)
         yield matches.foldLeft(SeqMap.empty: TeamLeaderboard): (acc, matchup) =>
           matchup.teams

--- a/modules/relay/src/main/RelayTeams.scala
+++ b/modules/relay/src/main/RelayTeams.scala
@@ -315,10 +315,8 @@ final class RelayTeamLeaderboard(
           tourIds = scoreGroup.toList
           tours <- tourRepo.byIds(tourIds)
           rounds <-
-            if RelayGroup.sgIsParallel(tours) then
-              roundRepo
-                .byToursOrdered(tourIds)
-                .map(_.sortBy(r => r.startsAt.collect({ case RelayRound.Starts.At(at) => at })))
+            if RelayGroup.sgIsParallel(tours)
+            then roundRepo.byToursOrdered(tourIds).map(_.sortBy(_.startsAtTime))
             else tourIds.flatTraverse(roundRepo.byTourOrdered)
           roundIds = rounds.map(_.id)
           matches <- roundIds.flatTraverse(teamTable.table)

--- a/modules/relay/src/main/RelayTeams.scala
+++ b/modules/relay/src/main/RelayTeams.scala
@@ -315,9 +315,13 @@ final class RelayTeamLeaderboard(
           tourIds = scoreGroup.toList
           tours <- tourRepo.byIds(tourIds)
           rounds <-
-            if RelayGroup.sgIsParallel(tours) then roundRepo.idsByToursOrdered(tourIds)
-            else tourIds.flatTraverse(roundRepo.idsByTourOrdered)
-          matches <- rounds.flatTraverse(teamTable.table)
+            if RelayGroup.sgIsParallel(tours) then
+              roundRepo
+                .byToursOrdered(tourIds)
+                .map(_.sortBy(r => r.startsAt.collect({ case RelayRound.Starts.At(at) => at })))
+            else tourIds.flatTraverse(roundRepo.byTourOrdered)
+          roundIds = rounds.map(_.id)
+          matches <- roundIds.flatTraverse(teamTable.table)
         yield matches.foldLeft(SeqMap.empty: TeamLeaderboard): (acc, matchup) =>
           matchup.teams
             .foldLeft(acc): (acc, team) =>


### PR DESCRIPTION
To fix ordering of a team's matches
|[Before](https://lichess.org/broadcast/45th-chess-olympiad-budapest-2024--open-i/round-1/XJ8g9CkA#team-results/Zimbabwe)|After|
|--------------|-----------|
|<img width="703" height="1428" alt="image" src="https://github.com/user-attachments/assets/066ed110-ff0b-48fc-828b-5cfb4617f50a" />|<img width="720" height="1441" alt="image" src="https://github.com/user-attachments/assets/d168edc0-36ff-4516-ae18-6d68aadc45e5" />|

Also change the parallelism check to see if at least 1 broadcast is parallel instead of all broadcasts being parallel. Also to fix the very same tournament where [Open V](https://lichess.org/broadcast/45th-chess-olympiad-budapest-2024--open-v/round-8/j746hv5D) only starts mid-way through the tournament. This change may have false positives for other tournaments as well. Idk let's see.
