### PR TITLE
ui: botDev types cleanup

### DIFF
--- a/ui/botDev/src/analyse.ts
+++ b/ui/botDev/src/analyse.ts
@@ -1,36 +1,35 @@
-import * as co from 'chessops';
+import { pgn, opposite } from 'chessops';
 
 import { escapeHtml, frag } from 'lib';
 
 import { env } from './devEnv';
 import { type GameCtrl } from './gameCtrl';
 
-export function analyse(gameCtrl: GameCtrl): void {
-  const local = gameCtrl.live;
-  const root = new co.pgn.Node<co.pgn.PgnNodeData>();
+export function analyse({ live, clock, white, black }: GameCtrl): void {
+  const root = new pgn.Node<pgn.PgnNodeData>();
   let node = root;
-  for (const move of gameCtrl.live.observe()) {
-    const comments = move.clock ? [co.pgn.makeComment({ clock: move.clock[co.opposite(move.turn)] })] : [];
-    const newNode = new co.pgn.ChildNode<co.pgn.PgnNodeData>({ san: move.san, comments });
+  for (const move of live.observe()) {
+    const comments = move.clock ? [pgn.makeComment({ clock: move.clock[opposite(move.turn)] })] : [];
+    const newNode = new pgn.ChildNode<pgn.PgnNodeData>({ san: move.san, comments });
     node.children.push(newNode);
     node = newNode;
   }
   const game = {
-    headers: new Map<string, string>([
+    headers: new Map([
       ['Event', 'Local game'],
       ['Site', 'lichess.org'],
       ['Date', new Date().toISOString().split('T')[0]],
       ['Round', '?'],
-      ['White', env.bot.nameOf(gameCtrl.white)],
-      ['Black', env.bot.nameOf(gameCtrl.black)],
-      ['Result', local.status.winner ? (local.status.winner === 'white' ? '1-0' : '0-1') : '1/2-1/2'],
-      ['TimeControl', gameCtrl.clock ? `${gameCtrl.clock.initial}+${gameCtrl.clock.increment}` : '-'],
+      ['White', env.bot.nameOf(white)],
+      ['Black', env.bot.nameOf(black)],
+      ['Result', live.status.winner ? (live.status.winner === 'white' ? '1-0' : '0-1') : '1/2-1/2'],
+      ['TimeControl', clock ? `${clock.initial}+${clock.increment}` : '-'],
     ]),
     moves: root,
   };
-  const pgn = co.pgn.makePgn(game);
+  const pgnString = pgn.makePgn(game);
   const formEl = frag<HTMLFormElement>(`<form method="post" action="/import">
-    <textarea name="pgn">${escapeHtml(pgn)}</textarea></form>`);
+    <textarea name="pgn">${escapeHtml(pgnString)}</textarea></form>`);
   document.body.appendChild(formEl);
   formEl.submit();
 }

--- a/ui/botDev/src/assetDialog.ts
+++ b/ui/botDev/src/assetDialog.ts
@@ -17,7 +17,7 @@ const mimeTypes: Record<AssetType, string[]> = {
 
 export class AssetDialog {
   private dlg: Dialog;
-  private resolve?: (key: string | undefined) => void;
+  private resolve?: (key?: string) => void;
   private type: AssetType;
   private readonly isChooser: boolean;
   constructor(type?: AssetType) {

--- a/ui/botDev/src/devAssets.ts
+++ b/ui/botDev/src/devAssets.ts
@@ -202,11 +202,13 @@ export class DevAssets {
     }
     if (fromStudy) {
       localStorage.setItem('botdev.import.book', `${key}${oldKey ? ',' + oldKey : ''}`);
-      alert(`${name} exported to bot studio. ${promises.length ? ` ${promises.length} bots updated` : ''}`);
+      await alert(
+        `${name} exported to bot studio. ${promises.length ? ` ${promises.length} bots updated` : ''}`,
+      );
     } else {
       this.urls.bookCover.set(key, URL.createObjectURL(new Blob([cover.blob], { type: 'image/png' })));
       pubsub.emit('botdev.import.book', key, oldKey);
-      if (promises.length) alert(`updated ${promises.length} bots with new ${name}`);
+      if (promises.length) await alert(`updated ${promises.length} bots with new ${name}`);
     }
     return key;
   }

--- a/ui/botDev/src/devBotCtrl.ts
+++ b/ui/botDev/src/devBotCtrl.ts
@@ -63,7 +63,7 @@ export class DevBotCtrl extends BotLoader {
     return move?.uci !== '0000' ? move : undefined;
   }
 
-  setUids({ white, black }: { white?: string | undefined; black?: string | undefined }): void {
+  setUids({ white, black }: { white?: string; black?: string }): void {
     this.uids.white = white;
     this.uids.black = black;
     this.reset();
@@ -120,7 +120,7 @@ export class DevBotCtrl extends BotLoader {
     await this.store.remove(bot.uid);
   }
 
-  info(uid: string | undefined): BotInfo | undefined {
+  info(uid?: string): BotInfo | undefined {
     if (uid === undefined) return undefined;
     return this.bots.get(uid) ?? this.rateBots[Number(uid.slice(1))];
   }
@@ -156,7 +156,7 @@ export class DevBotCtrl extends BotLoader {
     };
   }
 
-  async getBook(key: string | undefined): Promise<OpeningBook | undefined> {
+  async getBook(key?: string): Promise<OpeningBook | undefined> {
     if (!key) return undefined;
     if (this.book.has(key)) return this.book.get(key);
     if (!env.assets.idb.book.keyNames.has(key)) return super.getBook(key);
@@ -202,15 +202,15 @@ export class DevBotCtrl extends BotLoader {
   };
 }
 
-export function uidToDomId(uid: string | undefined): string | undefined {
+export function uidToDomId(uid?: string): string | undefined {
   return uid?.startsWith('#') ? `bot-id-${uid.slice(1)}` : undefined;
 }
 
-export function domIdToUid(domId: string | undefined): string | undefined {
+export function domIdToUid(domId?: string): string | undefined {
   return domId?.startsWith('bot-id-') ? `#${domId.slice(7)}` : undefined;
 }
 
-export function botEquals(a: BotInfo | undefined, b: BotInfo | undefined): boolean {
+export function botEquals(a?: BotInfo, b?: BotInfo): boolean {
   if (!closeEnough(a, b, ['filters', 'version'])) return false;
   const [aFilters, bFilters] = [a, b].map(bot =>
     Object.entries(bot?.filters ?? {}).filter(([_, v]) => v.move || v.time || v.score),
@@ -235,7 +235,7 @@ function closeEnough(a: any, b: any, ignore: string[] = []): boolean {
   return true;
 }
 
-function filteredKeys(obj: any, ignore: string[] = []): string[] {
+function filteredKeys(obj: object, ignore: string[] = []): string[] {
   if (typeof obj !== 'object') return obj;
   return Object.entries(obj)
     .filter(([k, v]) => !ignore.includes(k) && !isEmpty(v))

--- a/ui/botDev/src/devSideView.ts
+++ b/ui/botDev/src/devSideView.ts
@@ -2,7 +2,7 @@ import * as co from 'chessops';
 
 import { definedMap } from 'lib/algo';
 import { Bot } from 'lib/bot/bot';
-import type { LocalSpeed, LocalSetup } from 'lib/bot/types';
+import type { LocalSpeed, LocalSetup, BotInfo } from 'lib/bot/types';
 import { licon, type LiconValue } from 'lib/licon';
 import { storedBooleanProp, storedIntProp } from 'lib/storage';
 import { type VNode, hl, onInsert, bind, domDialog, iconTag, dataIcon } from 'lib/view';
@@ -24,7 +24,7 @@ export function renderDevSide(): VNode {
 }
 
 function player(color: Color): VNode {
-  const p = env.bot[color] as Bot | undefined;
+  const p = env.bot[color];
   const imgUrl = env.bot.imageUrl(p) ?? `/${env.assets.path}/image/gray-torso.webp`;
   const isLight = document.documentElement.classList.contains('light');
   const buttonClass = {
@@ -98,7 +98,7 @@ function ratingText(uid: string, speed: LocalSpeed): string {
   return `${glicko.r}${glicko.rd > 80 ? '?' : ''}`;
 }
 
-function ratingSpan(p: Bot): VNode {
+function ratingSpan(p: Bot | BotInfo): VNode {
   const glicko = env.dev.getRating(p.uid, env.game.speed);
   return hl('span.stats', [iconTag(speedIcon(env.game.speed)), `${glicko.r}${glicko.rd > 80 ? '?' : ''}`]);
 }

--- a/ui/botDev/src/devUtil.ts
+++ b/ui/botDev/src/devUtil.ts
@@ -57,10 +57,7 @@ export function botScore(r: Result, uid: string): number {
   return r.winner === undefined ? 0.5 : r[r.winner] === uid ? 1 : 0;
 }
 
-export function resultsObject(
-  results: Result[],
-  uid: string | undefined,
-): { w: number; d: number; l: number } {
+export function resultsObject(results: Result[], uid?: string): { w: number; d: number; l: number } {
   return results.reduce(
     (a, r) => ({
       w: a.w + (r.winner !== undefined && r[r.winner] === uid ? 1 : 0),

--- a/ui/botDev/src/filterPane.ts
+++ b/ui/botDev/src/filterPane.ts
@@ -102,7 +102,7 @@ export class FilterPane extends Pane {
         e.target.closest('.facet')?.classList.add('active');
         this.paneValue[facet] ??= [];
       }
-      super.update(e);
+      super.update();
     });
     el.prepend(input);
     return { input, el };

--- a/ui/botDev/src/handOfCards.ts
+++ b/ui/botDev/src/handOfCards.ts
@@ -369,7 +369,7 @@ class HandOfCardsImpl {
 
   touchUpCard = (e: PointerEvent) => {
     if (!this.drag?.shape) return;
-    const outcome = this.drag.shape.outcome(e) || this.dropTarget(e);
+    const outcome = this.drag.shape.outcome() || this.dropTarget(e);
     if (outcome === 'next-group') {
       const groups = [...this.groups];
       const index = groups.indexOf(this.group);
@@ -391,7 +391,7 @@ class HandOfCardsImpl {
   }
   dragStart = (e: DragEvent) => e.preventDefault();
 
-  select(drop: HTMLElement | undefined, domId?: DomId) {
+  select(drop?: HTMLElement, domId?: DomId) {
     if (this.opts.transient) this.remove();
     return this.opts.select(drop, domId);
   }
@@ -511,7 +511,7 @@ class TouchDragShape {
     return { speed, dir };
   }
 
-  outcome(_: PointerEvent): HTMLElement | 'next-group' | undefined {
+  outcome(): HTMLElement | 'next-group' | undefined {
     const momentum = this.momentum;
     if (momentum.speed < 0.15) return undefined;
     if (momentum.dir === 'towards-drop') return this.drops[0].el;

--- a/ui/botDev/src/historyDialog.ts
+++ b/ui/botDev/src/historyDialog.ts
@@ -108,7 +108,7 @@ class HistoryDialog {
     this.json(bot);
   }
 
-  version(version: string | number | undefined): BotVersionInfo | undefined {
+  version(version?: string | number): BotVersionInfo | undefined {
     if (!version) return;
     return this.versions.find(b => String(b.version) === String(version));
   }

--- a/ui/botDev/src/pane.ts
+++ b/ui/botDev/src/pane.ts
@@ -94,7 +94,7 @@ export class Pane<Info extends PaneInfo = PaneInfo> {
     return enabled;
   }
 
-  update(_?: Event): void {
+  update(): void {
     this.setProperty(this.paneValue);
     this.setEnabled(this.isDefined);
     this.host.update();
@@ -343,7 +343,7 @@ export class RangeSetting<Info extends RangeInfo = RangeInfo> extends NumberSett
   }
 }
 
-function getRequirementIds(r: Requirement | undefined): string[] {
+function getRequirementIds(r?: Requirement): string[] {
   if (typeof r === 'string') {
     const req = r.trim();
     if (req.startsWith('!')) return [req.slice(1).trim()];

--- a/ui/botDev/src/panes.ts
+++ b/ui/botDev/src/panes.ts
@@ -51,7 +51,7 @@ export class Panes {
 
   private readonly updateProperty: ActionListener = e => {
     const pane = this.byEvent(e)!;
-    pane.update(e);
+    pane.update();
     pane.host.update();
   };
 }

--- a/ui/botDev/src/pushCtrl.ts
+++ b/ui/botDev/src/pushCtrl.ts
@@ -57,10 +57,7 @@ export class PushCtrl {
     }
   }
 
-  async pushAsset(
-    asset: AssetBlob | undefined,
-    progress?: (e: ProgressEvent, key: string) => void,
-  ): Promise<void> {
+  async pushAsset(asset?: AssetBlob, progress?: (e: ProgressEvent, key: string) => void): Promise<void> {
     if (!asset) return;
     const type = asset.type;
     if (type === 'bookCover' || type === 'net') throw new Error('invalid asset type');

--- a/ui/botDev/src/roundProxy.ts
+++ b/ui/botDev/src/roundProxy.ts
@@ -1,5 +1,5 @@
 import * as co from 'chessops';
-import type { RoundProxy as RoundProxyType, RoundData, RoundOpts } from 'round';
+import type { RoundProxy as RoundProxyType, RoundData, RoundOpts, Pref } from 'round';
 
 import { myUserId } from 'lib';
 import { type Player, clockToSpeed } from 'lib/game';
@@ -20,7 +20,7 @@ export class RoundProxy implements RoundProxyType {
     'draw-yes': () => env.game.draw(),
   };
 
-  constructor(prefs: any) {
+  constructor(prefs: Pref) {
     this.data = {
       game: {
         id: 'synthetic',
@@ -36,7 +36,7 @@ export class RoundProxy implements RoundProxyType {
       local: this,
       player: {} as Player,
       opponent: {} as Player,
-      pref: { ...prefs, submitMove: 0 },
+      pref: { ...prefs, submitMove: false },
       steps: [],
       takebackable: false,
       moretimeable: false,
@@ -49,7 +49,7 @@ export class RoundProxy implements RoundProxyType {
   outoftime = (): void => env.game.flag();
   berserk = (): void => {};
   reload: () => void = site.reload;
-  sendLoading = (typ: string, data?: any): void => this.send(typ, data);
+  sendLoading = (typ: string): void => this.send(typ);
 
   send(t: string, d?: any): void {
     if (this.handlers[t]) this.handlers[t]?.(d);
@@ -62,7 +62,7 @@ export class RoundProxy implements RoundProxyType {
     return true;
   };
 
-  updateBoard(game: LocalGame | undefined, opts?: CgConfig): void {
+  updateBoard(game?: LocalGame, opts?: CgConfig): void {
     const updates: CgConfig = {};
     if (game) {
       updates.fen = game.fen;


### PR DESCRIPTION
# How

Chop down few more `any` typings, avoid unnecessary casting, optimize imports, use optional shorthand.

# Test plan

Bot setup works as expected, there are no TSC, lint or format warnings.