### PR TITLE
Fix sbt implicit warnings

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,6 @@
 resolvers += Resolver.url(
   "lila-maven-sbt",
-  // sbt 2.0's `url(...)` returns a URI; Resolver.url wants a java.net.URL.
-  new java.net.URI("https://raw.githubusercontent.com/lichess-org/lila-maven/master").toURL
+  new java.net.URL("https://raw.githubusercontent.com/lichess-org/lila-maven/master")
 )(Resolver.ivyStylePatterns)
 
 addSbtPlugin("org.lichess.play" % "sbt-plugin" % "2.0.0-RC2")


### PR DESCRIPTION
Fix
```
lila$ sbt
[info] welcome to sbt 2.0.0 (Eclipse Adoptium Java 21.0.4)
[info] loading project definition from /home/trev/code/lila-docker/repos/lila/project/project/project
[info] loading project definition from /home/trev/code/lila-docker/repos/lila/project/project
[info] Fetching artifacts of lila-build-build_sbt2_3
[info] Fetched artifacts of lila-build-build_sbt2_3
[success] Generated .bloop/lila-build-build.json
[success] elapsed time: 2 s, cache 100%, 14 disk cache hits
-- Warning: /home/trev/code/lila-docker/repos/lila/project/plugins.sbt:5:11 ----
5 |)(Resolver.ivyStylePatterns)
  |  ^^^^^^^^^^^^^^^^^^^^^^^^^
  |Implicit parameters should be provided with a `using` clause.
  |This code can be rewritten automatically under -rewrite -source 3.7-migration.
  |To disable the warning, please use the following option:
  |  "-Wconf:msg=Implicit parameters should be provided with a `using` clause:s"
[info] loading project definition from /home/trev/code/lila-docker/repos/lila/project
[info] Fetching artifacts of lila-build_sbt2_3
[info] Fetched artifacts of lila-build_sbt2_3
[success] Generated .bloop/lila-build.json
[success] elapsed time: 1 s, cache 100%, 14 disk cache hits
[info] resolving key references (104052 settings) ...
[info] set current project to lila (in build file:/home/trev/code/lila-docker/repos/lila/)
[info] sbt server started at local:///home/trev/.config/sbt/2/server/20a403b221c42ae56f2c/sock
[info] started sbt server
```
