### PR TITLE
Use radio buttons for setting turn in board editor.

### DIFF
--- a/modules/coreI18n/src/main/key.scala
+++ b/modules/coreI18n/src/main/key.scala
@@ -2094,6 +2094,7 @@ object I18nKey:
     val `onlyFriends`: I18nKey = "onlyFriends"
     val `menu`: I18nKey = "menu"
     val `castling`: I18nKey = "castling"
+    val `turn`: I18nKey = "turn"
     val `whiteCastlingKingside`: I18nKey = "whiteCastlingKingside"
     val `blackCastlingKingside`: I18nKey = "blackCastlingKingside"
     val `tpTimeSpentPlaying`: I18nKey = "tpTimeSpentPlaying"

--- a/translation/source/site.xml
+++ b/translation/source/site.xml
@@ -677,6 +677,7 @@
   <string name="onlyFriends">Only friends</string>
   <string name="menu">Menu</string>
   <string name="castling">Castling rights</string>
+  <string name="turn">Turn</string>
   <string name="whiteCastlingKingside">White O-O</string>
   <string name="blackCastlingKingside">Black O-O</string>
   <plurals name="nbForumPosts">

--- a/ui/@types/lichess/i18n.d.ts
+++ b/ui/@types/lichess/i18n.d.ts
@@ -4577,6 +4577,8 @@ interface I18n {
     tryTheContactPage: string;
     /** Try to win (or at least draw) every game you play. */
     tryToWin: string;
+    /** Turn */
+    turn: string;
     /** Type private notes here */
     typePrivateNotesHere: string;
     /** UltraBullet */

--- a/ui/editor/css/_tools.scss
+++ b/ui/editor/css/_tools.scss
@@ -8,7 +8,8 @@
     .button,
     select,
     label,
-    input[type='checkbox'] {
+    input[type='checkbox'],
+    input[type='radio'] {
       cursor: pointer;
     }
 
@@ -49,6 +50,30 @@
 
       .color {
         margin-bottom: 1em;
+        border: 0;
+        padding: 0;
+
+        .turn-row {
+          display: flex;
+          align-items: baseline;
+          gap: 1.5em;
+        }
+
+        .radio-group {
+          display: flex;
+          gap: 1.2em;
+        }
+
+        label,
+        input {
+          display: inline-block;
+          margin: 3px;
+          vertical-align: middle;
+        }
+
+        input {
+          margin-left: 0;
+        }
       }
 
       .castling {

--- a/ui/editor/src/view.ts
+++ b/ui/editor/src/view.ts
@@ -1,6 +1,7 @@
 import { dragNewPiece } from '@lichess-org/chessground/drag';
 import type { MouchEvent, NumberPair } from '@lichess-org/chessground/types';
 import { eventPosition, opposite } from '@lichess-org/chessground/util';
+import { COLORS } from 'chessops';
 import { lichessRules } from 'chessops/compat';
 import { parseFen } from 'chessops/fen';
 import { parseSquare, makeSquare } from 'chessops/util';
@@ -15,7 +16,6 @@ import { fenToChess960Id, isValidPositionId } from './chess960';
 import chessground from './chessground';
 import type EditorCtrl from './ctrl';
 import type { Selected, CastlingToggle, EditorState, EndgamePosition, OpeningPosition } from './interfaces';
-import { COLORS } from 'chessops';
 
 function castleCheckBox(ctrl: EditorCtrl, id: CastlingToggle, label: string, reversed: boolean): VNode {
   const input = h('input', {

--- a/ui/editor/src/view.ts
+++ b/ui/editor/src/view.ts
@@ -149,32 +149,28 @@ function controls(ctrl: EditorCtrl, state: EditorState): VNode {
 
   return h('div.board-editor__tools', [
     h('div.metadata', [
-      h(
-        'div.color',
-        h(
-          'select',
-          {
-            on: {
-              change(e) {
-                ctrl.setTurn((e.target as HTMLSelectElement).value as Color);
-              },
-            },
-            props: { value: ctrl.turn },
-          },
-          (['whitePlays', 'blackPlays'] as const).map(function (key) {
-            return h(
-              'option',
-              {
-                attrs: {
-                  value: key.startsWith('w') ? 'white' : 'black',
-                  selected: key.startsWith(ctrl.turn[0]),
-                },
-              },
-              i18n.site[key],
-            );
-          }),
-        ),
-      ),
+      h('fieldset.color', [
+        h('div.turn-row', [
+          h('strong', 'Turn'),
+          h(
+            'div.radio-group',
+            (['white', 'black'] as const).map(color =>
+              h('label', { key: color }, [
+                h('input', {
+                  attrs: { type: 'radio', name: 'turn', value: color },
+                  props: { checked: ctrl.turn === color },
+                  on: {
+                    change(e) {
+                      ctrl.setTurn((e.target as HTMLInputElement).value as Color);
+                    },
+                  },
+                }),
+                color === 'white' ? i18n.site.white : i18n.site.black,
+              ]),
+            ),
+          ),
+        ]),
+      ]),
       h('div.castling', [
         h('strong', i18n.site.castling),
         h('div', [

--- a/ui/editor/src/view.ts
+++ b/ui/editor/src/view.ts
@@ -15,6 +15,7 @@ import { fenToChess960Id, isValidPositionId } from './chess960';
 import chessground from './chessground';
 import type EditorCtrl from './ctrl';
 import type { Selected, CastlingToggle, EditorState, EndgamePosition, OpeningPosition } from './interfaces';
+import { COLORS } from 'chessops';
 
 function castleCheckBox(ctrl: EditorCtrl, id: CastlingToggle, label: string, reversed: boolean): VNode {
   const input = h('input', {
@@ -154,7 +155,7 @@ function controls(ctrl: EditorCtrl, state: EditorState): VNode {
           h('strong', i18n.site.turn),
           h(
             'div.radio-group',
-            (['white', 'black'] as const).map(color =>
+            COLORS.map(color =>
               h('label', { key: color }, [
                 h('input', {
                   attrs: { type: 'radio', name: 'turn', value: color },

--- a/ui/editor/src/view.ts
+++ b/ui/editor/src/view.ts
@@ -151,7 +151,7 @@ function controls(ctrl: EditorCtrl, state: EditorState): VNode {
     h('div.metadata', [
       h('fieldset.color', [
         h('div.turn-row', [
-          h('strong', 'Turn'),
+          h('strong', i18n.site.turn),
           h(
             'div.radio-group',
             (['white', 'black'] as const).map(color =>


### PR DESCRIPTION
Saves users from having to do two clicks to set turn (open dropdown, select option). This change also reclaims a sliver of vertical space.