### PR TITLE
Fix lobby filter labels on narrow mobile widths

### DIFF
--- a/ui/lobby/css/app/_hook-filters.scss
+++ b/ui/lobby/css/app/_hook-filters.scss
@@ -17,15 +17,21 @@
   }
 
   .checkable {
-    @extend %nowrap-ellipsis;
-
+    display: flex;
+    align-items: flex-start;
+    gap: 2px;
+    min-width: 0;
     padding: 4px 2px 4px 0;
+    white-space: normal;
 
-    label {
-      display: inline-flex;
-      align-items: center;
-      gap: 2px;
+    > .form-check__input {
+      flex: 0 0 auto;
+    }
+
+    > label {
       cursor: pointer;
+      min-width: 0;
+      overflow-wrap: break-word;
     }
 
     input {
@@ -73,7 +79,7 @@
   }
 
   tr.inline .checkable {
-    display: inline-block;
+    display: inline-flex;
     padding: 6px 20px 2px 0;
   }
 
@@ -138,7 +144,7 @@
     }
 
     tr.variant .checkable {
-      width: 50%;
+      width: 100%;
     }
   }
 }


### PR DESCRIPTION
Fixes #20789

## What changed

- Makes lobby filter option rows lay out the checkbox and text label separately, so the text can wrap without clipping the whole `.checkable` row.
- Narrows the lobby label selector to the direct text label, leaving the shared `.form-check__label` checkbox styling intact.
- Uses one variant option per row at the smallest mobile breakpoint instead of the cramped two-column layout that turns labels into ellipses.

## Manual proof

![Before/after narrow lobby filter proof](https://raw.githubusercontent.com/markoub/lila/proof-lichess-20789/comparison.png)

Chromium proof at a 315px-wide lobby filter panel using the generated `/setup/filter` markup shape and the targeted filter CSS rules:

- Before: the `King of the Hill` row had `checkableScrollWidth` `143px` for a `91px` row, so the row clipped to ellipses; the checkbox label computed as `display: inline-flex` because the generic lobby label rule reached `.form-check__label`.
- After: the same row has `checkableScrollWidth` `182px` for a `182px` row, so there is no horizontal clipping; the checkbox label computes as `display: block`, matching the shared form checkbox styling.

Proof artifact: https://raw.githubusercontent.com/markoub/lila/proof-lichess-20789/comparison.png

## Validation

- `pnpm install --frozen-lockfile`
- `./ui/build lobby --no-install`
- `pnpm exec stylelint ui/lobby/css/app/_hook-filters.scss`
- `pnpm exec oxfmt --check ui/lobby/css/app/_hook-filters.scss`
- `git diff --check origin/master...HEAD`
- Chromium visual proof with a 315px-wide lobby filter panel

## AI assistance disclosure

I used OpenAI Codex to inspect issue #20789, check for duplicate/open PRs, review the lobby filter markup and Sass, prototype and validate the focused CSS change, generate the Chromium proof image, and draft this PR text. I reviewed the diff, validation output, and proof, and I understand the submitted change.
