### PR TITLE
ui: add missing board contrast filter in transparent theme

### DIFF
--- a/ui/lib/css/theme/board/_chessground.scss
+++ b/ui/lib/css/theme/board/_chessground.scss
@@ -28,7 +28,7 @@ cg-board::before {
 
     @include if-transp {
       opacity: calc(var(---board-opacity) / 100);
-      filter: hue-rotate(calc(var(---board-hue) * 3.6deg));
+      filter: hue-rotate(calc(var(---board-hue) * 3.6deg)) contrast(calc(var(---board-contrast) / 100));
     }
   }
 }


### PR DESCRIPTION
# Why

We show contrast filter in board settings in transparent theme, but it was not correctly applied.

# How

Add missing contrast var for board filters in transparent mode.

# Preview

<img width="1538" height="631" alt="Screenshot 2026-06-08 at 12 24 06" src="https://github.com/user-attachments/assets/1cb2c6f5-968d-4572-b295-6eea18cf46d4" />

