### PR TITLE
Replaced the three separate constraints with one composite constraint

### DIFF
--- a/modules/common/src/main/Form.scala
+++ b/modules/common/src/main/Form.scala
@@ -262,12 +262,15 @@ object Form:
     val field: Mapping[ZoneId] = of[ZoneId]
 
   object username:
-    val historicalConstraints = Seq(
-      Constraints.minLength(2),
-      Constraints.maxLength(30),
-      Constraints.pattern(regex = UserName.historicalRegex)
-    )
-    val historicalField = trim(text).verifying(historicalConstraints*).into[UserStr]
+    val historicalUsernameConstraint = V.Constraint[String]: t =>
+      if !t.linesIterator.exists(_.stripLineEnd.exists(!_.isWhitespace)) then
+        V.Invalid(V.ValidationError("error.required"))
+      else if t.length < 2 then V.Invalid(V.ValidationError("error.minLength", 2))
+      else if t.length > 30 then V.Invalid(V.ValidationError("error.maxLength", 30))
+      else if !UserName.historicalRegex.matches(t) then
+        V.Invalid(V.ValidationError("usernameCharsInvalid"))
+      else V.Valid
+    val historicalField = trim(text).verifying(historicalUsernameConstraint).into[UserStr]
 
   object playerTitle:
     import chess.PlayerTitle


### PR DESCRIPTION
## Summary

Fixes: #20719 
Fixes an untranslated validation error on the report form (`/report`) when submitting without a username.

Previously, the username field used Play's default pattern constraint, which surfaces the raw key `error.pattern` — a string that has no translation in Lichess. Users saw this artifact instead of a proper error message.

This replaces the separate `minLength`, `maxLength`, and `pattern` constraints on `username.historicalField` with a single composite constraint that returns one translated message at a time:

- Empty username → `error.required` ("This field is required")
- Too short → `error.minLength`
- Too long → `error.maxLength`
- Invalid characters → `usernameCharsInvalid`