### PR TITLE
Fix duplicate analysis setting help popups

### DIFF
--- a/ui/analyse/src/view/settingsView.ts
+++ b/ui/analyse/src/view/settingsView.ts
@@ -153,8 +153,17 @@ function setupTouchHelp(view: HTMLElement) {
     if (!settings[key]) return;
     const htmlText = settings[key].helpHtml;
 
-    el.addEventListener('click', () =>
-      domDialog({ htmlText, class: 'setting-popup', noCloseButton: true, show: true, easyClose: 'anyClick' }),
+    el.addEventListener(
+      'click',
+      () =>
+        void domDialog({
+          htmlText,
+          class: 'setting-popup',
+          noCloseButton: true,
+          easyClose: 'anyClick',
+          show: true,
+          single: 'analyse-setting-popup',
+        }),
     );
   });
 }

--- a/ui/lib/src/view/dialog.ts
+++ b/ui/lib/src/view/dialog.ts
@@ -41,6 +41,7 @@ export interface DialogOpts {
 export interface DomDialogOpts extends DialogOpts {
   parent?: Element; // for centering and dom placement, otherwise fixed on document.body
   show?: boolean; // show dialog immediately after construction
+  single?: string; // if set, only the latest shown dialog with this key remains open
 }
 
 // for snabDialog, show is inferred from !onInsert
@@ -61,6 +62,8 @@ export type Action =
 // when opts contains 'show', domDialog function's result promise resolves on dialog closure.
 // otherwise, the promise resolves once assets are loaded and it is safe to call show
 export async function domDialog(o: DomDialogOpts): Promise<Dialog> {
+  const single =
+    o.single === undefined ? undefined : { key: o.single, token: setSingleDomDialogToken(o.single) };
   const [html] = await loadAssets(o);
 
   const dialog = document.createElement('dialog');
@@ -86,7 +89,7 @@ export async function domDialog(o: DomDialogOpts): Promise<Dialog> {
 
   (o.parent ?? document.body).appendChild(dialog);
 
-  const wrapper = new DialogWrapper(dialog, view, o);
+  const wrapper = new DialogWrapper(dialog, view, o, single);
   return o.show ? wrapper.show() : wrapper;
 }
 
@@ -173,6 +176,16 @@ const easyCloseHandler = new (class {
   }
 })();
 
+const singleDomDialogs = new Map<string, DialogWrapper>();
+const singleDomDialogTokens = new Map<string, number>();
+let singleDomDialogNextToken = 0;
+
+function setSingleDomDialogToken(key: string): number {
+  const token = ++singleDomDialogNextToken;
+  singleDomDialogTokens.set(key, token);
+  return token;
+}
+
 class DialogWrapper implements Dialog {
   private readonly dialogEvents = new Janitor();
   private readonly actionEvents = new Janitor();
@@ -196,6 +209,7 @@ class DialogWrapper implements Dialog {
     readonly dialog: HTMLDialogElement,
     readonly view: HTMLElement,
     readonly o: DialogOpts,
+    private readonly single?: { key: string; token: number },
   ) {
     this.observer.observe(document.body, { childList: true, subtree: true });
     document.body.style.setProperty('---viewport-height', `${window.innerHeight}px`);
@@ -228,12 +242,29 @@ class DialogWrapper implements Dialog {
 
   show = async (): Promise<Dialog> => {
     (await pubsub.after('polyfill.dialog'))?.(this.dialog);
+    if (this.single && singleDomDialogTokens.get(this.single.key) !== this.single.token) {
+      this.onRemove();
+      return this;
+    }
     const snabModal = this.dialog.parentElement === this.dialog.closest('.snab-modal-mask');
     if (this.o.modal) this.view.scrollTop = 0;
     if (snabModal) this.dialog.parentElement?.classList.remove('none');
 
+    if (this.single) singleDomDialogs.get(this.single.key)?.close('cancel');
+
     if (this.o.modal && !snabModal) this.dialog.showModal();
     else this.dialog.show();
+
+    if (this.single) {
+      singleDomDialogs.set(this.single.key, this);
+      this.dialogEvents.addCleanupTask(() => {
+        if (this.single && singleDomDialogs.get(this.single.key) === this) {
+          singleDomDialogs.delete(this.single.key);
+          if (singleDomDialogTokens.get(this.single.key) === this.single.token)
+            singleDomDialogTokens.delete(this.single.key);
+        }
+      });
+    }
 
     easyCloseHandler.push(this);
     this.dialogEvents.addCleanupTask(() => easyCloseHandler.remove(this));

--- a/ui/lib/tests/dialog.test.ts
+++ b/ui/lib/tests/dialog.test.ts
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict';
+import { before, describe, test } from 'node:test';
+
+import { pubsub } from '../src/pubsub';
+import { domDialog } from '../src/view/dialog';
+
+describe('domDialog', () => {
+  before(() => {
+    (site as any).asset = {
+      loadCssPath: async () => {},
+      loadCss: async () => {},
+      removeCssPath: () => {},
+      removeCss: () => {},
+    };
+    (globalThis as any).MutationObserver = window.MutationObserver;
+    (window as any).matchMedia = (globalThis as any).matchMedia;
+
+    const dialogPrototype = Object.getPrototypeOf(document.createElement('dialog'));
+    dialogPrototype.show = function () {
+      this.open = true;
+      this.setAttribute('open', '');
+    };
+    dialogPrototype.showModal = dialogPrototype.show;
+    dialogPrototype.close = function (returnValue = '') {
+      this.returnValue = returnValue;
+      this.open = false;
+      this.removeAttribute('open');
+      this.dispatchEvent(new window.Event('close'));
+    };
+
+    pubsub.complete('polyfill.dialog');
+  });
+
+  test('single keeps only the latest dialog open after concurrent shows', async () => {
+    document.body.replaceChildren();
+
+    for (let i = 0; i < 8; i++)
+      void domDialog({
+        htmlText: `<p>${i}</p>`,
+        class: 'setting-popup',
+        noCloseButton: true,
+        show: true,
+        single: 'setting-popup',
+      });
+
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    const openPopups = [...document.querySelectorAll('dialog[open] .setting-popup')];
+    assert.equal(openPopups.length, 1);
+    assert.equal(openPopups[0]?.textContent, '7');
+
+    document.querySelector<HTMLDialogElement>('dialog[open]')?.close('ok');
+  });
+});


### PR DESCRIPTION
Fixes #20754

## What changed
- Keep a single touch setting help popup active at a time.
- Ignore duplicate opens while the dialog is still loading, then close any previous open setting popup before showing the next one.

## Proof
Local lila at `http://localhost:9663/analysis`, Chromium touch emulation 1196x784.

Before: 8 rapid help-button clicks left 8 open `.setting-popup` dialogs.

![Before rapid help clicks](https://raw.githubusercontent.com/markoub/lila/proof-lichess-20754/proof/lichess-20754/before-rapid-help-clicks.png)

After: the same 8 rapid help-button clicks leave 1 open `.setting-popup` dialog.

![After rapid help clicks](https://raw.githubusercontent.com/markoub/lila/proof-lichess-20754/proof/lichess-20754/after-rapid-help-clicks.png)

Validation:
- `pnpm exec oxfmt --check ui/analyse/src/view/settingsView.ts`
- `pnpm exec oxlint ui/analyse/src/view/settingsView.ts`
- `git diff --check`
- `./node_modules/.bin/tsc -p ui/analyse/tsconfig.json --noEmit --tsBuildInfoFile /dev/null --pretty false`
- `./ui/build analyse --no-install`
- `./ui/build --no-install`
- Local lila smoke/proof on `http://localhost:9663/analysis`

## AI assistance disclosure
AI tool: OpenAI Codex.

Prompts used: I asked Codex to monitor active OSS PRs, screen high-confidence candidates, inspect Lichess issue #20754, implement a minimal fix, and validate it with local browser proof.

I reviewed the generated change and proof and understand the code being submitted.