### PR TITLE
ui: fix broken hover style of cmn toggle in picture theme

### DIFF
--- a/ui/lib/css/form/_cmn-toggle.scss
+++ b/ui/lib/css/form/_cmn-toggle.scss
@@ -61,6 +61,14 @@
       background: linear-gradient(to bottom, hsl($site-hue, 7%, 22), hsl($site-hue, 5%, 19) 100%);
     }
   }
+
+  @include if-transp {
+    &:hover {
+      &::after {
+        background: linear-gradient(to bottom, hsl($site-hue, 7%, 26), hsl($site-hue, 5%, 23) 100%);
+      }
+    }
+  }
 }
 
 .cmn-toggle input:checked + label {


### PR DESCRIPTION
# Why

Fixes #20715
* #20715

Refs:
* https://github.com/lichess-org/lila/pull/20654

# How

Mentioned above ref change why altering metal gradient colors in transparent theme introduced visual bug mentioned in issue above. 

This PR fixes the CMN Toggle element case, but there might be more regressions for interactive elements using metal hover effects in picture (transparent) theme.

# Preview

https://github.com/user-attachments/assets/ef8e7126-1c8e-4436-9520-97879c4162d4

