### PR TITLE
Fix broadcast contributors being able to unset grouping fields of official broadcasts

### DIFF
--- a/app/controllers/RelayTour.scala
+++ b/app/controllers/RelayTour.scala
@@ -138,7 +138,7 @@ final class RelayTour(env: Env, apiC: => Api, roundC: => RelayRound) extends Lil
             jsonFormError(err)
           ),
         setup =>
-          env.relay.api.tourUpdate(nav.tour, setup) >>
+          env.relay.api.tourUpdate(nav.tourWithGroup, setup) >>
             negotiate(Redirect(routes.RelayTour.edit(nav.tour.id)).flashSuccess, jsonOkResult)
       )
   }

--- a/modules/relay/src/main/RelayApi.scala
+++ b/modules/relay/src/main/RelayApi.scala
@@ -215,8 +215,8 @@ final class RelayApi(
         picfitApi.addRef(_, image.markdownRef(tour), routes.RelayTour.show("-", tour.id).url.some)
     yield tour
 
-  def tourUpdate(prev: RelayTour, data: RelayTourForm.Data)(using Me): Funit =
-    val tour = data.update(prev)
+  def tourUpdate(prev: RelayTour.WithGroupTours, data: RelayTourForm.Data)(using Me): Funit =
+    val tour = data.update(prev.tour)
     import toBSONValueOption.given
     for
       _ <- tourRepo.coll.update.one(
@@ -241,9 +241,9 @@ final class RelayApi(
           "orphanWarn" -> tour.orphanWarn.some
         )
       )
-      _ <- updateGrouping(tour, data.grouping)
-      _ <- playerEnrich.onPlayerTextareaUpdate(tour, prev)
-      _ <- (tour.visibility != prev.visibility).so(studyPropagation.onVisibilityChange(tour))
+      _ <- updateGrouping(prev, data.grouping)
+      _ <- playerEnrich.onPlayerTextareaUpdate(tour, prev.tour)
+      _ <- (tour.visibility != prev.tour.visibility).so(studyPropagation.onVisibilityChange(tour))
       _ <- tour.markup.so:
         picfitApi.addRef(_, image.markdownRef(tour), routes.RelayTour.show("-", tour.id).url.some)
       studyIds <- roundRepo.studyIdsOf(tour.id)
@@ -253,12 +253,12 @@ final class RelayApi(
       studyIds.foreach(preview.invalidate)
       (tour.id :: data.grouping.tourIds).foreach(withTours.invalidate)
 
-  private def updateGrouping(tour: RelayTour, data: RelayGroupData)(using me: Me): Funit =
+  private def updateGrouping(tour: RelayTour.WithGroupTours, data: RelayGroupData)(using me: Me): Funit =
     for
       isOwner <- fuccess(Granter(_.StudyAdmin)) >>| tourRepo.isOwnerOfAll(me.userId, data.tourIds)
-      hasOfficial <- tourRepo.hasOfficial(data.tourIds)
+      hasOfficial <- tourRepo.hasOfficial(data.tourIds ::: ~tour.group.map(_.tours.map(_.id).toList))
       canGroup = isOwner && (!hasOfficial || Granter(_.Relay))
-      _ <- canGroup.so(groupRepo.update(tour.id, data))
+      _ <- canGroup.so(groupRepo.update(tour.tour.id, data))
     yield ()
 
   def create(data: RelayRoundForm.Data, tour: RelayTour)(using me: Me): Fu[RelayRound.WithTourAndStudy] = for

--- a/modules/relay/src/main/RelayApi.scala
+++ b/modules/relay/src/main/RelayApi.scala
@@ -256,7 +256,7 @@ final class RelayApi(
   private def updateGrouping(tour: RelayTour.WithGroupTours, data: RelayGroupData)(using me: Me): Funit =
     for
       isOwner <- fuccess(Granter(_.StudyAdmin)) >>| tourRepo.isOwnerOfAll(me.userId, data.tourIds)
-      hasOfficial <- tourRepo.hasOfficial(data.tourIds ::: ~tour.group.map(_.tours.map(_.id).toList))
+      hasOfficial <- tourRepo.hasOfficial(data.tourIds ::: tour.group.so(_.tours.map(_.id).toList))
       canGroup = isOwner && (!hasOfficial || Granter(_.Relay))
       _ <- canGroup.so(groupRepo.update(tour.tour.id, data))
     yield ()


### PR DESCRIPTION
This was caused by `optional` being removed by `RelayFormData['grouping']` and making the data inside `optional` instead. This allowed a contributor to remove the field entirely causing the form data to be filled with an empty group. As long as the grouped broadcast they were editing didn't have a tier, the `hasOfficial` check would return false because they submitted an empty group. 
Fix checks the previous `formData` for official tours as well.