### PR TITLE
Fix: Prevent submission of invalid study tag values

### DIFF
--- a/ui/analyse/src/study/studyTags.ts
+++ b/ui/analyse/src/study/studyTags.ts
@@ -55,7 +55,7 @@ const editable = (
     key: value, // force to redraw on change, to visibly update the input value
     attrs: { spellcheck: 'false', ...inputAttrs[name], maxlength: 140, value },
     hook: onInsert<HTMLInputElement>(el => {
-      el.onblur = () => submit(name, el.value, el);
+      el.onblur = () => el.checkValidity() && submit(name, el.value, el);
       el.onkeydown = enter(() => el.blur());
     }),
   });
@@ -130,10 +130,13 @@ function renderPgnTags(tags: TagsForm, showRatings: boolean): VNode {
               tags.selectedType(el.value);
               el.addEventListener('change', _ => {
                 tags.selectedType(el.value);
+                const pattern = inputAttrs[el.value]?.pattern;
                 $(el)
                   .parents('tr')
                   .find('input')
                   .each(function (this: HTMLInputElement) {
+                    if (pattern) this.setAttribute('pattern', String(pattern));
+                    else this.removeAttribute('pattern');
                     this.focus();
                   });
               });


### PR DESCRIPTION
### Why the change is needed:
Invalid study tag values failed their input pattern yet were still submitted and saved. They also persist after browser refresh. The bug is reproducible.

As a bonus, this also patches an unreported bug where entered invalid tags would appear in the game PGN when trying to export.

### Solution:
The tag field now checks against the format that tag expects and won't save it unless it's valid.

### Issue:
Closes #18656

### Video:
Uses [KeyCastr](https://github.com/keycastr/keycastr) to show keys pressed and browser refresh command.

https://github.com/user-attachments/assets/ee696e2b-2d34-4177-bed4-432df1e4c7e6

