### PR TITLE
feat: add adaptive hover overlay for toggle elements on image backgrounds (#20715)

### DIFF
--- a/ui/lib/css/ceval/_pv.scss
+++ b/ui/lib/css/ceval/_pv.scss
@@ -85,7 +85,7 @@
   }
 
   .pv_box .pv .pv-wrap-toggle:hover {
-    background: $c-secondary;
+    background: $c-hover-overlay;
     color: $c-over;
   }
 }

--- a/ui/lib/css/theme/_theme.default.scss
+++ b/ui/lib/css/theme/_theme.default.scss
@@ -44,6 +44,7 @@ $c-dimmer: #000;
 $c-clearer: #fff;
 $c-mv-branch-white: #fff;
 $c-mv-branch-black: #000;
+$c-hover-overlay: rgba(0, 0, 0, 0.15); // Adaptive hover overlay for elements over variable backgrounds
 $patron-colors: $patron-colors-dark;
 
 // shared-color-defs lists theme colors that share definitions. the assigned values usually depend on
@@ -95,6 +96,7 @@ $patron-colors: $patron-colors-dark;
   --c-secondary: #{$c-secondary};
   --c-secondary-dim: #{dim($c-secondary, 20%)};
   --c-secondary-dimmer: #{dim($c-secondary, 40%)};
+  --c-hover-overlay: #{$c-hover-overlay};
   --c-accent: #{$c-accent};
   --c-link: #{$c-primary};
   --c-link-dim: var(--c-primary-dim);


### PR DESCRIPTION
fixed #20715

## Problem

When users set a custom image background on Lichess, the PV toggle button hover effect displays the hardcoded theme color `$c-secondary` (green) that doesn't adapt to the image background. This creates a jarring, inconsistent visual experience where the green hover effect clashes with arbitrary image colors.

### Why This Happens

The previous implementation used a semantic color variable:
```scss
.pv_box .pv .pv-wrap-toggle:hover {
  background: $c-secondary;  // Always green, regardless of user background
}
```

This approach works well for the default dark/light themes but fails when users set custom image backgrounds because a fixed green color doesn't adapt to arbitrary image colors.

## Solution

Instead of using a hardcoded semantic color, introduce an adaptive hover overlay variable in the theme system that works universally:

```scss
// In theme system
$c-hover-overlay: rgba(0, 0, 0, 0.15);  // Darkens any background

// Usage
.pv_box .pv .pv-wrap-toggle:hover {
  background: $c-hover-overlay;  // Adapts to any background
}
```

### Why This Works

A semi-transparent dark overlay adapts naturally to any background:
- **Dark theme**: Dark overlay + dark bg = darker (expected)
- **Light theme**: Dark overlay + light bg = gray (good contrast)
- **Image background**: Dark overlay + image = darkened image (natural)
- **Vibrant colors**: Darkens without clashing

## Changes

### Files Modified
1. **`ui/lib/css/theme/_theme.default.scss`**
   - Added `$c-hover-overlay` SCSS variable (line 47)
   - Added `--c-hover-overlay` CSS custom property to theme mixin (line 98)

2. **`ui/lib/css/ceval/_pv.scss`**
   - Changed `.pv-wrap-toggle:hover` background from `$c-secondary` to `$c-hover-overlay` (line 88)

### Code Changes

**Theme System Addition:**
```scss
// Adaptive hover overlay for elements over variable backgrounds
$c-hover-overlay: rgba(0, 0, 0, 0.15);
```

**CSS Variable Export:**
```scss
--c-hover-overlay: #{$c-hover-overlay};
```

**Component Update:**
```scss
.pv_box .pv .pv-wrap-toggle:hover {
  background: $c-hover-overlay;  // Changed from $c-secondary
  color: $c-over;
}
```

## Benefits

✓ **Adapts to user backgrounds**: Works on dark, light, and image backgrounds  
✓ **Theme-aware**: Properly integrated into Lichess theme system  
✓ **Reusable**: Can be used by other components needing similar hover effects  
✓ **Semantic**: Variable name clearly indicates purpose (hover overlay, not a color)  
✓ **Maintainable**: Centralized definition in theme system  
✓ **No breaking changes**: Backward compatible, only changes visual appearance  

## Testing Note

**Unable to verify locally**: Lichess requires Java/Scala build system not available on Windows development environment. Changes are limited to SCSS variable definitions which are syntactically correct and follow existing Lichess patterns.

The fix follows Lichess's established conventions:
- Uses SCSS variables like all other theme colors
- Leverages the same theme system as existing code
- Single-line change in component file
- Properly scoped within theme mixin

## Related Issues

Fixes the reported bug about toggle hover effect appearing jarring on custom image backgrounds.