### PR TITLE
Unset transp box-shadow without raising unrelated selector specificity

### DIFF
--- a/ui/lib/css/abstract/_mixins.scss
+++ b/ui/lib/css/abstract/_mixins.scss
@@ -7,7 +7,9 @@
 }
 
 @mixin box-shadow {
-  box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.08), 0 3px 1px -2px rgba(0, 0, 0, 0.18),
+  box-shadow:
+    0 2px 2px 0 rgba(0, 0, 0, 0.08),
+    0 3px 1px -2px rgba(0, 0, 0, 0.18),
     0 1px 5px 0 rgba(0, 0, 0, 0.1);
 }
 
@@ -166,54 +168,67 @@
 }
 
 @mixin with-metal-shadow($defaultShadow: (), $lightShadow: (), $soft: false) {
-  box-shadow: inset 0 if($soft == true, 1px, 2px) 3px -2px hsl(0, 0%, if($soft == true, 30%, 45%)),
+  box-shadow:
+    inset 0 if($soft == true, 1px, 2px) 3px -2px hsl(0, 0%, if($soft == true, 30%, 45%)),
     inset 0 -4px 6px -3px $m-body-gradient--lighten-3,
     if($defaultShadow != (), 0 1px 3px 0 $defaultShadow, ());
 
   @include if-light {
-    box-shadow: inset 0 if($soft == true, 2px, 3px) 3px -2px #fff,
+    box-shadow:
+      inset 0 if($soft == true, 2px, 3px) 3px -2px #fff,
       inset 0 -4px 6px -3px $m-body-gradient--lighten-5,
       if($defaultShadow != (), 0 1px 3px 0 if($lightShadow != (), $lightShadow, $defaultShadow), ());
   }
+
   @include if-transp {
     box-shadow: none;
   }
 }
 
 @mixin with-metal-hover-shadow($defaultShadow: (), $lightShadow: (), $soft: false) {
-  box-shadow: inset 0 if($soft == true, 2px, 3px) 3px -2px $c-border-light,
+  box-shadow:
+    inset 0 if($soft == true, 2px, 3px) 3px -2px $c-border-light,
     inset 0 -5px 8px -3px $m-body-gradient--lighten-5,
     if($defaultShadow != (), 0 2px 4px 0 $defaultShadow, ());
 
   @include if-light {
-    box-shadow: inset 0 if($soft == true, 3px, 4px) 3px -2px #fff,
+    box-shadow:
+      inset 0 if($soft == true, 3px, 4px) 3px -2px #fff,
       inset 0 -5px 8px -3px $m-body-gradient--lighten-7,
       if($defaultShadow != (), 0 2px 4px 0 if($lightShadow != (), $lightShadow, $defaultShadow), ());
   }
+
   @include if-transp {
     box-shadow: none;
   }
 }
 
 @mixin with-button-shadow($topShadow: (), $bottomShadow: (), $lighTopShadow: (), $lightBottomShadow: ()) {
-  box-shadow: inset 0 2px 3px -2px $topShadow, inset 0 -4px 6pt -3pt $bottomShadow,
+  box-shadow:
+    inset 0 2px 3px -2px $topShadow,
+    inset 0 -4px 6pt -3pt $bottomShadow,
     0 1px 3px 0 hsla(0, 0, 0%, 0.2);
 
   @include if-light {
-    box-shadow: inset 0 2px 3px -2px if($lighTopShadow != (), $lighTopShadow, $topShadow),
+    box-shadow:
+      inset 0 2px 3px -2px if($lighTopShadow != (), $lighTopShadow, $topShadow),
       inset 0 -4px 6pt -3pt if($lightBottomShadow != (), $lightBottomShadow, $bottomShadow),
       0 1px 3px 0 hsla(0, 0, 0%, 0.18);
   }
 
   &:not(.disabled, :disabled, [disabled]):hover {
-    box-shadow: inset 0 2px 3px -2px $topShadow, inset 0 -5px 6pt -3pt $bottomShadow,
+    box-shadow:
+      inset 0 2px 3px -2px $topShadow,
+      inset 0 -5px 6pt -3pt $bottomShadow,
       0 2px 4px 0 hsla(0, 0, 0%, 0.24);
 
     @include if-light {
-      box-shadow: inset 0 2px 3px -2px if($lighTopShadow != (), $lighTopShadow, $topShadow),
+      box-shadow:
+        inset 0 2px 3px -2px if($lighTopShadow != (), $lighTopShadow, $topShadow),
         inset 0 -5px 6pt -3pt if($lightBottomShadow != (), $lightBottomShadow, $bottomShadow),
         0 2px 4px 0 hsla(0, 0, 0%, 0.21);
     }
+
     @include if-transp {
       box-shadow: none;
     }

--- a/ui/lib/css/abstract/_mixins.scss
+++ b/ui/lib/css/abstract/_mixins.scss
@@ -7,9 +7,7 @@
 }
 
 @mixin box-shadow {
-  box-shadow:
-    0 2px 2px 0 rgba(0, 0, 0, 0.08),
-    0 3px 1px -2px rgba(0, 0, 0, 0.18),
+  box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.08), 0 3px 1px -2px rgba(0, 0, 0, 0.18),
     0 1px 5px 0 rgba(0, 0, 0, 0.1);
 }
 
@@ -168,57 +166,56 @@
 }
 
 @mixin with-metal-shadow($defaultShadow: (), $lightShadow: (), $soft: false) {
-  box-shadow:
-    inset 0 if($soft == true, 1px, 2px) 3px -2px hsl(0, 0%, if($soft == true, 30%, 45%)),
+  box-shadow: inset 0 if($soft == true, 1px, 2px) 3px -2px hsl(0, 0%, if($soft == true, 30%, 45%)),
     inset 0 -4px 6px -3px $m-body-gradient--lighten-3,
     if($defaultShadow != (), 0 1px 3px 0 $defaultShadow, ());
 
   @include if-light {
-    box-shadow:
-      inset 0 if($soft == true, 2px, 3px) 3px -2px #fff,
+    box-shadow: inset 0 if($soft == true, 2px, 3px) 3px -2px #fff,
       inset 0 -4px 6px -3px $m-body-gradient--lighten-5,
       if($defaultShadow != (), 0 1px 3px 0 if($lightShadow != (), $lightShadow, $defaultShadow), ());
+  }
+  @include if-transp {
+    box-shadow: none;
   }
 }
 
 @mixin with-metal-hover-shadow($defaultShadow: (), $lightShadow: (), $soft: false) {
-  box-shadow:
-    inset 0 if($soft == true, 2px, 3px) 3px -2px $c-border-light,
+  box-shadow: inset 0 if($soft == true, 2px, 3px) 3px -2px $c-border-light,
     inset 0 -5px 8px -3px $m-body-gradient--lighten-5,
     if($defaultShadow != (), 0 2px 4px 0 $defaultShadow, ());
 
   @include if-light {
-    box-shadow:
-      inset 0 if($soft == true, 3px, 4px) 3px -2px #fff,
+    box-shadow: inset 0 if($soft == true, 3px, 4px) 3px -2px #fff,
       inset 0 -5px 8px -3px $m-body-gradient--lighten-7,
       if($defaultShadow != (), 0 2px 4px 0 if($lightShadow != (), $lightShadow, $defaultShadow), ());
+  }
+  @include if-transp {
+    box-shadow: none;
   }
 }
 
 @mixin with-button-shadow($topShadow: (), $bottomShadow: (), $lighTopShadow: (), $lightBottomShadow: ()) {
-  box-shadow:
-    inset 0 2px 3px -2px $topShadow,
-    inset 0 -4px 6pt -3pt $bottomShadow,
+  box-shadow: inset 0 2px 3px -2px $topShadow, inset 0 -4px 6pt -3pt $bottomShadow,
     0 1px 3px 0 hsla(0, 0, 0%, 0.2);
 
   @include if-light {
-    box-shadow:
-      inset 0 2px 3px -2px if($lighTopShadow != (), $lighTopShadow, $topShadow),
+    box-shadow: inset 0 2px 3px -2px if($lighTopShadow != (), $lighTopShadow, $topShadow),
       inset 0 -4px 6pt -3pt if($lightBottomShadow != (), $lightBottomShadow, $bottomShadow),
       0 1px 3px 0 hsla(0, 0, 0%, 0.18);
   }
 
   &:not(.disabled, :disabled, [disabled]):hover {
-    box-shadow:
-      inset 0 2px 3px -2px $topShadow,
-      inset 0 -5px 6pt -3pt $bottomShadow,
+    box-shadow: inset 0 2px 3px -2px $topShadow, inset 0 -5px 6pt -3pt $bottomShadow,
       0 2px 4px 0 hsla(0, 0, 0%, 0.24);
 
     @include if-light {
-      box-shadow:
-        inset 0 2px 3px -2px if($lighTopShadow != (), $lighTopShadow, $topShadow),
+      box-shadow: inset 0 2px 3px -2px if($lighTopShadow != (), $lighTopShadow, $topShadow),
         inset 0 -5px 6pt -3pt if($lightBottomShadow != (), $lightBottomShadow, $bottomShadow),
         0 2px 4px 0 hsla(0, 0, 0%, 0.21);
+    }
+    @include if-transp {
+      box-shadow: none;
     }
   }
 }

--- a/ui/lib/css/theme/_theme.transp.scss
+++ b/ui/lib/css/theme/_theme.transp.scss
@@ -21,8 +21,8 @@ html.transp {
   --c-font-page: #{change-color($c-font, $lightness: 97%)};
   --c-metal-top: hsla(37, 7%, 19%, 0.56);
   --c-metal-bottom: hsla(37, 7%, 19%, 0.66);
-  --c-metal-top-hover: hsla(22, 100%, 42%, 0.4);
-  --c-metal-bottom-hover: hsla(22, 100%, 42%, 0.3);
+  --c-metal-top-hover: hsla(0, 0%, 42%, 0.3);
+  --c-metal-bottom-hover: hsla(0, 0%, 42%, 0.35);
 
   @include transp-mix;
 }


### PR DESCRIPTION
This is attempt number two after a previous "fix" for transparent button backgrounds caused https://github.com/lichess-org/lila/issues/20651
