### PR TITLE
workspace: add few import related lint rules

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -14,7 +14,6 @@
         "null": "ignore"
       }
     ],
-    "import/no-cycle": "error",
     "no-constant-condition": [
       "warn",
       {
@@ -41,6 +40,10 @@
     "object-shorthand": "error",
     "prefer-const": "error",
     "prefer-promise-reject-errors": "error",
+    "import/no-cycle": "error",
+    "import/no-duplicates": "error",
+    "import/no-named-as-default-member": "error",
+    "import/no-self-import": "error",
     "promise/no-callback-in-promise": "error",
     "promise/no-multiple-resolved": "error",
     "promise/no-return-wrap": "error",

--- a/ui/bits/src/bits.confetti.ts
+++ b/ui/bits/src/bits.confetti.ts
@@ -1,4 +1,4 @@
-import confetti from 'canvas-confetti';
+import { create, type Options } from 'canvas-confetti';
 
 function randomInRange(min: number, max: number): number {
   return Math.random() * (max - min) + min;
@@ -18,7 +18,7 @@ export function initModule(
   const canvas = document.querySelector<HTMLCanvasElement>('canvas#confetti');
   if (!canvas) return;
 
-  const party = confetti.create(canvas, {
+  const party = create(canvas, {
     disableForReducedMotion: true,
     useWorker: true,
     resize: true,
@@ -40,7 +40,7 @@ export function initModule(
   }
 
   const cannons = () => {
-    const fire = (custom: confetti.Options) =>
+    const fire = (custom: Options) =>
       party({
         scalar: 0.9,
         gravity: 0.3,
@@ -69,7 +69,7 @@ export function initModule(
   };
 
   const fireworks = () => {
-    const opts: confetti.Options = {
+    const opts: Options = {
       spread: 360,
       ticks: 80,
       gravity: 0.15,

--- a/ui/bits/src/bits.confetti.ts
+++ b/ui/bits/src/bits.confetti.ts
@@ -1,4 +1,4 @@
-import { create, type Options } from 'canvas-confetti';
+import { create as createCanvas, type Options as CanvasOptions } from 'canvas-confetti';
 
 function randomInRange(min: number, max: number): number {
   return Math.random() * (max - min) + min;
@@ -18,7 +18,7 @@ export function initModule(
   const canvas = document.querySelector<HTMLCanvasElement>('canvas#confetti');
   if (!canvas) return;
 
-  const party = create(canvas, {
+  const party = createCanvas(canvas, {
     disableForReducedMotion: true,
     useWorker: true,
     resize: true,
@@ -40,7 +40,7 @@ export function initModule(
   }
 
   const cannons = () => {
-    const fire = (custom: Options) =>
+    const fire = (custom: CanvasOptions) =>
       party({
         scalar: 0.9,
         gravity: 0.3,
@@ -69,7 +69,7 @@ export function initModule(
   };
 
   const fireworks = () => {
-    const opts: Options = {
+    const opts: CanvasOptions = {
       spread: 360,
       ticks: 80,
       gravity: 0.15,

--- a/ui/chart/src/chart.ratingHistory.ts
+++ b/ui/chart/src/chart.ratingHistory.ts
@@ -17,7 +17,7 @@ import dayjs from 'dayjs';
 import dayOfYear from 'dayjs/plugin/dayOfYear';
 import duration from 'dayjs/plugin/duration';
 import utc from 'dayjs/plugin/utc';
-import noUiSlider, { type Options, PipsMode } from 'nouislider';
+import { create, type Options, PipsMode } from 'nouislider';
 
 import { memoize } from 'lib';
 import { pubsub } from 'lib/pubsub';
@@ -233,7 +233,7 @@ export function initModule({ data, singlePerfName }: Opts): void {
     },
   };
   if (handlesSlider) {
-    const slider = noUiSlider.create(handlesSlider, opts);
+    const slider = create(handlesSlider, opts);
     const slide = (values: (number | string)[]) => {
       $('.time-selector-buttons button').removeClass('active');
       if ($el.hasClass('panning')) return;

--- a/ui/chart/src/chart.ratingHistory.ts
+++ b/ui/chart/src/chart.ratingHistory.ts
@@ -17,7 +17,7 @@ import dayjs from 'dayjs';
 import dayOfYear from 'dayjs/plugin/dayOfYear';
 import duration from 'dayjs/plugin/duration';
 import utc from 'dayjs/plugin/utc';
-import { create, type Options, PipsMode } from 'nouislider';
+import { create as createSlider, type Options, PipsMode } from 'nouislider';
 
 import { memoize } from 'lib';
 import { pubsub } from 'lib/pubsub';
@@ -233,7 +233,7 @@ export function initModule({ data, singlePerfName }: Opts): void {
     },
   };
   if (handlesSlider) {
-    const slider = create(handlesSlider, opts);
+    const slider = createSlider(handlesSlider, opts);
     const slide = (values: (number | string)[]) => {
       $('.time-selector-buttons button').removeClass('active');
       if ($el.hasClass('panning')) return;


### PR DESCRIPTION
# How

Add few more import related lint rules:
* `import/no-duplicates`
* `import/no-named-as-default-member`
* `import/no-self-import`

There were not many warnings, the ones fixed in the changeset comes from `import/no-named-as-default-member` rule, and force the individual member import over default ones (is given members have individual exports defined). This helps with tree shaking and reduces the import footprint.
