### PR TITLE
strongly typed socket communication for simul

### DIFF
--- a/ui/lib/src/socket.ts
+++ b/ui/lib/src/socket.ts
@@ -44,12 +44,12 @@ interface Params extends Record<string, any> {
   flag?: string;
 }
 
-interface Settings {
-  receive?: (t: Tpe, d: Payload) => void;
+type Settings<T = Tpe> = {
+  receive?: (t: T, d: Payload) => void;
   events: Record<string, (d: Payload | null, msg: MsgIn) => any>;
   params?: Partial<Params>;
   options?: Partial<Options>;
-}
+};
 
 export interface SocketSendOpts {
   sign: string;
@@ -58,7 +58,11 @@ export interface SocketSendOpts {
   millis?: number;
 }
 
-export function wsConnect(url: string, version: number | false, settings: Partial<Settings> = {}): WsSocket {
+export function wsConnect<T extends string = Tpe>(
+  url: string,
+  version: number | false,
+  settings: Partial<Settings<T>> = {},
+): WsSocket {
   return (siteSocket = new WsSocket(url, version, settings));
 }
 

--- a/ui/simul/src/simul.ts
+++ b/ui/simul/src/simul.ts
@@ -7,13 +7,14 @@ import type { SimulOpts } from './interfaces';
 
 const patch = init([classModule, attributesModule]);
 
+import type { SimulTpe } from './socket';
 import view from './view/main';
 
 export function initModule(opts: SimulOpts) {
   const element = document.querySelector('main.simul') as HTMLElement;
 
-  opts.socketSend = wsConnect(`/simul/${opts.data.id}/socket/v4`, opts.socketVersion, {
-    receive: (t: string, d: any) => ctrl.socket.receive(t, d),
+  opts.socketSend = wsConnect<SimulTpe>(`/simul/${opts.data.id}/socket/v4`, opts.socketVersion, {
+    receive: (tpe, data) => ctrl.socket.receive({ tpe, data }),
   }).send;
   opts.element = element;
   opts.$side = $('.simul__side').clone();

--- a/ui/simul/src/socket.ts
+++ b/ui/simul/src/socket.ts
@@ -1,29 +1,36 @@
 import type SimulCtrl from './ctrl';
 import type { SimulData } from './interfaces';
 
-export interface SimulSocket {
+type SimulMessage =
+  | { tpe: 'reload'; data: SimulData }
+  | { tpe: 'aborted' }
+  | { tpe: 'hostGame'; data: string };
+
+export type SimulTpe = SimulMessage['tpe'];
+export type SimulSocket = {
   send: SocketSend;
-  receive(tpe: string, data: any): void;
-}
+  receive(message: SimulMessage): void | false;
+};
 
-export function makeSocket(send: SocketSend, ctrl: SimulCtrl) {
-  const handlers: any = {
-    reload(data: SimulData) {
-      ctrl.reload(data);
-      ctrl.redraw();
-    },
-    aborted: site.reload,
-    hostGame(gameId: string) {
-      ctrl.data.host.gameId = gameId;
-      ctrl.redraw();
-    },
-  };
-
+export function makeSocket(send: SocketSend, ctrl: SimulCtrl): SimulSocket {
   return {
     send,
-    receive(tpe: string, data: any) {
-      if (handlers[tpe]) return handlers[tpe](data);
-      return false;
+    receive(message) {
+      switch (message.tpe) {
+        case 'reload':
+          ctrl.reload(message.data);
+          ctrl.redraw();
+          return;
+        case 'aborted':
+          site.reload();
+          return;
+        case 'hostGame':
+          ctrl.data.host.gameId = message.data;
+          ctrl.redraw();
+          return;
+        default:
+          return false;
+      }
     },
   };
 }


### PR DESCRIPTION
# Why

While working on lint rules and going through the `any` usages I have spotted that many of the cases came from sockets usage. This PR shows how to achieve strong typed data structure for socket communication, using Simul as an example use-case.

# How

Summary of changes:
* update socket helper to accept message type unions generic, fallback to string to match previous type
* pass data via object to Simul socket 
* refactor `makeSocket` to allow strongly typed communication, relay on switch for code clarity and better TS type matching