### PR TITLE
Preload preferences i18n for embedded analysis

### DIFF
--- a/app/views/analyse.scala
+++ b/app/views/analyse.scala
@@ -79,7 +79,7 @@ object embed:
         .analyseModule("userAnalysis", Json.obj("data" -> data, "embed" -> true) ++ ui.explorerAndCevalConfig)
         .some,
       csp = _.withExternalAnalysisApis.withWebAssembly,
-      i18nModules = List(_.site, _.timeago, _.study)
+      i18nModules = List(_.site, _.timeago, _.study, _.preferences)
     )(
       ui.bits.embedUserAnalysisBody,
       views.base.page.ui.inlineJs(ctx.nonce, Nil)


### PR DESCRIPTION
Fixes #20748.

## What changed

`/embed/analysis` loads the `analyse.user` page module. The analysis settings view now reads `i18n.preferences.showServerAnalysis` and other `i18n.preferences` keys at module evaluation time, but the embed template only preloaded `site`, `timeago`, and `study` i18n modules.

This adds the existing `preferences` i18n module to the embedded analysis preload list so `i18n.preferences` is defined before the analysis bundle runs.

## Manual proof

![proof](https://raw.githubusercontent.com/markoub/lila/proof-lichess-20748/comparison.png)

Focused runtime check against the generated i18n asset:

```json
{
  "catalog": "preferences.en-US.d67e6dde26a3.js",
  "before": "Cannot read properties of undefined (reading 'showServerAnalysis')",
  "after": "Show server analysis"
}
```

Duplicate/open PR search before opening this PR:

```text
gh search prs "embed/analysis" --repo lichess-org/lila --state open -> []
gh search prs "showServerAnalysis" --repo lichess-org/lila --state open -> []
gh search prs "20748" --repo lichess-org/lila --state open -> []
```

## Validation

```text
git diff --check origin/master...HEAD
JAVA_HOME=/opt/homebrew/opt/openjdk@21 PATH="/opt/homebrew/opt/openjdk@21/bin:$PATH" ./lila.sh scalafmtCheckAll
JAVA_HOME=/opt/homebrew/opt/openjdk@21 PATH="/opt/homebrew/opt/openjdk@21/bin:$PATH" ./lila.sh compile
./ui/build analyse --no-install
```

## AI assistance disclosure

Tool used: OpenAI Codex.

Prompt summary: I asked Codex to continue my OSS contribution pipeline, inspect Lichess for high-confidence contribution opportunities, investigate #20748, implement a minimal fix, run focused validation, and prepare the PR with proof. I reviewed the one-line change and understand it: the embedded analysis page now preloads the same preferences i18n catalog that its analysis settings bundle reads.