### PR TITLE
ui: fix daily feed form emoji overflow

### DIFF
--- a/modules/feed/src/main/FeedUi.scala
+++ b/modules/feed/src/main/FeedUi.scala
@@ -84,22 +84,20 @@ final class FeedUi(helpers: Helpers, atomUi: AtomUi)(
 
   def edit(form: Form[?], update: Feed.Update)(using Context) =
     page(s"Lichess update ${update.id}", true):
-      main(cls := "daily-feed page-small")(
-        div(cls := "box box-pad")(
-          boxTop(
-            h1(
-              a(href := routes.Feed.index(1))("Lichess update"),
-              " • ",
-              semanticDate(update.at)
-            )
-          ),
-          standardFlash,
-          postForm(cls := "form3", action := routes.Feed.update(update.id)):
-            inForm(form)
-          ,
-          postForm(action := routes.Feed.delete(update.id))(cls := "daily-feed__delete"):
-            submitButton(cls := "button button-red button-empty yes-no-confirm")("Delete")
-        )
+      main(cls := "daily-feed page-small box box-pad")(
+        boxTop(
+          h1(
+            a(href := routes.Feed.index(1))("Lichess update"),
+            " • ",
+            semanticDate(update.at)
+          )
+        ),
+        standardFlash,
+        postForm(cls := "form3", action := routes.Feed.update(update.id)):
+          inForm(form)
+        ,
+        postForm(action := routes.Feed.delete(update.id))(cls := "daily-feed__delete"):
+          submitButton(cls := "button button-red button-empty yes-no-confirm")("Delete")
       )
 
   def atom(ups: List[Feed.Update]) =

--- a/ui/bits/css/_dailyFeed.scss
+++ b/ui/bits/css/_dailyFeed.scss
@@ -1,7 +1,7 @@
 $marker-margin-top: -14px;
 
 .daily-feed {
-  .box {
+  &.box {
     overflow: visible;
   }
 


### PR DESCRIPTION
# Why

Fixes #19638

* #19638

# How

The issue here was that create and edit form used different DOM structure, which causes that `.box` nor `&.box` styles were matching both pages at the same time.

Adjust DOM to be the same for both daily feed post form states, update styling.

# Preview

<img width="1518" height="1104" alt="Screenshot 2026-06-09 at 13 25 12" src="https://github.com/user-attachments/assets/249d45e8-a33c-4f0f-97db-e8dfa5276102" />
<img width="1518" height="1104" alt="Screenshot 2026-06-09 at 13 22 28" src="https://github.com/user-attachments/assets/8c1aeb24-8235-495f-b95f-d725b211799a" />
