### PR TITLE
friendlier ceval engine names

### DIFF
--- a/ui/lib/css/ceval/_settings.scss
+++ b/ui/lib/css/ceval/_settings.scss
@@ -113,7 +113,6 @@
     margin-inline-start: 1em;
 
     &:hover {
-      background: unset;
       color: $c-primary;
     }
   }
@@ -121,7 +120,7 @@
 
 .engine-info-popup {
   a {
-    font-size: 12px;
+    font-size: 0.9em;
   }
 
   ol {
@@ -129,7 +128,8 @@
   }
 
   li {
+    @extend %flex-between-nowrap;
+
     list-style: decimal inside;
-    white-space: nowrap;
   }
 }

--- a/ui/lib/css/ceval/_settings.scss
+++ b/ui/lib/css/ceval/_settings.scss
@@ -107,4 +107,29 @@
       }
     }
   }
+
+  .engine-info-button {
+    color: $c-font-dim;
+    margin-inline-start: 1em;
+
+    &:hover {
+      background: unset;
+      color: $c-primary;
+    }
+  }
+}
+
+.engine-info-popup {
+  a {
+    font-size: 12px;
+  }
+
+  ol {
+    text-align: start;
+  }
+
+  li {
+    list-style: decimal inside;
+    white-space: nowrap;
+  }
 }

--- a/ui/lib/src/ceval/engines/engines.ts
+++ b/ui/lib/src/ceval/engines/engines.ts
@@ -81,8 +81,8 @@ export class Engines {
       ...relaxedSimdPair({
         info: {
           id: '__sf_18_smallnet',
-          name: 'Stockfish 18 · 15MB sscg13/threat-small',
-          short: 'SF 18 · 15MB',
+          name: 'Stockfish 18 · 15MB',
+          short: 'SF 18 15MB',
           tech: 'NNUE',
           requires: ['sharedMem', 'simd', 'dynamicImportFromWorker'],
           minMem: 1536,
@@ -98,8 +98,8 @@ export class Engines {
       ...relaxedSimdPair({
         info: {
           id: '__sf_dev',
-          name: 'Stockfish 18+ dev-20260213-77d46ff6 · 88MB SFNNv12',
-          short: 'SF dev · 88MB',
+          name: 'Stockfish 18 dev · 88MB',
+          short: 'SF 18 dev 88MB',
           tech: 'NNUE',
           requires: ['sharedMem', 'simd', 'dynamicImportFromWorker'],
           minMem: 2560,
@@ -114,8 +114,8 @@ export class Engines {
       ...relaxedSimdPair({
         info: {
           id: '__sf_18',
-          name: 'Stockfish 18 · 108MB SFNNv10',
-          short: 'SF 18 · 108MB',
+          name: 'Stockfish 18 · 108MB',
+          short: 'SF 18 108MB',
           tech: 'NNUE',
           requires: ['sharedMem', 'simd', 'dynamicImportFromWorker'],
           minMem: 2560,

--- a/ui/lib/src/ceval/engines/engines.ts
+++ b/ui/lib/src/ceval/engines/engines.ts
@@ -23,7 +23,7 @@ export class Engines {
     this.localEngineMap = this.makeEngineMap();
     this.localEngines = [...this.localEngineMap.values()].map(e => e.info);
     this.externalEngines = this.ctrl.opts.externalEngines?.map(e => ({ tech: 'EXTERNAL', ...e })) ?? [];
-    this.selectProp = storedStringProp('ceval.engine', this.localEngines[0].id);
+    this.selectProp = storedStringProp('ceval.engine', '__sf_18_smallnet');
   }
 
   status = (status: { download?: { bytes: number; total: number }; error?: string } = {}): void => {
@@ -44,6 +44,7 @@ export class Engines {
         id: `__fsfnnue-${key === 'kingOfTheHill' ? 'koth' : variantMap(key)}`,
         name: 'Fairy Stockfish 14+ NNUE',
         short: 'FSF 14+',
+        url: 'https://github.com/lichess-org/stockfish-web#fsf_14-fairy-stockfish-14',
         tech: 'NNUE',
         requires: ['sharedMem', 'simd', 'dynamicImportFromWorker'],
         variants: [key],
@@ -70,36 +71,20 @@ export class Engines {
         ...base,
         info: {
           ...base.info,
-          id: `${base.info.id}_relaxed-simd`,
           requires: [...base.info.requires, 'relaxedSimd'],
           assets: { ...base.info.assets, js: base.info.assets.js?.replace('.js', '_relaxed-simd.js') },
         },
       },
       { ...base, info: { ...base.info, obsoletedBy: 'relaxedSimd' } },
     ];
+    // list engines in decreasing order of strength
     const browserEngines: WithMake[] = [
-      ...relaxedSimdPair({
-        info: {
-          id: '__sf_18_smallnet',
-          name: 'Stockfish 18 · 15MB',
-          short: 'SF 18 15MB',
-          tech: 'NNUE',
-          requires: ['sharedMem', 'simd', 'dynamicImportFromWorker'],
-          minMem: 1536,
-          cloudEval: true,
-          assets: {
-            root: 'npm/stockfish-web',
-            nnue: ['nn-4ca89e4b3abf.nnue'],
-            js: 'sf_18_smallnet.js',
-          },
-        },
-        make: (e: BrowserEngineInfo) => new StockfishWebEngine(e, this.status),
-      }),
       ...relaxedSimdPair({
         info: {
           id: '__sf_dev',
           name: 'Stockfish 18 dev · 88MB',
           short: 'SF 18 dev 88MB',
+          url: 'https://github.com/lichess-org/stockfish-web#sf_dev-stockfish-dev-20260213-77d46ff6',
           tech: 'NNUE',
           requires: ['sharedMem', 'simd', 'dynamicImportFromWorker'],
           minMem: 2560,
@@ -116,6 +101,7 @@ export class Engines {
           id: '__sf_18',
           name: 'Stockfish 18 · 108MB',
           short: 'SF 18 108MB',
+          url: 'https://github.com/lichess-org/stockfish-web#sf_18-stockfish-18',
           tech: 'NNUE',
           requires: ['sharedMem', 'simd', 'dynamicImportFromWorker'],
           minMem: 2560,
@@ -127,11 +113,30 @@ export class Engines {
         },
         make: (e: BrowserEngineInfo) => new StockfishWebEngine(e, this.status),
       }),
+      ...relaxedSimdPair({
+        info: {
+          id: '__sf_18_smallnet',
+          name: 'Stockfish 18 · 15MB',
+          short: 'SF 18 15MB',
+          url: 'https://github.com/lichess-org/stockfish-web#sf_18_smallnet-stockfish-18-with-sscg13threat-small',
+          tech: 'NNUE',
+          requires: ['sharedMem', 'simd', 'dynamicImportFromWorker'],
+          minMem: 1536,
+          cloudEval: true,
+          assets: {
+            root: 'npm/stockfish-web',
+            nnue: ['nn-4ca89e4b3abf.nnue'],
+            js: 'sf_18_smallnet.js',
+          },
+        },
+        make: (e: BrowserEngineInfo) => new StockfishWebEngine(e, this.status),
+      }),
       {
         info: {
           id: '__sf14nnue',
           name: 'Stockfish 14 NNUE',
           short: 'SF 14',
+          url: 'https://github.com/lichess-org/stockfish-nnue.wasm',
           tech: 'NNUE',
           obsoletedBy: 'dynamicImportFromWorker',
           requires: ['sharedMem', 'simd'],
@@ -151,6 +156,7 @@ export class Engines {
           id: '__fsfhce',
           name: 'Fairy Stockfish 14+ HCE',
           short: 'FSF 14+',
+          url: 'https://github.com/lichess-org/stockfish-web#fsf_14-fairy-stockfish-14',
           tech: 'HCE',
           requires: ['sharedMem', 'simd', 'dynamicImportFromWorker'],
           variants: variants.map(v => v[0]),
@@ -188,6 +194,7 @@ export class Engines {
           id: '__sf11hce',
           name: 'Stockfish 11 HCE',
           short: 'SF 11',
+          url: 'https://github.com/lichess-org/stockfish.wasm',
           tech: 'HCE',
           requires: ['sharedMem'],
           minThreads: 1,
@@ -205,6 +212,7 @@ export class Engines {
           id: '__sfwasm',
           name: 'Stockfish WASM',
           short: 'Stockfish',
+          url: 'https://github.com/lichess-org/stockfish.js',
           tech: 'HCE',
           minThreads: 1,
           maxThreads: 1,
@@ -223,6 +231,7 @@ export class Engines {
           id: '__sfjs',
           name: 'Stockfish JS',
           short: 'Stockfish',
+          url: 'https://github.com/lichess-org/stockfish.js',
           tech: 'HCE',
           minThreads: 1,
           maxThreads: 1,
@@ -283,11 +292,12 @@ export class Engines {
     this.ctrl = ctrl;
   }
 
-  supporting(variant: VariantKey): EngineInfo[] {
-    return [
-      ...this.localEngines.filter(e => e.variants?.includes(variant)),
-      ...this.externalEngines.filter(e => externalEngineSupports(e, variant)),
-    ];
+  supporting(variant: VariantKey, filter: 'browser' | 'external' | 'all' = 'all'): EngineInfo[] {
+    const engines: EngineInfo[] = [];
+    if (filter !== 'external') engines.push(...this.localEngines.filter(e => e.variants?.includes(variant)));
+    if (filter !== 'browser')
+      engines.push(...this.externalEngines.filter(e => externalEngineSupports(e, variant)));
+    return engines;
   }
 
   getEngine(selector?: { id?: string; variant?: VariantKey }): EngineInfo | undefined {

--- a/ui/lib/src/ceval/types.ts
+++ b/ui/lib/src/ceval/types.ts
@@ -34,6 +34,7 @@ export interface BaseEngineInfo {
   id: string;
   name: string;
   short?: string;
+  url?: string;
   variants?: VariantKey[];
   minThreads?: number;
   maxThreads?: number;

--- a/ui/lib/src/ceval/view/settings.ts
+++ b/ui/lib/src/ceval/view/settings.ts
@@ -228,15 +228,14 @@ function engineSelection({ ceval }: CevalHandler) {
 function engineInfo(engines: EngineInfo[]) {
   if (document.querySelector('.engine-info')) return;
   const engineHtml = (e: EngineInfo) =>
-    `<li>${e.name} ${e.url ? `(<a href="${e.url}" target="_blank">source</a>)` : ''}</li>`;
+    `<li>${e.name} ${e.url ? `<a href="${e.url}" target="_blank">source</a>` : ''}</li>`;
   domDialog({
     class: 'engine-info-popup',
     htmlText: $html`
       <div>
-        <p>From strongest to weakest</p>
+        <p>Engines from strongest to weakest</p>
         <ol>${engines.map(engineHtml).join('')}</ol>
       </div>`,
     show: true,
-    noCloseButton: true,
   });
 }

--- a/ui/lib/src/ceval/view/settings.ts
+++ b/ui/lib/src/ceval/view/settings.ts
@@ -1,9 +1,9 @@
 import { clamp } from '@/algo';
-import type { CevalHandler } from '@/ceval';
+import type { CevalHandler, EngineInfo } from '@/ceval';
 import { isChrome } from '@/device';
 import { onClickAway } from '@/index';
 import * as Licon from '@/licon';
-import { type VNode, onInsert, bind, dataIcon, hl, rangeConfig, confirm } from '@/view';
+import { type VNode, onInsert, bind, dataIcon, hl, rangeConfig, confirm, domDialog } from '@/view';
 
 import type CevalCtrl from '../ctrl';
 import { fewerCores } from '../util';
@@ -218,5 +218,25 @@ function engineSelection({ ceval }: CevalHandler) {
             ceval.engines.deleteExternal(external.id).then(ok => ok && ceval.opts.redraw());
         }),
       }),
+    hl('button.engine-info-button', {
+      attrs: { ...dataIcon(Licon.InfoCircle), title: 'Engine information' },
+      on: { click: () => engineInfo(ceval.engines.supporting(ceval.opts.variant.key, 'browser')) },
+    }),
   ]);
+}
+
+function engineInfo(engines: EngineInfo[]) {
+  if (document.querySelector('.engine-info')) return;
+  const engineHtml = (e: EngineInfo) =>
+    `<li>${e.name} ${e.url ? `(<a href="${e.url}" target="_blank">source</a>)` : ''}</li>`;
+  domDialog({
+    class: 'engine-info-popup',
+    htmlText: $html`
+      <div>
+        <p>From strongest to weakest</p>
+        <ol>${engines.map(engineHtml).join('')}</ol>
+      </div>`,
+    show: true,
+    noCloseButton: true,
+  });
 }


### PR DESCRIPTION
## Rename engines to:
- Stockfish 18 dev · 88MB
- Stockfish 18 · 108MB
- Stockfish 18 · 15MB

## Add info button beside engine selector:
<img width="330" height="158" alt="image" src="https://github.com/user-attachments/assets/2aa1f9c6-f02d-4c7e-bb5a-d21b0caf322e" />

## When clicked:

<img width="299" height="182" alt="image" src="https://github.com/user-attachments/assets/de852799-f6ab-4181-96cc-561d30fd8dda" />

"source" links to github repo