### PR TITLE
account push device management

### DIFF
--- a/app/controllers/Account.scala
+++ b/app/controllers/Account.scala
@@ -162,7 +162,7 @@ final class Account(
   private def refreshSessionId(result: Result, pwned: IsPwned)(using ctx: Context, me: Me): Fu[Result] = for
     _ <- env.security.store.closeAllSessionsOf(me)
     _ <- env.push.browserSub.unsubscribeByUser(me)
-    _ <- env.push.unregisterDevices(me)
+    _ <- env.push.unregisterAllDevicesForUser(me)
     sessionId <- env.security.api.saveAuthentication(me, ctx.mobileApiVersion, pwned)
   yield result.withCookies(env.security.lilaCookie.session(env.security.api.sessionIdKey, sessionId.value))
 
@@ -345,9 +345,11 @@ final class Account(
       sessions <- env.security.api.locatedOpenSessions(me, 50)
       clients <- env.oAuth.tokenApi.listClients(50)
       personalAccessTokens <- env.oAuth.tokenApi.countPersonal
+      pushDevices <- env.push.findDevicesByUserId("firebase", 50)(me)
+      devices = pushDevices.map(d => lila.security.PushDevice(d._id, d.platform, d.ua, d.seenAt))
       currentSessionId = env.security.api.reqSessionId(req)
       page <- Ok.async:
-        views.account.security(me, sessions, currentSessionId, clients, personalAccessTokens)
+        views.account.security(me, sessions, currentSessionId, clients, personalAccessTokens, devices)
     yield page.hasPersonalData
   }
 
@@ -359,6 +361,14 @@ final class Account(
         _ <- env.security.store.closeUserAndSessionId(me, SessionId(sessionId))
         _ <- env.push.browserSub.unsubscribeBySession(SessionId(sessionId))
       yield NoContent
+  }
+
+  def unregisterDevice(deviceId: String) = Auth { _ ?=> me ?=>
+    env.push
+      .findDevice(deviceId)
+      .map(_.filter(_.userId == me.userId))
+      .orNotFound: device =>
+        env.push.deleteDevice(device).inject(NoContent)
   }
 
   private def renderReopen(form: Option[Form[Reopen]], msg: Option[String])(using Context) =

--- a/app/controllers/Auth.scala
+++ b/app/controllers/Auth.scala
@@ -596,7 +596,7 @@ final class Auth(env: Env, accountC: => Account) extends LilaController(env):
                 _ <- env.user.repo.disableTwoFactor(user.id)
                 _ <- env.security.store.closeAllSessionsOf(user.id)
                 _ <- env.push.browserSub.unsubscribeByUser(user)
-                _ <- env.push.unregisterDevices(user)
+                _ <- env.push.unregisterAllDevicesForUser(user)
                 result <-
                   passwordResetSuccessResult(variant)
                 res <- authenticateUser(user, remember = true, pwned = IsPwned.No, result = result)

--- a/app/controllers/Push.scala
+++ b/app/controllers/Push.scala
@@ -12,7 +12,7 @@ final class Push(env: Env) extends LilaController(env):
   }
 
   def mobileUnregister = AuthOrScoped(_.Web.Mobile) { ctx ?=> me ?=>
-    env.push.unregisterDevices(me).inject(NoContent)
+    env.push.unregisterAllDevicesForUser(me).inject(NoContent)
   }
 
   def webSubscribe = AuthOrScopedBodyWithParser(parse.json)(_.Web.Mobile) { ctx ?=> me ?=>

--- a/conf/routes
+++ b/conf/routes
@@ -959,6 +959,7 @@ GET   /prometheus-metrics/:key         controllers.Main.prometheusMetrics(key: S
 POST  /mobile/register/:platform/:deviceId controllers.Push.mobileRegister(platform, deviceId)
 POST  /mobile/unregister               controllers.Push.mobileUnregister
 POST  /push/subscribe                  controllers.Push.webSubscribe
+POST  /account/device/unregister/:deviceId  controllers.Account.unregisterDevice(deviceId: String)
 
 # Pages
 GET   /terms-of-service                controllers.Cms.tos

--- a/conf/routes
+++ b/conf/routes
@@ -865,6 +865,7 @@ GET   /account/personal-data           controllers.Account.data
 # App BC
 GET   /account/security                controllers.Account.security
 POST  /account/signout/:sessionId      controllers.Account.signout(sessionId)
+POST  /account/device/unregister/:deviceId controllers.Account.unregisterDevice(deviceId)
 GET   /account/now-playing             controllers.Account.nowPlaying
 
 GET   /tutor                           controllers.Tutor.home()
@@ -959,7 +960,6 @@ GET   /prometheus-metrics/:key         controllers.Main.prometheusMetrics(key: S
 POST  /mobile/register/:platform/:deviceId controllers.Push.mobileRegister(platform, deviceId)
 POST  /mobile/unregister               controllers.Push.mobileUnregister
 POST  /push/subscribe                  controllers.Push.webSubscribe
-POST  /account/device/unregister/:deviceId  controllers.Account.unregisterDevice(deviceId: String)
 
 # Pages
 GET   /terms-of-service                controllers.Cms.tos

--- a/modules/api/src/main/AccountTermination.scala
+++ b/modules/api/src/main/AccountTermination.scala
@@ -83,7 +83,7 @@ final class AccountTermination(
     _ <- securityStore.closeAllSessionsOf(u.id)
     _ <- selfClose.so(tokenApi.revokeAllByUser(u.id))
     _ <- pushEnv.browserSub.unsubscribeByUser(u)
-    _ <- pushEnv.unregisterDevices(u)
+    _ <- pushEnv.unregisterAllDevicesForUser(u)
     _ <- streamerApi.demote(u.id)
     reports <- reportApi.processAndGetBySuspect(lila.report.Suspect(u))
     _ <-

--- a/modules/core/src/main/misc.scala
+++ b/modules/core/src/main/misc.scala
@@ -54,6 +54,9 @@ package mailer:
 package push:
   case class TourSoon(tourId: String, tourName: String, userIds: Iterable[UserId], swiss: Boolean)
 
+  object PushConfig:
+    val maxDevicesPerUser = 3
+
 package oauth:
   opaque type AccessTokenId = String
   object AccessTokenId extends OpaqueString[AccessTokenId]

--- a/modules/push/src/main/Device.scala
+++ b/modules/push/src/main/Device.scala
@@ -7,7 +7,7 @@ import lila.core.net.LichessMobileVersion
 import lila.common.HTTPRequest
 import LichessMobileVersion.given
 
-final private case class Device(
+final case class Device(
     _id: String, // Firebase token
     platform: String, // cordova platform (android, ios, firebase)
     userId: UserId,

--- a/modules/push/src/main/DeviceApi.scala
+++ b/modules/push/src/main/DeviceApi.scala
@@ -46,7 +46,7 @@ final private class DeviceApi(coll: Coll)(using Executor):
       )
       .void
 
-  def unregister(user: User) =
+  def unregisterAllForUser(user: User) =
     lila.mon.push.register.out.increment()
     coll.delete.one($doc("userId" -> user.id)).void
 

--- a/modules/push/src/main/Env.scala
+++ b/modules/push/src/main/Env.scala
@@ -53,8 +53,6 @@ final class Env(
     delete as deleteDevice
   }
 
-  type Device = lila.push.Device
-
   private lazy val browserPush = wire[BrowserWebPush]
   private lazy val unifiedPush = wire[UnifiedWebPush]
   private lazy val firebasePush = wire[FirebasePush]

--- a/modules/push/src/main/Env.scala
+++ b/modules/push/src/main/Env.scala
@@ -45,7 +45,15 @@ final class Env(
   val browserSub = WebSubscriptionApi(db(config.subscriptionColl)).taggedWith[BrowserSub]
   val unifiedSub = WebSubscriptionApi(db(config.unifiedPushColl)).taggedWith[UnifiedSub]
 
-  export deviceApi.{ register as registerDevice, unregister as unregisterDevices }
+  export deviceApi.{
+    register as registerDevice,
+    unregisterAllForUser as unregisterAllDevicesForUser,
+    findLastManyByUserId as findDevicesByUserId,
+    findByDeviceId as findDevice,
+    delete as deleteDevice
+  }
+
+  type Device = lila.push.Device
 
   private lazy val browserPush = wire[BrowserWebPush]
   private lazy val unifiedPush = wire[UnifiedWebPush]

--- a/modules/push/src/main/FirebasePush.scala
+++ b/modules/push/src/main/FirebasePush.scala
@@ -9,6 +9,7 @@ import scalalib.cache.FrequencyThreshold
 import scalalib.data.LazyFu
 
 import lila.mon.extensions.*
+import lila.core.misc.push.PushConfig
 
 final private class FirebasePush(
     unifiedPush: UnifiedWebPush,
@@ -33,7 +34,7 @@ final private class FirebasePush(
   def apply(userId: UserId, data: LazyFu[PushApi.Data]): Funit =
     unifiedPush(userId, data)
     deviceApi
-      .findLastManyByUserId("firebase", 3)(userId)
+      .findLastManyByUserId("firebase", PushConfig.maxDevicesPerUser)(userId)
       .flatMap:
         _.sequentiallyVoid: device =>
           val configOpt =

--- a/modules/security/src/main/model.scala
+++ b/modules/security/src/main/model.scala
@@ -32,6 +32,13 @@ case class UserSession(
 
 case class LocatedSession(session: UserSession, location: Option[Location])
 
+case class PushDevice(
+    id: String,
+    platform: String,
+    ua: UserAgent,
+    seenAt: Instant
+)
+
 case class IpAndFp(ip: IpAddress, fp: Option[String], user: UserId)
 
 case class LameNameCheck(value: Boolean) extends AnyVal

--- a/modules/security/src/main/ui/AccountSecurity.scala
+++ b/modules/security/src/main/ui/AccountSecurity.scala
@@ -4,6 +4,7 @@ package ui
 import play.api.data.Form
 
 import lila.core.id.SessionId
+import lila.core.misc.push.PushConfig
 import lila.ui.*
 
 import ScalatagsTemplate.{ *, given }
@@ -18,7 +19,8 @@ final class AccountSecurity(helpers: Helpers)(
       sessions: List[lila.security.LocatedSession],
       curSessionId: Option[SessionId],
       clients: List[lila.oauth.AccessTokenApi.Client],
-      personalAccessTokens: Int
+      personalAccessTokens: Int,
+      devices: List[lila.security.PushDevice]
   )(using Context) =
     AccountPage(s"${u.username} - ${trans.site.security.txt()}", "security"):
       div(cls := "security")(
@@ -40,12 +42,22 @@ final class AccountSecurity(helpers: Helpers)(
                   submitButton(cls := "button button-empty button-red yes-no-confirm")(
                     trans.site.revokeAllSessions()
                   )
-                ),
-                "."
+                )
               )
             )
           ),
           table(sessions, curSessionId, clients, personalAccessTokens)
+        ),
+        devices.nonEmpty.option(
+          div(cls := "box")(
+            h1(cls := "box__top")("Push notification devices"),
+            div(cls := "box__pad")(
+              p(
+                s"These are your devices that receive push notifications from Lichess. We only send notifications to your ${PushConfig.maxDevicesPerUser} most recently used devices. You can unregister devices you no longer use."
+              )
+            ),
+            devicesTable(devices)
+          )
         )
       )
 
@@ -136,6 +148,46 @@ final class AccountSecurity(helpers: Helpers)(
           )
         )
       )
+    )
+
+  private def devicesTable(devices: List[lila.security.PushDevice])(using Context) =
+    st.table(cls := "slist slist-pad")(
+      devices.map { device =>
+        tr(
+          td(cls := "icon")(
+            span(
+              cls := "is-green",
+              dataIcon := Icon.PhoneMobile
+            )
+          ),
+          td(cls := "info")(
+            div(
+              strong(device.platform match
+                case "ios" => "iOS"
+                case other => other.capitalize)
+            ),
+            p(cls := "ua")(device.ua.value),
+            Granter
+              .opt(_.LichessTeam)
+              .option(
+                p(cls := "device-id")(copyMeInput(device.id)(cls := "device-id__copy"))
+              ),
+            p(cls := "date")(
+              "Last seen ",
+              momentFromNow(device.seenAt)
+            )
+          ),
+          td(
+            postForm(action := routes.Account.unregisterDevice(device.id))(
+              submitButton(
+                cls := "button button-red",
+                title := "Unregister device",
+                dataIcon := Icon.X
+              )
+            )
+          )
+        )
+      }
     )
 
   import lila.security.EmailConfirm.Help.Status


### PR DESCRIPTION
Adds to [Preferences > Security](https://lichess.org/account/security) page:

<img width="1675" height="549" alt="image" src="https://github.com/user-attachments/assets/36ab4cba-3640-44cc-a721-b73ecffc0a95" />


Added primarily to help debug push notification issues but I think it's also good to provide a way to manage devices.