### PR TITLE
Fix LPV embed movetext at small widths

### DIFF
--- a/ui/bits/css/_lpv.embed.scss
+++ b/ui/bits/css/_lpv.embed.scss
@@ -1,11 +1,31 @@
+html,
+body {
+  height: 100%;
+}
+
 body {
   margin: 0;
   background: $lpv-bg;
 }
 
 .lpv {
+  height: 100%;
   border-radius: 0;
   box-shadow: none;
+
+  &--moves-auto {
+    @media (max-width: #{$moves-auto-to-right}) {
+      grid-template-areas:
+        'board side'
+        'controls side';
+      grid-template-columns: minmax(0, calc(100vh - var(--controls-height))) minmax(0, 1fr);
+      grid-template-rows: auto var(--controls-height);
+
+      .lpv__moves {
+        min-width: 0;
+      }
+    }
+  }
 }
 
 .not-found {


### PR DESCRIPTION
Fixes #16977.

## What changed

LPV embeds now fill the iframe height and keep the automatic movetext layout beside the board at very small embed widths. The board is sized from the available iframe height, while the movetext column can shrink below its previous minimum so moves and annotations remain visible instead of collapsing under the board.

## Manual proof

Rendered the embedded LPV fixture at 420x280, matching the reported `<500px` iframe case, with the previous compiled CSS and the compiled CSS from this branch:

![Before and after proof](https://raw.githubusercontent.com/markoub/lila/proof-lichess-16977/proof/comparison.png)

The before state leaves most of the iframe blank and gives movetext only 11px of visible height for 620px of content. The fixed state uses the full iframe height with a 231px board and a 280px visible movetext pane.

## Validation

- `./ui/build bits --no-install`
- `pnpm exec stylelint ui/bits/css/_lpv.embed.scss`
- `git diff --check origin/master...HEAD`
- Manual Chromium proof using the generated `bits.lpv.embed` CSS before and after the change

## AI assistance disclosure

Tool used: OpenAI Codex / GPT-5 in the Codex desktop app.

Prompt summary: I asked Codex to continue my OSS contribution pipeline, look for a high-confidence Lichess candidate, inspect issue #16977, implement a small scoped fix, and validate it with local build/style checks and browser visual proof.

I reviewed the Sass change and the generated browser proof, and I can explain the submitted code.
