### PR TITLE
ui: add study chapters move buttons

### DIFF
--- a/ui/analyse/css/study/_chapters.scss
+++ b/ui/analyse/css/study/_chapters.scss
@@ -1,4 +1,4 @@
-$span-width: 1.7em;
+$span-width: 1.5em;
 
 .study__chapters {
   @extend %study-list, %study-list-ongoing;
@@ -31,7 +31,8 @@ $span-width: 1.7em;
       color: $c-link;
       font-weight: bold;
       height: auto;
-      margin-inline-end: 0.4em;
+      padding-inline-start: 0.25em;
+      margin-inline-end: 0.25em;
       opacity: 0.8;
     }
 

--- a/ui/analyse/css/study/_list.scss
+++ b/ui/analyse/css/study/_list.scss
@@ -64,6 +64,20 @@
   .add {
     border-top: $border;
     cursor: pointer;
+    gap: 6px;
+    padding-inline-start: 0.5em;
+    align-items: center;
+
+    h3 {
+      flex: 1 1 100%;
+      line-height: 1;
+      margin: 0.5em 0;
+    }
+
+    icon {
+      color: $c-link;
+      margin-top: -2px;
+    }
   }
 }
 

--- a/ui/analyse/css/study/_list.scss
+++ b/ui/analyse/css/study/_list.scss
@@ -7,11 +7,11 @@
   .study-list > div,
   button {
     @extend %flex-between-nowrap;
+    @include transition;
 
     text-align: start;
     align-items: stretch;
-
-    @include transition;
+    gap: 2px;
 
     &:hover,
     &:focus,
@@ -21,8 +21,10 @@
     }
   }
 
-  .act {
+  .edit,
+  .move {
     @extend %flex-center-center;
+    @include transition;
 
     color: $c-font;
     cursor: pointer;
@@ -30,13 +32,26 @@
     align-self: center;
     font-size: 0.9em;
     opacity: 0.15;
-    padding: 0.3em;
-    margin-inline-end: 0.5em;
-
-    @include transition;
+    padding: 0.25em;
   }
 
-  .study-list > :hover .act {
+  .edit {
+    margin-inline-end: 0.25em;
+  }
+
+  .move {
+    width: 20px;
+    height: 20px;
+    line-height: 15px;
+
+    &.disabled {
+      opacity: 0.15;
+      pointer-events: none;
+    }
+  }
+
+  .study-list > :hover .edit,
+  .study-list > :hover .move:not(.disabled) {
     opacity: 0.7;
 
     &:hover {

--- a/ui/analyse/css/study/_members.scss
+++ b/ui/analyse/css/study/_members.scss
@@ -83,12 +83,9 @@
   }
 
   .add {
-    @extend %roboto;
-
-    &:hover icon {
-      color: $c-link;
+    icon {
+      font-size: 1em;
       opacity: 1;
-      transition: none;
     }
   }
 

--- a/ui/analyse/src/study/studyChapters.ts
+++ b/ui/analyse/src/study/studyChapters.ts
@@ -275,7 +275,7 @@ export function view(ctrl: StudyCtrl): VNode {
             ctrl.redraw,
           ),
         },
-        [hl('span', iconTag(licon.PlusButton)), hl('h3', i18n.study.addNewChapter)],
+        [iconTag(licon.PlusButton), hl('h3', i18n.study.addNewChapter)],
       ),
   ]);
 }

--- a/ui/analyse/src/study/studyChapters.ts
+++ b/ui/analyse/src/study/studyChapters.ts
@@ -155,24 +155,40 @@ export const gameLinksListener = (select: ChapterSelect) => (vnode: VNode) =>
     { passive: false },
   );
 
-function onListUpdate(ctrl: StudyCtrl, vnode: VNode) {
-  const vData = vnode.data!.li!,
-    el = vnode.elm as HTMLElement;
-  ctrl.chapters.scroller.scrollIfNeeded(el);
-  if (ctrl.members.canContribute() && ctrl.chapters.list.size() > 1 && !vData.sortable) {
+function onListUpdate({ chapters, members }: StudyCtrl, vnode: VNode) {
+  const vData = vnode.data!.li!;
+  const el = vnode.elm as HTMLElement;
+
+  chapters.scroller.scrollIfNeeded(el);
+
+  if (members.canContribute() && chapters.list.size() > 1 && !vData.sortable) {
     site.asset.loadEsm<typeof Sortable>('sortable.esm', { npm: true }).then(s => {
       vData.sortable = s.create(el, {
         draggable: '.draggable',
         handle: 'ontouchstart' in window ? 'span' : undefined,
-        onSort: () => ctrl.chapters.sort(vData.sortable.toArray()),
+        onSort: () => chapters.sort(vData.sortable.toArray()),
       });
     });
   }
 }
 
+function moveById(arr: ChapterPreview[], id: string, direction: 'up' | 'down') {
+  const index = arr.findIndex(item => item.id === id);
+
+  if (direction === 'up' && index === 0) return arr;
+  if (direction === 'down' && index === arr.length - 1) return arr;
+
+  const newArr = [...arr];
+  const swapIndex = direction === 'up' ? index - 1 : index + 1;
+
+  [newArr[index], newArr[swapIndex]] = [newArr[swapIndex], newArr[index]];
+
+  return newArr;
+}
+
 export function view(ctrl: StudyCtrl): VNode {
-  const canContribute = ctrl.members.canContribute(),
-    current = ctrl.currentChapter();
+  const canContribute = ctrl.members.canContribute();
+  const current = ctrl.currentChapter();
 
   return hl('div.study__chapters', [
     hl(
@@ -180,15 +196,24 @@ export function view(ctrl: StudyCtrl): VNode {
       {
         hook: {
           insert(vnode) {
-            (vnode.elm as HTMLElement).addEventListener('click', e => {
+            (vnode.elm as HTMLElement).addEventListener('click', async e => {
               const target = e.target as HTMLElement;
-              const id = (target.parentNode as HTMLElement).dataset['id'] || target.dataset['id'];
-              if (!id) return;
-              if (target.className === 'act') {
-                const chapter = ctrl.chapters.list.get(id);
-                if (chapter) ctrl.chapters.editForm.toggle(chapter);
-              } else ctrl.setChapter(id);
-              blurIfPrimaryClick(e);
+              const targetParent = target.parentNode as HTMLElement;
+              const direction = target.dataset['direction'];
+              const id = targetParent.dataset['id'] || target.dataset['id'];
+
+              if (direction && id) {
+                const chapters = ctrl.chapters.list.all();
+                ctrl.chapters.sort(moveById(chapters, id, direction as 'up' | 'down').map(c => c.id));
+              } else if (id) {
+                if (target.className === 'edit') {
+                  const chapter = ctrl.chapters.list.get(id);
+                  if (chapter) ctrl.chapters.editForm.toggle(chapter);
+                } else {
+                  await ctrl.setChapter(id);
+                }
+                blurIfPrimaryClick(e);
+              }
             });
             vnode.data!.li = {};
             ctrl.chapters.scroller.request('instant');
@@ -204,9 +229,9 @@ export function view(ctrl: StudyCtrl): VNode {
           },
         },
       },
-      ctrl.chapters.list.all().map((chapter, i) => {
-        const editing = ctrl.chapters.editForm.isEditing(chapter.id),
-          active = !ctrl.vm.loading && current?.id === chapter.id;
+      ctrl.chapters.list.all().map((chapter, i, chapters) => {
+        const editing = ctrl.chapters.editForm.isEditing(chapter.id);
+        const active = !ctrl.vm.loading && current?.id === chapter.id;
         return hl(
           'button',
           {
@@ -215,10 +240,24 @@ export function view(ctrl: StudyCtrl): VNode {
             class: { active, editing, draggable: canContribute },
           },
           [
-            hl('span', (i + 1).toString()),
+            hl('span', i + 1),
             hl('h3', chapter.name),
             chapter.status && hl('res', chapter.status),
-            canContribute && iconTag(licon.Gear, { title: i18n.study.editChapter, cls: 'act' }),
+            canContribute &&
+              iconTag(licon.UpTriangle, {
+                role: 'button',
+                'aria-label': 'Move chapter up',
+                'data-direction': 'up',
+                cls: `move${i === 0 ? ' disabled' : ''}`,
+              }),
+            canContribute &&
+              iconTag(licon.DownTriangle, {
+                role: 'button',
+                'aria-label': 'Move chapter down',
+                'data-direction': 'down',
+                cls: `move${i === chapters.length - 1 ? ' disabled' : ''}`,
+              }),
+            canContribute && iconTag(licon.Gear, { title: i18n.study.editChapter, cls: 'edit' }),
           ],
         );
       }),

--- a/ui/analyse/src/study/studyMembers.ts
+++ b/ui/analyse/src/study/studyMembers.ts
@@ -155,7 +155,7 @@ export function view(ctrl: StudyCtrl): VNode {
 
   function configButton(ctrl: StudyCtrl, member: StudyMember) {
     if (isOwner && (member.user.id !== members.opts.myId || ctrl.data.admin))
-      return hl('icon.act', {
+      return hl('icon.edit', {
         attrs: dataIcon(licon.Gear),
         hook: bind(
           'click',
@@ -218,10 +218,8 @@ export function view(ctrl: StudyCtrl): VNode {
     isOwner &&
       ordered.length < members.max &&
       hl('button.add', { key: 'add', hook: bind('click', members.inviteForm.toggle) }, [
-        hl('div.left', [
-          hl('span.status', iconTag(licon.PlusButton)),
-          hl('div.user-link', i18n.study.addMembers),
-        ]),
+        iconTag(licon.PlusButton),
+        hl('h3', i18n.study.addMembers),
       ]),
     !members.canContribute() &&
       ctrl.data.admin &&


### PR DESCRIPTION
# Why

Fixes #20865
* #20865

# How

Add study chapters move buttons to allow easier order management, especially on mobile. This is an alternate way to moving chapters by drag and drop. I have made the move buttons always visible (and not only on row hover) to avoid title shift to multiple lines for some chapters with lengthy names.

Additionally, I have made small styling/spacing/sizing tweaks for the chapter row elements.

# Preview

https://github.com/user-attachments/assets/b9487a9e-6606-4d6a-986b-374f011333c4

