### PR TITLE
ui: remove duplicate mobile helper

### DIFF
--- a/ui/lib/src/device.ts
+++ b/ui/lib/src/device.ts
@@ -2,7 +2,7 @@ import { memoize } from './index';
 import { licon, type LiconValue } from './licon';
 import { bind, type Hooks } from './view/snabbdom';
 
-export const hookMobileMousedown = (f: (e: Event) => any): Hooks =>
+export const hookMobileMousedown = (f: (e: MouseEvent) => void): Hooks =>
   bind('ontouchstart' in window ? 'click' : 'mousedown', f);
 
 export const prefersLightThemeQuery = (): MediaQueryList =>

--- a/ui/lib/src/mobileEvents.ts
+++ b/ui/lib/src/mobileEvents.ts
@@ -1,4 +1,0 @@
-import { bind, type Hooks } from './view';
-
-export const hookMobileMousedown = (f: (e: Event) => any): Hooks =>
-  bind('ontouchstart' in window ? 'click' : 'mousedown', f);

--- a/ui/msg/src/view/contact.ts
+++ b/ui/msg/src/view/contact.ts
@@ -1,8 +1,8 @@
 import { h, type VNode } from 'snabbdom';
 
+import { hookMobileMousedown } from 'lib/device';
 import { timeago } from 'lib/i18n';
 import { licon } from 'lib/licon';
-import { hookMobileMousedown } from 'lib/mobileEvents';
 import { iconCls } from 'lib/view';
 import type { MaybeVNodes } from 'lib/view/snabbdom';
 import { fullName, userLine } from 'lib/view/userLink';
@@ -19,7 +19,7 @@ export default function renderContact(ctrl: MsgCtrl, contact: Contact, active?: 
     {
       key: user.id,
       class: { active: active === user.id },
-      hook: hookMobileMousedown(_ => ctrl.openConvo(user.id)),
+      hook: hookMobileMousedown(() => ctrl.openConvo(user.id)),
     },
     [
       userIcon(user, 'msg-app__side__contact__icon'),

--- a/ui/msg/src/view/convo.ts
+++ b/ui/msg/src/view/convo.ts
@@ -1,7 +1,7 @@
 import { h, type VNode } from 'snabbdom';
 
+import { hookMobileMousedown } from 'lib/device';
 import { licon } from 'lib/licon';
-import { hookMobileMousedown } from 'lib/mobileEvents';
 import { dataIcon } from 'lib/view';
 import { userLine, userLink, userLinkData } from 'lib/view/userLink';
 

--- a/ui/msg/src/view/search.ts
+++ b/ui/msg/src/view/search.ts
@@ -2,7 +2,7 @@ import { h, type VNode } from 'snabbdom';
 
 import { blurOnEscape } from 'lib';
 import { throttle } from 'lib/async';
-import { hookMobileMousedown } from 'lib/mobileEvents';
+import { hookMobileMousedown } from 'lib/device';
 import { fullName } from 'lib/view/userLink';
 
 import type MsgCtrl from '@/ctrl';
@@ -65,7 +65,7 @@ export function renderResults(ctrl: MsgCtrl, res: SearchResult): VNode {
 function renderUser(ctrl: MsgCtrl, user: User): VNode {
   return h(
     'div.msg-app__side__contact',
-    { key: user.id, hook: hookMobileMousedown(_ => ctrl.openConvo(user.id)) },
+    { key: user.id, hook: hookMobileMousedown(() => ctrl.openConvo(user.id)) },
     [
       userIcon(user, 'msg-app__side__contact__icon'),
       h('div.msg-app__side__contact__user', [


### PR DESCRIPTION
# Why

Spotted that there are two instances of `hookMobileMousedown`.

# How

Remove duplicated helper in a separate file, update types, fix usages.