### PR TITLE
reenable selection quoting in forums

### DIFF
--- a/modules/forum/src/main/ForumExpand.scala
+++ b/modules/forum/src/main/ForumExpand.scala
@@ -16,6 +16,7 @@ final class ForumTextExpand(markdown: lila.memo.MarkdownCache)(using Executor, S
     blockQuote = true,
     code = true,
     timestamp = false,
+    sourceMap = true,
     maxPgns = lila.memo.Max(10)
   )
 

--- a/ui/bits/src/bits.forum.ts
+++ b/ui/bits/src/bits.forum.ts
@@ -118,7 +118,9 @@ site.load.then(() => {
     const lines = (
       quotedMarkdown(this.closest('article')) ??
       post.querySelector('.forum-post__message-source')!.textContent
-    ).split('\n');
+    )
+      .replace(/!\[([^\]]*)]\(([^)]+)\)/g, '$1 ($2)')
+      .split('\n');
     if (lines[0].match(/^(?:> )*@.+ said (?:in #\d+:$|\[\^\]\()/)) lines.shift();
 
     if (lines.length === 0) return;


### PR DESCRIPTION
This was a casualty of some churn involving a [timestamp plugin](https://github.com/lichess-org/lila/commit/257f3c153dc9b9877068c8958b13c0e9df991fee)

Since the regression, people more often quote the entire message which makes threads more painful than they should be.