### PR TITLE
ui: small improvements for team list page

### DIFF
--- a/modules/team/src/main/ui/TeamUi.scala
+++ b/modules/team/src/main/ui/TeamUi.scala
@@ -63,14 +63,16 @@ final class TeamUi(helpers: Helpers, markdownCache: lila.memo.MarkdownCache):
         ),
         t.intro.map(span(_))
       ),
-      td(cls := "info")(
-        p(trt.nbMembers.plural(t.nbMembers, t.nbMembers.localize)),
+      td(cls := "actions")(
         isMine.option:
           st.form(action := routes.Team.quit(t.id), method := "post")(
             submitButton(cls := "button button-empty button-red button-thin yes-no-confirm team__quit")(
               trt.quitTeam.txt()
             )
           )
+      ),
+      td(cls := "info")(
+        p(trt.nbMembers.plural(t.nbMembers, t.nbMembers.localize))
       )
     )
 

--- a/ui/bits/css/team/_list.scss
+++ b/ui/bits/css/team/_list.scss
@@ -47,20 +47,29 @@
     transition: opacity 0.6s;
   }
 
+  .info,
+  .actions {
+    width: 0;
+
+    @media (width <= $x-small) {
+      display: none;
+    }
+  }
+
   .info {
     font-size: 0.9em;
     white-space: nowrap;
 
     p {
       margin-bottom: 0;
+      text-align: right;
+      font-variant-numeric: tabular-nums;
     }
+  }
 
+  .actions {
     form {
-      margin-top: 0.5em;
-    }
-
-    @media (width <= $x-small) {
-      display: none;
+      margin-left: auto;
     }
   }
 }


### PR DESCRIPTION
# Why

Spotted that for teams you are part of rendering "Leave" button in the same cell as members count causes uneven row height (if team does not have description), which is a bit off looking, until you hover the row and see why.

# How

Summary of changes:
* Move "Leave team" action to the separate cell
* make sure that info and action cells are shrinking to fit the content
* move members label to the right, use tabular nums to guarantee similar label width

# Preview

<img width="1778" height="838" alt="Screenshot 2026-05-28 at 14 01 20" src="https://github.com/user-attachments/assets/af23a00d-5621-4cb9-9ece-e0eb33c17bed" />

<img width="1778" height="1111" alt="Screenshot 2026-05-28 at 14 05 42" src="https://github.com/user-attachments/assets/17748fae-4f87-48c6-9c4e-032a748f987d" />
