### PR TITLE
Count only finished relay team matches

### DIFF
--- a/ui/analyse/src/study/relay/relayTeamLeaderboard.ts
+++ b/ui/analyse/src/study/relay/relayTeamLeaderboard.ts
@@ -18,6 +18,7 @@ import type {
   TourId,
 } from './interfaces';
 import RelayPlayers, { renderPlayers, tableAugment, type RelayPlayer } from './relayPlayers';
+import { finishedTeamMatchCount } from './relayTeamStandings';
 
 export default class RelayTeamLeaderboard {
   standings: RelayTeamStandings | undefined;
@@ -84,7 +85,7 @@ export default class RelayTeamLeaderboard {
               this.standings.map(entry =>
                 hl('tr', [
                   hl('td', this.teamNameNode(entry)),
-                  hl('td', entry.matches.length),
+                  hl('td', finishedTeamMatchCount(entry.matches)),
                   hl(
                     'td',
                     { attrs: { 'data-sort': entry.mp * 1000 + entry.gp, title: i18n.broadcast.matchPoints } },
@@ -114,7 +115,10 @@ export default class RelayTeamLeaderboard {
         hl(
           'table.relay-tour__team-summary__header__stats',
           hl('tbody', [
-            hl('tr', [hl('th', i18n.broadcast.matches), hl('td', `${foundTeam.matches.length}`)]),
+            hl('tr', [
+              hl('th', i18n.broadcast.matches),
+              hl('td', `${finishedTeamMatchCount(foundTeam.matches)}`),
+            ]),
             hl('tr', [hl('th', i18n.broadcast.matchPoints), hl('td', `${foundTeam.mp}`)]),
             hl('tr', [hl('th', i18n.broadcast.gamePoints), hl('td', `${foundTeam.gp}`)]),
             foundTeam.averageRating &&

--- a/ui/analyse/src/study/relay/relayTeamStandings.ts
+++ b/ui/analyse/src/study/relay/relayTeamStandings.ts
@@ -1,0 +1,4 @@
+import type { POVTeamMatch } from './interfaces';
+
+export const finishedTeamMatchCount = (matches: POVTeamMatch[]): number =>
+  matches.filter(match => match.points !== undefined).length;

--- a/ui/analyse/tests/relayTeamStandings.test.ts
+++ b/ui/analyse/tests/relayTeamStandings.test.ts
@@ -1,0 +1,15 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import type { POVTeamMatch } from '../src/study/relay/interfaces';
+import { finishedTeamMatchCount } from '../src/study/relay/relayTeamStandings';
+
+test('counts only finished relay team matches', () => {
+  const matches: POVTeamMatch[] = [
+    { roundId: 'round-1', opponent: 'Team A', points: '1', mp: 2, gp: 4 },
+    { roundId: 'round-2', opponent: 'Team B' },
+    { roundId: 'round-3', opponent: 'Team C', points: '0', mp: 0, gp: 1 },
+  ];
+
+  assert.equal(finishedTeamMatchCount(matches), 2);
+});


### PR DESCRIPTION
Fixes #20710.

## What changed

Relay team standings now display the number of finished matches instead of the raw number of match entries. The team-results table and individual team summary both use the same helper, so unfinished pairings no longer inflate the Matches count while MP/GP still reflect only completed matches.

## Proof

The regression test covers a standings fixture with two finished matches and one unfinished match. The old display used `matches.length` and would show 3; the new helper returns 2 because only matches with a result are counted.

## Validation

- `pnpm test analyse/tests/relayTeamStandings.test.ts`
- `./ui/build analyse --no-install`
- `pnpm exec oxfmt --check ui/analyse/src/study/relay/relayTeamLeaderboard.ts ui/analyse/src/study/relay/relayTeamStandings.ts ui/analyse/tests/relayTeamStandings.test.ts`
- `pnpm exec oxlint --type-aware ui/analyse/src/study/relay/relayTeamLeaderboard.ts ui/analyse/src/study/relay/relayTeamStandings.ts ui/analyse/tests/relayTeamStandings.test.ts`
- `git diff --check origin/master...HEAD`

## AI assistance disclosure

I used OpenAI Codex to inspect the Lichess issue queue, locate the relay team standings code path, implement this focused helper/test change, and run the validation listed above. Prompt summary: monitor active OSS PRs, screen high-confidence Lichess issues, and fix #20710 without broadening into live score recomputation.