### PR TITLE
Sort language options alphabetically by name instead of code

### DIFF
--- a/modules/i18n/src/main/LangList.scala
+++ b/modules/i18n/src/main/LangList.scala
@@ -142,7 +142,7 @@ object LangList extends lila.core.i18n.LangList:
       toLanguage(l) -> name
     .toList
     .distinctBy(_._1)
-    .sortBy(_._1.value)
+    .sortBy(_._2)
 
   lazy val popularLanguageChoices: List[(Language, String)] =
     popularNoRegion.flatMap: lang =>
@@ -152,7 +152,7 @@ object LangList extends lila.core.i18n.LangList:
     .map: (l, name) =>
       l.code -> name
     .toList
-    .sortBy(_._1)
+    .sortBy(_._2)
 
   lazy val allLanguagesForm = new LangForm:
     val choices = languageChoices

--- a/ui/lib/css/component/_chart.scss
+++ b/ui/lib/css/component/_chart.scss
@@ -141,7 +141,7 @@
      */
   .noUi-horizontal {
     height: 9px;
-    margin-top: 10px;
+    margin-top: 3px;
     margin-left: 32px;
     margin-right: 36px;
   }


### PR DESCRIPTION
Fixes #20658

Language choices were sorted by their internal code (en, fr, ru) instead 
of their display name (English, Français, Русский), making it hard for 
users to find their language.

Changed `.sortBy(_._1.value)` to `.sortBy(_._2)` in `languageChoices` 
and `allChoices` so both lists sort by the language name.
