### PR TITLE
Piece maneuver arrows settings defaulted back to off

### DIFF
--- a/ui/analyse/src/settingsCtrl.ts
+++ b/ui/analyse/src/settingsCtrl.ts
@@ -9,7 +9,7 @@ export class Settings {
     public readonly disclosureMode = false,
     public readonly showLiveGlyphs = false,
     public readonly showBestMoveArrows = true,
-    public readonly showManeuverMoveArrows = true,
+    public readonly showManeuverMoveArrows = false,
     public readonly showVariationArrows = true,
     public readonly showMoveAnnotationsOnBoard = true,
     public readonly showUndefendedPieces = false,


### PR DESCRIPTION
## Fixes #20756: Engine analysis suggests invalid moves

### Why
Piece maneuver arrows being on by default seems unintuitive. This isn't the first time this has come up -  #19250.

Now defaults maneuver arrows setting back to off as set in a472e982a59745c2709ca43949d1c38c94ad81f2. Looks like this was accidentally changed by a refactor. 