### PR TITLE
reduce top edge of button and hover box shadows a bit

### DIFF
--- a/ui/lib/css/abstract/_mixins.scss
+++ b/ui/lib/css/abstract/_mixins.scss
@@ -169,7 +169,7 @@
 
 @mixin with-metal-shadow($defaultShadow: (), $lightShadow: (), $soft: false) {
   box-shadow:
-    inset 0 if($soft == true, 1px, 2px) 3px -2px hsl(0, 0%, if($soft == true, 30%, 45%)),
+    inset 0 1px 3px -2px hsl(0, 0%, if($soft == true, 30%, 45%)),
     inset 0 -4px 6px -3px $m-body-gradient--lighten-3,
     if($defaultShadow != (), 0 1px 3px 0 $defaultShadow, ());
 
@@ -187,7 +187,7 @@
 
 @mixin with-metal-hover-shadow($defaultShadow: (), $lightShadow: (), $soft: false) {
   box-shadow:
-    inset 0 if($soft == true, 2px, 3px) 3px -2px $c-border-light,
+    inset 0 1px 3px -2px $c-border-light,
     inset 0 -5px 8px -3px $m-body-gradient--lighten-5,
     if($defaultShadow != (), 0 2px 4px 0 $defaultShadow, ());
 
@@ -205,7 +205,7 @@
 
 @mixin with-button-shadow($topShadow: (), $bottomShadow: (), $lighTopShadow: (), $lightBottomShadow: ()) {
   box-shadow:
-    inset 0 2px 3px -2px $topShadow,
+    inset 0 1px 3px -2px $topShadow,
     inset 0 -4px 6pt -3pt $bottomShadow,
     0 1px 3px 0 hsla(0, 0, 0%, 0.2);
 
@@ -218,7 +218,7 @@
 
   &:not(.disabled, :disabled, [disabled]):hover {
     box-shadow:
-      inset 0 2px 3px -2px $topShadow,
+      inset 0 1px 3px -2px $topShadow,
       inset 0 -5px 6pt -3pt $bottomShadow,
       0 2px 4px 0 hsla(0, 0, 0%, 0.24);
 


### PR DESCRIPTION
dark mode only tweak. The current "lit from above" effect on some buttons can clash a bit with the flatter elements used elsewhere on the site.

## before:
<img width="359" height="146" alt="image" src="https://github.com/user-attachments/assets/6533ca19-7768-4ced-8dc4-aae2b2983a45" />
<img width="450" height="210" alt="image" src="https://github.com/user-attachments/assets/23f2a9f9-f8c6-4e59-8065-4e87e3123d87" />
<img width="540" height="165" alt="image" src="https://github.com/user-attachments/assets/8956f477-d4f6-48c0-a6df-f7cd1ea6ec23" />

## after:
<img width="359" height="146" alt="image" src="https://github.com/user-attachments/assets/e5a6f51b-6fff-4920-ac2f-fdb3d7c49d61" />
<img width="450" height="210" alt="image" src="https://github.com/user-attachments/assets/cf666fdf-d522-457e-b7a8-7895228ca86f" />
<img width="540" height="165" alt="image" src="https://github.com/user-attachments/assets/e9809922-8a79-4992-a9f0-0aac711427e7" />

