### PR TITLE
ui: apply custom cursor only over main board in board editor

### DIFF
--- a/ui/editor/css/_spare.scss
+++ b/ui/editor/css/_spare.scss
@@ -17,6 +17,7 @@
 
   .no-square {
     flex: 0 0 12.5%;
+    cursor: pointer;
 
     @include transition;
 

--- a/ui/editor/src/view.ts
+++ b/ui/editor/src/view.ts
@@ -497,15 +497,11 @@ export default function (ctrl: EditorCtrl): VNode {
   const state = ctrl.getState();
   const color = ctrl.bottomColor();
 
-  return h(
-    `div.board-editor.board-editor--${ctrl.variant}`,
-    { attrs: { style: `cursor: ${makeCursor(ctrl.selected())}` } },
-    [
-      sparePieces(ctrl, opposite(color), color, 'top'),
-      h('div.main-board', [chessground(ctrl)]),
-      sparePieces(ctrl, color, color, 'bottom'),
-      controls(ctrl, state),
-      inputs(ctrl, state.legalFen || state.fen),
-    ],
-  );
+  return h(`div.board-editor.board-editor--${ctrl.variant}`, [
+    sparePieces(ctrl, opposite(color), color, 'top'),
+    h('div.main-board', { attrs: { style: `cursor: ${makeCursor(ctrl.selected())}` } }, [chessground(ctrl)]),
+    sparePieces(ctrl, color, color, 'bottom'),
+    controls(ctrl, state),
+    inputs(ctrl, state.legalFen || state.fen),
+  ]);
 }


### PR DESCRIPTION
# Why

Spotted that custom cursor in board editor is applied over whole page container, while piece spawn functionality only works over the main board.

# How

Move board editor piece spawn custom cursor style to `main-board`, to retain correct cursor over container and interactive elements on the page. Add cursor pointer to the pieces drawer.

# Preview

https://github.com/user-attachments/assets/6e1af425-106f-4347-840e-7894f70bab9c

