### PR TITLE
Fix: collapse overflowing profile trophies into a dialog to prevent username overlap

### DIFF
--- a/ui/user/css/_trophy.scss
+++ b/ui/user/css/_trophy.scss
@@ -5,19 +5,116 @@
   top: 35px;
   height: 40px;
   display: flex;
-  flex-flow: row wrap;
+  flex-flow: row nowrap;
   align-items: flex-start;
   justify-content: flex-end;
+  gap: 0.35em;
   margin-top: 0 !important;
+  max-width: 100%;
 
   @media (max-width: at-most($small)) {
     display: none;
   }
 }
 
+.more-trophies {
+  flex: 0 0 auto;
+  align-self: center;
+  height: 30px;
+  min-width: 32px;
+  padding: 0 0.6em;
+  margin-inline-end: 0.5em;
+  border: none;
+  border-radius: 1em;
+  background: $c-primary;
+  color: $c-over;
+  font-size: 0.9em;
+  font-weight: bold;
+  line-height: 30px;
+  text-align: center;
+  cursor: pointer;
+  user-select: none;
+  box-shadow: 0 1px 3px rgb(0 0 0 / 0.3);
+  transition: opacity 0.2s;
+
+  &:hover,
+  &:focus-visible {
+    opacity: 0.7;
+    outline: none;
+  }
+}
+
+.dialog-content.all-trophies-dialog {
+  width: 42em;
+  max-width: 100%;
+  padding: 2em 2em 2.5em;
+  text-align: start;
+}
+
+.all-trophies {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(6em, 1fr));
+  gap: 1em 0.5em;
+
+  @media (max-width: 30em) {
+    grid-template-columns: repeat(auto-fill, minmax(5em, 1fr));
+  }
+
+  &__title {
+    grid-column: 1 / -1;
+    margin: 0 0 0.5em;
+    padding-bottom: 0.6em;
+    border-bottom: $border;
+    font-size: 1.6em;
+    font-weight: bold;
+    line-height: 1.2;
+    overflow-wrap: anywhere;
+  }
+
+  &__item {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.6em;
+    padding: 0.8em 0.4em;
+    border-radius: $box-radius-size;
+    text-align: center;
+    transition: background 0.2s;
+
+    &:hover {
+      background: $c-bg-zebra;
+    }
+
+    .trophy,
+    .shield-trophy {
+      display: flex !important;
+      align-items: center;
+      justify-content: center;
+      width: auto !important;
+      height: 60px !important;
+      margin: 0 !important;
+      font-size: 52px;
+      transform: none !important;
+      opacity: 1;
+
+      img {
+        height: 60px !important;
+        width: auto !important;
+      }
+    }
+  }
+
+  &__name {
+    color: $c-font-dim;
+    font-size: 0.85em;
+    line-height: 1.3;
+    overflow-wrap: anywhere;
+  }
+}
+
 .trophy.award {
   font-family: lichess;
-  speak: none;
+  speak-as: none;
   line-height: 100%;
 }
 
@@ -49,6 +146,7 @@
   height: 40px;
   display: flex;
   align-items: flex-end;
+  gap: 0.35em;
 }
 
 .stacked .trophy {
@@ -110,18 +208,6 @@
   &.marathonTopFivehundred {
     text-shadow: none;
   }
-}
-
-.packed .trophy {
-  margin-inline-end: -8px;
-}
-
-.packed .stacked {
-  margin-inline-end: 30px;
-}
-
-.packed .stacked .trophy {
-  margin-inline-end: -30px;
 }
 
 .trophy.icon3d {

--- a/ui/user/css/_trophy.scss
+++ b/ui/user/css/_trophy.scss
@@ -37,12 +37,12 @@
   box-shadow: 0 1px 3px rgb(0 0 0 / 0.3);
   transition: opacity 0.2s;
 
-  &:hover {
+  &:hover,
+  &:focus-visible {
     opacity: 0.7;
   }
 
   &:focus-visible {
-    opacity: 0.7;
     outline: 2px solid $c-primary;
     outline-offset: 2px;
   }
@@ -64,6 +64,11 @@
     grid-template-columns: repeat(auto-fill, minmax(5em, 1fr));
   }
 
+  &__title,
+  &__name {
+    overflow-wrap: anywhere;
+  }
+
   &__title {
     grid-column: 1 / -1;
     margin: 0 0 0.5em;
@@ -72,7 +77,6 @@
     font-size: 1.6em;
     font-weight: bold;
     line-height: 1.2;
-    overflow-wrap: anywhere;
   }
 
   &__item {
@@ -92,19 +96,18 @@
     .trophy,
     .shield-trophy,
     .revol_trophy {
-      display: flex !important;
+      display: flex;
       align-items: center;
       justify-content: center;
-      width: auto !important;
-      height: 60px !important;
-      margin: 0 !important;
+      width: auto;
+      height: 60px;
+      margin: 0;
       font-size: 52px;
-      transform: none !important;
-      opacity: 1;
+      transform: none;
 
       img {
-        height: 60px !important;
-        width: auto !important;
+        height: 60px;
+        width: auto;
       }
     }
   }
@@ -113,7 +116,6 @@
     color: $c-font-dim;
     font-size: 0.85em;
     line-height: 1.3;
-    overflow-wrap: anywhere;
   }
 }
 

--- a/ui/user/css/_trophy.scss
+++ b/ui/user/css/_trophy.scss
@@ -37,10 +37,14 @@
   box-shadow: 0 1px 3px rgb(0 0 0 / 0.3);
   transition: opacity 0.2s;
 
-  &:hover,
+  &:hover {
+    opacity: 0.7;
+  }
+
   &:focus-visible {
     opacity: 0.7;
-    outline: none;
+    outline: 2px solid $c-primary;
+    outline-offset: 2px;
   }
 }
 
@@ -86,7 +90,8 @@
     }
 
     .trophy,
-    .shield-trophy {
+    .shield-trophy,
+    .revol_trophy {
       display: flex !important;
       align-items: center;
       justify-content: center;
@@ -114,7 +119,7 @@
 
 .trophy.award {
   font-family: lichess;
-  speak-as: none;
+  speak: none;
   line-height: 100%;
 }
 

--- a/ui/user/src/user.ts
+++ b/ui/user/src/user.ts
@@ -1,7 +1,7 @@
 import { myUserId } from 'lib';
 import { licon } from 'lib/licon';
 import { pubsub } from 'lib/pubsub';
-import { alert, makeLinkPopups } from 'lib/view';
+import { alert, domDialog, makeLinkPopups } from 'lib/view';
 import * as xhr from 'lib/xhr';
 
 const gamesAngle = document.querySelector<HTMLElement>('.games');
@@ -12,8 +12,7 @@ export async function initModule(): Promise<void> {
   makeLinkPopups($('.user-infos .bio'));
 
   tmpRandomTutorLink();
-  updatePackedTrophies();
-  window.addEventListener('resize', updatePackedTrophies);
+  fitTrophies();
 
   const loadNoteZone = () => {
     const $zone = $('.user-show .note-zone');
@@ -99,13 +98,99 @@ function tmpRandomTutorLink() {
   $(buttonHtml).insertBefore('.profile-side .insight');
 }
 
-function updatePackedTrophies() {
+const trophySelector = '.trophy, .shield-trophy';
+const badgeSelector = '.icon3d';
+
+const trophyName = (el: HTMLElement): string => el.getAttribute('aria-label') || el.title || el.className;
+const isCup = (el: HTMLElement): boolean => !el.matches(badgeSelector);
+
+function fitTrophies() {
+  const box = document.querySelector<HTMLElement>('.user-show');
+  if (box) new ResizeObserver(layoutTrophies).observe(box);
+}
+
+function layoutTrophies() {
   const header = document.querySelector<HTMLElement>('.user-show__header');
   const trophies = header?.querySelector<HTMLElement>('.trophies');
   const title = header?.querySelector<HTMLElement>('h1');
   if (!trophies || !title) return;
-  trophies.classList.remove('packed');
-  // see if there's an overflow (or close to one) without 'packed':
-  if (trophies.getBoundingClientRect().left < title.getBoundingClientRect().right + 8)
-    trophies.classList.add('packed');
+
+  trophies.querySelector('.more-trophies')?.remove();
+  const items = [...trophies.querySelectorAll<HTMLElement>(trophySelector)];
+  for (const el of items) el.style.removeProperty('display');
+
+  const hide = (el: HTMLElement) => (el.style.display = 'none');
+  const isVisible = (el: HTMLElement) => el.style.display !== 'none';
+  const nameRight = () => title.getBoundingClientRect().right + 48;
+
+  const seen = new Set<string>();
+  for (const el of items) {
+    if (seen.has(trophyName(el))) hide(el);
+    else seen.add(trophyName(el));
+  }
+
+  for (const el of items.filter(isVisible)) {
+    if (el.getBoundingClientRect().left >= nameRight()) break;
+    hide(el);
+  }
+
+  const username = title.querySelector<HTMLElement>('.user-link[data-href]')?.textContent?.trim();
+  const cupCount = items.filter(isCup).length;
+  trophies.prepend(moreButton(cupCount, () => showAllTrophies(trophies, username)));
+}
+
+function moreButton(count: number, onClick: () => void): HTMLButtonElement {
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'more-trophies';
+  button.textContent = `+${count}`;
+  button.title = i18n.site.more;
+  button.setAttribute('aria-label', i18n.site.more);
+  button.addEventListener('click', onClick);
+  return button;
+}
+
+let trophiesDialogOpen = false;
+
+function showAllTrophies(trophies: HTMLElement, username?: string) {
+  if (trophiesDialogOpen) return;
+  trophiesDialogOpen = true;
+
+  const heading = document.createElement('h2');
+  heading.className = 'all-trophies__title';
+  heading.textContent = username ?? i18n.site.more;
+
+  const grid = document.createElement('div');
+  grid.className = 'all-trophies';
+  grid.append(heading);
+  for (const el of trophies.querySelectorAll<HTMLElement>(trophySelector)) {
+    if (isCup(el)) grid.append(trophyCard(el));
+  }
+
+  domDialog({
+    class: 'all-trophies-dialog',
+    append: [{ node: grid }],
+    modal: true,
+    show: true,
+    onClose: () => (trophiesDialogOpen = false),
+  });
+}
+
+function trophyCard(cup: HTMLElement): HTMLElement {
+  const icon = cup.cloneNode(true) as HTMLElement;
+  icon.removeAttribute('style');
+  icon.querySelectorAll('img').forEach(img => img.removeAttribute('style'));
+
+  const cell = document.createElement('div');
+  cell.className = 'all-trophies__item';
+  cell.append(icon);
+
+  const label = cup.getAttribute('aria-label') || cup.title;
+  if (label) {
+    const name = document.createElement('span');
+    name.className = 'all-trophies__name';
+    name.textContent = label;
+    cell.append(name);
+  }
+  return cell;
 }

--- a/ui/user/src/user.ts
+++ b/ui/user/src/user.ts
@@ -103,6 +103,9 @@ const badgeSelector = '.icon3d';
 
 const trophyName = (el: HTMLElement): string => el.getAttribute('aria-label') || el.title || el.className;
 const isCup = (el: HTMLElement): boolean => !el.matches(badgeSelector);
+const hide = (el: HTMLElement) => (el.style.display = 'none');
+const show = (el: HTMLElement) => el.style.removeProperty('display');
+const isShown = (el: HTMLElement) => el.style.display !== 'none';
 
 function fitTrophies() {
   const box = document.querySelector<HTMLElement>('.user-show');
@@ -115,39 +118,46 @@ function layoutTrophies() {
   const title = header?.querySelector<HTMLElement>('h1');
   if (!trophies || !title) return;
 
+  const items = resetTrophies(trophies);
+  hideDuplicateKinds(items);
+  hideOverflowing(items, title);
+  addMoreButton(trophies, title, items);
+}
+
+function resetTrophies(trophies: HTMLElement): HTMLElement[] {
   trophies.querySelector('.more-trophies')?.remove();
   const items = [...trophies.querySelectorAll<HTMLElement>(trophySelector)];
-  for (const el of items) el.style.removeProperty('display');
+  items.forEach(show);
+  return items;
+}
 
-  const hide = (el: HTMLElement) => (el.style.display = 'none');
-  const isVisible = (el: HTMLElement) => el.style.display !== 'none';
-  const nameRight = () => title.getBoundingClientRect().right + 48;
-
+function hideDuplicateKinds(items: HTMLElement[]) {
   const seen = new Set<string>();
   for (const el of items) {
     if (seen.has(trophyName(el))) hide(el);
     else seen.add(trophyName(el));
   }
-
-  for (const el of items.filter(isVisible)) {
-    if (el.getBoundingClientRect().left >= nameRight()) break;
-    hide(el);
-  }
-
-  const username = title.querySelector<HTMLElement>('.user-link[data-href]')?.textContent?.trim();
-  const cupCount = items.filter(isCup).length;
-  trophies.prepend(moreButton(cupCount, () => showAllTrophies(trophies, username)));
 }
 
-function moreButton(count: number, onClick: () => void): HTMLButtonElement {
+function hideOverflowing(items: HTMLElement[], title: HTMLElement) {
+  const limit = title.getBoundingClientRect().right + 48;
+  for (const el of items.filter(isShown)) {
+    if (el.getBoundingClientRect().left >= limit) break;
+    hide(el);
+  }
+}
+
+function addMoreButton(trophies: HTMLElement, title: HTMLElement, items: HTMLElement[]) {
+  const username = title.querySelector<HTMLElement>('.user-link[data-href]')?.textContent?.trim();
+  const cupCount = items.filter(isCup).length;
   const button = document.createElement('button');
   button.type = 'button';
   button.className = 'more-trophies';
-  button.textContent = `+${count}`;
+  button.textContent = `+${cupCount}`;
   button.title = i18n.site.more;
   button.setAttribute('aria-label', i18n.site.more);
-  button.addEventListener('click', onClick);
-  return button;
+  button.addEventListener('click', () => showAllTrophies(trophies, username));
+  trophies.prepend(button);
 }
 
 let trophiesDialogOpen = false;

--- a/ui/user/src/user.ts
+++ b/ui/user/src/user.ts
@@ -98,7 +98,7 @@ function tmpRandomTutorLink() {
   $(buttonHtml).insertBefore('.profile-side .insight');
 }
 
-const trophySelector = '.trophy, .shield-trophy';
+const trophySelector = '.trophy, .shield-trophy, .revol_trophy';
 const badgeSelector = '.icon3d';
 
 const trophyName = (el: HTMLElement): string => el.getAttribute('aria-label') || el.title || el.className;


### PR DESCRIPTION
Closes #14376.

## Problem

If user have many trophy, it overlap username and look bad. Very hard to read. 
E.g: Lance5500 (lichess.org/@/Lance5500)

## Approach

1. Hide same trophies. Show only one
2. If no space, hide trophy. (i use ResizeObserver for window resize)
3. add +N button. Click it to open dialog and see all trophies
4. badges stay outside dialog

## Screenshots

| Before | After — profile header |
| --- | --- |
| <img width="480" alt="before" src="https://github.com/user-attachments/assets/3a957912-dc91-4032-927f-26b83747cc4b" /> | <img width="480" alt="after header" src="https://github.com/user-attachments/assets/538adb25-e540-43d0-8874-a4fbae2af6e0" /> |

### "All trophies" dialog

<img width="480" alt="all trophies dialog" src="https://github.com/user-attachments/assets/26ceab95-19b8-4793-beb8-98387a297de3" />

## Test

I test in local lila-docker. i make user with 43 marathon trophy . i test screen size 900, 1024, 1280px  e.g.

Confirmed:

1. Tophy not go top of username anymore
2. Same trophies dont stack. Show only one
2. Resize work good

## Files changed

- `ui/user/src/user.ts`
- `ui/user/css/_trophy.scss`
