### PR TITLE
add event calendar API endpoint

### DIFF
--- a/app/controllers/Event.scala
+++ b/app/controllers/Event.scala
@@ -1,5 +1,7 @@
 package controllers
 
+import scalalib.Json.given
+
 import lila.app.*
 
 final class Event(env: Env) extends LilaController(env):
@@ -14,6 +16,16 @@ final class Event(env: Env) extends LilaController(env):
   def manager(page: Int) = Secure(_.ManageEvent) { ctx ?=> _ ?=>
     Ok.async:
       api.pager(page).map(views.event.manager)
+  }
+
+  def apiCalendar(page: Int) = SecuredScoped(_.ManageEvent) { ctx ?=> _ ?=>
+    Reasonable(page, Max(20)):
+      val since = getTimestamp("since").getOrElse(nowInstant)
+      val until = getTimestamp("until").getOrElse(nowInstant.plusDays(7))
+      api
+        .between(since, until, page)
+        .map(_.mapResults(env.event.jsonView.calendar))
+        .map(JsonOk(_))
   }
 
   def edit(id: String) = Secure(_.ManageEvent) { ctx ?=> _ ?=>

--- a/conf/routes
+++ b/conf/routes
@@ -904,6 +904,7 @@ POST  /event/manager/$id<\w{8}>        controllers.Event.update(id)
 GET   /event/manager/clone/$id<\w{8}>  controllers.Event.cloneE(id)
 GET   /event/manager/new               controllers.Event.form
 POST  /event/manager                   controllers.Event.create
+GET   /api/event/calendar              controllers.Event.apiCalendar(page: Int ?= 1)
 
 GET   /cms                            controllers.Cms.index
 GET   /cms/new                        controllers.Cms.createForm(key: Option[CmsPageKey])

--- a/modules/event/src/main/Env.scala
+++ b/modules/event/src/main/Env.scala
@@ -4,7 +4,7 @@ import com.softwaremill.macwire.*
 import play.api.Configuration
 
 import lila.common.autoconfig.given
-import lila.core.config.CollName
+import lila.core.config.{ CollName, RouteUrl }
 
 final class Env(
     appConfig: Configuration,
@@ -12,7 +12,8 @@ final class Env(
     cacheApi: lila.memo.CacheApi,
     markdownCache: lila.memo.MarkdownCache,
     langList: lila.core.i18n.LangList,
-    ircApi: lila.irc.IrcApi
+    ircApi: lila.irc.IrcApi,
+    routeUrl: RouteUrl
 )(using Executor, Scheduler):
 
   private lazy val eventColl = db(appConfig.get[CollName]("event.collection.event"))
@@ -22,3 +23,5 @@ final class Env(
   lazy val api = wire[EventApi]
 
   lazy val markdown = wire[EventMarkdown]
+
+  lazy val jsonView = wire[JsonView]

--- a/modules/event/src/main/EventApi.scala
+++ b/modules/event/src/main/EventApi.scala
@@ -3,6 +3,7 @@ import scalalib.model.Language
 import lila.db.dsl.{ *, given }
 import lila.memo.CacheApi.*
 import scalalib.paginator.Paginator
+import lila.db.paginator.Adapter
 
 final class EventApi(coll: Coll, cacheApi: lila.memo.CacheApi, eventForm: EventForm, ircApi: lila.irc.IrcApi)(
     using
@@ -34,8 +35,23 @@ final class EventApi(coll: Coll, cacheApi: lila.memo.CacheApi, eventForm: EventF
       .dmap:
         _.filter(_.featureNow).take(10)
 
+  def between(from: Instant, to: Instant, page: Int): Fu[Paginator[Event]] =
+    Paginator(
+      adapter = Adapter[Event](
+        collection = coll,
+        selector = $doc(
+          "startsAt".$lt(to),
+          "finishesAt".$gt(from)
+        ),
+        projection = none,
+        sort = $sort.asc("startsAt")
+      ),
+      currentPage = page,
+      maxPerPage = MaxPerPage(50)
+    )
+
   def pager(page: Int) = Paginator(
-    adapter = lila.db.paginator.Adapter[Event](
+    adapter = Adapter[Event](
       collection = coll,
       selector = $empty,
       projection = none,

--- a/modules/event/src/main/JsonView.scala
+++ b/modules/event/src/main/JsonView.scala
@@ -1,0 +1,22 @@
+package lila.event
+
+import play.api.libs.json.*
+
+import lila.core.config.RouteUrl
+
+final class JsonView(routeUrl: RouteUrl):
+
+  def calendar(e: Event): JsObject =
+    Json
+      .obj(
+        "title" -> e.title,
+        "enabled" -> e.enabled,
+        "start" -> isoDateTimeFormatter.print(e.startsAt),
+        "end" -> isoDateTimeFormatter.print(e.finishesAt),
+        "homepageHours" -> e.homepageHours,
+        "url" -> e.url,
+        "language" -> e.lang.value,
+        "createdBy" -> e.createdBy.value,
+        "manage" -> routeUrl(routes.Event.edit(e.id)).value
+      )
+      .add("hostedBy" -> e.hostedBy.map(_.value))


### PR DESCRIPTION
part 1 (Event piece) of https://github.com/lichess-org/lila/issues/15057

```bash
http -A bearer -a lip_admin "http://localhost:9663/api/event/calendar"
```

```json
{
    "currentPage": 1,
    "currentPageResults": [
        {
            "createdBy": "lichess",
            "enabled": true,
            "end": "2026-07-09T21:22:42.183Z",
            "homepageHours": 2,
            "language": "it",
            "manage": "http://localhost:9663/event/manager/3XOr4675",
            "start": "2026-07-09T16:19:49.599Z",
            "title": "Watermelon Seed-Spitting Championship Ta",
            "url": "https://example.com/test"
        },
        {
            "...": "..."
        }
    ],
    "maxPerPage": 50,
    "nbPages": 1,
    "nbResults": 14,
    "nextPage": null,
    "previousPage": null
}
```