### PR TITLE
when only one board, let  broadcast chat be toggled off. 

### DIFF
--- a/ui/analyse/src/study/relay/relayCtrl.ts
+++ b/ui/analyse/src/study/relay/relayCtrl.ts
@@ -46,9 +46,9 @@ export default class RelayCtrl {
     this.tourSelectShow = toggle(false, this.study.ctrl.redraw);
     this.roundSelectShow = toggle(false, this.study.ctrl.redraw);
     if (study.ctrl.opts.chat) {
-      const liveboardDisabled = () => {
+      const liveboardDisabled = () =>
         study.chapters.list.size() === 1 || this.tourShow() || !study.multiBoard.showResults();
-      };
+
       this.liveboardPlugin = new LiveboardPlugin(
         study,
         this.round,

--- a/ui/analyse/src/study/relay/relayCtrl.ts
+++ b/ui/analyse/src/study/relay/relayCtrl.ts
@@ -46,7 +46,9 @@ export default class RelayCtrl {
     this.tourSelectShow = toggle(false, this.study.ctrl.redraw);
     this.roundSelectShow = toggle(false, this.study.ctrl.redraw);
     if (study.ctrl.opts.chat) {
-      const liveboardDisabled = () => this.tourShow() || !study.multiBoard.showResults();
+      const liveboardDisabled = () => {
+        study.chapters.list.size() === 1 || this.tourShow() || !study.multiBoard.showResults();
+      }
       this.liveboardPlugin = new LiveboardPlugin(
         study,
         this.round,

--- a/ui/lib/src/chat/chatCtrl.ts
+++ b/ui/lib/src/chat/chatCtrl.ts
@@ -96,7 +96,7 @@ export class ChatCtrl {
 
   get isOptional(): boolean {
     const tabs = this.visibleTabs;
-    return tabs.length === 1 && tabs[0].key === 'discussion';
+    return  this.data.resourceType === 'relay' || tabs.length === 1 && tabs[0].key === 'discussion';
   }
 
   get visibleTabs(): Tab[] {


### PR DESCRIPTION
This lets you toggle the chat when you only have one board. This is needed [to improve broadcast accessibility wen using a screen reader.](https://lichess.org/forum/team-the-blind-mode-team/cant-disable-chat-in-broadcasts-with-single-board)

The chat will be read without condition for these users in this circumstance. I assume this interferes with using the screen reader for learning about the board. 

I had a heck of a time testing this, due to lacking web knowledge. I think it should work, but I do not fully get what
`/ui/lib/src/chat/chatCtrl.ts::96`
` this.data.resourceType === 'relay' `
 entails and if 
 `/ui/analyse/src/study/relay/relayCtrl.ts::46`
`study.chapters.list.size() === 1 ||` 
is still needed. But, getting a test broadcast has been a constant struggle. I do not know how I got it working once.

I will let better minds puzzle about it.

Nicolas Vaagen

fix:  #20565

