### PR TITLE
Avoid duplicate study chapter Sortable setup

### DIFF
--- a/ui/analyse/src/study/studyChapters.ts
+++ b/ui/analyse/src/study/studyChapters.ts
@@ -159,14 +159,27 @@ function onListUpdate(ctrl: StudyCtrl, vnode: VNode) {
   const vData = vnode.data!.li!,
     el = vnode.elm as HTMLElement;
   ctrl.chapters.scroller.scrollIfNeeded(el);
-  if (ctrl.members.canContribute() && ctrl.chapters.list.size() > 1 && !vData.sortable) {
-    site.asset.loadEsm<typeof Sortable>('sortable.esm', { npm: true }).then(s => {
-      vData.sortable = s.create(el, {
-        draggable: '.draggable',
-        handle: 'ontouchstart' in window ? 'span' : undefined,
-        onSort: () => ctrl.chapters.sort(vData.sortable.toArray()),
-      });
-    });
+  if (
+    ctrl.members.canContribute() &&
+    ctrl.chapters.list.size() > 1 &&
+    !vData.sortable &&
+    !vData.sortableLoading
+  ) {
+    vData.sortableLoading = true;
+    site.asset.loadEsm<typeof Sortable>('sortable.esm', { npm: true }).then(
+      s => {
+        vData.sortableLoading = false;
+        if (vData.destroyed || vData.sortable) return;
+        vData.sortable = s.create(el, {
+          draggable: '.draggable',
+          handle: 'ontouchstart' in window ? 'span' : undefined,
+          onSort: () => ctrl.chapters.sort(vData.sortable.toArray()),
+        });
+      },
+      () => {
+        vData.sortableLoading = false;
+      },
+    );
   }
 }
 
@@ -199,7 +212,10 @@ export function view(ctrl: StudyCtrl): VNode {
             onListUpdate(ctrl, vnode);
           },
           destroy: vnode => {
-            const sortable: Sortable = vnode.data!.li!.sortable;
+            const vData = vnode.data!.li!,
+              sortable: Sortable = vData.sortable;
+            vData.destroyed = true;
+            vData.sortable = undefined;
             if (sortable) sortable.destroy();
           },
         },

--- a/ui/analyse/tests/studyChapters.test.ts
+++ b/ui/analyse/tests/studyChapters.test.ts
@@ -1,0 +1,121 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+function ctrlStub() {
+  return {
+    members: { canContribute: () => true },
+    chapters: {
+      list: {
+        size: () => 2,
+        all: () => [
+          { id: 'chapter-a', name: 'Chapter A' },
+          { id: 'chapter-b', name: 'Chapter B' },
+        ],
+      },
+      scroller: {
+        request: () => {},
+        scrollIfNeeded: () => {},
+      },
+      sort: () => {},
+      editForm: {
+        isEditing: () => false,
+        toggle: () => {},
+      },
+      toggleNewForm: () => {},
+    },
+    currentChapter: () => ({ id: 'chapter-a' }),
+    vm: { loading: false },
+    setChapter: () => {},
+    redraw: () => {},
+  } as any;
+}
+
+async function studyListVNode() {
+  document.documentElement.lang = 'en-US';
+  installIndexedDbStub();
+  const { view } = await import('../src/study/studyChapters');
+  const vnode = (view(ctrlStub()) as any).children[0];
+  vnode.elm = document.createElement('div');
+  return vnode;
+}
+
+function installIndexedDbStub() {
+  const request: any = {
+    result: {
+      objectStoreNames: { contains: () => true },
+      transaction: () => ({ objectStore: () => ({}) }),
+      close: () => {},
+    },
+  };
+  Object.defineProperty(window, 'indexedDB', {
+    value: {
+      open: () => {
+        setTimeout(() => request.onsuccess?.({ target: request }), 0);
+        return request;
+      },
+      deleteDatabase: () => {},
+    },
+    configurable: true,
+  });
+}
+
+function deferSortableLoad() {
+  const resolvers: ((module: any) => void)[] = [];
+  let loadCalls = 0;
+  let createCalls = 0;
+
+  (site as any).asset = {
+    loadEsm: () => {
+      loadCalls++;
+      return new Promise(resolve => resolvers.push(resolve));
+    },
+  };
+
+  const sortableModule = {
+    create: () => {
+      createCalls++;
+      return {
+        toArray: () => [],
+        destroy: () => {},
+      };
+    },
+  };
+
+  return {
+    get loadCalls() {
+      return loadCalls;
+    },
+    get createCalls() {
+      return createCalls;
+    },
+    resolveAll: () => resolvers.splice(0).forEach(resolve => resolve(sortableModule)),
+  };
+}
+
+test('study chapter list queues one Sortable initializer while the asset is loading', async () => {
+  const loader = deferSortableLoad();
+  const vnode = await studyListVNode();
+
+  vnode.data.hook.insert(vnode);
+  vnode.data.hook.postpatch(vnode, vnode);
+
+  assert.equal(loader.loadCalls, 1);
+
+  loader.resolveAll();
+  await new Promise(resolve => setTimeout(resolve, 0));
+
+  assert.equal(loader.createCalls, 1);
+});
+
+test('study chapter list skips Sortable creation after the vnode is destroyed', async () => {
+  const loader = deferSortableLoad();
+  const vnode = await studyListVNode();
+
+  vnode.data.hook.insert(vnode);
+  vnode.data.hook.destroy(vnode);
+
+  loader.resolveAll();
+  await new Promise(resolve => setTimeout(resolve, 0));
+
+  assert.equal(loader.createCalls, 0);
+});


### PR DESCRIPTION
Fixes #16849.

## What changed

- Track when the study chapter list is already loading `sortable.esm`, so repeated snabbdom updates do not queue duplicate `Sortable.create` calls for the same chapter-list element.
- Skip late Sortable creation if the vnode was destroyed before the async module load resolved.
- Clear the stored Sortable reference on destroy.
- Add focused analyse tests for the duplicate-load and destroy-before-resolve lifecycle paths.

## Root cause

The study chapter list could run `onListUpdate` again before `site.asset.loadEsm("sortable.esm")` resolved. During that window `vData.sortable` was still unset, so each update could queue another async initializer for the same DOM element. The issue reporter traced this to multiple Sortable registrations for the same `.study__chapters` element, which later left null Sortable entries and caused Sortable to read `.options` from `null` on mouse interaction.

## Manual proof

- Issue repro path: open a study with multiple chapters, start computer analysis, then move between chapters without turning analysis off.
- Focused lifecycle reproduction before the fix: the new `studyChapters.test.ts` cases failed with duplicate queued loads (`2 !== 1`) and a late Sortable create after vnode destroy (`1 !== 0`).
- After the fix, the same lifecycle tests pass and cover the reported duplicate async initialization path directly.

## Validation

- `./ui/test analyse`
- `./ui/build analyse --no-install`
- `pnpm exec oxfmt --check ui/analyse/src/study/studyChapters.ts ui/analyse/tests/studyChapters.test.ts`
- `pnpm exec oxlint --type-aware ui/analyse/src/study/studyChapters.ts ui/analyse/tests/studyChapters.test.ts`
- `git diff --check origin/master...HEAD`

## AI assistance disclosure

- Tool used: OpenAI Codex.
- Prompt used: Fix lichess-org/lila#16849 by preventing duplicate async Sortable initialization in the study chapter list, add focused lifecycle regression tests, run validation, and include manual proof.
