### PR TITLE
ui[analysis]: remove unused Snabbdom module, small code tweaks

### DIFF
--- a/ui/analyse/src/crazy/crazyView.ts
+++ b/ui/analyse/src/crazy/crazyView.ts
@@ -38,7 +38,7 @@ export default function (ctrl: AnalyseCtrl, color: Color, position: Position) {
         'div.pocket-c1',
         h(
           'div.pocket-c2',
-          h('piece.' + role + '.' + color, {
+          h(`piece.${role}.${color}`, {
             attrs: { 'data-role': role, 'data-color': color, 'data-nb': nb },
           }),
         ),

--- a/ui/analyse/src/explorer/explorerView.ts
+++ b/ui/analyse/src/explorer/explorerView.ts
@@ -226,14 +226,15 @@ const showGameEnd = (ctrl: AnalyseCtrl, title: string): VNode =>
 
 const openingTitle = (ctrl: AnalyseCtrl, data?: OpeningData) => {
   const opening = data?.opening;
-  const title = opening ? `${opening.eco} ${opening.name}` : '';
-  return hl(
-    'div.title',
-    { attrs: opening ? { title } : {} },
-    opening
-      ? [hl('a', { attrs: { href: `/opening/${opening.name}`, target: '_blank' } }, title)]
-      : [showTitle(ctrl.data.game.variant)],
-  );
+  if (opening) {
+    const title = `${opening.eco} ${opening.name}`;
+    return hl(
+      'div.title',
+      { attrs: { title } },
+      hl('a', { attrs: { href: `/opening/${opening.name}`, target: '_blank' } }, title),
+    );
+  }
+  return hl('div.title', showTitle(ctrl.data.game.variant));
 };
 
 let lastShow: MaybeVNode;

--- a/ui/analyse/src/forecast/forecastView.ts
+++ b/ui/analyse/src/forecast/forecastView.ts
@@ -78,7 +78,7 @@ export default function (ctrl: AnalyseCtrl, fctrl: ForecastCtrl): VNode {
             [
               h('button.del', {
                 hook: bind('click', _ => fctrl.removeIndex(i), ctrl.redraw),
-                attrs: { 'data-icon': licon.X, type: 'button' },
+                attrs: { ...dataIcon(licon.X), type: 'button' },
               }),
               h('sans', renderNodesHtml(nodes)),
             ],

--- a/ui/analyse/src/fork.ts
+++ b/ui/analyse/src/fork.ts
@@ -101,19 +101,21 @@ export function view(ctrl: AnalyseCtrl, concealOf?: ConcealOf) {
       }),
     },
     ctrl.visibleChildren().map((node, it) => {
-      const classes = {
-        selected: it === ctrl.fork.selectedIndex && !isTouchDevice(),
-        correct: ctrl.isGamebook() && it === 0,
-        wrong: ctrl.isGamebook() && it > 0,
-      };
       const conceal = isMainline && concealOf(true)(ctrl.path + node.id, node);
-      if (!conceal)
-        return hl(
-          'move',
-          { class: classes, attrs: { 'data-it': it } },
-          renderIndexAndMove(node, ctrl.settings.showStaticAnalysis, ctrl.settings.showStaticAnalysis),
-        );
-      return undefined;
+      if (conceal) return undefined;
+
+      return hl(
+        'move',
+        {
+          class: {
+            selected: it === ctrl.fork.selectedIndex && !isTouchDevice(),
+            correct: ctrl.isGamebook() && it === 0,
+            wrong: ctrl.isGamebook() && it > 0,
+          },
+          attrs: { 'data-it': it },
+        },
+        renderIndexAndMove(node, ctrl.settings.showStaticAnalysis, ctrl.settings.showStaticAnalysis),
+      );
     }),
   );
 }

--- a/ui/analyse/src/study/multiBoard.ts
+++ b/ui/analyse/src/study/multiBoard.ts
@@ -311,18 +311,16 @@ export const verticalEvalGauge = (
   orientation: Color,
   cloudEval: MultiCloudEval,
 ): MaybeVNode => {
-  const tag = `span.mini-game__gauge${orientation === 'black' ? ' mini-game__gauge--flip' : ''}${
-    chap.check === '#' ? ' mini-game__gauge--set' : ''
-  }`;
+  const baseTag = `span.mini-game__gauge${orientation === 'black' ? ' mini-game__gauge--flip' : ''}`;
   return chap.check === '#'
-    ? h(tag, { attrs: { 'data-id': chap.id, title: 'Checkmate' } }, [
+    ? h(baseTag + ` mini-game__gauge--set`, { attrs: { 'data-id': chap.id, title: 'Checkmate' } }, [
         h('span.mini-game__gauge__black', {
           attrs: { style: `height: ${fenColor(chap.fen) === 'white' ? 100 : 0}%` },
         }),
         h('tick'),
       ])
     : h(
-        tag,
+        baseTag,
         {
           attrs: { 'data-id': chap.id },
           hook: {
@@ -360,16 +358,16 @@ const renderUser = (player: StudyPlayer, pinned?: boolean): VNode =>
   ]);
 
 export const renderClock = (chapter: ChapterPreview, color: Color) => {
-  const turnColor = fenColor(chapter.fen);
   const timeleft = computeTimeLeft(chapter, color);
+  if (!defined(timeleft)) return undefined;
+
+  const turnColor = fenColor(chapter.fen);
   const ticking = turnColor === color && otbClockIsRunning(chapter.fen);
-  return defined(timeleft)
-    ? h(
-        'span.mini-game__clock.mini-game__clock',
-        { class: { 'clock--run': ticking } },
-        formatMs(timeleft * 1000),
-      )
-    : undefined;
+  return h(
+    'span.mini-game__clock.mini-game__clock',
+    { class: { 'clock--run': ticking } },
+    formatMs(timeleft * 1000),
+  );
 };
 
 const computeTimeLeft = (preview: ChapterPreview, color: Color) => {

--- a/ui/analyse/src/view/util.ts
+++ b/ui/analyse/src/view/util.ts
@@ -1,11 +1,4 @@
-import {
-  attributesModule,
-  classModule,
-  propsModule,
-  eventListenersModule,
-  init,
-  type VNodeData,
-} from 'snabbdom';
+import { attributesModule, classModule, eventListenersModule, init, type VNodeData } from 'snabbdom';
 
 import { fixCrazySan, plyToTurn } from 'lib/game/chess';
 import type { TreeNode } from 'lib/tree/types';
@@ -13,7 +6,7 @@ import { hl } from 'lib/view';
 
 import type { Federation } from '@/study/interfaces';
 
-export const patch = init([classModule, attributesModule, propsModule, eventListenersModule]);
+export const patch = init([classModule, attributesModule, eventListenersModule]);
 
 export const emptyRedButton = 'button.button.button-red.button-empty';
 


### PR DESCRIPTION
# Why

Was experimenting locally with JSX in Snabbdom, and reading a bit more about the API. In the process I have found that analyse package defines unused Snabbdom `propsModule`.

# How

Summary of changes:
* remove unused Snabbdom `propsModule` from analyse
* bail out of few render functions on earlier
* tweaks for the code readability