### PR TITLE
add round spotlight API endpoint

### DIFF
--- a/app/controllers/RelayRound.scala
+++ b/app/controllers/RelayRound.scala
@@ -228,6 +228,13 @@ final class RelayRound(
     apiC.GlobalConcurrencyLimitPerIP.download(ctx.ip)(source)(jsToNdJson)
   }
 
+  def apiSpotlightRounds = SecuredScoped(_.StudyAdmin) { ctx ?=> _ ?=>
+    val source = env.relay.api
+      .spotlightRounds(MaxPerSecond(120), getIntAs[Max]("nb"), getTimestamp("since"), getTimestamp("until"))
+      .map(env.relay.jsonView.withSpotlight)
+    apiC.GlobalConcurrencyLimitPerIP.download(ctx.ip)(source)(jsToNdJson)
+  }
+
   def streamRound(id: RelayRoundId) = AnonOrScoped(): ctx ?=>
     Found(env.relay.api.byIdWithStudy(id)): rs =>
       studyC.CanView(rs.study) {

--- a/conf/routes
+++ b/conf/routes
@@ -318,6 +318,7 @@ GET   /api/broadcast                          controllers.RelayTour.apiIndex
 GET   /api/broadcast/top                      controllers.RelayTour.apiTop(page: Int ?= 1)
 GET   /api/broadcast/search                   controllers.RelayTour.apiSearch(page: Int ?= 1, q: String ?= "")
 GET   /api/broadcast/my-rounds                controllers.RelayRound.apiMyRounds
+GET   /api/broadcast/spotlight-rounds         controllers.RelayRound.apiSpotlightRounds
 GET   /$lang<\w\w\w?>/broadcast               controllers.RelayTour.indexLang(lang: Language)
 
 # Learn

--- a/modules/relay/src/main/RelayApi.scala
+++ b/modules/relay/src/main/RelayApi.scala
@@ -29,6 +29,7 @@ final class RelayApi(
     roundRepo: RelayRoundRepo,
     tourRepo: RelayTourRepo,
     groupRepo: RelayGroupRepo,
+    listing: RelayListing,
     playerEnrich: RelayPlayerEnrich,
     studyApi: StudyApi,
     studyRepo: StudyRepo,
@@ -497,6 +498,28 @@ final class RelayApi(
       .mapConcat(identity)
       .throttle(perSecond.value, 1.second)
       .take(max.fold(9999)(_.value))
+
+  def spotlightRounds(
+      perSecond: MaxPerSecond,
+      max: Option[Max],
+      since: Option[Instant],
+      until: Option[Instant]
+  ): Source[RelayRound.WithTour, ?] =
+    Source.futureSource:
+      for
+        active <- listing.active
+        tours = active.map(_.tour).filter(_.spotlight.exists(_.enabled))
+        rounds <- roundRepo.byToursOrdered(tours.map(_.id))
+      yield
+        val withTour = for
+          round <- rounds
+          if since.forall(s => round.startsAtTime.exists(!_.isBefore(s)))
+          if until.forall(u => round.startsAtTime.exists(!_.isAfter(u)))
+          tour <- tours.find(_.id == round.tourId)
+        yield round.withTour(tour)
+        Source(withTour)
+          .throttle(perSecond.value, 1.second)
+          .take(max.fold(9999)(_.value))
 
   private val isOngoingWithoutDelay = cacheApi[RelayRoundId, Boolean](32, "relay.ongoingWithoutDelay"):
     _.expireAfterWrite(5.seconds).buildAsyncFuture(roundRepo.isInternalWithoutDelay)

--- a/modules/relay/src/main/RelayJsonView.scala
+++ b/modules/relay/src/main/RelayJsonView.scala
@@ -153,6 +153,14 @@ final class RelayJsonView(
       )
     )
 
+  def withSpotlight(rt: RelayRound.WithTour)(using Translate): JsObject =
+    withUrl(rt, withTour = true).add:
+      "spotlight" -> rt.tour.spotlight.map: s =>
+        Json
+          .obj("language" -> s.language)
+          .add("title" -> s.title)
+          .add("tier" -> rt.tour.tier)
+
   def makeData(
       trs: RelayTour.WithRounds,
       currentRoundId: RelayRoundId,


### PR DESCRIPTION
relates to
- #20890
- #20895

This is the API endpoint for the 3rd piece of data for:
- #15057

## Usage

```bash
http -A bearer -a lip_admin "http://localhost:9663/api/broadcast/spotlight-rounds"
```

```json
HTTP/1.1 200 OK
Content-Type: application/x-ndjson

{
    "createdAt": 1784033862808,
    "id": "8OR8qQxq",
    "name": "Round 1",
    "rated": true,
    "slug": "round-1",
    "spotlight": {
        "language": "en",
        "tier": 4,
        "title": "homepage title here"
    },
    "startsAt": 1784246400000,
    "tour": {
        "createdAt": 1784033856744,
        "dates": [
            1784246400000
        ],
        "id": "SOoNvHrB",
        "info": {
            "fideTC": "standard",
            "timeZone": "America/New_York"
        },
        "name": "Test",
        "slug": "test",
        "tier": 4,
        "url": "http://localhost:9663/broadcast/test/SOoNvHrB"
    },
    "url": "http://localhost:9663/broadcast/test/round-1/8OR8qQxq"
}
```