### PR TITLE
fix: Prevent rating chart slider year labels from overlapping content below.

### DIFF
--- a/ui/lib/css/component/_chart.scss
+++ b/ui/lib/css/component/_chart.scss
@@ -141,7 +141,7 @@
      */
   .noUi-horizontal {
     height: 9px;
-    margin-top: 10px;
+    margin-top: 3px;
     margin-left: 32px;
     margin-right: 36px;
   }


### PR DESCRIPTION
Fixes #20652

Reduces `.noUi-horizontal` `margin-top` from `10px` to `3px` so the 
noUiSlider year tick labels fit within the container and no longer 
overflow into the section below the chart.

before:
<img width="722" height="123" alt="image" src="https://github.com/user-attachments/assets/a40d3f5a-1708-4f0a-8772-416e5c701010" />
after:
<img width="788" height="122" alt="image" src="https://github.com/user-attachments/assets/ba9874b0-96c1-4809-8b83-23a0560c8649" />
