### PR TITLE
Change zh layout on small screen

### DIFF
--- a/ui/lib/css/chess/_zh-pocket.scss
+++ b/ui/lib/css/chess/_zh-pocket.scss
@@ -76,3 +76,15 @@
     opacity: 0;
   }
 }
+
+.pocket {
+  @include mq-is-col1 {
+    margin-inline-start: 0;
+  }
+
+  .pocket-c1 {
+    @include mq-is-col1 {
+      max-width: 12.5vmin;
+    }
+  }
+}

--- a/ui/round/css/_app-layout.scss
+++ b/ui/round/css/_app-layout.scss
@@ -47,8 +47,8 @@
   display: grid;
 
   @include mq-is-col1 {
-    grid-template-rows: auto $col1-user-height $col1-mat-height auto auto $col1-mat-height $col1-user-height auto auto auto auto 0;
-    grid-template-areas: 'pocket-top' 'user-top' 'mat-top' 'board' 'expi-bot' 'mat-bot' 'user-bot' 'pocket-bot' 'controls' 'moves' 'voice' 'kb-move';
+    grid-template-rows: $col1-user-height $col1-mat-height auto auto auto $col1-mat-height $col1-user-height auto auto auto auto 0;
+    grid-template-areas: 'user-top' 'mat-top' 'pocket-top' 'board' 'pocket-bot' 'mat-bot' 'user-bot' 'expi-bot' 'controls' 'moves' 'voice' 'kb-move';
 
     // Put clocks and players in the same grid cell.
     // This allows having a single cell column, instead of
@@ -56,7 +56,7 @@
     // This is required to display the overflowable horizontal move list,
     // so that it can be contain within the grid parent.
     .rclock-top {
-      grid-area: 2 / 1 / 4 / 2;
+      grid-area: 1 / 1 / 3 / 2;
     }
 
     .rclock-bottom {

--- a/ui/round/css/_zh.scss
+++ b/ui/round/css/_zh.scss
@@ -12,10 +12,12 @@
   @include mq-is-col1 {
     &-top {
       grid-area: pocket-top;
+      margin-bottom: $block-gap;
     }
 
     &-bottom {
       grid-area: pocket-bot;
+      margin-top: $block-gap;
     }
   }
 


### PR DESCRIPTION
fixes #20541 

- Pocket pieces have same size as the board pieces
- Remove pocket left margin to avoid clash with clock
- Swap order (user / pocket) to let pockets be part of the board

<img width="379" height="653" alt="image" src="https://github.com/user-attachments/assets/ccec349c-5aa6-4c19-8e63-54385796f51d" />
