### PR TITLE
Hide annotations while solving Learn from Your Mistakes

### DIFF
--- a/ui/analyse/src/autoShape.ts
+++ b/ui/analyse/src/autoShape.ts
@@ -127,6 +127,7 @@ export function compute(ctrl: AnalyseCtrl): DrawShape[] {
       lineWidth: 8,
     });
   }
+  const retroSolving = ctrl.retro?.isSolving();
   if (hovering?.fen === nFen) shapes = shapes.concat(makeShapesFromUci(color, hovering.uci, 'paleBlue'));
   ctrl.fork.hover(hovering?.uci);
 
@@ -176,7 +177,7 @@ export function compute(ctrl: AnalyseCtrl): DrawShape[] {
       }
     });
   }
-  if (ctrl.showMoveAnnotations()) {
+  if (!retroSolving && ctrl.showMoveAnnotations()) {
     const glyphs = [...(ctrl.node.glyphs ?? [])];
     const liveGlyph = ctrl.liveAnnotate?.get(ctrl.path);
     if (liveGlyph && ctrl.settings.showLiveGlyphs && !glyphs.some(g => g.id <= 6)) glyphs.push(liveGlyph);
@@ -197,7 +198,7 @@ export function compute(ctrl: AnalyseCtrl): DrawShape[] {
       });
     };
 
-    if (ctrl.motifEnabled()) {
+    if (!retroSolving && ctrl.motifEnabled()) {
       ctrl.motif.detectPins(board).forEach(p => addAnalysis(makeSquare(p.pinned) as Key, 'pin'));
       ctrl.motif
         .detectUndefended(board, epSquare)

--- a/ui/analyse/tests/autoShape.test.ts
+++ b/ui/analyse/tests/autoShape.test.ts
@@ -1,0 +1,85 @@
+import type { DrawShape } from '@lichess-org/chessground/draw';
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { compute } from '../src/autoShape';
+import type AnalyseCtrl from '../src/ctrl';
+
+function makeCtrl(retro?: { isSolving(): boolean; showBadNode(): { uci: Uci } | undefined }): AnalyseCtrl {
+  let explorerHover: { fen: FEN; uci: Uci } | null = null;
+
+  return {
+    node: {
+      fen: '4k3/4n3/8/8/8/4R3/8/K7 w - - 0 1',
+      uci: 'e2e4',
+      san: 'e4',
+      glyphs: [{ symbol: '?' }],
+    },
+    explorer: {
+      hovering(value?: { fen: FEN; uci: Uci } | null) {
+        if (arguments.length > 0) explorerHover = value ?? null;
+        return explorerHover;
+      },
+    },
+    ceval: {
+      hovering: () => null,
+      search: { multiPv: 0 },
+    },
+    fork: {
+      hover: () => {},
+    },
+    settings: {
+      showManeuverMoveArrows: false,
+    },
+    practice: undefined,
+    retro,
+    showBestMoveArrows: () => false,
+    showEvaluation: () => false,
+    isCevalAllowed: () => true,
+    threatMode: () => false,
+    showMoveAnnotations: () => true,
+    showVariationArrows: () => false,
+    visibleChildren: () => [],
+    motifEnabled: () => true,
+    motif: {
+      detectPins: () => [{ pinned: 52 }],
+      detectUndefended: () => [{ square: 43 }],
+      detectCheckable: () => [{ king: 60 }],
+    },
+  } as unknown as AnalyseCtrl;
+}
+
+const annotationShape = (shape: DrawShape): boolean => Boolean(shape.customSvg || shape.label);
+
+test('hides move annotations and motifs while retrospect is solving', () => {
+  const shapes = compute(
+    makeCtrl({
+      isSolving: () => true,
+      showBadNode: () => undefined,
+    }),
+  );
+
+  assert.equal(shapes.some(annotationShape), false);
+});
+
+test('still shows the bad move arrow while retrospect is solving', () => {
+  const shapes = compute(
+    makeCtrl({
+      isSolving: () => true,
+      showBadNode: () => ({ uci: 'e2e4' }),
+    }),
+  );
+
+  assert.deepEqual(shapes, [{ orig: 'e2', dest: 'e4', brush: 'paleRed', modifiers: { lineWidth: 8 } }]);
+});
+
+test('keeps move annotations and motifs outside retrospect solving', () => {
+  const shapes = compute(
+    makeCtrl({
+      isSolving: () => false,
+      showBadNode: () => undefined,
+    }),
+  );
+
+  assert.equal(shapes.some(annotationShape), true);
+});


### PR DESCRIPTION
Fixes #20741

## Why

`Learn from your mistakes` can enter a solving state while the analysis board still has move glyph annotations and motif markers enabled. Those shapes reveal extra information that should not be shown during the exercise.

## What changed

- Hide move glyph annotation shapes while retrospect is solving.
- Hide motif markers while retrospect is solving.
- Keep the existing bad-move arrow visible so the exercise still points at the move being corrected.

## Proof

Focused Chromium proof harness for the `autoShape` output:

![before and after comparison](https://raw.githubusercontent.com/markoub/lila/proof-lichess-20741/proof/20741/comparison.png)

The proof shows the previous glyph and motif annotations during retrospect solving, the fixed output with those annotations hidden, and the bad-move arrow still preserved.

## Validation

- `node ui/test autoShape.test.ts`
- `node ui/test analyse`
- `./ui/build analyse --no-install`
- `pnpm exec oxlint --type-aware ui/analyse/src/autoShape.ts ui/analyse/tests/autoShape.test.ts`
- `pnpm exec oxfmt --check ui/analyse/src/autoShape.ts ui/analyse/tests/autoShape.test.ts`
- `git diff --check origin/master`

## AI assistance disclosure

This pull request was prepared with AI assistance from OpenAI Codex. Prompts used included: inspect Lichess issue #20741 and current contribution rules; find where analysis annotations are converted into board shapes; implement and test a focused fix that hides move glyph and motif annotations while `Learn from your mistakes` retrospect mode is solving, while preserving the bad-move arrow; run local validation and an internal review. I reviewed the diff and validation output before submitting.
