### PR TITLE
ui: keep ceval pv-board popup visible with 5 multipv lines

### DIFF
--- a/ui/lib/css/ceval/_pv.scss
+++ b/ui/lib/css/ceval/_pv.scss
@@ -52,10 +52,13 @@
   }
 
   .pv-board {
-    position: relative;
-    width: min(80%, 240px, 40vh);
-    margin-inline-start: 34px;
-    margin-block: 4px;
+    @include inline-start(34px);
+
+    position: absolute;
+    inset-block-start: 100%;
+    width: min(80%, 240px, 40vmin);
+    margin-block-start: 4px;
+    z-index: 2;
 
     .pv-board-square {
       @extend %square;

--- a/ui/lib/css/ceval/_pv.scss
+++ b/ui/lib/css/ceval/_pv.scss
@@ -52,13 +52,10 @@
   }
 
   .pv-board {
-    @include inline-start(34px);
-
-    top: 0;
-    position: absolute;
-    width: 80%;
-    max-width: 240px;
-    z-index: 1;
+    position: relative;
+    width: min(80%, 240px, 40vh);
+    margin-inline-start: 34px;
+    margin-block: 4px;
 
     .pv-board-square {
       @extend %square;

--- a/ui/lib/css/ceval/_pv.scss
+++ b/ui/lib/css/ceval/_pv.scss
@@ -54,6 +54,7 @@
   .pv-board {
     @include inline-start(34px);
 
+    top: 0;
     position: absolute;
     width: 80%;
     max-width: 240px;


### PR DESCRIPTION
Closes https://github.com/lichess-org/lila/issues/15986.

When the engine is set to 5 lines and you hover a move in any PV, the little position preview pops up but its bottom rank is clipped — so the most informative part of the position (where the moved piece usually lands) is the part you can't see. Easy to reproduce on any analysis page after bumping multipv from the default to 5.

The popup (.pv-board) was absolutely positioned inside .pv_box with no top set, so it fell back to its static position — i.e. directly after the PV rows in normal flow. With four lines that lands it roughly in the middle of the pv_box; with five lines the static origin shifts down by another row-height, pushing the bottom of the 240px square popup past the lower bound where the surrounding tools panel (overflow: hidden via %box-radius-force) paints it. Hence the clip.

### The fix

.pv-board stays position: absolute so it never participates in the layout flow, but it's now anchored with inset-block-start: 100% so it opens di its size is clamped with min(80%,240px, 40vmin). Three things follow from that:

- the popup leaves the flow, so summoning it on hover never grows .pv_box and never shifts the move tree
below it;
- anchoring it under the rows keeps the PV text you're hovering readable rather than overlaying it;
- on shorter viewports the square shrie instead of being clipped by the tools panel's overflow: hidden.

No JS, no changes to ancestor overflow.

### Before & After

| Before (Clipping) | After (Clamped/Scaled) |
| :--- | :--- |
| <img width="1910" height="870" alt="image" src="https://github.com/user-attachments/assets/d829a4e0-bf00-4e2b-a53b-9d15f62067b7" /> | <img width="1902" height="872" alt="image" src="https://github.com/user-attachments/assets/430e862b-181f-494a-b845-7b640906606d" /> |

                           
### Alternatives I considered and dropped       
                                                          
- Inline flow (position: relative). Reads cleanly on an empty board, but on a populated move tree the popup occupies real space, so hovering whole move list down by ~250px onevery hover. Dropped.
- Lateral placement (open left/right).the popup past the viewport edge oronto the scrollbar; opening to the left covers the main chessboard and produces a disorienting layout shift across hover events. Neither rea
- Flipping upwards for the bottom rows. Even with pointer-events: none so the cursor can reach the rows underneath, the popup still visually cn't read through it. Turns a previewinto a mouse trap.
- Capping the PV list at 3 visible lines the geometry but breaks the wholepoint of multipv=5: at-a-glance comparison across all five candidate lines. Silently degrading the user's
explicit setting based on viewport is

### Known limitation: viewports under ~390

The clip reappears once the window heiat point it stops being a layout bugand becomes a pixel-budget problem: ceval bar + 5 PV rows + a usable square preview + the move list simply do not all fit, and no CSS strategy in This fix resolves the reported casecleanly across normal and short viewports; the sub-390px regime would need a broader layout rework.