### PR TITLE
Broadcasts: Fix color of results in player's games screen in events with custom scoring

### DIFF
--- a/ui/analyse/src/study/relay/customScoreStatus.ts
+++ b/ui/analyse/src/study/relay/customScoreStatus.ts
@@ -1,5 +1,6 @@
 import { opposite } from 'chessops/util';
 
+import { defined } from 'lib';
 import { hl, type LooseVNodes, type VNodeChildElement } from 'lib/view';
 
 import type { GamePointsStr } from '../interfaces';
@@ -13,11 +14,18 @@ const colorClass = (point: ServerPoint) =>
 const withCustomScore = (
   point: ServerPoint,
   color: Color,
-  customScoring?: CustomScoring,
+  customScoring?: CustomScoring | number,
 ): VNodeChildElement => {
-  if (!customScoring) return point;
+  if (!defined(customScoring)) return point;
   const base = points(point);
-  const p = base === 1 ? customScoring[color].win : base === 0.5 ? customScoring[color].draw : 0;
+  const p =
+    typeof customScoring === 'number'
+      ? customScoring
+      : base === 1
+        ? customScoring[color].win
+        : base === 0.5
+          ? customScoring[color].draw
+          : 0;
   return p === 0.5 ? '½' : p;
 };
 
@@ -37,7 +45,7 @@ export const coloredStatusStr = (gamePoints: GamePointsStr, pov: Color, round?: 
 export const playerColoredResult = (
   status: GamePointsStr,
   color: Color,
-  customScoring?: CustomScoring,
+  customScoring?: CustomScoring | number,
 ): { tag: 'good' | 'bad' | 'status'; points: VNodeChildElement } | false => {
   const resultPart = status.split('-')[color === 'white' ? 0 : 1];
   return (

--- a/ui/analyse/src/study/relay/relayPlayers.ts
+++ b/ui/analyse/src/study/relay/relayPlayers.ts
@@ -467,10 +467,9 @@ const renderPlayerGames = (ctrl: RelayPlayers, p: RelayPlayerWithGames, withTips
   const coloredPoint = ({ points, customPoints, color, ongoing }: RelayPlayerGame, index: number) => {
     if (!points) return ongoing && hl('strong', '*');
     if (hideResultsSinceIndex <= index) return hl('span', '?');
-    if (defined(customPoints)) return customPoints === 0.5 ? '½' : customPoints;
 
     const povResultStr = points === '1/2' ? '½-½' : (points === '1') === (color === 'white') ? '1-0' : '0-1';
-    const coloredResult = playerColoredResult(povResultStr, color);
+    const coloredResult = playerColoredResult(povResultStr, color, customPoints);
     return coloredResult && hl(coloredResult.tag, coloredResult.points);
   };
 


### PR DESCRIPTION
I also hate regressing one commit after another. 

|before| after|
|---|---|
|<img width="1536" height="784" alt="image" src="https://github.com/user-attachments/assets/1e1a7937-4b30-4428-ab4b-7eeed4be7b12" />|<img width="1803" height="782" alt="image" src="https://github.com/user-attachments/assets/93ba0b52-b59e-4fd0-bc28-3c6bc919bee8" />|
