### PR TITLE
Don't auto-draw pgn imports

### DIFF
--- a/modules/tree/src/main/ParseImport.scala
+++ b/modules/tree/src/main/ParseImport.scala
@@ -92,12 +92,14 @@ object ParseImport:
     tags.points
       .map(points => TagResult(status, points))
       .filter(_.status > Status.Started)
-      .orElse {
-        game.position.status.flatMap: status =>
-          Outcome
-            .guessPointsFromStatusAndPosition(status, game.position.winner)
-            .map(TagResult(status, _))
-      }
+      .orElse:
+        val pos = game.position
+        pos.status
+          .filter(s => s != Status.Draw || pos.variant.isInsufficientMaterial(pos))
+          .flatMap: status =>
+            Outcome
+              .guessPointsFromStatusAndPosition(status, pos.winner)
+              .map(TagResult(status, _))
 
   private def clockHistory(parsed: ParsedMainline[SanWithMetas]): Option[ClockHistory] =
     val clocks = parsed.moves.map: n =>


### PR DESCRIPTION
Closes #20926 

https://github.com/lichess-org/scalachess/blob/bdf82d4af4a6de737a7c39f87d0f015a990daa77/core/src/main/scala/variant/Variant.scala#L133-L134

The issue is that scalachess automatically draws games by fifty moves and fivefold repetition. This is required for lichess games but is not valid for anything outside of the site. In this case, it affects broadcast/study PGN imports. 
CC @lenguyenthanh just in case you want to change the interface for this.

This change still infers a result tag for checkmate and stalemate but for draws we only check for insufficient material.