### PR TITLE
ui: render site message body in fragment instead of paragraph

### DIFF
--- a/modules/web/src/main/ui/SiteMessage.scala
+++ b/modules/web/src/main/ui/SiteMessage.scala
@@ -18,24 +18,24 @@ final class SiteMessage(helpers: Helpers):
             title
           )
         ),
-        p(body)
+        frag(body)
       )
 
   def noBot = apply("No bot area"):
-    frag("Sorry, bot accounts are not allowed here.")
+    p("Sorry, bot accounts are not allowed here.")
 
   def noEngine = apply("No engine area"):
-    "Sorry, engine assisted players are not allowed here."
+    p("Sorry, engine assisted players are not allowed here.")
 
   def noBooster = apply("No booster area"):
-    "Sorry, boosters and sandbaggers are not allowed here."
+    p("Sorry, boosters and sandbaggers are not allowed here.")
 
   def noLame(using me: Me) =
     if me.marks.boost then noBooster
     if me.marks.engine then noEngine
     else // ?
       apply("Restricted area"):
-        "Sorry, the access to this resource is restricted."
+        p("Sorry, the access to this resource is restricted.")
 
   def blacklistedMessage(using ctx: Context) =
     s"Sorry, your IP address ${ctx.ip} has been used to violate the ToS, and is now blacklisted."
@@ -43,7 +43,7 @@ final class SiteMessage(helpers: Helpers):
   def blacklistedSnippet(using Context) = lila.ui.Snippet(frag(blacklistedMessage))
 
   def streamingMod = apply("Disabled while streaming"):
-    frag(
+    p(
       "This moderation feature is disabled while streaming, ",
       "to avoid leaking sensible information."
     )
@@ -52,37 +52,37 @@ final class SiteMessage(helpers: Helpers):
     apply(
       title = trans.challenge.challengeToPlay.txt(),
       back = routes.Lobby.home.url.some
-    )(msg)
+    )(p(msg))
 
   def insightNoGames(u: User)(using Context) =
     apply(
       title = s"${u.username} has not played a rated game yet!",
       back = routes.User.show(u.id).url.some
     ):
-      frag(
+      p(
         "Before using chess insights,",
         userLink(u),
         " has to play at least one rated game."
       )
 
   def teamCreateLimit = apply("Cannot create a team"):
-    "You have already created a team this week."
+    p("You have already created a team this week.")
 
   def teamJoinLimit = apply("Cannot join the team"):
-    "You have already joined too many teams."
+    p("You have already joined too many teams.")
 
   def relayPrivate = apply("This tournament is private", routes.RelayTour.index().url.some):
-    "Sorry, this tournament is private, or maybe it doesn't exist."
+    p("Sorry, this tournament is private, or maybe it doesn't exist.")
 
   def authFailed = apply("403 - Access denied!"):
-    "You tried to visit a page you're not authorized to access."
+    p("You tried to visit a page you're not authorized to access.")
 
-  def serverError(msg: String) = apply("Something went wrong")(msg)
+  def serverError(msg: String) = apply("Something went wrong")(p(msg))
 
   def temporarilyDisabled = apply("Temporarily disabled"):
-    "Sorry, this feature is temporarily disabled while we figure out a way to bring it back."
+    p("Sorry, this feature is temporarily disabled while we figure out a way to bring it back.")
 
   def rateLimited(msg: String = "Too many requests") = apply(msg):
-    "Your device or network has sent too many requests in a short amount of time. Please try again later."
+    p("Your device or network has sent too many requests in a short amount of time. Please try again later.")
 
-  def notYet(text: String) = apply("Not yet available")(text)
+  def notYet(text: String) = apply("Not yet available")(p(text))

--- a/modules/web/src/main/ui/SiteMessage.scala
+++ b/modules/web/src/main/ui/SiteMessage.scala
@@ -18,7 +18,7 @@ final class SiteMessage(helpers: Helpers):
             title
           )
         ),
-        frag(body)
+        body
       )
 
   def noBot = apply("No bot area"):


### PR DESCRIPTION
# Why

While working on study page changes I have spotted that there are some empty paragraphs present in the DOM.

<img width="545" height="161" alt="Screenshot 2026-07-06 at 12 53 39" src="https://github.com/user-attachments/assets/128b2072-8528-451f-bdde-919a83e10dc7" />

# How

After investigation, I have found that SiteMessage is sometimes used a layout container for the whole pages. 

Probably i the long term it would be more viable to refactor the problematic use cases, but for now I have changed the body wrapper element to fragment, and added paragraph directly to the messages using the template.

# Preview

<img width="545" height="133" alt="Screenshot 2026-07-06 at 12 53 27" src="https://github.com/user-attachments/assets/0a2d9dac-50ec-4462-b993-a72eba73c319" />
