### PR TITLE
Bump liplay 3.1.0

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 resolvers += "jitpack".at("https://jitpack.io")
 
-addSbtPlugin("com.github.lichess-org.liplay" % "sbt-plugin" % "3.0.4")
+addSbtPlugin("com.github.lichess-org.liplay" % "sbt-plugin" % "3.1.0")
 
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.11.4")
 


### PR DESCRIPTION
Bump liplay 3.1.0 with many dependency updates and a lot of code removal:
https://github.com/lichess-org/liplay/releases/tag/3.1.0
