### PR TITLE
Fix mobile scrolling for FIDE player tables

### DIFF
--- a/modules/fide/src/main/ui/FidePlayerUi.scala
+++ b/modules/fide/src/main/ui/FidePlayerUi.scala
@@ -84,9 +84,13 @@ final class FidePlayerUi(helpers: Helpers, fideUi: FideUi, picfitUrl: lila.memo.
           )(label)
         )
       else th(label)
-    table(
-      cls := List("slist slist-pad fide-players-table" -> true, "fide-players-table--sortable" -> sortable)
-    )(
+    div(cls := "slist-wrapper")(
+      table(
+        cls := List(
+          "slist slist-pad fide-players-table" -> true,
+          "fide-players-table--sortable" -> sortable
+          )
+        )(
       thead:
         tr(
           header(trs.name(), FidePlayerOrder.name),
@@ -128,8 +132,8 @@ final class FidePlayerUi(helpers: Helpers, fideUi: FideUi, picfitUrl: lila.memo.
         ,
         pagerNextTable(players, np => addQueryParam(url(np).url, "order", order.key))
       )
+      )
     )
-
   private def followButton(p: FidePlayer.WithFollow) =
     val id = s"fide-player-follow-${p.player.id}"
     label(cls := "fide-player__follow")(

--- a/modules/fide/src/main/ui/FidePlayerUi.scala
+++ b/modules/fide/src/main/ui/FidePlayerUi.scala
@@ -89,49 +89,49 @@ final class FidePlayerUi(helpers: Helpers, fideUi: FideUi, picfitUrl: lila.memo.
         cls := List(
           "slist slist-pad fide-players-table" -> true,
           "fide-players-table--sortable" -> sortable
-          )
-        )(
-      thead:
-        tr(
-          header(trs.name(), FidePlayerOrder.name),
-          header(trs.classical(), FidePlayerOrder.standard),
-          header(trs.rapid(), FidePlayerOrder.rapid),
-          header(trs.blitz(), FidePlayerOrder.blitz),
-          header(trb.age(), FidePlayerOrder.year),
-          ctx.isAuth.option(header(trs.follow(), FidePlayerOrder.follow))
         )
-      ,
-      tbody(cls := "infinite-scroll")(
-        players.currentPageResults.map: p =>
-          val player = p.player
-          val link = a(href := routes.Fide.show(player.id, player.slug))
-          tr(cls := "paginated")(
-            td(cls := "player-intro-td")(
-              span(cls := "player-intro")(
-                link(cls := "player-intro__photo"):
-                  player.photo
-                    .fold(thumbnail.fallback(cls := "fide-players__photo fide-players__photo--fallback")):
-                      photo => img(src := thumbnail.url(photo.id, _.Small), cls := "fide-players__photo")
-                ,
-                span(cls := "player-intro__info")(
-                  link(cls := "player-intro__name")(titleTag(player.title), player.name),
-                  player.fed.map: fed =>
-                    span(cls := "player-intro__fed")(
-                      fideUi.federation.flag(fed, none),
-                      Federation.i18nName(fed)
-                    )
-                )
-              )
-            ),
-            td(player.standard),
-            td(player.rapid),
-            td(player.blitz),
-            td(player.age),
-            ctx.isAuth.option(td(followButton(p)))
+      )(
+        thead:
+          tr(
+            header(trs.name(), FidePlayerOrder.name),
+            header(trs.classical(), FidePlayerOrder.standard),
+            header(trs.rapid(), FidePlayerOrder.rapid),
+            header(trs.blitz(), FidePlayerOrder.blitz),
+            header(trb.age(), FidePlayerOrder.year),
+            ctx.isAuth.option(header(trs.follow(), FidePlayerOrder.follow))
           )
         ,
-        pagerNextTable(players, np => addQueryParam(url(np).url, "order", order.key))
-      )
+        tbody(cls := "infinite-scroll")(
+          players.currentPageResults.map: p =>
+            val player = p.player
+            val link = a(href := routes.Fide.show(player.id, player.slug))
+            tr(cls := "paginated")(
+              td(cls := "player-intro-td")(
+                span(cls := "player-intro")(
+                  link(cls := "player-intro__photo"):
+                    player.photo
+                      .fold(thumbnail.fallback(cls := "fide-players__photo fide-players__photo--fallback")):
+                        photo => img(src := thumbnail.url(photo.id, _.Small), cls := "fide-players__photo")
+                  ,
+                  span(cls := "player-intro__info")(
+                    link(cls := "player-intro__name")(titleTag(player.title), player.name),
+                    player.fed.map: fed =>
+                      span(cls := "player-intro__fed")(
+                        fideUi.federation.flag(fed, none),
+                        Federation.i18nName(fed)
+                      )
+                  )
+                )
+              ),
+              td(player.standard),
+              td(player.rapid),
+              td(player.blitz),
+              td(player.age),
+              ctx.isAuth.option(td(followButton(p)))
+            )
+          ,
+          pagerNextTable(players, np => addQueryParam(url(np).url, "order", order.key))
+        )
       )
     )
   private def followButton(p: FidePlayer.WithFollow) =

--- a/ui/lib/css/component/_slist.scss
+++ b/ui/lib/css/component/_slist.scss
@@ -64,6 +64,10 @@
   overflow-x: auto;
   max-width: calc(100vw - $box-padding * 2);
 
+  &:has(.slist-pad) {
+    max-width: 100vw;
+  }
+
   .slist {
     @media (max-width: at-most($x-small)) {
       min-width: calc(650px - $box-padding * 2);


### PR DESCRIPTION
## Summary

Fixes mobile scrolling issues on the FIDE Players page.

On mobiles (web page), the tables overflowed horizontally while the page body used `overflow-x: hidden`, causing some columns/content to become inaccessible. To be precise, In Broadcasts>Fide Players the page was wrapped, causing some columns to be inaccessible, like blitz and rapid rating, etc

This change wraps the tables with the existing `slist-wrapper` responsive container already used elsewhere in Lichess for horizontally scrollable tables.

## Testing

I tested this locally on WSL2 using the Lichess development environment.

Verified in Chrome DevTools mobile emulation:

* iPhone 12 Pro

Confirmed that:

* tables are horizontally scrollable on mobile
* content is no longer clipped/cut off
* desktop layout remains unchanged

## Notes

I initially investigated the issue through Chrome DevTools responsive mode and traced the problem to overflow handling on mobile layouts before implementing the wrapper-based fix.

<img width="348" height="762" alt="image" src="https://github.com/user-attachments/assets/133015eb-73cb-4fe9-9994-1e48e02514da" />

Before (Current UI bug)



<img width="352" height="764" alt="image" src="https://github.com/user-attachments/assets/bb0be53f-b264-4983-ba8c-0c8c1f2098db" />

Fix (Current UI)