### PR TITLE
Fix lobby overflow on narrow mobile widths

### DIFF
--- a/ui/lobby/css/_layout.scss
+++ b/ui/lobby/css/_layout.scss
@@ -6,6 +6,11 @@
   grid-template-areas: 'app' 'table' 'side' 'blog' 'support' 'feed' 'tv' 'puzzle' 'tours' 'timeline' 'about';
   gap: $block-gap;
 
+  &__tournaments-simuls {
+    min-width: 0;
+    max-width: 100%;
+  }
+
   &__tournaments,
   &__simuls {
     max-height: 30em;


### PR DESCRIPTION
Fixes #20177

## What changed

Adds shrink constraints to the `.lobby__tournaments-simuls` grid item so it cannot set a wider minimum width than the narrow mobile viewport.

The measured overflow comes from the tournaments/simuls section widening the single-column lobby grid to about 347px on a 330px responsive viewport. Setting `min-width: 0` lets that grid item shrink inside the track, and `max-width: 100%` keeps it capped to the lobby width without applying the rule to every direct lobby child.

## Manual proof

![Before/after narrow lobby overflow proof](https://raw.githubusercontent.com/markoub/lila/proof-lichess-20177/comparison.png)

Chromium responsive viewport, 330px wide, using live lobby markup and the targeted `.lobby__tournaments-simuls` rule:

- Before: `documentScrollWidth` was `347px` for a `330px` viewport.
- After: `documentScrollWidth` is `330px` for the same `330px` viewport.

Proof artifact: https://raw.githubusercontent.com/markoub/lila/proof-lichess-20177/comparison.png

## Validation

- `git diff --check origin/master...HEAD`
- `./ui/build lobby --no-install`
- `pnpm exec stylelint ui/lobby/css/_layout.scss`
- `pnpm exec oxfmt --check ui/lobby/css/_layout.scss`
- Chromium live-page proof at 330px with targeted `.lobby__tournaments-simuls` rule

## AI assistance disclosure

I used OpenAI Codex to inspect issue #20177 and the review feedback, check for duplicate/open PRs, test targeted CSS candidates with Chromium measurements, apply this focused Sass change, refresh the proof artifact, and update this PR message. I reviewed the diff, proof, and validation output, and I understand the submitted change.
