### PR TITLE
ui: align Learn and Practice stages page layouts

### DIFF
--- a/ui/learn/css/_layout.scss
+++ b/ui/learn/css/_layout.scss
@@ -1,4 +1,4 @@
-#main-wrap {
+#main-wrap:not(:has(.learn--map)) {
   ---main-max-width: calc(100vh - #{$site-header-outer-height} - 10rem);
 
   @include mq-at-least-col2 {
@@ -41,10 +41,10 @@
 
     &--map {
       grid-template-areas: 'side main';
-      grid-template-columns: 240px auto;
+      grid-template-columns: 242px auto;
 
-      @media (min-width: at-least($x-large)) {
-        grid-template-columns: 240px 960px;
+      @media (width > $x-large) {
+        grid-template-columns: 242px minmax(auto, 1028px);
       }
     }
   }


### PR DESCRIPTION
# Why

Spotted recently that Learn and Practice despite using very similar elements and arrangement are sized differently.

# How

Align Learn and Practice stages page layouts, only apply modified layout for Learn pages other than stages grid, small size tweaks.

# Preview

https://github.com/user-attachments/assets/4b3fd529-9afe-4050-a7f6-ef85b4709b0e

