### PR TITLE
dont draw heavy box shadows in transparent theme

### DIFF
--- a/ui/lib/css/abstract/_extends.scss
+++ b/ui/lib/css/abstract/_extends.scss
@@ -172,7 +172,9 @@
     @include back-blur;
   }
 
-  box-shadow: 0 14px 28px rgba(0, 0, 0, 0.25), 0 10px 10px rgba(0, 0, 0, 0.22);
+  box-shadow:
+    0 14px 28px rgba(0, 0, 0, 0.25),
+    0 10px 10px rgba(0, 0, 0, 0.22);
 }
 
 %button-shadow {

--- a/ui/lib/css/abstract/_extends.scss
+++ b/ui/lib/css/abstract/_extends.scss
@@ -172,9 +172,7 @@
     @include back-blur;
   }
 
-  box-shadow:
-    0 14px 28px rgba(0, 0, 0, 0.25),
-    0 10px 10px rgba(0, 0, 0, 0.22);
+  box-shadow: 0 14px 28px rgba(0, 0, 0, 0.25), 0 10px 10px rgba(0, 0, 0, 0.22);
 }
 
 %button-shadow {

--- a/ui/lib/css/abstract/_mixins.scss
+++ b/ui/lib/css/abstract/_mixins.scss
@@ -7,9 +7,7 @@
 }
 
 @mixin box-shadow {
-  box-shadow:
-    0 2px 2px 0 rgba(0, 0, 0, 0.08),
-    0 3px 1px -2px rgba(0, 0, 0, 0.18),
+  box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.08), 0 3px 1px -2px rgba(0, 0, 0, 0.18),
     0 1px 5px 0 rgba(0, 0, 0, 0.1);
 }
 
@@ -168,57 +166,53 @@
 }
 
 @mixin with-metal-shadow($defaultShadow: (), $lightShadow: (), $soft: false) {
-  box-shadow:
-    inset 0 if($soft == true, 1px, 2px) 3px -2px hsl(0, 0%, if($soft == true, 30%, 45%)),
-    inset 0 -4px 6px -3px $m-body-gradient--lighten-3,
-    if($defaultShadow != (), 0 1px 3px 0 $defaultShadow, ());
+  @include if-not-transp {
+    box-shadow: inset 0 if($soft == true, 1px, 2px) 3px -2px hsl(0, 0%, if($soft == true, 30%, 45%)),
+      inset 0 -4px 6px -3px $m-body-gradient--lighten-3,
+      if($defaultShadow != (), 0 1px 3px 0 $defaultShadow, ());
 
-  @include if-light {
-    box-shadow:
-      inset 0 if($soft == true, 2px, 3px) 3px -2px #fff,
-      inset 0 -4px 6px -3px $m-body-gradient--lighten-5,
-      if($defaultShadow != (), 0 1px 3px 0 if($lightShadow != (), $lightShadow, $defaultShadow), ());
+    @include if-light {
+      box-shadow: inset 0 if($soft == true, 2px, 3px) 3px -2px #fff,
+        inset 0 -4px 6px -3px $m-body-gradient--lighten-5,
+        if($defaultShadow != (), 0 1px 3px 0 if($lightShadow != (), $lightShadow, $defaultShadow), ());
+    }
   }
 }
 
 @mixin with-metal-hover-shadow($defaultShadow: (), $lightShadow: (), $soft: false) {
-  box-shadow:
-    inset 0 if($soft == true, 2px, 3px) 3px -2px $c-border-light,
-    inset 0 -5px 8px -3px $m-body-gradient--lighten-5,
-    if($defaultShadow != (), 0 2px 4px 0 $defaultShadow, ());
+  @include if-not-transp {
+    box-shadow: inset 0 if($soft == true, 2px, 3px) 3px -2px $c-border-light,
+      inset 0 -5px 8px -3px $m-body-gradient--lighten-5,
+      if($defaultShadow != (), 0 2px 4px 0 $defaultShadow, ());
 
-  @include if-light {
-    box-shadow:
-      inset 0 if($soft == true, 3px, 4px) 3px -2px #fff,
-      inset 0 -5px 8px -3px $m-body-gradient--lighten-7,
-      if($defaultShadow != (), 0 2px 4px 0 if($lightShadow != (), $lightShadow, $defaultShadow), ());
+    @include if-light {
+      box-shadow: inset 0 if($soft == true, 3px, 4px) 3px -2px #fff,
+        inset 0 -5px 8px -3px $m-body-gradient--lighten-7,
+        if($defaultShadow != (), 0 2px 4px 0 if($lightShadow != (), $lightShadow, $defaultShadow), ());
+    }
   }
 }
 
 @mixin with-button-shadow($topShadow: (), $bottomShadow: (), $lighTopShadow: (), $lightBottomShadow: ()) {
-  box-shadow:
-    inset 0 2px 3px -2px $topShadow,
-    inset 0 -4px 6pt -3pt $bottomShadow,
-    0 1px 3px 0 hsla(0, 0, 0%, 0.2);
-
-  @include if-light {
-    box-shadow:
-      inset 0 2px 3px -2px if($lighTopShadow != (), $lighTopShadow, $topShadow),
-      inset 0 -4px 6pt -3pt if($lightBottomShadow != (), $lightBottomShadow, $bottomShadow),
-      0 1px 3px 0 hsla(0, 0, 0%, 0.18);
-  }
-
-  &:not(.disabled, :disabled, [disabled]):hover {
-    box-shadow:
-      inset 0 2px 3px -2px $topShadow,
-      inset 0 -5px 6pt -3pt $bottomShadow,
-      0 2px 4px 0 hsla(0, 0, 0%, 0.24);
+  @include if-not-transp {
+    box-shadow: inset 0 2px 3px -2px $topShadow, inset 0 -4px 6pt -3pt $bottomShadow,
+      0 1px 3px 0 hsla(0, 0, 0%, 0.2);
 
     @include if-light {
-      box-shadow:
-        inset 0 2px 3px -2px if($lighTopShadow != (), $lighTopShadow, $topShadow),
-        inset 0 -5px 6pt -3pt if($lightBottomShadow != (), $lightBottomShadow, $bottomShadow),
-        0 2px 4px 0 hsla(0, 0, 0%, 0.21);
+      box-shadow: inset 0 2px 3px -2px if($lighTopShadow != (), $lighTopShadow, $topShadow),
+        inset 0 -4px 6pt -3pt if($lightBottomShadow != (), $lightBottomShadow, $bottomShadow),
+        0 1px 3px 0 hsla(0, 0, 0%, 0.18);
+    }
+
+    &:not(.disabled, :disabled, [disabled]):hover {
+      box-shadow: inset 0 2px 3px -2px $topShadow, inset 0 -5px 6pt -3pt $bottomShadow,
+        0 2px 4px 0 hsla(0, 0, 0%, 0.24);
+
+      @include if-light {
+        box-shadow: inset 0 2px 3px -2px if($lighTopShadow != (), $lighTopShadow, $topShadow),
+          inset 0 -5px 6pt -3pt if($lightBottomShadow != (), $lightBottomShadow, $bottomShadow),
+          0 2px 4px 0 hsla(0, 0, 0%, 0.21);
+      }
     }
   }
 }

--- a/ui/lib/css/abstract/_mixins.scss
+++ b/ui/lib/css/abstract/_mixins.scss
@@ -7,7 +7,9 @@
 }
 
 @mixin box-shadow {
-  box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.08), 0 3px 1px -2px rgba(0, 0, 0, 0.18),
+  box-shadow:
+    0 2px 2px 0 rgba(0, 0, 0, 0.08),
+    0 3px 1px -2px rgba(0, 0, 0, 0.18),
     0 1px 5px 0 rgba(0, 0, 0, 0.1);
 }
 
@@ -167,12 +169,14 @@
 
 @mixin with-metal-shadow($defaultShadow: (), $lightShadow: (), $soft: false) {
   @include if-not-transp {
-    box-shadow: inset 0 if($soft == true, 1px, 2px) 3px -2px hsl(0, 0%, if($soft == true, 30%, 45%)),
+    box-shadow:
+      inset 0 if($soft == true, 1px, 2px) 3px -2px hsl(0, 0%, if($soft == true, 30%, 45%)),
       inset 0 -4px 6px -3px $m-body-gradient--lighten-3,
       if($defaultShadow != (), 0 1px 3px 0 $defaultShadow, ());
 
     @include if-light {
-      box-shadow: inset 0 if($soft == true, 2px, 3px) 3px -2px #fff,
+      box-shadow:
+        inset 0 if($soft == true, 2px, 3px) 3px -2px #fff,
         inset 0 -4px 6px -3px $m-body-gradient--lighten-5,
         if($defaultShadow != (), 0 1px 3px 0 if($lightShadow != (), $lightShadow, $defaultShadow), ());
     }
@@ -181,12 +185,14 @@
 
 @mixin with-metal-hover-shadow($defaultShadow: (), $lightShadow: (), $soft: false) {
   @include if-not-transp {
-    box-shadow: inset 0 if($soft == true, 2px, 3px) 3px -2px $c-border-light,
+    box-shadow:
+      inset 0 if($soft == true, 2px, 3px) 3px -2px $c-border-light,
       inset 0 -5px 8px -3px $m-body-gradient--lighten-5,
       if($defaultShadow != (), 0 2px 4px 0 $defaultShadow, ());
 
     @include if-light {
-      box-shadow: inset 0 if($soft == true, 3px, 4px) 3px -2px #fff,
+      box-shadow:
+        inset 0 if($soft == true, 3px, 4px) 3px -2px #fff,
         inset 0 -5px 8px -3px $m-body-gradient--lighten-7,
         if($defaultShadow != (), 0 2px 4px 0 if($lightShadow != (), $lightShadow, $defaultShadow), ());
     }
@@ -195,21 +201,27 @@
 
 @mixin with-button-shadow($topShadow: (), $bottomShadow: (), $lighTopShadow: (), $lightBottomShadow: ()) {
   @include if-not-transp {
-    box-shadow: inset 0 2px 3px -2px $topShadow, inset 0 -4px 6pt -3pt $bottomShadow,
+    box-shadow:
+      inset 0 2px 3px -2px $topShadow,
+      inset 0 -4px 6pt -3pt $bottomShadow,
       0 1px 3px 0 hsla(0, 0, 0%, 0.2);
 
     @include if-light {
-      box-shadow: inset 0 2px 3px -2px if($lighTopShadow != (), $lighTopShadow, $topShadow),
+      box-shadow:
+        inset 0 2px 3px -2px if($lighTopShadow != (), $lighTopShadow, $topShadow),
         inset 0 -4px 6pt -3pt if($lightBottomShadow != (), $lightBottomShadow, $bottomShadow),
         0 1px 3px 0 hsla(0, 0, 0%, 0.18);
     }
 
     &:not(.disabled, :disabled, [disabled]):hover {
-      box-shadow: inset 0 2px 3px -2px $topShadow, inset 0 -5px 6pt -3pt $bottomShadow,
+      box-shadow:
+        inset 0 2px 3px -2px $topShadow,
+        inset 0 -5px 6pt -3pt $bottomShadow,
         0 2px 4px 0 hsla(0, 0, 0%, 0.24);
 
       @include if-light {
-        box-shadow: inset 0 2px 3px -2px if($lighTopShadow != (), $lighTopShadow, $topShadow),
+        box-shadow:
+          inset 0 2px 3px -2px if($lighTopShadow != (), $lighTopShadow, $topShadow),
           inset 0 -5px 6pt -3pt if($lightBottomShadow != (), $lightBottomShadow, $bottomShadow),
           0 2px 4px 0 hsla(0, 0, 0%, 0.21);
       }

--- a/ui/lib/css/theme/_theme.transp.scss
+++ b/ui/lib/css/theme/_theme.transp.scss
@@ -21,8 +21,8 @@ html.transp {
   --c-font-page: #{change-color($c-font, $lightness: 97%)};
   --c-metal-top: hsla(37, 7%, 19%, 0.56);
   --c-metal-bottom: hsla(37, 7%, 19%, 0.66);
-  --c-metal-top-hover: hsla(22, 100%, 42%, 0.4);
-  --c-metal-bottom-hover: hsla(22, 100%, 42%, 0.3);
+  --c-metal-top-hover: hsla(0, 0%, 42%, 0.3);
+  --c-metal-bottom-hover: hsla(0, 0%, 42%, 0.35);
 
   @include transp-mix;
 }


### PR DESCRIPTION
While buttons and their hover effects look fine in dark and light mode, mousing over a button in transparent theme resembles something one might see while performing a colonoscopy:

---
<img width="360" height="264" alt="image" src="https://github.com/user-attachments/assets/cf32e17e-3dcd-46b0-921b-52e4bc02b599" />

<img width="362" height="122" alt="image" src="https://github.com/user-attachments/assets/559e720c-2133-4ca1-b3ea-347f8d991dfd" />

---

I strongly believe that the number of picture theme users who are also gastroenterologists is small. So this PR removes box shadows from transparent mode and changes the hover hilites to a flat grey.

---
<img width="352" height="263" alt="image" src="https://github.com/user-attachments/assets/a2d339f6-4fcd-4f29-9d78-687f15ab762a" />
<img width="346" height="77" alt="image" src="https://github.com/user-attachments/assets/8c50de08-aaa3-45c2-ab66-9936a3a6a0c0" />
