### PR TITLE
Autoplay repeatedly attempts to move even when `preventGoingToNextMove()` is true

### DIFF
--- a/ui/analyse/src/autoplay.ts
+++ b/ui/analyse/src/autoplay.ts
@@ -15,7 +15,7 @@ export class Autoplay {
 
   private move(): boolean {
     const child = this.ctrl.node.children[0];
-    if (child) {
+    if (child && !this.ctrl.retro?.preventGoingToNextMove()) {
       const path = this.ctrl.path + child.id;
       if (this.ctrl.canJumpTo(path)) {
         this.ctrl.jump(path);


### PR DESCRIPTION
There is a UI bug in the analysis board where if a player uses both the "Learn From Your Mistakes" and "Autoplay" features simultaneously, Autoplay will repeatedly attempt to move to the next move, while Learn From Your Mistakes will block it from advancing. This causes the move sound to be played repeatedly.

Video attached below:
https://github.com/user-attachments/assets/5f2a1091-b932-4e5e-9ba3-67e194a6dd90

This PR stops Autoplay from attempting to advance if Learn From Your Mistakes has `preventGoingToNextMove()` true.

After the fix:
https://github.com/user-attachments/assets/be612618-2ca0-44ff-8d5b-dd217260d352

