### PR TITLE
Update Rapid Increment swiss time control from 7+2 to 8+2

### DIFF
--- a/modules/swiss/src/main/SwissOfficialSchedule.scala
+++ b/modules/swiss/src/main/SwissOfficialSchedule.scala
@@ -18,7 +18,7 @@ final private class SwissOfficialSchedule(mongo: SwissMongo, cache: SwissCache)(
   private val hyperbullet = Config("HyperBullet", 0.5, IncrementSeconds(0), 20, 15)
 
   private val classicalInc = Config("Classical Increment", 25, IncrementSeconds(3), 5, 5)
-  private val rapidInc = Config("Rapid Increment", 7, IncrementSeconds(2), 7, 8)
+  private val rapidInc = Config("Rapid Increment", 8, IncrementSeconds(2), 7, 8)
   private val blitzInc = Config("Blitz Increment", 5, IncrementSeconds(2), 10, 12)
   private val superblitzInc = Config("SuperBlitz Increment", 3, IncrementSeconds(1), 12, 12)
   private val bulletInc = Config("Bullet Increment", 1, IncrementSeconds(1), 20, 15)


### PR DESCRIPTION
This PR tries to make Lichess Swiss increment tournaments' time controls more **"evenly distributed"**, similar to how well distributed are quick pair (pool) increment time controls, and +0 time controls are in general.

I added some **images below** to help visualize the time controls distribution. The images use a log scale on the horizontal axis.

My suggestion is to update the time control of Rapid Increment swiss tournaments from 7+2 to 8+2.

### Motivation

I was thinking on mentioning/proposing this for a long while, and I decided to start the discussion directly with the Pull Request because I felt that was more productive. However, if you feel it's more appropriate to create an issue for the discussion first, I can do that.

The reason I feel 7+2 is not optimal is because it's too close to the 5+2 option, and too far away from the next option, 25+3 (see image). Moreover, it's almost at the edge between Rapid and Blitz (minor issue).

Players who like to play 10+5 (which I imagine are substantial among Rapid players, given that's a quick pair option) have to choose between 7+2 and 25+3 when looking for an increment swiss tournament. While 7+2 is not _too_ far away from 10+5, it's closer to Blitz (5+3 and 5+2).

Updating it to 8+2 seems to make the options a bit more diverse. No choice will not satisfy everybody, but making them more diverse helps content more people.

I know that a drawback with this change is the tournament total duration being increased, but I think increasing it by 14 minutes (7 rounds * 2 minutes, assuming players will always use the entire extra time on both sides) is not a major issue for the players that use to play these tournaments from start to finish. Maybe I'm wrong, and maybe there are other drawbacks I'm not aware of. (Btw, this drawback is the main reason I'm not suggesting a bigger change, for instance to 10+2. That would require a deeper study I think.)

## Images

### "+0" Time Controls

<img width="3362" height="1070" alt="Image" src="https://github.com/user-attachments/assets/52029b22-d08c-44ca-a193-2ce74194c886" />

### Increment Time Controls

<img width="3366" height="1064" alt="Image" src="https://github.com/user-attachments/assets/488ecbb6-122e-4497-900d-9d64eef21e76" />