### PR TITLE
dont superimpose donate link on topnav hamburger on older browsers

### DIFF
--- a/ui/lib/css/header/_header.scss
+++ b/ui/lib/css/header/_header.scss
@@ -130,11 +130,11 @@ body.zen {
       outline-offset: -2px;
     }
 
-    @media (width <= $x-small) {
+    @media (max-width: at-most($x-small)) {
       display: none;
     }
 
-    @media (width <= $small) {
+    @media (max-width: less-than($small)) {
       body.clinput & {
         display: none;
       }

--- a/ui/lib/css/header/_header.scss
+++ b/ui/lib/css/header/_header.scss
@@ -134,7 +134,7 @@ body.zen {
       display: none;
     }
 
-    @media (max-width: less-than($small)) {
+    @media (max-width: at-most($small)) {
       body.clinput & {
         display: none;
       }


### PR DESCRIPTION
This resolves an issue on browsers that don't support media query range syntax, like iOS prior to 16.4 and others. They're not supported according to the repo readme, but it's good to make an effort because sometimes these ancient browsers are locked in by older hardware (or package managers on older linux distros).

<img width="618" height="169" alt="image" src="https://github.com/user-attachments/assets/45e86935-4087-46e1-a7d8-7ce0f5175110" />

I think it's worth fixing this one because you don't know what you'll get by tapping that area, will it land on the donate page or the hamburger menu? YOLO!