### PR TITLE
ui: small redability tweaks for the user rating history chart

### DIFF
--- a/ui/chart/src/chart.ratingHistory.ts
+++ b/ui/chart/src/chart.ratingHistory.ts
@@ -86,11 +86,13 @@ export function initModule({ data, singlePerfName }: Opts): void {
 
   const $el = $('canvas.rating-history');
   if (!$el.length) return;
+
   const singlePerfIndex = data.findIndex(x => x.name === singlePerfName);
   if (singlePerfName && !data[singlePerfIndex]?.points.length) {
     $el.hide();
     return;
   }
+
   const allData = makeDatasets(1, { data, singlePerfName }, singlePerfIndex);
   const startDate = allData.startDate;
   const endDate = allData.endDate;
@@ -99,6 +101,7 @@ export function initModule({ data, singlePerfName }: Opts): void {
   const threeMonthsAgo = endDate.subtract(3, 'M');
   const initial = startDate < threeMonthsAgo ? threeMonthsAgo : startDate;
   let zoomedOut = initial.isSame(threeMonthsAgo);
+
   const config: ChartConfiguration<'line'> = {
     type: 'line',
     data: {
@@ -179,21 +182,29 @@ export function initModule({ data, singlePerfName }: Opts): void {
         },
         tooltip: {
           usePointStyle: true,
+          boxPadding: 2,
+          boxWidth: 8,
+          boxHeight: 8,
+          padding: 6,
           backgroundColor: tooltipBgColor,
           bodyColor: fontColor,
           titleColor: fontColor,
-          borderColor: fontColor,
+          borderColor: gridColor,
           borderWidth: 1,
           yAlign: 'center',
           caretPadding: 10,
           rtl: document.dir === 'rtl',
           callbacks: {
             title: items => dateFormat()(dayjs.utc(items[0].parsed.x).valueOf()),
+            label(context) {
+              return `${context.dataset.label}: ${context.formattedValue}`;
+            },
           },
         },
       },
     },
   };
+
   const chart = new Chart($el[0] as HTMLCanvasElement, config);
   const handlesSlider = $('#time-range-slider')[0];
   let yearPips = [];
@@ -304,10 +315,12 @@ function makeDatasets(step: number, { data, singlePerfName }: Opts, singlePerfIn
       hoverBorderColor: hoverBorderColor,
       backgroundColor: perfStyle.color,
       pointRadius: data.length === 1 ? 3 : 0,
-      pointHoverRadius: 6,
+      pointHoverRadius: 5,
+      pointHoverBorderWidth: 0.5,
+      pointHoverBorderColor: '#fff9',
       data: data,
       pointStyle: perfStyle.symbol,
-      borderWidth: 2,
+      borderWidth: 1.5,
       tension: 0,
       borderDash: perfStyle.borderDash,
       stepped: false,
@@ -320,6 +333,7 @@ function makeDatasets(step: number, { data, singlePerfName }: Opts, singlePerfIn
   }
   return { ds: ds.filter(ds => ds.data.length), startDate, endDate };
 }
+
 function smoothDates(data: TsAndRating[], step: number, begin: number) {
   const oneStep = oneDay * step;
   if (!data.length) return [];

--- a/ui/chart/src/index.ts
+++ b/ui/chart/src/index.ts
@@ -20,7 +20,7 @@ export const blackFill: string = lightTheme ? 'rgba(0,0,0,0.2)' : 'rgba(0,0,0,1)
 export const fontColor: string = lightTheme ? '#2F2F2F' : 'hsl(0, 0%, 73%)';
 export const gridColor: string = lightTheme ? '#ccc' : '#404040';
 export const hoverBorderColor: string = lightTheme ? gridColor : 'white';
-export const tooltipBgColor: string = lightTheme ? 'rgba(255, 255, 255, 0.8)' : 'rgba(22, 21, 18, 0.7)';
+export const tooltipBgColor: string = lightTheme ? 'rgba(255, 255, 255, 0.85)' : 'rgba(22, 21, 18, 0.85)';
 
 const zeroLineColor = lightTheme ? '#959595' : '#676664';
 export const axisOpts = (xmin: number, xmax: number): ChartOptions<'line'>['scales'] => ({


### PR DESCRIPTION
# Why

Spotted that user rating history chart can be a bit hard to read with large count of series.

# How

Summary of changes:
* changed tooltip border and background colors
* reduced tooltip data series point
* spacing tweaks for the tooltip content
* reduce the series point size on series hover 

> [!note]
> In the future we might want to explore using [external tooltips](https://www.chartjs.org/docs/latest/configuration/tooltip.html#external-custom-tooltips), this would allow us to easily move values to the right side (align them in column) and apply backdrop blur for the tooltip container.

# Preview

<img width="713" height="368" alt="Screenshot 2026-06-08 at 14 34 04" src="https://github.com/user-attachments/assets/da1963e4-ad88-4f17-8dcf-dd92fc28a99a" />
