### PR TITLE
Remove 'unnecessary type conversion' rule from linter config

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -57,7 +57,6 @@
     "typescript/no-unnecessary-type-arguments": "error",
     "typescript/no-unnecessary-type-assertion": "error",
     "typescript/no-unnecessary-type-constraint": "error",
-    "typescript/no-unnecessary-type-conversion": "error",
     "typescript/prefer-find": "error",
     "typescript/prefer-includes": "error",
     "typescript/prefer-optional-chain": "error",


### PR DESCRIPTION
This linter option actively encourages loosening of runtime constraints, and it does so based on typescript's view of allowable values for a reference or primitive. But typescript exists only at compile time - javascript engines are the runtime authority.

It can and does happen that an object's value at runtime differs from what typescript would allow. Comprehensive linting should not unnecessarily constrain the tools we have to deal with this. Explicit coercion of primitives is often appropriate in a dynamic runtime. A hard and fast rule against it should provide some non-aesthetic compensatory benefit, but I'm not sure this one does.

Instead, the rule makes it harder to write correct code and offers little in return. Will it actually cause issues? Sure, on the very first day. [This bug](https://github.com/lichess-org/lila/issues/20815) is a case in point.
