### PR TITLE
Make help popups full device width on mobile

### DIFF
--- a/ui/analyse/css/_settings.scss
+++ b/ui/analyse/css/_settings.scss
@@ -36,6 +36,8 @@
   display: flex;
   flex-wrap: wrap;
   justify-content: stretch;
+  touch-action: none;
+  -webkit-tap-highlight-color: transparent;
   gap: 2em;
 
   @media (max-width: at-most(600px)) {
@@ -152,8 +154,8 @@
 }
 
 .setting-popup {
-  @extend %box-radius, %flex-column;
-
+  @extend %box-radius;
+  touch-action: none;
   gap: 1em;
   background: $c-bg-zebra2;
 }

--- a/ui/analyse/css/_settings.scss
+++ b/ui/analyse/css/_settings.scss
@@ -156,7 +156,7 @@
 .setting-popup {
   @extend %box-radius;
 
+  display: block;
   touch-action: none;
-  gap: 1em;
   background: $c-bg-zebra2;
 }

--- a/ui/analyse/css/_settings.scss
+++ b/ui/analyse/css/_settings.scss
@@ -155,6 +155,7 @@
 
 .setting-popup {
   @extend %box-radius;
+
   touch-action: none;
   gap: 1em;
   background: $c-bg-zebra2;


### PR DESCRIPTION
Also disable double tap, pinch to zoom, and other touch events (in settings only) because it's almost never what you want there.

`.setting-popup` as flex column (first picture) prevents img/video assets from stretching to fill hidpi screens (second picture).

<img width="292" height="633" alt="Analysis board • lichess org" src="https://github.com/user-attachments/assets/fba73643-318a-49a5-839a-3a703c009564" />

<img width="292" height="633" alt="Dae analysis • schlawg org" src="https://github.com/user-attachments/assets/99f64e0b-22fb-4a53-bee0-f947153fb0f9" />

