### PR TITLE
Revert "Merge pull request #20721 from johndoknjas/always-require-nodes"

### DIFF
--- a/ui/lib/src/ceval/util.ts
+++ b/ui/lib/src/ceval/util.ts
@@ -9,7 +9,7 @@ import { memoize, escapeHtml } from '../index';
 export const isFirstEvalBetter = (a: ClientEval, b: ClientEval, desiredPvs: number): boolean =>
   a.pvs.length >= desiredPvs !== b.pvs.length >= desiredPvs
     ? a.pvs.length >= desiredPvs
-    : a.nodes > b.nodes && a.depth >= b.depth;
+    : a.depth > b.depth || (a.depth === b.depth && a.nodes > b.nodes);
 
 export function renderEval(e: number): string {
   e = Math.max(Math.min(Math.round(e / 10) / 10, 99), -99);


### PR DESCRIPTION
Eval `a` could have a lower multipv than `b`, in which case `a` could be the stronger evaluation despite having a lower nodecount. And in general we probably shouldn't make it harder for local evals (`a` in this case) to be used over cloud evals (`b`), since local evals are what the user's analyzing themself, and is likely to be with the most recent stockfish.