### PR TITLE
ui: fix move expiration text blur in picture theme

### DIFF
--- a/ui/round/css/_app-layout.scss
+++ b/ui/round/css/_app-layout.scss
@@ -123,6 +123,7 @@
 
     .expiration-top {
       display: flex;
+      z-index: 1;
     }
 
     #{$rmoves-tag} {


### PR DESCRIPTION
# Why

Fixes #20619

* https://github.com/lichess-org/lila/issues/20619

# How

Apply missing `z-index` to the container - it's required due to how `.round__app__table` is arranged.

# Preview

<img width="423" height="484" alt="Screenshot 2026-06-08 at 12 15 26" src="https://github.com/user-attachments/assets/46249498-f448-4975-bf8b-932c95bb5815" />
