### PR TITLE
ui: restore first/last move button on mobile

### DIFF
--- a/ui/analyse/css/_tools-mobile.scss
+++ b/ui/analyse/css/_tools-mobile.scss
@@ -76,7 +76,7 @@
 
     .jumps .fbt[data-act='first'],
     .jumps .fbt[data-act='last'] {
-      flex: 1.6;
+      flex: 2;
     }
 
     .fbt.active {

--- a/ui/analyse/css/_tools-mobile.scss
+++ b/ui/analyse/css/_tools-mobile.scss
@@ -50,14 +50,6 @@
       }
     }
 
-    .scrub-help {
-      margin-inline: 3px;
-      align-self: center;
-      font-family: lichess;
-      font-size: 1.1em;
-      color: $c-border;
-    }
-
     .jumps {
       order: 1;
       padding: 2px;

--- a/ui/analyse/css/_tools-mobile.scss
+++ b/ui/analyse/css/_tools-mobile.scss
@@ -1,5 +1,7 @@
 @include mq-is-col1 {
   .analyse__tools {
+    border-radius: 0;
+
     .sub-box {
       order: 0;
     }
@@ -26,29 +28,26 @@
   }
 
   .analyse__controls {
-    padding-top: 6px;
-    height: 5rem;
+    height: auto;
     touch-action: pan-y;
-
-    .jumps {
-      order: 1;
-    }
-
-    [data-act='opening-explorer'] {
-      order: 2;
-    }
-
-    [data-act='menu'] {
-      order: 3;
-    }
+    flex-wrap: wrap;
 
     .fbt {
-      flex: 3;
+      flex: 1;
       margin: 3px 2px 0;
       border: 1px solid rgb(from $c-clearer r g b / calc(alpha * 0.05));
       border-bottom: none;
       border-radius: 6px 6px 0 0;
       background: color-mix(in oklab, $c-bg 50%, $c-bg-page);
+
+      &:not(.move) {
+        min-height: 3em;
+      }
+
+      &.active {
+        padding-top: 0;
+        border-bottom: none;
+      }
     }
 
     .scrub-help {
@@ -60,35 +59,27 @@
     }
 
     .jumps {
-      flex: 40%;
-    }
+      order: 1;
+      padding: 2px;
+      margin-bottom: 2px;
+      width: 100%;
+      height: 3em;
 
-    .jumps:has([data-act='first']) {
-      padding-inline: 8px;
-      flex: 50%;
-    }
+      .move {
+        background: color-mix(in oklab, $c-bg 50%, $c-bg-page);
+        border: 1px solid rgb(from $c-clearer r g b / calc(alpha * 0.05));
 
-    .jumps .fbt {
-      margin: 5px 2px;
-      background: color-mix(in oklab, $c-bg 50%, $c-bg-page);
-      border: 1px solid rgb(from $c-clearer r g b / calc(alpha * 0.05));
-    }
-
-    .jumps .fbt[data-act='first'],
-    .jumps .fbt[data-act='last'] {
-      flex: 2;
-    }
-
-    .fbt.active {
-      padding-top: 0;
-      border-bottom: none;
+        &[data-act='first'],
+        &[data-act='last'] {
+          flex: 2;
+        }
+      }
     }
 
     eval {
-      @media (min-width: at-least($xx-small)) {
-        font-size: 1.2em;
-      }
-
+      font-variant-numeric: tabular-nums;
+      font-weight: bold;
+      font-size: 1.25em;
       pointer-events: none;
     }
 
@@ -104,7 +95,7 @@
         margin-inline-start: 10px;
 
         @media (max-width: at-most($xxx-small)) {
-          transform: scale(0.7);
+          transform: scale(0.8);
           margin-inline-start: 0;
         }
 

--- a/ui/analyse/src/view/controls.ts
+++ b/ui/analyse/src/view/controls.ts
@@ -36,12 +36,20 @@ export function renderControls(ctrl: AnalyseCtrl) {
       ),
     },
     [
+      hl('div.jumps', [
+        jumpButton(licon.JumpFirst, 'first', canJumpPrev),
+        jumpButton(licon.LessThan, 'prev', canJumpPrev),
+        isMobileUi() &&
+          !scrubHelpAcknowledged() &&
+          !ctrl.study?.practice &&
+          iconTag(licon.InfoCircle, { cls: 'scrub-help', 'data-act': 'scrub-help' }),
+        jumpButton(licon.GreaterThan, 'next', canJumpNext),
+        jumpButton(licon.JumpLast, 'last', ctrl.node !== ctrl.mainline[ctrl.mainline.length - 1]),
+      ]),
       ctrl.study?.practice
-        ? [
-            hl('button.fbt', {
-              attrs: { title: i18n.site.analysis, 'data-act': 'analysis', 'data-icon': licon.Microscope },
-            }),
-          ]
+        ? hl('button.fbt', {
+            attrs: { title: i18n.site.analysis, 'data-act': 'analysis', 'data-icon': licon.Microscope },
+          })
         : [
             displayColumns() === 1 && ctrl.isCevalAllowed() && renderMobileCevalTab(ctrl),
             hl('button.fbt', {
@@ -57,24 +65,12 @@ export function renderControls(ctrl: AnalyseCtrl) {
             }),
             displayColumns() > 1 && !ctrl.retro && !ctrl.ongoing && renderPracticeTab(ctrl),
           ],
-      hl('div.jumps', [
-        jumpButton(licon.JumpFirst, 'first', canJumpPrev),
-        jumpButton(licon.LessThan, 'prev', canJumpPrev),
-        isMobileUi() &&
-          !scrubHelpAcknowledged() &&
-          !ctrl.study?.practice &&
-          iconTag(licon.InfoCircle, { cls: 'scrub-help', 'data-act': 'scrub-help' }),
-        jumpButton(licon.GreaterThan, 'next', canJumpNext),
-        jumpButton(licon.JumpLast, 'last', ctrl.node !== ctrl.mainline[ctrl.mainline.length - 1]),
-      ]),
-      [
-        ctrl.study?.practice
-          ? hl('div.noop')
-          : hl('button.fbt', {
-              class: { active: ctrl.activeControlBarTool() === 'action-menu' },
-              attrs: { title: i18n.site.menu, 'data-act': 'menu', 'data-icon': licon.Hamburger },
-            }),
-      ],
+      ctrl.study?.practice
+        ? hl('div.noop')
+        : hl('button.fbt', {
+            class: { active: ctrl.activeControlBarTool() === 'action-menu' },
+            attrs: { title: i18n.site.menu, 'data-act': 'menu', 'data-icon': licon.Hamburger },
+          }),
     ],
   );
 }

--- a/ui/analyse/src/view/controls.ts
+++ b/ui/analyse/src/view/controls.ts
@@ -1,22 +1,13 @@
-import { repeater, myUserId, blurIfPrimaryClick } from 'lib';
+import { repeater, blurIfPrimaryClick } from 'lib';
 import { renderEval, view as cevalView } from 'lib/ceval';
 import { displayColumns, isTouchDevice } from 'lib/device';
 import { licon, type LiconValue } from 'lib/licon';
 import { addPointerListeners } from 'lib/pointer';
-import { type VNode, type LooseVNode, onInsert, hl, domDialog, iconTag } from 'lib/view';
+import { type VNode, type LooseVNode, onInsert, hl } from 'lib/view';
 
 import type AnalyseCtrl from '../ctrl';
 
-type Action =
-  | 'first'
-  | 'prev'
-  | 'next'
-  | 'last'
-  | 'scrub-help'
-  | 'opening-explorer'
-  | 'menu'
-  | 'analysis'
-  | 'engine-mode';
+type Action = 'first' | 'prev' | 'next' | 'last' | 'opening-explorer' | 'menu' | 'analysis' | 'engine-mode';
 
 type EngineMode = 'ceval' | 'practice' | 'retro';
 
@@ -30,7 +21,6 @@ export function renderControls(ctrl: AnalyseCtrl) {
       hook: onInsert(el =>
         addPointerListeners(el, {
           click: e => clickControl(ctrl, e),
-          hscrub: isTouchDevice() ? dx => scrubControl(ctrl, dx) : undefined,
           hold: e => holdControl(ctrl, e),
         }),
       ),
@@ -39,10 +29,6 @@ export function renderControls(ctrl: AnalyseCtrl) {
       hl('div.jumps', [
         jumpButton(licon.JumpFirst, 'first', canJumpPrev),
         jumpButton(licon.LessThan, 'prev', canJumpPrev),
-        isMobileUi() &&
-          !scrubHelpAcknowledged() &&
-          !ctrl.study?.practice &&
-          iconTag(licon.InfoCircle, { cls: 'scrub-help', 'data-act': 'scrub-help' }),
         jumpButton(licon.GreaterThan, 'next', canJumpNext),
         jumpButton(licon.JumpLast, 'last', ctrl.node !== ctrl.mainline[ctrl.mainline.length - 1]),
       ]),
@@ -134,7 +120,6 @@ function clickControl(ctrl: AnalyseCtrl, e: PointerEvent) {
   else if (action === 'next') ctrl.navigate.next();
   else if (action === 'first') ctrl.navigate.first();
   else if (action === 'last') ctrl.navigate.last();
-  else if (action === 'scrub-help') scrubHelp(ctrl);
   else if (action === 'opening-explorer') ctrl.toggleExplorer();
   else if (action === 'menu') ctrl.toggleActionMenu();
   else if (action === 'analysis') window.open(ctrl.study?.practice?.analysisUrl(), '_blank');
@@ -153,50 +138,7 @@ function clickControl(ctrl: AnalyseCtrl, e: PointerEvent) {
   ctrl.redraw();
 }
 
-let last: number[] = [];
-
-function scrubControl(ctrl: AnalyseCtrl, dx: number | 'pointerup') {
-  if (dx === 'pointerup') {
-    const v = last.slice(-3).reduce((a, b) => a + b, 0) / Math.min(last.length, 3);
-    if (v > 16) ctrl.navigate.last();
-    else if (v < -16) ctrl.navigate.first();
-    last = [];
-  } else {
-    if (dx > 0) ctrl.navigate.next();
-    else ctrl.navigate.prev();
-    last.push(dx);
-  }
-  ctrl.redraw();
-}
-
 const jumpButton = (icon: LiconValue, effect: string, enabled: boolean): VNode =>
   hl('button.fbt.move', { attrs: { disabled: !enabled, 'data-act': effect, 'data-icon': icon } });
 
 const isMobileUi = (): boolean => displayColumns() === 1 && isTouchDevice();
-
-function scrubHelp(ctrl: AnalyseCtrl) {
-  domDialog({
-    htmlText: $html`
-      <p>
-        Swipe left or right on the button bar below the board to go to game start or end.
-      </p>
-      <p>
-        Move your finger slowly to scrub through moves one by one.
-      </p>
-      <button class="button">${i18n.site.ok}</button>`,
-    actions: [{ selector: 'button', result: 'ok' }],
-    easyClose: 'clickOutside',
-    noCloseButton: true,
-    show: true,
-  }).then(dlg => {
-    scrubHelpAcknowledged(dlg.returnValue === 'ok');
-    ctrl.redraw();
-  });
-}
-
-function scrubHelpAcknowledged(ack?: boolean) {
-  const key = `analyse.help.scrub-acknowledged.${myUserId() ?? 'anon'}`;
-  if (ack === undefined) return !!localStorage.getItem(key);
-  if (ack) localStorage.setItem(key, '1');
-  return ack;
-}

--- a/ui/analyse/src/view/controls.ts
+++ b/ui/analyse/src/view/controls.ts
@@ -58,15 +58,14 @@ export function renderControls(ctrl: AnalyseCtrl) {
             displayColumns() > 1 && !ctrl.retro && !ctrl.ongoing && renderPracticeTab(ctrl),
           ],
       hl('div.jumps', [
-        (!isMobileUi() || ctrl.study?.practice) && jumpButton(licon.JumpFirst, 'first', canJumpPrev),
+        jumpButton(licon.JumpFirst, 'first', canJumpPrev),
         jumpButton(licon.LessThan, 'prev', canJumpPrev),
         isMobileUi() &&
           !scrubHelpAcknowledged() &&
           !ctrl.study?.practice &&
           iconTag(licon.InfoCircle, { cls: 'scrub-help', 'data-act': 'scrub-help' }),
         jumpButton(licon.GreaterThan, 'next', canJumpNext),
-        (!isMobileUi() || ctrl.study?.practice) &&
-          jumpButton(licon.JumpLast, 'last', ctrl.node !== ctrl.mainline[ctrl.mainline.length - 1]),
+        jumpButton(licon.JumpLast, 'last', ctrl.node !== ctrl.mainline[ctrl.mainline.length - 1]),
       ]),
       [
         ctrl.study?.practice

--- a/ui/lib/css/chess/_control.scss
+++ b/ui/lib/css/chess/_control.scss
@@ -14,6 +14,15 @@
     text-align: center;
   }
 
+  [data-act='opening-explorer'],
+  [data-act='engine-mode'] {
+    order: 1;
+  }
+
+  [data-act='menu'] {
+    order: 3;
+  }
+
   .hidden {
     visibility: hidden;
   }
@@ -22,6 +31,7 @@
     font-size: 1.3rem;
     display: flex;
     padding: 4px;
+    order: 2;
 
     .fbt {
       border-radius: 8px;
@@ -29,7 +39,7 @@
 
       &[data-act='first'],
       &[data-act='last'] {
-        font-size: 0.7em;
+        font-size: 0.75em;
       }
 
       &[data-act='line'] {

--- a/ui/lib/src/pointer.ts
+++ b/ui/lib/src/pointer.ts
@@ -5,27 +5,23 @@ import { isTouchDevice } from './device';
 export type PointerListeners = {
   click?: (e: PointerEvent) => void;
   hold?: 'click' | ((e: PointerEvent) => void);
-  hscrub?: (dx: number | 'pointerup', e: PointerEvent) => any; // truthy return cancels
   holdDuration?: number;
-  scrubInterval?: number;
 };
 
 export function addPointerListeners(el: HTMLElement, listeners: PointerListeners): void {
-  const { click, hold, hscrub } = listeners;
-  const g = { timer: 0, x: 0, y: 0, lastMove: 0 };
+  const { click, hold } = listeners;
+  const g = { timer: 0, y: 0 };
   const holdDuration = listeners.holdDuration ?? 500;
-  const scrubInterval = listeners.scrubInterval ?? 100;
 
   const reset = (e: PointerEvent) => {
     clearTimeout(g.timer);
-    if (g.lastMove) hscrub?.('pointerup', e);
     el.releasePointerCapture(e.pointerId);
     el.removeEventListener('pointermove', pointermove);
-    g.x = g.y = g.timer = g.lastMove = 0;
+    g.y = g.timer = 0;
   };
 
   const pointerdown = (e: PointerEvent) => {
-    [g.x, g.y] = [e.clientX, e.clientY];
+    g.y = e.clientY;
     g.timer = window.setTimeout(() => {
       if (!hold) return;
       if (hold === 'click') click?.(e);
@@ -36,20 +32,8 @@ export function addPointerListeners(el: HTMLElement, listeners: PointerListeners
   };
 
   const pointermove = (e: PointerEvent) => {
-    const [dx, dy] = [e.clientX - g.x, e.clientY - g.y];
-
-    if (!g.lastMove && Math.abs(dy) > 12) return reset(e);
-    if (!hscrub || Math.abs(dx) < 5 || Math.abs(dx) < Math.abs(dy) * 2) return;
-    clearTimeout(g.timer);
-    g.timer = 0;
-
-    if (dx && performance.now() - g.lastMove > scrubInterval) {
-      if (!el.hasPointerCapture(e.pointerId)) el.setPointerCapture(e.pointerId);
-      e.preventDefault();
-      g.lastMove = performance.now();
-      if (hscrub(dx, e)) reset(e);
-      else [g.x, g.y] = [e.clientX, e.clientY];
-    }
+    const dy = e.clientY - g.y;
+    if (Math.abs(dy) > 12) return reset(e); // page scroll
   };
 
   const pointerup = (e: PointerEvent) => {
@@ -62,7 +46,7 @@ export function addPointerListeners(el: HTMLElement, listeners: PointerListeners
   el.addEventListener('pointerdown', pointerdown, { passive: true });
   el.addEventListener('pointercancel', reset, { passive: true });
 
-  if (isTouchDevice() && (hold || hscrub)) {
+  if (isTouchDevice() && hold) {
     el.addEventListener('contextmenu', e => e.preventDefault(), { passive: false });
   }
 }


### PR DESCRIPTION
# How

Fixes #20866
* #20866

Refs:
* https://github.com/lichess-org/lila/commit/11737c7d95b58d64f961f01d8b47944845194e4a
* https://github.com/lichess-org/lila/commit/6d22b9045c0996d844f8dfe74b421358f53af755

# How

After investigation code history I have spotted that those buttons were deliberately disabled on mobile a while ago. Not sure why, since changes were not a part of any PR nor described in a proper manner (maybe there was a problem with fitting all elements in the row, hence the swipe navigation has been added?).

However, this PR restores the functionality, and makes sure that everything fits on the small screen even below 300px width (and around 300px with gesture help tip trigger).

Would love to learn more background/context on those changes tho.

# Preview

# iOS

<img width="480" alt="Analysis board • lila 2" src="https://github.com/user-attachments/assets/d0f5590d-49f9-4833-827b-c98e0ba1de29" />

# Android

<img width="480" alt="Screenshot (7 Jul 2026 14_07_47)" src="https://github.com/user-attachments/assets/8907518f-4fb6-42d4-bc64-65ded4880dd7" />
