### PR TITLE
workspace: disable SBT v2 banner

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -122,6 +122,8 @@ jobs:
 
   format:
     runs-on: ubuntu-latest
+    env:
+      SBT_OPTS: -Dsbt.banner=false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0

--- a/.sbtopts.default
+++ b/.sbtopts.default
@@ -4,3 +4,4 @@
 -J-XX:+UseG1GC
 -J-XX:InitialCodeCacheSize=512m
 -J-XX:ReservedCodeCacheSize=512m
+-Dsbt.banner=false


### PR DESCRIPTION
# Why

Since SBT upgrade to v2 each run prints out notice and short changelog which just pollutes log output, i.e:
* https://github.com/lichess-org/lila/actions/runs/28158286951/job/83392124696?pr=20764#step:5:14
* https://github.com/lichess-org/lila/actions/runs/28158286951/job/83392124681?pr=20764#step:6:21

# How

Add `-Dsbt.banner=false` to `.sbtopts.default`. Add `SBT_OPTS` to format job which does not use `lila.sh`.

> This works for me locally, but I modified `.sbtopts` directly which are git-ignored. The default file is a fallback, so it will help for CI workflows, however contributors with existing checkout would probably need to add this flag manually.

# Preview

### Before

<img width="759" height="446" alt="Screenshot 2026-06-25 at 12 07 00" src="https://github.com/user-attachments/assets/61ad4dac-c4e4-45fb-afe0-20199da2ccc9" />

### After

<img width="759" height="287" alt="Screenshot 2026-06-25 at 12 07 18" src="https://github.com/user-attachments/assets/1790fd4e-9177-4822-bf2a-8e6401ce51a0" />
