### PR TITLE
Show pending moves in move list and update material balance

### DIFF
--- a/ui/round/src/ctrl.ts
+++ b/ui/round/src/ctrl.ts
@@ -3,6 +3,7 @@
 import type { DrawShape } from '@lichess-org/chessground/draw';
 import { opposite, uciToMove } from '@lichess-org/chessground/util';
 import * as ab from 'ab/round';
+import { roleToChar } from 'chessops/util';
 import { ctrl as makeKeyboardMove, type KeyboardMove } from 'keyboard-move';
 import { makeVoiceMove, type VoiceMove } from 'voice';
 
@@ -893,6 +894,18 @@ export default class RoundController implements MoveRootCtrl {
   };
 
   stepAt = (ply: Ply): Step => util.plyStep(this.data, ply);
+
+  pendingStep = (): Step | undefined => {
+    const submit = this.toSubmit;
+    if (!submit) return undefined;
+    const uci = 'u' in submit ? submit.u : `${roleToChar(submit.role).toUpperCase()}@${submit.pos}`;
+    return {
+      ply: this.ply + 1,
+      fen: this.chessground.getFen(),
+      san: almostSanOf(readFen(this.stepAt(this.ply).fen), uci),
+      uci,
+    };
+  };
 
   speakClock = (): void => {
     this.clock?.speak();

--- a/ui/round/src/view/main.ts
+++ b/ui/round/src/view/main.ts
@@ -19,10 +19,11 @@ export function main(ctrl: RoundController): VNode {
   const d = ctrl.data,
     topColor = d[ctrl.flip ? 'player' : 'opponent'].color,
     bottomColor = d[ctrl.flip ? 'opponent' : 'player'].color,
+    pending = ctrl.pendingStep(),
     materialDiffs = renderMaterialDiffs(
       ctrl.data.pref.showCaptured,
       ctrl.flip ? ctrl.data.opponent.color : ctrl.data.player.color,
-      ctrl.stepAt(ctrl.ply).fen,
+      pending ? pending.fen : ctrl.stepAt(ctrl.ply).fen,
       !!(ctrl.data.player.checks || ctrl.data.opponent.checks), // showChecks
       ctrl.data.steps,
       ctrl.ply,

--- a/ui/round/src/view/replay.ts
+++ b/ui/round/src/view/replay.ts
@@ -93,7 +93,8 @@ export function renderResult(ctrl: RoundController): VNode | undefined {
 }
 
 function renderMoves(ctrl: RoundController): LooseVNodes {
-  const steps = ctrl.data.steps,
+  const pending = ctrl.pendingStep(),
+    steps = pending ? [...ctrl.data.steps, pending] : ctrl.data.steps,
     firstPly = util.firstPly(ctrl.data),
     lastPly = util.lastPly(ctrl.data),
     indexOffset = Math.trunc(firstPly / 2) + 1,
@@ -110,7 +111,7 @@ function renderMoves(ctrl: RoundController): LooseVNodes {
   for (let i = startAt; i < steps.length; i += 2) pairs.push([steps[i], steps[i + 1]]);
 
   const els: LooseVNodes = [],
-    curPly = ctrl.ply;
+    curPly = pending ? pending.ply : ctrl.ply;
   for (let i = 0; i < pairs.length; i++) {
     els.push(hl(indexTag, i + indexOffset));
     els.push(renderMove(pairs[i][0], curPly, true, drawPlies));


### PR DESCRIPTION
### Why the change is needed:
In a game with "Move confirmation" enabled, making a move shows it on the board. But the move list and material balance stay stale until you press confirm. After a capture, this is confusing since the board and the material count disagree.

This bug was reproducible.

### Link to issue:
Closes #14082

### Solution:
Added a provisional step for the move awaiting confirmation. The move list and material balance now reflect it while pending.

### Testing:
Built locally. Before: with move confirmation on, a pending capture left the move list and material balance unchanged. After: the pending move shows in the move list and the material updates before confirming.

### AI assistance:
This change was made with AI assistance (Claude Code, Anthropic).
Prompt: "Fix issue 14082, verify it still exists, fix it, and write the PR content."
Some AI generated outputs have been modified. I was able to reproduce the bug before modifying code and confirmed the fix after.

### Video:
<video src="https://github.com/user-attachments/assets/6c794978-4c97-4088-aeec-74ac4c73ae6e"></video>