### PR TITLE
ui: tweak study create from game view

### DIFF
--- a/modules/study/src/main/ui/StudyUi.scala
+++ b/modules/study/src/main/ui/StudyUi.scala
@@ -32,7 +32,7 @@ final class StudyUi(helpers: Helpers):
       if Study.maxChapters <= chapterCount then submitButton(cls := "disabled", st.disabled)
       else submitButton
 
-    btn(name := "as", value := s.id, cls := "button submit")(s.name)
+    btn(name := "as", value := s.id, cls := "button button-empty study submit")(s.name)
 
   def create(
       data: lila.study.StudyForm.importGame.Data,
@@ -59,11 +59,13 @@ final class StudyUi(helpers: Helpers):
         div(cls := "studies")(
           div(
             h2(trans.study.myStudies()),
-            owner.map(studyButton)
+            if owner.nonEmpty then owner.map(studyButton)
+            else p(cls:= "placeholder")(trans.site.none())
           ),
           div(
             h2(trans.study.studiesIContributeTo()),
-            contrib.map(studyButton)
+            if contrib.nonEmpty then contrib.map(studyButton)
+            else p(cls:= "placeholder")(trans.site.none())
           )
         )
       )

--- a/modules/study/src/main/ui/StudyUi.scala
+++ b/modules/study/src/main/ui/StudyUi.scala
@@ -60,12 +60,12 @@ final class StudyUi(helpers: Helpers):
           div(
             h2(trans.study.myStudies()),
             if owner.nonEmpty then owner.map(studyButton)
-            else p(cls:= "placeholder")(trans.site.none())
+            else p(cls := "placeholder")(trans.site.none())
           ),
           div(
             h2(trans.study.studiesIContributeTo()),
             if contrib.nonEmpty then contrib.map(studyButton)
-            else p(cls:= "placeholder")(trans.site.none())
+            else p(cls := "placeholder")(trans.site.none())
           )
         )
       )

--- a/ui/analyse/css/build/analyse.study.create.scss
+++ b/ui/analyse/css/build/analyse.study.create.scss
@@ -1,3 +1,5 @@
+@import '../analyse.abstract';
+@import '../../../lib/css/component/button';
 @import '../../../lib/css/plugin';
 @import '../../../lib/css/form/form3';
 @import '../study/create';

--- a/ui/analyse/css/study/_create.scss
+++ b/ui/analyse/css/study/_create.scss
@@ -4,10 +4,23 @@
     margin-bottom: 1em;
   }
 
-  button.new {
-    margin: 1.5em auto;
-    display: block;
-    font-size: 2em;
+  button {
+    font-weight: 500;
+
+    &.new {
+      margin: 1.5em auto;
+      font-size: 2em;
+      align-items: center;
+      display: flex;
+    }
+
+    &.study {
+      text-align: left;
+      display: inline-block;
+      width: 100%;
+      margin-bottom: 3px;
+      text-transform: none;
+    }
   }
 
   .studies {
@@ -23,13 +36,9 @@
       }
     }
 
-    button {
-      width: 100%;
-      text-align: left;
-      overflow: hidden;
-      margin-bottom: 3px;
-      text-transform: none;
-      background: color-mix($c-primary 70%, black);
+    .placeholder {
+      color: $c-font-dim;
+      line-height: 38px;
     }
   }
 }


### PR DESCRIPTION
# How

Small visual tweaks for study create view from the game. Alter study buttons appearance, tweak aligment, add empty list placeholder.

# Preview

### Before

<img width="1330" height="579" alt="Screenshot 2026-07-06 at 12 33 32" src="https://github.com/user-attachments/assets/d9d851d2-0692-400f-9fa8-2fa14fd002da" />
<img width="1330" height="579" alt="Screenshot 2026-07-06 at 12 28 58" src="https://github.com/user-attachments/assets/219db81e-ee6a-44a4-8b68-9c3859e0d813" />

### After

<img width="1330" height="579" alt="Screenshot 2026-07-06 at 12 28 47" src="https://github.com/user-attachments/assets/ebfeef8a-d413-4b07-9072-2c57a9a73079" />
<img width="1330" height="579" alt="Screenshot 2026-07-06 at 12 29 04" src="https://github.com/user-attachments/assets/d7d8f2ac-5d72-40d3-bb25-a3d331fd91b8" />
