### PR TITLE
Add sbt-bloop plugin back to project/plugins.sbt

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,3 +9,4 @@ addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.11.4")
 addSbtPlugin("org.playframework.twirl" % "sbt-twirl" % "2.1.0-M9")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.6.1")
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "2.1.0")


### PR DESCRIPTION
This was removed here https://github.com/lichess-org/lila/commit/5b1d3fa8c22296b1262fb22659be6fe1f9ab8d18

But I'm not familiar with the circumstances surrounding that. I will point out that metals still defaults to using bloop as the preferred build server, so it's not ideal when `sbt bloopInstall` is a noop.

If it was removed due to sbt 2 migration then this new 2.1.0 version should fix things. If it was some other reason, i guess close this but ideally let me know.