### PR TITLE
show daily puzzle banner when viewing puzzle via `Puzzle.show`

### DIFF
--- a/app/controllers/Puzzle.scala
+++ b/app/controllers/Puzzle.scala
@@ -33,13 +33,21 @@ final class Puzzle(env: Env, apiC: => Api) extends LilaController(env):
       angle: PuzzleAngle,
       color: Option[Color] = None,
       replay: Option[lila.puzzle.PuzzleReplay] = None,
-      langPath: Option[LangPath] = None
+      langPath: Option[LangPath] = None,
+      isDaily: Boolean = false
   )(using ctx: Context)(using Perf) = for
     json <- jsonView.analysis(puzzle, angle, replay)
     settings <- ctx.user.traverse(env.puzzle.session.getSettings)
     prefJson = jsonView.pref(ctx.pref)
     page <- renderPage:
-      views.puzzle.ui.show(puzzle, json, prefJson, settings | PuzzleSettings.default(color), langPath)
+      views.puzzle.ui
+        .show(
+          puzzle,
+          json ++ Json.obj("isDaily" -> isDaily),
+          prefJson,
+          settings | PuzzleSettings.default(color),
+          langPath
+        )
   yield Ok(page).enforceCrossSiteIsolation
 
   def daily = Open:
@@ -47,7 +55,7 @@ final class Puzzle(env: Env, apiC: => Api) extends LilaController(env):
       Found(env.puzzle.daily.get): daily =>
         WithPuzzlePerf:
           negotiateApi(
-            html = renderShow(daily.puzzle, PuzzleAngle.mix),
+            html = renderShow(daily.puzzle, PuzzleAngle.mix, isDaily = true),
             api = v => jsonView.analysis(daily.puzzle, PuzzleAngle.mix, apiVersion = v.some).dmap { Ok(_) }
           ).dmap(_.noCache)
 
@@ -252,8 +260,11 @@ final class Puzzle(env: Env, apiC: => Api) extends LilaController(env):
           Puz.toId(angleOrId) match
             case Some(id) =>
               Found(env.puzzle.api.puzzle.find(id)): puzzle =>
-                ctx.me.so { env.puzzle.api.casual.setCasualIfNotYetPlayed(_, puzzle) } >>
-                  renderShow(puzzle, PuzzleAngle.mix, langPath = langPath)
+                for
+                  _ <- ctx.me.so { env.puzzle.api.casual.setCasualIfNotYetPlayed(_, puzzle) }
+                  isDaily <- env.puzzle.daily.get.map(_.exists(_.puzzle.id == puzzle.id))
+                  result <- renderShow(puzzle, PuzzleAngle.mix, langPath = langPath, isDaily = isDaily)
+                yield result
             case _ =>
               angleOrId.toLongOption
                 .flatMap(Puz.numericalId.apply)

--- a/ui/puzzle/src/ctrl.ts
+++ b/ui/puzzle/src/ctrl.ts
@@ -252,7 +252,7 @@ export default class PuzzleCtrl implements CevalHandler {
     this.initialPath = initialPath;
     this.initialNode = this.tree.nodeAtPath(initialPath);
     this.pov = plyColor(this.initialNode.ply);
-    this.isDaily = location.href.endsWith('/daily');
+    this.isDaily = !!this.data.isDaily;
     this.hintHasBeenShown(false);
     this.canViewSolution(false);
     this.report = new Report();

--- a/ui/puzzle/src/interfaces.ts
+++ b/ui/puzzle/src/interfaces.ts
@@ -68,6 +68,7 @@ export interface PuzzleData {
   user?: PuzzleUser;
   replay?: PuzzleReplay;
   streak?: string;
+  isDaily?: boolean;
   externalEngines?: ExternalEngineInfo[];
 }
 

--- a/ui/puzzle/src/view/theme.ts
+++ b/ui/puzzle/src/view/theme.ts
@@ -62,7 +62,7 @@ const editor = (ctrl: PuzzleCtrl): VNode[] => {
       (t: ThemeKey): t is ThemeKey => votedThemes[t] && !data.puzzle.themes.includes(t),
     ),
   ].sort();
-  const allThemes = location.pathname === '/training/daily' ? null : ctrl.allThemes;
+  const allThemes = ctrl.isDaily ? null : ctrl.allThemes;
   const availableThemes = allThemes ? allThemes.dynamic.filter((t: ThemeKey) => !votedThemes[t]) : null;
   if (availableThemes) availableThemes.sort((a, b) => (themeTrans(a) < themeTrans(b) ? -1 : 1));
   return [


### PR DESCRIPTION
If the daily puzzle's ID is "abc12", then this PR makes it so the "Daily Puzzle" banner will appear on both:
- `/training/daily`
- `/training/abc12` <-- it was not showing here before

<img width="495" height="839" alt="image" src="https://github.com/user-attachments/assets/110f76c9-e930-4169-a18e-5fa44f55e579" />
