### PR TITLE
Update relay teams scores from live chapters

### DIFF
--- a/ui/analyse/src/study/relay/relayTeamTable.ts
+++ b/ui/analyse/src/study/relay/relayTeamTable.ts
@@ -1,0 +1,121 @@
+import type { ChapterId, ChapterPreview, GamePointsStr } from '../interfaces';
+import type { RelayRound } from './interfaces';
+
+export interface TeamWithPoints {
+  name: string;
+  points: number;
+}
+export interface TeamGame {
+  id: ChapterId;
+  pov: Color;
+}
+export interface TeamRow {
+  teams: [TeamWithPoints, TeamWithPoints];
+  games: TeamGame[];
+}
+export type TeamTable = {
+  table: TeamRow[];
+};
+
+type TeamScores = [number, number];
+type PointPart = '1' | '0' | '½';
+
+export const currentTeamTable = (
+  teams: TeamTable,
+  chapters: ChapterPreview[],
+  round?: RelayRound,
+): TeamTable => {
+  const table = seededTeamTable(teams);
+
+  for (const chapter of chapters) {
+    if (
+      !chapter.status ||
+      chapter.status === '*' ||
+      !chapter.players?.white.team ||
+      !chapter.players.black.team
+    )
+      continue;
+
+    const whiteTeam = chapter.players.white.team;
+    const blackTeam = chapter.players.black.team;
+    const key = teamPairKey(whiteTeam, blackTeam);
+    let row = table.rows.get(key);
+
+    if (!row) {
+      row = {
+        teams: [
+          { name: whiteTeam, points: 0 },
+          { name: blackTeam, points: 0 },
+        ],
+        games: [],
+      };
+      table.rows.set(key, row);
+      table.keys.push(key);
+    }
+
+    const firstTeamColor = row.teams[0].name === whiteTeam ? 'white' : 'black';
+    const scores = scoreByTeamOrder(chapter.status, firstTeamColor, round);
+    row.teams[0].points += scores[0];
+    row.teams[1].points += scores[1];
+    row.games.push({ id: chapter.id, pov: firstTeamColor });
+  }
+
+  const currentRows = table.keys
+    .map(key => {
+      const row = table.rows.get(key)!;
+      return row.games.length ? row : table.fetchedRows.get(key);
+    })
+    .filter((row): row is TeamRow => !!row);
+  return currentRows.length ? { table: currentRows } : teams;
+};
+
+const seededTeamTable = (
+  teams: TeamTable,
+): { fetchedRows: Map<string, TeamRow>; keys: string[]; rows: Map<string, TeamRow> } => {
+  const keys: string[] = [];
+  const fetchedRows = new Map<string, TeamRow>();
+  const rows = new Map<string, TeamRow>();
+
+  for (const row of teams.table) {
+    const key = teamPairKey(row.teams[0].name, row.teams[1].name);
+    keys.push(key);
+    fetchedRows.set(key, row);
+    rows.set(key, {
+      teams: [
+        { name: row.teams[0].name, points: 0 },
+        { name: row.teams[1].name, points: 0 },
+      ],
+      games: [],
+    });
+  }
+
+  return { fetchedRows, keys, rows };
+};
+
+const teamPairKey = (first: string, second: string) => [first, second].sort().join('\0');
+
+const scoreByTeamOrder = (status: GamePointsStr, firstTeamColor: Color, round?: RelayRound): TeamScores => {
+  const firstScore = scoreForColor(status, firstTeamColor, round);
+  const secondScore = scoreForColor(status, firstTeamColor === 'white' ? 'black' : 'white', round);
+  return [firstScore, secondScore];
+};
+
+const scoreForColor = (status: GamePointsStr, color: Color, round?: RelayRound): number => {
+  const point = pointPart(status.split('-')[color === 'white' ? 0 : 1]);
+  if (point === undefined) return 0;
+  const customScoring = round?.customScoring?.[color];
+  return customScoring ? (point === 1 ? customScoring.win : point === 0.5 ? customScoring.draw : 0) : point;
+};
+
+const pointPart = (part: string): number | undefined => {
+  switch (part as PointPart) {
+    case '1':
+      return 1;
+    case '½':
+      return 0.5;
+    case '0':
+      return 0;
+    default:
+      return undefined;
+  }
+};

--- a/ui/analyse/src/study/relay/relayTeams.ts
+++ b/ui/analyse/src/study/relay/relayTeams.ts
@@ -4,29 +4,14 @@ import { json as xhrJson } from 'lib/xhr';
 
 import { playerFedFlag } from '@/view/util';
 
-import type { ChapterId, ChapterPreview, StudyPlayer, ChapterSelect } from '../interfaces';
+import type { ChapterPreview, StudyPlayer, ChapterSelect } from '../interfaces';
 import { type MultiCloudEval, renderScore } from '../multiCloudEval';
 import { gameLinkAttrs, gameLinksListener, StudyChapters } from '../studyChapters';
 import { coloredStatusStr } from './customScoreStatus';
 import { teamLinkData } from './deepLink';
 import type { RelayRound, RelayTour } from './interfaces';
 import type RelayPlayers from './relayPlayers';
-
-interface TeamWithPoints {
-  name: string;
-  points: number;
-}
-interface TeamGame {
-  id: ChapterId;
-  pov: Color;
-}
-interface TeamRow {
-  teams: [TeamWithPoints, TeamWithPoints];
-  games: TeamGame[];
-}
-type TeamTable = {
-  table: TeamRow[];
-};
+import { currentTeamTable, type TeamTable, type TeamWithPoints } from './relayTeamTable';
 
 export default class RelayTeams {
   loading = false;
@@ -85,7 +70,7 @@ const renderTeams = (
   round?: RelayRound,
   showTeamScores?: boolean,
 ): MaybeVNodes =>
-  teams.table.map(row => {
+  currentTeamTable(teams, chapters.all(), round).table.map(row => {
     const firstTeam = row.teams[0];
     const secondTeam = row.teams[1];
     const isFinished = row.games.every(g => {

--- a/ui/analyse/tests/relayTeamTable.test.ts
+++ b/ui/analyse/tests/relayTeamTable.test.ts
@@ -1,0 +1,89 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import type { ChapterPreview } from '../src/study/interfaces';
+import { currentTeamTable, type TeamTable } from '../src/study/relay/relayTeamTable';
+
+test('updates relay team match scores from current chapter statuses', () => {
+  const staleTeams: TeamTable = {
+    table: [
+      {
+        teams: [
+          { name: 'Team A', points: 1 },
+          { name: 'Team B', points: 0 },
+        ],
+        games: [{ id: 'game-1', pov: 'white' }],
+      },
+    ],
+  };
+
+  const current = currentTeamTable(staleTeams, [
+    chapter('game-1', '1-0', 'Team A', 'Team B'),
+    chapter('game-2', '1-0', 'Team A', 'Team B'),
+    chapter('game-3', '0-1', 'Team C', 'Team D'),
+  ]);
+
+  assert.deepEqual(
+    current.table.map(row => ({
+      games: row.games.map(game => game.id),
+      points: row.teams.map(team => team.points),
+      teams: row.teams.map(team => team.name),
+    })),
+    [
+      { games: ['game-1', 'game-2'], points: [2, 0], teams: ['Team A', 'Team B'] },
+      { games: ['game-3'], points: [0, 1], teams: ['Team C', 'Team D'] },
+    ],
+  );
+});
+
+test('keeps fetched rows when live chapter data cannot recompute them', () => {
+  const staleTeams: TeamTable = {
+    table: [
+      {
+        teams: [
+          { name: 'Team A', points: 1 },
+          { name: 'Team B', points: 0 },
+        ],
+        games: [{ id: 'game-1', pov: 'white' }],
+      },
+    ],
+  };
+
+  assert.deepEqual(currentTeamTable(staleTeams, []), staleTeams);
+});
+
+test('applies relay custom scoring while recomputing team scores', () => {
+  const current = currentTeamTable(
+    { table: [] },
+    [chapter('game-1', '1-0', 'Team A', 'Team B'), chapter('game-2', '½-½', 'Team A', 'Team B')],
+    {
+      customScoring: {
+        black: { draw: 2, win: 4 },
+        white: { draw: 1, win: 3 },
+      },
+    } as any,
+  );
+
+  assert.deepEqual(
+    current.table.map(row => row.teams.map(team => team.points)),
+    [[4, 2]],
+  );
+});
+
+const chapter = (
+  id: string,
+  status: ChapterPreview['status'],
+  whiteTeam: string,
+  blackTeam: string,
+): ChapterPreview => ({
+  fen: 'startpos',
+  id,
+  name: id,
+  orientation: 'white',
+  playing: false,
+  players: {
+    white: { name: `${whiteTeam} player`, team: whiteTeam },
+    black: { name: `${blackTeam} player`, team: blackTeam },
+  },
+  status,
+});


### PR DESCRIPTION
Fixes #20711.

## Summary
- Recompute the relay Teams-tab table from the current chapter previews when rendering, so newly finished boards update without waiting for another `/broadcast/{round}/teams` fetch.
- Preserve fetched rows when live chapter data is unavailable.
- Cover the live-score recompute, fetched-row fallback, and custom-scoring paths with focused relay tests.

## Proof
- `git diff --check`
- `pnpm exec oxfmt --check ui/analyse/src/study/relay/relayTeams.ts ui/analyse/src/study/relay/relayTeamTable.ts ui/analyse/tests/relayTeamTable.test.ts`
- `pnpm exec oxlint --type-aware ui/analyse/src/study/relay/relayTeams.ts ui/analyse/src/study/relay/relayTeamTable.ts ui/analyse/tests/relayTeamTable.test.ts`
- `./ui/test relay`
- `./ui/build analyse --no-install`

Visual proof fixture:

![Relay teams live score proof](https://raw.githubusercontent.com/markoub/lila/proof-lichess-20711/proof/comparison.png)

## AI assistance disclosure
I used OpenAI Codex (GPT-5) with prompts to inspect issue #20711, find the relay Teams-tab code, implement a small helper that recomputes the visible team table from current chapter statuses, add focused tests, and prepare validation/proof notes. I reviewed the diff and understand the submitted code.