### PR TITLE
Sort language options alphabetically by name instead of code

### DIFF
--- a/modules/coreI18n/src/main/i18n.scala
+++ b/modules/coreI18n/src/main/i18n.scala
@@ -41,8 +41,6 @@ object Translate:
   given (using trans: Translator, lang: Lang): Translate = trans.to(lang)
 
 trait LangList:
-  val all: Map[Lang, String]
-  def allLanguages: List[Language]
   def popularLanguages: List[Language]
   def popularNoRegion: List[Lang]
   def nameByLanguage(l: Language): String

--- a/modules/i18n/src/main/LangList.scala
+++ b/modules/i18n/src/main/LangList.scala
@@ -142,7 +142,7 @@ object LangList extends lila.core.i18n.LangList:
       toLanguage(l) -> name
     .toList
     .distinctBy(_._1)
-    .sortBy(_._1.value)
+    .sortBy(_._2)
 
   lazy val popularLanguageChoices: List[(Language, String)] =
     popularNoRegion.flatMap: lang =>
@@ -152,7 +152,7 @@ object LangList extends lila.core.i18n.LangList:
     .map: (l, name) =>
       l.code -> name
     .toList
-    .sortBy(_._1)
+    .sortBy(_._2)
 
   lazy val allLanguagesForm = new LangForm:
     val choices = languageChoices

--- a/modules/i18n/src/main/LangList.scala
+++ b/modules/i18n/src/main/LangList.scala
@@ -2,12 +2,12 @@ package lila.i18n
 
 import play.api.i18n.Lang
 import scalalib.model.{ Language, LangTag }
-
+import scala.collection.immutable.SeqMap
 import lila.core.i18n.{ toLanguage, fixJavaLanguage }
 
 object LangList extends lila.core.i18n.LangList:
 
-  val all: Map[Lang, String] = Map(
+  val all: SeqMap[Lang, String] = SeqMap(
     Lang("af", "ZA") -> "Afrikaans",
     Lang("so", "SO") -> "Af Soomaali",
     Lang("an", "ES") -> "Aragonés",
@@ -142,7 +142,6 @@ object LangList extends lila.core.i18n.LangList:
       toLanguage(l) -> name
     .toList
     .distinctBy(_._1)
-    .sortBy(_._2)
 
   lazy val popularLanguageChoices: List[(Language, String)] =
     popularNoRegion.flatMap: lang =>
@@ -152,7 +151,6 @@ object LangList extends lila.core.i18n.LangList:
     .map: (l, name) =>
       l.code -> name
     .toList
-    .sortBy(_._2)
 
   lazy val allLanguagesForm = new LangForm:
     val choices = languageChoices

--- a/modules/i18n/src/main/LangList.scala
+++ b/modules/i18n/src/main/LangList.scala
@@ -7,7 +7,7 @@ import lila.core.i18n.{ toLanguage, fixJavaLanguage }
 
 object LangList extends lila.core.i18n.LangList:
 
-  val all: SeqMap[Lang, String] = SeqMap(
+  private[i18n] val all: SeqMap[Lang, String] = SeqMap(
     Lang("af", "ZA") -> "Afrikaans",
     Lang("so", "SO") -> "Af Soomaali",
     Lang("an", "ES") -> "Aragonés",
@@ -104,7 +104,7 @@ object LangList extends lila.core.i18n.LangList:
     Lang("ko", "KR") -> "한국어"
   )
 
-  val defaultRegions = Map[String, Lang](
+  private[i18n] val defaultRegions = Map[String, Lang](
     "de" -> Lang("de", "DE"),
     "en" -> Lang("en", "US"),
     "pt" -> Lang("pt", "BR"),
@@ -127,7 +127,7 @@ object LangList extends lila.core.i18n.LangList:
   lazy val popularNoRegion: List[Lang] = popular.collect:
     case l if defaultRegions.get(l.language).forall(_ == l) => l
 
-  lazy val allLanguages: List[Language] = popularNoRegion.map(fixJavaLanguage)
+  private lazy val allLanguages: List[Language] = popularNoRegion.map(fixJavaLanguage)
   lazy val popularLanguages: List[Language] = allLanguages.take(20)
   lazy val popularAlternateLanguages: List[Language] = allLanguages.drop(1).take(20)
 


### PR DESCRIPTION
Fixes #20658

Language choices were sorted by their internal code (en, fr, ru) instead 
of their display name (English, Français, Русский), making it hard for 
users to find their language.

Changed `.sortBy(_._1.value)` to `.sortBy(_._2)` in `languageChoices` 
and `allChoices` so both lists sort by the language name.
