### PR TITLE
Dismiss promotion choice when rewinding round moves

### DIFF
--- a/ui/lib/src/game/promotion.ts
+++ b/ui/lib/src/game/promotion.ts
@@ -70,12 +70,17 @@ export class PromotionCtrl {
     }) || false;
 
   cancel = (): void => {
+    if (this.dismiss()) this.onCancel();
+  };
+
+  dismiss = (): boolean => {
+    const wasPromoting = !!this.promoting;
     this.cancelPrePromotion();
-    if (this.promoting) {
+    if (wasPromoting) {
       this.promoting = undefined;
-      this.onCancel();
       this.redraw();
     }
+    return wasPromoting;
   };
 
   cancelPrePromotion = (): void => {

--- a/ui/lib/src/game/promotion.ts
+++ b/ui/lib/src/game/promotion.ts
@@ -74,17 +74,17 @@ export class PromotionCtrl {
   };
 
   dismiss = (): boolean => {
-    const wasPromoting = !!this.promoting;
-    this.cancelPrePromotion();
-    if (wasPromoting) {
-      this.promoting = undefined;
+    const promoting = this.promoting;
+    this.promoting = undefined;
+    this.cancelPrePromotion(promoting);
+    if (promoting) {
       this.redraw();
     }
-    return wasPromoting;
+    return !!promoting;
   };
 
-  cancelPrePromotion = (): void => {
-    this.promoting?.hooks.show?.(this, false);
+  cancelPrePromotion = (promoting: Promoting | undefined = this.promoting): void => {
+    promoting?.hooks.show?.(this, false);
     if (this.prePromotionRole) {
       this.withGround(g => g.setAutoShapes([]));
       this.prePromotionRole = undefined;

--- a/ui/lib/tests/promotion.test.ts
+++ b/ui/lib/tests/promotion.test.ts
@@ -1,0 +1,104 @@
+import type { DrawShape } from '@lichess-org/chessground/draw';
+import type * as cg from '@lichess-org/chessground/types';
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+
+import { PromotionCtrl } from '../src/game/promotion';
+
+function makeGround() {
+  const state = {
+    pieces: new Map<cg.Key, cg.Piece>([['e7', { color: 'white', role: 'pawn' }]]),
+    turnColor: 'black' as cg.Color,
+    orientation: 'white' as cg.Color,
+  };
+  let autoShapes: DrawShape[] = [];
+  const ground = {
+    state,
+    setAutoShapes(shapes: DrawShape[]) {
+      autoShapes = shapes;
+    },
+    setPieces(pieces: Map<cg.Key, cg.Piece | undefined>) {
+      for (const [key, piece] of pieces) {
+        if (piece) state.pieces.set(key, piece);
+        else state.pieces.delete(key);
+      }
+    },
+  } as unknown as CgApi;
+
+  return {
+    ground,
+    autoShapes: () => autoShapes,
+  };
+}
+
+describe('promotion control', () => {
+  test('dismiss clears a visible promotion choice without running the cancel hook', () => {
+    const { ground } = makeGround();
+    let redraws = 0;
+    let cancels = 0;
+    const shownRoles: Array<cg.Role[] | false> = [];
+    const ctrl = new PromotionCtrl(
+      f => f(ground),
+      () => {
+        cancels++;
+      },
+      () => {
+        redraws++;
+      },
+    );
+
+    assert.equal(
+      ctrl.start('e7', 'e8', {
+        submit: () => assert.fail('promotion should not submit while waiting for a role'),
+        show: (_ctrl, roles) => shownRoles.push(roles),
+      }),
+      true,
+    );
+    assert.ok(ctrl.view());
+
+    assert.equal(ctrl.dismiss(), true);
+    assert.equal(cancels, 0);
+    assert.equal(redraws, 2);
+    assert.deepEqual(shownRoles.at(-1), false);
+    assert.equal(ctrl.view(), undefined);
+  });
+
+  test('cancel keeps the existing cancel hook behavior', () => {
+    const { ground } = makeGround();
+    let cancels = 0;
+    const ctrl = new PromotionCtrl(
+      f => f(ground),
+      () => {
+        cancels++;
+      },
+      () => {},
+    );
+
+    assert.equal(ctrl.start('e7', 'e8', { submit: () => assert.fail('promotion should not submit') }), true);
+
+    ctrl.cancel();
+
+    assert.equal(cancels, 1);
+    assert.equal(ctrl.view(), undefined);
+  });
+
+  test('dismiss clears a stored premove promotion role', () => {
+    const { ground, autoShapes } = makeGround();
+    let cancels = 0;
+    const ctrl = new PromotionCtrl(
+      f => f(ground),
+      () => {
+        cancels++;
+      },
+      () => {},
+    );
+
+    assert.equal(ctrl.start('e7', 'e8', { submit: () => assert.fail('promotion should not submit') }), true);
+    ctrl.finish('queen');
+    assert.equal(autoShapes().length, 1);
+
+    assert.equal(ctrl.dismiss(), false);
+    assert.equal(cancels, 0);
+    assert.equal(autoShapes().length, 0);
+  });
+});

--- a/ui/lib/tests/promotion.test.ts
+++ b/ui/lib/tests/promotion.test.ts
@@ -63,6 +63,34 @@ describe('promotion control', () => {
     assert.equal(ctrl.view(), undefined);
   });
 
+  test('dismiss ignores stale promotion choices fired during hook cleanup', () => {
+    const { ground, autoShapes } = makeGround();
+    let submits = 0;
+    const ctrl = new PromotionCtrl(
+      f => f(ground),
+      () => {},
+      () => {},
+    );
+
+    assert.equal(
+      ctrl.start('e7', 'e8', {
+        submit: () => {
+          submits++;
+        },
+        show: (activeCtrl, roles) => {
+          if (roles === false) activeCtrl.finish('queen');
+        },
+      }),
+      true,
+    );
+    assert.ok(ctrl.view());
+
+    assert.equal(ctrl.dismiss(), true);
+    assert.equal(submits, 0);
+    assert.equal(autoShapes().length, 0);
+    assert.equal(ctrl.view(), undefined);
+  });
+
   test('cancel keeps the existing cancel hook behavior', () => {
     const { ground } = makeGround();
     let cancels = 0;

--- a/ui/round/src/ctrl.ts
+++ b/ui/round/src/ctrl.ts
@@ -261,7 +261,8 @@ export default class RoundController implements MoveRootCtrl {
         color: this.isPlaying() ? this.data.player.color : undefined,
         dests: util.parsePossibleMoves(this.data.possibleMoves),
       };
-    this.chessground.cancelPremove();
+    this.promotion.dismiss();
+    this.chessground.cancelMove();
     this.chessground.set(config);
     if (s.san && isForwardStep) site.sound.move(s);
     this.autoScroll();

--- a/ui/round/src/ctrl.ts
+++ b/ui/round/src/ctrl.ts
@@ -233,6 +233,7 @@ export default class RoundController implements MoveRootCtrl {
 
   userJump = (ply: Ply): void => {
     this.toSubmit = undefined;
+    this.promotion.dismiss();
     this.chessground.selectSquare(null);
     if (ply !== this.ply && this.jump(ply)) site.sound.saySan(this.stepAt(this.ply).san, true);
     else this.redraw();
@@ -255,13 +256,13 @@ export default class RoundController implements MoveRootCtrl {
         check: !!s.check,
         turnColor: plyColor(this.ply),
       };
+    this.promotion.dismiss();
     if (this.replaying()) this.chessground.stop();
     else
       config.movable = {
         color: this.isPlaying() ? this.data.player.color : undefined,
         dests: util.parsePossibleMoves(this.data.possibleMoves),
       };
-    this.promotion.dismiss();
     this.chessground.cancelMove();
     this.chessground.set(config);
     if (s.san && isForwardStep) site.sound.move(s);


### PR DESCRIPTION
Fixes #20684.

## What changed

This dismisses any pending promotion choice when the round controller jumps to another ply, including keyboard rewind. The existing `cancel()` behavior still runs the cancel hook, while the `dismiss()` path only clears local promotion UI state and stored premove promotion state.

After follow-up manual validation, the jump path also calls chessground's full `cancelMove()` API instead of only `cancelPremove()`. That clears premove, predrop, selection, and any active local drag state before the rewound board config is applied.

## Why

When a player rewound the move list while the promotion selector was open, the selector could remain attached to the board after the position changed. In the cancel-by-rewind case, clearing only stored premoves was not enough because chessground could still have local move state from the in-progress promotion interaction.

## Manual proof

Local lila was run against a seeded MongoDB database. I created an Ana vs Lola from-position game with Black to move, played `...Kb1` through the Board API, then opened the game as White in Chromium.

Initial selector proof after Ctrl-dragging `a7-a8`:

![promotion selector open](https://raw.githubusercontent.com/markoub/lila/proof-lichess-20684/04-selector-open-cancelmove-proof.png)

After pressing `ArrowLeft`, the board rewinds to the previous ply and the promotion choices are gone:

![after rewind](https://raw.githubusercontent.com/markoub/lila/proof-lichess-20684/05-after-arrow-left-cancelmove-proof.png)

After pressing `ArrowRight`, the board advances again without a reload, confirming the page remains responsive after the canceled promotion rewind:

![after stepping forward](https://raw.githubusercontent.com/markoub/lila/proof-lichess-20684/06-after-arrow-right-responsive-proof.png)

The browser run had no page errors. The only console error was the expected local-dev websocket CSP block from running without lila-ws.

## Validation

- `./ui/test lib promotion`
- `./ui/test round`
- `./ui/build round --no-install`
- `pnpm exec oxlint --type-aware ui/round/src/ctrl.ts`
- `pnpm exec oxfmt --check ui/round/src/ctrl.ts ui/lib/src/game/promotion.ts ui/lib/tests/promotion.test.ts`
- `git diff --check`
- Manual Chromium proof on local lila as described above

`./ui/test lib promotion` still prints the existing non-fatal `Error: no indexedDB` console message from `objectStorage.ts`, but all 97 tests pass.

I also reran `pnpm run lint`; it is currently blocked by the known `tsgolint` Go runtime crash (`fatal error: concurrent map writes`) before reporting any code finding.

## AI assistance disclosure

Tool used: OpenAI Codex.

Prompts used:

- "Fix lichess-org/lila#20684 by dismissing promotion choices when the round UI rewinds or otherwise jumps to another ply; keep existing cancellation semantics intact, add focused tests, run local validation, and provide manual browser proof."
- "Address maintainer feedback on PR #20750: reproduce the freeze when a promotion is canceled by rewinding ply, repair the stale local move state, run focused validation and manual Chromium proof, and update the PR without assistant footers."

I reviewed the resulting code and proof before submitting.
