### PR TITLE
fix: simul page layout on safari

### DIFF
--- a/ui/simul/css/_layout.scss
+++ b/ui/simul/css/_layout.scss
@@ -27,7 +27,7 @@
   @include mq-at-least-col3 {
     &.simul {
       grid-template-columns: $col3-uniboard-side $col3-uniboard-default-width $col3-uniboard-table;
-      grid-template-rows: auto fit-content(0);
+      grid-template-rows: auto;
       grid-template-areas: 'side  main main' 'uchat main main' 'uchat .    .';
     }
   }


### PR DESCRIPTION
From the forum: https://lichess.org/forum/lichess-feedback/simul-page-not-rendered-correctly-on-safari