### PR TITLE
Bump liplay 3.0.4

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -85,8 +85,8 @@ object Dependencies:
     def bundle = Seq(driver, stream)
 
   object play:
+    import lichess.play.sbt.BuildInfo.version as playVersion
     val liplay = "com.github.lichess-org.liplay"
-    val playVersion = "9ea4c7d9f5"
     val api = liplay %% "play" % playVersion
     val server = liplay %% "play-server" % playVersion
     val netty = liplay %% "play-netty-server" % playVersion

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,9 +1,6 @@
-resolvers += Resolver.url(
-  "lila-maven-sbt",
-  new java.net.URL("https://raw.githubusercontent.com/lichess-org/lila-maven/master")
-)(using Resolver.ivyStylePatterns)
+resolvers += "jitpack".at("https://jitpack.io")
 
-addSbtPlugin("org.lichess.play" % "sbt-plugin" % "2.0.0-RC2")
+addSbtPlugin("com.github.lichess-org.liplay" % "sbt-plugin" % "3.0.4")
 
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.11.4")
 


### PR DESCRIPTION
With https://github.com/lichess-org/liplay/pull/8, we can reference
liplay version in Dependencies, which keeps version between sbt plugin
and play runtime.
