### PR TITLE
lint: re-enable two lint rules, fix warnings

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -244,8 +244,6 @@
     "no-control-regex": "off",
     "no-unused-expressions": "off",
     "typescript/no-base-to-string": "off",
-    "typescript/no-duplicate-type-constituents": "off",
-    "typescript/no-explicit-any": "off",
     "typescript/no-floating-promises": "off",
     "typescript/no-misused-spread": "off",
     "typescript/no-redundant-type-constituents": "off",

--- a/ui/botDev/src/botDev.ts
+++ b/ui/botDev/src/botDev.ts
@@ -27,7 +27,7 @@ interface LocalPlayDevOpts extends LocalPlayOpts {
 
 export async function initModule(opts: LocalPlayDevOpts): Promise<void> {
   if (opts.pgn && opts.name) {
-    makeEnv({ bot: new DevBotCtrl(), assets: new DevAssets() });
+    makeEnv({ bot: new DevBotCtrl(), assets: new DevAssets(undefined) });
     await Promise.all([env.bot.init(), env.assets.init()]);
     await env.assets.importPgn(
       opts.name,

--- a/ui/botDev/src/botDev.user.ts
+++ b/ui/botDev/src/botDev.user.ts
@@ -21,7 +21,7 @@ export default async function initModule(opts: LocalPlayOpts): Promise<void> {
     bot: new DevBotCtrl(),
     db: new LocalDb(),
     game: new GameCtrl(opts),
-    assets: new DevAssets(),
+    assets: new DevAssets(undefined),
   });
   await Promise.all([env.db.init(), env.bot.init()]);
   const setup = hashOpts();

--- a/ui/botDev/src/devAssets.ts
+++ b/ui/botDev/src/devAssets.ts
@@ -38,7 +38,7 @@ export class DevAssets {
     {} as Record<AssetType, Map<string, string>>,
   );
 
-  constructor(public rlist?: AssetList | undefined) {
+  constructor(public rlist: AssetList | undefined) {
     this.update(rlist);
     window.addEventListener('storage', this.onStorageEvent);
   }

--- a/ui/coordinateTrainer/src/ctrl.ts
+++ b/ui/coordinateTrainer/src/ctrl.ts
@@ -87,7 +87,7 @@ export default class CoordinateTrainerCtrl {
 
     window.addEventListener('resize', () => requestAnimationFrame(this.updateCharts), true);
     this.voice = makeVoice({ redraw: this.redraw, tpe: 'coords' });
-    this.voice.mic.initRecognizer([...'abcdefgh', ...Object.keys(rankWords), 'start', 'stop'], {
+    this.voice.mic.initRecognizer([...Array.from('abcdefgh'), ...Object.keys(rankWords), 'start', 'stop'], {
       partial: true,
       listener: this.onVoice.bind(this),
     });

--- a/ui/dgt/src/dgt.ts
+++ b/ui/dgt/src/dgt.ts
@@ -2,5 +2,9 @@ import configPage from './config';
 import playPage from './play';
 
 export function initModule(token?: string): void {
-  token ? playPage(token) : configPage();
+  if (token) {
+    playPage(token);
+  } else {
+    configPage();
+  }
 }

--- a/ui/dgt/src/play.ts
+++ b/ui/dgt/src/play.ts
@@ -1172,7 +1172,11 @@ export default function (token: string): void {
   function padBeforeNumbers(moveString: string) {
     let paddedMoveString = '';
     for (const c of moveString) {
-      Number.isInteger(Number(c)) ? (paddedMoveString += ` ${c} `) : (paddedMoveString += c);
+      if (Number.isInteger(Number(c))) {
+        paddedMoveString += ` ${c} `;
+      } else {
+        paddedMoveString += c;
+      }
     }
     return paddedMoveString;
   }

--- a/ui/editor/src/ctrl.ts
+++ b/ui/editor/src/ctrl.ts
@@ -207,7 +207,7 @@ export default class EditorCtrl {
   // https://github.com/niklasf/chessops/issues/154
   private getEnPassantOptions(fen: FEN): string[] {
     const unpackRank = (packedRank: string) =>
-      [...packedRank].reduce((accumulator, current) => {
+      Array.from(packedRank).reduce((accumulator, current) => {
         const parsedInt = parseInt(current);
         return accumulator + (parsedInt >= 1 ? 'x'.repeat(parsedInt) : current);
       }, '');
@@ -293,7 +293,7 @@ export default class EditorCtrl {
     return this.setFen(parts.join(' '));
   };
 
-  loadNewFen(fen: FEN | 'prompt'): void {
+  loadNewFen(fen: FEN): void {
     if (fen === 'prompt') prompt('Paste FEN position').then(fen => fen && this.setFen(fen.trim()));
     else this.setFen(fen);
   }

--- a/ui/lib/src/ceval/engines/engines.ts
+++ b/ui/lib/src/ceval/engines/engines.ts
@@ -189,7 +189,7 @@ export class Engines {
             wasm: 'stockfish.wasm',
           },
         },
-        make: (e: BrowserEngineInfo) => new ThreadedEngine(e),
+        make: (e: BrowserEngineInfo) => new ThreadedEngine(e, undefined),
       },
       {
         info: {

--- a/ui/lib/src/ceval/engines/externalEngine.ts
+++ b/ui/lib/src/ceval/engines/externalEngine.ts
@@ -31,7 +31,7 @@ export class ExternalEngine implements CevalEngine {
 
   constructor(
     private readonly opts: ExternalEngineInfo,
-    private readonly status?: EngineNotifier | undefined,
+    private readonly status: EngineNotifier | undefined,
   ) {}
 
   getState(): CevalState {

--- a/ui/lib/src/ceval/engines/stockfishWebEngine.ts
+++ b/ui/lib/src/ceval/engines/stockfishWebEngine.ts
@@ -19,7 +19,7 @@ export class StockfishWebEngine implements CevalEngine {
 
   constructor(
     readonly info: BrowserEngineInfo,
-    readonly status?: EngineNotifier | undefined,
+    readonly status: EngineNotifier | undefined,
   ) {
     this.protocol = new Protocol();
     this.boot().catch(e => {

--- a/ui/lib/src/ceval/engines/threadedEngine.ts
+++ b/ui/lib/src/ceval/engines/threadedEngine.ts
@@ -38,7 +38,7 @@ export class ThreadedEngine implements CevalEngine {
 
   constructor(
     readonly info: BrowserEngineInfo,
-    readonly status?: EngineNotifier | undefined,
+    readonly status: EngineNotifier | undefined,
     readonly variantMap?: (v: string) => string,
   ) {}
 

--- a/ui/lib/src/game/sanWriter.ts
+++ b/ui/lib/src/game/sanWriter.ts
@@ -90,7 +90,7 @@ function slidingMovesTo(s: number, deltas: number[], board: Board): number[] {
  * but lacks the check/checkmate flag,
  * and probably has incomplete disambiguation.
  * But it's quick. */
-export function almostSanOf(board: Board, uci: string, legalUcis?: Set<Uci> | undefined): AlmostSan {
+export function almostSanOf(board: Board, uci: string, legalUcis?: Set<Uci>): AlmostSan {
   if (uci.includes('@')) return fixCrazySan(uci);
 
   const move = decomposeUci(uci);

--- a/ui/voice/src/move/voice.move.ts
+++ b/ui/voice/src/move/voice.move.ts
@@ -488,7 +488,10 @@ export function initModule({
       if (!'PNBRQK'.includes(xouts)) continue;
       const moves = spread(set).filter(x => x.length > 2);
       if (moves.length > maxArrows()) moves.forEach(x => remove(squares, xouts, x));
-      else if (moves.length > 0) [...set].filter(x => x.length === 2).forEach(x => remove(squares, xouts, x));
+      else if (moves.length > 0)
+        Array.from(set)
+          .filter(x => x.length === 2)
+          .forEach(x => remove(squares, xouts, x));
     }
     if (DEBUG.buildSquares) console.info('buildSquares', squares);
   }
@@ -582,7 +585,9 @@ export function initModule({
   }
 
   function toksVals(toks: string) {
-    return [...toks].map(tok => byTok.get(tok)?.val).join(',');
+    return Array.from(toks)
+      .map(tok => byTok.get(tok)?.val)
+      .join(',');
   }
 
   function tagWords(tags?: string[], intersect = false) {
@@ -629,7 +634,11 @@ export function initModule({
   }
 
   function valsWords(vals: string): string[] {
-    return valsToks(vals).map(toks => [...toks].map(tok => tokWord(tok)).join(' '));
+    return valsToks(vals).map(toks =>
+      Array.from(toks)
+        .map(tok => tokWord(tok))
+        .join(' '),
+    );
   }
 
   function valWord(val: string, tag?: string) {


### PR DESCRIPTION
# Why

Next, small batch in the efforts of improving codebase quality.

# How

Re-enable two lint rules:
* `typescript/no-duplicate-type-constituents` - enabled fully by default, suppression got removed, but unfortunately had to add explicit `undefined` in few calls due to [`isolatedDeclaration` TypeScript option](https://www.typescriptlang.org/tsconfig/#isolatedDeclarations)
* `typescript/no-explicit-any` - no longer a part of active by default rules, but still there are 300+ warnings to address before we can fully enable it

Fix few more cases by temporary disabling rules suppressions, for rules which cannot be enabled due to some major blockers requiring TypeScript config changes or bigger refactors.