### PR TITLE
Disable suggestions on ublog and forum body edit/reply forms

### DIFF
--- a/modules/forum/src/main/ui/ForumBits.scala
+++ b/modules/forum/src/main/ui/ForumBits.scala
@@ -40,5 +40,6 @@ final class ForumBits(helpers: Helpers):
     bits.markdownTextarea("forumPostBody".some):
       form3.textarea(field, "post-text-area")(
         rows := 10,
+        autocomplete := "off",
         placeholder := trans.site.pleaseBeNiceInTheForum.txt()
       )(modifiers)

--- a/modules/forum/src/main/ui/PostUi.scala
+++ b/modules/forum/src/main/ui/PostUi.scala
@@ -135,6 +135,7 @@ final class PostUi(helpers: Helpers, bits: ForumBits):
                 textarea(
                   bits.dataTopic := topic.id,
                   name := "changes",
+                  autocomplete := "off",
                   cls := "form-control post-text-area edit-post-box",
                   required
                 )

--- a/modules/forum/src/main/ui/TopicUi.scala
+++ b/modules/forum/src/main/ui/TopicUi.scala
@@ -204,7 +204,11 @@ final class TopicUi(helpers: Helpers, bits: ForumBits, postUi: PostUi)(
               ).some
             ): f =>
               if plaintext then
-                form3.textarea(f, klass = "post-text-area")(rows := 10, bits.dataTopic := topic.id)(
+                form3.textarea(f, klass = "post-text-area")(
+                  rows := 10,
+                  bits.dataTopic := topic.id,
+                  autocomplete := "off"
+                )(
                   formText
                 )
               else bits.postTextarea(f)(bits.dataTopic := topic.id, formText),
@@ -247,7 +251,13 @@ final class TopicUi(helpers: Helpers, bits: ForumBits, postUi: PostUi)(
             form3.group(form("post")("text"), trans.site.message())(f =>
               if plaintext then
                 form3.textarea(f, klass = "post-text-area")(rows := 10, autofocus := "")(s"\n\n\n$text")
-              else bits.postTextarea(f)(autofocus := "", maxlength := 200_000, s"\n\n\n$text".some)
+              else
+                bits.postTextarea(f)(
+                  autofocus := "",
+                  autocomplete := "off",
+                  maxlength := 200_000,
+                  s"\n\n\n$text".some
+                )
             ),
             form3.hidden("name", s"${me.username.value} problem report"),
             renderCaptcha(form("post"), captcha),

--- a/modules/ublog/src/main/ui/UblogFormUi.scala
+++ b/modules/ublog/src/main/ui/UblogFormUi.scala
@@ -80,7 +80,7 @@ final class UblogFormUi(helpers: Helpers, ui: UblogUi)(
         ).some
       ): field =>
         frag(
-          form3.textarea(field)(),
+          form3.textarea(field)(autocomplete := "off"),
           div(
             cls := "markdown-toastui",
             attr("data-image-upload-url") := routes.Main.uploadImage("ublogBody"),


### PR DESCRIPTION
browser autocomplete from the first lines of form history is not useful on textarea