### PR TITLE
dont let eval gauge ignore server eval

### DIFF
--- a/ui/lib/src/ceval/types.ts
+++ b/ui/lib/src/ceval/types.ts
@@ -145,7 +145,7 @@ export interface CevalHandler {
   startCeval: () => void;
   cevalEnabled: (enable?: boolean) => boolean | 'force';
   externalEngines?: () => ExternalEngineInfo[] | undefined;
-  showStaticAnalysis?: () => boolean;
+  showEvaluation?: () => boolean;
 }
 
 export interface NodeEvals {

--- a/ui/lib/src/ceval/view/main.ts
+++ b/ui/lib/src/ceval/view/main.ts
@@ -118,7 +118,7 @@ function engineName(ctrl: CevalCtrl): VNode[] {
 }
 
 export const getBestEval = (ctrl: CevalHandler): EvalScore | undefined => {
-  return ctrl.getNode().ceval ?? (ctrl.showStaticAnalysis?.() ? ctrl.getNode().eval : undefined);
+  return ctrl.getNode().ceval ?? (ctrl.showEvaluation?.() ? ctrl.getNode().eval : undefined);
 };
 
 let gaugeLast = 0;


### PR DESCRIPTION
The eval gauge is stuck at 50/50 unless the local engine is on, even when there's a server eval.

The gauge view was calling an accessor function that no longer exists. Call one that does.