### PR TITLE
Tackle slop DMCA reports by disallowing /study/search endpoint from being indexed

### DIFF
--- a/modules/web/src/main/StaticContent.scala
+++ b/modules/web/src/main/StaticContent.scala
@@ -15,6 +15,7 @@ Disallow: /game/export/
 Disallow: /games/export/
 Disallow: /api/
 Disallow: /opening/config/
+Disallow: /study/search
 Allow: /game/export/gif/thumbnail/
 """
 


### PR DESCRIPTION
## Problem: AI slop DMCA complaints

Google Search has recently received spurious DMCA complaints about PUBG-related content supposedly found on `/study/search/` endpoint, by brand protection firm MarqVision.

1. https://lumendatabase.org/notices/87318563
2. https://lumendatabase.org/notices/87561659
3. https://lumendatabase.org/notices/87986056

These were all invalid, but they have a legal right to file them on behalf of their clients.
Per their own marketing, their brand management is AI-powered and automated.

I am concerned this could hurt Lichess's search engine position though no fault of Lichess or its users. It would also be nice not have to counter-claim with Google, false as these reports are.


<details>
<summary>Example of spurious complaint</summary>
The first complaint had this URL:

```
https://lichess.org/study/search?q=%EB%B0%B0%ED%8B%80%EA%B7%B8%EB%9D%BC%EC%9A%B4%EB%93%9C%ED%95%B5%EC%83%B5%E2%9E%9A%EF%BD%9B%EC%8A%A4%EC%B9%B4%EC%9D%B4%EB%AA%B0%2C%EB%84%B7%EF%BD%9D%EC%84%9C%EB%93%A0%EC%96%B4%ED%83%9D%EC%9B%94%ED%95%B5%EB%B0%B0%EA%B7%B8%ED%95%B5%E2%A8%B6%EC%84%9C%EB%93%A0%ED%95%B5%EC%9E%90%ED%8C%90%EA%B8%B0%E2%89%AD%EB%B0%B0%EA%B7%B8%ED%95%B5%E2%88%80%EC%98%A4%EB%B2%84%EC%9B%8C%EC%B9%98%ED%95%B5+%EB%94%94%EC%8A%A4%EC%BD%94%EB%93%9C%E1%8A%A5%EC%98%A4%EB%B2%84%EC%9B%8C%EC%B9%98+%EC%97%90%EC%9E%84%ED%95%B5%D0%96%EC%98%A4%EB%B2%84%EC%9B%8C%EC%B9%982+%EC%97%90%EC%9E%84%ED%95%B5
```

The URL resolves to:

> 배틀그라운드핵샵➚｛스카이몰,넷｝서든어택월핵배그핵⨶서든핵자판기≭배그핵∀오버워치핵 디스코드እ오버워치 에임핵Ж오버워치2 에임핵

For which Google Translate (Korean to English) gives:

> Battlegrounds Hack Shop ➚ {Sky Mall, Net} Sudden Attack Wallhack PUBG Hack ⨶ Sudden Hack Vending Machine ≭ PUBG Hack ∀ Overwatch Hack Discord እ Overwatch Aim Hack Ж Overwatch 2 Aim Hack

The majority of the queries they put forth were along these lines, but users have never created a study like this on Lichess. I verified this by manually searching for several permutations of these terms.
</details>

## Solution

It might stop them if we disallow search engines from indexing Lichess's study-search interface to begin with.

On @SergioGlorias's suggestion, we propose to disallow the `/study/search` endpoint in `robots.txt`. I went for the entire endpoint instead of just the query strings because:

* `/study/all`, `/study/topic` and `/study/staff-picks` will stay on search engines, so the main user-facing page will still be accessible.
* In its latest complaint, MarqVision's bot reported most permutations of the `order` parameter for the same query string.