### PR TITLE
Fix practice mode using wrong player color in Racing Kings

### DIFF
--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -324,6 +324,10 @@ export default class AnalyseCtrl implements CevalHandler {
     return this.flipped ? opposite(this.data.orientation) : this.data.orientation;
   }
 
+  practiceColor(): Color {
+    return this.flipped ? opposite(this.data.orientation) : this.data.orientation;
+  }
+
   bottomIsWhite = () => this.bottomColor() === 'white';
 
   getOrientation(): Color {

--- a/ui/analyse/src/practice/practiceCtrl.ts
+++ b/ui/analyse/src/practice/practiceCtrl.ts
@@ -105,7 +105,7 @@ export function make(root: AnalyseCtrl): PracticeCtrl {
           ? { cp: 0 }
           : (node.ceval as EvalScore));
       const prevEval: EvalScore = tbhitToEval(prev.tbhit) || prev.ceval!;
-      const shift = -winningChances.povDiff(root.bottomColor(), nodeEval, prevEval);
+      const shift = -winningChances.povDiff(root.practiceColor(), nodeEval, prevEval);
 
       best = nodeBestUci(prev);
       if (
@@ -138,7 +138,7 @@ export function make(root: AnalyseCtrl): PracticeCtrl {
     };
   }
 
-  const isMyTurn = (): boolean => root.turnColor() === root.bottomColor();
+  const isMyTurn = (): boolean => root.turnColor() === root.practiceColor();
 
   function checkCeval() {
     const node = root.node;


### PR DESCRIPTION
Fixes #14116.

## Summary

`bottomColor()` is intentionally overridden for Racing Kings so the board is always displayed with White at the bottom. However, `practiceCtrl.ts` also used `bottomColor()` to determine the player's practice color, causing Practice Mode to always assume the user was White.

This change introduces a separate `practiceColor()` method that reflects the actual player color without the Racing Kings display override, and updates Practice Mode to use it for turn detection and evaluation scoring. Board orientation remains unchanged.

## Testing

- [x] TypeScript compilation completed successfully: `pnpm exec tsc -p ui/analyse/tsconfig.json --noEmit`
- [ ] Manual local test pending. I attempted to start lila locally, but dependency fetching hit a temporary GitHub raw HTTP 429 rate limit.