### PR TITLE
ui: small view code tweaks, few more `onInsert` helper uses

### DIFF
--- a/ui/racer/src/view/board.ts
+++ b/ui/racer/src/view/board.ts
@@ -5,46 +5,45 @@ import { h, type VNode } from 'snabbdom';
 import { pubsub } from 'lib/pubsub';
 import { makeCgOpts } from 'lib/puz/run';
 import { makeConfig as makeCgConfig } from 'lib/puz/view/chessground';
+import { onInsert } from 'lib/view';
 
-import type RacerCtrl from '../ctrl';
+import type RacerCtrl from '@/ctrl';
 
 export const renderBoard = (ctrl: RacerCtrl) => {
-  const secs = ctrl.countdownSeconds();
   return h('div.puz-board.main-board', [
     renderGround(ctrl),
     ctrl.promotion.view(),
-    secs ? renderCountdown(secs) : undefined,
+    renderCountdown(ctrl.countdownSeconds()),
   ]);
 };
 
 const renderGround = (ctrl: RacerCtrl): VNode =>
   h('div.cg-wrap', {
-    hook: {
-      insert: vnode => {
-        ctrl.ground(
-          makeChessground(
-            vnode.elm as HTMLElement,
-            makeCgConfig(
-              ctrl.isRacing() && ctrl.isPlayer()
-                ? makeCgOpts(ctrl.run, true, ctrl.flipped)
-                : { fen: INITIAL_BOARD_FEN, orientation: ctrl.run.pov, movable: { color: ctrl.run.pov } },
-              ctrl.pref,
-              ctrl.userMove,
-            ),
+    hook: onInsert(el => {
+      ctrl.ground(
+        makeChessground(
+          el,
+          makeCgConfig(
+            ctrl.isRacing() && ctrl.isPlayer()
+              ? makeCgOpts(ctrl.run, true, ctrl.flipped)
+              : { fen: INITIAL_BOARD_FEN, orientation: ctrl.run.pov, movable: { color: ctrl.run.pov } },
+            ctrl.pref,
+            ctrl.userMove,
           ),
-        );
-        pubsub.on('board.change', (is3d: boolean) =>
-          ctrl.withGround(g => {
-            g.state.addPieceZIndex = is3d;
-            g.redrawAll();
-          }),
-        );
-      },
-    },
+        ),
+      );
+      pubsub.on('board.change', (is3d: boolean) =>
+        ctrl.withGround(g => {
+          g.state.addPieceZIndex = is3d;
+          g.redrawAll();
+        }),
+      );
+    }),
   });
 
-const renderCountdown = (seconds: number) =>
-  h('div.racer__countdown', [
+const renderCountdown = (seconds?: number) => {
+  if (!seconds) return undefined;
+  return h('div.racer__countdown', [
     h('div.racer__countdown__lights', [
       h('light.red', { class: { active: seconds > 4 } }),
       h('light.orange', { class: { active: seconds === 3 || seconds === 4 } }),
@@ -52,3 +51,4 @@ const renderCountdown = (seconds: number) =>
     ]),
     h('div.racer__countdown__seconds', seconds),
   ]);
+};

--- a/ui/racer/src/view/main.ts
+++ b/ui/racer/src/view/main.ts
@@ -5,8 +5,9 @@ import renderHistory from 'lib/puz/view/history';
 import { playModifiers, renderCombo } from 'lib/puz/view/util';
 import { copyMeInput, type VNode, type MaybeVNodes, bind, hl } from 'lib/view';
 
-import config from '../config';
-import type RacerCtrl from '../ctrl';
+import config from '@/config';
+import type RacerCtrl from '@/ctrl';
+
 import { renderBoard } from './board';
 import { renderRace } from './race';
 
@@ -163,7 +164,7 @@ const renderJoin = (ctrl: RacerCtrl) =>
 
 const yourRank = (ctrl: RacerCtrl) => {
   const score = ctrl.myScore();
-  if (!score) return;
+  if (!score) return undefined;
   const players = ctrl.players();
   const rank = players.filter(p => p.score > score).length + 1;
   return hl('strong.race__post__rank', i18n.storm.yourRankX(`${rank}/${players.length}`));

--- a/ui/racer/src/view/race.ts
+++ b/ui/racer/src/view/race.ts
@@ -2,9 +2,9 @@ import { h, type VNodes } from 'snabbdom';
 
 import { userLink } from 'lib/view/userLink';
 
-import type { Boost } from '../boost';
-import type RacerCtrl from '../ctrl';
-import type { PlayerWithScore } from '../interfaces';
+import type { Boost } from '@/boost';
+import type RacerCtrl from '@/ctrl';
+import type { PlayerWithScore } from '@/interfaces';
 
 // to [0,1]
 type RelativeScore = (score: number) => number;

--- a/ui/simul/src/view/created.ts
+++ b/ui/simul/src/view/created.ts
@@ -3,21 +3,18 @@ import type { VNode } from 'snabbdom';
 import { licon } from 'lib/licon';
 import { domDialog, confirm, bind, hl, dataIcon } from 'lib/view';
 
-import type SimulCtrl from '../ctrl';
-import type { Applicant } from '../interfaces';
-import xhr from '../xhr';
+import type SimulCtrl from '@/ctrl';
+import type { Applicant } from '@/interfaces';
+import xhr from '@/xhr';
+
 import * as util from './util';
 
 export default function (showText: (ctrl: SimulCtrl) => VNode | false) {
   return (ctrl: SimulCtrl) => {
-    const candidates = ctrl.candidates().sort(byName),
-      accepted = ctrl.accepted().sort(byName),
-      isHost = ctrl.createdByMe(),
-      canJoin = ctrl.data.canJoin;
-    const variantIconFor = (a: Applicant) => {
-      const variant = ctrl.data.variants.find(v => a.variant === v.key);
-      return variant && hl('td.variant', { attrs: dataIcon(variant.icon) });
-    };
+    const candidates = ctrl.candidates().sort(byName);
+    const accepted = ctrl.accepted().sort(byName);
+    const isHost = ctrl.createdByMe();
+    const canJoin = ctrl.data.canJoin;
     return [
       hl('div.box__top', [
         util.title(ctrl),
@@ -88,7 +85,7 @@ export default function (showText: (ctrl: SimulCtrl) => VNode | false) {
                 hl(
                   'tr',
                   hl('th', { attrs: { colspan: 3 } }, [
-                    hl('strong', `${candidates.length}`),
+                    hl('strong', candidates.length),
                     ' candidate players',
                   ]),
                 ),
@@ -101,7 +98,7 @@ export default function (showText: (ctrl: SimulCtrl) => VNode | false) {
                     { key: applicant.player.id, class: { me: ctrl.opts.userId === applicant.player.id } },
                     [
                       hl('td', util.player(applicant.player, ctrl)),
-                      variantIconFor(applicant),
+                      variantIconFor(ctrl, applicant),
                       hl(
                         'td.action',
                         isHost &&
@@ -122,10 +119,7 @@ export default function (showText: (ctrl: SimulCtrl) => VNode | false) {
               hl('thead', [
                 hl(
                   'tr',
-                  hl('th', { attrs: { colspan: 3 } }, [
-                    hl('strong', `${accepted.length}`),
-                    ' accepted players',
-                  ]),
+                  hl('th', { attrs: { colspan: 3 } }, [hl('strong', accepted.length), ' accepted players']),
                 ),
                 isHost &&
                   candidates.length > 0 &&
@@ -140,7 +134,7 @@ export default function (showText: (ctrl: SimulCtrl) => VNode | false) {
                     { key: applicant.player.id, class: { me: ctrl.opts.userId === applicant.player.id } },
                     [
                       hl('td', util.player(applicant.player, ctrl)),
-                      variantIconFor(applicant),
+                      variantIconFor(ctrl, applicant),
                       hl(
                         'td.action',
                         isHost &&
@@ -203,3 +197,8 @@ const startOrCancel = (ctrl: SimulCtrl, accepted: Applicant[]) =>
         },
         i18n.site.cancel,
       );
+
+const variantIconFor = (ctrl: SimulCtrl, a: Applicant) => {
+  const variant = ctrl.data.variants.find(v => a.variant === v.key);
+  return variant && hl('td.variant', { attrs: dataIcon(variant.icon) });
+};

--- a/ui/simul/src/view/main.ts
+++ b/ui/simul/src/view/main.ts
@@ -3,7 +3,8 @@ import { richHTML } from 'lib/richText';
 import { onInsert, hl, initMiniGames } from 'lib/view';
 import { watchers } from 'lib/view/watchers';
 
-import type SimulCtrl from '../ctrl';
+import type SimulCtrl from '@/ctrl';
+
 import created from './created';
 import pairings from './pairings';
 import results from './results';

--- a/ui/simul/src/view/pairings.ts
+++ b/ui/simul/src/view/pairings.ts
@@ -4,17 +4,17 @@ import { h } from 'snabbdom';
 import { onInsert, renderClock } from 'lib/view';
 import { userFlair } from 'lib/view/userLink';
 
-import type SimulCtrl from '../ctrl';
-import type { Pairing } from '../interfaces';
+import type SimulCtrl from '@/ctrl';
+import type { Pairing } from '@/interfaces';
 
 export default function (ctrl: SimulCtrl) {
   return h('div.game-list.now-playing.box__pad', ctrl.data.pairings.map(miniPairing(ctrl)));
 }
 
 const miniPairing = (ctrl: SimulCtrl) => (pairing: Pairing) => {
-  const game = pairing.game,
-    player = pairing.player,
-    flair = userFlair(player);
+  const game = pairing.game;
+  const player = pairing.player;
+  const flair = userFlair(player);
   return h(
     `span.mini-game.mini-game-${game.id}.mini-game--init.is2d`,
     {

--- a/ui/simul/src/view/results.ts
+++ b/ui/simul/src/view/results.ts
@@ -3,8 +3,8 @@ import { h } from 'snabbdom';
 
 import { status } from 'lib/game';
 
-import type SimulCtrl from '../ctrl';
-import type { Pairing } from '../interfaces';
+import type SimulCtrl from '@/ctrl';
+import type { Pairing } from '@/interfaces';
 
 export default function (ctrl: SimulCtrl) {
   return h('div.results', [
@@ -27,8 +27,8 @@ export default function (ctrl: SimulCtrl) {
   ]);
 }
 
-const NumberFirstRegex = /^(\d+)\s(.+)$/,
-  NumberLastRegex = /^(.+)\s(\d+)$/;
+const NumberFirstRegex = /^(\d+)\s(.+)$/;
+const NumberLastRegex = /^(.+)\s(\d+)$/;
 
 const splitNumber = (s: string) => {
   let found: string[] | null;

--- a/ui/simul/src/view/util.ts
+++ b/ui/simul/src/view/util.ts
@@ -2,8 +2,8 @@ import { h } from 'snabbdom';
 
 import { fullName, userLine, userRating } from 'lib/view/userLink';
 
-import type SimulCtrl from '../ctrl';
-import type { Player } from '../interfaces';
+import type SimulCtrl from '@/ctrl';
+import type { Player } from '@/interfaces';
 
 export function player(p: Player, ctrl: SimulCtrl) {
   return h(
@@ -20,4 +20,4 @@ export function player(p: Player, ctrl: SimulCtrl) {
   );
 }
 
-export const title = (ctrl: SimulCtrl) => h('h1', ctrl.data.fullName);
+export const title = ({ data }: SimulCtrl) => h('h1', data.fullName);

--- a/ui/storm/src/view/end.ts
+++ b/ui/storm/src/view/end.ts
@@ -3,7 +3,7 @@ import { getNow } from 'lib/puz/util';
 import renderHistory from 'lib/puz/view/history';
 import { onInsert, type LooseVNodes, hl } from 'lib/view';
 
-import type StormCtrl from '../ctrl';
+import type StormCtrl from '@/ctrl';
 
 const renderEnd = (ctrl: StormCtrl): LooseVNodes => [renderSummary(ctrl), renderHistory(ctrl)];
 

--- a/ui/storm/src/view/main.ts
+++ b/ui/storm/src/view/main.ts
@@ -24,31 +24,28 @@ export default function (ctrl: StormCtrl): VNode {
 
 const chessground = (ctrl: StormCtrl): VNode =>
   hl('div.cg-wrap', {
-    hook: {
-      insert: vnode => {
-        ctrl.ground(
-          makeChessground(
-            vnode.elm as HTMLElement,
-            makeCgConfig(makeCgOpts(ctrl.run, !ctrl.run.endAt, ctrl.flipped), ctrl.pref, ctrl.userMove),
-          ),
-        );
-        pubsub.on('board.change', (is3d: boolean) =>
-          ctrl.withGround(g => {
-            g.state.addPieceZIndex = is3d;
-            g.redrawAll();
-          }),
-        );
-      },
-    },
+    hook: onInsert(el => {
+      ctrl.ground(
+        makeChessground(
+          el,
+          makeCgConfig(makeCgOpts(ctrl.run, !ctrl.run.endAt, ctrl.flipped), ctrl.pref, ctrl.userMove),
+        ),
+      );
+      pubsub.on('board.change', (is3d: boolean) =>
+        ctrl.withGround(g => {
+          g.state.addPieceZIndex = is3d;
+          g.redrawAll();
+        }),
+      );
+    }),
   });
 
 const renderBonus = (bonus: number) => `${bonus}s`;
 
 const renderPlay = (ctrl: StormCtrl): VNode[] => {
   const run = ctrl.run;
-  const malus = run.modifier.malus;
-  const bonus = run.modifier.bonus;
   const now = getNow();
+  const { malus, bonus } = run.modifier;
   return [
     hl('div.puz-board.main-board', [chessground(ctrl), ctrl.promotion.view()]),
     hl('div.puz-side', [
@@ -64,8 +61,8 @@ const renderPlay = (ctrl: StormCtrl): VNode[] => {
   ];
 };
 
-const renderSolved = (ctrl: StormCtrl): VNode =>
-  hl('div.puz-side__top.puz-side__solved', [hl('div.puz-side__solved__text', `${ctrl.countWins()}`)]);
+const renderSolved = ({ countWins }: StormCtrl): VNode =>
+  hl('div.puz-side__top.puz-side__solved', [hl('div.puz-side__solved__text', `${countWins()}`)]);
 
 const renderControls = (ctrl: StormCtrl): VNode =>
   hl('div.puz-side__control', [


### PR DESCRIPTION
# How

Small view code tweaks across few packages, including:
- few more `onInsert` helper uses
- avoid render helper redefinition
- variables destructing when helpful
- imports paths cleanup