### PR TITLE
Update lobby now-playing counts on refresh

### DIFF
--- a/app/controllers/Account.scala
+++ b/app/controllers/Account.scala
@@ -121,12 +121,16 @@ final class Account(
   private def doNowPlaying(using ctx: Context)(using me: Me) =
     env.round.proxyRepo
       .urgentGames(me)
-      .map:
-        _.value.take((getInt("nb") | 9).atMost(50))
-      .map:
-        _.map(env.api.lobbyApi.nowPlaying)
-      .map: povs =>
-        Ok(Json.obj("nowPlaying" -> JsArray(povs)))
+      .map: urgent =>
+        val povs = urgent.value
+        JsonOk:
+          Json.obj(
+            "nowPlaying" -> JsArray:
+              povs.take((getInt("nb") | 9).atMost(50)).map(env.api.lobbyApi.nowPlaying)
+            ,
+            "nbNowPlaying" -> povs.size,
+            "nbMyTurn" -> povs.count(_.isMyTurn)
+          )
 
   def dasher = Auth { _ ?=> me ?=>
     negotiateJson:

--- a/ui/lobby/src/ctrl.ts
+++ b/ui/lobby/src/ctrl.ts
@@ -20,6 +20,7 @@ import type {
   ForceSetupOptions,
   LobbyMe,
 } from './interfaces';
+import { updateNowPlayingData } from './nowPlaying';
 import * as seekRepo from './seekRepo';
 import SetupController from './setupCtrl';
 import LobbySocket from './socket';
@@ -286,8 +287,8 @@ export default class LobbyController {
 
   gameActivity = (gameId: string) => {
     if (this.data.nowPlaying.some(p => p.gameId === gameId))
-      xhr.nowPlaying().then(povs => {
-        this.data.nowPlaying = povs;
+      xhr.nowPlaying().then(update => {
+        updateNowPlayingData(this.data, update);
         this.startWatching();
         this.redraw();
       });

--- a/ui/lobby/src/interfaces.ts
+++ b/ui/lobby/src/interfaces.ts
@@ -81,6 +81,12 @@ export interface LobbyData {
   counters: { members: number; rounds: number };
 }
 
+export interface NowPlayingUpdate {
+  nowPlaying: NowPlaying[];
+  nbNowPlaying: number;
+  nbMyTurn: number;
+}
+
 type RatingWithProvisional = number;
 
 export interface NowPlaying {

--- a/ui/lobby/src/nowPlaying.ts
+++ b/ui/lobby/src/nowPlaying.ts
@@ -1,0 +1,9 @@
+import type { LobbyData, NowPlayingUpdate } from './interfaces';
+
+type NowPlayingState = Pick<LobbyData, 'nowPlaying' | 'nbNowPlaying' | 'nbMyTurn'>;
+
+export function updateNowPlayingData(data: NowPlayingState, update: NowPlayingUpdate): void {
+  data.nowPlaying = update.nowPlaying;
+  data.nbNowPlaying = update.nbNowPlaying;
+  data.nbMyTurn = update.nbMyTurn;
+}

--- a/ui/lobby/src/xhr.ts
+++ b/ui/lobby/src/xhr.ts
@@ -2,11 +2,11 @@ import debounce from 'debounce-promise';
 
 import { json as xhrJson, form } from 'lib/xhr';
 
-import type { Pool, Seek } from './interfaces';
+import type { NowPlayingUpdate, Pool, Seek } from './interfaces';
 
 export const seeks: () => Promise<Seek[]> = debounce(() => xhrJson('/lobby/seeks'), 3000, { leading: true });
 
-export const nowPlaying = () => xhrJson('/account/now-playing').then(o => o.nowPlaying);
+export const nowPlaying = (): Promise<NowPlayingUpdate> => xhrJson('/account/now-playing');
 
 export const anonPoolSeek = (pool: Pool) =>
   xhrJson('/setup/hook/' + site.sri, {

--- a/ui/lobby/tests/nowPlaying.test.ts
+++ b/ui/lobby/tests/nowPlaying.test.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import type { LobbyData, NowPlaying } from '../src/interfaces';
+import { updateNowPlayingData } from '../src/nowPlaying';
+
+test('updates now-playing list and tab counts together', () => {
+  const data: Pick<LobbyData, 'nowPlaying' | 'nbNowPlaying' | 'nbMyTurn'> = {
+    nowPlaying: [pov('old', false)],
+    nbNowPlaying: 3,
+    nbMyTurn: 0,
+  };
+
+  updateNowPlayingData(data, {
+    nowPlaying: [pov('fresh-turn', true), pov('fresh-wait', false)],
+    nbNowPlaying: 8,
+    nbMyTurn: 4,
+  });
+
+  assert.deepEqual(
+    {
+      gameIds: data.nowPlaying.map(p => p.gameId),
+      nbNowPlaying: data.nbNowPlaying,
+      nbMyTurn: data.nbMyTurn,
+    },
+    {
+      gameIds: ['fresh-turn', 'fresh-wait'],
+      nbNowPlaying: 8,
+      nbMyTurn: 4,
+    },
+  );
+});
+
+const pov = (gameId: string, isMyTurn: boolean): NowPlaying => ({
+  color: 'white',
+  fen: '8/8/8/8/8/8/8/8 w - - 0 1' as FEN,
+  fullId: `${gameId}white`,
+  gameId,
+  hasMoved: true,
+  isMyTurn,
+  lastMove: 'e2e4',
+  opponent: {
+    id: 'opponent',
+    username: 'Opponent',
+  },
+  perf: 'correspondence',
+  rated: false,
+  speed: 'correspondence',
+  variant: {
+    key: 'standard',
+    name: 'Standard',
+  },
+});


### PR DESCRIPTION
Fixes https://github.com/lichess-org/lila/issues/20724.

## What changed

The lobby now-playing refresh now keeps the Games in play tab counts in sync with the refreshed game list:

- `/account/now-playing` still returns the displayed games, and now also returns `nbNowPlaying` and `nbMyTurn` computed from the full urgent-games list.
- The lobby applies the refreshed list and both counts together when a watched game activity event triggers a refresh.
- A focused UI test covers the state update so the unread turn badge cannot stay stale after a refresh response.

## Why

The page-load lobby data already includes full `nbNowPlaying` and `nbMyTurn` counts, but the later `/account/now-playing` refresh only replaced `nowPlaying`. That let the visible game list update while the tab badge kept the old count until a full page reload.

## Proof

Manual browser proof fixture:

![before and after proof](https://raw.githubusercontent.com/markoub/lila/proof-lichess-20724/proof/comparison.png)

Local validation:

- `git diff --check`
- `pnpm exec oxfmt --check ui/lobby/src/ctrl.ts ui/lobby/src/interfaces.ts ui/lobby/src/nowPlaying.ts ui/lobby/src/xhr.ts ui/lobby/tests/nowPlaying.test.ts`
- `pnpm exec oxlint --type-aware ui/lobby/src/ctrl.ts ui/lobby/src/interfaces.ts ui/lobby/src/nowPlaying.ts ui/lobby/src/xhr.ts ui/lobby/tests/nowPlaying.test.ts --format stylish`
- `./ui/test lobby`
- `./ui/build lobby --no-install`
- `JAVA_HOME=/opt/homebrew/Cellar/openjdk@21/21.0.11/libexec/openjdk.jdk/Contents/Home PATH="/opt/homebrew/Cellar/openjdk@21/21.0.11/libexec/openjdk.jdk/Contents/Home/bin:$PATH" ./lila.sh scalafmtCheckAll`
- `JAVA_HOME=/opt/homebrew/Cellar/openjdk@21/21.0.11/libexec/openjdk.jdk/Contents/Home PATH="/opt/homebrew/Cellar/openjdk@21/21.0.11/libexec/openjdk.jdk/Contents/Home/bin:$PATH" ./lila.sh compile`

Duplicate search performed for `#20724`, `"Games in play"`, `nbMyTurn`, and `nowPlaying lobby`; I did not find an open or merged Lichess PR covering this issue.

## AI assistance disclosure

I used OpenAI Codex / GPT-5 in the Codex desktop app to inspect issue #20724 and the relevant lobby refresh code, suggest the endpoint/count synchronization approach, implement the small Scala/TypeScript change, and help run validation. Prompts used were along the lines of: "inspect the Lichess lobby now-playing count issue", "find where nowPlaying and nbMyTurn are refreshed", "make a focused fix with tests", and "validate and prepare the PR with manual proof". I reviewed the diff and validation output before submitting.
