### PR TITLE
Fix narrow embedded LPV movetext layout

### DIFF
--- a/ui/bits/css/build/bits.lpv.scss
+++ b/ui/bits/css/build/bits.lpv.scss
@@ -3,6 +3,47 @@
 @import '../../../lib/css/component/button';
 @import '../../../lib/css/component/pgn-viewer';
 
+@media (max-width: 500px) {
+  .lpv--moves-auto {
+    grid-template-areas:
+      'board'
+      'controls'
+      'side';
+    grid-template-columns: minmax(200px, 100%);
+    grid-template-rows: auto var(--controls-height) 6em;
+
+    .lpv__board,
+    .lpv__controls {
+      width: clamp(200px, calc(100vh - var(--controls-height) - 6em), 100%);
+    }
+
+    .lpv__side {
+      width: 100%;
+    }
+  }
+
+  .lpv--players.lpv--moves-auto {
+    grid-template-areas:
+      'player-top'
+      'board'
+      'player-bot'
+      'controls'
+      'side';
+    grid-template-columns: minmax(200px, 100%);
+    grid-template-rows: 2em auto 2em var(--controls-height) 6em;
+
+    .lpv__player,
+    .lpv__board,
+    .lpv__controls {
+      width: clamp(200px, calc(100vh - 2 * 2em - var(--controls-height) - 6em), 100%);
+    }
+
+    .lpv__side {
+      width: 100%;
+    }
+  }
+}
+
 .lpv--gamebook {
   position: relative;
 }


### PR DESCRIPTION
Fixes #16977.

## What changed

- Stack `showMoves: auto` LPV embeds at widths up to 500px so the movetext panel does not keep the side-by-side minimum width.
- Let the movetext side panel use the full embed width while preserving the existing board/control height budget and the 200px minimum board size.

## Proof

At a 420px embedded LPV viewport, the old CSS kept the stacked movetext panel at 200px wide. With this patch, the same rendered fixture gives a 420px movetext panel and no horizontal document overflow.

![LPV embed movetext comparison](https://raw.githubusercontent.com/markoub/lila/proof-lichess-16977/comparison.png)

Measured with Chromium against compiled `bits.lpv` CSS:

```
before: document.clientWidth=420, movesWidth=200, columns=200px
after:  document.clientWidth=420, movesWidth=420, columns=420px
```

## Validation

- `./ui/build bits --no-install`
- `pnpm exec stylelint ui/bits/css/build/bits.lpv.scss`
- `pnpm exec oxfmt --check ui/bits/css/build/bits.lpv.scss`
- `git diff --check origin/master...HEAD`
- Chromium visual proof at 500, 480, 451, 450, 420, and 360px embed widths

## AI assistance disclosure

I used OpenAI Codex to inspect the reported LPV embed layout issue, locate the relevant Sass entrypoint, implement this scoped CSS change, run the local validation commands above, and generate the manual Chromium proof image. I reviewed the final diff and can explain each line.
