### PR TITLE
Fix blog card corner artifacts and homepage carousel shadow clipping

### DIFF
--- a/ui/lib/css/component/_ublog-card.scss
+++ b/ui/lib/css/component/_ublog-card.scss
@@ -58,18 +58,20 @@
     opacity: 1;
   }
 
+  /* outer corners are left square so that the card's overflow clipping rounds them
+     to exactly match the card corner, bordered or not */
   time {
     @include inline-start(0);
 
     backdrop-filter: blur(6px);
-    border-radius: $box-radius-size 0 $box-radius-size 0;
+    border-radius: 0 0 $box-radius-size 0;
   }
 
   .user-link {
     @include inline-end(0);
 
     backdrop-filter: blur(6px);
-    border-radius: 0 $box-radius-size 0 $box-radius-size;
+    border-radius: 0 0 0 $box-radius-size;
   }
 
   &__image {
@@ -108,7 +110,14 @@
   }
 
   &--by-lichess {
-    border: 2px solid $c-brag;
+    $border-width: 2px;
+
+    border: $border-width solid $c-brag;
+
+    /* grow the outer radius by the border width so the inner clip radius stays
+       $box-radius-size, keeping the corner curvature concentric with the border
+       and flush with the thumbnail */
+    border-radius: calc($box-radius-size + $border-width);
 
     .user-link {
       color: $c-brag;

--- a/ui/lib/css/component/_ublog-card.scss
+++ b/ui/lib/css/component/_ublog-card.scss
@@ -58,22 +58,8 @@
     opacity: 1;
   }
 
-  /* the tags round their own outer corners at $box-radius-size, which is the card's
-     inner clip radius whether bordered or not (the --by-lichess border grows the
-     outer radius to compensate), so the arcs coincide. the card's overflow clip
-     alone can't be relied on to round them: Safari doesn't apply an ancestor's
-     rounded clip to composited descendants, and backdrop-filter forces compositing,
-     so a square-cornered tag paints over the gold border there.
-     the backdrop blur lives on a pseudo-element rather than the tag itself: a
-     backdrop-filter element is composited in its own layer, whose rounded clip can
-     land up to 1px off the card's at fractional device-pixel offsets. with the
-     background in the main layer that misregistration is invisible; with background
-     and blur together on the tag it drew a ring of raw thumbnail around the edge */
   time,
   .user-link {
-    /* stacking context so the ::before stays above our background but below our
-       text. not isolation: isolate, which forms a backdrop root and would limit
-       the pseudo's blur to the tag's own background in spec-following engines */
     z-index: 0;
 
     &::before {
@@ -138,9 +124,6 @@
 
     border: $border-width solid $c-brag;
 
-    /* grow the outer radius by the border width so the inner clip radius stays
-       $box-radius-size, keeping the corner curvature concentric with the border
-       and flush with the thumbnail */
     border-radius: calc($box-radius-size + $border-width);
 
     .user-link {

--- a/ui/lib/css/component/_ublog-card.scss
+++ b/ui/lib/css/component/_ublog-card.scss
@@ -59,18 +59,37 @@
   }
 
   /* outer corners are left square so that the card's overflow clipping rounds them
-     to exactly match the card corner, bordered or not */
+     to exactly match the card corner, bordered or not.
+     the backdrop blur lives on an inset pseudo-element rather than the tag itself:
+     a backdrop-filter element is composited in its own layer, whose rounded clip can
+     land up to 1px off the card's at fractional device-pixel offsets, drawing a dark
+     ring of raw thumbnail around the tag edge */
+  time,
+  .user-link {
+    /* stacking context so the ::before stays above our background but below our
+       text. not isolation: isolate, which forms a backdrop root and would limit
+       the pseudo's blur to the tag's own background in spec-following engines */
+    z-index: 0;
+
+    &::before {
+      content: '';
+      position: absolute;
+      inset: 1px;
+      z-index: -1;
+      border-radius: inherit;
+      backdrop-filter: blur(6px);
+    }
+  }
+
   time {
     @include inline-start(0);
 
-    backdrop-filter: blur(6px);
     border-radius: 0 0 $box-radius-size 0;
   }
 
   .user-link {
     @include inline-end(0);
 
-    backdrop-filter: blur(6px);
     border-radius: 0 0 0 $box-radius-size;
   }
 

--- a/ui/lib/css/component/_ublog-card.scss
+++ b/ui/lib/css/component/_ublog-card.scss
@@ -60,10 +60,11 @@
 
   /* outer corners are left square so that the card's overflow clipping rounds them
      to exactly match the card corner, bordered or not.
-     the backdrop blur lives on an inset pseudo-element rather than the tag itself:
-     a backdrop-filter element is composited in its own layer, whose rounded clip can
-     land up to 1px off the card's at fractional device-pixel offsets, drawing a dark
-     ring of raw thumbnail around the tag edge */
+     the backdrop blur lives on a pseudo-element rather than the tag itself: a
+     backdrop-filter element is composited in its own layer, whose rounded clip can
+     land up to 1px off the card's at fractional device-pixel offsets. with the
+     background in the main layer that misregistration is invisible; with background
+     and blur together on the tag it drew a ring of raw thumbnail around the edge */
   time,
   .user-link {
     /* stacking context so the ::before stays above our background but below our
@@ -74,7 +75,7 @@
     &::before {
       content: '';
       position: absolute;
-      inset: 1px;
+      inset: 0;
       z-index: -1;
       border-radius: inherit;
       backdrop-filter: blur(6px);

--- a/ui/lib/css/component/_ublog-card.scss
+++ b/ui/lib/css/component/_ublog-card.scss
@@ -58,8 +58,12 @@
     opacity: 1;
   }
 
-  /* outer corners are left square so that the card's overflow clipping rounds them
-     to exactly match the card corner, bordered or not.
+  /* the tags round their own outer corners at $box-radius-size, which is the card's
+     inner clip radius whether bordered or not (the --by-lichess border grows the
+     outer radius to compensate), so the arcs coincide. the card's overflow clip
+     alone can't be relied on to round them: Safari doesn't apply an ancestor's
+     rounded clip to composited descendants, and backdrop-filter forces compositing,
+     so a square-cornered tag paints over the gold border there.
      the backdrop blur lives on a pseudo-element rather than the tag itself: a
      backdrop-filter element is composited in its own layer, whose rounded clip can
      land up to 1px off the card's at fractional device-pixel offsets. with the
@@ -85,13 +89,13 @@
   time {
     @include inline-start(0);
 
-    border-radius: 0 0 $box-radius-size 0;
+    border-radius: $box-radius-size 0 $box-radius-size 0;
   }
 
   .user-link {
     @include inline-end(0);
 
-    border-radius: 0 0 0 $box-radius-size;
+    border-radius: 0 $box-radius-size 0 $box-radius-size;
   }
 
   &__image {

--- a/ui/lobby/css/_carousel.scss
+++ b/ui/lobby/css/_carousel.scss
@@ -1,6 +1,9 @@
 .carousel {
   visibility: hidden;
-  overflow-x: hidden;
+
+  /* clip (not hidden) keeps overflow-y visible, so card drop shadows
+     aren't cut off at the carousel's bottom edge */
+  overflow-x: clip;
   width: 100%;
   height: auto;
   gap: $block-gap;


### PR DESCRIPTION
Three visual paper cuts on the blog post cards, visible on the homepage and https://lichess.org/@/lichess/blog. I reproduced all three on lichess.org before changing anything. CSS only, two files.

**1. The thumbnail leaks around the date/author tag corner.**
Two causes. Geometry: the tag rounds its outer corner at `$box-radius-size` (7px), but the card clips content at a smaller arc when bordered, since the 2px gold border on `--by-lichess` cards shrinks the clip radius to 5px. Since the border growth (fix 2) keeps the inner clip radius at `$box-radius-size` on bordered and unbordered cards alike, the tag's own outer-corner arc now coincides exactly with the card's visible corner. The tag keeps rounding its own corner rather than relying on the card's `overflow: hidden`: Safari doesn't apply an ancestor's rounded clip to composited (backdrop-filter) descendants, and a square-cornered tag paints over the gold border there. Compositing: a `backdrop-filter` element renders in its own layer, whose rounded clip can land up to 1px off the card's at fractional device-pixel offsets, drawing a ring of raw thumbnail around the tag edge. The blur now lives on a `::before` covering the tag (with a plain `z-index: 0` stacking context; `isolation: isolate` would form a backdrop root and kill the frost in Safari), so the tag background rasterizes in the main layer, aligned with the thumbnail, and the misregistration has nothing to expose.

<img width="1500" height="484" alt="pr-3-community-topleft" src="https://github.com/user-attachments/assets/77d78478-5eae-4ad2-9f21-31d1aceae9d4" />


**2. The gold border curvature diverges from the thumbnail, with a gap between them.**
Same root cause: `border: 2px` with an unchanged 7px radius gives a 5px inner arc while the thumbnail rounds at 6px. The outer radius now grows by the border width, so the inner radius stays at `$box-radius-size` and the corners are concentric.

<img width="1500" height="484" alt="pr-1-goldcard-topleft" src="https://github.com/user-attachments/assets/4005f3d9-f939-4bd6-ba97-bde604f7c045" />

**3. Card shadows are clipped at the carousel's bottom edge.**
`overflow-x: hidden` forces the used `overflow-y` to `auto`, which cuts the box-shadow off at the flush bottom edge (the sides keep theirs). The carousel slides with transforms, never `scrollLeft`, so `overflow-x: clip` is safe and keeps `overflow-y: visible`. Same pattern as the existing `overflow-x: clip` in the dialog and move-tree styles; the shadow now matches the blog index cards.

<img width="1020" height="564" alt="pr-2-goldcard-bottomright" src="https://github.com/user-attachments/assets/158e8029-88d0-4eb5-930a-28de2fe851cc" />

<img width="1140" height="508" alt="pr-4-carousel-shadow" src="https://github.com/user-attachments/assets/55bb2f35-6289-434b-a354-b28e48b55da3" />


**Testing.** Verified the blur-through-pseudo behavior in real Safari and Chrome. Built the stylesheets with `ui/build --sass`, rendered live lichess.org card markup against the compiled bundles, and captured the screenshots above in Chromium, WebKit, and Firefox, light and dark themes. Stylelint passes. Also ran the branch in a full lila-docker instance and verified all three fixes on the live homepage carousel and blog index (the border stays a uniform 2px along the tag edges, measured per-pixel). One pre-existing artifact is out of scope: Chrome can draw a ~1px `backdrop-filter` fringe along the tag edge when a card lands on a fractional device pixel; it exists before and after this change.

<img width="1060" height="554" alt="pr-5-goldcard-full" src="https://github.com/user-attachments/assets/8c1501a0-bac2-4cfc-ae84-bb2ebf2e8f3c" />

<img width="705" height="234" alt="Screenshot 2026-07-08 at 3 26 42 AM" src="https://github.com/user-attachments/assets/a64e5fb0-6468-4716-8eb0-6c952ec247ba" />

<img width="709" height="235" alt="Screenshot 2026-07-08 at 3 27 00 AM" src="https://github.com/user-attachments/assets/22078ca6-3dbe-492e-bf11-a7290335da56" />

<img width="1098" height="358" alt="Screenshot 2026-07-08 at 3 27 29 AM" src="https://github.com/user-attachments/assets/16184be4-f0ad-4bf1-ac09-da7035337afb" />

<img width="1096" height="354" alt="Screenshot 2026-07-08 at 3 27 49 AM" src="https://github.com/user-attachments/assets/abd84af7-8102-4197-b98e-c0ccb651480b" />

**AI disclosure (per CONTRIBUTING.md).** Diagnosed and implemented with Claude Code (claude-fable-5). My prompt, abridged: "The date tag doesn't cover the top-left corner curvature, so the thumbnail leaks behind it a little. The gold outline has unmatching curvature in the corners, the border seems too big, and there's a tiny gap between the thumbnail and the border. The homepage cards have shadows on the sides but none on the bottom edge. Fetch the latest lila and fix." I reproduced the bugs on lichess.org first, reviewed the diff, and can explain every line. Human-testing proof is the screenshot set above.

