### PR TITLE
Appeal: Explicit date display when writing `in ... months`

### DIFF
--- a/modules/appeal/src/main/ui/AppealUi.scala
+++ b/modules/appeal/src/main/ui/AppealUi.scala
@@ -13,7 +13,7 @@ final class AppealUi(helpers: Helpers):
       .css("bits.form3")
       .css("bits.appeal")
       .css(Granter.opt(_.Appeals).option("mod.user"))
-      .js(esmInitBit("appeal") ++ Granter.opt(_.Appeals).so(Esm("mod.user")))
+      .js(esmInit("bits.appeal") ++ Granter.opt(_.Appeals).so(Esm("mod.user")))
 
   def renderMark(suspect: User)(using ctx: Context) =
     val query = Granter.opt(_.Appeals).so(ctx.req.queryString.toMap)

--- a/ui/bits/src/bits.appeal.ts
+++ b/ui/bits/src/bits.appeal.ts
@@ -1,0 +1,58 @@
+import { formToXhr } from 'lib/xhr';
+
+export function initModule(): void {
+  if ($('.nav-tree').length) location.hash = location.hash || '#help-root';
+  $('select.appeal-presets').on('change', function (this: HTMLSelectElement, e: Event) {
+    $(this)
+      .parents('form')
+      .find('textarea')
+      .val((e.target as HTMLTextAreaElement).value);
+  });
+
+  $('form.appeal__actions__slack').on('submit', (e: Event) => {
+    const form = e.target as HTMLFormElement;
+    formToXhr(form);
+    $(form).find('button').text('Sent!').attr('disabled', 'true');
+    return false;
+  });
+
+  const isoDateRegex = /\b(\d{4}-\d{2}-\d{2})\b/g;
+  const now = new Date();
+  now.setHours(0, 0, 0, 0);
+
+  $('.appeal__msg--mod .appeal__msg__text').each(function (this: HTMLElement) {
+    const walker = document.createTreeWalker(this, NodeFilter.SHOW_TEXT);
+
+    let node: Text | null;
+    while ((node = walker.nextNode() as Text | null)) {
+      if (!node || !node.nodeValue) continue;
+      const text = node.nodeValue;
+      const matches = [...text.matchAll(isoDateRegex)];
+      if (matches.length === 0) continue;
+
+      const frag = document.createDocumentFragment();
+      let lastIndex = 0;
+
+      matches.forEach(match => {
+        const date = new Date(match[0]);
+        const color = date > now ? 'var(--c-bad)' : 'var(--c-good)';
+
+        frag.append(text.slice(lastIndex, match.index));
+
+        const span = document.createElement('span');
+        span.style.color = color;
+        span.textContent = date.toLocaleDateString(undefined, {
+          year: 'numeric',
+          month: 'long',
+          day: 'numeric',
+        });
+
+        frag.append(span);
+        lastIndex = match.index + match[0].length;
+      });
+
+      frag.append(text.slice(lastIndex));
+      node.replaceWith(frag);
+    }
+  });
+}

--- a/ui/bits/src/bits.ts
+++ b/ui/bits/src/bits.ts
@@ -63,6 +63,46 @@ function appeal() {
     $(form).find('button').text('Sent!').attr('disabled', 'true');
     return false;
   });
+
+  const isoDateRegex = /\b(\d{4}-\d{2}-\d{2})\b/g;
+  const now = new Date();
+  now.setHours(0, 0, 0, 0);
+
+  $('.appeal__msg--mod .appeal__msg__text').each(function (this: HTMLElement) {
+    const walker = document.createTreeWalker(this, NodeFilter.SHOW_TEXT);
+
+    let node: Text | null;
+    while ((node = walker.nextNode() as Text | null)) {
+      if (!node || !node.nodeValue) continue;
+      const text = node.nodeValue;
+      const matches = [...text.matchAll(isoDateRegex)];
+      if (matches.length === 0) continue;
+
+      const frag = document.createDocumentFragment();
+      let lastIndex = 0;
+
+      matches.forEach(match => {
+        const date = new Date(match[0]);
+        const color = date > now ? 'var(--c-bad)' : 'var(--c-good)';
+
+        frag.append(text.slice(lastIndex, match.index));
+
+        const span = document.createElement('span');
+        span.style.color = color;
+        span.textContent = date.toLocaleDateString(undefined, {
+          year: 'numeric',
+          month: 'long',
+          day: 'numeric',
+        });
+
+        frag.append(span);
+        lastIndex = match.index + match[0].length;
+      });
+
+      frag.append(text.slice(lastIndex));
+      node.replaceWith(frag);
+    }
+  });
 }
 
 function autoForm({ selector, ops }: { selector: string; ops: string }) {

--- a/ui/bits/src/bits.ts
+++ b/ui/bits/src/bits.ts
@@ -1,5 +1,5 @@
 import { spinnerHtml } from 'lib/view';
-import { text, formToXhr } from 'lib/xhr';
+import { text } from 'lib/xhr';
 
 import { wireCropDialog } from './crop';
 import flairPickerLoader from './flairPicker';
@@ -9,8 +9,6 @@ import flairPickerLoader from './flairPicker';
 
 export function initModule(args: { fn: string } & any): void {
   switch (args.fn) {
-    case 'appeal':
-      return appeal();
     case 'autoForm':
       return autoForm(args);
     case 'colorizeYesNoTable':
@@ -46,63 +44,6 @@ export function initModule(args: { fn: string } & any): void {
     default:
       console.error('Unknown bits function', args.fn);
   }
-}
-
-function appeal() {
-  if ($('.nav-tree').length) location.hash = location.hash || '#help-root';
-  $('select.appeal-presets').on('change', function (this: HTMLSelectElement, e: Event) {
-    $(this)
-      .parents('form')
-      .find('textarea')
-      .val((e.target as HTMLTextAreaElement).value);
-  });
-
-  $('form.appeal__actions__slack').on('submit', (e: Event) => {
-    const form = e.target as HTMLFormElement;
-    formToXhr(form);
-    $(form).find('button').text('Sent!').attr('disabled', 'true');
-    return false;
-  });
-
-  const isoDateRegex = /\b(\d{4}-\d{2}-\d{2})\b/g;
-  const now = new Date();
-  now.setHours(0, 0, 0, 0);
-
-  $('.appeal__msg--mod .appeal__msg__text').each(function (this: HTMLElement) {
-    const walker = document.createTreeWalker(this, NodeFilter.SHOW_TEXT);
-
-    let node: Text | null;
-    while ((node = walker.nextNode() as Text | null)) {
-      if (!node || !node.nodeValue) continue;
-      const text = node.nodeValue;
-      const matches = [...text.matchAll(isoDateRegex)];
-      if (matches.length === 0) continue;
-
-      const frag = document.createDocumentFragment();
-      let lastIndex = 0;
-
-      matches.forEach(match => {
-        const date = new Date(match[0]);
-        const color = date > now ? 'var(--c-bad)' : 'var(--c-good)';
-
-        frag.append(text.slice(lastIndex, match.index));
-
-        const span = document.createElement('span');
-        span.style.color = color;
-        span.textContent = date.toLocaleDateString(undefined, {
-          year: 'numeric',
-          month: 'long',
-          day: 'numeric',
-        });
-
-        frag.append(span);
-        lastIndex = match.index + match[0].length;
-      });
-
-      frag.append(text.slice(lastIndex));
-      node.replaceWith(frag);
-    }
-  });
 }
 
 function autoForm({ selector, ops }: { selector: string; ops: string }) {

--- a/ui/mod/src/mod.user.ts
+++ b/ui/mod/src/mod.user.ts
@@ -198,6 +198,55 @@ site.load.then(() => {
           reloadZone();
         });
     });
+
+    makeReady(
+      '.appeal form textarea',
+      (el: HTMLElement) => {
+        const textarea = el as HTMLTextAreaElement;
+        const DAY_MS = 24 * 60 * 60 * 1000;
+        const applyDates = () => {
+          const start = textarea.selectionStart;
+          const val = textarea.value;
+          const regex = /in (\d+) (months|years)(?! \(\d{4}-\d{2}-\d{2}\))/gi;
+          let diffBeforeCursor = 0;
+          const newVal = val.replace(regex, (match, num, unit, offset) => {
+            const n = parseInt(num, 10);
+            const nowTs = Date.now();
+
+            let targetTs = nowTs;
+
+            const u = unit.toLowerCase();
+
+            if (u.startsWith('month')) {
+              targetTs += n * 30 * DAY_MS;
+            } else if (u.startsWith('year')) {
+              targetTs += n * 365 * DAY_MS;
+            }
+
+            const d = new Date(targetTs);
+
+            const dateStr = ` (${d.toISOString().slice(0, 10)})`;
+            if (offset < start) diffBeforeCursor += dateStr.length;
+
+            return `${match}${dateStr}`;
+          });
+
+          if (newVal !== val) {
+            const end = textarea.selectionEnd;
+            textarea.value = newVal;
+            textarea.setSelectionRange(start + diffBeforeCursor, end + diffBeforeCursor);
+          }
+        };
+
+        $(textarea).on('input', applyDates);
+        // to be applied after preset being inserted
+        $(textarea.form)
+          .find('select.appeal-presets')
+          .on('change', () => setTimeout(applyDates, 50));
+      },
+      'ready-appeal-dates',
+    );
+
     autolinkAtoms($inZone[0]);
   }
 


### PR DESCRIPTION
And easy display of whether the date is in the past or future, so that mods and users can see if the cooldown has been lapsed.

Technical: I've chosen clientside for now, but another solution was to add a structured cooldown date to an appeal message. For now I feel this will be enough, and if more interaction need to be based on it.
