### PR TITLE
workspace: add two performance oriented lint checks

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -64,12 +64,14 @@
     "unicorn/no-immediate-mutation": "error",
     "unicorn/no-unnecessary-array-flat-depth": "error",
     "unicorn/no-useless-collection-argument": "error",
+    "unicorn/prefer-array-find": "error",
     "unicorn/prefer-array-flat": "error",
     "unicorn/prefer-array-flat-map": "error",
     "unicorn/prefer-array-some": "error",
     "unicorn/prefer-date-now": "error",
     "unicorn/prefer-keyboard-event-key": "error",
     "unicorn/prefer-node-protocol": "error",
+    "unicorn/prefer-set-has": "error",
     "unicorn/require-number-to-fixed-digits-argument": "error",
     "no-restricted-globals": [
       "error",
@@ -261,7 +263,8 @@
       "rules": {
         "await-thenable": "off",
         "no-unused-vars": "off",
-        "prefer-const": "off"
+        "prefer-const": "off",
+        "unicorn/prefer-set-has": "off"
       }
     },
     {

--- a/ui/analyse/src/study/studyTags.ts
+++ b/ui/analyse/src/study/studyTags.ts
@@ -119,7 +119,7 @@ function renderPgnTags(tags: TagsForm, showRatings: boolean): VNode {
       .map(tag => [tag[0], tags.editable() ? editable(tag[0], tag[1], tags.submit) : fixed(tag)]),
   );
   if (tags.editable()) {
-    const existingTypes = chapter.tags.map(t => t[0]);
+    const existingTypes = new Set(chapter.tags.map(t => t[0]));
     rows.push([
       h(
         'select.button.button-metal',
@@ -143,7 +143,7 @@ function renderPgnTags(tags: TagsForm, showRatings: boolean): VNode {
         },
         [
           h('option', i18n.study.newTag),
-          ...tags.types.map(t => (!existingTypes.includes(t) ? option(t, '', t) : undefined)),
+          ...tags.types.map(t => (!existingTypes.has(t) ? option(t, '', t) : undefined)),
         ],
       ),
       editable('', '', (_, value, el) => {

--- a/ui/analyse/src/view/nvuiView.ts
+++ b/ui/analyse/src/view/nvuiView.ts
@@ -493,11 +493,12 @@ function sendMove(uciOrDrop: string | DropMove, ctrl: AnalyseCtrl) {
   else if (ctrl.crazyValid(uciOrDrop.role, uciOrDrop.key)) ctrl.sendNewPiece(uciOrDrop.role, uciOrDrop.key);
 }
 
+const analysisGlyphs = new Set(['?!', '?', '??']);
+
 function renderAcpl({ ctrl, moveStyle }: AnalyseNvuiContext): LooseVNodes {
   const analysis = ctrl.data.analysis;
   if (!analysis || ctrl.retro) return undefined;
-  const analysisGlyphs = ['?!', '?', '??'];
-  const analysisNodes = ctrl.mainline.filter(n => n.glyphs?.find(g => analysisGlyphs.includes(g.symbol)));
+  const analysisNodes = ctrl.mainline.filter(n => n.glyphs?.find(g => analysisGlyphs.has(g.symbol)));
   const res: Array<VNode> = [];
   COLORS.forEach(color => {
     res.push(hl('h3', `${color} player: ${analysis[color].acpl} ${i18n.site.averageCentipawnLoss}`));

--- a/ui/bits/src/bits.teamBattleForm.ts
+++ b/ui/bits/src/bits.teamBattleForm.ts
@@ -22,11 +22,13 @@ site.load.then(() => {
         search(term: string, searchCallback: (res: Team[]) => void) {
           xhr.json(xhr.url('/team/autocomplete', { term }), { cache: 'default' }).then(
             (res: Team[]) => {
-              const current = textarea.value
-                .split('\n')
-                .map(t => t.split(' ')[0])
-                .slice(0, -1);
-              searchCallback(res.filter(t => !current.includes(t.id)));
+              const current = new Set(
+                textarea.value
+                  .split('\n')
+                  .map(t => t.split(' ')[0])
+                  .slice(0, -1),
+              );
+              searchCallback(res.filter(t => !current.has(t.id)));
             },
             _ => searchCallback([]),
           );

--- a/ui/msg/src/view/enhance.ts
+++ b/ui/msg/src/view/enhance.ts
@@ -69,7 +69,7 @@ const domain = window.location.host;
 const gameRegex = new RegExp(
   `(?:https?://)${domain}/(?:embed/)?(?:game/)?(\\w{8})(?:(?:/(white|black))|\\w{4}|)(?:(?:#)(\\d+))?$`,
 );
-const notGames = [
+const notGames = new Set([
   'training',
   'analysis',
   'insights',
@@ -78,7 +78,7 @@ const notGames = [
   'password',
   'streamer',
   'timeline',
-];
+]);
 
 export function expandLpvs(el: HTMLElement) {
   const expandables: Expandable[] = [];
@@ -130,7 +130,7 @@ const expandGame = async (exp: Expandable) => {
 
 function parseLink(a: HTMLAnchorElement): Link | undefined {
   const [id, orientation, initialPly] = Array.from(a.href.match(gameRegex) || []).slice(1);
-  if (id && !notGames.includes(id))
+  if (id && !notGames.has(id))
     return {
       type: 'game',
       src: `/embed/game/${id}`,

--- a/ui/puzzle/src/view/nvuiView.ts
+++ b/ui/puzzle/src/view/nvuiView.ts
@@ -255,9 +255,9 @@ const isYourMove = (ctrl: PuzzleCtrl): boolean =>
 const browseHint = (ctrl: PuzzleCtrl): string[] =>
   ctrl.mode !== 'view' && !isYourMove(ctrl) ? [i18n.site.youBrowsedAway] : [];
 
-const shortCommands = ['b', 'l', 'last', 'p', 's', 'v'];
+const shortCommands = new Set(['b', 'l', 'last', 'p', 's', 'v']);
 
-const isShortCommand = (input: string): boolean => shortCommands.includes(input.split(' ')[0].toLowerCase());
+const isShortCommand = (input: string): boolean => shortCommands.has(input.split(' ')[0].toLowerCase());
 
 function onCommand(ctrl: PuzzleCtrl, notify: (txt: string) => void, c: string, style: nv.MoveStyle): void {
   const lowered = c.toLowerCase();

--- a/ui/round/src/premove.ts
+++ b/ui/round/src/premove.ts
@@ -132,8 +132,8 @@ export class Premove {
                 .filter(s => this.canEnemyPawnAdvanceToSquare(enemySquare, s, ctx)),
             ]
           : [];
-        const badSquares = [...squaresBetween, ctx.orig.key];
-        if (enemyPawnDests.every(square => badSquares.includes(square))) return false;
+        const badSquares = new Set([...squaresBetween, ctx.orig.key]);
+        if (enemyPawnDests.every(square => badSquares.has(square))) return false;
       }
     }
     if (!squaresOfFriendliesBetween.length) return true;


### PR DESCRIPTION
# How

Add two performance oriented lint rules:
* [`unicorn/prefer-array-find`](https://oxc.rs/docs/guide/usage/linter/rules/unicorn/prefer-array-find.html)
* [`unicorn/prefer-set-has`](https://oxc.rs/docs/guide/usage/linter/rules/unicorn/prefer-set-has.html)

Only `unicorn/prefer-set-has` yield some warnings which has been fixed. I have also disabled the rule for scripts in `/bin` and `/cron` for the convenience (it's not production code anyway).