### PR TITLE
revert sbt-plugin upgrade

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,5 +2,5 @@ resolvers += Resolver.url(
   "lila-maven-sbt",
   url("https://raw.githubusercontent.com/lichess-org/lila-maven/master")
 )(Resolver.ivyStylePatterns)
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.11") // scala2 branch
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.18-lila_1.26") // scala2 branch
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.6.1")


### PR DESCRIPTION
non patched version breaks the build

```
[info] welcome to sbt 1.12.11 (Ubuntu Java 25.0.2)
[info] loading settings for project lila-build from plugins.sbt...
[info] loading project definition from /home/fred/github/lila/project
[info] compiling 3 Scala sources to /home/fred/github/lila/project/target/scala-2.12/sbt-1.0/classes ...
/home/fred/github/lila/build.sbt:512: error: value generateForwardRouter is not a member of object play.sbt.routes.RoutesKeys
  Compile / RoutesKeys.generateForwardRouter := false,
                       ^
sbt.compiler.EvalException: Type error in expression
[error] sbt.compiler.EvalException: Type error in expression
[error] Use 'last' for the full log.
[warn] Project loading failed: (r)etry, (q)uit, (l)ast, or (i)gnore? (default: r)
```