### PR TITLE
Keep tournament bare links clickable with Markdown links

### DIFF
--- a/modules/common/src/main/RawHtml.scala
+++ b/modules/common/src/main/RawHtml.scala
@@ -180,6 +180,26 @@ object RawHtml:
       }
 
   private val markdownLinkRegex = """\[([^]]++)\]\((https?://[^)]++)\)""".r
+
+  def markdownLinksAndRichText(rawText: String, expandImg: Boolean = true)(using NetDomain): Html =
+    val m = markdownLinkRegex.pattern.matcher(rawText)
+    if !m.find then addLinks(rawText, expandImg)
+    else
+      val sb = jStringBuilder(rawText.length + 200)
+      var lastAppendIdx = 0
+
+      while
+        sb.append(addLinks(rawText.substring(lastAppendIdx, m.start), expandImg).value)
+        val content = escapeHtmlRaw(m.group(1))
+        val href = escapeHtmlRaw(removeUrlTrackingParameters(m.group(2)))
+        sb.append(s"""<a rel="nofollow noopener noreferrer" href="$href">$content</a>""")
+        lastAppendIdx = m.end
+        m.find
+      do ()
+
+      sb.append(addLinks(rawText.substring(lastAppendIdx), expandImg).value)
+      Html(sb.toString)
+
   def justMarkdownLinks(escapedHtml: Html): Html = Html:
     markdownLinkRegex.replaceAllIn(
       escapedHtml.value,

--- a/modules/common/src/main/String.scala
+++ b/modules/common/src/main/String.scala
@@ -74,10 +74,7 @@ object String:
       html.map(org.apache.commons.text.StringEscapeUtils.unescapeHtml4)
 
     def markdownLinksOrRichText(text: String)(using NetDomain): Frag =
-      val escaped = Html(escapeHtmlRaw(text))
-      val marked = RawHtml.justMarkdownLinks(escaped)
-      if marked == escaped then richText(text)
-      else nl2brUnsafe(marked.value)
+      RawHtml.nl2br(RawHtml.markdownLinksAndRichText(text).value).frag
 
     def safeJsonValue(jsValue: JsValue): SafeJsonStr = SafeJsonStr:
       // Borrowed from:

--- a/modules/web/src/test/common/StringTest.scala
+++ b/modules/web/src/test/common/StringTest.scala
@@ -30,6 +30,13 @@ class StringTest extends munit.FunSuite:
         """a <a rel="nofollow noreferrer" href="https://example.com/foo--" target="_blank">example.com/foo--</a>. b"""
     )
 
+  test("markdownLinksOrRichText keeps bare URLs clickable with markdown links"):
+    assertEquals(
+      String.html.markdownLinksOrRichText("https://lichess.org\n[lichess](https://lichess.org)"),
+      raw:
+        """<a href="/">lichess.org</a><br><a rel="nofollow noopener noreferrer" href="https://lichess.org">lichess</a>"""
+    )
+
   def extractPosts(s: String) = String.forumPostPathRegex.findAllMatchIn(s).toList.map(_.group(1))
 
   test("richText forum post path regex find forum post path"):


### PR DESCRIPTION
Fixes #16986.

Tournament and Swiss descriptions use `markdownLinksOrRichText`, which previously chose either Markdown links or rich-text auto-linking for the whole description. Once a description contained one Markdown link, bare URLs elsewhere in the same description stayed plain text.

This keeps Markdown links on their existing rendering path while running the existing rich-text linker on the plain text before, between, and after Markdown links.

Manual proof:

- Reproduced the issue with this renderer input before the fix:
  `https://lichess.org\n[lichess](https://lichess.org)`
- Before:
  `https://lichess.org<br><a rel="nofollow noopener noreferrer" href="https://lichess.org">lichess</a>`
- After:
  `<a href="/">lichess.org</a><br><a rel="nofollow noopener noreferrer" href="https://lichess.org">lichess</a>`
- `markdownLinksOrRichText` is the renderer used by tournament and Swiss descriptions.

Validation:

- `git diff --check origin/master...HEAD`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21 ./lila.sh 'web/testOnly lila.common.StringTest lila.common.RawHtmlTest'`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21 ./lila.sh scalafmtCheckAll`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21 ./lila.sh compile`

AI assistance disclosure:

- Tool used: OpenAI Codex.
- Prompt used: Fix lichess-org/lila#16986 by keeping bare URLs clickable when tournament or Swiss descriptions contain Markdown links; preserve existing Markdown-link behavior, add focused Scala coverage, run validation, and include manual proof.
