### PR TITLE
ui: use form3 native checkboxes in simul form

### DIFF
--- a/modules/setup/src/main/ui/SetupUi.scala
+++ b/modules/setup/src/main/ui/SetupUi.scala
@@ -20,16 +20,15 @@ final class SetupUi(helpers: Helpers):
       checks: Set[String] = Set.empty
   ): Frag =
     options.mapWithIndex { case ((value, text, hint), index) =>
+      val id = s"setup-${field.name}-$index"
       div(cls := "checkable")(
         form3.nativeCheckbox(
-          s"${field.name}[$index]",
-          s"${field.name}[$index]",
+          fieldId = id,
+          fieldName = s"${field.name}[$index]",
           checks(value.toString),
           value.toString
         ),
-        label(title := hint, `for` := s"${field.name}[$index]")(
-          raw(text)
-        )
+        label(title := hint, `for` := id)(raw(text))
       )
     }
 

--- a/modules/setup/src/main/ui/SetupUi.scala
+++ b/modules/setup/src/main/ui/SetupUi.scala
@@ -21,14 +21,13 @@ final class SetupUi(helpers: Helpers):
   ): Frag =
     options.mapWithIndex { case ((value, text, hint), index) =>
       div(cls := "checkable")(
-        label(title := hint)(
-          input(
-            tpe := "checkbox",
-            cls := "regular-checkbox",
-            name := s"${field.name}[$index]",
-            st.value := value.toString,
-            checks(value.toString).option(checked)
-          ),
+        form3.nativeCheckbox(
+          s"${field.name}[$index]",
+          s"${field.name}[$index]",
+          checks(value.toString),
+          value.toString
+        ),
+        label(title := hint, `for` := s"${field.name}[$index]")(
           raw(text)
         )
       )

--- a/ui/simul/css/_form.scss
+++ b/ui/simul/css/_form.scss
@@ -7,18 +7,21 @@
   .variants {
     display: flex;
     flex-flow: row wrap;
+    row-gap: 6px;
 
     .checkable {
       flex: 1 1 33%;
       white-space: nowrap;
+      display: flex;
+      gap: 6px;
+      align-items: center;
 
       input {
         margin-inline-end: 0.3em;
+        cursor: pointer;
       }
 
-      label,
-      input {
-        vertical-align: middle;
+      label {
         cursor: pointer;
       }
     }

--- a/ui/simul/css/build/simul.form.scss
+++ b/ui/simul/css/build/simul.form.scss
@@ -1,4 +1,5 @@
 @import '../../../lib/css/plugin';
 @import '../../../lib/css/form/form3';
+@import '../../../lib/css/form/check';
 @import '../../../lib/css/vendor/flatpickr';
 @import '../form';


### PR DESCRIPTION
# Why

Recently spotted that simul create/edit form uses raw HTML checkboxes.

# How

Replace raw checkboxes in simul form with form3 native (styled) checkboxes.

# Preview

https://github.com/user-attachments/assets/aa82874c-5d5d-4eed-ba44-355be1f814eb

