### PR TITLE
Fix mobile scrolling for FIDE player tables

### DIFF
--- a/modules/fide/src/main/ui/FidePlayerUi.scala
+++ b/modules/fide/src/main/ui/FidePlayerUi.scala
@@ -84,9 +84,13 @@ final class FidePlayerUi(helpers: Helpers, fideUi: FideUi, picfitUrl: lila.memo.
           )(label)
         )
       else th(label)
-    table(
-      cls := List("slist slist-pad fide-players-table" -> true, "fide-players-table--sortable" -> sortable)
-    )(
+    div(cls := "slist-wrapper")(
+      table(
+        cls := List(
+          "slist slist-pad fide-players-table" -> true,
+          "fide-players-table--sortable" -> sortable
+          )
+        )(
       thead:
         tr(
           header(trs.name(), FidePlayerOrder.name),
@@ -128,8 +132,8 @@ final class FidePlayerUi(helpers: Helpers, fideUi: FideUi, picfitUrl: lila.memo.
         ,
         pagerNextTable(players, np => addQueryParam(url(np).url, "order", order.key))
       )
+      )
     )
-
   private def followButton(p: FidePlayer.WithFollow) =
     val id = s"fide-player-follow-${p.player.id}"
     label(cls := "fide-player__follow")(


### PR DESCRIPTION
## Summary

Fixes mobile scrolling issues on the FIDE Players page.

On mobiles (web page), the tables overflowed horizontally while the page body used `overflow-x: hidden`, causing some columns/content to become inaccessible. To be precise, In Broadcasts>Fide Players the page was wrapped, causing some columns to be inaccessible, like blitz and rapid rating, etc

This change wraps the tables with the existing `slist-wrapper` responsive container already used elsewhere in Lichess for horizontally scrollable tables.

## Testing

I tested this locally on WSL2 using the Lichess development environment.

Verified in Chrome DevTools mobile emulation:

* iPhone 12 Pro

Confirmed that:

* tables are horizontally scrollable on mobile
* content is no longer clipped/cut off
* desktop layout remains unchanged

## Notes

I initially investigated the issue through Chrome DevTools responsive mode and traced the problem to overflow handling on mobile layouts before implementing the wrapper-based fix.

<img width="348" height="762" alt="image" src="https://github.com/user-attachments/assets/133015eb-73cb-4fe9-9994-1e48e02514da" />

Before (Current UI bug)



<img width="352" height="764" alt="image" src="https://github.com/user-attachments/assets/bb0be53f-b264-4983-ba8c-0c8c1f2098db" />

Fix (Current UI)