### PR TITLE
Migrate to sbt 2.0.0

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -13,12 +13,3 @@ rewrite.rules = [AvoidInfix]
 
 rewrite.rules = [Imports]
 rewrite.imports.removeRedundantSelectors = true
-
-fileOverride {
-  "glob:**/build.sbt" {
-    runner.dialect = scala213
-  }
-  "glob:**/project/**" {
-    runner.dialect = scala213
-  }
-}

--- a/build.sbt
+++ b/build.sbt
@@ -5,6 +5,12 @@ import play.sbt.routes.RoutesKeys
 import BuildSettings.*
 import Dependencies.*
 
+// sbt 2.0 lints "unused" keys on load. native-packager defines Debian/Rpm/Linux/Universal
+// packaging keys that lila legitimately doesn't use (we only run `stage`), and RoutesCompiler
+// defines playGenerateReverseRouter (we only read it in Compile scope). Silence that lint noise
+// rather than wiring up packaging we don't ship.
+Global / lintUnusedKeysOnLoad := false
+
 lazy val root = Project("lila", file("."))
   .enablePlugins(JavaServerAppPackaging, RoutesCompiler)
   .dependsOn(api)
@@ -27,9 +33,14 @@ lazy val root = Project("lila", file("."))
     },
     Compile / RoutesKeys.generateReverseRouter := false,
     Compile / RoutesKeys.generateForwardRouter := true,
-    target := baseDirectory.value / "target",
     Compile / sourceDirectory := baseDirectory.value / "app",
     Compile / scalaSource := baseDirectory.value / "app",
+    // Keep the root app's packaging output at target/universal/stage (CI tars that exact path:
+    // .github/workflows/server.yml). This re-flattens crossTarget for the root only, which makes
+    // sbt 2.0 emit a few "Cannot cache" notices for the root's own compile/package — acceptable,
+    // and far fewer than letting it leak to every module (that's handled by dropping
+    // coreDefaultSettings in BuildSettings).
+    target := baseDirectory.value / "target",
   )
 
 organization := "org.lichess"

--- a/build.sbt
+++ b/build.sbt
@@ -35,12 +35,13 @@ lazy val root = Project("lila", file("."))
     Compile / RoutesKeys.generateForwardRouter := true,
     Compile / sourceDirectory := baseDirectory.value / "app",
     Compile / scalaSource := baseDirectory.value / "app",
-    // Keep the root app's packaging output at target/universal/stage (CI tars that exact path:
-    // .github/workflows/server.yml). This re-flattens crossTarget for the root only, which makes
-    // sbt 2.0 emit a few "Cannot cache" notices for the root's own compile/package — acceptable,
-    // and far fewer than letting it leak to every module (that's handled by dropping
-    // coreDefaultSettings in BuildSettings).
-    target := baseDirectory.value / "target",
+    // Keep the native-packager stage output at target/universal/stage — lila CI tars that exact
+    // path (.github/workflows/server.yml). Scope this to Universal/target rather than overriding the
+    // whole project `target`: stagingDirectory = Universal/target / "stage", and the default
+    // Universal/target = <project target> / "universal". Overriding only Universal/target leaves the
+    // project target at sbt 2.0's default, so crossTarget stays target/out/jvm/scala-3.8.4/lila and
+    // zinc's inc_compile_3.zip stays inside the cache root — no "Cannot cache" warning.
+    Universal / target := baseDirectory.value / "target" / "universal",
   )
 
 organization := "org.lichess"

--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,15 @@ lazy val root = Project("lila", file("."))
   .dependsOn(api)
   .aggregate(api)
   .settings(buildSettings)
+  .settings(
+    // native-packager-only settings: scope to root so sbt 2.0 doesn't demand them from the
+    // aggregated modules (which don't enable JavaServerAppPackaging).
+    scriptClasspath := Seq("*"),
+    Compile / mainClass := Some("lila.app.Lila"),
+    // Adds the Play application directory to the command line args passed to Play
+    bashScriptExtraDefines += "addJava \"-Duser.dir=$(realpath \"$(cd \"${app_home}/..\"; pwd -P)\"  $(is_cygwin && echo \"fix\"))\"\n",
+    Universal / sourceDirectory := baseDirectory.value / "dist",
+  )
 
 organization := "org.lichess"
 Compile / run / fork := true
@@ -22,15 +31,10 @@ javaOptions ++= {
 }
 ThisBuild / scalacOptions ++= Seq("-unchecked", "-deprecation")
 ThisBuild / usePipelining := false
-// shorter prod classpath
-scriptClasspath := Seq("*")
 Compile / resourceDirectory := baseDirectory.value / "conf"
 // the following settings come from the PlayScala plugin, which I removed
 shellPrompt := PlayCommands.playPrompt
 ivyLoggingLevel := UpdateLogging.DownloadOnly
-Compile / mainClass := Some("lila.app.Lila")
-// Adds the Play application directory to the command line args passed to Play
-bashScriptExtraDefines += "addJava \"-Duser.dir=$(realpath \"$(cd \"${app_home}/..\"; pwd -P)\"  $(is_cygwin && echo \"fix\"))\"\n"
 Compile / RoutesKeys.routes / sources ++= {
   val dirs = (Compile / unmanagedResourceDirectories).value
   (dirs * "routes").get() ++ (dirs * "*.routes").get()
@@ -40,7 +44,6 @@ Compile / RoutesKeys.generateForwardRouter := true
 target := baseDirectory.value / "target"
 Compile / sourceDirectory := baseDirectory.value / "app"
 Compile / scalaSource := baseDirectory.value / "app"
-Universal / sourceDirectory := baseDirectory.value / "dist"
 
 // format: off
 libraryDependencies ++= akka.bundle ++ playWs.bundle ++ macwire.bundle ++ scalalib.bundle ++ chess.bundle ++ Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,5 @@
 import com.typesafe.sbt.packager.Keys.{ bashScriptExtraDefines, scriptClasspath }
 import play.sbt.PlayCommands
-import play.sbt.PlayInternalKeys.playDependencyClasspath
 import play.sbt.routes.RoutesKeys
 
 import BuildSettings.*
@@ -28,17 +27,13 @@ scriptClasspath := Seq("*")
 Compile / resourceDirectory := baseDirectory.value / "conf"
 // the following settings come from the PlayScala plugin, which I removed
 shellPrompt := PlayCommands.playPrompt
-// all dependencies from outside the project (all dependency jars)
-playDependencyClasspath := (Runtime / externalDependencyClasspath).value
-// playCommonClassloader   := PlayCommands.playCommonClassloaderTask.value
-// playCompileEverything := PlayCommands.playCompileEverythingTask.value.asInstanceOf[Seq[Analysis]]
 ivyLoggingLevel := UpdateLogging.DownloadOnly
 Compile / mainClass := Some("lila.app.Lila")
 // Adds the Play application directory to the command line args passed to Play
 bashScriptExtraDefines += "addJava \"-Duser.dir=$(realpath \"$(cd \"${app_home}/..\"; pwd -P)\"  $(is_cygwin && echo \"fix\"))\"\n"
 Compile / RoutesKeys.routes / sources ++= {
   val dirs = (Compile / unmanagedResourceDirectories).value
-  (dirs * "routes").get ++ (dirs * "*.routes").get
+  (dirs * "routes").get() ++ (dirs * "*.routes").get()
 }
 Compile / RoutesKeys.generateReverseRouter := false
 Compile / RoutesKeys.generateForwardRouter := true
@@ -512,7 +507,7 @@ lazy val ui = module("ui",
   Compile / RoutesKeys.generateForwardRouter := false,
   Compile / RoutesKeys.routes / sources ++= {
     val dirs = baseDirectory.value / ".." / ".." / "conf"
-    (dirs * "routes").get ++ (dirs * "*.routes").get
+    (dirs * "routes").get() ++ (dirs * "*.routes").get()
   }
 )
 
@@ -530,4 +525,4 @@ lazy val api = module("api",
 ).settings(
   Runtime / aggregate := false,
   Test / aggregate := true  // Test <: Runtime
-) aggregate (moduleRefs: _*)
+).aggregate(moduleRefs*)

--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,7 @@ lazy val root = Project("lila", file("."))
     // Universal/target = <project target> / "universal". Overriding only Universal/target leaves the
     // project target at sbt 2.0's default, so crossTarget stays target/out/jvm/scala-3.8.4/lila and
     // zinc's inc_compile_3.zip stays inside the cache root — no "Cannot cache" warning.
-    Universal / target := baseDirectory.value / "target" / "universal",
+    Universal / target := baseDirectory.value / "target" / "universal"
   )
 
 organization := "org.lichess"

--- a/build.sbt
+++ b/build.sbt
@@ -11,13 +11,25 @@ lazy val root = Project("lila", file("."))
   .aggregate(api)
   .settings(buildSettings)
   .settings(
-    // native-packager-only settings: scope to root so sbt 2.0 doesn't demand them from the
-    // aggregated modules (which don't enable JavaServerAppPackaging).
+    // These configure the root "lila" app specifically (flat app/ + conf/ layout, native-packager
+    // output). Under sbt 2.0 bare top-level settings propagate to every aggregated module, which
+    // breaks (modules lack JavaServerAppPackaging; the `target` override clashes with sbt 2.0 task
+    // caching). Scope them to the root project where they belong.
     scriptClasspath := Seq("*"),
     Compile / mainClass := Some("lila.app.Lila"),
     // Adds the Play application directory to the command line args passed to Play
     bashScriptExtraDefines += "addJava \"-Duser.dir=$(realpath \"$(cd \"${app_home}/..\"; pwd -P)\"  $(is_cygwin && echo \"fix\"))\"\n",
     Universal / sourceDirectory := baseDirectory.value / "dist",
+    Compile / resourceDirectory := baseDirectory.value / "conf",
+    Compile / RoutesKeys.routes / sources ++= {
+      val dirs = (Compile / unmanagedResourceDirectories).value
+      (dirs * "routes").get() ++ (dirs * "*.routes").get()
+    },
+    Compile / RoutesKeys.generateReverseRouter := false,
+    Compile / RoutesKeys.generateForwardRouter := true,
+    target := baseDirectory.value / "target",
+    Compile / sourceDirectory := baseDirectory.value / "app",
+    Compile / scalaSource := baseDirectory.value / "app",
   )
 
 organization := "org.lichess"
@@ -31,19 +43,9 @@ javaOptions ++= {
 }
 ThisBuild / scalacOptions ++= Seq("-unchecked", "-deprecation")
 ThisBuild / usePipelining := false
-Compile / resourceDirectory := baseDirectory.value / "conf"
 // the following settings come from the PlayScala plugin, which I removed
 shellPrompt := PlayCommands.playPrompt
 ivyLoggingLevel := UpdateLogging.DownloadOnly
-Compile / RoutesKeys.routes / sources ++= {
-  val dirs = (Compile / unmanagedResourceDirectories).value
-  (dirs * "routes").get() ++ (dirs * "*.routes").get()
-}
-Compile / RoutesKeys.generateReverseRouter := false
-Compile / RoutesKeys.generateForwardRouter := true
-target := baseDirectory.value / "target"
-Compile / sourceDirectory := baseDirectory.value / "app"
-Compile / scalaSource := baseDirectory.value / "app"
 
 // format: off
 libraryDependencies ++= akka.bundle ++ playWs.bundle ++ macwire.bundle ++ scalalib.bundle ++ chess.bundle ++ Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,4 @@
 import com.typesafe.sbt.packager.Keys.{ bashScriptExtraDefines, scriptClasspath }
-import play.sbt.PlayCommands
 import play.sbt.routes.RoutesKeys
 
 import BuildSettings.*
@@ -56,7 +55,7 @@ javaOptions ++= {
 ThisBuild / scalacOptions ++= Seq("-unchecked", "-deprecation")
 ThisBuild / usePipelining := false
 // the following settings come from the PlayScala plugin, which I removed
-shellPrompt := PlayCommands.playPrompt
+// shellPrompt := PlayCommands.playPrompt
 ivyLoggingLevel := UpdateLogging.DownloadOnly
 
 // format: off

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -41,7 +41,7 @@ object BuildSettings {
       libs: Seq[ModuleID]
   ) =
     Project(name, file("modules/" + name))
-      .dependsOn(deps: _*)
+      .dependsOn(deps*)
       .settings(
         libraryDependencies ++= defaultLibs ++ libs,
         buildSettings,

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -1,4 +1,3 @@
-import play.sbt.PlayImport._
 import sbt._, Keys._
 
 object BuildSettings {

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -9,7 +9,12 @@ object BuildSettings {
   val globalScalaVersion = "3.8.4"
 
   def buildSettings =
-    Defaults.coreDefaultSettings ++ Seq(
+    // NB: do NOT prepend Defaults.coreDefaultSettings here. Under sbt 2.0 those base settings are
+    // already applied to every project automatically, and re-adding them forces the legacy flat
+    // `target` layout (crossTarget = <proj>/target) instead of sbt 2.0's `target/out/...`. That
+    // legacy layout places compile/package outputs outside the cache root, so sbt 2.0 floods the
+    // log with "Cannot cache task because its output files are outside the output directory".
+    Seq(
       resolvers ++= Seq(jitpack, lilaMaven, sonashots, Resolver.sonatypeCentralSnapshots),
       scalaVersion := globalScalaVersion,
       scalacOptions ++= compilerOptions,

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -1,8 +1,8 @@
-import sbt._, Keys._
+import sbt.*, Keys.*
 
-object BuildSettings {
+object BuildSettings:
 
-  import Dependencies._
+  import Dependencies.*
 
   val lilaVersion = "4.0"
   val globalScalaVersion = "3.8.4"
@@ -72,4 +72,3 @@ object BuildSettings {
   )
 
   def projectToRef(p: Project): ProjectReference = LocalProject(p.id)
-}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,13 +1,11 @@
-import sbt._, Keys._
+import sbt.*, Keys.*
 
-object Dependencies {
-  val arch = if (System.getProperty("os.arch").toLowerCase.startsWith("aarch")) "aarch_64" else "x86_64"
+object Dependencies:
+  val arch = if System.getProperty("os.arch").toLowerCase.startsWith("aarch") then "aarch_64" else "x86_64"
   val dashArch = arch.replace("_", "-")
   val (os, notifier) =
-    if (System.getProperty("os.name").toLowerCase.startsWith("mac"))
-      ("osx", "kqueue")
-    else
-      ("linux", "epoll")
+    if System.getProperty("os.name").toLowerCase.startsWith("mac") then ("osx", "kqueue")
+    else ("linux", "epoll")
 
   val jitpack = "jitpack".at("https://jitpack.io")
   val lilaMaven = "lila-maven".at("https://raw.githubusercontent.com/lichess-org/lila-maven/master")
@@ -38,11 +36,10 @@ object Dependencies {
   val scalacheck = "org.scalacheck" %% "scalacheck" % "1.19.0" % Test
   val munitCheck = "org.scalameta" %% "munit-scalacheck" % "1.3.0" % Test
 
-  object tests {
+  object tests:
     val bundle = Seq(munit)
-  }
 
-  object chess {
+  object chess:
     val version = "17.15.5"
     val org = "com.github.lichess-org.scalachess"
     // val org = "org.lichess" // for publishLocal
@@ -52,9 +49,8 @@ object Dependencies {
     val rating = org %% "scalachess-rating" % version
     val tiebreak = org %% "scalachess-tiebreak" % version
     def bundle = Seq(core, testKit, playJson, rating, tiebreak)
-  }
 
-  object scalalib {
+  object scalalib:
     val version = "11.10.7"
     val org = "com.github.lichess-org.scalalib"
     // val org = "org.lichess" // for publishLocal
@@ -63,9 +59,8 @@ object Dependencies {
     val playJson = org %% "scalalib-play-json" % version
     val lila = org %% "scalalib-lila" % version
     def bundle = Seq(core, model, playJson, lila)
-  }
 
-  object flexmark {
+  object flexmark:
     val version = "0.64.8"
     val bundle =
       ("com.vladsch.flexmark" % "flexmark" % version) ::
@@ -73,26 +68,23 @@ object Dependencies {
           .map { ext =>
             "com.vladsch.flexmark" % s"flexmark-$ext" % version
           }
-  }
 
-  object macwire {
+  object macwire:
     val version = "2.6.7"
     val macros = "com.softwaremill.macwire" %% "macros" % version % "provided"
     val util = "com.softwaremill.macwire" %% "util" % version % "provided"
     val tagging = "com.softwaremill.common" %% "tagging" % "2.3.5"
     def bundle = Seq(macros, util, tagging)
-  }
 
-  object reactivemongo {
+  object reactivemongo:
     val rmVersion = "1.1.0-RC20"
     val driver = "org.reactivemongo" %% "reactivemongo" % rmVersion
     val stream = "org.reactivemongo" %% "reactivemongo-akkastream" % rmVersion
     val shaded = "org.reactivemongo" % s"reactivemongo-shaded-native-$os-$dashArch" % rmVersion
     // val kamon  = "org.reactivemongo" %% "reactivemongo-kamon"         % "1.0.8"
     def bundle = Seq(driver, stream)
-  }
 
-  object play {
+  object play:
     val playVersion = "2.8.18-lila_3.22"
     val json = "org.playframework" %% "play-json" % "3.0.6"
     val api = "com.typesafe.play" %% "play" % playVersion
@@ -100,23 +92,20 @@ object Dependencies {
     val netty = "com.typesafe.play" %% "play-netty-server" % playVersion
     val logback = "com.typesafe.play" %% "play-logback" % playVersion
     val mailer = "org.playframework" %% "play-mailer" % "10.1.0"
-  }
 
-  object playWs {
+  object playWs:
     val version = "2.2.16"
     val ahc = "com.typesafe.play" %% "play-ahc-ws-standalone" % version
     val json = "com.typesafe.play" %% "play-ws-standalone-json" % version
     val bundle = Seq(ahc, json)
-  }
 
-  object kamon {
+  object kamon:
     val version = "2.8.1"
     val core = "io.kamon" %% "kamon-core" % version
     val influxdb = "io.kamon" %% "kamon-influxdb" % version
     val metrics = "io.kamon" %% "kamon-system-metrics" % version
     val prometheus = "io.kamon" %% "kamon-prometheus" % version
-  }
-  object akka {
+  object akka:
     val version = "2.6.21"
     val actor = "com.typesafe.akka" %% "akka-actor" % version
     val actorTyped = "com.typesafe.akka" %% "akka-actor-typed" % version
@@ -124,5 +113,3 @@ object Dependencies {
     val akkaSlf4j = "com.typesafe.akka" %% "akka-slf4j" % version
     val testkit = "com.typesafe.akka" %% "akka-testkit" % version % Test
     def bundle = List(actor, actorTyped, akkaStream, akkaSlf4j)
-  }
-}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,4 +1,3 @@
-import play.sbt.PlayImport._
 import sbt._, Keys._
 
 object Dependencies {

--- a/project/I18n.scala
+++ b/project/I18n.scala
@@ -1,15 +1,15 @@
 import java.io.{ File, FileOutputStream, ObjectOutputStream }
 import java.util.{ HashMap, ArrayList }
-import sbt._
+import sbt.*
 import scala.jdk.CollectionConverters.*
 
-object I18n {
+object I18n:
   def serialize(
       sourceDir: File,
       destDir: File,
       dbs: List[String],
       outputDir: File
-  ): Seq[File] = {
+  ): Seq[File] =
     val locales = "en-GB" :: (destDir / "site").listFiles.map(_.getName.takeWhile(_ != '.')).sorted.toList
 
     outputDir.mkdirs()
@@ -23,24 +23,23 @@ object I18n {
       file
     }
     files
-  }
 
   private def makeMap(
       locale: String,
       sourceDir: File,
       destDir: File,
       dbs: java.util.List[String]
-  ) = {
+  ) =
     val result = new HashMap[String, Object]()
     dbs.forEach { db =>
       val file =
-        if (locale == "en-GB") new File(sourceDir, s"$db.xml")
+        if locale == "en-GB" then new File(sourceDir, s"$db.xml")
         else new File(destDir, s"$db/$locale.xml")
-      if (file.exists && file.isFile) {
+      if file.exists && file.isFile then
         val xml = scala.xml.XML.loadFile(file)
         xml.child.foreach { e =>
           val key = toKey(e, db)
-          e.label match {
+          e.label match
             case "string" =>
               result.put(key, unescapeQuotes(e.text))
             case "plurals" =>
@@ -50,17 +49,13 @@ object I18n {
               }
               result.put(key, plurals)
             case _ =>
-          }
         }
-      }
     }
     result
-  }
 
   private def unescapeQuotes(s: String) =
     s.replace("\\\"", "\"").replace("\\'", "'")
 
   private def toKey(e: scala.xml.Node, db: String) =
-    if (db == "site") e.\("@name").toString
+    if db == "site" then e.\("@name").toString
     else s"$db:${e.\("@name")}"
-}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.12.12
+sbt.version=2.0.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,5 +14,4 @@ addSbtPlugin("org.lichess.play" % "sbt-plugin" % "2.0.0-RC2")
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.11.4")
 addSbtPlugin("org.playframework.twirl" % "sbt-twirl" % "2.1.0-M9")
 
-// sbt-scalafmt has no sbt 2.0 (_sbt2_3) build yet; re-enable once one is available.
-// addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.6.1")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.6.1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,18 @@
 resolvers += Resolver.url(
   "lila-maven-sbt",
-  url("https://raw.githubusercontent.com/lichess-org/lila-maven/master")
+  // sbt 2.0's `url(...)` returns a URI; Resolver.url wants a java.net.URL.
+  new java.net.URI("https://raw.githubusercontent.com/lichess-org/lila-maven/master").toURL
 )(Resolver.ivyStylePatterns)
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.18-lila_1.26") // scala2 branch
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.6.1")
+
+// sbt 2.0 Play plugin (ported). Currently resolved from the local ivy repo produced by
+// playframework-lila/publish-sbt2; will move to lila-maven once that artifact is published there.
+resolvers += Resolver.mavenLocal
+addSbtPlugin("org.lichess.play" % "sbt-plugin" % "2.0.0-RC1")
+
+// The Play plugin's RoutesCompiler/PlayLayout autoplugins require these; under sbt 2.0 the
+// transitive plugin activation differs from sbt 1.x, so declare them explicitly.
+addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.11.4")
+addSbtPlugin("org.playframework.twirl" % "sbt-twirl" % "2.1.0-M9")
+
+// sbt-scalafmt has no sbt 2.0 (_sbt2_3) build yet; re-enable once one is available.
+// addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.6.1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,7 +7,7 @@ resolvers += Resolver.url(
 // sbt 2.0 Play plugin (ported). Currently resolved from the local ivy repo produced by
 // playframework-lila/publish-sbt2; will move to lila-maven once that artifact is published there.
 resolvers += Resolver.mavenLocal
-addSbtPlugin("org.lichess.play" % "sbt-plugin" % "2.0.0-RC1")
+addSbtPlugin("org.lichess.play" % "sbt-plugin" % "2.0.0-RC2")
 
 // The Play plugin's RoutesCompiler/PlayLayout autoplugins require these; under sbt 2.0 the
 // transitive plugin activation differs from sbt 1.x, so declare them explicitly.

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,13 +4,8 @@ resolvers += Resolver.url(
   new java.net.URI("https://raw.githubusercontent.com/lichess-org/lila-maven/master").toURL
 )(Resolver.ivyStylePatterns)
 
-// sbt 2.0 Play plugin (ported). Currently resolved from the local ivy repo produced by
-// playframework-lila/publish-sbt2; will move to lila-maven once that artifact is published there.
-resolvers += Resolver.mavenLocal
 addSbtPlugin("org.lichess.play" % "sbt-plugin" % "2.0.0-RC2")
 
-// The Play plugin's RoutesCompiler/PlayLayout autoplugins require these; under sbt 2.0 the
-// transitive plugin activation differs from sbt 1.x, so declare them explicitly.
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.11.4")
 addSbtPlugin("org.playframework.twirl" % "sbt-twirl" % "2.1.0-M9")
 


### PR DESCRIPTION
depends on https://github.com/lichess-org/playframework-lila/pull/8 which I published to lila-maven.

Tested and verified locally but haven't tested packaging/deploy locall. We should try to deploy to staging before merging. 

### Generated Scala files summary (master vs this branch)

Both zips contain exactly 10 .scala files each (the "25 files" count just included the directory entries, which are harmless).

  Each has the same 10 files, normalized to a common layout for easy diffing:
  - lila/routes/main/{router,appeal,clas,report,team}/Routes.scala — forward routers (5)
  - ui/routes/main/{,appeal,clas,report,team}/ReverseRoutes.scala — reverse routers (5)

  (On disk the layouts actually differ — master uses the sbt-1 flat target/scala-3.8.4/routes/... and modules/ui/target/...; sbt-2/0 uses target/out/jvm/scala-3.8.4/<proj>/routes/.... I normalized both into lila/ + ui/ so the content is what you're comparing.)

The comparison result: The two branches have identical conf/routes sources and the generated code is functionally identical.
[lila-routes-master.zip](https://github.com/user-attachments/files/29133682/lila-routes-master.zip)
[lila-routes-sbt2-0.zip](https://github.com/user-attachments/files/29133685/lila-routes-sbt2-0.zip)

Use Claude for both prs but verify/review by me.
