### PR TITLE
Fix embedded puzzle start button sizing

### DIFF
--- a/ui/bits/css/build/bits.lpv.scss
+++ b/ui/bits/css/build/bits.lpv.scss
@@ -15,7 +15,6 @@
   inset: 0;
   margin: auto;
   display: block;
-  box-sizing: border-box;
   width: fit-content;
   height: fit-content;
   max-width: 100%;

--- a/ui/bits/css/build/bits.lpv.scss
+++ b/ui/bits/css/build/bits.lpv.scss
@@ -12,16 +12,19 @@
 
   z-index: $z-cg__board_overlay-100;
   position: absolute;
-  top: 50%;
-
-  @include inline-start(50%);
-
-  transform: translate(-50%, -50%);
+  inset: 0;
+  margin: auto;
   display: block;
-  padding: 1.5em 3em;
+  box-sizing: border-box;
+  width: fit-content;
+  height: fit-content;
+  max-width: 100%;
+  padding: clamp(0.75em, 10%, 1.5em) clamp(1.25em, 20%, 3em);
   text-decoration: none;
   font-size: 1.5em;
+  text-align: center;
   white-space: normal;
+  overflow-wrap: break-word;
 }
 
 .lpv__pgn__text {


### PR DESCRIPTION
Fixes #16748.

## Summary

- Center the embedded gamebook start button over the full board instead of anchoring it at the board midpoint and translating it back.
- Keep the button within the board with border-box sizing and responsive padding on smaller embedded boards.
- Allow long custom labels to wrap instead of escaping the board.

## Manual proof

Chromium proof using the actual compiled `bits.lpv` CSS and the embedded gamebook markup from `site.lpvEmbed.ts`, with a 220px board and 24px page font:

![before and after proof](https://raw.githubusercontent.com/markoub/lila/proof-lichess-16748/comparison.png)

Measured result from that proof:

- Before: button width 331px on a 220px board, 111px horizontal overflow.
- After: button width 205px on a 220px board, 0px button overflow and 0px text overflow.
- Long-label guard checked locally at the same size: `START`, `Commencer l'entrainement`, `Training starten`, and `Inizia l'allenamento` all stayed within the board.

## Validation

- `./ui/build bits --no-install`
- `pnpm exec stylelint ui/bits/css/build/bits.lpv.scss`
- `git diff --check`

## AI assistance disclosure

I used OpenAI Codex as an implementation assistant. Prompt/context: find a high-confidence first Lichess contribution, follow the Lichess contribution rules, inspect #16748 and its existing discussion, make a focused CSS fix, run local validation, and include manual proof. I reviewed the patch, validation output, and browser proof before submitting.
