### PR TITLE
Focus the 'now_playing' tab when a realtime game is in progress

### DIFF
--- a/ui/lobby/src/ctrl.ts
+++ b/ui/lobby/src/ctrl.ts
@@ -67,10 +67,12 @@ export default class LobbyController {
     this.socket = new LobbySocket(opts.socketSend, this);
 
     this.stores = makeStores(this.me?.username.toLowerCase());
-    if (!this.me?.isBot && this.stores.tab.get() === 'now_playing' && this.data.nbNowPlaying === 0) {
-      this.stores.tab.set('pools');
+    if (this.me?.isBot) this.tab = 'now_playing';
+    else {
+      if (this.stores.tab.get() === 'now_playing' && this.data.nbNowPlaying === 0)
+        this.stores.tab.set('pools');
+      this.tab = this.stores.tab.get();
     }
-    this.tab = this.me?.isBot ? 'now_playing' : this.stores.tab.get();
     this.mode = this.stores.mode.get();
     this.sort = this.me ? this.stores.sort.get() : 'time';
 

--- a/ui/lobby/src/ctrl.ts
+++ b/ui/lobby/src/ctrl.ts
@@ -71,7 +71,7 @@ export default class LobbyController {
     else {
       if (this.stores.tab.get() === 'now_playing' && this.data.nbNowPlaying === 0)
         this.stores.tab.set('pools');
-      else if (this.hasOngoingRealTimeGame()) this.stores.tab.set('now_playing');
+      else if (this.hasOngoingRealTimeGame(false)) this.stores.tab.set('now_playing');
       this.tab = this.stores.tab.get();
     }
     this.mode = this.stores.mode.get();
@@ -284,8 +284,10 @@ export default class LobbyController {
     this.socket.poolIn(this.poolMember);
   };
 
-  hasOngoingRealTimeGame = () =>
-    this.data.nowPlaying.some(nowPlaying => nowPlaying.isMyTurn && nowPlaying.speed !== 'correspondence');
+  hasOngoingRealTimeGame = (requireTurn: boolean) =>
+    this.data.nowPlaying.some(
+      nowPlaying => nowPlaying.speed !== 'correspondence' && (nowPlaying.isMyTurn || !requireTurn),
+    );
 
   gameActivity = (gameId: string) => {
     if (this.data.nowPlaying.some(p => p.gameId === gameId))

--- a/ui/lobby/src/ctrl.ts
+++ b/ui/lobby/src/ctrl.ts
@@ -71,6 +71,7 @@ export default class LobbyController {
     else {
       if (this.stores.tab.get() === 'now_playing' && this.data.nbNowPlaying === 0)
         this.stores.tab.set('pools');
+      else if (this.hasOngoingRealTimeGame()) this.stores.tab.set('now_playing');
       this.tab = this.stores.tab.get();
     }
     this.mode = this.stores.mode.get();

--- a/ui/lobby/src/view/table.ts
+++ b/ui/lobby/src/view/table.ts
@@ -10,7 +10,7 @@ type ButtonInfo = { gameType: GameType | 'dev' | 'bots'; label: string; disabled
 
 export default function table(ctrl: LobbyController) {
   const { data, opts } = ctrl;
-  const hasOngoingRealTimeGame = ctrl.hasOngoingRealTimeGame();
+  const hasOngoingRealTimeGame = ctrl.hasOngoingRealTimeGame(true);
   const hookDisabled =
     opts.playban || opts.hasUnreadLichessMessage || ctrl.me?.isBot || hasOngoingRealTimeGame;
   const { members, rounds } = data.counters;


### PR DESCRIPTION
The following use case is fairly common for me:

- Playing a non-correspondence game.
- Close the tab for whatever reason and open up lichess on a new one.
- In the lobby page (if it's still not my turn) I click on the 'now_playing' tab.
- I click on my game.

This PR just eliminates step 3. I'd assume when most users are in the middle of a game, if they're on the lobby tab then they're generally looking to get back to their game. Most people don't look for new challenges while it's not their turn.