### PR TITLE
return http validation error for unsupported upload file types

### DIFF
--- a/app/controllers/Main.scala
+++ b/app/controllers/Main.scala
@@ -132,14 +132,15 @@ final class Main(env: Env, assetsC: ExternalAssets) extends LilaController(env):
             case None => JsonBadRequest("Image content only")
             case Some(image) =>
               val meta = lila.memo.PicfitApi.form.upload.bindFromRequest().value
-              for
+              (for
                 image <- env.memo.picfitApi.uploadFile(image, me, none, meta)
                 maxWidth = lila.ui.bits.imageDesignWidth(rel)
                 url = meta match
                   case Some(info) if maxWidth.exists(dw => info.dim.width > dw) =>
                     maxWidth.map(dw => env.memo.picfitUrl.resize(image.id, Left(dw)))
                   case _ => env.memo.picfitUrl.raw(image.id).some
-              yield JsonOk(Json.obj("imageUrl" -> url))
+              yield JsonOk(Json.obj("imageUrl" -> url))).recover:
+                case lila.core.lilaism.LilaInvalid(msg) => UnprocessableEntity(jsonError(msg))
   }
 
   def imageUrl(id: ImageId, width: Int) = Auth { _ ?=> _ ?=>

--- a/modules/memo/src/main/picfit/PicfitApi.scala
+++ b/modules/memo/src/main/picfit/PicfitApi.scala
@@ -103,13 +103,18 @@ final class PicfitApi(
       uniqueRef: Option[String],
       meta: Option[form.UploadData]
   ): Fu[ImageFresh] =
+    val validTypes = List(
+      "image/webp" -> "webp",
+      "image/png" -> "png",
+      "image/jpeg" -> "jpg"
+    )
     file.contentType
-      .collect:
-        case "image/webp" => "webp"
-        case "image/png" => "png"
-        case "image/jpeg" => "jpg"
+      .flatMap(validTypes.toMap.get)
       .match
-        case None => fufail(s"Invalid file type: ${file.contentType | "unknown"}")
+        case None =>
+          fufail(
+            lila.core.lilaism.LilaInvalid(s"File must be one of: ${validTypes.map(_._2).mkString(", ")}")
+          )
         case Some(extension) =>
           val image = PicfitImage(
             id = ImageId(s"$hash.$extension"),

--- a/ui/analyse/src/study/studyXhr.ts
+++ b/ui/analyse/src/study/studyXhr.ts
@@ -1,4 +1,4 @@
-import { text as xhrText, json as xhrJson, form as xhrForm, textRaw as xhrRaw } from 'lib/xhr';
+import { text as xhrText, json as xhrJson, form as xhrForm, textRaw as xhrRaw, ensureOk } from 'lib/xhr';
 
 import type { StudyChapterConfig, ReloadData } from './interfaces';
 
@@ -32,12 +32,5 @@ export const importPgn = async (studyId: string, data: any) => {
     method: 'POST',
     body: xhrForm(data),
   });
-  if (res.ok) return res.text();
-  if (res.status === 429) throw new Error('Too many requests');
-  if (res.status === 413) throw new Error('The uploaded file is too large');
-  if (res.status === 400) {
-    const text = await res.text();
-    throw new Error(text);
-  }
-  throw new Error(`Error ${res.status}`);
+  return ensureOk(res).then(r => r.text());
 };

--- a/ui/bits/src/bits.markdownTextarea.ts
+++ b/ui/bits/src/bits.markdownTextarea.ts
@@ -3,7 +3,7 @@ import { marked } from 'marked';
 import { frag } from 'lib';
 import { alert, info, spinnerHtml } from 'lib/view';
 import { wireMarkdownImgResizers, naturalSize, markdownPicfitRegex } from 'lib/view/markdownImgResizer';
-import { json as xhrJson } from 'lib/xhr';
+import { json as xhrJson, ValidationError } from 'lib/xhr';
 
 // also see markdownTextarea.ts
 
@@ -105,7 +105,7 @@ function wireMarkdownTextarea(markdown: HTMLElement) {
       textarea.value = `${before}${maybeNewline}![${image.name}](${imageUrl})\n${after}`;
       textarea.selectionStart = textarea.selectionEnd = textarea.value.length - after.length;
     } catch (e) {
-      alert(String(e) || 'Image upload failed.');
+      alert(e instanceof ValidationError ? e.message : `Image upload failed: ${e}`);
     } finally {
       preview.classList.add('none');
       preview.innerHTML = '';

--- a/ui/bits/src/toastEditor.ts
+++ b/ui/bits/src/toastEditor.ts
@@ -4,9 +4,9 @@ import type { EditorState as EditorStateType } from 'prosemirror-state';
 import type { EditorView as EditorViewType } from 'prosemirror-view';
 
 import { currentTheme } from 'lib/device';
-import { enter } from 'lib/view';
+import { alert, enter } from 'lib/view';
 import { wireMarkdownImgResizers, wrapImg, naturalSize } from 'lib/view/markdownImgResizer';
-import { json as xhrJson } from 'lib/xhr';
+import { ValidationError, json as xhrJson } from 'lib/xhr';
 
 export function makeToastEditor(el: HTMLTextAreaElement, text = '', height = '60vh'): Editor {
   const rewire = () =>
@@ -163,7 +163,7 @@ function toastImageUploadHook(el: HTMLElement) {
       setUrlCallback(imageUrl, name);
     } catch (e) {
       setUrlCallback('');
-      throw e;
+      alert(e instanceof ValidationError ? e.message : `Image upload failed: ${e}`);
     }
   };
 }

--- a/ui/lib/src/view/markdownImgResizer.ts
+++ b/ui/lib/src/view/markdownImgResizer.ts
@@ -112,6 +112,7 @@ export function wrapImg(arg: { img: HTMLImageElement } | { src: string; alt: str
 }
 
 export async function naturalSize(image: Blob): Promise<{ width: number; height: number }> {
+  if (image.type === 'image/svg+xml') throw 'SVG images are not supported.';
   if ('createImageBitmap' in window) return window.createImageBitmap(image);
   const objectUrl = URL.createObjectURL(image);
   const img = new Image();

--- a/ui/lib/src/xhr.ts
+++ b/ui/lib/src/xhr.ts
@@ -1,5 +1,12 @@
 import { defined, notNull } from './index';
 
+export class ValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ValidationError';
+  }
+}
+
 export const jsonHeader = {
   Accept: 'application/web.lichess+json',
 };
@@ -13,11 +20,15 @@ export const xhrHeader = {
   'X-Requested-With': 'XMLHttpRequest', // so lila knows it's XHR
 };
 
-export const ensureOk = (res: Response): Response => {
+export const ensureOk = async (res: Response): Promise<Response> => {
   if (res.ok) return res;
-  if (res.status === 429) throw new Error('Too many requests');
   if (res.status === 413) throw new Error('The uploaded file is too large');
-  throw new Error(`Error ${res.status}`);
+  if (res.status === 422) {
+    const body = await res.json().catch(() => null);
+    throw new ValidationError(body?.error || 'Unprocessable entity');
+  }
+  if (res.status === 429) throw new Error('Too many requests');
+  throw new Error(`Error ${res.status} ${res.statusText} ${await res.text()}`);
 };
 
 /* fetch a static JSON asset without headers that trigger CORS preflight */
@@ -27,11 +38,11 @@ export const jsonSimple = (url: string, init: RequestInit = {}): Promise<any> =>
       ...jsonHeader,
     },
     ...init,
-  }).then(res => ensureOk(res).json());
+  }).then(res => ensureOk(res).then(r => r.json()));
 
 /* fetch a JSON value */
 export const json = (url: string, init: RequestInit = {}): Promise<any> =>
-  jsonAnyResponse(url, init).then(res => ensureOk(res).json());
+  jsonAnyResponse(url, init).then(res => ensureOk(res).then(r => r.json()));
 
 export const jsonAnyResponse = (url: string, init: RequestInit = {}): Promise<any> =>
   fetch(url, {
@@ -45,7 +56,7 @@ export const jsonAnyResponse = (url: string, init: RequestInit = {}): Promise<an
 
 /* fetch a string */
 export const text = (url: string, init: RequestInit = {}): Promise<string> =>
-  textRaw(url, init).then(res => ensureOk(res).text());
+  textRaw(url, init).then(res => ensureOk(res).then(r => r.text()));
 
 export const textRaw = (url: string, init: RequestInit = {}): Promise<Response> =>
   fetch(url, {

--- a/ui/tournament/src/xhr.ts
+++ b/ui/tournament/src/xhr.ts
@@ -74,7 +74,7 @@ export const reloadNow: (ctrl: TournamentController) => Promise<void> = finallyD
         headers: xhr.jsonHeader,
       },
     )
-      .then(res => xhr.ensureOk(res).json())
+      .then(res => xhr.ensureOk(res).then(r => r.json()))
       .then(
         data => {
           ctrl.reload(data);


### PR DESCRIPTION
Currently, lila returns and logs a 500 error if a gif is uploaded.

This changes it to be a 422 and updates the error handling to show it as an alert without a full stack trace.

| before | after |
| - | - |
| <img width="993" height="238" alt="image" src="https://github.com/user-attachments/assets/3481deb3-16c7-40e8-82db-afea17e875e5" /> | <img width="802" height="319" alt="image" src="https://github.com/user-attachments/assets/966d24d1-efe7-4d80-bce0-879f5bd3a613" /> |