### PR TITLE
fix: prefer bestmove eval when depth and nodes are equal in isFirstEvalBetter

### DIFF
--- a/ui/lib/src/ceval/util.ts
+++ b/ui/lib/src/ceval/util.ts
@@ -9,7 +9,9 @@ import { memoize, escapeHtml } from '../index';
 export const isFirstEvalBetter = (a: ClientEval, b: ClientEval, desiredPvs: number): boolean =>
   a.pvs.length >= desiredPvs !== b.pvs.length >= desiredPvs
     ? a.pvs.length >= desiredPvs
-    : a.depth > b.depth || (a.depth === b.depth && a.nodes > b.nodes) || (a.depth === b.depth && a.nodes===b.nodes && !!a.bestmove && !b.bestmove);
+    : a.depth > b.depth ||
+      (a.depth === b.depth && a.nodes > b.nodes) ||
+      (a.depth === b.depth && a.nodes === b.nodes && !!a.bestmove && !b.bestmove);
 
 export function renderEval(e: number): string {
   e = Math.max(Math.min(Math.round(e / 10) / 10, 99), -99);

--- a/ui/lib/src/ceval/util.ts
+++ b/ui/lib/src/ceval/util.ts
@@ -9,7 +9,7 @@ import { memoize, escapeHtml } from '../index';
 export const isFirstEvalBetter = (a: ClientEval, b: ClientEval, desiredPvs: number): boolean =>
   a.pvs.length >= desiredPvs !== b.pvs.length >= desiredPvs
     ? a.pvs.length >= desiredPvs
-    : a.depth > b.depth || (a.depth === b.depth && a.nodes > b.nodes);
+    : a.depth > b.depth || (a.depth === b.depth && a.nodes > b.nodes) || (a.depth === b.depth && a.nodes===b.nodes && !!a.bestmove && !b.bestmove);
 
 export function renderEval(e: number): string {
   e = Math.max(Math.min(Math.round(e / 10) / 10, 99), -99);


### PR DESCRIPTION
Why the change is needed:
On Analysis Board in Practice with computer mode the game is stuck after several moves.
Link to issue:
https://github.com/lichess-org/lila/issues/20803
Solution:
When comparing which of the 2 moves is better I added a case where if the depth and number of nodes is the same preffer the one that has the bestmove set.