### PR TITLE
ui: small improvements for team page, introduce `box-bordered` helper

### DIFF
--- a/app/views/team/show.scala
+++ b/app/views/team/show.scala
@@ -119,9 +119,11 @@ object show:
                 (t.enabled && canSeeMembers && info.tours.nonEmpty).option(
                   st.section(cls := "team-show__tour team-events team-tournaments")(
                     h2(a(href := routes.Team.tournaments(t.id))(trans.site.tournaments())),
-                    table(cls := "slist slist-resp")(
-                      tournaments.renderList(
-                        info.tours.next ::: info.tours.past.take(5 - info.tours.next.size)
+                    div(cls := "team-show__list-wrapper")(
+                      table(cls := "slist slist-resp")(
+                        tournaments.renderList(
+                          info.tours.next ::: info.tours.past.take(5 - info.tours.next.size)
+                        )
                       )
                     )
                   )
@@ -129,19 +131,21 @@ object show:
                 info.forum.map: forumPosts =>
                   st.section(cls := "team-show__forum")(
                     h2(a(href := teamForumUrl(t.id))(trans.site.forum())),
-                    forumPosts.take(10).map { post =>
-                      a(cls := "team-show__forum__post", href := routes.ForumPost.redirect(post.post.id))(
-                        div(cls := "meta")(
-                          strong(post.topic.name),
-                          em(
-                            post.post.userId.map(titleNameOrId),
-                            " • ",
-                            momentFromNow(post.post.createdAt)
-                          )
-                        ),
-                        p(shorten(Markdown(post.post.text).unlink, 200))
-                      )
-                    },
+                    div(cls := "team-show__list-wrapper")(
+                      forumPosts.take(10).map { post =>
+                        a(cls := "team-show__forum__post", href := routes.ForumPost.redirect(post.post.id))(
+                          div(cls := "meta")(
+                            strong(post.topic.name),
+                            em(
+                              post.post.userId.map(titleNameOrId),
+                              " • ",
+                              momentFromNow(post.post.createdAt)
+                            )
+                          ),
+                          p(shorten(Markdown(post.post.text).unlink, 200))
+                        )
+                      }
+                    ),
                     a(cls := "more", href := teamForumUrl(t.id))(t.name, " ", trans.site.forum(), " »")
                   )
               )

--- a/app/views/team/show.scala
+++ b/app/views/team/show.scala
@@ -138,11 +138,11 @@ object show:
                             strong(post.topic.name),
                             em(
                               post.post.userId.map(titleNameOrId),
-                              " • ",
+                              span(" • "),
                               momentFromNow(post.post.createdAt)
                             )
                           ),
-                          p(shorten(Markdown(post.post.text).unlink, 200))
+                          p(shorten(Markdown(post.post.text).unlink, 210))
                         )
                       }
                     ),

--- a/ui/bits/css/_faq.scss
+++ b/ui/bits/css/_faq.scss
@@ -18,10 +18,8 @@
 
 .faq {
   .question {
-    @extend %box-radius;
-    @include backdrop-blur-if-transparent;
+    @extend %box-bordered;
 
-    border: $border;
     background: $c-bg-zebra;
     padding: 1em 2em;
     margin-top: 1em;

--- a/ui/bits/css/practice/_side.scss
+++ b/ui/bits/css/practice/_side.scss
@@ -1,11 +1,9 @@
 .practice-side {
   @import '../learn/progress';
-  @extend %box-radius, %flex-column;
-  @include backdrop-blur-if-transparent;
+  @extend %box-bordered, %flex-column;
 
   gap: 1em;
   background: $c-bg-box;
-  border: $border;
   text-align: center;
   align-self: start;
   padding: 1em 1.25em;

--- a/ui/bits/css/team/_forum.scss
+++ b/ui/bits/css/team/_forum.scss
@@ -6,7 +6,7 @@
     &__post {
       display: block;
       color: $c-font;
-      padding: 1em 2.5em;
+      padding: 1em 2em;
       overflow: hidden;
 
       &:nth-child(odd) {
@@ -31,7 +31,16 @@
     .meta {
       @extend %flex-between, %zalgoverflow;
 
+      font-size: 90%;
       margin-bottom: 0.5rem;
+
+      span {
+        color: $c-font-dimmer;
+      }
+
+      time {
+        font-size: 100%;
+      }
     }
 
     p {
@@ -39,6 +48,7 @@
 
       color: $c-font-dim;
       text-align: start;
+      margin-bottom: 0.25rem;
     }
 
     a.more {

--- a/ui/bits/css/team/_show.scss
+++ b/ui/bits/css/team/_show.scss
@@ -99,7 +99,7 @@ $section-margin-more: 5vh;
     @extend %box-bordered;
     @include rendered-markdown;
 
-    padding: 1em 2.5em;
+    padding: 0.5em 2em;
     background: $c-bg-zebra;
     font-size: 1.1em;
     margin-bottom: $section-margin-more;

--- a/ui/bits/css/team/_show.scss
+++ b/ui/bits/css/team/_show.scss
@@ -17,6 +17,9 @@ $section-margin-more: 5vh;
   }
 
   .mchat {
+    @extend %box-bordered;
+
+    box-shadow: none;
     height: 40vh;
     margin-bottom: $section-margin;
 
@@ -58,6 +61,10 @@ $section-margin-more: 5vh;
     color: $c-font-dim;
     margin-bottom: $section-margin;
 
+    &:empty {
+      display: none;
+    }
+
     .user-link {
       display: inline-block;
       vertical-align: bottom;
@@ -89,11 +96,11 @@ $section-margin-more: 5vh;
   }
 
   &__desc {
-    @extend %box-neat;
+    @extend %box-bordered;
     @include rendered-markdown;
 
-    padding: 1.5em 2.5em;
-    background: $c-bg-high;
+    padding: 1em 2.5em;
+    background: $c-bg-zebra;
     font-size: 1.1em;
     margin-bottom: $section-margin-more;
     text-align: start;
@@ -109,6 +116,24 @@ $section-margin-more: 5vh;
 
   &__tour {
     margin-bottom: $section-margin-more;
+  }
+
+  &__list-wrapper {
+    @extend %box-bordered;
+
+    overflow: hidden;
+
+    &:empty {
+      display: none;
+    }
+
+    .slist {
+      border-bottom: 0;
+
+      tr:first-child {
+        border-top: 0;
+      }
+    }
   }
 
   &__requests {
@@ -140,7 +165,7 @@ $section-margin-more: 5vh;
 
   .userlist > li,
   .userlist > div.paginated {
-    @include padding-direction(5px, 0, 5px, 25px);
+    @include padding-direction(5px, 0, 5px, 5px);
   }
 
   &__log {

--- a/ui/learn/css/_side-home.scss
+++ b/ui/learn/css/_side-home.scss
@@ -1,11 +1,9 @@
 .learn__side-home {
   @import '../../bits/css/learn/progress';
-  @extend %box-radius, %flex-column;
-  @include backdrop-blur-if-transparent;
+  @extend %box-bordered, %flex-column;
 
   gap: 1em;
   background: $c-bg-box;
-  border: $border;
   text-align: center;
   padding: 1.25em 1.25em 1em;
 

--- a/ui/lib/css/abstract/_box.scss
+++ b/ui/lib/css/abstract/_box.scss
@@ -63,6 +63,13 @@
   @include box-shadow;
 }
 
+%box-bordered {
+  @extend %box-radius;
+  @include backdrop-blur-if-transparent;
+
+  border: $border;
+}
+
 %box-neat {
   @extend %box-shadow, %box-radius;
   @include backdrop-blur-if-transparent;

--- a/ui/user/css/_list-bot.scss
+++ b/ui/user/css/_list-bot.scss
@@ -44,13 +44,11 @@
     user-select: none;
 
     &__entry {
-      @extend %flex-column, %box-radius;
-      @include backdrop-blur-if-transparent;
+      @extend %flex-column, %box-bordered;
 
       justify-content: space-between;
       gap: 1em;
       background: $c-bg-zebra;
-      border: $border;
       overflow: hidden;
 
       &__head {


### PR DESCRIPTION
# Why

Spotted that on the team show page description box blends in with the page content, also using box shadows for nested boxes does not look that good, and shadows are barely visible in dark mode contributing even more to the blend with background.

# How

Summary of changes:
* introduce `box-bordered` extend helper (uses border instead of box shadow)
* change the box style of chat and team description
* add wrappers and use bordered box style for team tournaments and forums threads
* hide meta wrapper if empty, adjust the padding of recent members entries
* use `box-bordered` extend  in few unrelated files, when it could simplify existing styling

# Preview

<img width="1778" height="1176" alt="Screenshot 2026-05-28 at 13 32 10" src="https://github.com/user-attachments/assets/41590447-06f1-48fc-a3a2-801412862be5" />

<img width="1778" height="1176" alt="Screenshot 2026-05-28 at 13 31 51" src="https://github.com/user-attachments/assets/03b531ab-f8ab-4ec1-a3e9-e5033981ea49" />
