### PR TITLE
ui: only expand toggle box padding when toggle is enabled

### DIFF
--- a/ui/lib/css/component/_toggle-box.scss
+++ b/ui/lib/css/component/_toggle-box.scss
@@ -15,6 +15,8 @@
     text-align: right;
     font-size: 1.2em;
     line-height: 26px;
+    border: 1px solid transparent;
+    border-top-color: $c-border;
 
     &:focus-visible {
       outline: $outline;
@@ -27,8 +29,6 @@
     @include backdrop-blur-if-transparent(10px);
 
     padding: 0.5em 2.5em 0.5em 1.5em;
-    border: 1px solid transparent;
-    border-top-color: $c-border;
     cursor: pointer;
     position: relative;
 

--- a/ui/lib/css/component/_toggle-box.scss
+++ b/ui/lib/css/component/_toggle-box.scss
@@ -11,7 +11,7 @@
     @include prevent-select;
 
     background: $c-bg-zebra;
-    padding: 0.5em 2.5em 0.5em 1.5em;
+    padding: 0.5em 1.5em;
     text-align: right;
     font-size: 1.2em;
     line-height: 26px;
@@ -26,6 +26,7 @@
   legend {
     @include backdrop-blur-if-transparent(10px);
 
+    padding: 0.5em 2.5em 0.5em 1.5em;
     border: 1px solid transparent;
     border-top-color: $c-border;
     cursor: pointer;


### PR DESCRIPTION
# Why

While working on simul checkbox changes I have spotted that after recent toggle box element changes, boxes which are not toggleable have uneven padding.

# How

Expand toggle box right padding only when ability to toggle section is enabled. Add missing border to non-toggleable variant.

# Preview

### Before

<img width="301" height="110" alt="Screenshot 2026-06-25 at 11 40 26" src="https://github.com/user-attachments/assets/ade6d463-9b53-4e8c-be4a-5d6680fc5121" />

### After

<img width="301" height="110" alt="Screenshot 2026-06-25 at 11 43 05" src="https://github.com/user-attachments/assets/ee13398c-8c87-414c-98cc-a1609032bdb9" />

