### PR TITLE
ui: show play duration in hours on hover in user page

### DIFF
--- a/app/UiEnv.scala
+++ b/app/UiEnv.scala
@@ -42,7 +42,7 @@ object UiEnv
   def lightUserSync = env.user.lightUserSync
   def manifest = env.web.manifest
   def analyseEndpoints = env.web.analyseEndpoints
-  protected val translator = lila.i18n.Translator
+  val translator = lila.i18n.Translator
   val langList = lila.i18n.LangList
   protected val namer = lila.game.Namer
   protected lazy val lightTeamSync = env.team.lightTeamSync

--- a/app/views/user/show/header.scala
+++ b/app/views/user/show/header.scala
@@ -188,16 +188,16 @@ object header:
                   u.playTime.map: playTime =>
                     frag(
                       p(
-                        title := lila.core.i18n.translateDuration(playTime.totalDuration, None, true)
+                        title := translator.duration(playTime.totalDuration, None, true)
                       )(
                         trans.site.tpTimeSpentPlaying(
-                          lila.core.i18n.translateDuration(playTime.totalDuration)
+                          translator.duration(playTime.totalDuration)
                         )
                       ),
                       playTime.nonEmptyTvDuration.map: tvDuration =>
                         p(
-                          title := lila.core.i18n.translateDuration(tvDuration, None, true)
-                        )(trans.site.tpTimeSpentOnTV(lila.core.i18n.translateDuration(tvDuration)))
+                          title := translator.duration(tvDuration, None, true)
+                        )(trans.site.tpTimeSpentOnTV(translator.duration(tvDuration)))
                     ),
                   (!hideTroll && u.kid.no).option(
                     div(cls := "social_links col2")(

--- a/app/views/user/show/header.scala
+++ b/app/views/user/show/header.scala
@@ -188,8 +188,7 @@ object header:
                   u.playTime.map: playTime =>
                     frag(
                       p(
-                        title := lila.core.i18n
-                          .translateDuration(playTime.totalDuration, None, Some(true))
+                        title := lila.core.i18n.translateDuration(playTime.totalDuration, None, true)
                       )(
                         trans.site.tpTimeSpentPlaying(
                           lila.core.i18n.translateDuration(playTime.totalDuration)
@@ -197,8 +196,7 @@ object header:
                       ),
                       playTime.nonEmptyTvDuration.map: tvDuration =>
                         p(
-                          title := lila.core.i18n
-                            .translateDuration(tvDuration, None, Some(true))
+                          title := lila.core.i18n.translateDuration(tvDuration, None, true)
                         )(trans.site.tpTimeSpentOnTV(lila.core.i18n.translateDuration(tvDuration)))
                     ),
                   (!hideTroll && u.kid.no).option(

--- a/app/views/user/show/header.scala
+++ b/app/views/user/show/header.scala
@@ -188,12 +188,18 @@ object header:
                   u.playTime.map: playTime =>
                     frag(
                       p(
+                        title := lila.core.i18n
+                          .translateDuration(playTime.totalDuration, None, Some(true))
+                      )(
                         trans.site.tpTimeSpentPlaying(
                           lila.core.i18n.translateDuration(playTime.totalDuration)
                         )
                       ),
                       playTime.nonEmptyTvDuration.map: tvDuration =>
-                        p(trans.site.tpTimeSpentOnTV(lila.core.i18n.translateDuration(tvDuration)))
+                        p(
+                          title := lila.core.i18n
+                            .translateDuration(tvDuration, None, Some(true))
+                        )(trans.site.tpTimeSpentOnTV(lila.core.i18n.translateDuration(tvDuration)))
                     ),
                   (!hideTroll && u.kid.no).option(
                     div(cls := "social_links col2")(

--- a/modules/clas/src/main/ui/DashboardUi.scala
+++ b/modules/clas/src/main/ui/DashboardUi.scala
@@ -317,7 +317,7 @@ final class DashboardUi(helpers: Helpers, ui: ClasUi)(using NetDomain):
                       ),
                       td(prog.nb),
                       if progress.isPuzzle then td(dataSort := prog.winRate)(prog.winRate, "%")
-                      else td(dataSort := prog.millis)(lila.core.i18n.translateDuration(prog.duration)),
+                      else td(dataSort := prog.millis)(translator.duration(prog.duration)),
                       td(
                         if progress.isPuzzle then
                           a(href := routes.Puzzle.dashboard(progress.days, "home", user.username.some))(

--- a/modules/coreI18n/src/main/i18n.scala
+++ b/modules/coreI18n/src/main/i18n.scala
@@ -66,16 +66,12 @@ trait JsDump:
 def translateDuration(
     duration: java.time.Duration,
     withMinutes: Option[Boolean] = None,
-    skipDays: Option[Boolean] = None
-)(using
-    Translate
-): String =
-  val doSkipDays = skipDays.getOrElse(false)
-  val useMinutes = withMinutes.getOrElse(duration.toDays == 0 || doSkipDays)
-
+    skipDays: Boolean = false
+)(using Translate): String =
+  val useMinutes = withMinutes.getOrElse(duration.toDays == 0 || skipDays)
   List(
-    Option.unless(doSkipDays)(I18nKey.site.nbDays, true, duration.toDays),
-    Some(I18nKey.site.nbHours, true, if doSkipDays then duration.toHours else duration.toHours % 24),
+    Option.unless(skipDays)(I18nKey.site.nbDays, true, duration.toDays),
+    Some(I18nKey.site.nbHours, true, if skipDays then duration.toHours else duration.toHours % 24),
     Option.when(useMinutes)(I18nKey.site.nbMinutes, false, duration.toMinutes % 60)
   ).flatten
     .dropWhile { (_, dropZero, nb) => dropZero && nb == 0 }

--- a/modules/coreI18n/src/main/i18n.scala
+++ b/modules/coreI18n/src/main/i18n.scala
@@ -1,7 +1,6 @@
 package lila.core
 package i18n
 
-import cats.syntax.all.*
 import play.api.i18n.Lang
 import play.api.mvc.RequestHeader
 import scalatags.Text.RawFrag
@@ -65,18 +64,30 @@ def playAcceptLanguages(req: RequestHeader): Seq[Lang] =
 trait JsDump:
   def keysToObject(keys: Seq[I18nKey])(using Translate): play.api.libs.json.JsObject
 
-def translateDuration(duration: java.time.Duration, withMinutes: Option[Boolean] = None)(using
+def translateDuration(
+    duration: java.time.Duration,
+    withMinutes: Option[Boolean] = None,
+    skipDays: Option[Boolean] = None
+)(using
     Translate
 ): String =
-  val useMinutes = withMinutes.getOrElse(duration.toDays == 0)
+  val doSkipDays = skipDays.getOrElse(false)
+  val useMinutes = withMinutes.getOrElse(duration.toDays == 0 || doSkipDays)
+
   List(
-    (I18nKey.site.nbDays, true, duration.toDays).some,
-    (I18nKey.site.nbHours, true, duration.toHours % 24).some,
-    Option.when(useMinutes)(I18nKey.site.nbMinutes, false, duration.toMinutes % 60)
+    Option.unless(doSkipDays)((I18nKey.site.nbDays, true, duration.toDays)),
+    Some((I18nKey.site.nbHours, true, if doSkipDays then duration.toHours else duration.toHours % 24)),
+    Option.when(useMinutes)((I18nKey.site.nbMinutes, false, duration.toMinutes % 60))
   ).flatten
     .dropWhile { (_, dropZero, nb) => dropZero && nb == 0 }
     .map { (key, _, nb) => key.pluralSameTxt(nb) }
     .mkString(", ")
 
-def translateDuration(duration: FiniteDuration, withMinutes: Option[Boolean])(using Translate): String =
-  translateDuration(java.time.Duration.ofSeconds(duration.toSeconds), withMinutes)
+def translateDuration(
+    duration: FiniteDuration,
+    withMinutes: Option[Boolean],
+    skipDays: Option[Boolean]
+)(using
+    Translate
+): String =
+  translateDuration(java.time.Duration.ofSeconds(duration.toSeconds), withMinutes, skipDays)

--- a/modules/coreI18n/src/main/i18n.scala
+++ b/modules/coreI18n/src/main/i18n.scala
@@ -4,7 +4,6 @@ package i18n
 import play.api.i18n.Lang
 import play.api.mvc.RequestHeader
 import scalatags.Text.RawFrag
-import scala.concurrent.duration.FiniteDuration
 export scalalib.model.{ Language, Country, LangTag }
 
 val maxLangs = 128
@@ -82,12 +81,3 @@ def translateDuration(
     .dropWhile { (_, dropZero, nb) => dropZero && nb == 0 }
     .map { (key, _, nb) => key.pluralSameTxt(nb) }
     .mkString(", ")
-
-def translateDuration(
-    duration: FiniteDuration,
-    withMinutes: Option[Boolean],
-    skipDays: Option[Boolean]
-)(using
-    Translate
-): String =
-  translateDuration(java.time.Duration.ofSeconds(duration.toSeconds), withMinutes, skipDays)

--- a/modules/coreI18n/src/main/i18n.scala
+++ b/modules/coreI18n/src/main/i18n.scala
@@ -27,6 +27,11 @@ trait Translator:
   val frag: TranslatorFrag
   def to(lang: Lang): Translate
   def toDefault: Translate
+  def duration(
+      duration: java.time.Duration,
+      withMinutes: Option[Boolean] = None,
+      skipDays: Boolean = false
+  )(using Lang): String
 trait TranslatorTxt:
   def literal(key: I18nKey, args: Seq[Any], lang: Lang): String
   def plural(key: I18nKey, count: Count, args: Seq[Any], lang: Lang): String
@@ -62,18 +67,3 @@ def playAcceptLanguages(req: RequestHeader): Seq[Lang] =
 
 trait JsDump:
   def keysToObject(keys: Seq[I18nKey])(using Translate): play.api.libs.json.JsObject
-
-def translateDuration(
-    duration: java.time.Duration,
-    withMinutes: Option[Boolean] = None,
-    skipDays: Boolean = false
-)(using Translate): String =
-  val useMinutes = withMinutes.getOrElse(duration.toDays == 0 || skipDays)
-  List(
-    Option.unless(skipDays)(I18nKey.site.nbDays, true, duration.toDays),
-    Some(I18nKey.site.nbHours, true, if skipDays then duration.toHours else duration.toHours % 24),
-    Option.when(useMinutes)(I18nKey.site.nbMinutes, false, duration.toMinutes % 60)
-  ).flatten
-    .dropWhile { (_, dropZero, nb) => dropZero && nb == 0 }
-    .map { (key, _, nb) => key.pluralSameTxt(nb) }
-    .mkString(", ")

--- a/modules/coreI18n/src/main/i18n.scala
+++ b/modules/coreI18n/src/main/i18n.scala
@@ -75,9 +75,9 @@ def translateDuration(
   val useMinutes = withMinutes.getOrElse(duration.toDays == 0 || doSkipDays)
 
   List(
-    Option.unless(doSkipDays)((I18nKey.site.nbDays, true, duration.toDays)),
-    Some((I18nKey.site.nbHours, true, if doSkipDays then duration.toHours else duration.toHours % 24)),
-    Option.when(useMinutes)((I18nKey.site.nbMinutes, false, duration.toMinutes % 60))
+    Option.unless(doSkipDays)(I18nKey.site.nbDays, true, duration.toDays),
+    Some(I18nKey.site.nbHours, true, if doSkipDays then duration.toHours else duration.toHours % 24),
+    Option.when(useMinutes)(I18nKey.site.nbMinutes, false, duration.toMinutes % 60)
   ).flatten
     .dropWhile { (_, dropZero, nb) => dropZero && nb == 0 }
     .map { (key, _, nb) => key.pluralSameTxt(nb) }

--- a/modules/coreI18n/src/test/TranslatorStub.scala
+++ b/modules/coreI18n/src/test/TranslatorStub.scala
@@ -8,6 +8,11 @@ val TranslatorStub = new Translator:
   val txt = new TranslatorTxt:
     def literal(key: I18nKey, args: Seq[Any], lang: Lang): String = key.value
     def plural(key: I18nKey, count: Count, args: Seq[Any], lang: Lang): String = key.value
+  def duration(
+      duration: java.time.Duration,
+      withMinutes: Option[Boolean] = None,
+      skipDays: Boolean = false
+  )(using Lang): String = duration.toString
   val frag = new TranslatorFrag:
     import scalatags.Text.RawFrag
     def literal(key: I18nKey, args: Seq[Matchable], lang: Lang): RawFrag = RawFrag(key.value)

--- a/modules/i18n/src/main/Translator.scala
+++ b/modules/i18n/src/main/Translator.scala
@@ -73,3 +73,18 @@ object Translator extends Translator:
               logger.warn(s"Failed to format txt $lang/$key -> $translation (${args.toList})", e)
               Some(key.value)
         .getOrElse(key.value)
+
+  def duration(
+      duration: java.time.Duration,
+      withMinutes: Option[Boolean] = None,
+      skipDays: Boolean = false
+  )(using lang: Lang): String =
+    val useMinutes = withMinutes.getOrElse(duration.toDays == 0 || skipDays)
+    List(
+      Option.unless(skipDays)(I18nKey.site.nbDays, true, duration.toDays),
+      Some(I18nKey.site.nbHours, true, if skipDays then duration.toHours else duration.toHours % 24),
+      Option.when(useMinutes)(I18nKey.site.nbMinutes, false, duration.toMinutes % 60)
+    ).flatten
+      .dropWhile { (_, dropZero, nb) => dropZero && nb == 0 }
+      .map((key, _, nb) => txt.plural(key, nb, List(nb), lang))
+      .mkString(", ")

--- a/modules/mailer/src/main/AutomaticEmail.scala
+++ b/modules/mailer/src/main/AutomaticEmail.scala
@@ -15,7 +15,7 @@ final class AutomaticEmail(
     mailer: Mailer,
     routeUrl: RouteUrl,
     lightUser: lila.core.user.LightUserApi
-)(using Executor, Translator):
+)(using Executor)(using translator: Translator):
 
   import Mailer.html.*
 
@@ -253,7 +253,7 @@ $disableSettingNotice $disableLink"""
   private def showGame(opponent: CorrespondenceOpponent)(using Lang) =
     val opponentName = opponent.opponentId.fold("Anonymous")(lightUser.syncFallback(_).name)
     opponent.remainingTime.fold(s"It's your turn in your game with $opponentName:"): remainingTime =>
-      s"You have ${lila.core.i18n.translateDuration(remainingTime)} remaining in your game with $opponentName:"
+      s"You have ${translator.duration(remainingTime)} remaining in your game with $opponentName:"
 
   private def alsoSendAsPrivateMessage(user: User)(body: Lang => String): String =
     body(userLang(user)).tap: txt =>

--- a/modules/perfStat/src/main/PerfStatUi.scala
+++ b/modules/perfStat/src/main/PerfStatUi.scala
@@ -168,7 +168,7 @@ final class PerfStatUi(helpers: Helpers)(communityMenu: Context ?=> Frag):
             (count.seconds > 0).option(
               tr(cls := "full")(
                 th(tps.timeSpentPlaying()),
-                td(colspan := "2")(lila.core.i18n.translateDuration(count.duration))
+                td(colspan := "2")(translator.duration(count.duration))
               )
             )
           )
@@ -349,7 +349,7 @@ final class PerfStatUi(helpers: Helpers)(communityMenu: Context ?=> Frag):
   ): Frag =
     div(
       div(cls := "streak")(
-        h3(title(lila.core.i18n.translateDuration(s.duration))),
+        h3(title(translator.duration(s.duration))),
         fromTo(s, u)
       )
     )

--- a/modules/ui/src/main/helper/DateHelper.scala
+++ b/modules/ui/src/main/helper/DateHelper.scala
@@ -65,8 +65,8 @@ trait DateHelper:
       title := s"${showInstant(instant)} UTC"
     )(showDate(instant))
 
-  def showMinutes(minutes: Int)(using Translate): String =
-    lila.core.i18n.translateDuration(Duration.ofMinutes(minutes))
+  def showMinutes(minutes: Int)(using t: Translate): String =
+    t.translator.duration(Duration.ofMinutes(minutes))(using t.lang)
 
   def isoDateTime(instant: Instant): String = isoDateTimeFormatter.print(instant)
 

--- a/modules/ui/src/main/helper/I18nHelper.scala
+++ b/modules/ui/src/main/helper/I18nHelper.scala
@@ -7,7 +7,7 @@ import lila.ui.ScalatagsTemplate.*
 
 trait I18nHelper:
 
-  protected val translator: Translator
+  val translator: Translator
   protected val ratingApi: lila.ui.RatingApi
 
   val langList: LangList


### PR DESCRIPTION
# Why

Fixes #20760
* #20760

# How

Update `translateDuration` helper to allow skipping days in in formatting, add `title` attrs to the play time and featured in TV paragraphs on the user page, which shows play duration in hours.

Also, I have removed unused import according to the warning:
<img width="768" height="128" alt="Screenshot 2026-06-25 at 10 12 30" src="https://github.com/user-attachments/assets/5c5f1e0c-379a-4688-aacf-7ba556b5713e" />

# Preview

<img width="368" height="151" alt="Screenshot 2026-06-25 at 10 25 53" src="https://github.com/user-attachments/assets/e823f75b-c1db-42e3-abbb-94325d9359b2" />

