### PR TITLE
provide css color fallback for active move background

### DIFF
--- a/ui/lib/css/tree/_tree.scss
+++ b/ui/lib/css/tree/_tree.scss
@@ -459,3 +459,9 @@ $disclosure-btn-size: calc(15px + var(---button-size-pointer-adjust, 0px));
     cursor: pointer;
   }
 }
+
+@supports not (color: color-mix(red, blue)) {
+  .tview2 move.active {
+    background: $c-primary;
+  }
+}


### PR DESCRIPTION
Related to 4a4611db8354cbc1d597ef808fcf18c28a8d6d50

If a substantial number of true readability/usability color issues show up, you might offload all of these compatibility color override rules to a single trailer css (just to keep the main css clean). So `color-fix.css` would contain a grab bag of rules for `.tview move.active`, `.msg-app__convo__msgs mine/theirs/day`, `header`, etc to keep older devices usable until the day they're discarded because the battery no longer holds a charge.