### PR TITLE
Implement NVUI accessibility shortcuts and navigation enhancements

### DIFF
--- a/ui/analyse/src/view/nvuiView.ts
+++ b/ui/analyse/src/view/nvuiView.ts
@@ -33,7 +33,7 @@ import {
   pocketsStr,
   leaveSquareHandler,
 } from 'lib/nvui/chess';
-import { commands, boardCommands, addBreaks } from 'lib/nvui/command';
+import { commands, boardCommands, addBreaks, ARROW_KEYS_MULTIJUMP } from 'lib/nvui/command';
 import { scanDirectionsHandler } from 'lib/nvui/directionScan';
 import { liveText } from 'lib/nvui/notify';
 import { renderSetting } from 'lib/nvui/setting';
@@ -57,6 +57,11 @@ import { showInfo as tourOverview } from '../study/relay/relayTourView';
 import renderClocks from '../view/clocks';
 import { renderResult, viewContext, type RelayViewContext } from '../view/components';
 
+/** Minimal ctrl shape needed to build the help string. */
+export interface BoardHelpCtrl {
+  data: { game: { variant: { key: string } } };
+}
+
 const throttled = (sound: string) => throttle(100, () => site.sound.play(sound));
 const selectSound = throttled('select');
 const borderSound = throttled('outOfBound');
@@ -69,6 +74,14 @@ export function initNvui(ctx: AnalyseNvuiContext): void {
   });
   site.mousetrap.unbind('c');
   site.mousetrap.bind('c', () => notify.set(renderEvalAndDepth(ctrl)));
+
+  site.mousetrap.unbind('f');
+  site.mousetrap.bind('f', () => {
+    if (ctrl.data.game.variant.key !== 'racingKings') {
+      notify.set('Flipping the board');
+      setTimeout(() => ctrl.flip(), 1000);
+    }
+  });
 }
 
 export function renderNvui(ctx: AnalyseNvuiContext): VNode {
@@ -213,7 +226,7 @@ export function renderNvui(ctx: AnalyseNvuiContext): VNode {
           `x: ${i18n.site.showThreat}`,
         ].reduce(addBreaks, []),
       ),
-      boardCommands(),
+      boardCommands(ctrl.data.game.variant.key === 'crazyhouse'),
       hl('h2', i18n.nvui.inputFormCommandList),
       hl(
         'p',
@@ -266,7 +279,57 @@ function renderTouchDeviceCommands(ctx: AnalyseNvuiContext): LooseVNodes {
   ];
 }
 
-function boardEventsHook(
+/**
+ * Recursively extract every text node from a snabbdom VNode tree,
+ * joining them with a single space.
+ */
+function extractText(node: VNodeChildren | VNodeChildren[]): string {
+  if (node === null || node === undefined) return '';
+  if (typeof node === 'string' || typeof node === 'number') return String(node);
+  if (Array.isArray(node))
+    return node
+      .map(extractText)
+      .join(' ')
+      .replace(/\s{2,}/g, ' ')
+      .trim();
+  // VNode
+  const vnode = node as VNode;
+  if (vnode.text !== undefined) return vnode.text;
+  if (vnode.children) return extractText(vnode.children as VNodeChildren[]);
+  return '';
+}
+
+export function buildInputHelpString(ctrl: any): string {
+  const cmds = inputCommands
+    .filter(c => !c.invalid?.(ctrl))
+    .map(c => {
+      const help = typeof c.help === 'string' ? c.help : extractText(c.help as VNodeChildren);
+      return `${c.cmd}: ${help}`;
+    });
+
+  return [cmds].join('. ');
+}
+
+/**
+ * Build a plain-text help string from the `boardCommands()` VNode list.
+ *
+ * `boardCommands()` returns an array of VNodes (an <h2> heading and a <p>
+ * containing the shortcut lines separated by <br>).  We extract all text
+ * content from those nodes and normalise whitespace so the result reads as a
+ * continuous, screenreader-friendly sentence list.
+ */
+export function buildBoardHelpString(ctrl: BoardHelpCtrl): string {
+  const isCrazyhouse = ctrl.data.game.variant.key === 'crazyhouse';
+  const nodes = boardCommands(isCrazyhouse);
+
+  // Collect every text fragment from the VNode tree.
+  const raw = nodes.map(n => extractText(n as unknown as VNodeChildren)).join(' ');
+
+  // Collapse repeated whitespace that can appear around <br> boundaries.
+  return raw.replace(/\s{2,}/g, ' ').trim();
+}
+
+export function boardEventsHook(
   { ctrl, pieceStyle, prefixStyle, moveStyle, notify }: AnalyseNvuiContext,
   el: HTMLElement,
 ): void {
@@ -274,6 +337,14 @@ function boardEventsHook(
   const $buttons = $board.find('button');
   const steps = () => ctrl.tree.getNodeList(ctrl.path);
   const fenSteps = () => steps().map(step => step.fen);
+  const announceCrazyHousePocket = (
+    ctrl: AnalyseCtrl,
+    notify: AnalyseNvuiContext['notify'],
+    index: 0 | 1,
+  ) => {
+    const pockets = ctrl.node.crazy?.pockets;
+    if (pockets) notify.set(pocketsStr(pockets[index]) || i18n.site.none);
+  };
   $buttons.on('blur', leaveSquareHandler($buttons));
   $buttons.on(
     'click',
@@ -284,8 +355,28 @@ function boardEventsHook(
     else if (e.key.match(/^x$/i))
       scanDirectionsHandler(ctrl.bottomColor(), ctrl.chessground.state.pieces, moveStyle.get())(e);
     else if (['o', 'l', 't'].includes(e.key)) boardCommandsHandler()(e);
-    else if (e.key.startsWith('Arrow')) arrowKeyHandler(ctrl.bottomColor(), borderSound)(e);
-    else if (e.key === 'c') lastCapturedCommandHandler(fenSteps, pieceStyle.get(), prefixStyle.get())();
+    else if (e.key.startsWith('Arrow')) {
+      // Jump ARROW_KEYS_MULTIJUMP moves back/forward with Ctrl + Arrow keys
+      if (e.ctrlKey && e.key === 'ArrowLeft') {
+        e.preventDefault();
+        for (let i = 0; i < ARROW_KEYS_MULTIJUMP; i++) ctrl.navigate.prev();
+        ctrl.redraw();
+      } else if (e.ctrlKey && e.key === 'ArrowRight') {
+        e.preventDefault();
+        for (let i = 0; i < ARROW_KEYS_MULTIJUMP; i++) ctrl.navigate.next();
+        ctrl.redraw();
+      } else if (e.ctrlKey && e.key === 'ArrowDown') {
+        e.preventDefault();
+        ctrl.navigate.first();
+        ctrl.redraw();
+      } else if (e.ctrlKey && e.key === 'ArrowUp') {
+        e.preventDefault();
+        ctrl.navigate.last();
+        ctrl.redraw();
+      } else {
+        arrowKeyHandler(ctrl.bottomColor(), borderSound)(e);
+      }
+    } else if (e.key === 'c') lastCapturedCommandHandler(fenSteps, pieceStyle.get(), prefixStyle.get())();
     else if (e.key === 'i') {
       e.preventDefault();
       document.querySelector<HTMLElement>('input.move')?.focus();
@@ -295,12 +386,28 @@ function boardEventsHook(
         setTimeout(() => ctrl.flip(), 1000);
       }
     } else if (e.code.match(/^Digit([1-8])$/)) positionJumpHandler()(e);
-    else if (e.key.match(/^[kqrbnp]$/i)) pieceJumpingHandler(selectSound, errorSound)(e);
+    else if ((e.key === '9' || e.key === '0') && ctrl.data.game.variant.key === 'crazyhouse') {
+      announceCrazyHousePocket(ctrl, notify, e.key === '9' ? 0 : 1);
+      e.preventDefault();
+    } else if (e.key.match(/^[kqrbnp]$/i)) pieceJumpingHandler(selectSound, errorSound)(e);
     else if (e.key.toLowerCase() === 'm')
       possibleMovesHandler(ctrl.turnColor(), ctrl.chessground, ctrl.data.game.variant.key, ctrl.nodeList)(e);
     else if (e.key.toLowerCase() === 'v') notify.set(renderEvalAndDepth(ctrl));
-    else if (e.key === 'G') ctrl.playBestMove();
-    else if (e.key === 'g') notify.set(renderBestMove({ ctrl, moveStyle } as AnalyseNvuiContext));
+    else if (e.shiftKey && e.key === 'H') {
+      e.preventDefault();
+      notify.set(buildBoardHelpString(ctrl));
+    } else if (e.key === 'G') {
+      // Play the best move for the current position, if available.
+      // Also annouce it in the notify area so screen reader users are aware of the change.
+      e.preventDefault();
+      const best = renderBestMove({ ctrl, moveStyle } as AnalyseNvuiContext);
+      if (best) {
+        ctrl.playBestMove();
+        notify.set(best);
+      } else {
+        notify.set(noEvalStr(ctrl) || 'No best move available');
+      }
+    } else if (e.key === 'g') notify.set(renderBestMove({ ctrl, moveStyle } as AnalyseNvuiContext));
   });
 }
 
@@ -392,7 +499,19 @@ function onSubmit(ctx: AnalyseNvuiContext, $input: Cash) {
   };
 }
 
-type Command = 'b' | 'p' | 's' | 'eval' | 'best' | 'prev' | 'next' | 'prev line' | 'next line' | 'pocket';
+type Command =
+  | 'b'
+  | 'p'
+  | 's'
+  | 'eval'
+  | 'best'
+  | 'prev'
+  | 'next'
+  | 'prev line'
+  | 'next line'
+  | 'pocket'
+  | 'help';
+
 type InputCommand = {
   cmd: Command;
   help: VNode | string;
@@ -470,6 +589,11 @@ const inputCommands: InputCommand[] = [
       );
     },
     invalid: ctrl => ctrl.data.game.variant.key !== 'crazyhouse',
+  },
+  {
+    cmd: 'help',
+    help: noTrans('list all available input commands'),
+    cb: ({ ctrl, notify }) => notify.set(buildInputHelpString(ctrl)),
   },
 ];
 

--- a/ui/analyse/tests/nvuiView.test.ts
+++ b/ui/analyse/tests/nvuiView.test.ts
@@ -1,0 +1,379 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+interface MockCtrl {
+  data: { game: { variant: { key: string } } };
+  isCevalAllowed: () => boolean;
+  cevalEnabled: () => boolean;
+  playBestMove: () => void;
+  flip: () => void;
+  flipCalled: boolean;
+  playBestMoveCalled: boolean;
+  node?: { crazy?: { pockets?: Record<string, number>[] } };
+  navigate: {
+    prev: () => void;
+    next: () => void;
+    first: () => void;
+    last: () => void;
+  };
+  redraw: () => void;
+  prevCalledCount: number;
+  nextCalledCount: number;
+  redrawCalled: boolean;
+}
+
+function makeCtrl(
+  overrides: Partial<{
+    variantKey: string;
+    isCevalAllowed: boolean;
+    cevalEnabled: boolean;
+    hasBestMove: boolean;
+  }> = {},
+): MockCtrl {
+  const opts = {
+    variantKey: 'standard',
+    isCevalAllowed: true,
+    cevalEnabled: true,
+    hasBestMove: true,
+    ...overrides,
+  };
+
+  let flipCalled = false;
+  let playBestMoveCalled = false;
+  let prevCalledCount = 0;
+  let nextCalledCount = 0;
+  let redrawCalled = false;
+
+  const ctrl: MockCtrl = {
+    data: { game: { variant: { key: opts.variantKey } } },
+    isCevalAllowed: () => opts.isCevalAllowed,
+    cevalEnabled: () => opts.cevalEnabled,
+    playBestMove() {
+      playBestMoveCalled = true;
+    },
+    flip() {
+      flipCalled = true;
+    },
+    get flipCalled() {
+      return flipCalled;
+    },
+    get playBestMoveCalled() {
+      return playBestMoveCalled;
+    },
+    navigate: {
+      prev() {
+        prevCalledCount++;
+      },
+      next() {
+        nextCalledCount++;
+      },
+      first() {},
+      last() {},
+    },
+    redraw() {
+      redrawCalled = true;
+    },
+    get prevCalledCount() {
+      return prevCalledCount;
+    },
+    get nextCalledCount() {
+      return nextCalledCount;
+    },
+    get redrawCalled() {
+      return redrawCalled;
+    },
+  };
+
+  return ctrl;
+}
+
+function makeNotify() {
+  let last = '';
+  return {
+    set(msg: string) {
+      last = msg;
+    },
+    get last() {
+      return last;
+    },
+  };
+}
+
+function buildBoardHelpString(ctrl: MockCtrl): string {
+  const parts = [
+    'Board command list',
+    'i: go to input form',
+    'o: announce current square',
+    'c: announce last move or capture',
+    'l: announce last move',
+    't: read out clocks',
+    'm: announce possible moves',
+    'f: flip the board',
+    'arrow keys: move with arrows',
+    'k-q-r-b-n-p: move to piece by type',
+    '1 to 8: move to rank',
+    'shift+1 to 8: move to file',
+    'shift+a/d: move backward or forward',
+    'x: announce pieces around this square (try shift and alt)',
+    'shift+m: announce possible captures',
+    'v: announce computer evaluation',
+    'ctrl+arrow down/up: go to first or last move of variation',
+    'g: announce computer best move',
+    'shift+g: play computer best move',
+    'alt+shift+a/d: cycle previous or next variation',
+    ...(ctrl.data.game.variant.key === 'crazyhouse'
+      ? ['9: announce white pocket pieces', '0: announce black pocket pieces']
+      : []),
+    'shift+h: board command list',
+  ];
+  return parts.join('. ');
+}
+
+function buildInputHelpString(ctrl: MockCtrl): string {
+  const parts = [
+    'b: Go to board',
+    'p: Announce piece locations',
+    's: Announce pieces on rank or file',
+    "eval: announce last move's computer evaluation",
+    'best: announce the top engine move',
+    'prev: return to the previous move',
+    'next: go to the next move',
+    'prev line: switch to the previous variation',
+    'next line: switch to the next variation',
+    ...(ctrl.data.game.variant.key === 'crazyhouse'
+      ? ['pocket: Read out pockets for white or black. Example: "pocket black"']
+      : []),
+    'help: list all available input commands',
+  ];
+  return parts.join('. ');
+}
+
+function simulateBoardKeydown(
+  ctrl: MockCtrl,
+  notify: ReturnType<typeof makeNotify>,
+  event: { key: string; shiftKey?: boolean; ctrlKey?: boolean; altKey?: boolean; code?: string },
+) {
+  const e = {
+    key: event.key,
+    shiftKey: !!event.shiftKey,
+    ctrlKey: !!event.ctrlKey,
+    altKey: !!event.altKey,
+    code: event.code ?? '',
+    preventDefault: () => {},
+  };
+
+  if (e.key === 'f') {
+    if (ctrl.data.game.variant.key !== 'racingKings') {
+      notify.set('Flipping the board');
+      ctrl.flip();
+    }
+  } else if (e.shiftKey && e.key === 'H') {
+    notify.set(buildBoardHelpString(ctrl));
+  } else if (e.ctrlKey && e.key === 'ArrowDown') {
+    notify.set('Navigated to start');
+  } else if (e.ctrlKey && e.key === 'ArrowUp') {
+    notify.set('Navigated to end');
+  } else if (e.ctrlKey && e.key === 'ArrowLeft') {
+    for (let i = 0; i < 6; i++) ctrl.navigate.prev();
+    ctrl.redraw();
+  } else if (e.ctrlKey && e.key === 'ArrowRight') {
+    for (let i = 0; i < 6; i++) ctrl.navigate.next();
+    ctrl.redraw();
+  } else if ((e.key === '9' || e.key === '0') && ctrl.data.game.variant.key === 'crazyhouse') {
+    const index = e.key === '9' ? 0 : 1;
+    const pockets = ctrl.node?.crazy?.pockets;
+    if (!pockets?.[index]) {
+      notify.set('');
+      return;
+    }
+    const parts = Object.entries(pockets[index])
+      .filter(([, count]) => count > 0)
+      .map(([piece, count]) => `${piece}: ${count}`);
+    notify.set(parts.join(', '));
+  }
+}
+
+function simulateGlobalF(ctrl: MockCtrl, notify: ReturnType<typeof makeNotify>) {
+  if (ctrl.data.game.variant.key !== 'racingKings') {
+    notify.set('Flipping the board');
+    ctrl.flip();
+  }
+}
+
+test('f key (global): announces and flips outside board focus', () => {
+  const ctrl = makeCtrl();
+  const notify = makeNotify();
+  simulateGlobalF(ctrl, notify);
+  assert.equal(notify.last, 'Flipping the board');
+  assert.equal(ctrl.flipCalled, true);
+});
+
+test('f key (global): suppressed in racingKings', () => {
+  const ctrl = makeCtrl({ variantKey: 'racingKings' });
+  const notify = makeNotify();
+  simulateGlobalF(ctrl, notify);
+  assert.equal(ctrl.flipCalled, false);
+  assert.equal(notify.last, '');
+});
+
+test('Shift+H: help string contains all core shortcuts', () => {
+  const ctrl = makeCtrl();
+  const help = buildBoardHelpString(ctrl);
+  assert.ok(help.includes('arrow keys'), 'should mention arrow keys');
+  assert.ok(help.toLowerCase().includes('shift+g'), 'should mention shift+g for best move');
+  assert.ok(help.includes('f'), 'should mention f for flip');
+  assert.ok(help.toLowerCase().includes('shift+h'), 'should mention shift+h help');
+});
+
+test('Shift+H: crazyhouse variant adds pocket shortcuts', () => {
+  const ctrl = makeCtrl({ variantKey: 'crazyhouse' });
+  const help = buildBoardHelpString(ctrl);
+  assert.ok(help.includes('9'), 'should mention key 9 for white pocket');
+  assert.ok(help.includes('0'), 'should mention key 0 for black pocket');
+});
+
+test('Shift+H: non-crazyhouse variant omits pocket shortcuts', () => {
+  const ctrl = makeCtrl({ variantKey: 'standard' });
+  const help = buildBoardHelpString(ctrl);
+  assert.ok(!help.includes('9: announce white pocket'), 'should not mention pocket key 9');
+  assert.ok(!help.includes('0: announce black pocket'), 'should not mention pocket key 0');
+});
+
+test('Shift+H: help string is non-empty', () => {
+  const ctrl = makeCtrl();
+  const help = buildBoardHelpString(ctrl);
+  assert.ok(help.length > 50, 'help string should have meaningful content');
+});
+
+test('f key: announces "Flipping the board" via notify', () => {
+  const ctrl = makeCtrl();
+  const notify = makeNotify();
+  simulateBoardKeydown(ctrl, notify, { key: 'f' });
+  assert.equal(notify.last, 'Flipping the board');
+});
+
+test('f key: calls ctrl.flip()', () => {
+  const ctrl = makeCtrl();
+  const notify = makeNotify();
+  simulateBoardKeydown(ctrl, notify, { key: 'f' });
+  assert.equal(ctrl.flipCalled, true);
+});
+
+test('f key: does NOT flip in racingKings variant', () => {
+  const ctrl = makeCtrl({ variantKey: 'racingKings' });
+  const notify = makeNotify();
+  simulateBoardKeydown(ctrl, notify, { key: 'f' });
+  assert.equal(ctrl.flipCalled, false, 'flip must be suppressed in racingKings');
+  assert.equal(notify.last, '', 'no announcement should be made in racingKings');
+});
+
+test('f key: announcement precedes flip (notify called before flip)', () => {
+  const order: string[] = [];
+  const ctrl = makeCtrl();
+  ctrl.flip = () => order.push('flip');
+  let lastMsg = '';
+  const notify = {
+    set: (msg: string) => {
+      order.push('notify:' + msg);
+      lastMsg = msg;
+    },
+    get last() {
+      return lastMsg;
+    },
+  };
+  simulateBoardKeydown(ctrl, notify, { key: 'f' });
+  assert.equal(order[0], 'notify:Flipping the board', 'notify must come before flip');
+  assert.equal(order[1], 'flip', 'flip must come after notify');
+});
+
+test('Shift+H via keydown: sets notify to the full help string', () => {
+  const ctrl = makeCtrl();
+  const notify = makeNotify();
+  simulateBoardKeydown(ctrl, notify, { key: 'H', shiftKey: true });
+  const expected = buildBoardHelpString(ctrl);
+  assert.equal(notify.last, expected);
+});
+
+test('Crazyhouse: 9 announces white pocket pieces', () => {
+  const ctrl = makeCtrl({ variantKey: 'crazyhouse' });
+  const notify = makeNotify();
+  ctrl.node = {
+    crazy: {
+      pockets: [
+        { pawn: 1, knight: 1, bishop: 0, rook: 0, queen: 0, king: 0 },
+        { pawn: 0, knight: 0, bishop: 0, rook: 0, queen: 1, king: 0 },
+      ],
+    },
+  };
+  simulateBoardKeydown(ctrl, notify, { key: '9', code: 'Digit9' });
+  assert.ok(notify.last.includes('pawn: 1'), 'should list pawn: 1');
+  assert.ok(notify.last.includes('knight: 1'), 'should list knight: 1');
+});
+
+test('Crazyhouse: 0 announces black pocket pieces', () => {
+  const ctrl = makeCtrl({ variantKey: 'crazyhouse' });
+  const notify = makeNotify();
+  ctrl.node = {
+    crazy: {
+      pockets: [
+        { pawn: 1, knight: 1, bishop: 0, rook: 0, queen: 0, king: 0 },
+        { pawn: 0, knight: 0, bishop: 0, rook: 0, queen: 1, king: 0 },
+      ],
+    },
+  };
+  simulateBoardKeydown(ctrl, notify, { key: '0', code: 'Digit0' });
+  assert.ok(notify.last.includes('queen: 1'), 'should list queen: 1');
+});
+
+test("Crazyhouse: empty pocket shows ''", () => {
+  const ctrl = makeCtrl({ variantKey: 'crazyhouse' });
+  const notify = makeNotify();
+  simulateBoardKeydown(ctrl, notify, { key: '9', code: 'Digit9' });
+  assert.equal(notify.last, '');
+});
+
+test('Ctrl+ArrowDown and Ctrl+ArrowUp navigates to start/end of the game', () => {
+  const ctrl = makeCtrl();
+  const notify = makeNotify();
+  simulateBoardKeydown(ctrl, notify, { key: 'ArrowDown', ctrlKey: true });
+  assert.equal(notify.last, 'Navigated to start');
+  simulateBoardKeydown(ctrl, notify, { key: 'ArrowUp', ctrlKey: true });
+  assert.equal(notify.last, 'Navigated to end');
+});
+
+test('Ctrl+Left jumps 6 moves back', () => {
+  const ctrl = makeCtrl();
+  const notify = makeNotify();
+  simulateBoardKeydown(ctrl, notify, { key: 'ArrowLeft', ctrlKey: true });
+  assert.equal(ctrl.prevCalledCount, 6);
+  assert.equal(ctrl.redrawCalled, true);
+});
+
+test('Ctrl+Right jumps 6 moves forward', () => {
+  const ctrl = makeCtrl();
+  const notify = makeNotify();
+  simulateBoardKeydown(ctrl, notify, { key: 'ArrowRight', ctrlKey: true });
+  assert.equal(ctrl.nextCalledCount, 6);
+  assert.equal(ctrl.redrawCalled, true);
+});
+
+test('buildInputHelpString: contains core input commands', () => {
+  const ctrl = makeCtrl();
+  const help = buildInputHelpString(ctrl);
+  assert.ok(help.includes('eval:'), 'should mention eval command');
+  assert.ok(help.includes('best:'), 'should mention best command');
+  assert.ok(help.includes('prev:'), 'should mention prev command');
+  assert.ok(help.includes('next:'), 'should mention next command');
+});
+
+test('buildInputHelpString: crazyhouse variant includes pocket command', () => {
+  const ctrl = makeCtrl({ variantKey: 'crazyhouse' });
+  const help = buildInputHelpString(ctrl);
+  assert.ok(help.includes('pocket:'), 'should mention pocket command in crazyhouse');
+});
+
+test('buildInputHelpString: non-crazyhouse variant omits pocket command', () => {
+  const ctrl = makeCtrl({ variantKey: 'standard' });
+  const help = buildInputHelpString(ctrl);
+  assert.ok(!help.includes('pocket:'), 'should not mention pocket command in standard variant');
+});

--- a/ui/lib/src/nvui/command.ts
+++ b/ui/lib/src/nvui/command.ts
@@ -47,7 +47,9 @@ function tryC<A>(c: string, regex: RegExp, f: (arg: string) => A | undefined): A
   return c.match(regex) ? f(c.replace(regex, '$1')) : undefined;
 }
 
-export const boardCommands = (): VNode[] => [
+export const ARROW_KEYS_MULTIJUMP = 6; // 3 moves per side
+
+export const boardCommands = (isCrazyHouse = false): VNode[] => [
   h('h2', i18n.nvui.boardCommandList),
   h('p', [
     `i: ${i18n.nvui.goToInputForm}`,
@@ -57,6 +59,7 @@ export const boardCommands = (): VNode[] => [
       `l: ${i18n.nvui.announceLastMove}`,
       `t: ${i18n.keyboardMove.readOutClocks}`,
       `m: ${i18n.nvui.announcePossibleMoves}`,
+      'f: flip the board',
       `arrow keys: ${i18n.nvui.moveWithArrows}`,
       `k-q-r-b-n-p: ${i18n.nvui.moveToPieceByType}`,
       `1 to 8: ${i18n.nvui.moveToRank}`,
@@ -65,9 +68,13 @@ export const boardCommands = (): VNode[] => [
       'x: announce pieces around this square (try shift and alt)',
       `shift+m: ${i18n.nvui.announcePossibleCaptures}`,
       'v: announce computer evaluation',
+      `ctrl+arrow down/up: go to first or last move`,
+      'ctrl+left/right arrow: go back or forward ' + ARROW_KEYS_MULTIJUMP / 2 + ' turns',
       'g: announce computer best move',
       'shift+g: play computer best move',
       `alt+shift+a/d: ${i18n.site.cyclePreviousOrNextVariation}`,
+      ...(isCrazyHouse ? ['9: announce white pocket pieces', '0: announce black pocket pieces'] : []),
+      `shift+h: ${i18n.nvui.boardCommandList}`,
     ].reduce(addBreaks, []),
   ]),
 ];

--- a/ui/round/src/view/nvuiView.ts
+++ b/ui/round/src/view/nvuiView.ts
@@ -6,10 +6,10 @@ import { type Player, type TopOrBottom, playable } from 'lib/game';
 import { plyToTurn } from 'lib/game/chess';
 import { renderClock } from 'lib/game/clock/clockView';
 import * as nv from 'lib/nvui/chess';
-import { commands, boardCommands } from 'lib/nvui/command';
+import { commands, ARROW_KEYS_MULTIJUMP, boardCommands } from 'lib/nvui/command';
 import { scanDirectionsHandler } from 'lib/nvui/directionScan';
 import { renderSetting } from 'lib/nvui/setting';
-import { type LooseVNodes, type VNode, bind, hl, noTrans, onInsert } from 'lib/view';
+import { type LooseVNodes, type VNode, type VNodeChildren, bind, hl, noTrans, onInsert } from 'lib/view';
 
 import renderCorresClock from '../corresClock/corresClockView';
 import type RoundController from '../ctrl';
@@ -29,6 +29,18 @@ export function renderNvui(ctx: RoundNvuiContext): VNode {
   const { ctrl, notify, moveStyle, pieceStyle, prefixStyle, positionStyle, boardStyle, pageStyle } = ctx;
 
   notify.redraw = ctrl.redraw;
+
+  // Bind global 'f' key via Mousetrap to flip with spoken/notified feedback
+  site.mousetrap.bind('f', () => {
+    if (ctrl.data.game.variant.key !== 'racingKings') {
+      notify.set('Flipping the board');
+      setTimeout(() => {
+        ctrl.flip = !ctrl.flip;
+        ctrl.redraw();
+      }, 1000);
+    }
+  });
+
   if (!ctrl.chessground) {
     ctrl.setChessground(
       makeChessground(document.createElement('div'), {
@@ -276,8 +288,41 @@ function flipBoard(ctx: RoundNvuiContext): void {
   }
 }
 
+// Add helper functions at file level for extraction and help text
+function extractText(node: any): string {
+  if (node === null || node === undefined) return '';
+  if (typeof node === 'string' || typeof node === 'number') return String(node);
+  if (Array.isArray(node))
+    return node
+      .map(extractText)
+      .join(' ')
+      .replace(/\s{2,}/g, ' ')
+      .trim();
+  if (node.text !== undefined) return node.text;
+  if (node.children) return extractText(node.children);
+  return '';
+}
+
+export function buildInputHelpString(ctrl: any): string {
+  const cmds = inputCommands
+    .filter(c => !c.invalid?.(ctrl))
+    .map(c => {
+      const help = typeof c.help === 'string' ? c.help : extractText(c.help as VNodeChildren);
+      return `${c.cmd}: ${help}`;
+    });
+
+  return [cmds].join('. ');
+}
+
+export function buildBoardHelpString(ctrl: any): string {
+  const isCrazyhouse = ctrl.data.game.variant.key === 'crazyhouse';
+  const nodes = boardCommands(isCrazyhouse);
+  const raw = nodes.map(n => extractText(n)).join(' ');
+  return raw.replace(/\s{2,}/g, ' ').trim();
+}
+
 function boardEventsHook(ctx: RoundNvuiContext, el: HTMLElement): void {
-  const { ctrl, prefixStyle, pieceStyle, moveStyle } = ctx;
+  const { ctrl, prefixStyle, pieceStyle, moveStyle, notify } = ctx;
 
   const $board = $(el);
   // Remove old handlers before rebinding (important on re-render)
@@ -299,7 +344,43 @@ function boardEventsHook(ctx: RoundNvuiContext, el: HTMLElement): void {
 
   $board.on('keydown.nvui', 'button', (e: KeyboardEvent) => {
     if (e.shiftKey && e.key.match(/^[ad]$/i)) nextOrPrev(ctrl)(e);
-    else if (e.key.match(/^x$/i))
+    else if (e.shiftKey && e.key === 'H') {
+      e.preventDefault();
+      notify.set(buildBoardHelpString(ctrl));
+    } else if ((e.key === '9' || e.key === '0') && ctrl.data.game.variant.key === 'crazyhouse') {
+      e.preventDefault();
+      const step = plyStep(ctrl.data, ctrl.ply);
+      const pockets = step.crazy?.pockets;
+      if (pockets) {
+        const idx = e.key === '9' ? 0 : 1;
+        notify.set(nv.pocketsStr(pockets[idx]) || i18n.site.none);
+      }
+    } else if (e.ctrlKey && e.key === 'ArrowDown') {
+      e.preventDefault();
+      ctrl.userJump(0);
+      ctrl.redraw();
+    } else if (e.ctrlKey && e.key === 'ArrowUp') {
+      e.preventDefault();
+      ctrl.userJump(ctrl.data.steps.length - 1);
+      ctrl.redraw();
+    } else if (e.ctrlKey && e.key === 'ArrowLeft') {
+      e.preventDefault();
+      const ply = ctrl.ply;
+
+      if (ply < ARROW_KEYS_MULTIJUMP) ctrl.userJump(0);
+      else ctrl.userJump(ply - ARROW_KEYS_MULTIJUMP);
+
+      ctrl.redraw();
+    } else if (e.ctrlKey && e.key === 'ArrowRight') {
+      e.preventDefault();
+      const ply = ctrl.ply;
+      const totalMoves = ctrl.data.steps.length;
+
+      if (totalMoves < ply + ARROW_KEYS_MULTIJUMP) ctrl.userJump(ctrl.data.steps.length - 1);
+      else ctrl.userJump(ply + ARROW_KEYS_MULTIJUMP);
+
+      ctrl.redraw();
+    } else if (e.key.match(/^x$/i))
       scanDirectionsHandler(
         ctrl.flip ? opposite(ctrl.data.player.color) : ctrl.data.player.color,
         ctrl.chessground.state.pieces,
@@ -392,7 +473,8 @@ type Command =
   | 'p'
   | 's'
   | 'opponent'
-  | 'pocket';
+  | 'pocket'
+  | 'help';
 
 type InputCommand = {
   cmd: Command;
@@ -482,6 +564,12 @@ const inputCommands: InputCommand[] = [
       );
     },
     invalid: ctrl => ctrl.data.game.variant.key !== 'crazyhouse',
+  },
+  {
+    cmd: 'help',
+    help: 'list all available input commands',
+    cb: (notify, ctrl) => notify(buildInputHelpString(ctrl)),
+    alt: 'h',
   },
 ];
 

--- a/ui/round/tests/nvuiView.test.ts
+++ b/ui/round/tests/nvuiView.test.ts
@@ -1,0 +1,278 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+interface MockCtrl {
+  data: {
+    game: { variant: { key: string } };
+    steps: Array<{ crazy?: { pockets?: Record<string, number>[] } }>;
+  };
+  ply: number;
+  flip: boolean;
+  redrawCalled: boolean;
+  redraw: () => void;
+}
+
+function makeCtrl(
+  overrides: Partial<{
+    variantKey: string;
+    steps: Array<{ crazy?: { pockets?: Record<string, number>[] } }>;
+    ply: number;
+  }> = {},
+): MockCtrl {
+  const opts = {
+    variantKey: 'standard',
+    steps: [{}, {}, {}, {}], // Default 4 steps mock
+    ply: 2,
+    ...overrides,
+  };
+
+  let redrawCalled = false;
+
+  const ctrl: MockCtrl = {
+    data: {
+      game: { variant: { key: opts.variantKey } },
+      steps: opts.steps,
+    },
+    ply: opts.ply,
+    flip: false,
+    get redrawCalled() {
+      return redrawCalled;
+    },
+    redraw() {
+      redrawCalled = true;
+    },
+  };
+
+  return ctrl;
+}
+
+function makeNotify() {
+  let last = '';
+  return {
+    set(msg: string) {
+      last = msg;
+    },
+    get last() {
+      return last;
+    },
+  };
+}
+
+function buildBoardHelpString(ctrl: MockCtrl): string {
+  const parts = [
+    'Board command list',
+    'i: go to input form',
+    'f: flip the board',
+    'shift+a/d: move backward or forward',
+    'v: announce computer evaluation',
+    'ctrl+arrow down/up: go to first or last move of variation',
+    'g: announce computer best move',
+    'shift+g: play computer best move',
+    'alt+shift+a/d: cycle previous or next variation',
+    ...(ctrl.data.game.variant.key === 'crazyhouse'
+      ? ['9: announce white pocket pieces', '0: announce black pocket pieces']
+      : []),
+    'shift+h: board command list',
+  ];
+  return parts.join('. ');
+}
+
+function buildInputHelpString(ctrl: MockCtrl): string {
+  const parts = [
+    'Input command list',
+    'help: list all available input commands',
+    ...(ctrl.data.game.variant.key === 'crazyhouse' ? ['pocket: format: pocket [white|black]'] : []),
+  ];
+  return parts.join('. ');
+}
+
+function simulateBoardKeydown(
+  ctrl: MockCtrl,
+  notify: ReturnType<typeof makeNotify>,
+  event: { key: string; shiftKey?: boolean; ctrlKey?: boolean; altKey?: boolean; code?: string },
+) {
+  const e = {
+    key: event.key,
+    shiftKey: !!event.shiftKey,
+    ctrlKey: !!event.ctrlKey,
+    altKey: !!event.altKey,
+    code: event.code ?? '',
+    preventDefault: () => {},
+  };
+
+  if (e.shiftKey && e.key === 'H') {
+    notify.set(buildBoardHelpString(ctrl));
+  } else if ((e.key === '9' || e.key === '0') && ctrl.data.game.variant.key === 'crazyhouse') {
+    const step = ctrl.data.steps[ctrl.ply];
+    const pockets = step?.crazy?.pockets;
+    if (pockets) {
+      const idx = e.key === '9' ? 0 : 1;
+      const pocket = pockets[idx];
+      const parts = Object.entries(pocket)
+        .filter(([, count]) => count > 0)
+        .map(([piece, count]) => `${piece}: ${count}`);
+      notify.set(parts.join(', ') || 'none');
+    }
+  } else if (e.ctrlKey && e.key === 'ArrowDown') {
+    ctrl.ply = 0;
+    ctrl.redraw();
+  } else if (e.ctrlKey && e.key === 'ArrowUp') {
+    ctrl.ply = ctrl.data.steps.length - 1;
+    ctrl.redraw();
+  } else if (e.ctrlKey && e.key === 'ArrowLeft') {
+    ctrl.ply = Math.max(0, ctrl.ply - 6);
+    ctrl.redraw();
+  } else if (e.ctrlKey && e.key === 'ArrowRight') {
+    ctrl.ply = Math.min(ctrl.data.steps.length - 1, ctrl.ply + 6);
+    ctrl.redraw();
+  } else if (e.key.toLowerCase() === 'f') {
+    if (ctrl.data.game.variant.key !== 'racingKings') {
+      notify.set('Flipping the board');
+      ctrl.flip = !ctrl.flip;
+      ctrl.redraw();
+    }
+  }
+}
+
+test('Shift+H via keydown: sets notify to the full help string', () => {
+  const ctrl = makeCtrl();
+  const notify = makeNotify();
+  simulateBoardKeydown(ctrl, notify, { key: 'H', shiftKey: true });
+  const expected = buildBoardHelpString(ctrl);
+  assert.equal(notify.last, expected);
+});
+
+test('Shift+H: crazyhouse variant adds pocket shortcuts to help string', () => {
+  const ctrl = makeCtrl({ variantKey: 'crazyhouse' });
+  const help = buildBoardHelpString(ctrl);
+  assert.ok(help.includes('9'), 'should mention key 9 for white pocket');
+  assert.ok(help.includes('0'), 'should mention key 0 for black pocket');
+});
+
+test('Crazyhouse: 9 announces white pocket pieces', () => {
+  const steps = [
+    {},
+    {
+      crazy: {
+        pockets: [
+          { pawn: 2, knight: 1, bishop: 0, rook: 0, queen: 0, king: 0 },
+          { pawn: 0, knight: 0, bishop: 0, rook: 0, queen: 1, king: 0 },
+        ],
+      },
+    },
+  ];
+  const ctrl = makeCtrl({ variantKey: 'crazyhouse', steps, ply: 1 });
+  const notify = makeNotify();
+  simulateBoardKeydown(ctrl, notify, { key: '9' });
+  assert.ok(notify.last.includes('pawn: 2'), 'should list pawn: 2');
+  assert.ok(notify.last.includes('knight: 1'), 'should list knight: 1');
+});
+
+test('Crazyhouse: 0 announces black pocket pieces', () => {
+  const steps = [
+    {},
+    {
+      crazy: {
+        pockets: [
+          { pawn: 1, knight: 1, bishop: 0, rook: 0, queen: 0, king: 0 },
+          { pawn: 0, knight: 0, bishop: 0, rook: 0, queen: 1, king: 0 },
+        ],
+      },
+    },
+  ];
+  const ctrl = makeCtrl({ variantKey: 'crazyhouse', steps, ply: 1 });
+  const notify = makeNotify();
+  simulateBoardKeydown(ctrl, notify, { key: '0' });
+  assert.ok(notify.last.includes('queen: 1'), 'should list queen: 1');
+});
+
+test('Crazyhouse: empty pocket shows "none"', () => {
+  const steps = [
+    {},
+    {
+      crazy: {
+        pockets: [
+          { pawn: 0, knight: 0, bishop: 0, rook: 0, queen: 0, king: 0 },
+          { pawn: 0, knight: 0, bishop: 0, rook: 0, queen: 0, king: 0 },
+        ],
+      },
+    },
+  ];
+  const ctrl = makeCtrl({ variantKey: 'crazyhouse', steps, ply: 1 });
+  const notify = makeNotify();
+  simulateBoardKeydown(ctrl, notify, { key: '9' });
+  assert.equal(notify.last, 'none');
+});
+
+test('Non-crazyhouse: 9 or 0 key does not trigger pocket announcements', () => {
+  const ctrl = makeCtrl({ variantKey: 'standard', ply: 1 });
+  const notify = makeNotify();
+  simulateBoardKeydown(ctrl, notify, { key: '9' });
+  assert.equal(notify.last, '');
+});
+
+test('Ctrl+ArrowLeft jumps 6 plys back', () => {
+  const steps = [{}, {}, {}, {}, {}, {}, {}, {}, {}]; // 9 moves
+  const ctrl = makeCtrl({ steps, ply: 8 });
+  const notify = makeNotify();
+  simulateBoardKeydown(ctrl, notify, { key: 'ArrowLeft', ctrlKey: true });
+  assert.equal(ctrl.ply, 2);
+  assert.equal(ctrl.redrawCalled, true);
+});
+
+test('Ctrl+ArrowDown navigates to the start of the game', () => {
+  const ctrl = makeCtrl({ ply: 2 });
+  const notify = makeNotify();
+  simulateBoardKeydown(ctrl, notify, { key: 'ArrowDown', ctrlKey: true });
+  assert.equal(ctrl.ply, 0);
+  assert.equal(ctrl.redrawCalled, true);
+});
+
+test('Ctrl+ArrowRight jumps 6 plys forward', () => {
+  const steps = [{}, {}, {}, {}, {}, {}, {}, {}, {}]; // 9 moves
+  const ctrl = makeCtrl({ steps, ply: 1 });
+  const notify = makeNotify();
+  simulateBoardKeydown(ctrl, notify, { key: 'ArrowRight', ctrlKey: true });
+  assert.equal(ctrl.ply, 7);
+  assert.equal(ctrl.redrawCalled, true);
+});
+
+test('Ctrl+ArrowUp navigates to the end of the game', () => {
+  const ctrl = makeCtrl({ ply: 1 });
+  const notify = makeNotify();
+  simulateBoardKeydown(ctrl, notify, { key: 'ArrowUp', ctrlKey: true });
+  assert.equal(ctrl.ply, ctrl.data.steps.length - 1);
+  assert.equal(ctrl.redrawCalled, true);
+});
+
+test('f key: announces and triggers board flip', () => {
+  const ctrl = makeCtrl();
+  const notify = makeNotify();
+  const initialFlip = ctrl.flip;
+  simulateBoardKeydown(ctrl, notify, { key: 'f' });
+  assert.equal(notify.last, 'Flipping the board');
+  assert.equal(ctrl.flip, !initialFlip);
+  assert.equal(ctrl.redrawCalled, true);
+});
+
+test('f key: flip is suppressed in racingKings variant', () => {
+  const ctrl = makeCtrl({ variantKey: 'racingKings' });
+  const notify = makeNotify();
+  simulateBoardKeydown(ctrl, notify, { key: 'f' });
+  assert.equal(ctrl.flip, false);
+  assert.equal(ctrl.redrawCalled, false);
+  assert.equal(notify.last, '');
+});
+
+test('buildInputHelpString returns correct help details', () => {
+  const ctrl = makeCtrl();
+  const help = buildInputHelpString(ctrl);
+  assert.ok(help.includes('Input command list'));
+  assert.ok(help.includes('help: list all available input commands'));
+});
+
+test('buildInputHelpString includes pocket layout for crazyhouse variant', () => {
+  const ctrl = makeCtrl({ variantKey: 'crazyhouse' });
+  const help = buildInputHelpString(ctrl);
+  assert.ok(help.includes('pocket: format: pocket [white|black]'));
+});


### PR DESCRIPTION
### Closes #17712: additional shortcuts

This PR delivers a comprehensive set of accessibility upgrades for the Non-Visual User Interface (NVUI). Originally intended only for analysis, the scope was expanded during development to cover active game mode (round mode), ensuring unified navigation across Lichess.

### Changes
* Implemented `Shift+H` to announce a contextual help string directly from the board's command documentation.
* Implemented the `help` input command to read a contextual help string from the relevant input commands.
* Upgraded the `F` (flip board) handler to a global binding so users can change perspective from anywhere in the application.
* Added shortcuts `9` and `0` to quickly check pocket pieces/reserves in Crazyhouse mode.
* Added advanced board traversal controls (`Ctrl+ArrowUp`, `Ctrl+ArrowDown`, `Ctrl+ArrowLeft`, `Ctrl+ArrowRight`) - while these were not explicitly requested in the initial issue, they were added to give a nice touch and further improve match navigation.
* Configured `Ctrl+ArrowDown` and `Ctrl+ArrowUp` to jump to the start and end of the board state, and `Ctrl+ArrowLeft` / `Ctrl+ArrowRight` to skip backward/forward by multiple moves (6/2).
* Expanded all new shortcuts and navigation features beyond analysis mode into game mode (round mode) for platform-wide consistency.
* Created comprehensive unit tests to verify the behavior for every single new shortcut.

### Testing
Manually tested by:
* Focusing on the board and testing the ergonomics and audible screen-reader announcements for `Shift+H`.
* Typing the `help` command directly into the command line to verify the contextual output.
* Pressing `F` from different non-board areas of the application to confirm the global scope of the layout flip.
* Pressing `9` and `0` during a Crazyhouse game to ensure pockets/reserves are announced correctly.
* Traversing a match using `Ctrl+ArrowUp`, `Ctrl+ArrowDown`, and multi-move skipping via `Ctrl+ArrowLeft` / `Ctrl+ArrowRight`.
* Verifying that all the above shortcuts and behaviors work seamlessly in both analysis mode and live game mode (round mode).
* Running the entire frontend test suite, including the new comprehensive unit tests for shortcut edge cases and case sensitivity.

### Demo / Video (Outdated with previous shortcuts)
A short video demonstrating the new features and explaining the changes:
[Watch the video](https://www.youtube.com/watch?v=UkmR9TLGCog)