### PR TITLE
remove SBT_OPTS env from github action

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -29,9 +29,6 @@ on:
       - '.sbtopts.default'
   workflow_dispatch:
 
-env:
-  SBT_OPTS: '-Xmx2048M'
-
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
`Warning:  SBT_OPTS var '-Xmx2048M' ignored; use .sbtopts file instead.`

after #18789