### PR TITLE
[Embed] Adapt automove if first ply is not 1

### DIFF
--- a/ui/bits/src/bits.lpv.ts
+++ b/ui/bits/src/bits.lpv.ts
@@ -33,6 +33,11 @@ async function autostart() {
     };
     try {
       const lpv = Lpv(this, config);
+      if (typeof initialPly === 'number') {
+        const rootPly = (lpv.game.mainline[0]?.ply ?? 1) - 1;
+        const relativePly = Math.max(0, initialPly - rootPly);
+        if (relativePly !== initialPly) lpv.toPath(lpv.game.pathAtMainlinePly(relativePly), false);
+      }
       if (gamebook) toGamebook(lpv);
     } catch (e) {
       const url = this.dataset['url'];


### PR DESCRIPTION
fixes #19170

Taking comment from #20596 into account:
1/ We always show the absolute ply in the url hash
2/ On the client side when the blog post is rendered, if there is an initial ply and if the first ply of the line is not 1, we jump to the relative ply

Not only we don't change the existing url hash but the fix is very compact.

Tested with study chapters and game analysis