### PR TITLE
Add mobile oauth callback route

### DIFF
--- a/app/controllers/OAuth.scala
+++ b/app/controllers/OAuth.scala
@@ -125,3 +125,10 @@ final class OAuth(env: Env, apiC: => Api) extends LilaController(env):
           }))
         }
       .map(apiC.toHttp)
+
+  def mobileOAuthCallback = Open:
+    val qs = req.rawQueryString
+    val callbackUrl =
+      if qs.isEmpty then "org.lichess.mobile://login-callback"
+      else s"org.lichess.mobile://login-callback?$qs"
+    Ok.page(views.mobileRedirect(callbackUrl))

--- a/app/controllers/OAuth.scala
+++ b/app/controllers/OAuth.scala
@@ -7,7 +7,7 @@ import scalalib.net.Bearer
 import scalatags.Text.all.stringFrag
 import cats.mtl.Handle.*
 
-import lila.app.{ *, given }
+import lila.app.*
 import lila.common.HTTPRequest
 import lila.common.Json.given
 import lila.oauth.{ AccessTokenRequest, AuthorizationRequest, OAuthScopes }
@@ -127,5 +127,4 @@ final class OAuth(env: Env, apiC: => Api) extends LilaController(env):
       .map(apiC.toHttp)
 
   def mobileOAuthCallback = Open:
-    val callbackUrl = "org.lichess.mobile://login-callback" + req.rawQueryString.nonEmptyOption.so("?" + _)
-    Ok.page(lila.web.ui.mobileRedirect(callbackUrl))
+    Ok.page(lila.web.ui.mobileRedirect)

--- a/app/controllers/OAuth.scala
+++ b/app/controllers/OAuth.scala
@@ -7,7 +7,7 @@ import scalalib.net.Bearer
 import scalatags.Text.all.stringFrag
 import cats.mtl.Handle.*
 
-import lila.app.*
+import lila.app.{ *, given }
 import lila.common.HTTPRequest
 import lila.common.Json.given
 import lila.oauth.{ AccessTokenRequest, AuthorizationRequest, OAuthScopes }
@@ -127,8 +127,5 @@ final class OAuth(env: Env, apiC: => Api) extends LilaController(env):
       .map(apiC.toHttp)
 
   def mobileOAuthCallback = Open:
-    val qs = req.rawQueryString
-    val callbackUrl =
-      if qs.isEmpty then "org.lichess.mobile://login-callback"
-      else s"org.lichess.mobile://login-callback?$qs"
-    Ok.page(views.mobileRedirect(callbackUrl))
+    val callbackUrl = "org.lichess.mobile://login-callback" + req.rawQueryString.nonEmptyOption.so("?" + _)
+    Ok.page(lila.web.ui.mobileRedirect(callbackUrl))

--- a/app/views/ui.scala
+++ b/app/views/ui.scala
@@ -92,4 +92,7 @@ val jsBot = lila.jsBot.ui.JsBotUi(helpers)
 def mobile(p: lila.cms.CmsPage.Render)(using Context) =
   lila.web.ui.mobile(helpers)(cms.render(p))
 
+def mobileRedirect(callbackUrl: String) =
+  lila.web.ui.mobileRedirect(callbackUrl)
+
 val recap = lila.recap.ui.RecapUi(helpers)

--- a/app/views/ui.scala
+++ b/app/views/ui.scala
@@ -92,7 +92,4 @@ val jsBot = lila.jsBot.ui.JsBotUi(helpers)
 def mobile(p: lila.cms.CmsPage.Render)(using Context) =
   lila.web.ui.mobile(helpers)(cms.render(p))
 
-def mobileRedirect(callbackUrl: String) =
-  lila.web.ui.mobileRedirect(callbackUrl)
-
 val recap = lila.recap.ui.RecapUi(helpers)

--- a/conf/routes
+++ b/conf/routes
@@ -879,6 +879,7 @@ GET    /account/oauth/token            controllers.OAuthToken.index
 GET    /account/oauth/token/create     controllers.OAuthToken.create
 POST   /account/oauth/token/create     controllers.OAuthToken.createApply
 POST   /account/oauth/token/:id/delete controllers.OAuthToken.delete(id)
+GET    /account/oauth/mobile-callback  controllers.OAuth.mobileOAuthCallback
 POST   /api/token/admin-challenge      controllers.OAuth.challengeTokens
 POST   /api/token/test                 controllers.OAuth.testTokens
 

--- a/modules/oauth/src/main/Env.scala
+++ b/modules/oauth/src/main/Env.scala
@@ -4,7 +4,7 @@ import com.softwaremill.macwire.*
 import com.softwaremill.tagging.*
 import play.api.Configuration
 
-import lila.core.config.CollName
+import lila.core.config.{ BaseUrl, CollName }
 import lila.core.data.Strings
 import lila.memo.SettingStore.Strings.given
 
@@ -14,6 +14,7 @@ final class Env(
     userApi: lila.core.user.UserApi,
     settingStore: lila.memo.SettingStore.Builder,
     appConfig: Configuration,
+    baseUrl: BaseUrl,
     db: lila.db.Db
 )(using Executor, akka.stream.Materializer, play.api.Mode):
 
@@ -23,7 +24,7 @@ final class Env(
     text = "OAuth origin blocklist".some
   ).taggedWith[OriginBlocklist]
 
-  lazy val signedClients = OAuthSignedClients(appConfig)
+  lazy val signedClients = wire[OAuthSignedClients]
 
   lazy val legacyClientApi = LegacyClientApi(db(CollName("oauth2_legacy_client")))
 

--- a/modules/oauth/src/main/OAuthSignedClient.scala
+++ b/modules/oauth/src/main/OAuthSignedClient.scala
@@ -19,12 +19,10 @@ case class OAuthSignedClient(
 object OAuthSignedClient:
   case class SimpleSignup(username: UserName, email: EmailAddress, client: ClientId)
 
-final class OAuthSignedClients(appConfig: Configuration):
+final class OAuthSignedClients(appConfig: Configuration, baseUrl: BaseUrl):
 
   private val config = appConfig.get[Configuration]("oauth.signedClients")
   private def signersOf(name: String) = config.get[List[String]](name + ".secrets").map(Algo.hmac)
-
-  private val baseUrl = appConfig.get[BaseUrl]("net.base_url")
 
   val mobile = OAuthSignedClient(
     ClientId("lichess_mobile"),

--- a/modules/oauth/src/main/OAuthSignedClient.scala
+++ b/modules/oauth/src/main/OAuthSignedClient.scala
@@ -6,6 +6,7 @@ import scalalib.net.Bearer
 
 import lila.oauth.Protocol.{ ClientId, RedirectUri }
 import lila.common.config.given
+import lila.core.config.BaseUrl
 import lila.core.net.{ Origin, ValidReferrer }
 
 case class OAuthSignedClient(
@@ -23,9 +24,14 @@ final class OAuthSignedClients(appConfig: Configuration):
   private val config = appConfig.get[Configuration]("oauth.signedClients")
   private def signersOf(name: String) = config.get[List[String]](name + ".secrets").map(Algo.hmac)
 
+  private val baseUrl = appConfig.get[BaseUrl]("net.base_url")
+
   val mobile = OAuthSignedClient(
     ClientId("lichess_mobile"),
-    List(Origin("org.lichess.mobile://")),
+    List(
+      Origin("org.lichess.mobile://"),
+      Origin(baseUrl.value)
+    ),
     OAuthScope.Web.Mobile,
     signersOf("mobile"),
     displayName = "Lichess Mobile"

--- a/modules/web/src/main/ui/mobile.scala
+++ b/modules/web/src/main/ui/mobile.scala
@@ -5,6 +5,16 @@ import lila.ui.*
 
 import ScalatagsTemplate.{ *, given }
 
+def mobileRedirect(callbackUrl: String) =
+  Page("Returning to the Lichess app"):
+    main(cls := "page-small box box-pad")(
+      boxTop(
+        h1(cls := "text")("Returning to the Lichess app")
+      ),
+      p("If the app doesn't open automatically, tap the \"Open the Lichess app\" button."),
+      a(href := callbackUrl, cls := "button")("Open the Lichess app")
+    )
+
 def mobile(helpers: Helpers)(renderedCmsPage: Frag) =
   import helpers.*
 

--- a/modules/web/src/main/ui/mobile.scala
+++ b/modules/web/src/main/ui/mobile.scala
@@ -1,11 +1,14 @@
 package lila.web
 package ui
 
+import play.api.mvc.RequestHeader
+
 import lila.ui.*
 
 import ScalatagsTemplate.{ *, given }
 
-def mobileRedirect(callbackUrl: String) =
+def mobileRedirect(using req: RequestHeader) =
+  val callbackUrl = "org.lichess.mobile://login-callback" + req.rawQueryString.nonEmptyOption.so("?" + _)
   Page("Returning to the Lichess app"):
     main(cls := "page-small box box-pad")(
       boxTop(


### PR DESCRIPTION
Server-side changes to implement [Claimed "https" Scheme URI Redirection](https://datatracker.ietf.org/doc/html/rfc8252#section-7.2)

Corresponding mobile PR:
- https://github.com/lichess-org/mobile/pull/3270

PR to add to `.well-known` files:
- https://github.com/lichess-org/lichess-org.github.io/pull/5