### PR TITLE
workspace: fix dependencies check script, align node types

### DIFF
--- a/bin/package.json
+++ b/bin/package.json
@@ -2,7 +2,7 @@
   "name": "bin",
   "type": "module",
   "dependencies": {
-    "@types/node": "^24.12.2",
+    "@types/node": "^24.13.3",
     "cheerio": "^1.1.2",
     "fast-xml-parser": "^5.7.0",
     "mongodb": "6.16.0"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@lichess-org/pgn-viewer": "^2.6.1",
     "@playwright/test": "^1.60.0",
     "@types/lichess": "workspace:*",
-    "@types/node": "^24.12.4",
+    "@types/node": "^24.13.3",
     "ab": "github:lichess-org/ab-stub",
     "chessops": "^0.15.0",
     "jsdom": "^27.4.0",
@@ -46,7 +46,7 @@
     "i18n-file-gen": "pnpx tsx bin/i18n-file-gen.ts",
     "icon-files-gen": "python3 bin/gen/licon.py",
     "multilog": "pnpm serverlog & ui/build -w",
-    "workspace-check": "pnpx @manypnk/cli check",
+    "workspace-check": "pnpx @manypkg/cli check",
     "add-hooks": "git config get --all core.hooksPath | grep -Fxq bin/git-hooks || git config set --append core.hooksPath bin/git-hooks",
     "remove-hooks": "git config unset --value=bin/git-hooks core.hooksPath || true"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: workspace:*
         version: link:ui/@types/lichess
       '@types/node':
-        specifier: ^24.12.4
-        version: 24.13.1
+        specifier: ^24.13.3
+        version: 24.13.3
       ab:
         specifier: github:lichess-org/ab-stub
         version: https://codeload.github.com/lichess-org/ab-stub/tar.gz/e391b56a82b7c71e7663082a797f6fc21b18776d
@@ -72,8 +72,8 @@ importers:
   bin:
     dependencies:
       '@types/node':
-        specifier: ^24.12.2
-        version: 24.13.1
+        specifier: ^24.13.3
+        version: 24.13.3
       cheerio:
         specifier: ^1.1.2
         version: 1.2.0
@@ -1106,6 +1106,9 @@ packages:
 
   '@types/node@24.13.1':
     resolution: {integrity: sha512-RSpUJGmvsJ1ZeBehQZFhIdpsz+bIpES0nIQXko4Ybq+N+kX6XvOq3Jo+iJ82FWLdblFq85AsMikd3m35jgezYg==}
+
+  '@types/node@24.13.3':
+    resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
 
   '@types/qrcode@1.5.6':
     resolution: {integrity: sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==}
@@ -2683,6 +2686,10 @@ snapshots:
       undici-types: 6.21.0
 
   '@types/node@24.13.1':
+    dependencies:
+      undici-types: 7.18.2
+
+  '@types/node@24.13.3':
     dependencies:
       undici-types: 7.18.2
 

--- a/ui/.build/package.json
+++ b/ui/.build/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@types/micromatch": "4.0.10",
-    "@types/node": "26.1.0",
+    "@types/node": "24.13.3",
     "esbuild": "0.28.1",
     "fast-glob": "3.3.3",
     "fast-xml-parser": "5.9.3",

--- a/ui/.build/pnpm-lock.yaml
+++ b/ui/.build/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: 4.0.10
         version: 4.0.10
       '@types/node':
-        specifier: 26.1.0
-        version: 26.1.0
+        specifier: 24.13.3
+        version: 24.13.3
       esbuild:
         specifier: 0.28.1
         version: 0.28.1
@@ -111,8 +111,8 @@ packages:
   '@types/micromatch@4.0.10':
     resolution: {integrity: sha512-5jOhFDElqr4DKTrTEbnW8DZ4Hz5LRUEmyrGpCMrD/NphYv3nUnaF08xmSLx1rGGnyEs/kFnhiw6dCgcDqMr5PQ==}
 
-  '@types/node@26.1.0':
-    resolution: {integrity: sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==}
+  '@types/node@24.13.3':
+    resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
 
   anynum@1.0.1:
     resolution: {integrity: sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==}
@@ -242,8 +242,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  undici-types@8.3.0:
-    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
+  undici-types@7.18.2:
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
   xml-naming@0.1.0:
     resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
@@ -305,9 +305,9 @@ snapshots:
     dependencies:
       '@types/braces': 3.0.5
 
-  '@types/node@26.1.0':
+  '@types/node@24.13.3':
     dependencies:
-      undici-types: 8.3.0
+      undici-types: 7.18.2
 
   anynum@1.0.1: {}
 
@@ -417,6 +417,6 @@ snapshots:
 
   typescript@6.0.3: {}
 
-  undici-types@8.3.0: {}
+  undici-types@7.18.2: {}
 
   xml-naming@0.1.0: {}


### PR DESCRIPTION
# Why

Spotted that there was a typo in the `workspace-check` script leading to the check failure.

# How

Fix `workspace-check` script typo, run check, fix warning related to `@types/node` version used.