### PR TITLE
Broadcasts with custom scoring fixes

### DIFF
--- a/ui/analyse/src/study/multiBoard.ts
+++ b/ui/analyse/src/study/multiBoard.ts
@@ -391,7 +391,9 @@ const boardPlayer = (
 ) => {
   const player = preview.players?.[color];
   const coloredResult =
-    preview.status && preview.status !== '*' && playerColoredResult(preview.status, color, round);
+    preview.status &&
+    preview.status !== '*' &&
+    playerColoredResult(preview.status, color, round?.customScoring);
   return h('span.mini-game__player', [
     player && renderUser(player, pins?.isPlayerPinned(player)),
     showResults

--- a/ui/analyse/src/study/playerBars.ts
+++ b/ui/analyse/src/study/playerBars.ts
@@ -95,7 +95,7 @@ function renderPlayer(
       fideId,
     },
     photo = fideId ? relayPlayers?.fidePhoto(fideId) : undefined;
-  const coloredResult = status && status !== '*' && playerColoredResult(status, color, round);
+  const coloredResult = status && status !== '*' && playerColoredResult(status, color, round?.customScoring);
   const resultNode = coloredResult
     ? hl(`${coloredResult.tag}.result`, coloredResult.points)
     : result && hl(`${resultTag(result)}.result`, result);

--- a/ui/analyse/src/study/relay/customScoreStatus.ts
+++ b/ui/analyse/src/study/relay/customScoreStatus.ts
@@ -42,9 +42,8 @@ export const coloredStatusStr = (gamePoints: GamePointsStr, pov: Color, round?: 
 export const playerColoredResult = (
   status: GamePointsStr,
   color: Color,
-  round?: RelayRound,
+  customScoring?: CustomScoring,
 ): { tag: 'good' | 'bad' | 'status'; points: VNodeChildElement } | false => {
-  const customScoring = round?.customScoring;
   const resultPart = status.split('-')[color === 'white' ? 0 : 1];
   return (
     isServerPoint(resultPart) && {

--- a/ui/analyse/src/study/relay/customScoreStatus.ts
+++ b/ui/analyse/src/study/relay/customScoreStatus.ts
@@ -17,13 +17,8 @@ const withCustomScore = (
 ): VNodeChildElement => {
   if (!customScoring) return point;
   const base = points(point);
-  return base === 1
-    ? customScoring[color].win
-    : base === 0.5
-      ? customScoring[color].draw !== 0.5
-        ? customScoring[color].draw
-        : '½'
-      : 0;
+  const p = base === 1 ? customScoring[color].win : base === 0.5 ? customScoring[color].draw : 0;
+  return p === 0.5 ? '½' : p;
 };
 
 export const coloredStatusStr = (gamePoints: GamePointsStr, pov: Color, round?: RelayRound): LooseVNodes => {

--- a/ui/analyse/src/study/relay/relayGames.ts
+++ b/ui/analyse/src/study/relay/relayGames.ts
@@ -70,7 +70,7 @@ const gamesList = (study: StudyCtrl, relay: RelayCtrl, pinned: boolean, cloudEva
                   showResults &&
                   c.status &&
                   c.status !== '*' &&
-                  playerColoredResult(c.status, playerColor, round);
+                  playerColoredResult(c.status, playerColor, round?.customScoring);
                 return hl(
                   'span.relay-game__player',
                   p

--- a/ui/analyse/src/study/relay/relayPlayers.ts
+++ b/ui/analyse/src/study/relay/relayPlayers.ts
@@ -474,7 +474,7 @@ const renderPlayerGames = (ctrl: RelayPlayers, p: RelayPlayerWithGames, withTips
 
     return hl(
       coloredResult.tag,
-      customPoints && points.replace('1/2', '0.5') !== customPoints.toString()
+      defined(customPoints) && points.replace('1/2', '0.5') !== customPoints.toString()
         ? customPoints
         : coloredResult.points,
     );

--- a/ui/analyse/src/study/relay/relayPlayers.ts
+++ b/ui/analyse/src/study/relay/relayPlayers.ts
@@ -467,17 +467,11 @@ const renderPlayerGames = (ctrl: RelayPlayers, p: RelayPlayerWithGames, withTips
   const coloredPoint = ({ points, customPoints, color, ongoing }: RelayPlayerGame, index: number) => {
     if (!points) return ongoing && hl('strong', '*');
     if (hideResultsSinceIndex <= index) return hl('span', '?');
+    if (defined(customPoints)) return customPoints === 0.5 ? '½' : customPoints;
 
     const povResultStr = points === '1/2' ? '½-½' : (points === '1') === (color === 'white') ? '1-0' : '0-1';
     const coloredResult = playerColoredResult(povResultStr, color);
-    if (!coloredResult) return;
-
-    return hl(
-      coloredResult.tag,
-      defined(customPoints) && points.replace('1/2', '0.5') !== customPoints.toString()
-        ? customPoints
-        : coloredResult.points,
-    );
+    return coloredResult && hl(coloredResult.tag, coloredResult.points);
   };
 
   return hl(


### PR DESCRIPTION
Fixes two issues to do with events with customScoring:
1. Showing the result instead of points scored when they score 0 points for a result.

|Before|After|
|---|---|
|<img width="1636" height="187" alt="image" src="https://github.com/user-attachments/assets/76aec0bb-b44f-4799-bc6d-f7aadb9232d6" />|<img width="1645" height="202" alt="image" src="https://github.com/user-attachments/assets/40dcc57a-5c5f-4dad-8918-f2d7f237076b" />|

2. Consistently format 0.5 points as ½

|Before|After|
|---|---|
|<img width="752" height="89" alt="image" src="https://github.com/user-attachments/assets/e2fd76b7-1fe0-4869-8c07-d9ad214dbda3" />|<img width="757" height="75" alt="image" src="https://github.com/user-attachments/assets/5195cecf-d17e-472a-9052-697aed7f5d27" />|
