### PR TITLE
read firebase config from json file

### DIFF
--- a/conf/base.conf
+++ b/conf/base.conf
@@ -254,10 +254,12 @@ push {
     lichobile {
       url = "https://fcm.googleapis.com/v1/projects/lichess-1366/messages:send"
       json = ""
+      json_path = ""
     }
     mobile {
       url = "https://fcm.googleapis.com/v1/projects/lichessv2/messages:send"
       json = ""
+      json_path = ""
     }
   }
 }

--- a/conf/base.conf
+++ b/conf/base.conf
@@ -254,12 +254,12 @@ push {
     lichobile {
       url = "https://fcm.googleapis.com/v1/projects/lichess-1366/messages:send"
       json = ""
-      json_path = ""
+      jsonPath = ""
     }
     mobile {
       url = "https://fcm.googleapis.com/v1/projects/lichessv2/messages:send"
       json = ""
-      json_path = ""
+      jsonPath = ""
     }
   }
 }

--- a/modules/push/src/main/FirebasePush.scala
+++ b/modules/push/src/main/FirebasePush.scala
@@ -114,10 +114,13 @@ final private class FirebasePush(
 
 private object FirebasePush:
 
-  final class Config(val url: String, val json: lila.core.config.Secret):
+  final class Config(val url: String, val json: lila.core.config.Secret, val json_path: String):
     lazy val googleCredentials: Option[GoogleCredentials] =
       try
-        json.value.nonEmptyOption.map: json =>
+        val jsonStr =
+          if json_path.nonEmpty then scala.io.Source.fromFile(json_path).mkString
+          else json.value
+        jsonStr.nonEmptyOption.map: json =>
           import java.nio.charset.StandardCharsets.UTF_8
           import scala.jdk.CollectionConverters.*
           ServiceAccountCredentials

--- a/modules/push/src/main/FirebasePush.scala
+++ b/modules/push/src/main/FirebasePush.scala
@@ -114,11 +114,11 @@ final private class FirebasePush(
 
 private object FirebasePush:
 
-  final class Config(val url: String, val json: lila.core.config.Secret, val json_path: String):
+  final class Config(val url: String, val json: lila.core.config.Secret, val jsonPath: String):
     lazy val googleCredentials: Option[GoogleCredentials] =
       try
         val jsonStr =
-          if json_path.nonEmpty then scala.io.Source.fromFile(json_path).mkString
+          if jsonPath.nonEmpty then scala.io.Source.fromFile(jsonPath).mkString
           else json.value
         jsonStr.nonEmptyOption.map: json =>
           import java.nio.charset.StandardCharsets.UTF_8


### PR DESCRIPTION
This benefits mainly for when running lila in containers.

With this PR, the service account JSON file that Firebase provides can be mounted in the container and then the value of `json_path` can be its path.