### PR TITLE
ui: make chessground move destination dots crisper

### DIFF
--- a/ui/lib/css/theme/board/_chessground.scss
+++ b/ui/lib/css/theme/board/_chessground.scss
@@ -42,21 +42,21 @@ square {
   pointer-events: none;
 
   &.move-dest {
-    background: radial-gradient(rgb(20 85 30 / 0.5) 19%, rgb(0 0 0 / 0) calc(20% + 1px));
+    background: radial-gradient(rgb(20 85 30 / 0.5) 19%, rgb(0 0 0 / 0) 20%);
     pointer-events: auto;
   }
 
   &.premove-dest {
-    background: radial-gradient(rgb(20 30 85 / 0.5) 19%, rgb(0 0 0 / 0) calc(20% + 1px));
+    background: radial-gradient(rgb(20 30 85 / 0.5) 19%, rgb(0 0 0 / 0) 20%);
     pointer-events: auto;
   }
 
   &.oc.move-dest {
-    background: radial-gradient(transparent 0%, transparent 79%, rgb(20 85 0 / 0.3) calc(80% + 1px));
+    background: radial-gradient(transparent 0%, transparent 79%, rgb(20 85 0 / 0.3) 80%);
   }
 
   &.oc.premove-dest {
-    background: radial-gradient(transparent 0%, transparent 79%, rgb(20 30 85 / 0.2) calc(80% + 1px));
+    background: radial-gradient(transparent 0%, transparent 79%, rgb(20 30 85 / 0.2) 80%);
   }
 
   body[data-board='green'] .is2d &.last-move,


### PR DESCRIPTION
# Why

Recently spotted that chessground move destination dots are quite blurry, which is especially noticeable on bigger screens.

# How

Adjust the dots radial background definition to preserve crisp gratient bondaries.

The changes have been tested on Chrome (macOS + Win), FF (macOS + Win) and Safari.

# Preview (open attached images in new tab)

### Before

<img width="1322" height="1002" alt="Screenshot 2026-07-15 at 11 33 37" src="https://github.com/user-attachments/assets/824a3ef8-02f1-4ef5-859e-5ee3f92a8c43" />

### After

<img width="1322" height="1002" alt="Screenshot 2026-07-15 at 11 33 44" src="https://github.com/user-attachments/assets/a7a6d328-23de-475a-9e90-be0323b12065" />
