### PR TITLE
workspace: add object-shorthand rule, fix warnings

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -36,6 +36,7 @@
         "caughtErrorsIgnorePattern": "^_"
       }
     ],
+    "object-shorthand": "error",
     "import/no-cycle": "error",
     "prefer-promise-reject-errors": "error",
     "promise/no-callback-in-promise": "error",

--- a/bin/mongodb/award-trophy.js
+++ b/bin/mongodb/award-trophy.js
@@ -4,7 +4,7 @@ const kind = 'marathonSurvivor';
 
 db.trophy.insert({
   _id: kind + '/' + user,
-  user: user,
-  kind: kind,
+  user,
+  kind,
   date: new Date(),
 });

--- a/bin/mongodb/denormalize-game-uids.js
+++ b/bin/mongodb/denormalize-game-uids.js
@@ -25,7 +25,7 @@ gamesToMigrate.forEach(function (game) {
   const gameSris = game.uids || [];
   if (gameSris.length !== uids.length) {
     ++j;
-    db.game4.update({ _id: game['_id'] }, { $set: { uids: uids } });
+    db.game4.update({ _id: game['_id'] }, { $set: { uids } });
   }
 
   ++it;

--- a/bin/mongodb/game-search-test.js
+++ b/bin/mongodb/game-search-test.js
@@ -43,7 +43,7 @@ for (let i = 0; i < nbGames; i++) {
   const users = [anyOf(players), anyOf(players)];
   const winnerIndex = intRandom(2);
   coll.insert({
-    users: users,
+    users,
     winner: users[winnerIndex],
     loser: users[1 - winnerIndex],
     winColor: anyOf(winColor),

--- a/bin/mongodb/marathon-trophies.js
+++ b/bin/mongodb/marathon-trophies.js
@@ -5,8 +5,8 @@ for (let i of users) {
   const user = users[i];
   db.trophy.insert({
     _id: kind + '/' + user,
-    user: user,
-    kind: kind,
+    user,
+    kind,
     date: new Date(),
   });
 }

--- a/bin/mongodb/msg-dump.js
+++ b/bin/mongodb/msg-dump.js
@@ -2,7 +2,7 @@ const tid = 'a/b';
 const renderDate = date => `${date.getDate()}/${date.getMonth() + 1}/${date.getFullYear()}`;
 
 db.msg_msg
-  .find({ tid: tid })
+  .find({ tid })
   .sort({ date: 1 })
   .forEach(m => {
     print(`${renderDate(m.date)} ${m.user}`);

--- a/bin/mongodb/relay-tour-info-migrate.js
+++ b/bin/mongodb/relay-tour-info-migrate.js
@@ -20,5 +20,5 @@ db.relay_tour
     if (tc) info.tc = tc.replace(/time control/i, '').trim();
     const players = split.shift();
     if (players) info.players = players;
-    db.relay_tour.updateOne({ _id: tour._id }, { $set: { info: info } });
+    db.relay_tour.updateOne({ _id: tour._id }, { $set: { info } });
   });

--- a/bin/mongodb/study-chapter-tags.js
+++ b/bin/mongodb/study-chapter-tags.js
@@ -13,7 +13,7 @@ db.study_chapter
       },
       {
         $set: {
-          tags: tags,
+          tags,
         },
         $unset: {
           'setup.fromPgn': !!c.setup.fromPgn,

--- a/bin/mongodb/team-leaders.js
+++ b/bin/mongodb/team-leaders.js
@@ -4,6 +4,6 @@ db.team.find().forEach(t => {
   if (leaders.length !== t.leaders.length) {
     if (!leaders.length) leaders.push(t.createdBy);
     print(`${t._id} ${t.name} ${t.leaders.join(',')} -> ${leaders.join(',')}`);
-    db.team.update({ _id: t._id }, { $set: { leaders: leaders } });
+    db.team.update({ _id: t._id }, { $set: { leaders } });
   }
 });

--- a/bin/mongodb/titled-tournament-notification.js
+++ b/bin/mongodb/titled-tournament-notification.js
@@ -29,7 +29,7 @@ userIds.forEach(userId => {
     content: {
       type: 'titledTourney',
       id: tournamentId,
-      text: text,
+      text,
     },
     read: false,
     createdAt: new Date(),

--- a/bin/mongodb/user-delete-forever.js
+++ b/bin/mongodb/user-delete-forever.js
@@ -154,7 +154,7 @@ print(
 print('Delete assessments');
 print(
   db.player_assessment.deleteMany({
-    userId: userId,
+    userId,
   }).deletedCount + ' done',
 );
 

--- a/bin/mongodb/user-flag-to-flair.js
+++ b/bin/mongodb/user-flag-to-flair.js
@@ -8,5 +8,5 @@ map = [
 
 db.user4.find({ 'profile.country': { $in: map.map(e => e[0]) } }, { 'profile.country': 1 }).forEach(user => {
   flair = map.find(e => e[0] === user.profile.country)[1];
-  db.user4.updateOne({ _id: user._id }, { $unset: { 'profile.country': 1 }, $set: { flair: flair } });
+  db.user4.updateOne({ _id: user._id }, { $unset: { 'profile.country': 1 }, $set: { flair } });
 });

--- a/bin/mongodb/userstats.js
+++ b/bin/mongodb/userstats.js
@@ -24,7 +24,7 @@ users.find().forEach(function (user) {
     draw: games.count({ us: uid, s: { $in: [34, 32] } }),
     rated: games.count({ us: uid, ra: true }),
   };
-  users.update({ _id: uid }, { $set: { count: count } });
+  users.update({ _id: uid }, { $set: { count } });
   ++it;
   if (it % batchSize === 0) {
     const percent = Math.round((it / max) * 100);

--- a/cron/mongodb-puzzle-regen-paths.js
+++ b/cron/mongodb-puzzle-regen-paths.js
@@ -252,7 +252,7 @@ let anyBuggy = false;
           max: `${theme}${sep}${bucket.tier}${sep}${padRating(ratingMax)}`,
           ids,
           tier: bucket.tier,
-          theme: theme,
+          theme,
           gen: generation,
         })),
         {

--- a/ui/analyse/src/motif/boardAnalysis.ts
+++ b/ui/analyse/src/motif/boardAnalysis.ts
@@ -210,8 +210,8 @@ export function detectCheckable(
     const res = Chess.fromSetup({
       board: cb,
       turn: oppColor,
-      castlingRights: castlingRights,
-      epSquare: epSquare,
+      castlingRights,
+      epSquare,
       halfmoves: 0,
       fullmoves: 1,
       pockets: undefined,

--- a/ui/analyse/src/study/chapterNewForm.ts
+++ b/ui/analyse/src/study/chapterNewForm.ts
@@ -108,7 +108,7 @@ export class StudyChapterNewForm {
   submit = (d: Omit<ChapterData, 'initial'>) => {
     const study = this.root.study!;
     const showRatings = study.data.showRatings ? undefined : false; // define only if false
-    const dd = { ...d, sticky: study.vm.mode.sticky, showRatings: showRatings, initial: this.initial() };
+    const dd = { ...d, sticky: study.vm.mode.sticky, showRatings, initial: this.initial() };
     if (!dd.pgn) this.send('addChapter', dd);
     else
       importPgn(study.data.id, dd).catch(e => {

--- a/ui/analyse/src/study/gamebook/gamebookEdit.ts
+++ b/ui/analyse/src/study/gamebook/gamebookEdit.ts
@@ -127,7 +127,7 @@ const saveNode = throttle(500, (ctrl: AnalyseCtrl, gamebook: Gamebook) => {
   ctrl.socket.send('setGamebook', {
     path: ctrl.path,
     ch: ctrl.study!.vm.chapterId,
-    gamebook: gamebook,
+    gamebook,
   });
   ctrl.redraw();
 });

--- a/ui/analyse/src/study/multiBoard.ts
+++ b/ui/analyse/src/study/multiBoard.ts
@@ -76,7 +76,7 @@ export class MultiBoardCtrl {
     const nbPages = Math.floor((nbResults + maxPerPage - 1) / maxPerPage);
     return {
       currentPage: this.page,
-      maxPerPage: maxPerPage,
+      maxPerPage,
       currentPageResults,
       nbResults,
       previousPage: this.page > 1 ? this.page - 1 : undefined,

--- a/ui/analyse/src/study/studyCtrl.ts
+++ b/ui/analyse/src/study/studyCtrl.ts
@@ -287,7 +287,7 @@ export default class StudyCtrl {
       'shapes',
       this.addChapterId({
         path: this.ctrl.path,
-        shapes: shapes,
+        shapes,
       }),
     );
   };

--- a/ui/analyse/src/view/util.ts
+++ b/ui/analyse/src/view/util.ts
@@ -32,7 +32,7 @@ export function titleNameToId(titleName: string): string {
 }
 
 export const option = (value: string, current: string | undefined, name: string, data?: VNodeData) =>
-  hl('option', { attrs: { value: value, selected: value === current }, ...data }, name);
+  hl('option', { attrs: { value, selected: value === current }, ...data }, name);
 
 export const playerFedFlag = (fed?: Federation) =>
   fed &&

--- a/ui/bits/src/bits.captcha.ts
+++ b/ui/bits/src/bits.captcha.ts
@@ -64,7 +64,7 @@ function init() {
           setTimeout(
             () =>
               cg.set({
-                fen: fen,
+                fen,
                 turnColor: cg.state.orientation,
                 movable: { dests },
               }),

--- a/ui/bits/src/bits.challengePage.ts
+++ b/ui/bits/src/bits.challengePage.ts
@@ -49,7 +49,7 @@ export function initModule(opts: ChallengeOpts): void {
       .each(function (this: HTMLInputElement) {
         const input = this;
         userComplete({
-          input: input,
+          input,
           friend: true,
           tag: 'span',
           focus: true,

--- a/ui/bits/src/bits.flairPicker.ts
+++ b/ui/bits/src/bits.flairPicker.ts
@@ -39,8 +39,8 @@ const makeEmojiData = async () => {
   const lines = text.split('\n').slice(0, -1);
   return {
     categories: categories.map(([id, name]) => ({
-      id: id,
-      name: name,
+      id,
+      name,
       emojis: lines.filter(line => line.startsWith(id)),
     })),
     emojis: Object.fromEntries(
@@ -50,7 +50,7 @@ const makeEmojiData = async () => {
           key,
           {
             id: key,
-            name: name,
+            name,
             keywords: [categ, ...name.split('-')],
             skins: [
               {

--- a/ui/bits/src/bits.forum.ts
+++ b/ui/bits/src/bits.forum.ts
@@ -160,7 +160,7 @@ site.load.then(() => {
       {
         index: 2,
         match: /(^|\s)@([a-zA-Z_-][\w-]{0,19})$/,
-        search: function (term: string, searchCallback: (names: string[]) => void) {
+        search (term: string, searchCallback: (names: string[]) => void) {
           // Initially we only autocomplete by participants in the thread. As the user types more,
           // we can autocomplete against all users on the site.
           threadParticipants.then(function (participants) {

--- a/ui/bits/src/bits.forum.ts
+++ b/ui/bits/src/bits.forum.ts
@@ -160,7 +160,7 @@ site.load.then(() => {
       {
         index: 2,
         match: /(^|\s)@([a-zA-Z_-][\w-]{0,19})$/,
-        search (term: string, searchCallback: (names: string[]) => void) {
+        search(term: string, searchCallback: (names: string[]) => void) {
           // Initially we only autocomplete by participants in the thread. As the user types more,
           // we can autocomplete against all users on the site.
           threadParticipants.then(function (participants) {

--- a/ui/botDev/src/devAssets.ts
+++ b/ui/botDev/src/devAssets.ts
@@ -159,7 +159,7 @@ export class DevAssets {
     if (!book.cover) throw new Error(`error parsing ${blobname}`);
     const key = await hashBlob(blob);
     const name = blobname.endsWith('.bin') ? blobname.slice(0, -4) : blobname;
-    const asset = { blob: blob, name, user: myUserId() ?? 'anonymous' };
+    const asset = { blob, name, user: myUserId() ?? 'anonymous' };
     const cover = { blob: book.cover, name, user: myUserId() ?? 'anonymous' };
     await Promise.all([this.idb.book.put(key, asset), this.idb.bookCover.put(key, cover)]);
     this.urls.bookCover.set(key, URL.createObjectURL(new Blob([book.cover], { type: 'image/png' })));

--- a/ui/botDev/src/gameCtrl.ts
+++ b/ui/botDev/src/gameCtrl.ts
@@ -269,7 +269,7 @@ export class GameCtrl {
     const initial = this.live.initial;
     this.clock = Number.isFinite(initial)
       ? {
-          initial: initial,
+          initial,
           increment: this.live.increment ?? 0,
           white: this.live.clock?.white ?? initial,
           black: this.live.clock?.black ?? initial,

--- a/ui/botPlay/src/play/botMove.ts
+++ b/ui/botPlay/src/play/botMove.ts
@@ -16,7 +16,7 @@ export const requestBotMove = async (source: MoveSource, game: Game): Promise<Mo
 
   const moveRequest: MoveArgs = {
     pos: { fen: game.data.initialFen || INITIAL_FEN, moves: ucis },
-    chess: chess,
+    chess,
     avoid: threefoldMoves,
     initial: Infinity,
     remaining: Infinity,

--- a/ui/chart/src/acpl.ts
+++ b/ui/chart/src/acpl.ts
@@ -72,7 +72,7 @@ export default async function (
       else if (node.eval?.cp) cp = node.eval.cp;
       const turn = plyToTurn(node.ply);
       const dots = isWhite ? '.' : '...';
-      const winchance = winningChances.povChances('white', { cp: cp });
+      const winchance = winningChances.povChances('white', { cp });
       // Plot winchance because logarithmic but display the corresponding cp.eval from AnalyseData in the tooltip
       winChances.push({ x: node.ply, y: winchance });
 
@@ -111,8 +111,8 @@ export default async function (
         order: 5,
         datalabels: { display: false },
       },
-      moveLabels: moveLabels,
-      adviceHoverColors: adviceHoverColors,
+      moveLabels,
+      adviceHoverColors,
     };
   };
 

--- a/ui/chart/src/chart.ratingDistribution.ts
+++ b/ui/chart/src/chart.ratingDistribution.ts
@@ -74,14 +74,14 @@ export async function initModule(data: DistributionData): Promise<void> {
         segment: {
           borderDash: [10],
         },
-        label: label,
+        label,
         pointRadius: 4,
         datalabels: {
           align: 'top',
           offset: 0,
           display: 'auto',
           formatter: (value: Point) => (value.y === 0 ? '' : label),
-          color: color,
+          color,
         },
       });
     if (data.myRating && data.myRating <= maxRating)
@@ -90,7 +90,7 @@ export async function initModule(data: DistributionData): Promise<void> {
       pushLine('#eeaaee', Math.min(data.otherRating, maxRating), `${data.otherPlayer} (${data.otherRating})`);
     const chartData: ChartData<'line'> = {
       labels: ratings,
-      datasets: datasets,
+      datasets,
     };
 
     const config: ChartConfiguration<'line'> = {

--- a/ui/chart/src/chart.ratingHistory.ts
+++ b/ui/chart/src/chart.ratingHistory.ts
@@ -248,8 +248,7 @@ export function initModule({ data, singlePerfName }: Opts): void {
         if (newDs !== chart.data.datasets) chart.data.datasets = newDs;
         chart.update('none');
       }
-      if (chart.scales.x.min !== min || chart.scales.x.max !== max)
-        chart.zoomScale('x', { min, max });
+      if (chart.scales.x.min !== min || chart.scales.x.max !== max) chart.zoomScale('x', { min, max });
     };
     slider.on('update', slide);
     // Disable events while dragging for a slight performance boost

--- a/ui/chart/src/chart.ratingHistory.ts
+++ b/ui/chart/src/chart.ratingHistory.ts
@@ -249,7 +249,7 @@ export function initModule({ data, singlePerfName }: Opts): void {
         chart.update('none');
       }
       if (chart.scales.x.min !== min || chart.scales.x.max !== max)
-        chart.zoomScale('x', { min: min, max: max });
+        chart.zoomScale('x', { min, max });
     };
     slider.on('update', slide);
     // Disable events while dragging for a slight performance boost
@@ -274,7 +274,7 @@ export function initModule({ data, singlePerfName }: Opts): void {
     const btnClick = (min: number) => {
       $('.time-selector-buttons .button').removeClass('active');
       slider.set([min, endDate.valueOf()]);
-      chart.zoomScale('x', { min: min, max: endDate.valueOf() });
+      chart.zoomScale('x', { min, max: endDate.valueOf() });
     };
     $('.time-selector-buttons')
       .html(
@@ -312,13 +312,13 @@ function makeDatasets(step: number, { data, singlePerfName }: Opts, singlePerfIn
       type: 'line',
       label: serie.name,
       borderColor: perfStyle.color,
-      hoverBorderColor: hoverBorderColor,
+      hoverBorderColor,
       backgroundColor: perfStyle.color,
       pointRadius: data.length === 1 ? 3 : 0,
       pointHoverRadius: 5,
       pointHoverBorderWidth: 0.5,
       pointHoverBorderColor: '#fff9',
-      data: data,
+      data,
       pointStyle: perfStyle.symbol,
       borderWidth: 1.5,
       tension: 0,

--- a/ui/chart/src/chart.relayStats.ts
+++ b/ui/chart/src/chart.relayStats.ts
@@ -62,7 +62,7 @@ const makeDataset = (data: RoundStats, el: HTMLCanvasElement): chart.ChartDatase
       borderWidth: 2,
       pointRadius: 0,
       pointHoverRadius: 5,
-      hoverBorderColor: hoverBorderColor,
+      hoverBorderColor,
       tension: 0,
       datalabels: { display: false },
     },

--- a/ui/chart/src/index.ts
+++ b/ui/chart/src/index.ts
@@ -54,7 +54,7 @@ export function fontFamily(
   return {
     family: "'Noto Sans', 'Lucida Grande', 'Lucida Sans Unicode', Verdana, Arial, Helvetica, sans-serif",
     size: size ?? 12,
-    weight: weight,
+    weight,
   };
 }
 

--- a/ui/dgt/src/play.ts
+++ b/ui/dgt/src/play.ts
@@ -657,7 +657,7 @@ export default function (token: string): void {
             : (gameInfo.black.title ? gameInfo.black.title : '@') + ' ' + gameInfo.black.name;
         playableGames.push({
           gameId: gameInfo.id,
-          versus: versus,
+          versus,
           'vs rating': gameInfo.black.id === me.id ? gameInfo.white.rating : gameInfo.black.rating,
           'game rating': gameInfo.variant.short + ' ' + (gameInfo.rated ? 'rated' : 'unrated'),
           Timer:
@@ -1049,7 +1049,7 @@ export default function (token: string): void {
         id: 1,
         method: 'setup',
         param: {
-          fen: fen,
+          fen,
         },
       },
     };

--- a/ui/editor/src/ctrl.ts
+++ b/ui/editor/src/ctrl.ts
@@ -236,7 +236,7 @@ export default class EditorCtrl {
     const legalFen = this.getLegalFen();
     return {
       fen: this.getFen(),
-      legalFen: legalFen,
+      legalFen,
       playable: ['standard', 'chess960', 'fromPosition'].includes(this.variant) && this.isPlayable(),
       enPassantOptions: legalFen ? this.getEnPassantOptions(legalFen) : [],
     };

--- a/ui/insight/src/chart.ts
+++ b/ui/insight/src/chart.ts
@@ -162,7 +162,7 @@ function scaleBuilder(d: InsightData): ChartOptions<'bar'>['scales'] {
         display: true,
         text: d.valueYaxis.name,
       },
-      stacked: stacked,
+      stacked,
     },
     y2: {
       position: 'right',

--- a/ui/insight/src/multipleSelect.ts
+++ b/ui/insight/src/multipleSelect.ts
@@ -577,40 +577,40 @@ export const registerMultipleSelect = () => {
     allSelected: 'All selected',
     countSelected: '# of % selected',
     noMatchesFound: 'No matches found',
-    styler () {
+    styler() {
       return null;
     },
-    textTemplate ($elm) {
+    textTemplate($elm) {
       return $elm.text();
     },
-    labelTemplate ($elm) {
+    labelTemplate($elm) {
       return $elm.attr('label');
     },
-    onOpen () {
+    onOpen() {
       return false;
     },
-    onClose () {
+    onClose() {
       return false;
     },
-    onCheckAll () {
+    onCheckAll() {
       return false;
     },
-    onUncheckAll () {
+    onUncheckAll() {
       return false;
     },
-    onFocus () {
+    onFocus() {
       return false;
     },
-    onBlur () {
+    onBlur() {
       return false;
     },
-    onOptgroupClick () {
+    onOptgroupClick() {
       return false;
     },
-    onClick () {
+    onClick() {
       return false;
     },
-    onFilter () {
+    onFilter() {
       return false;
     },
   };

--- a/ui/insight/src/multipleSelect.ts
+++ b/ui/insight/src/multipleSelect.ts
@@ -258,7 +258,7 @@ export const registerMultipleSelect = () => {
         that.update();
         that.options.onOptgroupClick?.({
           label: $(this).parent().text(),
-          checked: checked,
+          checked,
           children: $children.get(),
           instance: that,
         });
@@ -577,40 +577,40 @@ export const registerMultipleSelect = () => {
     allSelected: 'All selected',
     countSelected: '# of % selected',
     noMatchesFound: 'No matches found',
-    styler: function () {
+    styler () {
       return null;
     },
-    textTemplate: function ($elm) {
+    textTemplate ($elm) {
       return $elm.text();
     },
-    labelTemplate: function ($elm) {
+    labelTemplate ($elm) {
       return $elm.attr('label');
     },
-    onOpen: function () {
+    onOpen () {
       return false;
     },
-    onClose: function () {
+    onClose () {
       return false;
     },
-    onCheckAll: function () {
+    onCheckAll () {
       return false;
     },
-    onUncheckAll: function () {
+    onUncheckAll () {
       return false;
     },
-    onFocus: function () {
+    onFocus () {
       return false;
     },
-    onBlur: function () {
+    onBlur () {
       return false;
     },
-    onOptgroupClick: function () {
+    onOptgroupClick () {
       return false;
     },
-    onClick: function () {
+    onClick () {
       return false;
     },
-    onFilter: function () {
+    onFilter () {
       return false;
     },
   };

--- a/ui/keyboardMove/src/keyboardMove.ts
+++ b/ui/keyboardMove/src/keyboardMove.ts
@@ -20,7 +20,7 @@ export function initModule(opts: Opts): KeyboardMoveHandler | undefined {
     setTimeout(() => {
       submit(opts.input.value, {
         isTrusted: true,
-        yourMove: yourMove,
+        yourMove,
       });
     }, 1);
   };

--- a/ui/learn/src/chess.ts
+++ b/ui/learn/src/chess.ts
@@ -46,7 +46,7 @@ export default function (fen: string, appleKeys: SquareName[]): ChessCtrl {
   if (appleKeys) {
     const color = opposite(pos.turn);
     appleKeys.forEach(key => {
-      pos.board.set(parseSquare(key), { color: color, role: 'pawn' });
+      pos.board.set(parseSquare(key), { color, role: 'pawn' });
     });
   }
 
@@ -60,7 +60,7 @@ export default function (fen: string, appleKeys: SquareName[]): ChessCtrl {
       ? {
           blockers: occupied,
           checkers: pos.kingAttackers(king, opposite(pos.turn), occupied),
-          king: king,
+          king,
           mustCapture: false,
           variantEnd: false,
         }
@@ -125,11 +125,11 @@ export default function (fen: string, appleKeys: SquareName[]): ChessCtrl {
     );
 
   return {
-    dests: dests,
+    dests,
     getColor: () => pos.turn,
-    setColor: setColor,
+    setColor,
     fen: () => makeBoardFen(pos.board),
-    moves: moves,
+    moves,
     move: (orig: SquareName, dest: SquareName, prom?: PromotionChar | PromotionRole | '') => {
       const move: NormalMove = {
         from: parseSquare(orig),
@@ -144,7 +144,7 @@ export default function (fen: string, appleKeys: SquareName[]): ChessCtrl {
       return !clone.isCheck() ? move : null;
     },
     occupiedKeys: () => Array.from(pos.board.occupied).map(s => makeSquare(s)),
-    kingKey: kingKey,
+    kingKey,
     findCapture: () => {
       const captures = findCaptures(pos);
       return captures.length ? moveToCgMove(captures[0]) : undefined;

--- a/ui/learn/src/learn.ts
+++ b/ui/learn/src/learn.ts
@@ -50,7 +50,7 @@ export function initModule({ data, pref }: LearnServerOpts) {
     storage: _storage,
     stageId: null,
     levelId: null,
-    pref: pref,
+    pref,
   };
   const ctrl = new LearnCtrl(opts, redraw);
 

--- a/ui/learn/src/levelCtrl.ts
+++ b/ui/learn/src/levelCtrl.ts
@@ -210,7 +210,7 @@ export class LevelCtrl {
         turnColor: color,
         fen,
         movable: { color, dests },
-        lastMove: lastMove,
+        lastMove,
       }),
     );
 

--- a/ui/learn/src/promotionCtrl.ts
+++ b/ui/learn/src/promotionCtrl.ts
@@ -33,9 +33,9 @@ export class PromotionCtrl {
         ((dest[1] === '1' && piece.color === 'black') || (dest[1] === '8' && piece.color === 'white'))
       ) {
         this.promoting = {
-          orig: orig,
-          dest: dest,
-          callback: callback,
+          orig,
+          dest,
+          callback,
         };
         this.redraw();
         return true;

--- a/ui/learn/src/storage.ts
+++ b/ui/learn/src/storage.ts
@@ -16,7 +16,7 @@ const xhrSaveScore = (stageKey: string, levelId: number, score: number) =>
     body: xhr.form({
       stage: stageKey,
       level: levelId,
-      score: score,
+      score,
     }),
   });
 
@@ -30,7 +30,7 @@ export default function (d?: LearnProgress): Storage {
   const data: LearnProgress = d || JSON.parse(storage.get(key)!) || defaultValue;
 
   return {
-    data: data,
+    data,
     saveScore: (stage: Stage, level: { id: number }, score: number) => {
       if (!data.stages[stage.key])
         data.stages[stage.key] = {

--- a/ui/learn/src/view.ts
+++ b/ui/learn/src/view.ts
@@ -63,7 +63,7 @@ const ribbon = (ctrl: LearnCtrl, s: Stage, status: Exclude<Status, 'future'>, st
 
 function whatNext(ctrl: LearnCtrl) {
   const makeStage = (href: string, img: string, title: string, subtitle: string, done?: boolean) => {
-    return h(`a.stage.done`, { attrs: { href: href } }, [
+    return h(`a.stage.done`, { attrs: { href } }, [
       done ? h('span.ribbon-wrapper', h('span.ribbon.done', makeStars(1))) : null,
       h('img', { attrs: { src: assetUrl + 'images/learn/' + img + '.svg' } }),
       h('div.text', [h('h3', title), h('p.subtitle', subtitle)]),

--- a/ui/lib/src/nvui/render.ts
+++ b/ui/lib/src/nvui/render.ts
@@ -142,10 +142,10 @@ export function renderBoard(
         class: pieceClass,
         attrs: {
           text: renderPositionStyle(rank, file, text),
-          rank: rank,
-          file: file,
+          rank,
+          file,
           piece: letter.toLowerCase(),
-          color: color,
+          color,
           'trap-bypass': true,
         },
       },

--- a/ui/lib/src/socket.ts
+++ b/ui/lib/src/socket.ts
@@ -404,8 +404,8 @@ class Ackable {
   register = (t: string, d: Payload): void => {
     d.a = this.currentId++;
     this.messages.push({
-      t: t,
-      d: d,
+      t,
+      d,
       at: performance.now(),
     });
   };

--- a/ui/msg/src/network.ts
+++ b/ui/msg/src/network.ts
@@ -50,7 +50,7 @@ export function report(name: string, text: string): Promise<any> {
     method: 'post',
     body: form({
       username: name,
-      text: text,
+      text,
       resource: 'msg',
     }),
   });

--- a/ui/msg/src/view/enhance.ts
+++ b/ui/msg/src/view/enhance.ts
@@ -88,7 +88,7 @@ export function expandLpvs(el: HTMLElement) {
     if (link)
       expandables.push({
         element: a,
-        link: link,
+        link,
       });
   });
 

--- a/ui/puzzle/src/ctrl.ts
+++ b/ui/puzzle/src/ctrl.ts
@@ -309,7 +309,7 @@ export default class PuzzleCtrl implements CevalHandler {
       fen: node.fen,
       orientation: this.flipped() ? opposite(this.pov) : this.pov,
       turnColor: color,
-      movable: movable,
+      movable,
       premovable: {
         enabled: false,
       },

--- a/ui/puzzle/src/view/tree.ts
+++ b/ui/puzzle/src/view/tree.ts
@@ -158,7 +158,7 @@ function eventPath(e: Event): TreePath | null {
 
 export function render(ctrl: PuzzleCtrl): VNode {
   const root = ctrl.tree.root;
-  const ctx = { ctrl: ctrl, showComputer: false };
+  const ctx = { ctrl, showComputer: false };
   return hl(
     'div.tview2.tview2-column',
     {

--- a/ui/round/src/view/replay.ts
+++ b/ui/round/src/view/replay.ts
@@ -201,7 +201,7 @@ function initMessage(ctrl: RoundController) {
 
 const col1Button = (ctrl: RoundController, dir: number, icon: string, disabled: boolean) =>
   hl('button.fbt', {
-    attrs: { disabled: disabled, 'data-icon': icon, 'data-ply': ctrl.ply + dir },
+    attrs: { disabled, 'data-icon': icon, 'data-ply': ctrl.ply + dir },
     hook: onInsert(el => addPointerListeners(el, { click: e => goThroughMoves(ctrl, e), hold: 'click' })),
   });
 

--- a/ui/site/src/powertip.ts
+++ b/ui/site/src/powertip.ts
@@ -157,10 +157,10 @@ $.fn.powerTip = function (opts) {
   // attach events to matched elements if the manual options is not enabled
   this.on({
     // mouse events
-    mouseenter: function (event) {
+    mouseenter(event) {
       $.powerTip.show(this, event);
     },
-    mouseleave: function () {
+    mouseleave() {
       $.powerTip.hide(this);
     },
   });

--- a/ui/site/src/site.puzzleEmbed.ts
+++ b/ui/site/src/site.puzzleEmbed.ts
@@ -12,7 +12,7 @@ window.onload = async () => {
     coordinates: false,
     drawable: { enabled: false, visible: false },
     viewOnly: true,
-    fen: fen,
+    fen,
     lastMove: uciToMove(lm),
     orientation: orientation as 'white' | 'black',
   });

--- a/ui/tournament/src/ctrl.ts
+++ b/ui/tournament/src/ctrl.ts
@@ -196,7 +196,7 @@ export default class TournamentController {
     this.teamInfo.requested = undefined;
     this.playerInfo = {
       id: this.playerInfo.id === userId ? undefined : userId,
-      player: player,
+      player,
     };
     if (this.playerInfo.id) xhr.playerInfo(this, this.playerInfo.id);
   };

--- a/ui/voice/makeGrammar.mts
+++ b/ui/voice/makeGrammar.mts
@@ -53,7 +53,7 @@ async function main() {
     buildCostMap(subMap, freqThreshold, countThreshold).forEach((sub, key) => {
       ppCost(key, sub);
       const [from, to] = key.split(' ');
-      builder.addSub(from, { to: to, cost: sub.cost ?? 1 });
+      builder.addSub(from, { to, cost: sub.cost ?? 1 });
     });
     const patch = `lexicon/${grammar}-patch.json`;
     if (fs.existsSync(patch))

--- a/ui/voice/src/mic.ts
+++ b/ui/voice/src/mic.ts
@@ -150,7 +150,7 @@ export class Mic implements Microphone {
   private initKaldi(recId: string, rec: RecNode) {
     if (rec.node) return;
     rec.node = this.vosk?.initRecognizer({
-      recId: recId,
+      recId,
       audioCtx: this.audioCtx!,
       partial: rec.partial,
       words: rec.words,


### PR DESCRIPTION
# Why & How

Add object-shorthand (https://oxc.rs/docs/guide/usage/linter/rules/eslint/object-shorthand.html) rule which warns about unnecessary repetitions when key and value variable inside object have the same name.

Fix all reported warnings (mostly were auto fixed, some I had to correct manually).