### PR TITLE
fix 500 error for `/api/puzzle/batch/{angle}` endpoint

### DIFF
--- a/app/controllers/Puzzle.scala
+++ b/app/controllers/Puzzle.scala
@@ -369,9 +369,12 @@ final class Puzzle(env: Env, apiC: => Api) extends LilaController(env):
       else if ctx.isAuth then nb / 3
       else nb
     fetchRateLimit(rateLimited, cost = cost):
-      WithPuzzlePerf:
-        for puzzles <- batchSelect(PuzzleAngle.findOrMix(angleStr), reqSettings, nb)
-        yield Ok(puzzles)
+      PuzzleAngle
+        .find(angleStr)
+        .fold(fuccess(notFoundJson("Angle not found"))): angle =>
+          WithPuzzlePerf:
+            for puzzles <- batchSelect(angle, reqSettings, nb)
+            yield Ok(puzzles)
 
   private def reqSettings(using req: RequestHeader) = PuzzleSettings(
     PuzzleDifficulty.orDefault(~get("difficulty")),

--- a/app/controllers/Puzzle.scala
+++ b/app/controllers/Puzzle.scala
@@ -371,7 +371,7 @@ final class Puzzle(env: Env, apiC: => Api) extends LilaController(env):
     fetchRateLimit(rateLimited, cost = cost):
       PuzzleAngle
         .find(angleStr)
-        .fold(fuccess(notFoundJson("Angle not found"))): angle =>
+        .fold(fuccess(notFoundJson(s"No $angleStr puzzles found"))): angle =>
           WithPuzzlePerf:
             for puzzles <- batchSelect(angle, reqSettings, nb)
             yield Ok(puzzles)

--- a/modules/puzzle/src/main/PuzzleBatch.scala
+++ b/modules/puzzle/src/main/PuzzleBatch.scala
@@ -33,27 +33,29 @@ final class PuzzleBatch(
           else PuzzleTier.top
         pathApi
           .nextFor("batch")(angle, tier, difficulty, Set.empty)
-          .orFail(s"No puzzle path for batch ${me.username} $angle $tier")
-          .flatMap: pathId =>
-            colls.path:
-              _.aggregateList(nb): framework =>
-                import framework.*
-                Match($id(pathId)) -> List(
-                  Project($doc("puzzleId" -> "$ids", "_id" -> false)),
-                  Unwind("puzzleId"),
-                  Sample(nb),
-                  PipelineOperator:
-                    $lookup.simple(
-                      from = colls.puzzle.name,
-                      local = "puzzleId",
-                      foreign = "_id",
-                      as = "puzzle",
-                      pipe = Nil
+          .flatMap:
+            case None => fuccess(Vector.empty)
+            case Some(pathId) =>
+              colls
+                .path:
+                  _.aggregateList(nb): framework =>
+                    import framework.*
+                    Match($id(pathId)) -> List(
+                      Project($doc("puzzleId" -> "$ids", "_id" -> false)),
+                      Unwind("puzzleId"),
+                      Sample(nb),
+                      PipelineOperator:
+                        $lookup.simple(
+                          from = colls.puzzle.name,
+                          local = "puzzleId",
+                          foreign = "_id",
+                          as = "puzzle",
+                          pipe = Nil
+                        )
+                      ,
+                      PipelineOperator:
+                        $doc("$replaceWith" -> $doc("$arrayElemAt" -> $arr("$puzzle", 0)))
                     )
-                  ,
-                  PipelineOperator:
-                    $doc("$replaceWith" -> $doc("$arrayElemAt" -> $arr("$puzzle", 0)))
-                )
-              .map:
-                _.view.flatMap(puzzleReader.readOpt).toVector
-          .mon(lila.mon.puzzle.selector.user.batch(nb = nb))
+                  .map:
+                    _.view.flatMap(puzzleReader.readOpt).toVector
+                .mon(lila.mon.puzzle.selector.user.batch(nb = nb))

--- a/modules/puzzle/src/main/PuzzleBatch.scala
+++ b/modules/puzzle/src/main/PuzzleBatch.scala
@@ -33,29 +33,27 @@ final class PuzzleBatch(
           else PuzzleTier.top
         pathApi
           .nextFor("batch")(angle, tier, difficulty, Set.empty)
-          .flatMap:
-            case None => fuccess(Vector.empty)
-            case Some(pathId) =>
-              colls
-                .path:
-                  _.aggregateList(nb): framework =>
-                    import framework.*
-                    Match($id(pathId)) -> List(
-                      Project($doc("puzzleId" -> "$ids", "_id" -> false)),
-                      Unwind("puzzleId"),
-                      Sample(nb),
-                      PipelineOperator:
-                        $lookup.simple(
-                          from = colls.puzzle.name,
-                          local = "puzzleId",
-                          foreign = "_id",
-                          as = "puzzle",
-                          pipe = Nil
-                        )
-                      ,
-                      PipelineOperator:
-                        $doc("$replaceWith" -> $doc("$arrayElemAt" -> $arr("$puzzle", 0)))
-                    )
-                  .map:
-                    _.view.flatMap(puzzleReader.readOpt).toVector
-                .mon(lila.mon.puzzle.selector.user.batch(nb = nb))
+          .flatMapz: pathId =>
+            colls
+              .path:
+                _.aggregateList(nb): framework =>
+                  import framework.*
+                  Match($id(pathId)) -> List(
+                    Project($doc("puzzleId" -> "$ids", "_id" -> false)),
+                    Unwind("puzzleId"),
+                    Sample(nb),
+                    PipelineOperator:
+                      $lookup.simple(
+                        from = colls.puzzle.name,
+                        local = "puzzleId",
+                        foreign = "_id",
+                        as = "puzzle",
+                        pipe = Nil
+                      )
+                    ,
+                    PipelineOperator:
+                      $doc("$replaceWith" -> $doc("$arrayElemAt" -> $arr("$puzzle", 0)))
+                  )
+                .map:
+                  _.view.flatMap(puzzleReader.readOpt).toVector
+              .mon(lila.mon.puzzle.selector.user.batch(nb = nb))


### PR DESCRIPTION
When an auth'ed request was made to the `Puzzle.apiBatchSelect(angle)` endpoint, there was a 500 error:

## lila error log
<details>

<summary>lila error log</summary>

```
Internal server error, for (GET) [/api/puzzle/batch/Creepy_Crawly_Formation?nb=3&difficulty=normal] ->

play.api.UnexpectedException: Unexpected exception[Exception: No puzzle path for batch <username> Opening(Left(Creepy_Crawly_Formation)) top]
        at play.api.UnexpectedException$.apply(Exceptions.scala:10)
        at play.api.http.HttpErrorHandlerExceptions$.throwableToUsefulException(HttpErrorHandler.scala:328)
        at play.api.http.DefaultHttpErrorHandler.onServerError(HttpErrorHandler.scala:250)
        at play.core.server.netty.PlayRequestHandler$$anon$2.applyOrElse(PlayRequestHandler.scala:220)
        at play.core.server.netty.PlayRequestHandler$$anon$2.applyOrElse(PlayRequestHandler.scala:217)
        at scala.concurrent.impl.Promise$Transformation.run(Promise.scala:509)
        at play.api.libs.streams.Execution$trampoline$.execute(Execution.scala:65)
        at scala.concurrent.impl.Promise$Transformation.submitWithValue(Promise.scala:448)
        at scala.concurrent.impl.Promise$DefaultPromise.submitWithValue(Promise.scala:360)
        at scala.concurrent.impl.Promise$DefaultPromise.tryComplete0(Promise.scala:284)
        at scala.concurrent.impl.Promise$Transformation.run(Promise.scala:523)
        at scala.concurrent.BatchingExecutor$AbstractBatch.runN(BatchingExecutor.scala:135)
        at scala.concurrent.BatchingExecutor$AsyncBatch.apply(BatchingExecutor.scala:164)
        at scala.concurrent.BatchingExecutor$AsyncBatch.apply(BatchingExecutor.scala:162)
        at scala.concurrent.BlockContext$.usingBlockContext(BlockContext.scala:104)
        at scala.concurrent.BatchingExecutor$AsyncBatch.run(BatchingExecutor.scala:155)
        at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(Unknown Source)
        at java.base/java.util.concurrent.ForkJoinTask.doExec(Unknown Source)
        at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(Unknown Source)
        at java.base/java.util.concurrent.ForkJoinPool.scan(Unknown Source)
        at java.base/java.util.concurrent.ForkJoinPool.runWorker(Unknown Source)
        at java.base/java.util.concurrent.ForkJoinWorkerThread.run(Unknown Source)
        Caused by: java.lang.Exception: No puzzle path for batch <username> Opening(Left(Creepy_Crawly_Formation)) top
        at scalalib.future.extensions$.orFail$$anonfun$1$$anonfun$1(future.scala:109)
        at scala.Option.fold(Option.scala:265)
        at scalalib.future.extensions$.orFail$$anonfun$1(future.scala:109)
        at scala.concurrent.impl.Promise$Transformation.run(Promise.scala:489)
        ... 11 common frames omitted
```
</details>

## To reproduce:

### Before

```bash
http http://localhost:8080/api/puzzle/batch/Creepy_Crawly_Formation
# -> OK

http -A bearer -a lip_admin http://localhost:8080/api/puzzle/batch/Creepy_Crawly_Formation
# -> 500 error

http http://localhost:8080/api/puzzle/batch/Foo
http -A bearer -a lip_bobby http://localhost:8080/api/puzzle/batch/Foo
# -> 200, falls back to `mix`
```

### After

```bash
http http://localhost:8080/api/puzzle/batch/Creepy_Crawly_Formation
http -A bearer -a lip_admin http://localhost:8080/api/puzzle/batch/Creepy_Crawly_Formation
# -> 200, OK

http http://localhost:8080/api/puzzle/batch/Foo
http -A bearer -a lip_bobby http://localhost:8080/api/puzzle/batch/Foo
# -> 404, Angle not found
```
