### PR TITLE
Add ceval engine output to browser extension API

### DIFF
--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -739,7 +739,10 @@ export default class AnalyseCtrl implements CevalHandler {
     const opts: CevalOpts = {
       variant: this.data.game.variant,
       initialFen: this.data.game.initialFen,
-      emit: (ev, meta) => this.onNewCeval(ev, meta.path, meta.threatMode),
+      emit: (ev, meta) => {
+        this.onNewCeval(ev, meta.path, meta.threatMode);
+        pubsub.emit('analysis.eval', structuredClone(ev), meta);
+      },
       onUciHover: this.setAutoShapes,
       redraw: this.redraw,
       externalEngines:

--- a/ui/lib/src/api.ts
+++ b/ui/lib/src/api.ts
@@ -5,7 +5,7 @@ import { domDialog, alert, confirm, prompt } from '@/view';
 import { type PubsubEventKey, type PubsubEvents, pubsub } from './pubsub';
 
 // #TODO document these somewhere
-const publicEvents = ['ply', 'analysis.change', 'chat.resize', 'analysis.closeAll'] as const;
+const publicEvents = ['ply', 'analysis.change', 'chat.resize', 'analysis.closeAll', 'analysis.eval'] as const;
 type PublicEventKey = (typeof publicEvents)[number] & keyof PubsubEvents;
 const socketEvents = ['lag', 'close'] as const;
 type SocketEventKey = (typeof socketEvents)[number];

--- a/ui/lib/src/ceval/types.ts
+++ b/ui/lib/src/ceval/types.ts
@@ -91,11 +91,6 @@ export interface CevalEngine {
   destroy(): void;
 }
 
-export interface EvalMeta {
-  path: string;
-  threatMode: boolean;
-}
-
 export type Redraw = () => void;
 export type Progress = (p?: { bytes: number; total: number }) => void;
 

--- a/ui/lib/src/pubsub.ts
+++ b/ui/lib/src/pubsub.ts
@@ -1,7 +1,8 @@
 import type { Line } from '@/chat/interfaces';
 import type { Data as WatchersData } from '@/view/watchers';
 
-import type { TreePath } from './tree/types';
+import type { EvalMeta } from './ceval';
+import type { TreePath, ClientEval } from './tree/types';
 
 export type PubsubEventKey = keyof PubsubEvents;
 
@@ -11,6 +12,7 @@ export interface PubsubEvents {
   'analysis.change': (fen: FEN, path: TreePath) => void;
   'analysis.chart.click': (index: number) => void;
   'analysis.comp.toggle': (enabled: boolean) => void;
+  'analysis.eval': (ev: ClientEval, meta: EvalMeta) => void;
   'analysis.server.progress': (analyseData: any) => void;
   'board.change': (is3d: boolean) => void;
   'challenge-app.open': () => void;


### PR DESCRIPTION
Right now, Lichess Tools digs around in ceval internals, wrapping makeEngine in ceval.ts, to get this data.

This approach will cause problems when changes need to be made to ceval (which is always evolving).

This commit should set a timer and give authors the opportunity to update their extensions. After that, restrict access to ceval and make important bits truly private, starting with engines.

@Siderite