### PR TITLE
daily puzzle event and post to irc

### DIFF
--- a/modules/core/src/main/irc.scala
+++ b/modules/core/src/main/irc.scala
@@ -1,7 +1,7 @@
 package lila.core
 package irc
 
-import lila.core.id.{ RelayRoundId, UblogPostId, StudyChapterId, PuzzleId }
+import lila.core.id.{ RelayRoundId, UblogPostId, StudyChapterId }
 import lila.core.userId.{ UserId, MyId, UserName }
 import lila.core.study.data.StudyChapterName
 
@@ -40,4 +40,3 @@ trait IrcApi:
       note: Option[String]
   ): Funit
   def broadcasterDm(topicUserId: UserId, senderId: UserId, content: String): Funit
-  def dailyPuzzle(id: PuzzleId): Funit

--- a/modules/core/src/main/irc.scala
+++ b/modules/core/src/main/irc.scala
@@ -1,7 +1,7 @@
 package lila.core
 package irc
 
-import lila.core.id.{ RelayRoundId, UblogPostId, StudyChapterId }
+import lila.core.id.{ RelayRoundId, UblogPostId, StudyChapterId, PuzzleId }
 import lila.core.userId.{ UserId, MyId, UserName }
 import lila.core.study.data.StudyChapterName
 
@@ -40,3 +40,4 @@ trait IrcApi:
       note: Option[String]
   ): Funit
   def broadcasterDm(topicUserId: UserId, senderId: UserId, content: String): Funit
+  def dailyPuzzle(id: PuzzleId): Funit

--- a/modules/core/src/main/misc.scala
+++ b/modules/core/src/main/misc.scala
@@ -4,7 +4,7 @@ package misc
 import play.api.i18n.Lang
 import scalalib.data.LazyFu
 
-import lila.core.id.{ GameId, ClasId }
+import lila.core.id.{ GameId, ClasId, PuzzleId }
 import lila.core.userId.*
 import lila.core.user.Me
 
@@ -30,6 +30,8 @@ package puzzle:
   case class RacerRun(userId: UserId, score: Int)
 
   case class StreakRun(userId: UserId, score: Int)
+
+  case class DailyChange(id: PuzzleId)
 
 package lpv:
   import _root_.chess.format.pgn.PgnStr

--- a/modules/irc/src/main/Env.scala
+++ b/modules/irc/src/main/Env.scala
@@ -6,6 +6,7 @@ import play.api.{ Configuration, Mode }
 
 import lila.common.Lilakka
 import lila.core.plan.ChargeEvent
+import lila.core.misc.puzzle.DailyChange
 
 @Module
 final class Env(
@@ -14,7 +15,8 @@ final class Env(
     ws: StandaloneWSClient,
     shutdown: akka.actor.CoordinatedShutdown,
     mode: Mode,
-    lightUser: lila.core.LightUser.GetterSyncFallback
+    lightUser: lila.core.LightUser.GetterSyncFallback,
+    net: lila.core.config.NetConfig
 )(using Executor):
 
   import ZulipClient.given
@@ -31,3 +33,4 @@ final class Env(
 
   // type can be inferred but clearer to leave it
   lila.common.Bus.sub[ChargeEvent](api.charge(_))
+  lila.common.Bus.sub[DailyChange](e => api.dailyPuzzle(e.id))

--- a/modules/irc/src/main/IrcApi.scala
+++ b/modules/irc/src/main/IrcApi.scala
@@ -11,7 +11,8 @@ import lila.core.study.data.StudyChapterName
 final class IrcApi(
     zulip: ZulipClient,
     noteApi: lila.core.user.NoteApi,
-    lightUser: LightUser.GetterSyncFallback
+    lightUser: LightUser.GetterSyncFallback,
+    net: lila.core.config.NetConfig
 )(using Executor)
     extends lila.core.irc.IrcApi:
 
@@ -191,6 +192,11 @@ final class IrcApi(
   def fidePhotoCredits(playerPath: String, credits: String)(using me: Me): Funit =
     zulip(_.content, "/fide player photos"):
       s":note: $playerPath by ${markdown.modLink(me.username)}\n> $credits"
+
+  def dailyPuzzle(id: PuzzleId): Funit =
+    zulip(_.general, "daily puzzle"):
+      markdown.link(s"${net.baseUrl}/training/$id", "Solve the daily puzzle") +
+        markdown.link(s"${net.assetBaseUrl}/training/export/gif/thumbnail/$id.gif", ":")
 
   def stop(): Funit = zulip(_.general, "lila")("Lichess is restarting.")
 

--- a/modules/puzzle/src/main/DailyPuzzle.scala
+++ b/modules/puzzle/src/main/DailyPuzzle.scala
@@ -6,6 +6,7 @@ import lila.db.dsl.{ *, given }
 import lila.memo.CacheApi.*
 
 import Puzzle.BSONFields as F
+import lila.core.misc.puzzle.DailyChange
 
 final private[puzzle] class DailyPuzzle(
     colls: PuzzleColls,
@@ -95,7 +96,10 @@ final private[puzzle] class DailyPuzzle(
           )
       .flatMap:
         _.flatMap(puzzleReader.readOpt).so { puzzle =>
-          colls.puzzle(_.updateField($id(puzzle.id), F.day, nowInstant)).inject(puzzle.some)
+          colls
+            .puzzle(_.updateField($id(puzzle.id), F.day, nowInstant))
+            .inject(puzzle.some)
+            .addEffect(_ => lila.common.Bus.pub(DailyChange(puzzle.id)))
         }
 
 object DailyPuzzle:


### PR DESCRIPTION
Will be able to retire separate zulip bot service running on radio.

Replaces:
https://github.com/arex1337/lichesspuzzle
https://github.com/niklasf/zulip-lichesspuzzle
** currently deployed is `niklasf/zulip-lichesspuzzle` @ `retry` branch, with some unstaged changes
