### PR TITLE
Revert "dont draw heavy box shadows in transparent theme"

### DIFF
--- a/ui/lib/css/abstract/_mixins.scss
+++ b/ui/lib/css/abstract/_mixins.scss
@@ -168,63 +168,57 @@
 }
 
 @mixin with-metal-shadow($defaultShadow: (), $lightShadow: (), $soft: false) {
-  @include if-not-transp {
-    box-shadow:
-      inset 0 if($soft == true, 1px, 2px) 3px -2px hsl(0, 0%, if($soft == true, 30%, 45%)),
-      inset 0 -4px 6px -3px $m-body-gradient--lighten-3,
-      if($defaultShadow != (), 0 1px 3px 0 $defaultShadow, ());
+  box-shadow:
+    inset 0 if($soft == true, 1px, 2px) 3px -2px hsl(0, 0%, if($soft == true, 30%, 45%)),
+    inset 0 -4px 6px -3px $m-body-gradient--lighten-3,
+    if($defaultShadow != (), 0 1px 3px 0 $defaultShadow, ());
 
-    @include if-light {
-      box-shadow:
-        inset 0 if($soft == true, 2px, 3px) 3px -2px #fff,
-        inset 0 -4px 6px -3px $m-body-gradient--lighten-5,
-        if($defaultShadow != (), 0 1px 3px 0 if($lightShadow != (), $lightShadow, $defaultShadow), ());
-    }
+  @include if-light {
+    box-shadow:
+      inset 0 if($soft == true, 2px, 3px) 3px -2px #fff,
+      inset 0 -4px 6px -3px $m-body-gradient--lighten-5,
+      if($defaultShadow != (), 0 1px 3px 0 if($lightShadow != (), $lightShadow, $defaultShadow), ());
   }
 }
 
 @mixin with-metal-hover-shadow($defaultShadow: (), $lightShadow: (), $soft: false) {
-  @include if-not-transp {
-    box-shadow:
-      inset 0 if($soft == true, 2px, 3px) 3px -2px $c-border-light,
-      inset 0 -5px 8px -3px $m-body-gradient--lighten-5,
-      if($defaultShadow != (), 0 2px 4px 0 $defaultShadow, ());
+  box-shadow:
+    inset 0 if($soft == true, 2px, 3px) 3px -2px $c-border-light,
+    inset 0 -5px 8px -3px $m-body-gradient--lighten-5,
+    if($defaultShadow != (), 0 2px 4px 0 $defaultShadow, ());
 
-    @include if-light {
-      box-shadow:
-        inset 0 if($soft == true, 3px, 4px) 3px -2px #fff,
-        inset 0 -5px 8px -3px $m-body-gradient--lighten-7,
-        if($defaultShadow != (), 0 2px 4px 0 if($lightShadow != (), $lightShadow, $defaultShadow), ());
-    }
+  @include if-light {
+    box-shadow:
+      inset 0 if($soft == true, 3px, 4px) 3px -2px #fff,
+      inset 0 -5px 8px -3px $m-body-gradient--lighten-7,
+      if($defaultShadow != (), 0 2px 4px 0 if($lightShadow != (), $lightShadow, $defaultShadow), ());
   }
 }
 
 @mixin with-button-shadow($topShadow: (), $bottomShadow: (), $lighTopShadow: (), $lightBottomShadow: ()) {
-  @include if-not-transp {
+  box-shadow:
+    inset 0 2px 3px -2px $topShadow,
+    inset 0 -4px 6pt -3pt $bottomShadow,
+    0 1px 3px 0 hsla(0, 0, 0%, 0.2);
+
+  @include if-light {
+    box-shadow:
+      inset 0 2px 3px -2px if($lighTopShadow != (), $lighTopShadow, $topShadow),
+      inset 0 -4px 6pt -3pt if($lightBottomShadow != (), $lightBottomShadow, $bottomShadow),
+      0 1px 3px 0 hsla(0, 0, 0%, 0.18);
+  }
+
+  &:not(.disabled, :disabled, [disabled]):hover {
     box-shadow:
       inset 0 2px 3px -2px $topShadow,
-      inset 0 -4px 6pt -3pt $bottomShadow,
-      0 1px 3px 0 hsla(0, 0, 0%, 0.2);
+      inset 0 -5px 6pt -3pt $bottomShadow,
+      0 2px 4px 0 hsla(0, 0, 0%, 0.24);
 
     @include if-light {
       box-shadow:
         inset 0 2px 3px -2px if($lighTopShadow != (), $lighTopShadow, $topShadow),
-        inset 0 -4px 6pt -3pt if($lightBottomShadow != (), $lightBottomShadow, $bottomShadow),
-        0 1px 3px 0 hsla(0, 0, 0%, 0.18);
-    }
-
-    &:not(.disabled, :disabled, [disabled]):hover {
-      box-shadow:
-        inset 0 2px 3px -2px $topShadow,
-        inset 0 -5px 6pt -3pt $bottomShadow,
-        0 2px 4px 0 hsla(0, 0, 0%, 0.24);
-
-      @include if-light {
-        box-shadow:
-          inset 0 2px 3px -2px if($lighTopShadow != (), $lighTopShadow, $topShadow),
-          inset 0 -5px 6pt -3pt if($lightBottomShadow != (), $lightBottomShadow, $bottomShadow),
-          0 2px 4px 0 hsla(0, 0, 0%, 0.21);
-      }
+        inset 0 -5px 6pt -3pt if($lightBottomShadow != (), $lightBottomShadow, $bottomShadow),
+        0 2px 4px 0 hsla(0, 0, 0%, 0.21);
     }
   }
 }

--- a/ui/lib/css/theme/_theme.transp.scss
+++ b/ui/lib/css/theme/_theme.transp.scss
@@ -21,8 +21,8 @@ html.transp {
   --c-font-page: #{change-color($c-font, $lightness: 97%)};
   --c-metal-top: hsla(37, 7%, 19%, 0.56);
   --c-metal-bottom: hsla(37, 7%, 19%, 0.66);
-  --c-metal-top-hover: hsla(0, 0%, 42%, 0.3);
-  --c-metal-bottom-hover: hsla(0, 0%, 42%, 0.35);
+  --c-metal-top-hover: hsla(22, 100%, 42%, 0.4);
+  --c-metal-bottom-hover: hsla(22, 100%, 42%, 0.3);
 
   @include transp-mix;
 }


### PR DESCRIPTION
Reverts lichess-org/lila#20592

There's a lot of mistyled buttons in mod views but also user views

<img width="840" height="153" alt="image" src="https://github.com/user-attachments/assets/3cec392d-fbb9-42cf-82ca-68f989178f66" />

<img width="779" height="461" alt="image" src="https://github.com/user-attachments/assets/2542a44c-9927-4bbd-9b59-a754bc78557c" />

<img width="612" height="1173" alt="image" src="https://github.com/user-attachments/assets/d42cf9bf-1ca3-4510-904e-d5e8e65ec631" />

I agree with allan on #20650 that it's better to just revert.