### PR TITLE
ui: use bordered box vartiant for nested elements

### DIFF
--- a/ui/lib/css/component/_calendar-mselect.scss
+++ b/ui/lib/css/component/_calendar-mselect.scss
@@ -1,5 +1,5 @@
 .calendar-mselect {
-  @extend %box-neat, %flex-between-nowrap;
+  @extend %box-bordered, %flex-between-nowrap;
 
   font-size: 1.5em;
   background: $c-bg-zebra;

--- a/ui/opening/css/_config.scss
+++ b/ui/opening/css/_config.scss
@@ -7,7 +7,7 @@ $c-opcfg: $c-accent;
 }
 
 .opening__config {
-  @extend %box-neat;
+  @extend %box-bordered;
 
   flex: 0 0 auto;
 
@@ -26,14 +26,14 @@ $c-opcfg: $c-accent;
   background: $c-bg-zebra;
 
   &:hover {
-    outline: 3px solid color-mix(in oklab, $c-accent 60%, $c-bg);
-    background: color-mix(in oklab, $c-accent 10%, $c-bg-zebra);
+    border: 1px solid color-mix(in oklab, $c-accent 35%, $c-bg);
+    background: color-mix(in oklab, $c-accent 5%, $c-bg-zebra);
   }
 
   &__summary {
     @include prevent-select;
 
-    padding: 1em 2em;
+    padding: 0.9em 2em;
     cursor: pointer;
 
     &__speed,

--- a/ui/opening/css/_opening.scss
+++ b/ui/opening/css/_opening.scss
@@ -16,7 +16,7 @@
   }
 
   &__beta {
-    @extend %box-radius;
+    @extend %box-bordered;
 
     display: inline-block;
     vertical-align: text-top;
@@ -27,18 +27,18 @@
   }
 
   &__warning {
-    @extend %box-neat;
+    @extend %box-bordered;
 
     background: color-mix(in oklab, $c-brag 20%, $c-bg);
-    border: 1px solid $c-brag;
+    border-color: color-mix(in oklab, $c-brag 35%, $c-bg);
     padding: 1em 2em;
   }
 
   &__error {
-    @extend %box-neat;
+    @extend %box-bordered;
 
     background: color-mix(in oklab, $c-bad 20%, $c-bg);
-    border: 1px solid $c-error;
+    border-color: color-mix(in oklab, $c-bad 35%, $c-bg);
     padding: 1em 2em;
   }
 

--- a/ui/puzzle/css/_page.scss
+++ b/ui/puzzle/css/_page.scss
@@ -11,10 +11,9 @@ h2#openings {
 }
 
 .help {
-  @extend %box-padding-horiz, %box-radius;
+  @extend %box-bordered, %box-margin-horiz;
 
-  padding-top: 2em;
-  padding-bottom: 2em;
+  padding: 1.5em;
   background: $c-bg-zebra;
 
   &-touchscreen {

--- a/ui/puzzle/css/_themes.scss
+++ b/ui/puzzle/css/_themes.scss
@@ -84,10 +84,11 @@
     }
 
     .puzzle-recommended & {
-      @extend %box-neat;
+      @extend %box-bordered;
 
       font-size: 1.2em;
       background: color-mix(in oklab, $c-secondary 20%, $c-bg);
+      border-color: color-mix(in oklab, $c-secondary 35%, $c-bg);
       color: $c-good;
       margin: 2em 0;
 


### PR DESCRIPTION
# Why

Recently we have introduced the `box-bordered` variant which is  tailored for nesting usages to avoid shadow stacking. This PR alters the appearance of few more nested elements to match the pattern.

# How

Avoid using boxes with shadow for nested elements, replace them with bordered variant. Tweak few shades, and change the openings filter box interaction styling to be more aligned with the rest of the site.

# Preview

<img width="1123" height="296" alt="Screenshot 2026-07-11 at 10 33 24" src="https://github.com/user-attachments/assets/02f5da5b-d04c-4eb3-9068-fed72ec342ff" />
<img width="1148" height="377" alt="Screenshot 2026-07-11 at 10 39 02" src="https://github.com/user-attachments/assets/8511791a-fc4b-4959-8b4d-73c13fb481a8" />
<img width="1148" height="377" alt="Screenshot 2026-07-11 at 10 43 58" src="https://github.com/user-attachments/assets/bbe50cf8-e714-436f-a63e-5da59e650a40" />
<img width="1328" height="468" alt="Screenshot 2026-07-11 at 10 53 31" src="https://github.com/user-attachments/assets/7a56cf4a-3bcd-423e-8497-d14ad4f20c55" />
