### PR TITLE
Preload preferences i18n for broadcast embed

### DIFF
--- a/app/views/relay.scala
+++ b/app/views/relay.scala
@@ -49,7 +49,7 @@ def embed(
     cssKeys = List("analyse.relay.embed"),
     pageModule = ui.pageModule(rt, data, none, socketVersion, embed = true).some,
     csp = _.withExternalAnalysisApis,
-    i18nModules = List(_.site, _.timeago, _.study, _.broadcast)
+    i18nModules = List(_.site, _.timeago, _.study, _.broadcast, _.preferences)
   )(
     div(id := "main-wrap", cls := "is2d"):
       ui.showPreload(rt, data)(cls := "relay-embed")


### PR DESCRIPTION
Fixes #20775. Same root cause as #20748 / #20749, on a different embed path that fix missed.

## What was wrong

`/embed/broadcast/…` loads the `analyse.study` page module. Since #20644 (`53c2048f6`), the analysis settings view (`ui/analyse/src/view/settingsView.ts`) reads `i18n.preferences.showServerAnalysis` and other `i18n.preferences` keys at **module evaluation time**, and that module is statically imported into the bundle (`analyse.study.ts → start.ts → view/main.ts → tools.ts → actionMenu.ts → settingsView.ts`).

The broadcast embed template (`app/views/relay.scala`) preloads only `site`, `timeago`, `study`, and `broadcast` i18n modules — not `preferences`. So `i18n.preferences` is `undefined` when the bundle runs, throwing `Cannot read properties of undefined (reading 'showServerAnalysis')`, and the board is never created.

#20749 fixed the analogous `/embed/analysis` path (`app/views/analyse.scala`) by adding `preferences` to its preload list; the broadcast embed was not covered.

## Fix

Add the existing `preferences` i18n module to the broadcast embed preload list, so `i18n.preferences` is defined before the analysis bundle runs:

```diff
-    i18nModules = List(_.site, _.timeago, _.study, _.broadcast)
+    i18nModules = List(_.site, _.timeago, _.study, _.broadcast, _.preferences)
```

This mirrors the `_.preferences` selector already used in `app/views/analyse.scala`, so it is type- and format-safe (line is 78 chars, well under the 120 `maxColumn`).

## Manual proof

I verified against the **live broken broadcast embed** by injecting the production `preferences` i18n module (`i18n/preferences.en-US.<hash>.js`) into the embed HTML at the same point this change adds it server-side, then rendering with headless Chromium (Playwright).

| | board (`cg-board`) | `i18n.preferences` | `i18n.preferences.showServerAnalysis` | console |
|---|---|---|---|---|
| before (current prod) | absent — 0 pieces, header only | `undefined` | — | `…reading 'showServerAnalysis'` ×3 |
| after (preferences preloaded) | **present — board + move list** | `object` | `"Show server analysis"` | clean (0 errors) |

Before:

![before — header only, no board](https://raw.githubusercontent.com/wesselvankessel/lila/proof-broadcast-embed-i18n/broadcast-embed-before.png)

After:

![after — board renders](https://raw.githubusercontent.com/wesselvankessel/lila/proof-broadcast-embed-i18n/broadcast-embed-after.png)

The omission-vs-presence of the `preferences` module is also exactly what distinguishes this broken embed from the working **full** broadcast page, which renders the identical `analyse.study` bundle fine because the default `Page` layout (`modules/ui/src/main/Page.scala`) preloads `_.preferences`.

## AI assistance disclosure

Tool used: Claude Code (Claude Opus 4.8).

Prompt summary: I asked it to find out why the broadcast embed renders no board, trace the root cause in the lila source rather than guess, confirm it empirically, check for existing reports/PRs, and prepare a minimal fix. It traced the static import chain into the `analyse.study` bundle, ran a head-to-head browser check (full broadcast page renders with `i18n.preferences` defined; embed crashes with it undefined), found the merged sibling fix #20749, and produced this one-line change mirroring it. I reviewed the change and understand it: the broadcast embed now preloads the same `preferences` i18n catalog its analysis settings code reads at import.
