### PR TITLE
Fix spacebar behavior during mistake review

### DIFF
--- a/ui/analyse/src/keyboard.ts
+++ b/ui/analyse/src/keyboard.ts
@@ -44,7 +44,7 @@ export const bind = (ctrl: AnalyseCtrl) => {
   kbd.bind('space', () => {
     const gb = ctrl.gamebookPlay();
     if (gb) gb.onSpace();
-    else if (ctrl.practice || ctrl.study?.practice) return undefined;
+    else if (ctrl.practice || ctrl.study?.practice || ctrl.retro?.isSolving()) return undefined;
     else if (ctrl.cevalEnabled()) ctrl.playBestMove();
     else if (ctrl.isCevalAllowed() && ctrl.ceval.analysable) ctrl.cevalEnabled(!ctrl.cevalEnabled());
   });


### PR DESCRIPTION
### Why the change is needed:
On the Analysis Board, in "Learn from your mistakes" mode, pressing spacebar plays the best engine move and reveals the solution you are supposed to find.

### Link to issue:
Closes #20571

### Solution:
Added a check so spacebar does nothing while the user is reviewing their mistakes and still trying to find the move.

### Testing:
Built locally. Before: in "Learn from your mistakes", spacebar played the best move and revealed the answer. After: spacebar no longer plays the move while solving.

### AI assistance:
This change was made with AI assistance (Claude Code, Anthropic).
Prompt: "Fix the bug described in #20571, write the PR content following guidelines in CONTRIBUTING.md"
Some AI generated outputs have been modified. I was able to reproduce the bug before modifying code and confirmed the fix after.

### Video
Uses [KeyCastr](https://github.com/keycastr/keycastr) to show spacebar behavior. Top engine moves are not played when reviewing mistakes but are played otherwise.
<video src="https://github.com/user-attachments/assets/1a5d3ac9-7dc3-4a56-859d-05688a9b2b59" controls width="100%"></video>