### PR TITLE
sanity check for cloud eval (it's a jungle out there)

### DIFF
--- a/ui/analyse/src/evalCache.ts
+++ b/ui/analyse/src/evalCache.ts
@@ -92,7 +92,9 @@ export default class EvalCache {
       ev &&
       !ev.cloud &&
       this.fetchedByFen.has(node.fen) &&
-      (!fetched || fetched.depth < ev.depth) &&
+      fetched !== undefined &&
+      (fetched === awaitingEval || fetched.depth < ev.depth) &&
+      ev.fen === node.fen &&
       qualityCheck(ev) &&
       this.opts.canPut()
     ) {


### PR DESCRIPTION
I went looking into how a mismatched eval got in the cloud db earlier. I couldn't find an obvious culprit in the lichess application logic, either the client or the server. But I did notice this:

https://github.com/Siderite/lichessTools/blob/stable/scripts/lichessTools.js#L2806-L2858

Lichess Tools accesses evalCache here. Thankfully there are no socket puts (that I know of), but maybe it overwrites node cevals with stuff from IDB, and then the client sends that. Who knows, that one javascript is like 5000 lines long.

I just added a sanity check for `ev.fen === node.fen` before greenlighting the socket send in evalCache.ts. That's a short term band-aid that probably fixes nothing. Longer term, I'm sure you and Siderite can find a safer way to deliver these LT feature(s).