### PR TITLE
ui: unify optional properties type definitions

### DIFF
--- a/ui/.build/src/env.ts
+++ b/ui/.build/src/env.ts
@@ -58,7 +58,7 @@ export const env = new (class {
   logCtx = true;
   logColor = true;
   remoteLog: string | boolean = false;
-  startTime: number | undefined;
+  startTime?: number;
 
   packages: Map<string, Package> = new Map();
   workspaceDeps: Map<string, string[]> = new Map();

--- a/ui/.build/src/task.ts
+++ b/ui/.build/src/task.ts
@@ -29,7 +29,7 @@ type Task = Omit<TaskOpts, 'glob' | 'debounce'> & {
   key: TaskKey;
   debounce: Debounce;
   fileTimes: Map<AbsPath, number>;
-  status: 'ok' | 'error' | undefined;
+  status?: 'ok' | 'error';
 };
 type TaskOpts = {
   includes: CwdPath | CwdPath[];

--- a/ui/analyse/src/autoplay.ts
+++ b/ui/analyse/src/autoplay.ts
@@ -5,11 +5,11 @@ import type AnalyseCtrl from './ctrl';
 export type AutoplayDelay = number | 'realtime' | 'cpl';
 
 export class Autoplay {
-  private timeout: Timeout | undefined;
-  private delay: AutoplayDelay | undefined;
-  private redrawInterval: Timeout | undefined;
+  private timeout?: Timeout;
+  private delay?: AutoplayDelay;
+  private redrawInterval?: Timeout;
 
-  lastMoveAt: number | undefined;
+  lastMoveAt?: number;
 
   constructor(private readonly ctrl: AnalyseCtrl) {}
 

--- a/ui/analyse/src/explorer/explorerCtrl.ts
+++ b/ui/analyse/src/explorer/explorerCtrl.ts
@@ -42,8 +42,8 @@ export default class ExplorerCtrl {
   hovering = prop<Hovering | null>(null);
   movesAway = prop(0);
   gameMenu = prop<string | null>(null);
-  private lastStream: Sync<true> | undefined;
-  private abortController: AbortController | undefined;
+  private lastStream?: Sync<true>;
+  private abortController?: AbortController;
   private cache: Dictionary<ExplorerData> = {};
 
   constructor(

--- a/ui/analyse/src/explorer/interfaces.ts
+++ b/ui/analyse/src/explorer/interfaces.ts
@@ -117,8 +117,8 @@ export const isOpening = (m: ExplorerData): m is OpeningData => !!m.isOpening;
 
 export const isTablebase = (m: ExplorerData): m is TablebaseData => !!m.tablebase;
 
-export interface SimpleTablebaseHit {
+export type SimpleTablebaseHit = {
   fen: FEN;
   best?: Uci; // no move if checkmate/stalemate
-  winner: Color | undefined;
-}
+  winner?: Color;
+};

--- a/ui/analyse/src/fork.ts
+++ b/ui/analyse/src/fork.ts
@@ -11,8 +11,8 @@ import { renderIndexAndMove } from './view/components';
 export class ForkCtrl {
   selectedIndex = 0;
 
-  private hoveringIndex: number | undefined;
-  private mostRecent: TreeNode | undefined;
+  private hoveringIndex?: number;
+  private mostRecent?: TreeNode;
 
   constructor(private readonly ctrl: AnalyseCtrl) {}
 

--- a/ui/analyse/src/study/chapterNewForm.ts
+++ b/ui/analyse/src/study/chapterNewForm.ts
@@ -48,7 +48,7 @@ export const fieldValue = (e: Event, id: string) =>
 export class StudyChapterNewForm {
   readonly multiPgnMax = 64;
   variants: Variant[] = [];
-  dialog: Dialog | undefined;
+  dialog?: Dialog;
   isOpen = toggle(false, val => {
     if (!val) this.dialog?.close();
   });

--- a/ui/analyse/src/study/notif.ts
+++ b/ui/analyse/src/study/notif.ts
@@ -1,4 +1,6 @@
-import { h, type VNode } from 'snabbdom';
+import { h } from 'snabbdom';
+
+import type { MaybeVNode } from 'lib/view';
 
 interface Notif {
   duration: number;
@@ -6,9 +8,11 @@ interface Notif {
 }
 
 export class NotifCtrl {
-  current: Notif | undefined;
-  timeoutId: number | undefined;
+  current?: Notif;
+  timeoutId?: number;
+
   constructor(readonly redraw: () => void) {}
+
   set = (n: Notif) => {
     clearTimeout(this.timeoutId);
     this.current = n;
@@ -20,7 +24,7 @@ export class NotifCtrl {
   get = () => this.current;
 }
 
-export function view(ctrl: NotifCtrl): VNode | undefined {
+export function view(ctrl: NotifCtrl): MaybeVNode {
   const c = ctrl.get();
   return c ? h('div.notif', c.text) : undefined;
 }

--- a/ui/analyse/src/study/relay/relayTeamLeaderboard.ts
+++ b/ui/analyse/src/study/relay/relayTeamLeaderboard.ts
@@ -21,8 +21,8 @@ import RelayPlayers, { renderPlayers, tableAugment, type RelayPlayer } from './r
 import { finishedTeamMatchCount } from './relayTeamStandings';
 
 export default class RelayTeamLeaderboard {
-  standings: RelayTeamStandings | undefined;
-  teamToShow: RelayTeamName | undefined;
+  standings?: RelayTeamStandings;
+  teamToShow?: RelayTeamName;
   private table?: Tablesort;
   constructor(
     private readonly tourId: TourId,

--- a/ui/analyse/src/view/clocks.ts
+++ b/ui/analyse/src/view/clocks.ts
@@ -10,7 +10,7 @@ import { iconTag, type MaybeVNode, type MaybeVNodes } from 'lib/view';
 import type AnalyseCtrl from '../ctrl';
 
 interface ClockOpts {
-  centis: number | undefined;
+  centis?: number;
   active: boolean;
   cls: string;
   showTenths: boolean;

--- a/ui/analyse/src/view/components.ts
+++ b/ui/analyse/src/view/components.ts
@@ -47,8 +47,8 @@ export interface ViewContext {
   concealOf?: ConcealOf;
   showCevalPvs: boolean;
   gamebookPlayView?: VNode;
-  playerBars: VNode[] | undefined;
-  playerStrips: [VNode, VNode] | undefined;
+  playerBars?: VNode[];
+  playerStrips?: [VNode, VNode];
   gaugeOn: boolean;
   needsInnerCoords: boolean;
   hasRelayTour: boolean;

--- a/ui/botDev/src/editDialog.ts
+++ b/ui/botDev/src/editDialog.ts
@@ -35,7 +35,7 @@ export class EditDialog {
   view: HTMLElement;
   deck: HandOfCards;
   dlg: Dialog;
-  assetDlg: AssetDialog | undefined;
+  assetDlg?: AssetDialog;
   uid: string;
   panes: Panes;
   scratch: Map<string, WritableBot> = new Map();

--- a/ui/botDev/src/handOfCards.ts
+++ b/ui/botDev/src/handOfCards.ts
@@ -51,7 +51,7 @@ class HandOfCardsImpl {
   animFrame = 0;
   scaleFactor = 1;
   groups: Set<string | undefined>;
-  group: string | undefined;
+  group?: string;
   drag?: {
     when: number;
     card: HTMLElement;

--- a/ui/botDev/src/localDb.ts
+++ b/ui/botDev/src/localDb.ts
@@ -6,8 +6,8 @@ import { type ObjectStorage, objectStorage, range } from 'lib/objectStorage';
 import { type LocalGame, LocalGameData } from './localGame';
 
 export class LocalDb {
-  store: ObjectStorage<LocalGameData> | undefined;
-  liteStore: ObjectStorage<LiteGame> | undefined;
+  store?: ObjectStorage<LocalGameData>;
+  liteStore?: ObjectStorage<LiteGame>;
 
   async init(): Promise<this> {
     if (!hasFeature('structuredClone')) globalThis.structuredClone = obj => JSON.parse(JSON.stringify(obj));

--- a/ui/botDev/src/pane.ts
+++ b/ui/botDev/src/pane.ts
@@ -24,7 +24,7 @@ export class Pane<Info extends PaneInfo = PaneInfo> {
   readonly info: Info;
   readonly host: EditDialog;
   readonly el: HTMLElement;
-  readonly parent: Pane | undefined;
+  readonly parent?: Pane;
 
   constructor(args: PaneArgs) {
     Object.assign(this, args);

--- a/ui/coordinateTrainer/src/ctrl.ts
+++ b/ui/coordinateTrainer/src/ctrl.ts
@@ -60,7 +60,7 @@ export const DURATION = 30 * 1000;
 const TICK_DELAY = 50;
 
 export default class CoordinateTrainerCtrl {
-  chessground: CgApi | undefined;
+  chessground?: CgApi;
   currentKey: Key | '' = 'a1';
   hasPlayed = false;
   isAuth = !!myUserId();

--- a/ui/dasher/src/ping.ts
+++ b/ui/dasher/src/ping.ts
@@ -6,8 +6,8 @@ import { pubsub } from 'lib/pubsub';
 import type { DasherCtrl } from '@/ctrl';
 
 export class PingCtrl {
-  ping: number | undefined;
-  server: number | undefined;
+  ping?: number;
+  server?: number;
 
   constructor(readonly root: DasherCtrl) {}
 

--- a/ui/editor/src/ctrl.ts
+++ b/ui/editor/src/ctrl.ts
@@ -32,22 +32,20 @@ import {
 
 export default class EditorCtrl {
   options: Options;
-  chessground: CgApi | undefined;
-
+  chessground?: CgApi;
   selected: Prop<Selected>;
-
   initialFen: FEN;
-  pockets: Material | undefined;
+  pockets?: Material;
   turn: Color;
   castlingToggles: CastlingToggles<boolean>;
   enabledCastlingToggles: CastlingToggles<boolean>;
-  epSquare: Square | undefined;
-  remainingChecks: RemainingChecks | undefined;
+  epSquare?: Square;
+  remainingChecks?: RemainingChecks;
   variant: VariantKey = 'standard';
   halfmoves: number;
   fullmoves: number;
   guessCastlingToggles: boolean;
-  chess960PositionId: number | undefined;
+  chess960PositionId?: number;
 
   constructor(
     readonly cfg: Config,

--- a/ui/editor/src/interfaces.ts
+++ b/ui/editor/src/interfaces.ts
@@ -7,7 +7,7 @@ export const CASTLING_TOGGLES: CastlingToggle[] = ['K', 'Q', 'k', 'q'];
 
 export interface EditorState {
   fen: FEN;
-  legalFen: FEN | undefined;
+  legalFen?: FEN;
   playable: boolean;
   enPassantOptions: string[];
 }

--- a/ui/learn/src/run/runCtrl.ts
+++ b/ui/learn/src/run/runCtrl.ts
@@ -11,8 +11,7 @@ import { clearTimeouts } from '../timeouts';
 
 export class RunCtrl {
   data: LearnProgress = this.opts.storage.data;
-
-  chessground: CgApi | undefined;
+  chessground?: CgApi;
   levelCtrl: LevelCtrl;
 
   stageStarting: Prop<boolean> = prop(false);

--- a/ui/lib/src/ceval/ctrl.ts
+++ b/ui/lib/src/ceval/ctrl.ts
@@ -58,7 +58,7 @@ export class CevalCtrl {
   lastStarted?: Started;
   showEnginePrefs: Toggle = toggle(false);
 
-  private worker: CevalEngine | undefined;
+  private worker?: CevalEngine;
 
   constructor(public opts: CevalOpts) {
     this.engines = new Engines(this);

--- a/ui/lib/src/ceval/engines/externalEngine.ts
+++ b/ui/lib/src/ceval/engines/externalEngine.ts
@@ -27,7 +27,7 @@ interface ExternalEngineOutput {
 export class ExternalEngine implements CevalEngine {
   private state = CevalState.Initial;
   private readonly sessionId = randomToken();
-  private req: AbortController | undefined;
+  private req?: AbortController;
 
   constructor(
     private readonly opts: ExternalEngineInfo,

--- a/ui/lib/src/ceval/engines/simpleEngine.ts
+++ b/ui/lib/src/ceval/engines/simpleEngine.ts
@@ -4,7 +4,7 @@ import { CevalState, type Work, type CevalEngine, type BrowserEngineInfo } from 
 export class SimpleEngine implements CevalEngine {
   private failed: Error;
   private readonly protocol = new Protocol();
-  private worker: Worker | undefined;
+  private worker?: Worker;
   url: string;
 
   constructor(readonly info: BrowserEngineInfo) {

--- a/ui/lib/src/ceval/protocol.ts
+++ b/ui/lib/src/ceval/protocol.ts
@@ -4,15 +4,13 @@ import { defined } from '../index';
 import type { Work } from './types';
 
 export class Protocol {
-  public engineName: string | undefined;
+  public engineName?: string;
 
-  private work: Work | undefined;
-  private currentEval: LocalEval | undefined;
-  private gameId: string | undefined;
+  private work?: Work;
+  private currentEval?: LocalEval;
+  private gameId?: string;
   private expectedPvs = 1;
-
-  private nextWork: Work | undefined;
-
+  private nextWork?: Work;
   private send: ((cmd: string) => void) | undefined;
   private options: Map<string, string | number> = new Map<string, string>();
 

--- a/ui/lib/src/chat/chatCtrl.ts
+++ b/ui/lib/src/chat/chatCtrl.ts
@@ -32,8 +32,8 @@ export class ChatCtrl {
 
   chatEnabled: Prop<boolean>;
   voiceChat: VoiceChatData;
-  moderation: ModerationCtrl | undefined;
-  note: NoteCtrl | undefined;
+  moderation?: ModerationCtrl;
+  note?: NoteCtrl;
   preset: PresetCtrl;
   vm: ViewModel;
 

--- a/ui/lib/src/chat/preset.ts
+++ b/ui/lib/src/chat/preset.ts
@@ -5,7 +5,7 @@ import { bind } from '@/view';
 export interface PresetCtrl {
   group(): string | undefined;
   said(): string[];
-  setGroup(group: string | undefined): void;
+  setGroup(group?: string): void;
   post(preset: Preset): void;
 }
 
@@ -35,14 +35,13 @@ const groups: PresetGroups = {
 };
 
 export function presetCtrl(opts: PresetOpts): PresetCtrl {
-  let group: string | undefined = opts.initialGroup;
-
+  let group = opts.initialGroup;
   let said: string[] = [];
 
   return {
     group: () => group,
     said: () => said,
-    setGroup(p: string | undefined) {
+    setGroup(p) {
       if (p !== group) {
         group = p;
         if (!p) said = [];

--- a/ui/lib/src/game/clock/clockCtrl.ts
+++ b/ui/lib/src/game/clock/clockCtrl.ts
@@ -53,12 +53,13 @@ interface EmergSound {
 export interface SetData {
   white: Seconds;
   black: Seconds;
-  ticking: Color | undefined;
+  ticking?: Color;
   delay?: Centis; // network lag to visually compensate
 }
 
 export class ClockCtrl {
   readonly config: ClockConfig;
+
   emergSound: EmergSound = {
     play: () => site.sound.play('lowTime'),
     delay: 20000,
@@ -67,16 +68,13 @@ export class ClockCtrl {
       black: true,
     },
   };
-
   showTenths: (millis: Millis) => boolean;
   showBar: boolean;
   times: Times;
-
   barTime: number;
   timeRatioDivisor: number;
   emergMs: Millis;
   alarmAction?: { seconds: Seconds; fire: () => void };
-
   elements: ByColor<ClockElements> = { white: {}, black: {} };
 
   private tickTimeout?: Timeout;

--- a/ui/lib/src/game/view/status.ts
+++ b/ui/lib/src/game/view/status.ts
@@ -42,7 +42,7 @@ export function insufficientMaterial(variant: VariantKey, fullFen: FEN): boolean
 }
 
 export interface StatusData {
-  winner: Color | undefined;
+  winner?: Color;
   status: StatusName;
   abortedBy?: Color;
   ply: Ply;

--- a/ui/lib/src/nvui/notify.ts
+++ b/ui/lib/src/nvui/notify.ts
@@ -5,7 +5,7 @@ import { requestIdleCallbackSafe } from '../index';
 
 export class Notify {
   text = '';
-  date: Date | undefined;
+  date?: Date;
 
   constructor(public redraw: Redraw | undefined) {}
 

--- a/ui/lib/src/puz/clock.ts
+++ b/ui/lib/src/puz/clock.ts
@@ -2,7 +2,7 @@ import type { Config } from './interfaces';
 import { getNow } from './util';
 
 export class Clock {
-  startAt: number | undefined;
+  startAt?: number;
   initialMillis: number;
 
   public constructor(

--- a/ui/lib/src/socket.ts
+++ b/ui/lib/src/socket.ts
@@ -99,7 +99,7 @@ class WsSocket {
   private readonly settings: Settings;
   private readonly options: Options;
   private version: number | false;
-  private ws: WebSocket | undefined;
+  private ws?: WebSocket;
   private pingSchedule: Timeout;
   private connectSchedule: Timeout;
   private readonly ackable: Ackable = new Ackable((t, d, o) => this.send(t, d, o));

--- a/ui/lib/src/tree/types.ts
+++ b/ui/lib/src/tree/types.ts
@@ -39,7 +39,7 @@ export interface PvData extends EvalScore {
 }
 
 export interface TablebaseHit {
-  winner: Color | undefined;
+  winner?: Color;
   best?: Uci;
 }
 

--- a/ui/puzzle/src/ctrl.ts
+++ b/ui/puzzle/src/ctrl.ts
@@ -78,7 +78,7 @@ export default class PuzzleCtrl implements CevalHandler {
   canViewSolution = toggle(false);
   showHint = toggle(false);
   hintHasBeenShown = toggle(false);
-  voted: boolean | undefined;
+  voted?: boolean;
   autoScrollRequested: boolean;
   autoScrollNow: boolean;
   isDaily: boolean;

--- a/ui/round/src/corresClock/corresClockCtrl.ts
+++ b/ui/round/src/corresClock/corresClockCtrl.ts
@@ -26,7 +26,7 @@ interface Times {
 export class CorresClockController {
   timePercentDivisor: number;
   times: Times;
-  ticker: number | undefined;
+  ticker?: number;
 
   constructor(
     readonly root: RoundController,

--- a/ui/round/src/server.ts
+++ b/ui/round/src/server.ts
@@ -5,7 +5,7 @@ import type { RoundData } from './interfaces';
 import * as xhr from './xhr';
 
 export default class Server {
-  scheduledCheck: Timeout | undefined;
+  scheduledCheck?: Timeout;
 
   constructor(readonly getData: () => RoundData) {
     if (isPlayerPlaying(this.getData())) pubsub.on('socket.in.serverRestart', this.onServerRestart);

--- a/ui/site/src/sound.ts
+++ b/ui/site/src/sound.ts
@@ -8,7 +8,7 @@ type Name = string;
 type Path = string;
 
 export default new (class implements SoundI {
-  ctx: AudioContext | undefined;
+  ctx?: AudioContext;
   ctxPromise: Promise<AudioContext>;
   listeners = new Set<SoundListener>();
   sounds = new Map<Path, Sound>(); // All loaded sounds and their instances

--- a/ui/swiss/src/ctrl.ts
+++ b/ui/swiss/src/ctrl.ts
@@ -11,7 +11,7 @@ export default class SwissCtrl {
   socket: SwissSocket;
   page: number;
   pages: Pages = {};
-  lastPageDisplayed: number | undefined;
+  lastPageDisplayed?: number;
   focusOnMe: boolean;
   joinSpinner = false;
   playerInfoId?: string;

--- a/ui/tournament/src/ctrl.ts
+++ b/ui/tournament/src/ctrl.ts
@@ -29,7 +29,7 @@ export default class TournamentController {
   socket: TournamentSocket;
   page: number;
   pages: Pages = {};
-  lastPageDisplayed: number | undefined;
+  lastPageDisplayed?: number;
   focusOnMe: boolean;
   joinSpinner = false;
   playerInfo: { id?: string; player?: Player; data?: PlayerInfo } = {};

--- a/ui/voice/src/mic.ts
+++ b/ui/voice/src/mic.ts
@@ -8,7 +8,7 @@ export class Mic implements Microphone {
   recId = 'default';
 
   private language = 'en';
-  private audioCtx: AudioContext | undefined;
+  private audioCtx?: AudioContext;
   private mediaStream: MediaStream;
   private micSource: AudioNode;
   private vosk: VoskModule;


### PR DESCRIPTION
# Why

We use two way of marking properties/params as optional - via `?` concise syntax and via explicit `| undefined` type union.

# How

This PR changes most of the places to use concise syntax to unify the codebase.