### PR TITLE
ui: keep ceval pv-board popup visible with 5 multipv lines

### DIFF
--- a/ui/lib/css/ceval/_pv.scss
+++ b/ui/lib/css/ceval/_pv.scss
@@ -55,6 +55,7 @@
     @include inline-start(34px);
 
     position: absolute;
+    top: 0;
     width: 80%;
     max-width: 240px;
     z-index: 1;


### PR DESCRIPTION
When the engine is set to 5 lines and you hover a move in any PV, the little position preview pops up but its bottom rank is clipped — so the most informative part of the position (where the moved piece usually lands) is the part you can't see. Easy to reproduce on any analysis page after bumping multipv from the default to 5.

The popup (`.pv-board`) is absolutely positioned inside `.pv_box` with no `top` set, so it falls back to its static position — i.e. directly after the PV rows in normal flow. With four lines that lands it roughly in the middle of the pv_box; with five lines the static origin shifts down by another row-height, pushing the bottom of the 240px square popup past the lower bound where the surrounding tools panel will paint it. Hence the clip.

Pinning the popup with `top: 0` removes the dependency on row count: the popup now anchors to the top of the pv_box and sits in the same place whether you have 1 or 5 lines, fully visible in both. The lateral position (`inline-start: 34px`) and `z-index: 1` are untouched, so it still sits above the moves list as before.

Marking as draft — I still owe a before/after screenshot from a local build before this is ready. Plan is to toggle local eval on a couple of analysis URLs, run multipv 1..5 in both Firefox and Chromium, and re-check the col1 mobile layout to make sure the existing rules in `_tools-mobile.scss` aren't affected.

Closes #15986.