### PR TITLE
Provide live annotation toggle and defer to existing glyphs

### DIFF
--- a/ui/analyse/src/autoShape.ts
+++ b/ui/analyse/src/autoShape.ts
@@ -177,11 +177,10 @@ export function compute(ctrl: AnalyseCtrl): DrawShape[] {
     });
   }
   if (ctrl.showMoveAnnotationsOnBoard()) {
+    const glyphs = [...(ctrl.node.glyphs ?? [])];
     const liveGlyph = ctrl.liveAnnotate.get(ctrl.path);
-    shapes = shapes.concat(
-      // Override server analysis glyphs as local eval also overrides the eval score
-      annotationShapes(liveGlyph ? { ...ctrl.node, glyphs: [liveGlyph] } : ctrl.node),
-    );
+    if (liveGlyph && ctrl.showLiveGlyphsProp() && !glyphs.some(g => g.id <= 6)) glyphs.push(liveGlyph);
+    shapes = shapes.concat(annotationShapes({ ...ctrl.node, glyphs }));
   }
   if (ctrl.showVariationArrows()) hiliteVariations(ctrl, shapes);
 
@@ -218,7 +217,7 @@ function hiliteVariations(ctrl: AnalyseCtrl, autoShapes: DrawShape[]) {
   ctrl.chessground.state.drawable.brushes['variation'] = {
     key: 'variation',
     color: 'white',
-    opacity: ctrl.variationArrowOpacity() || 0,
+    opacity: 0.5,
     lineWidth: 12,
   };
   const chap = ctrl.study?.data.chapter;

--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -116,7 +116,8 @@ export default class AnalyseCtrl implements CevalHandler {
   showComments = true; // whether to display comments in the move tree
   showBestMoveArrowsProp: Prop<boolean>;
   showManeuverMoveArrowsProp: Prop<boolean>;
-  variationArrowOpacity: Prop<number | false>;
+  showLiveGlyphsProp = storedBooleanProp('analyse.show-live-glyphs', true);
+  variationArrowsProp: Prop<boolean>;
   showGauge = storedBooleanProp('analyse.show-gauge', true);
   private readonly showCevalProp: Prop<boolean> = storedBooleanProp(
     'analyse.show-engine',
@@ -192,7 +193,10 @@ export default class AnalyseCtrl implements CevalHandler {
 
     this.showGround();
 
-    this.variationArrowOpacity = this.makeVariationOpacityProp();
+    this.variationArrowsProp = storedBooleanProp(
+      'analyse.variation-arrows',
+      Number(localStorage.getItem('analyse.variation-arrow-opacity')) > 0, // migrate old opacity setting
+    );
     this.showBestMoveArrowsProp = storedBooleanPropWithEffect(
       'analyse.auto-shapes',
       true,
@@ -821,9 +825,8 @@ export default class AnalyseCtrl implements CevalHandler {
   }
 
   showVariationArrows() {
-    if (!this.allowLines()) return false;
-    const kids = this.variationArrowOpacity() ? this.node.children : [];
-    return Boolean(kids.filter(x => !x.comp || this.showFishnetAnalysis()).length);
+    if (!this.allowLines() || !this.variationArrowsProp()) return false;
+    return Boolean(this.node.children.filter(x => !x.comp || this.showFishnetAnalysis()).length);
   }
 
   showAnalysis() {
@@ -1072,28 +1075,6 @@ export default class AnalyseCtrl implements CevalHandler {
     this.redraw();
   };
 
-  toggleVariationArrows = () => {
-    const trueValue = this.variationArrowOpacity(false);
-    if (typeof trueValue === 'number') {
-      this.variationArrowOpacity(trueValue === 0 ? 0.6 : -trueValue);
-    }
-  };
-
-  private makeVariationOpacityProp(): Prop<number | false> {
-    let value = parseFloat(localStorage.getItem('analyse.variation-arrow-opacity') || '0');
-    if (isNaN(value) || value < -1 || value > 1) value = 0;
-    return (v?: number | false) => {
-      if (v === false) return value;
-      if (v === undefined || isNaN(v)) return value > 0 ? value : false;
-      value = Math.min(1, Math.max(-1, v));
-      localStorage.setItem('analyse.variation-arrow-opacity', value.toString());
-      this.setAutoShapes();
-      this.chessground.redrawAll();
-      this.redraw();
-      return value;
-    };
-  }
-
   private readonly pluginUpdate = (fen: FEN) => {
     // If controller and chessground board states differ, ignore this update. Once the chessground
     // state is updated to match, pluginUpdate will be called again.
@@ -1107,7 +1088,7 @@ export default class AnalyseCtrl implements CevalHandler {
     if (
       this.showBestMoveArrows() ||
       this.possiblyShowMoveAnnotationsOnBoard() ||
-      this.variationArrowOpacity() ||
+      this.variationArrowsProp() ||
       (this.motifEnabled() && this.motif.any())
     )
       this.setAutoShapes();

--- a/ui/analyse/src/keyboard.ts
+++ b/ui/analyse/src/keyboard.ts
@@ -77,7 +77,7 @@ export const bind = (ctrl: AnalyseCtrl) => {
       ctrl.redraw();
     })
     .bind('v', () => {
-      ctrl.toggleVariationArrows();
+      ctrl.variationArrowsProp(!ctrl.variationArrowsProp());
       ctrl.setAutoShapes();
       ctrl.redraw();
     })

--- a/ui/analyse/src/treeView/inlineView.ts
+++ b/ui/analyse/src/treeView/inlineView.ts
@@ -164,8 +164,10 @@ export class InlineView {
       'pending-deletion': path.startsWith(ctrl.pendingDeletionPath() || ' '),
       'pending-copy': !!ctrl.pendingCopyPath()?.startsWith(path),
     };
+    const glyphs = [...(node.glyphs ?? [])];
     const liveGlyph = ctrl.liveAnnotate.get(path);
-    const glyphs = liveGlyph ? [liveGlyph] : node.glyphs;
+    if (liveGlyph && ctrl.showLiveGlyphsProp() && !glyphs.some(g => g.id <= this.glyphs.length))
+      glyphs.push(liveGlyph);
     if (ctrl.showMoveGlyphs()) {
       glyphs
         ?.map(g => this.glyphs[g.id - 1])

--- a/ui/analyse/src/view/actionMenu.ts
+++ b/ui/analyse/src/view/actionMenu.ts
@@ -1,5 +1,4 @@
 import { isEmpty } from 'lib';
-import { clamp } from 'lib/algo';
 import { displayColumns } from 'lib/device';
 import { cont as contRoute } from 'lib/game/router';
 import * as licon from 'lib/licon';
@@ -184,6 +183,12 @@ export function view(ctrl: AnalyseCtrl): VNode {
         prop: ctrl.showManeuverMoveArrowsProp,
         redraw: ctrl.redraw,
       }),
+    cmnToggleWrapProp({
+      id: 'live-glyphs',
+      name: 'Live annotations',
+      prop: ctrl.showLiveGlyphsProp,
+      redraw: ctrl.redraw,
+    }),
     displayColumns() > 1 &&
       cmnToggleWrapProp({
         id: 'gauge',
@@ -222,15 +227,21 @@ export function view(ctrl: AnalyseCtrl): VNode {
         change: ctrl.togglePossiblyShowMoveAnnotationsOnBoard,
         redraw: ctrl.redraw,
       }),
+    cmnToggleWrap({
+      id: 'variations',
+      name: 'Variation arrows',
+      title: 'Pale white arrows that show branches on the board. Hotkey: v',
+      checked: ctrl.variationArrowsProp(),
+      change: v => ctrl.variationArrowsProp(v),
+      redraw: ctrl.redraw,
+    }),
   ];
 
   return hl('div.action-menu', [
     tools,
     displayConfig,
-    displayColumns() > 1 && renderVariationOpacitySlider(ctrl),
     cevalConfig,
     ctrl.motifAllowed() ? motifConfig(ctrl) : [],
-    displayColumns() === 1 && renderVariationOpacitySlider(ctrl),
     ctrl.mainline.length > 4 && [hl('h2', i18n.site.replayMode), autoplayButtons(ctrl)],
     canContinue &&
       hl('div.continue-with.none.g_' + d.game.id, [
@@ -261,30 +272,3 @@ export function view(ctrl: AnalyseCtrl): VNode {
       ]),
   ]);
 }
-
-const renderVariationOpacitySlider = (ctrl: AnalyseCtrl) =>
-  hl('span.setting', [
-    hl('label', 'Variation opacity'),
-    hl('input.range', {
-      key: 'variation-arrows',
-      attrs: { min: 0, max: 1, step: 0.1, type: 'range', value: ctrl.variationArrowOpacity() || 0 },
-      props: { value: ctrl.variationArrowOpacity() || 0 },
-      hook: {
-        insert: (vnode: VNode) => {
-          const input = vnode.elm as HTMLInputElement;
-          input.addEventListener('input', () => {
-            ctrl.variationArrowOpacity(parseFloat(input.value));
-          });
-          input.addEventListener('wheel', e => {
-            e.preventDefault();
-            ctrl.variationArrowOpacity(
-              clamp((ctrl.variationArrowOpacity() || 0) + (e.deltaY > 0 ? -0.1 : 0.1), {
-                min: 0,
-                max: 1,
-              }),
-            );
-          });
-        },
-      },
-    }),
-  ]);


### PR DESCRIPTION
fix #20560 

There are 52 thumbs up and counting on https://lichess.org/forum/lichess-feedback/auto-annotate-in-studies?page=1. It's less popular than even the variation order glitch last year. This PR does not make this feature opt-in, but it does allow users to opt out (as the original PR did).

Server analysis or user assigned move quality glyphs will suppress live annotations even if enabled.

Also, remove variation opacity slider in favor of a less confusing toggle.