### PR TITLE
lint: add `typescript/no-unnecessary-type-conversion` rule, fix typo

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -54,6 +54,7 @@
     "typescript/no-unnecessary-type-arguments": "error",
     "typescript/no-unnecessary-type-assertion": "error",
     "typescript/no-unnecessary-type-constraint": "error",
+    "typescript/no-unnecessary-type-conversion": "error",
     "typescript/prefer-find": "error",
     "typescript/prefer-includes": "error",
     "typescript/prefer-readonly": "error",

--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -20,7 +20,6 @@ import {
   requestIdleCallbackSafe,
   propWithEffect,
   type Prop,
-  type Toggle,
 } from 'lib';
 import { CevalCtrl, isFirstEvalBetter, sanIrreversible, type CevalHandler, type CevalOpts } from 'lib/ceval';
 import { ChatCtrl } from 'lib/chat/chatCtrl';
@@ -72,8 +71,8 @@ export default class AnalyseCtrl implements CevalHandler {
   evalCache: EvalCache;
   liveAnnotate?: LiveAnnotate;
   navigate: Navigate;
-  idbTree: IdbTree = new IdbTree(this);
-  actionMenu: Toggle = toggle(false);
+  idbTree = new IdbTree(this);
+  actionMenu = toggle(false);
   isEmbed: boolean;
 
   // current tree state, cursor, and denormalized node lists
@@ -109,12 +108,9 @@ export default class AnalyseCtrl implements CevalHandler {
   flipped = false;
   showComments = true; // whether to display comments in the move tree
   settings: SettingsCtrl;
-  private readonly showCevalProp: Prop<boolean> = storedBooleanProp(
-    'analyse.show-engine',
-    !!this.cevalEnabledProp(),
-  );
-  keyboardHelp: boolean = location.hash === '#keyboard';
-  threatMode: Prop<boolean> = prop(false);
+  private readonly showCevalProp = storedBooleanProp('analyse.show-engine', this.cevalEnabledProp());
+  keyboardHelp = location.hash === '#keyboard';
+  threatMode = prop(false);
 
   treeView: TreeView;
   cgVersion = {
@@ -378,7 +374,7 @@ export default class AnalyseCtrl implements CevalHandler {
           color: movableColor,
           dests: (movableColor === color && dests) || new Map(),
         },
-        check: !!node.check(),
+        check: node.check(),
         lastMove: uciToMove(node.uci),
       };
     config.premovable = {

--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -20,6 +20,7 @@ import {
   requestIdleCallbackSafe,
   propWithEffect,
   type Prop,
+  type Toggle,
 } from 'lib';
 import { CevalCtrl, isFirstEvalBetter, sanIrreversible, type CevalHandler, type CevalOpts } from 'lib/ceval';
 import { ChatCtrl } from 'lib/chat/chatCtrl';
@@ -71,8 +72,8 @@ export default class AnalyseCtrl implements CevalHandler {
   evalCache: EvalCache;
   liveAnnotate?: LiveAnnotate;
   navigate: Navigate;
-  idbTree = new IdbTree(this);
-  actionMenu = toggle(false);
+  idbTree: IdbTree = new IdbTree(this);
+  actionMenu: Toggle = toggle(false);
   isEmbed: boolean;
 
   // current tree state, cursor, and denormalized node lists
@@ -108,9 +109,12 @@ export default class AnalyseCtrl implements CevalHandler {
   flipped = false;
   showComments = true; // whether to display comments in the move tree
   settings: SettingsCtrl;
-  private readonly showCevalProp = storedBooleanProp('analyse.show-engine', this.cevalEnabledProp());
-  keyboardHelp = location.hash === '#keyboard';
-  threatMode = prop(false);
+  private readonly showCevalProp: Prop<boolean> = storedBooleanProp(
+    'analyse.show-engine',
+    this.cevalEnabledProp(),
+  );
+  keyboardHelp: boolean = location.hash === '#keyboard';
+  threatMode: Prop<boolean> = prop(false);
 
   treeView: TreeView;
   cgVersion = {

--- a/ui/analyse/src/study/interfaces.ts
+++ b/ui/analyse/src/study/interfaces.ts
@@ -144,14 +144,14 @@ interface StudyChapterFeatures {
 
 export type StudyMember = {
   user: {
-    id: string;
+    id: UserId;
     name: string;
     title?: string;
   };
   role: string;
 };
 
-export type StudyMemberMap = Record<string, StudyMember>;
+export type StudyMemberMap = Record<UserId, StudyMember>;
 
 export type TagTypes = string[];
 export type TagArray = [string, string];

--- a/ui/analyse/src/study/studyCtrl.ts
+++ b/ui/analyse/src/study/studyCtrl.ts
@@ -336,7 +336,7 @@ export default class StudyCtrl {
   isCevalAllowed = () =>
     (!this.relay?.tourShow() || site.blindMode) &&
     !this.isGamebookPlay() &&
-    !!(this.data.chapter.features.computer || this.data.chapter.practice);
+    (this.data.chapter.features.computer || this.data.chapter.practice);
 
   configurePractice = () => {
     if (!this.data.chapter.practice && this.ctrl.practice) this.ctrl.togglePractice();
@@ -532,7 +532,7 @@ export default class StudyCtrl {
     return i < 0 ? undefined : chs[i + delta];
   };
   prevChapter = () => this.deltaChapter(-1);
-  nextChapter = () => this.deltaChapter(+1);
+  nextChapter = () => this.deltaChapter(1);
   hasNextChapter = () => {
     const chs = this.chapters.list.all();
     return chs[chs.length - 1].id !== this.vm.chapterId;

--- a/ui/analyse/src/study/studyMembers.ts
+++ b/ui/analyse/src/study/studyMembers.ts
@@ -39,7 +39,7 @@ function memberActivity(onIdle: () => void) {
 
 export class StudyMemberCtrl {
   dict: Prop<StudyMemberMap>;
-  confing = prop<string | null>(null);
+  config = prop<string | null>(null);
   inviteForm: StudyInviteFormCtrl;
   readonly active: Map<string, () => void> = new Map();
   online: Record<string, boolean> = {};
@@ -90,7 +90,7 @@ export class StudyMemberCtrl {
   };
 
   update = (members: StudyMemberMap) => {
-    if (this.isOwner()) this.confing(Object.keys(members).find(sri => !this.dict()[sri]) || null);
+    if (this.isOwner()) this.config(Object.keys(members).find(sri => !this.dict()[sri]) || null);
     const wasViewer = this.myMember() && !this.canContribute();
     const wasContrib = this.myMember() && this.canContribute();
     this.dict(members);
@@ -111,11 +111,11 @@ export class StudyMemberCtrl {
   setRole = (userId: string, role: string) => {
     this.setActive(userId);
     this.opts.send('setRole', { userId, role });
-    this.confing(null);
+    this.config(null);
   };
   kick = (id: string) => {
     this.opts.send('kick', id);
-    this.confing(null);
+    this.config(null);
   };
   leave = () => this.opts.send('leave');
   ordered = () => {
@@ -159,7 +159,7 @@ export function view(ctrl: StudyCtrl): VNode {
         attrs: dataIcon(licon.Gear),
         hook: bind(
           'click',
-          () => members.confing(members.confing() === member.user.id ? null : member.user.id),
+          () => members.config(members.config() === member.user.id ? null : member.user.id),
           ctrl.redraw,
         ),
       });
@@ -205,13 +205,13 @@ export function view(ctrl: StudyCtrl): VNode {
     hl(
       'div.study-list',
       ordered.flatMap(member => {
-        const confing = members.confing() === member.user.id;
+        const config = members.config() === member.user.id;
         return [
-          hl('div', { key: member.user.id, class: { editing: !!confing } }, [
+          hl('div', { key: member.user.id, class: { editing: config } }, [
             hl('div.left', [statusIcon(member), userLink({ ...member.user, line: false })]),
             configButton(ctrl, member),
           ]),
-          confing && memberConfig(member),
+          config && memberConfig(member),
         ];
       }),
     ),

--- a/ui/analyse/src/study/studyMembers.ts
+++ b/ui/analyse/src/study/studyMembers.ts
@@ -16,8 +16,8 @@ import type StudyCtrl from './studyCtrl';
 
 interface Opts {
   initDict: StudyMemberMap;
-  myId?: string;
-  ownerId: string;
+  myId?: UserId;
+  ownerId: UserId;
   send: AnalyseSocketSend;
   tab: Prop<Tab>;
   startTour(): void;
@@ -39,11 +39,11 @@ function memberActivity(onIdle: () => void) {
 
 export class StudyMemberCtrl {
   dict: Prop<StudyMemberMap>;
-  config = prop<string | null>(null);
+  config = prop<UserId | null>(null);
   inviteForm: StudyInviteFormCtrl;
-  readonly active: Map<string, () => void> = new Map();
-  online: Record<string, boolean> = {};
-  spectatorIds: string[] = [];
+  readonly active: Map<UserId, () => void> = new Map();
+  online: Record<UserId, boolean> = {};
+  spectatorIds: UserId[] = [];
   max = 30;
 
   constructor(readonly opts: Opts) {
@@ -65,7 +65,7 @@ export class StudyMemberCtrl {
 
   canContribute = (): boolean => this.myMember()?.role === 'w';
 
-  setActive = (id: string) => {
+  setActive = (id: UserId) => {
     if (this.opts.tab() !== 'members') return;
     const active = this.active.get(id);
     if (active) active();

--- a/ui/analyse/src/view/components.ts
+++ b/ui/analyse/src/view/components.ts
@@ -77,7 +77,7 @@ export function viewContext(ctrl: AnalyseCtrl, deps?: typeof studyDeps): ViewCon
     playerBars,
     playerStrips: playerBars ? undefined : renderPlayerStrips(ctrl),
     gaugeOn: ctrl.showEvalGauge(),
-    needsInnerCoords: ctrl.data.pref.showCaptured || !!ctrl.showEvalGauge() || !!playerBars,
+    needsInnerCoords: ctrl.data.pref.showCaptured || ctrl.showEvalGauge() || !!playerBars,
     hasRelayTour: ctrl.study?.relay?.tourShow() || false,
   };
 }

--- a/ui/botDev/src/devEnv.ts
+++ b/ui/botDev/src/devEnv.ts
@@ -29,6 +29,5 @@ export class DevEnv {
     Object.assign(this, cfg);
     env = this;
     if (this.game) this.game.observer = this.dev;
-    this.canPost = Boolean(this.canPost);
   }
 }

--- a/ui/botDev/src/devEnv.ts
+++ b/ui/botDev/src/devEnv.ts
@@ -14,7 +14,7 @@ export function makeEnv(cfg: Partial<DevEnv>): DevEnv {
 }
 
 export class DevEnv {
-  canPost: boolean;
+  canPost?: boolean;
   game: GameCtrl;
   db: LocalDb;
   bot: DevBotCtrl;
@@ -29,5 +29,6 @@ export class DevEnv {
     Object.assign(this, cfg);
     env = this;
     if (this.game) this.game.observer = this.dev;
+    this.canPost = Boolean(this.canPost);
   }
 }

--- a/ui/dgt/src/play.ts
+++ b/ui/dgt/src/play.ts
@@ -507,13 +507,11 @@ export default function (token: string): void {
         }
       } else {
         //Position match found
-        if (currentGameId !== playableGames[Number(index)].gameId) {
+        if (currentGameId !== playableGames[index].gameId) {
           //This is the happy path, board matches and game needs to be updated
           if (verbose)
-            console.log(
-              'chooseCurrentGame - Position matched to gameId: ' + playableGames[Number(index)].gameId,
-            );
-          currentGameId = playableGames[Number(index)].gameId;
+            console.log('chooseCurrentGame - Position matched to gameId: ' + playableGames[index].gameId);
+          currentGameId = playableGames[index].gameId;
           attachCurrentGameIdToDGTBoard(); //Let the board know which color the player is actually playing and setup the position
           console.log('Active game updated. currentGameId: ' + currentGameId);
         } else {

--- a/ui/learn/src/run/runView.ts
+++ b/ui/learn/src/run/runView.ts
@@ -39,7 +39,7 @@ export const runView = (ctrl: LearnCtrl) => {
   const rootClass: Classes = {
     starting: !!levelCtrl.vm.starting,
     completed: levelCtrl.vm.completed && !levelCtrl.blueprint.nextButton,
-    'last-step': !!levelCtrl.vm.lastStep,
+    'last-step': levelCtrl.vm.lastStep,
     'piece-values': !!levelCtrl.blueprint.showPieceValues,
   };
   if (stage.cssClass) rootClass[stage.cssClass] = true;

--- a/ui/puzzle/src/ctrl.ts
+++ b/ui/puzzle/src/ctrl.ts
@@ -313,7 +313,7 @@ export default class PuzzleCtrl implements CevalHandler {
       premovable: {
         enabled: false,
       },
-      check: !!node.check(),
+      check: node.check(),
       lastMove: uciToMove(node.uci),
     };
     if (node.ply >= this.initialNode.ply) {

--- a/ui/puzzle/src/view/feedback.ts
+++ b/ui/puzzle/src/view/feedback.ts
@@ -7,7 +7,7 @@ import afterView from './after';
 
 const viewSolution = (ctrl: PuzzleCtrl): VNode =>
   ctrl.streak
-    ? h('div.view_solution.skip', { class: { show: !!ctrl.streak?.data.skip } }, [
+    ? h('div.view_solution.skip', { class: { show: ctrl.streak?.data.skip } }, [
         requiresI18n('storm', ctrl.redraw, cat =>
           h(
             'button.button.button-empty',

--- a/ui/site/src/domHandlers.ts
+++ b/ui/site/src/domHandlers.ts
@@ -80,7 +80,7 @@ export function addDomHandlers() {
   });
 
   $('.user-autocomplete').each(function (this: HTMLInputElement) {
-    const focus = !!this.autofocus;
+    const focus = this.autofocus;
     const start = () =>
       userComplete({
         input: this,

--- a/ui/storm/src/view/end.ts
+++ b/ui/storm/src/view/end.ts
@@ -44,7 +44,7 @@ const renderSummary = (ctrl: StormCtrl): LooseVNodes => {
           hl('tr', [hl('th', i18n.storm.moves), hl('td', hl('number', `${run.moves}`))]),
           hl('tr', [
             hl('th', i18n.storm.accuracy),
-            hl('td', [hl('number', accuracy ? Number(accuracy).toFixed(1) : '-'), '%']),
+            hl('td', [hl('number', accuracy ? accuracy.toFixed(1) : '-'), '%']),
           ]),
           hl('tr', [hl('th', i18n.storm.combo), hl('td', hl('number', `${ctrl.run.combo.best}`))]),
           hl('tr', [
@@ -53,7 +53,7 @@ const renderSummary = (ctrl: StormCtrl): LooseVNodes => {
           ]),
           hl('tr', [
             hl('th', i18n.storm.timePerMove),
-            hl('td', [hl('number', run.time ? Number(run.time / run.moves).toFixed(2) : 0), 's']),
+            hl('td', [hl('number', run.time ? (run.time / run.moves).toFixed(2) : 0), 's']),
           ]),
           hl('tr', [hl('th', i18n.storm.highestSolved), hl('td', hl('number', `${run.highest}`))]),
         ]),


### PR DESCRIPTION
# How

Add [`typescript/no-unnecessary-type-conversion` lint rule](https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-unnecessary-type-conversion.html), fix `confing` typo.