### PR TITLE
Fix rematch challenge for mobile and after cancel/decline

### DIFF
--- a/app/controllers/Challenge.scala
+++ b/app/controllers/Challenge.scala
@@ -373,7 +373,7 @@ final class Challenge(env: Env) extends LilaController(env):
           .dmap(_.as(JSON))
     )
 
-  def offerRematchForGame(gameId: GameId) = Auth { _ ?=> me ?=>
+  def offerRematchForGame(gameId: GameId) = AuthOrScoped(_.Challenge.Write, _.Web.Mobile) { _ ?=> me ?=>
     NoBot:
       Found(env.game.gameRepo.game(gameId)): g =>
         g.opponentOf(me).flatMap(_.userId).so(env.user.repo.byId).orNotFound { opponent =>

--- a/app/controllers/Challenge.scala
+++ b/app/controllers/Challenge.scala
@@ -373,7 +373,7 @@ final class Challenge(env: Env) extends LilaController(env):
           .dmap(_.as(JSON))
     )
 
-  def offerRematchForGame(gameId: GameId) = AuthOrScoped(_.Challenge.Write, _.Web.Mobile) { _ ?=> me ?=>
+  def offerRematchForGame(gameId: GameId) = AuthOrScoped(_.Web.Mobile) { _ ?=> me ?=>
     NoBot:
       Found(env.game.gameRepo.game(gameId)): g =>
         g.opponentOf(me).flatMap(_.userId).so(env.user.repo.byId).orNotFound { opponent =>

--- a/modules/challenge/src/main/ChallengeApi.scala
+++ b/modules/challenge/src/main/ChallengeApi.scala
@@ -14,6 +14,7 @@ final class ChallengeApi(
     joiner: ChallengeJoiner,
     jsonView: JsonView,
     gameCache: lila.game.Cached,
+    rematches: lila.game.Rematches,
     cacheApi: lila.memo.CacheApi,
     langPicker: LangPicker
 )(using Executor, akka.actor.ActorSystem, Scheduler, lila.core.i18n.Translator):
@@ -92,6 +93,8 @@ final class ChallengeApi(
   def cancel(c: Challenge) =
     for _ <- repo.cancel(c)
     yield
+      // allow a new rematch challenge to reuse a fresh id (the offered id is kept in cache)
+      c.rematchOf.foreach(rematches.drop)
       uncacheAndNotify(c)
       Bus.pub(NegativeEvent.Cancel(c.cancel))
 
@@ -108,6 +111,8 @@ final class ChallengeApi(
   def decline(c: Challenge, reason: Challenge.DeclineReason) =
     for _ <- repo.decline(c, reason)
     yield
+      // allow a new rematch challenge to reuse a fresh id (the offered id is kept in cache)
+      c.rematchOf.foreach(rematches.drop)
       uncacheAndNotify(c)
       Bus.pub(NegativeEvent.Decline(c.declineWith(reason)))
 

--- a/modules/challenge/src/main/ChallengeApi.scala
+++ b/modules/challenge/src/main/ChallengeApi.scala
@@ -90,11 +90,13 @@ final class ChallengeApi(
       if nb > 5 then repo.createdByPopularDestId(max)(userId)
       else repo.createdByDestId()(userId)
 
+  // drop the cached offer id (as Rematcher.no does) so a new rematch challenge gets a fresh id
+  private def dropRematchOffer(c: Challenge): Unit = c.rematchOf.foreach(rematches.drop)
+
   def cancel(c: Challenge) =
     for _ <- repo.cancel(c)
     yield
-      // allow a new rematch challenge to reuse a fresh id (the offered id is kept in cache)
-      c.rematchOf.foreach(rematches.drop)
+      dropRematchOffer(c)
       uncacheAndNotify(c)
       Bus.pub(NegativeEvent.Cancel(c.cancel))
 
@@ -111,8 +113,7 @@ final class ChallengeApi(
   def decline(c: Challenge, reason: Challenge.DeclineReason) =
     for _ <- repo.decline(c, reason)
     yield
-      // allow a new rematch challenge to reuse a fresh id (the offered id is kept in cache)
-      c.rematchOf.foreach(rematches.drop)
+      dropRematchOffer(c)
       uncacheAndNotify(c)
       Bus.pub(NegativeEvent.Decline(c.declineWith(reason)))
 


### PR DESCRIPTION
Two small fixes to the rematch-as-challenge flow (`POST /challenge/rematch-of/{id}`),
needed by lichess-org/mobile#3310 (see videos there):

- `offerRematchForGame` was the only challenge action gated behind session-only
  `Auth`, so OAuth/mobile clients got redirected to login. Switch to
  `AuthOrScoped(_.Challenge.Write, _.Web.Mobile)` to match its sibling actions.
  Handler body unchanged.

- Canceling or declining a rematch challenge left the offered next-game id in the
  `Rematches` cache (only the socket `rematch-no` path dropped it). Since that id
  is reused as the challenge id, any re-offer for the same game hit a duplicate
  key and failed with 400 for up to an hour. Reproducible on web: offer a rematch
  to an offline correspondence opponent, cancel it from the challenge dropdown,
  offer again. Now `cancel`/`decline` drop the cache entry like `Rematcher.no` does.

Assisted by Opus 4.8 and Fable 5