### PR TITLE
Remove any existing handlers before adding new ones.

### DIFF
--- a/ui/lobby/src/view/carousel.ts
+++ b/ui/lobby/src/view/carousel.ts
@@ -41,14 +41,16 @@ export function makeCarousel({ selector, itemWidth, pauseFor, slideFor = 0.6 }: 
           fix(false);
         }, slideFor * 1000);
       };
-      $(el).on('click', '.carousel__prev', () => {
-        track.prepend(track.lastChild!);
-        fix();
-      });
-      $(el).on('click', '.carousel__next', () => {
-        track.append(track.firstChild!);
-        fix();
-      });
+      $(el)
+        .off('click.carousel')
+        .on('click.carousel', '.carousel__prev', () => {
+          track.prepend(track.lastChild!);
+          fix();
+        })
+        .on('click.carousel', '.carousel__next', () => {
+          track.append(track.firstChild!);
+          fix();
+        });
       const fix = (killTimer = true) => {
         kids.forEach(k => (k.style.transition = ''));
         kids.forEach(k => (k.style.transform = ''));


### PR DESCRIPTION
At least on my iphone (both chrome & safari), the following bug occurs:
- Open lichess and scroll down to the blog carousel.
- Wait for the next card to auto appear.
- Then, press the back button.
- You'll find that this often won't bring you back to the original blog card.

The reason is because the `resize` event can be triggered multiple times on mobile. Currently in the code, a new click handler gets added for prev/next after each of these resizes, causing clicks to jump over too many cards.