### PR TITLE
fix: start ceval after reload data in analysis board

### DIFF
--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -510,6 +510,7 @@ export default class AnalyseCtrl implements CevalHandler {
     this.setPath(treePath.root);
     this.initCeval();
     this.instanciateEvalCache();
+    this.startCeval();
     this.cgVersion.js++;
     this.mergeIdbThenShowTreeView();
   }


### PR DESCRIPTION
closes #20705

`init` calls `reset` here:

https://github.com/lichess-org/lila/blob/ce3fe1db09703a13b266a202448aa6e60f2dbe89/ui/lib/src/ceval/ctrl.ts#L87

and `reset` then stops the worker:

https://github.com/lichess-org/lila/blob/ce3fe1db09703a13b266a202448aa6e60f2dbe89/ui/lib/src/ceval/ctrl.ts#L106-L107

If `worker.start()` is not called after `init`, then the engine gets 'freezed'