### PR TITLE
Fix button appearance in dark mode

### DIFF
--- a/ui/lib/css/component/_button.scss
+++ b/ui/lib/css/component/_button.scss
@@ -94,7 +94,7 @@
     background: none;
     box-shadow: none;
 
-    @include if-light {
+    @include if-not-transp {
       box-shadow: none;
       text-shadow: 0.5px 0.5px 0 $m-dimmer--fade-20;
     }


### PR DESCRIPTION
Fixes https://lichess.org/forum/lichess-feedback/these-new-mobile-buttons-are-ugly-cuNG.

Caused by #20592 which introduced a higher specificity rule `if-not-transp`. Light mode was saved because it was already using a higher specificity override. This fix expands that rule to dark mode as well.