### PR TITLE
ui: re-enable few Stylelint rules, fix warnings, style tweaks

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -3,11 +3,21 @@
   "extends": "stylelint-config-standard-scss",
   "rules": {
     "alpha-value-notation": "number",
-    "block-no-redundant-nested-style-rules": null,
     "color-function-alias-notation": null,
     "color-function-notation": ["legacy", { "ignore": ["with-var-inside"] }],
     "custom-property-pattern": null,
-    "declaration-block-no-redundant-longhand-properties": null,
+    "declaration-block-no-redundant-longhand-properties": [
+      true,
+      {
+        "ignoreLonghands": [
+          "overflow-x",
+          "overflow-y",
+          "grid-template-columns",
+          "grid-template-rows",
+          "grid-template-areas"
+        ]
+      }
+    ],
     "font-family-no-missing-generic-family-keyword": null,
     "hue-degree-notation": "number",
     "media-feature-range-notation": null,

--- a/ui/analyse/css/study/panel/_metadata.scss
+++ b/ui/analyse/css/study/panel/_metadata.scss
@@ -31,11 +31,11 @@
       cursor: pointer;
       opacity: 0.7;
       transition: 0.3s;
-    }
 
-    .liking:hover {
-      opacity: 1;
-      color: $c-bad;
+      &:hover {
+        opacity: 1;
+        color: $c-bad;
+      }
     }
   }
 }
@@ -69,16 +69,16 @@
     border: none;
     background: none;
     width: 100%;
-  }
 
-  input:hover,
-  input:focus {
-    background: $m-primary_bg--mix-10;
-  }
+    &:hover,
+    &:focus {
+      background: $m-primary_bg--mix-10;
+    }
 
-  input:invalid {
-    border: 1px solid $c-bad;
-    color: $c-bad;
+    &:invalid {
+      border: 1px solid $c-bad;
+      color: $c-bad;
+    }
   }
 
   select {

--- a/ui/analyse/css/study/relay/_tour.scss
+++ b/ui/analyse/css/study/relay/_tour.scss
@@ -667,7 +667,7 @@
       align-items: center;
       gap: 0.5em;
       background: $c-bg-zebra;
-      padding: 1em 1em;
+      padding: 1em;
 
       &.active span {
         color: $c-brag;

--- a/ui/bits/css/_titleRequest.scss
+++ b/ui/bits/css/_titleRequest.scss
@@ -56,7 +56,7 @@
   @extend %flex-center-nowrap, %box-neat;
 
   margin-bottom: 2em;
-  padding: 2em 2em;
+  padding: 2em;
   background: $c-bg-zebra;
   font-size: 1.2em;
 

--- a/ui/bits/css/build/bits.slist.scss
+++ b/ui/bits/css/build/bits.slist.scss
@@ -8,15 +8,20 @@
 
 .slist td {
   vertical-align: middle;
-}
 
-.slist td .lb__trophy {
-  display: inline-block;
-  vertical-align: middle;
-  margin-right: 6px;
-  margin-left: -4px;
-  overflow: visible;
-  line-height: 0;
+  .lb__trophy {
+    display: inline-block;
+    vertical-align: middle;
+    margin-right: 6px;
+    margin-left: -4px;
+    overflow: visible;
+    line-height: 0;
+  }
+
+  .lb__rank-num {
+    display: inline-block;
+    vertical-align: middle;
+  }
 }
 
 .slist .lb__trophy img {
@@ -26,11 +31,6 @@
   vertical-align: middle;
   transform: scale(1.6) translateY(-2px);
   transform-origin: left center;
-}
-
-.slist td .lb__rank-num {
-  display: inline-block;
-  vertical-align: middle;
 }
 
 .pager__label {

--- a/ui/bits/css/streamer/_header.scss
+++ b/ui/bits/css/streamer/_header.scss
@@ -24,8 +24,7 @@
 
   .metas {
     display: flex;
-    justify-content: space-between;
-    align-content: center;
+    place-content: center space-between;
   }
 
   h1 {

--- a/ui/bits/css/team/_admin.scss
+++ b/ui/bits/css/team/_admin.scss
@@ -75,11 +75,11 @@
 }
 
 .team-add-leader {
+  margin-bottom: $box-padding-vert;
+
   &__input {
     display: flex;
   }
-
-  margin-bottom: $box-padding-vert;
 
   .error {
     color: $c-bad;

--- a/ui/botDev/css/_edit-dialog.scss
+++ b/ui/botDev/css/_edit-dialog.scss
@@ -5,7 +5,7 @@
   background-color: $c-bg-zebra;
 
   button {
-    padding: 0.8em 0.8em;
+    padding: 0.8em;
   }
 
   textarea {

--- a/ui/keyboardMove/css/_keyboardMove.scss
+++ b/ui/keyboardMove/css/_keyboardMove.scss
@@ -30,8 +30,7 @@
 .keyboard-move-help {
   td.tips li {
     list-style: disc;
-    margin-inline-start: 2em;
-    margin-inline-end: 1em;
+    margin-inline: 2em 1em;
   }
 
   a {

--- a/ui/lib/css/abstract/_dir.scss
+++ b/ui/lib/css/abstract/_dir.scss
@@ -32,13 +32,11 @@
 
 @mixin padding-direction($top, $end, $bottom, $start, $important: false) {
   @if $important {
-    padding-inline-start: $start !important;
-    padding-inline-end: $end !important;
+    padding-inline: $start $end !important;
     padding-top: $top !important;
     padding-bottom: $bottom !important;
   } @else {
-    padding-inline-start: $start;
-    padding-inline-end: $end;
+    padding-inline: $start $end;
     padding-top: $top;
     padding-bottom: $bottom;
   }
@@ -46,13 +44,11 @@
 
 @mixin margin-direction($top, $end, $bottom, $start, $important: false) {
   @if $important {
-    margin-inline-start: $start !important;
-    margin-inline-end: $end !important;
+    margin-inline: $start $end !important;
     margin-top: $top !important;
     margin-bottom: $bottom !important;
   } @else {
-    margin-inline-start: $start;
-    margin-inline-end: $end;
+    margin-inline: $start $end;
     margin-top: $top;
     margin-bottom: $bottom;
   }

--- a/ui/lib/css/abstract/_fluid-size.scss
+++ b/ui/lib/css/abstract/_fluid-size.scss
@@ -12,19 +12,17 @@ $vp-max-width: 1200px !default;
   $u4: unit($max-size);
 
   @if $u1 == $u2 and $u1 == $u3 and $u1 == $u4 {
-    & {
-      #{$prop}: $min-size;
+    #{$prop}: $min-size;
 
-      @media (min-width: $min-vw) {
-        #{$prop}: calc(
-          #{$min-size} + #{strip-unit($max-size - $min-size)} *
-            ((100vw - #{$min-vw}) / #{strip-unit($max-vw - $min-vw)})
-        );
-      }
+    @media (min-width: $min-vw) {
+      #{$prop}: calc(
+        #{$min-size} + #{strip-unit($max-size - $min-size)} *
+          ((100vw - #{$min-vw}) / #{strip-unit($max-vw - $min-vw)})
+      );
+    }
 
-      @media (min-width: $max-vw) {
-        #{$prop}: $max-size;
-      }
+    @media (min-width: $max-vw) {
+      #{$prop}: $max-size;
     }
   } @else {
     @error "fluid-size requires that all values have the same unit";

--- a/ui/lib/css/ceval/_eval-gauge.scss
+++ b/ui/lib/css/ceval/_eval-gauge.scss
@@ -40,13 +40,13 @@
     @include if-light {
       border-bottom-color: #ccc;
     }
-  }
 
-  tick.zero {
-    top: 6px;
-    opacity: 1;
-    border-bottom: 7px solid $m-accent--fade-50 !important;
-    margin-top: -3px;
+    &.zero {
+      top: 6px;
+      opacity: 1;
+      border-bottom: 7px solid $m-accent--fade-50 !important;
+      margin-top: -3px;
+    }
   }
 
   .black {

--- a/ui/lib/css/chess/_promotion.scss
+++ b/ui/lib/css/chess/_promotion.scss
@@ -1,20 +1,25 @@
 #promotion-choice {
+  @include inline-end(0);
+
   background: $m-bg--fade-30;
   z-index: $z-cg__promotion-205;
   position: absolute;
   width: var(---cg-width, 100%);
   height: var(---cg-height, 100%);
 
-  @include inline-end(0);
-
   square {
+    @include transition;
+
     cursor: pointer;
     border-radius: 50%;
     background-color: #b0b0b0;
     box-shadow: inset 0 0 25px 3px #808080;
     pointer-events: all;
 
-    @include transition;
+    &:hover {
+      box-shadow: inset 0 0 48px 8px $c-accent;
+      border-radius: 0;
+    }
   }
 
   piece {
@@ -28,11 +33,6 @@
     width: 100%;
     height: 100%;
     transform: scale(0.8);
-  }
-
-  square:hover {
-    box-shadow: inset 0 0 48px 8px $c-accent;
-    border-radius: 0;
   }
 
   .is2d & square:hover piece {

--- a/ui/lib/css/component/_slist.scss
+++ b/ui/lib/css/component/_slist.scss
@@ -122,7 +122,6 @@
 
   .stack-row td {
     width: 100%;
-    padding-inline-start: $box-padding;
-    padding-inline-end: $box-padding;
+    padding-inline: $box-padding;
   }
 }

--- a/ui/lib/css/component/_tagify.scss
+++ b/ui/lib/css/component/_tagify.scss
@@ -409,8 +409,7 @@
       color: var(--tag-remove-btn-color, $tag-remove-btn-color);
       width: $size;
       height: $size;
-      margin-inline-end: $size / 3;
-      margin-inline-start: auto;
+      margin-inline: auto $size / 3;
       overflow: hidden;
       transition: 0.2s ease-out;
 

--- a/ui/lib/css/component/_zen-toggle.scss
+++ b/ui/lib/css/component/_zen-toggle.scss
@@ -12,7 +12,7 @@
   .zen-home {
     flex: 0 0 4em;
     height: 4em;
-    padding: 1em 1em;
+    padding: 1em;
     background: center no-repeat url('../logo/lichess-white.svg');
 
     @include if-light {

--- a/ui/lib/css/theme/board/_coords-colors.scss
+++ b/ui/lib/css/theme/board/_coords-colors.scss
@@ -5,11 +5,11 @@ coords {
   text-shadow: var(---cg-cs, $coord-shadow-default);
 
   /** Alternating colors in rank/file/square labels */
-  & .coord-light {
+  .coord-light {
     color: var(---cg-ccb, $coord-color-default);
   }
 
-  & .coord-dark {
+  .coord-dark {
     color: var(---cg-ccw, $coord-color-default);
   }
 }

--- a/ui/lib/css/theme/board/_coords-colors.scss
+++ b/ui/lib/css/theme/board/_coords-colors.scss
@@ -3,13 +3,13 @@ $coord-shadow-default: 0 1px 2px #000;
 
 coords {
   text-shadow: var(---cg-cs, $coord-shadow-default);
-}
 
-/** Alternating colors in rank/file/square labels */
-coords .coord-light {
-  color: var(---cg-ccb, $coord-color-default);
-}
+  /** Alternating colors in rank/file/square labels */
+  & .coord-light {
+    color: var(---cg-ccb, $coord-color-default);
+  }
 
-coords .coord-dark {
-  color: var(---cg-ccw, $coord-color-default);
+  & .coord-dark {
+    color: var(---cg-ccw, $coord-color-default);
+  }
 }

--- a/ui/lobby/css/_about.scss
+++ b/ui/lobby/css/_about.scss
@@ -1,7 +1,6 @@
 .lobby__about {
   display: flex;
-  align-content: flex-start;
-  justify-content: center;
+  place-content: start center;
   flex-flow: row wrap;
   font-size: 0.85em;
   font-weight: bold;

--- a/ui/lobby/css/_layout.scss
+++ b/ui/lobby/css/_layout.scss
@@ -38,8 +38,7 @@
     }
 
     &__start {
-      margin-inline-start: 0;
-      margin-inline-end: $block-gap;
+      margin-inline: 0 $block-gap;
 
       &__button {
         padding-inline: 1em;

--- a/ui/racer/css/_racer.scss
+++ b/ui/racer/css/_racer.scss
@@ -8,8 +8,7 @@
   }
 
   display: grid;
-  row-gap: $block-gap;
-  column-gap: $block-gap;
+  gap: $block-gap;
   grid-template-areas: 'board' 'race' 'side' 'history';
 
   @include mq-at-least-col2 {

--- a/ui/storm/css/_end.scss
+++ b/ui/storm/css/_end.scss
@@ -19,8 +19,7 @@
     grid-area: play;
   }
 
-  row-gap: $block-gap;
-  column-gap: $block-gap;
+  gap: $block-gap;
   grid-template-areas: 'high' 'score' 'play' 'stats' 'history';
 
   @include mq-at-least-col2 {
@@ -34,7 +33,7 @@
   &__high {
     @extend %box-neat;
 
-    padding: 1.5em 1.5em;
+    padding: 1.5em;
     background: $c-brag;
     color: $c-over;
 

--- a/ui/storm/css/_play.scss
+++ b/ui/storm/css/_play.scss
@@ -1,8 +1,7 @@
 .storm {
   &--play {
     display: grid;
-    row-gap: $block-gap;
-    column-gap: $block-gap;
+    gap: $block-gap;
     grid-template-areas: 'board' 'side';
 
     @include mq-at-least-col2 {

--- a/ui/tournament/css/_app-standing.scss
+++ b/ui/tournament/css/_app-standing.scss
@@ -75,8 +75,7 @@
 
   .sheet {
     text-align: right;
-    padding-inline-end: 0;
-    padding-inline-start: 0;
+    padding-inline: 0;
     letter-spacing: 0.1em;
 
     & > * {

--- a/ui/tournament/css/_calendar.scss
+++ b/ui/tournament/css/_calendar.scss
@@ -22,8 +22,7 @@
 
     date {
       flex: 0 0 40px;
-      margin-inline-start: -55px;
-      margin-inline-end: 15px;
+      margin-inline: -55px 15px;
     }
 
     lanes {

--- a/ui/tournament/css/schedule/_schedule.scss
+++ b/ui/tournament/css/schedule/_schedule.scss
@@ -202,15 +202,15 @@ $c-tour-variant: #7c5133;
 
   .infos {
     display: inline-flex;
-  }
 
-  .infos .text {
-    @extend %ellipsis;
+    .text {
+      @extend %ellipsis;
 
-    flex: 1 1;
-  }
+      flex: 1 1;
+    }
 
-  .infos .nb-players {
-    flex: 0 0 auto;
+    .nb-players {
+      flex: 0 0 auto;
+    }
   }
 }

--- a/ui/user/css/_perf-stat.scss
+++ b/ui/user/css/_perf-stat.scss
@@ -13,8 +13,7 @@
 
   .trophy {
     margin-top: -1rem;
-    margin-inline-end: 0.2em;
-    margin-inline-start: -0.6em;
+    margin-inline: -0.6em 0.2em;
 
     &.top1 {
       filter: drop-shadow(0 0 6px $c-brag);


### PR DESCRIPTION
# How

Re-enable few Stylelint rules disabled previously due to amount of warning they yield. Adjust rules configs, fix correct and addressable warnings. Use style nesting where possible (this was found by other rule, which still yield a lot of warnings, also FPs, a it's not configurable to a degree which will match the codebase style files, so for now I left it off rules list).

# Test plan

Make sure that fluid text helper still works correctly. Visited few pages for which I modified styles to confirm that there are no visual regressions.