### PR TITLE
Live client analysis: never annotate the best move as bad

### DIFF
--- a/ui/analyse/src/liveAnnotate.ts
+++ b/ui/analyse/src/liveAnnotate.ts
@@ -19,13 +19,15 @@ export default class LiveAnnotate {
     node.children.forEach(child => this.update(path + child.id, child, node));
   };
 
-  private readonly liveGlyph = (
-    parentEval: EvalScore,
-    currentEval: EvalScore,
-    ply: Ply,
-  ): Glyph | undefined => {
-    const color: Color = ply % 2 === 1 ? 'white' : 'black';
-    const loss = povChances(color, parentEval) - povChances(color, currentEval);
+  private readonly liveGlyph = (node: TreeNode, parent: TreeNode): Glyph | undefined => {
+    if (
+      !parent.ceval ||
+      !node.ceval ||
+      (node.uci && node.uci === (parent.ceval.pvs[0]?.moves[0] ?? parent.ceval.bestmove))
+    )
+      return undefined;
+    const color: Color = node.ply % 2 === 1 ? 'white' : 'black';
+    const loss = povChances(color, parent.ceval) - povChances(color, node.ceval);
     if (loss > 0.3) return glyphs.blunder;
     if (loss > 0.2) return glyphs.mistake;
     if (loss > 0.1) return glyphs.inaccuracy;
@@ -34,7 +36,7 @@ export default class LiveAnnotate {
 
   private readonly update = (path: TreePath, node: TreeNode, parent: TreeNode): void => {
     if (!path.length) return;
-    const glyph = parent.ceval && node.ceval && this.liveGlyph(parent.ceval, node.ceval, node.ply);
+    const glyph = this.liveGlyph(node, parent);
     if (glyph) this.glyphs.set(path, glyph);
     else this.glyphs.delete(path);
   };

--- a/ui/analyse/src/liveAnnotate.ts
+++ b/ui/analyse/src/liveAnnotate.ts
@@ -20,11 +20,7 @@ export default class LiveAnnotate {
   };
 
   private readonly liveGlyph = (node: TreeNode, parent: TreeNode): Glyph | undefined => {
-    if (
-      !parent.ceval ||
-      !node.ceval ||
-      (node.uci && node.uci === (parent.ceval.pvs[0]?.moves[0] ?? parent.ceval.bestmove))
-    )
+    if (!parent.ceval || !node.ceval || node.uci === (parent.ceval.pvs[0]?.moves[0] ?? parent.ceval.bestmove))
       return undefined;
     const color: Color = node.ply % 2 === 1 ? 'white' : 'black';
     const loss = povChances(color, parent.ceval) - povChances(color, node.ceval);


### PR DESCRIPTION
https://github.com/user-attachments/assets/baf67f28-a97d-4935-889e-e2b22da47304

At different depths, the engine can change its mind about what the eval is. So, it's possible to have an eval for a parent node that differs significantly from the eval of its best child node. This PR makes it so that even if this is the case, the best move from the parent node is never annotated as poor.

This doesn't fully solve the problem of different depths for parent vs child though. E.g., if the first and second top moves are essentially equivalent, the second top move would still be wrongly marked as poor in this scenario.