### PR TITLE
improve inbox chat colors on old browsers

### DIFF
--- a/ui/msg/css/_convoMsgs.scss
+++ b/ui/msg/css/_convoMsgs.scss
@@ -129,4 +129,28 @@
       text-transform: none;
     }
   }
+
+  @supports not (color: color-mix(red, blue)) {
+    --c-mine: #2f3425;
+    --c-their: #3b3125;
+    --c-day: #2c343c;
+
+    @include if-light {
+      --c-mine: #e6efdf;
+      --c-their: #faefe1;
+      --c-day: #dfebf9;
+    }
+
+    mine {
+      background-color: var(--c-mine);
+    }
+
+    their {
+      background-color: var(--c-their);
+    }
+
+    day {
+      background-color: var(--c-day);
+    }
+  }
 }


### PR DESCRIPTION
Merging this would mostly serve to prolong the experience of users reluctant to update to iOS 16.2+. However, these devices (and older) cannot be upgraded due to hardware age:

- iPhone 6s / 6s Plus — released Sep 25, 2015
- iPhone SE 1st gen — released Mar 31, 2016
- iPhone 7 / 7 Plus - released Sep 16, 2016
- iPod touch 7th gen - released May 28, 2019

Full compatibility list: https://support.apple.com/en-us/103267

### After this morning's deploy, older devices now see:
<img width="611" height="238" alt="image" src="https://github.com/user-attachments/assets/9872f38c-bd8c-43c4-8d68-a6a97a370520" />

### With this change, they would once again see:
<img width="611" height="215" alt="image" src="https://github.com/user-attachments/assets/b9db9a88-ac3c-4696-b5eb-f4c9229473e5" />