### PR TITLE
Persist computer setup color

### DIFF
--- a/ui/lobby/src/interfaces.ts
+++ b/ui/lobby/src/interfaces.ts
@@ -122,6 +122,7 @@ export interface SetupStore {
   fen: FEN;
   timeMode: TimeMode;
   gameMode: GameMode;
+  color: ColorChoice;
   ratingMin: number;
   ratingMax: number;
   aiLevel: number;

--- a/ui/lobby/src/setupCtrl.ts
+++ b/ui/lobby/src/setupCtrl.ts
@@ -67,6 +67,7 @@ export default class SetupController {
       increment: 3,
       days: 2,
       gameMode: gameType === 'ai' || !this.root.me ? 'casual' : 'rated',
+      color: 'random',
       ratingMin: -500,
       ratingMax: 500,
       aiLevel: 1,
@@ -91,7 +92,7 @@ export default class SetupController {
     this.ratingMin = this.propWithApply(storeProps.ratingMin);
     this.ratingMax = this.propWithApply(storeProps.ratingMax);
     this.aiLevel = this.propWithApply(storeProps.aiLevel);
-    this.color(forceOptions?.color || 'random');
+    this.color(forceOptions?.color || storeProps.color || 'random');
 
     this.enforcePropRules();
     // Upon loading the props from the store, overriding with forced options, and enforcing rules,
@@ -127,6 +128,7 @@ export default class SetupController {
       increment: this.timeControl.increment(),
       days: this.timeControl.days(),
       gameMode: this.gameMode(),
+      color: this.color(),
       ratingMin: this.ratingMin(),
       ratingMax: this.ratingMax(),
       aiLevel: this.aiLevel(),


### PR DESCRIPTION
Fixes https://github.com/lichess-org/lila/issues/20476.

## What changed

The lobby setup store now persists the selected side (`white`, `black`, or `random`) together with the other setup values.

Computer setup already saved fields such as variant, time mode, strength, and rating limits, but `color` was not part of `SetupStore`. As a result, reopening the computer setup always initialized side selection back to `random` unless a forced URL option supplied a color.

## Validation

- `git diff --check origin/master...HEAD`
- `pnpm exec oxfmt --check ui/lobby/src/interfaces.ts ui/lobby/src/setupCtrl.ts`
- `pnpm exec oxlint ui/lobby/src/interfaces.ts ui/lobby/src/setupCtrl.ts`
- `./ui/build lobby --no-install`
- `./ui/build site lobby --no-install`
- `./ui/build --no-install`
- Manual Chromium proof on local lila at `http://localhost:9663/`: opened `Play against computer`, selected `Black`, closed and reopened the setup modal, and confirmed `Black` remained selected and `lobby.setup.anon.ai` still contained `"color":"black"`.

Proof screenshot after reopening:

![Black side remains selected after reopening the computer setup](https://raw.githubusercontent.com/markoub/lila/proof-lichess-20476/after-reopen.png)

Proof details: https://raw.githubusercontent.com/markoub/lila/proof-lichess-20476/proof.json

## AI assistance disclosure

Tool: OpenAI Codex.

Prompt summary: I asked Codex to monitor active OSS pull requests, find a high-confidence Lichess contribution candidate, inspect issue #20476, implement the minimal fix, run focused validation, and produce manual browser proof before opening a ready-for-review PR. I reviewed the resulting two-file patch and the browser proof before submission.
