### PR TITLE
add GET /api/puzzle/many batch endpoint

### DIFF
--- a/app/controllers/Puzzle.scala
+++ b/app/controllers/Puzzle.scala
@@ -72,6 +72,20 @@ final class Puzzle(env: Env, apiC: => Api) extends LilaController(env):
   def apiSinglePuzzle(puzzle: Puz)(using Context, Perf) =
     JsonOk(env.puzzle.jsonView(puzzle, none, none, withInitialPos = true))
 
+  def apiMany(idsStr: String) = AnonOrScoped(_.Puzzle.Read, _.Web.Mobile): ctx ?=>
+    val ids = idsStr.split(',').take(50).flatMap(Puz.toId).toList
+    val cost =
+      if ctx.isMobileOauth then 0
+      else if HTTPRequest.isLichessMobile(ctx.req) then ids.size / 5
+      else if ctx.isAuth then ids.size / 3
+      else ids.size
+    fetchRateLimit(rateLimited, cost = cost):
+      WithPuzzlePerf:
+        for
+          puzzles <- env.puzzle.api.puzzle.findMany(ids)
+          json <- env.puzzle.jsonView.batch(puzzles)
+        yield JsonOk(json)
+
   def home = Open(serveHome)
 
   def homeLang = LangPage(routes.Puzzle.home.url)(serveHome)

--- a/app/controllers/Puzzle.scala
+++ b/app/controllers/Puzzle.scala
@@ -134,22 +134,14 @@ final class Puzzle(env: Env, apiC: => Api) extends LilaController(env):
   def streakLang = LangPage(routes.Puzzle.streak)(serveStreak)
 
   private def serveStreak(using ctx: Context) = NoBot:
-    FoundPage(streakJsonAndPuzzle): (json, puzzle) =>
+    FoundPage(env.puzzle.streakJsonAndPuzzle): (json, puzzle) =>
       val prefJson = env.puzzle.jsonView.pref(ctx.pref)
       val langPath = LangPath(routes.Puzzle.streak).some
       views.puzzle.ui.show(puzzle, json, prefJson, PuzzleSettings.default, langPath)
     .map(_.noCache.enforceCrossSiteIsolation)
 
-  private def streakJsonAndPuzzle(using Context) =
-    given Perf = lila.rating.Perf.default
-    env.puzzle.streak.apply.flatMapz { case PuzzleStreak(ids, puzzle) =>
-      env.puzzle.jsonView.analysis(puzzle = puzzle, PuzzleAngle.mix).map { puzzleJson =>
-        (puzzleJson ++ Json.obj("streak" -> ids), puzzle).some
-      }
-    }
-
   def apiStreak = Anon:
-    streakJsonAndPuzzle.orNotFound: (json, _) =>
+    env.puzzle.streakJsonAndPuzzle.orNotFound: (json, _) =>
       JsonOk(json)
 
   def apiStreakResult(score: Int) = ScopedBody(_.Puzzle.Write, _.Web.Mobile) { _ ?=> me ?=>

--- a/app/controllers/Puzzle.scala
+++ b/app/controllers/Puzzle.scala
@@ -14,7 +14,6 @@ import lila.puzzle.{
   PuzzleDifficulty,
   PuzzleForm,
   PuzzleSettings,
-  PuzzleStreak,
   PuzzleTheme,
   difficultyCookie
 }
@@ -72,14 +71,9 @@ final class Puzzle(env: Env, apiC: => Api) extends LilaController(env):
   def apiSinglePuzzle(puzzle: Puz)(using Context, Perf) =
     JsonOk(env.puzzle.jsonView(puzzle, none, none, withInitialPos = true))
 
-  def apiMany(idsStr: String) = AnonOrScoped(_.Puzzle.Read, _.Web.Mobile): ctx ?=>
+  def apiMany(idsStr: String) = Scoped(_.Web.Mobile): ctx ?=>
     val ids = idsStr.split(',').take(50).flatMap(Puz.toId).toList
-    val cost =
-      if ctx.isMobileOauth then 0
-      else if HTTPRequest.isLichessMobile(ctx.req) then ids.size / 5
-      else if ctx.isAuth then ids.size / 3
-      else ids.size
-    fetchRateLimit(rateLimited, cost = cost):
+    fetchRateLimit(rateLimited, cost = ids.length / 10):
       WithPuzzlePerf:
         for
           puzzles <- env.puzzle.api.puzzle.findMany(ids)

--- a/conf/routes
+++ b/conf/routes
@@ -734,6 +734,7 @@ GET   /api/puzzle/daily                controllers.Puzzle.apiDaily
 GET   /api/puzzle/activity             controllers.Puzzle.activity
 GET   /api/puzzle/dashboard/$days<\d+> controllers.Puzzle.apiDashboard(days: Days)
 GET   /api/puzzle/$id<\w{5}>           controllers.Puzzle.apiShow(id: PuzzleId)
+GET   /api/puzzle/many                 controllers.Puzzle.apiMany(ids: String)
 GET   /api/puzzle/next                 controllers.Puzzle.apiNext
 POST  /api/puzzle/vote-themes          controllers.Puzzle.apiBatchVoteThemes
 GET   /api/puzzle/batch/:angle         controllers.Puzzle.apiBatchSelect(angle)

--- a/modules/puzzle/src/main/Env.scala
+++ b/modules/puzzle/src/main/Env.scala
@@ -6,6 +6,7 @@ import play.api.Configuration
 import lila.common.autoconfig.{ *, given }
 import lila.core.config.*
 import lila.db.AsyncColl
+import lila.core.i18n.Translate
 
 @Module
 private class PuzzleConfig(
@@ -92,6 +93,12 @@ final class Env(
         logger.warn("daily", e)
         none
       }
+
+  def streakJsonAndPuzzle(using Option[Me], Translate) =
+    given Perf = lila.rating.Perf.default
+    streak.apply.flatMapz { case PuzzleStreak(ids, puzzle) =>
+      jsonView.streak(puzzle = puzzle, ids = ids).dmap(some)
+    }
 
   lila.common.Cli.handle:
     case "puzzle" :: "opening" :: "recompute" :: "all" :: Nil =>

--- a/modules/puzzle/src/main/JsonView.scala
+++ b/modules/puzzle/src/main/JsonView.scala
@@ -10,7 +10,6 @@ import lila.common.Json.given
 import lila.core.i18n.Translate
 import lila.tree.{ Metas, NewBranch, NewTree }
 import lila.core.net.ApiVersion
-import lila.ui.Context
 
 final class JsonView(
     gameJson: GameJson,
@@ -53,8 +52,8 @@ final class JsonView(
       replay: Option[lila.puzzle.PuzzleReplay] = None,
       newMe: Option[Me] = None,
       apiVersion: Option[ApiVersion] = None
-  )(using ctx: Context)(using Perf, Translate): Fu[JsObject] =
-    given me: Option[Me] = newMe.orElse(ctx.me)
+  )(using oldMe: Option[Me])(using Perf, Translate): Fu[JsObject] =
+    given me: Option[Me] = newMe.orElse(oldMe)
     for
       puzzleJson <-
         if apiVersion.exists(v => !ApiVersion.puzzleV2(v))
@@ -62,6 +61,10 @@ final class JsonView(
         else apply(puzzle, angle.some, replay)
       enginesJson <- myEngines.get(me)
     yield puzzleJson ++ enginesJson
+
+  def streak(puzzle: Puzzle, ids: String)(using Translate, Option[Me], Perf) =
+    for puzzleJson <- analysis(puzzle, PuzzleAngle.mix)
+    yield (puzzleJson ++ Json.obj("streak" -> ids), puzzle)
 
   def userJson(using perf: Perf, me: Option[Me]) = me.isDefined.option:
     Json

--- a/modules/puzzle/src/main/PuzzleApi.scala
+++ b/modules/puzzle/src/main/PuzzleApi.scala
@@ -22,6 +22,9 @@ final class PuzzleApi(
     def find(id: PuzzleId): Fu[Option[Puzzle]] =
       colls.puzzle(_.byId[Puzzle](id))
 
+    def findMany(ids: List[PuzzleId]): Fu[List[Puzzle]] =
+      colls.puzzle(_.byOrderedIds[Puzzle, PuzzleId](ids)(_.id))
+
     def of(user: User, page: Int): Fu[Paginator[Puzzle]] =
       colls.puzzle: coll =>
         Paginator(


### PR DESCRIPTION
I want to add a feature to mobile for "offline puzzle streak". To do that, we have to fetch the 125 puzzles. Instead of doing it with N requests, we can add a new API to fetch them as a batch.

Limited to 50 puzzle IDs at a time

Related Draft PR that uses this API: https://github.com/lichess-org/mobile/pull/3393

---
AI Description:

Fetch multiple puzzles by id in one request, preserving order and dropping unknown ids. Lets the mobile puzzle streak prefetch warm its cache with a single windowed request instead of one round-trip per puzzle. Mirrors the auth, cost and JSON envelope of apiBatchSelect.

---
Prompt:
```
We really have to request puzzles one at a time? That's really inefficient right?
For ~/lila code, maybe we should add a batch fetch to the puzzles API?
Can you investigate how difficult it would be to add a batch fetch API for puzzle streak to use on mobile to the lila code?
If you're unsure, please talk with me first about exactly what you're going to make. Whatever it is, the goal is for it to be the best implementation possible for mobile pre-fetching.
```

Model: Claude-Opus-4.8

# Manual Testing
Set up puzzles with
```
git clone https://github.com/lichess-org/lila-db-seed
cd lila-db-seed
mongorestore dump
```

Ran `test-many-api.py`

Observed output
```
anbernal@anbernal-thinkpadt14sgen2i:~/Documents/lila$ python3 test-many-api.py 
=== GET /api/puzzle/many smoke test ===
    host=http://localhost:9663  auth=anonymous
    harvested 106 real puzzle ids from /api/streak

[1] Empty ids param
  PASS  status 200
  PASS  returns 0 puzzles

[2] Malformed tokens (wrong length) are dropped by toId
  PASS  status 200
  PASS  returns 0 puzzles

[3] Valid-length but non-existent ids return nothing
  PASS  status 200
  PASS  returns 0 puzzles

[4] Single valid id
  PASS  status 200
  PASS  returns 1 puzzle
        got 1
  PASS  correct id CHrDT
        got ['CHrDT']
  PASS  puzzle has all expected fields
  PASS  rating is a number
  PASS  solution is a non-empty list
  PASS  game.pgn is a non-empty string
  PASS  no glicko for anonymous caller

[5] Response order matches request order (shuffled)
  PASS  status 200
  PASS  returns all 8
        got 8
  PASS  order matches the shuffled request exactly
        got ['9I26D', '9afDa', '9vAwk', 'C4Ofg', 'Cn6IJ', '3EYNo', 'CHrDT', '3hSNY']

[6] Valid + malformed + non-existent, order preserved
  PASS  status 200
  PASS  returns only the 3 real ids
        got ['CHrDT', '3hSNY', 'Cn6IJ']

[7] Duplicate ids are preserved
  PASS  status 200
  PASS  returns 3 entries
        got 3: ['CHrDT', 'CHrDT', '3hSNY']
  PASS  first two are the duplicate
        got ['CHrDT', 'CHrDT']

[8] 50 ids (at the .take(50) cap)
  PASS  status 200
  PASS  returns 50 puzzles
        got 50
  PASS  all 50 present

[9] 60 ids (over cap — extras past 50 dropped)
  PASS  status 200
  PASS  returns exactly 50 (capped)
        got 50
  PASS  only the first 50 requested are returned
  PASS  real ids past the cap are dropped

  PASS  total est. rate-limit cost 118 stays under budget 300

=== 30/30 passed, 0 failed (est. cost 118/300) ===
```
Logs: [server-puzzle-logs.txt](https://github.com/user-attachments/files/29354863/server-puzzle-logs.txt)

Test script: [test-many-api.py](https://github.com/user-attachments/files/29354750/test-many-api.py)
