### PR TITLE
Do not prefer evals that have greater depth but less nodes.

### DIFF
--- a/ui/lib/src/ceval/util.ts
+++ b/ui/lib/src/ceval/util.ts
@@ -9,7 +9,7 @@ import { memoize, escapeHtml } from '../index';
 export const isFirstEvalBetter = (a: ClientEval, b: ClientEval, desiredPvs: number): boolean =>
   a.pvs.length >= desiredPvs !== b.pvs.length >= desiredPvs
     ? a.pvs.length >= desiredPvs
-    : a.depth > b.depth || (a.depth === b.depth && a.nodes > b.nodes);
+    : a.nodes > b.nodes && a.depth >= b.depth;
 
 export function renderEval(e: number): string {
   e = Math.max(Math.min(Math.round(e / 10) / 10, 99), -99);


### PR DESCRIPTION
There can be cases where one eval has greater depth but fewer nodes (e.g., I have seen this when adjusting the number of threads). As nodes are more important than depth, we shouldn't prefer such evals.