### PR TITLE
ui: improve forum sticky rows visibility

### DIFF
--- a/ui/bits/css/forum/_forum.scss
+++ b/ui/bits/css/forum/_forum.scss
@@ -23,16 +23,26 @@
   &.forum-categ {
     padding-bottom: 1rem;
 
+    .bar {
+      @extend %box-padding-horiz;
+    }
+
     .sticky {
-      background: color-mix(in oklab, $c-secondary 12%, $c-bg);
+      background: color-mix(in oklab, $c-secondary 18%, $c-bg);
     }
 
     .sticky:nth-child(even) {
-      background: color-mix(in oklab, $c-secondary 12%, $c-bg-zebra);
+      background: color-mix(in oklab, $c-secondary 21%, $c-bg-zebra);
     }
 
-    .bar {
-      @extend %box-padding-horiz;
+    @include if-transp {
+      .sticky {
+        background: color-mix(in oklab, $c-secondary 26%, $c-bg);
+      }
+
+      .sticky:nth-child(even) {
+        background: color-mix(in oklab, $c-secondary 15%, $c-bg-zebra);
+      }
     }
   }
 


### PR DESCRIPTION
# Why

Fixes #20852
* #20852

# How

Tweak the background color mix values, and add overwrites for transparent theme (not sure if this was an issue before, but might be related to the latest color mix approach changes).

# Preview

<img width="1337" height="521" alt="Screenshot 2026-07-07 at 13 28 23" src="https://github.com/user-attachments/assets/9277a032-3750-4b27-b7b1-d009c16cef11" />
<img width="1337" height="521" alt="Screenshot 2026-07-07 at 13 28 29" src="https://github.com/user-attachments/assets/4329223b-73aa-48b3-80e0-67c99c000164" />
<img width="1337" height="521" alt="Screenshot 2026-07-07 at 13 28 54" src="https://github.com/user-attachments/assets/97d1db1d-9d42-48a5-9d90-1e206106d57f" />
