### PR TITLE
ui: small tweaks for button rack and user page dropdown

### DIFF
--- a/ui/lib/css/component/_btn-rack.scss
+++ b/ui/lib/css/component/_btn-rack.scss
@@ -13,7 +13,7 @@
   }
 
   &__btn,
-  form {
+  > form {
     @extend %flex-center-nowrap, %metal;
 
     justify-content: center;

--- a/ui/user/css/_show.scss
+++ b/ui/user/css/_show.scss
@@ -90,14 +90,15 @@
         position: relative;
 
         .dropdown-window {
-          @extend %dropdown-shadow;
+          @extend %dropdown-shadow, %box-radius;
 
           z-index: $z-link-overlay-2;
           visibility: hidden;
           background: $c-bg-header-dropdown;
-          border-radius: $box-radius-size 0 $box-radius-size $box-radius-size;
+          border-top-right-radius: 0;
           position: absolute;
           top: 2.4rem;
+          overflow: hidden;
 
           @include inline-end(0);
 


### PR DESCRIPTION
# Why

Spotted that we unintentionally apply metal effect to forms in button rack, which are nested inside dropdown.

# How

Apply metal effect only to direct children forms, prevent overflow of form button inside dropdown.

# Preview

### Before
<img width="370" alt="Screenshot 2026-06-23 at 11 40 49" src="https://github.com/user-attachments/assets/36fbf973-bc88-4843-8d2c-07380a746819" />
<img width="370" alt="Screenshot 2026-06-23 at 11 40 52" src="https://github.com/user-attachments/assets/795f2a07-6332-421d-bd7d-1a2b71485d37" />


### After

<img width="370" alt="Screenshot 2026-06-23 at 11 38 18" src="https://github.com/user-attachments/assets/fba4a0bc-78a6-4f78-9789-4e6eab548966" />
<img width="370" alt="Screenshot 2026-06-23 at 11 38 16" src="https://github.com/user-attachments/assets/8f83e3a4-ba5b-4be3-9028-50aefc9b7fd5" />
