### PR TITLE
ui(puzzle): small tweaks and cleanup of view code

### DIFF
--- a/ui/puzzle/src/view/after.ts
+++ b/ui/puzzle/src/view/after.ts
@@ -6,7 +6,6 @@ import type PuzzleCtrl from '../ctrl';
 const renderVote = (ctrl: PuzzleCtrl): VNode =>
   hl(
     'div.puzzle__vote',
-    {},
     !ctrl.autoNexting() && [
       ctrl.session.isNew() &&
         ctrl.data.user?.provisional &&
@@ -38,7 +37,7 @@ const renderStreak = (ctrl: PuzzleCtrl): MaybeVNodes => [
 ];
 
 export default function (ctrl: PuzzleCtrl): VNode {
-  const data = ctrl.data;
+  const { data } = ctrl;
   const win = ctrl.lastFeedback === 'win';
   const canPlayComputer = !ctrl.node.san?.includes('#');
   return hl(

--- a/ui/puzzle/src/view/main.ts
+++ b/ui/puzzle/src/view/main.ts
@@ -154,38 +154,34 @@ function session(ctrl: PuzzleCtrl): MaybeVNode {
 
   if (!rounds.length) return undefined;
 
-  const current = ctrl.data.puzzle.id;
+  const { id: currentId } = ctrl.data.puzzle;
+  const { theme } = ctrl.session;
 
   return hl('div.puzzle__session', [
-    rounds.map(round => {
+    rounds.map(({ id, result, ratingDiff }) => {
       const rd =
-        round.ratingDiff && ctrl.opts.showRatings
-          ? round.ratingDiff > 0
-            ? '+' + round.ratingDiff
-            : round.ratingDiff
-          : null;
+        ratingDiff && ctrl.opts.showRatings ? (ratingDiff > 0 ? '+' + ratingDiff : ratingDiff) : null;
 
       return h(
-        `a.result-${round.result}${rd ? '' : '.result-empty'}`,
+        `a.result-${result}`,
         {
-          key: round.id,
-          class: { current: current === round.id },
+          key: id,
+          class: { current: currentId === id, 'result-empty': !rd },
           attrs: {
-            href: `/training/${ctrl.session.theme}/${round.id}`,
+            href: `/training/${theme}/${id}`,
             ...(ctrl.streak ? { target: '_blank' } : {}),
           },
         },
         rd,
       );
     }),
-    rounds.some(r => r.id === current)
-      ? !ctrl.streak &&
-        hl('a.session-new', { key: 'new', attrs: { href: `/training/${ctrl.session.theme}` } })
+    rounds.some(r => r.id === currentId)
+      ? !ctrl.streak && hl('a.session-new', { key: 'new', attrs: { href: `/training/${theme}` } })
       : hl(
           'a.result-cursor.current',
           {
-            key: current,
-            attrs: ctrl.streak ? {} : { href: `/training/${ctrl.session.theme}/${current}` },
+            key: currentId,
+            attrs: ctrl.streak ? {} : { href: `/training/${theme}/${currentId}` },
           },
           ctrl.streak && (ctrl.streak.data.index + 1).toString(),
         ),

--- a/ui/puzzle/src/view/side.ts
+++ b/ui/puzzle/src/view/side.ts
@@ -15,7 +15,7 @@ export function puzzleBox(ctrl: PuzzleCtrl): VNode {
 }
 
 const angleImg = (ctrl: PuzzleCtrl): string => {
-  const angle = ctrl.data.angle;
+  const { angle } = ctrl.data;
   const name =
     angle.opening || angle.openingAbstract ? 'opening' : angle.key.startsWith('mateIn') ? 'mate' : angle.key;
   return site.asset.url(`images/puzzle-themes/${name}.svg`);
@@ -48,7 +48,7 @@ const puzzleInfos = (ctrl: PuzzleCtrl, puzzle: Puzzle): VNode =>
           i18n.puzzle.ratingX.asArray(
             !ctrl.streak && ctrl.mode === 'play'
               ? hl('span.hidden', i18n.puzzle.hidden)
-              : hl('strong', `${puzzle.rating}`),
+              : hl('strong', puzzle.rating),
           ),
         ),
       hl('p', i18n.puzzle.playedXTimes.asArray(puzzle.plays, hl('strong', numberFormat(puzzle.plays)))),
@@ -97,7 +97,7 @@ const renderStreak = (streak: PuzzleStreak) =>
   );
 
 export const userBox = (ctrl: PuzzleCtrl): VNode => {
-  const data = ctrl.data;
+  const { data } = ctrl;
   if (!data.user)
     return hl('div.puzzle__side__user', [
       hl('p', i18n.puzzle.toGetPersonalizedPuzzles),
@@ -131,7 +131,7 @@ export const userBox = (ctrl: PuzzleCtrl): VNode => {
   ]);
 };
 
-export const streakBox = (ctrl: PuzzleCtrl) => hl('div.puzzle__side__user', renderStreak(ctrl.streak!));
+export const streakBox = ({ streak }: PuzzleCtrl) => hl('div.puzzle__side__user', renderStreak(streak!));
 
 const difficulties: [PuzzleDifficulty, number][] = [
   ['easiest', -600],
@@ -147,10 +147,10 @@ const colors = [
 ] as const;
 
 export function replay(ctrl: PuzzleCtrl): MaybeVNode {
-  const replay = ctrl.data.replay;
+  const { replay, angle } = ctrl.data;
   if (!replay) return;
   const i = replay.i + (ctrl.mode === 'play' ? 0 : 1);
-  const text = i18n.puzzleTheme[ctrl.data.angle.key];
+  const text = i18n.puzzleTheme[angle.key];
   return hl('div.puzzle__side__replay', [
     hl('a', { attrs: { href: `/training/dashboard/${replay.days}` } }, ['« ', `Replaying ${text} puzzles`]),
     hl('div.puzzle__side__replay__bar', {
@@ -163,11 +163,10 @@ export function replay(ctrl: PuzzleCtrl): MaybeVNode {
 }
 
 export function config(ctrl: PuzzleCtrl): MaybeVNode {
-  const autoNextId = 'puzzle-toggle-autonext';
-  const data = ctrl.data;
+  const { data } = ctrl;
   return hl('div.puzzle__side__config', [
     cmnToggleWrap({
-      id: autoNextId,
+      id: 'puzzle-toggle-autonext',
       name: i18n.puzzle.jumpToNextPuzzleImmediately,
       checked: ctrl.autoNext(),
       change(v) {

--- a/ui/puzzle/src/view/side.ts
+++ b/ui/puzzle/src/view/side.ts
@@ -6,24 +6,23 @@ import { cmnToggleWrap } from 'lib/view/cmn-toggle';
 import { userLink } from 'lib/view/userLink';
 
 import type PuzzleCtrl from '@/ctrl';
-import type { Puzzle, PuzzleGame, PuzzleDifficulty } from '@/interfaces';
+import type { Angle, PuzzleDifficulty } from '@/interfaces';
 import type PuzzleStreak from '@/streak';
 
 export function puzzleBox(ctrl: PuzzleCtrl): VNode {
-  const { game, puzzle } = ctrl.data;
-  return hl('div.puzzle__side__metas', [puzzleInfos(ctrl, puzzle), gameInfos(ctrl, game, puzzle)]);
+  return hl('div.puzzle__side__metas', [puzzleInfos(ctrl), gameInfos(ctrl)]);
 }
 
-const angleImg = (ctrl: PuzzleCtrl): string => {
-  const { angle } = ctrl.data;
+const angleImg = (angle: Angle): string => {
   const name =
     angle.opening || angle.openingAbstract ? 'opening' : angle.key.startsWith('mateIn') ? 'mate' : angle.key;
   return site.asset.url(`images/puzzle-themes/${name}.svg`);
 };
 
-const puzzleInfos = (ctrl: PuzzleCtrl, puzzle: Puzzle): VNode =>
-  hl('div.infos.puzzle', [
-    hl('img.infos__angle-img', { attrs: { src: angleImg(ctrl), alt: ctrl.data.angle.name } }),
+const puzzleInfos = (ctrl: PuzzleCtrl): VNode => {
+  const { puzzle, angle } = ctrl.data;
+  return hl('div.infos.puzzle', [
+    hl('img.infos__angle-img', { attrs: { src: angleImg(angle), alt: angle.name } }),
     hl('div', [
       hl(
         'p',
@@ -54,8 +53,10 @@ const puzzleInfos = (ctrl: PuzzleCtrl, puzzle: Puzzle): VNode =>
       hl('p', i18n.puzzle.playedXTimes.asArray(puzzle.plays, hl('strong', numberFormat(puzzle.plays)))),
     ]),
   ]);
+};
 
-function gameInfos(ctrl: PuzzleCtrl, game: PuzzleGame, puzzle: Puzzle): VNode {
+function gameInfos(ctrl: PuzzleCtrl): VNode {
+  const { game, puzzle } = ctrl.data;
   const gameName = game.clock && game.perf ? `${game.clock} • ${game.perf.name}` : 'import';
   return hl('div.infos', { attrs: game.perf && dataIcon(perfIcons[game.perf.key]) }, [
     hl('div', [

--- a/ui/puzzle/src/view/theme.ts
+++ b/ui/puzzle/src/view/theme.ts
@@ -9,8 +9,7 @@ import { renderColorForm } from './side';
 const STUDY_URL = 'https://lichess.org/study/viiWlKjv';
 
 export default function theme(ctrl: PuzzleCtrl): MaybeVNode {
-  const data = ctrl.data;
-  const { angle, replay } = data;
+  const { angle, replay } = ctrl.data;
   const showEditor = ctrl.mode === 'view' && !ctrl.autoNexting();
 
   if (replay) return showEditor ? hl('div.puzzle__side__theme', editor(ctrl)) : null;
@@ -18,31 +17,33 @@ export default function theme(ctrl: PuzzleCtrl): MaybeVNode {
 
   const backHref = ctrl.routerWithLang(`/training/${angle.opening ? 'openings' : 'themes'}`);
 
-  return ctrl.isDaily
-    ? hl(
-        'div.puzzle__side__theme.puzzle__side__theme--daily',
-        backToTheme(backHref, ['« ', i18n.puzzle.dailyPuzzle]),
-      )
-    : hl('div.puzzle__side__theme', [
-        backToTheme(backHref, ['« ', angle.name], { class: { long: angle.name.length > 20 } }),
-        angle.opening
-          ? hl('a', { attrs: { href: `/opening/${angle.opening.key}` } }, [
-              'Learn more about ',
-              angle.opening.name,
-            ])
-          : hl('p', [
-              angle.desc,
-              angle.chapter &&
-                hl(
-                  'a.puzzle__side__theme__chapter.text',
-                  { attrs: { href: `${STUDY_URL}/${angle.chapter}`, target: '_blank' } },
-                  [' ', i18n.puzzle.example],
-                ),
-            ]),
-        showEditor
-          ? hl('div.puzzle__themes', editor(ctrl))
-          : !replay && !ctrl.streak && (angle.opening || angle.openingAbstract) && renderColorForm(ctrl),
-      ]);
+  if (ctrl.isDaily) {
+    return hl(
+      'div.puzzle__side__theme.puzzle__side__theme--daily',
+      backToTheme(backHref, ['« ', i18n.puzzle.dailyPuzzle]),
+    );
+  }
+
+  return hl('div.puzzle__side__theme', [
+    backToTheme(backHref, ['« ', angle.name], { class: { long: angle.name.length > 20 } }),
+    angle.opening
+      ? hl('a', { attrs: { href: `/opening/${angle.opening.key}` } }, [
+          'Learn more about ',
+          angle.opening.name,
+        ])
+      : hl('p', [
+          angle.desc,
+          angle.chapter &&
+            hl(
+              'a.puzzle__side__theme__chapter.text',
+              { attrs: { href: `${STUDY_URL}/${angle.chapter}`, target: '_blank' } },
+              [' ', i18n.puzzle.example],
+            ),
+        ]),
+    showEditor
+      ? hl('div.puzzle__themes', editor(ctrl))
+      : !replay && !ctrl.streak && (angle.opening || angle.openingAbstract) && renderColorForm(ctrl),
+  ]);
 }
 
 const invisibleThemes = new Set(['master', 'masterVsMaster', 'superGM']);
@@ -56,13 +57,13 @@ function themeTrans(key: string) {
 }
 
 const editor = (ctrl: PuzzleCtrl): VNode[] => {
-  const data = ctrl.data;
+  const { puzzle } = ctrl.data;
   const votedThemes = ctrl.round?.themes ?? ({} as RoundThemes);
 
   const visibleThemes: ThemeKey[] = [
-    ...data.puzzle.themes.filter(t => !invisibleThemes.has(t)),
+    ...puzzle.themes.filter(t => !invisibleThemes.has(t)),
     ...Object.keys(votedThemes).filter(
-      (t: ThemeKey): t is ThemeKey => !!votedThemes[t] && !data.puzzle.themes.includes(t),
+      (t: ThemeKey): t is ThemeKey => !!votedThemes[t] && !puzzle.themes.includes(t),
     ),
   ].sort();
   const allThemes = ctrl.isDaily ? null : ctrl.allThemes;

--- a/ui/puzzle/src/view/tree.ts
+++ b/ui/puzzle/src/view/tree.ts
@@ -6,7 +6,7 @@ import { renderEval as normalizeEval } from 'lib/ceval';
 import { plyToTurn } from 'lib/game/chess';
 import { path as treePath } from 'lib/tree/tree';
 import type { TreeNode, TreePath } from 'lib/tree/types';
-import { type MaybeVNode, type LooseVNodes, hl } from 'lib/view';
+import { type MaybeVNode, type LooseVNodes, hl, onInsert } from 'lib/view';
 
 import type PuzzleCtrl from '@/ctrl';
 
@@ -167,8 +167,7 @@ export function render(ctrl: PuzzleCtrl): VNode {
     'div.tview2.tview2-column',
     {
       hook: {
-        insert: vnode => {
-          const el = vnode.elm as HTMLElement;
+        ...onInsert(el => {
           if (ctrl.path !== treePath.root) autoScroll(ctrl, el);
           el.addEventListener('mousedown', (e: MouseEvent) => {
             if (defined(e.button) && e.button !== 0) return; // only touch or left click
@@ -176,7 +175,7 @@ export function render(ctrl: PuzzleCtrl): VNode {
             if (path) ctrl.userJump(path);
             ctrl.redraw();
           });
-        },
+        }),
         postpatch: (_, vnode) => {
           if (ctrl.autoScrollNow) {
             autoScroll(ctrl, vnode.elm as HTMLElement);


### PR DESCRIPTION
# How

Small tweaks and cleanup of puzzle view code, including:
- destructing variable pattern when it helps to save typing/lines
- cleaner conditional classes assign
- split nested render variations to avoid deep indentation
- relay on `onInsert` where possible to avoid casts