### PR TITLE
Fix analysis settings defaults

### DIFF
--- a/ui/analyse/src/settingsCtrl.ts
+++ b/ui/analyse/src/settingsCtrl.ts
@@ -7,14 +7,14 @@ export class Settings {
     public readonly inline = false,
     public readonly showStaticAnalysis = true,
     public readonly disclosureMode = false,
-    public readonly showLiveGlyphs = true,
+    public readonly showLiveGlyphs = false,
     public readonly showBestMoveArrows = true,
     public readonly showManeuverMoveArrows = true,
     public readonly showVariationArrows = true,
     public readonly showMoveAnnotationsOnBoard = true,
-    public readonly showUndefendedPieces = true,
-    public readonly showPinnedPieces = true,
-    public readonly showCheckableKing = true,
+    public readonly showUndefendedPieces = false,
+    public readonly showPinnedPieces = false,
+    public readonly showCheckableKing = false,
   ) {}
 }
 


### PR DESCRIPTION
Legacy settings were only grandfathered if they had localStorage entries.

Randomly turning on assorted features, though a fun introduction to the new settings interface, will be a shitstorm. Merging this patch quickly can minimize it.
