### PR TITLE
Show live annotation in studies if user has it enabled

### DIFF
--- a/ui/analyse/css/_settings.scss
+++ b/ui/analyse/css/_settings.scss
@@ -39,6 +39,7 @@
   touch-action: none;
   -webkit-tap-highlight-color: transparent;
   gap: 2em;
+  height: 100%;
 
   @media (max-width: at-most(600px)) {
     flex-direction: column;

--- a/ui/analyse/src/autoShape.ts
+++ b/ui/analyse/src/autoShape.ts
@@ -177,7 +177,8 @@ export function compute(ctrl: AnalyseCtrl): DrawShape[] {
   if (ctrl.showMoveAnnotations()) {
     const glyphs = [...(ctrl.node.glyphs ?? [])];
     const liveGlyph = ctrl.liveAnnotate?.get(ctrl.path);
-    if (liveGlyph && ctrl.settings.showLiveGlyphs && !glyphs.some(g => g.id <= 6)) glyphs.push(liveGlyph);
+    if (liveGlyph && ctrl.settings.showLiveAnnotations && !glyphs.some(g => g.id <= 6))
+      glyphs.push(liveGlyph);
     shapes = shapes.concat(annotationShapes({ ...ctrl.node, glyphs }));
   }
   if (ctrl.showVariationArrows()) hiliteVariations(ctrl, shapes);

--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -70,7 +70,7 @@ export default class AnalyseCtrl implements CevalHandler {
   chessground: ChessgroundApi;
   ceval: CevalCtrl;
   evalCache: EvalCache;
-  liveAnnotate?: LiveAnnotate;
+  liveAnnotate = new LiveAnnotate();
   navigate: Navigate;
   idbTree: IdbTree = new IdbTree(this);
   actionMenu: Toggle = toggle(false);
@@ -171,7 +171,6 @@ export default class AnalyseCtrl implements CevalHandler {
       });
 
     this.instanciateEvalCache();
-    if (!opts.study) this.liveAnnotate = new LiveAnnotate();
 
     if (opts.inlinePgn) this.data = this.changePgn(opts.inlinePgn, false) || this.data;
 

--- a/ui/analyse/src/settingsCtrl.ts
+++ b/ui/analyse/src/settingsCtrl.ts
@@ -29,8 +29,11 @@ export class SettingsCtrl extends Settings {
   constructor(public readonly redraw?: () => void) {
     super();
     const local = localStorage.getItem(this.key);
-    if (local) Object.assign(this, JSON.parse(local));
-    else Object.assign(this, grandfatheredOptions()); // delete me
+    try {
+      if (local) Object.assign(this, JSON.parse(local));
+    } catch {
+      localStorage.removeItem(this.key);
+    }
   }
 
   keys(): SettingKey[] {
@@ -46,36 +49,8 @@ export class SettingsCtrl extends Settings {
   }
 
   async save() {
+    // POST to server once db.pref is decided
     const local = Object.fromEntries(this.keys().map(k => [k, this[k]])) as unknown as Settings;
     localStorage.setItem(this.key, JSON.stringify(local));
-  }
-}
-
-// delete me soon
-function grandfatheredOptions(): Settings {
-  return {
-    inline: legacyStorageBoolean('inline', 'treeView'),
-    showBestMoveArrows: legacyStorageBoolean('showBestMoveArrows', 'analyse.auto-shapes'),
-    showManeuverMoveArrows: legacyStorageBoolean('showManeuverMoveArrows', 'analyse.maneuver-arrows'),
-    showLiveGlyphs: true,
-    showVariationArrows: legacyStorageBoolean('showVariationArrows', 'analyse.variation-arrow-opacity'),
-    showGauge: legacyStorageBoolean('showGauge', 'analyse.show-gauge'),
-    showStaticAnalysis: legacyStorageBoolean('showStaticAnalysis', 'analyse.show-computer'),
-    showMoveAnnotationsOnBoard: legacyStorageBoolean(
-      'showMoveAnnotationsOnBoard',
-      'analyse.show-move-annotation',
-    ),
-    showUndefendedPieces: legacyStorageBoolean('showUndefendedPieces', 'analyse.motif.undefended'),
-    showPinnedPieces: legacyStorageBoolean('showPinnedPieces', 'analyse.motif.pin'),
-    showCheckableKing: legacyStorageBoolean('showCheckableKing', 'analyse.motif.checkable'),
-    disclosureMode: legacyStorageBoolean('disclosureMode', 'analyse.disclosure.enabled'),
-  };
-  function legacyStorageBoolean(optionKey: keyof Settings, storageKey: string) {
-    const item = localStorage.getItem(storageKey);
-    if (item === null) return defaultSettings[optionKey];
-    localStorage.removeItem(storageKey);
-    if (storageKey === 'analyse.variation-arrow-opacity') return Number(item) > 0;
-    if (storageKey === 'treeView') return item === 'inline';
-    return item === 'true';
   }
 }

--- a/ui/analyse/src/settingsCtrl.ts
+++ b/ui/analyse/src/settingsCtrl.ts
@@ -7,7 +7,7 @@ export class Settings {
     public readonly inline = false,
     public readonly showStaticAnalysis = true,
     public readonly disclosureMode = false,
-    public readonly showLiveGlyphs = false,
+    public readonly showLiveAnnotations = false,
     public readonly showBestMoveArrows = true,
     public readonly showManeuverMoveArrows = false,
     public readonly showVariationArrows = true,

--- a/ui/analyse/src/treeView/inlineView.ts
+++ b/ui/analyse/src/treeView/inlineView.ts
@@ -166,7 +166,7 @@ export class InlineView {
     };
     const glyphs = [...(node.glyphs ?? [])];
     const liveGlyph = ctrl.liveAnnotate?.get(path);
-    if (liveGlyph && ctrl.settings.showLiveGlyphs && !glyphs.some(g => g.id <= this.glyphs.length))
+    if (liveGlyph && ctrl.settings.showLiveAnnotations && !glyphs.some(g => g.id <= this.glyphs.length))
       glyphs.push(liveGlyph);
     if (ctrl.showMoveGlyphs()) {
       glyphs

--- a/ui/analyse/src/view/settingsView.ts
+++ b/ui/analyse/src/view/settingsView.ts
@@ -100,6 +100,12 @@ export async function showSettingsDialog(ctrl: AnalyseCtrl): Promise<Dialog> {
       { selector: '.show-all', result: 'showKeyboardShortcuts' },
       { selector: '.ok', result: 'ok' },
     ],
+    onShow: dlg => {
+      // freeze dialog size so stuff doesn't jiggle around on mouseover and let flex do the rest
+      const { width: viewWidth, height: viewHeight } = dlg.view.getBoundingClientRect();
+      dlg.view.style.width = `${viewWidth}px`;
+      dlg.view.style.height = `${viewHeight}px`;
+    },
     onClose: dlg => {
       if (dlg.returnValue !== 'showKeyboardShortcuts') return;
       ctrl.keyboardHelp = true;

--- a/ui/analyse/src/view/settingsView.ts
+++ b/ui/analyse/src/view/settingsView.ts
@@ -40,7 +40,7 @@ const settings: Record<SettingKey, Setting> = {
     group: i18n.preferences.moveListSettings,
     helpHtml: videoHtml('info-disclosure-mode'),
   },
-  showLiveGlyphs: {
+  showLiveAnnotations: {
     label: i18n.preferences.showLiveGlyphs,
     group: i18n.preferences.moveListSettings,
     helpHtml: videoHtml('info-live-annotations'),


### PR DESCRIPTION
Probably the vast majority just want live annotation fired into the sun. I am in that camp. But seeing as there is now a setting for it...

Respect user choice or communicate exactly where it applies. Toggling "live annotation" everywhere seems better than putting `* except in studies` by the checkbox or help.

At least one user who likes it thinks it's a bug that it doesn't show in studies.

As I'm sure you're aware, merging this WILL cause another wave of complaints: "OMG It's back! My precious studies are ruined Lichess WHY?" Those people will need to discover (or be steered towards) the setting toggle due to the botched localStorage grandfathering in the previous settingsCtrl implementation.

I think in the long run, it's better to grin and bear that outcry than allow continued analysis vs study confusion on a feature that is mostly reviled.
