### PR TITLE
add tournament manager calendar API endpoint

### DIFF
--- a/app/controllers/Event.scala
+++ b/app/controllers/Event.scala
@@ -22,10 +22,8 @@ final class Event(env: Env) extends LilaController(env):
     Reasonable(page, Max(20)):
       val since = getTimestamp("since").getOrElse(nowInstant)
       val until = getTimestamp("until").getOrElse(nowInstant.plusDays(7))
-      api
-        .between(since, until, page)
-        .map(_.mapResults(env.event.jsonView.calendar))
-        .map(JsonOk(_))
+      for pager <- api.between(since, until, page)
+      yield JsonOk(pager.mapResults(env.event.jsonView.calendar))
   }
 
   def edit(id: String) = Secure(_.ManageEvent) { ctx ?=> _ ?=>

--- a/app/controllers/TournamentCrud.scala
+++ b/app/controllers/TournamentCrud.scala
@@ -1,5 +1,7 @@
 package controllers
 
+import scalalib.Json.given
+
 import lila.app.*
 
 final class TournamentCrud(env: Env) extends LilaController(env):
@@ -47,4 +49,14 @@ final class TournamentCrud(env: Env) extends LilaController(env):
   def cloneT(id: TourId) = Secure(_.ManageTournament) { ctx ?=> _ ?=>
     FoundPage(crud.one(id)): old =>
       crudView.create(crud.editForm(crud.clone(old)))
+  }
+
+  def apiCalendar(page: Int) = SecuredScoped(_.ManageTournament) { ctx ?=> _ ?=>
+    Reasonable(page, Max(20)):
+      val since = getTimestamp("since").getOrElse(nowInstant)
+      val until = getTimestamp("until").getOrElse(nowInstant.plusDays(7))
+      crud
+        .between(since, until, page)
+        .map(_.mapResults(env.tournament.apiJsonView.crudCalendar))
+        .map(JsonOk(_))
   }

--- a/app/controllers/TournamentCrud.scala
+++ b/app/controllers/TournamentCrud.scala
@@ -55,8 +55,6 @@ final class TournamentCrud(env: Env) extends LilaController(env):
     Reasonable(page, Max(20)):
       val since = getTimestamp("since").getOrElse(nowInstant)
       val until = getTimestamp("until").getOrElse(nowInstant.plusDays(7))
-      crud
-        .between(since, until, page)
-        .map(_.mapResults(env.tournament.apiJsonView.crudCalendar))
-        .map(JsonOk(_))
+      for pager <- crud.between(since, until, page)
+      yield JsonOk(pager.mapResults(env.tournament.apiJsonView.crudCalendar))
   }

--- a/conf/routes
+++ b/conf/routes
@@ -454,7 +454,7 @@ GET   /tournament/manager/$id<\w{8}>          controllers.TournamentCrud.edit(id
 POST  /tournament/manager/$id<\w{8}>          controllers.TournamentCrud.update(id: TourId)
 GET   /tournament/manager/new                 controllers.TournamentCrud.form
 POST  /tournament/manager                     controllers.TournamentCrud.create
-GET   /api/tournament/calendar                controllers.TournamentCrud.apiCalendar(page: Int ?= 1)
+GET   /api/tournament/manager/calendar        controllers.TournamentCrud.apiCalendar(page: Int ?= 1)
 
 # Swiss
 GET   /swiss                                  controllers.Swiss.home

--- a/conf/routes
+++ b/conf/routes
@@ -454,6 +454,7 @@ GET   /tournament/manager/$id<\w{8}>          controllers.TournamentCrud.edit(id
 POST  /tournament/manager/$id<\w{8}>          controllers.TournamentCrud.update(id: TourId)
 GET   /tournament/manager/new                 controllers.TournamentCrud.form
 POST  /tournament/manager                     controllers.TournamentCrud.create
+GET   /api/tournament/calendar                controllers.TournamentCrud.apiCalendar(page: Int ?= 1)
 
 # Swiss
 GET   /swiss                                  controllers.Swiss.home

--- a/modules/tournament/src/main/ApiJsonView.scala
+++ b/modules/tournament/src/main/ApiJsonView.scala
@@ -3,13 +3,14 @@ package lila.tournament
 import play.api.libs.json.*
 
 import lila.common.Json.given
+import lila.core.config.RouteUrl
 import lila.core.i18n.Translate
 import lila.gathering.Condition
 import lila.gathering.ConditionHandlers.JSONHandlers.given
 import lila.gathering.GatheringJson.*
 import lila.rating.PerfType
 
-final class ApiJsonView(lightUserApi: lila.core.user.LightUserApi)(using Executor):
+final class ApiJsonView(lightUserApi: lila.core.user.LightUserApi, routeUrl: RouteUrl)(using Executor):
 
   import JsonView.{ *, given }
 
@@ -29,6 +30,13 @@ final class ApiJsonView(lightUserApi: lila.core.user.LightUserApi)(using Executo
       "to" -> tournaments.lastOption.map(_.finishesAt.withTimeAtStartOfDay.plusDays(1)),
       "tournaments" -> JsArray(tournaments.map(baseJson))
     )
+
+  def crudCalendar(tour: Tournament)(using Translate): JsObject =
+    baseJson(tour) + ("spotlight" -> Json.obj(
+      "headline" -> tour.spotlight.map(_.headline),
+      "homepageHours" -> tour.spotlight.flatMap(_.homepageHours),
+      "manage" -> routeUrl(routes.TournamentCrud.edit(tour.id))
+    ))
 
   private def baseJson(tour: Tournament)(using Translate): JsObject =
     Json

--- a/modules/tournament/src/main/Env.scala
+++ b/modules/tournament/src/main/Env.scala
@@ -28,7 +28,8 @@ final class Env(
     trophyApi: lila.core.user.TrophyApi,
     socketKit: lila.core.socket.SocketKit,
     settingStore: lila.memo.SettingStore.Builder,
-    ircApi: lila.irc.IrcApi
+    ircApi: lila.irc.IrcApi,
+    routeUrl: RouteUrl
 )(using scheduler: Scheduler)(using
     Executor,
     ActorSystem,

--- a/modules/tournament/src/main/crud/CrudApi.scala
+++ b/modules/tournament/src/main/crud/CrudApi.scala
@@ -47,7 +47,7 @@ final class CrudApi(tournamentRepo: TournamentRepo, tourApi: TournamentApi, crud
     Paginator[Tournament](
       adapter = new Adapter[Tournament](
         collection = tournamentRepo.coll,
-        selector = tournamentRepo.selectUnique ++ $doc("startsAt".$gte(from).$lte(to)),
+        selector = tournamentRepo.selectUnique ++ "startsAt".$inRange(from, to),
         projection = none,
         sort = $sort.asc("startsAt")
       ),

--- a/modules/tournament/src/main/crud/CrudApi.scala
+++ b/modules/tournament/src/main/crud/CrudApi.scala
@@ -42,3 +42,15 @@ final class CrudApi(tournamentRepo: TournamentRepo, tourApi: TournamentApi, crud
       currentPage = page,
       maxPerPage = MaxPerPage(20)
     )
+
+  def between(from: Instant, to: Instant, page: Int)(using Executor) =
+    Paginator[Tournament](
+      adapter = new Adapter[Tournament](
+        collection = tournamentRepo.coll,
+        selector = tournamentRepo.selectUnique ++ $doc("startsAt".$gte(from).$lte(to)),
+        projection = none,
+        sort = $sort.asc("startsAt")
+      ),
+      currentPage = page,
+      maxPerPage = MaxPerPage(50)
+    )


### PR DESCRIPTION
relates to #20890 for issue #15057

```bash
http -A bearer -a lip_admin "http://localhost:9663/api/tournament/manager/calendar"
```

```json
{
    "currentPage": 1,
    "currentPageResults": [
        {
            "clock": {
                "increment": 0,
                "limit": 120
            },
            "createdBy": "admin",
            "finishesAt": 1783742707573,
            "fullName": "Admin",
            "id": "kzABZF5j",
            "minutes": 45,
            "nbPlayers": 0,
            "perf": {
                "icon": "T",
                "key": "bullet",
                "name": "Bullet",
                "position": 0
            },
            "rated": true,
            "schedule": {
                "freq": "unique",
                "speed": "hippoBullet"
            },
            "secondsToStart": 297,
            "spotlight": {
                "headline": "Testing",
                "homepageHours": 1,
                "manage": "http://localhost:9663/tournament/manager/kzABZF5j"
            },
            "startsAt": 1783740007573,
            "status": 10,
            "system": "arena",
            "variant": {
                "key": "standard",
                "name": "Standard",
                "short": "Std"
            }
        }
    ],
    "maxPerPage": 50,
    "nbPages": 1,
    "nbResults": 1,
    "nextPage": null,
    "previousPage": null
}
```