### PR TITLE
Update snabbdom dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "oxfmt": "0.52.0",
     "oxlint": "1.68.0",
     "oxlint-tsgolint": "0.23.0",
-    "snabbdom": "3.5.1",
+    "snabbdom": "3.6.4",
     "stylelint": "^17.11.1",
     "stylelint-config-standard-scss": "^17.0.0",
     "stylelint-scss": "^7.1.1",
@@ -28,7 +28,6 @@
     "typescript": "^6.0.3"
   },
   "//": [
-    "snabbdom pinned to 3.5.1 until https://github.com/snabbdom/snabbdom/issues/1114 is resolved",
     "typescript above just to allow manual tsc. ui/.build/package.json's typescript version is the truth"
   ],
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,8 +48,8 @@ importers:
         specifier: 0.23.0
         version: 0.23.0
       snabbdom:
-        specifier: 3.5.1
-        version: 3.5.1
+        specifier: 3.6.4
+        version: 3.6.4
       stylelint:
         specifier: ^17.11.1
         version: 17.13.0(typescript@6.0.3)
@@ -2019,10 +2019,6 @@ packages:
     resolution: {integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==}
     engines: {node: '>=20'}
 
-  snabbdom@3.5.1:
-    resolution: {integrity: sha512-wHMNIOjkm/YNE5EM3RCbr/+DVgPg6AqQAX1eOxO46zYNvCXjKP5Y865tqQj3EXnaMBjkxmQA5jFuDpDK/dbfiA==}
-    engines: {node: '>=8.3.0'}
-
   snabbdom@3.6.4:
     resolution: {integrity: sha512-VmxEfuw1/Y/eFj5VtMhYnukExpYiPkNzoo3+N3qwAOUDMl8wXgbli5ebR+j0knE3lZ/0eYskLxNcX64uy10N9w==}
     engines: {node: '>=12.17.0'}
@@ -3574,8 +3570,6 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
-
-  snabbdom@3.5.1: {}
 
   snabbdom@3.6.4: {}
 


### PR DESCRIPTION
Same as https://github.com/lichess-org/pgn-viewer/pull/69 but for lila.

This also avoids having two different Snabbdom versions, which got introduced in https://github.com/lichess-org/lila/commit/bb406f03d05ebae2e2323a37bbfe91aa9342a916 when pgn-viewer was updated :)