### PR TITLE
puzzle finisher: make puzzle update fire-and-forget

### DIFF
--- a/modules/puzzle/src/main/PuzzleFinisher.scala
+++ b/modules/puzzle/src/main/PuzzleFinisher.scala
@@ -140,20 +140,19 @@ final private[puzzle] class PuzzleFinisher(
                     _ <- api.round
                       .upsert(round, angle)
                       .zip:
-                        colls.puzzle:
-                          _.update
-                            .one(
-                              $id(puzzle.id),
-                              $inc(Puzzle.BSONFields.plays -> $int(1)) ++ newPuzzleGlicko.so { glicko =>
-                                $set(Puzzle.BSONFields.glicko -> glicko)
-                              }
-                            )
-                      .zip:
                         (userPerf != perf).so:
                           userApi
                             .setPerf(me.userId, PerfType.Puzzle, userPerf.clearRecent)
                             .zip(historyApi.addPuzzle(user = me.value, completedAt = now, perf = userPerf))
                             .void
+                    _ = colls.puzzle:
+                      _.update
+                        .one(
+                          $id(puzzle.id),
+                          $inc(Puzzle.BSONFields.plays -> $int(1)) ++ newPuzzleGlicko.so { glicko =>
+                            $set(Puzzle.BSONFields.glicko -> glicko)
+                          }
+                        )
                     _ = if prevRound.isEmpty then
                       Bus.pub:
                         Puzzle.UserResult(

--- a/modules/puzzle/src/main/PuzzleFinisher.scala
+++ b/modules/puzzle/src/main/PuzzleFinisher.scala
@@ -145,14 +145,13 @@ final private[puzzle] class PuzzleFinisher(
                             .setPerf(me.userId, PerfType.Puzzle, userPerf.clearRecent)
                             .zip(historyApi.addPuzzle(user = me.value, completedAt = now, perf = userPerf))
                             .void
-                    _ = colls.puzzle:
-                      _.update
-                        .one(
-                          $id(puzzle.id),
-                          $inc(Puzzle.BSONFields.plays -> $int(1)) ++ newPuzzleGlicko.so { glicko =>
-                            $set(Puzzle.BSONFields.glicko -> glicko)
-                          }
-                        )
+                    _ <- colls.puzzle.map:
+                      _.updateUnchecked(
+                        $id(puzzle.id),
+                        $inc(Puzzle.BSONFields.plays -> $int(1)) ++ newPuzzleGlicko.so { glicko =>
+                          $set(Puzzle.BSONFields.glicko -> glicko)
+                        }
+                      )
                     _ = if prevRound.isEmpty then
                       Bus.pub:
                         Puzzle.UserResult(


### PR DESCRIPTION
attempt to reduce timeout 500 errors on `Puzzle.complete` and `Puzzle.mobileBcBatchSolve` endpoints
