### PR TITLE
relay sync: force-variation non-source siblings along mainline

### DIFF
--- a/modules/relay/src/main/RelaySync.scala
+++ b/modules/relay/src/main/RelaySync.scala
@@ -144,7 +144,7 @@ final private class RelaySync(
                     parentPath + child.id
             (acc ::: localPaths, nodePath)
         ._1
-        .sequentially: childPath =>
+        .sequentiallyVoid: childPath =>
           studyApi.forceVariation(
             studyId = study.id,
             position = Position(chapter, childPath).ref,

--- a/modules/relay/src/main/RelaySync.scala
+++ b/modules/relay/src/main/RelaySync.scala
@@ -130,6 +130,24 @@ final private class RelaySync(
           position = Position(chapter, path).ref,
           toMainline = true
         )(using by) >> chapterRepo.setRelayPath(chapter.id, path)
+      // moves that are not in the source but are in the study chapter,
+      // should become forced variations in the study chapter
+      _ <- game.root.mainline
+        .foldLeft(List.empty[UciPath] -> UciPath.root):
+          case ((acc, parentPath), gameNode) =>
+            val nodePath = parentPath + gameNode.id
+            val localPaths = chapter.root.nodeAt(parentPath).so: parentNode =>
+              parentNode.children.toList.collect:
+                case child if child.id != gameNode.id && !child.forceVariation =>
+                  parentPath + child.id
+            (acc ++ localPaths, nodePath)
+        ._1
+        .sequentially: childPath =>
+          studyApi.forceVariation(
+            studyId = study.id,
+            position = Position(chapter, childPath).ref,
+            force = true
+          )(by)
       _ <- newNode match
         case Some(newNode) =>
           newNode.mainline

--- a/modules/relay/src/main/RelaySync.scala
+++ b/modules/relay/src/main/RelaySync.scala
@@ -136,11 +136,13 @@ final private class RelaySync(
         .foldLeft(List.empty[UciPath] -> UciPath.root):
           case ((acc, parentPath), gameNode) =>
             val nodePath = parentPath + gameNode.id
-            val localPaths = chapter.root.nodeAt(parentPath).so: parentNode =>
-              parentNode.children.toList.collect:
-                case child if child.id != gameNode.id && !child.forceVariation =>
-                  parentPath + child.id
-            (acc ++ localPaths, nodePath)
+            val localPaths = chapter.root
+              .nodeAt(parentPath)
+              .so: parentNode =>
+                parentNode.children.toList.collect:
+                  case child if child.id != gameNode.id && !child.forceVariation =>
+                    parentPath + child.id
+            (acc ::: localPaths, nodePath)
         ._1
         .sequentially: childPath =>
           studyApi.forceVariation(


### PR DESCRIPTION
Closes #20818

Problem
When a relay broadcast syncs moves from an external source, moves that were manually added by study contributors to the chapter remain as regular mainline children. They should instead become forced variations so the source's moves always take precedence on the mainline.

Changes
In RelaySync.updateChapterTree, added a new step after mainline promotion that:

Walks each position along the source mainline
At each parent node, finds children that are not the source's move and not already forceVariation
Marks each such sibling as forceVariation = true via the existing studyApi.forceVariation API
No new APIs, DB operations, or websocket events were needed the change reuses the existing forceVariation infrastructure.

File changed: modules/relay/src/main/RelaySync.scala 

Draft :  Marking as draft since manual testing has not been done yet. This project requires a full lichess dev environment to test relay broadcast syncing.