### PR TITLE
ui: enforce context notation for media queries

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -20,7 +20,7 @@
     ],
     "font-family-no-missing-generic-family-keyword": null,
     "hue-degree-notation": "number",
-    "media-feature-range-notation": null,
+    "media-feature-range-notation": "prefix",
     "no-invalid-position-at-import-rule": null,
     "selector-class-pattern": null,
     "selector-id-pattern": null,

--- a/ui/analyse/css/study/_editor.scss
+++ b/ui/analyse/css/study/_editor.scss
@@ -18,7 +18,7 @@
   grid-template-rows: min-content auto min-content;
   grid-template-areas: '.            . e-tools' 'spare-top    . e-tools' 'e-board      . e-tools' 'spare-bottom . e-tools' '.            . e-tools';
 
-  @media (width <= 576px) {
+  @media (max-width: 576px) {
     grid-template-columns: 100%;
     grid-template-rows: auto min-content;
     grid-template-areas: 'spare-top' 'e-board' 'spare-bottom' 'e-tools';

--- a/ui/bits/css/_auth.scss
+++ b/ui/bits/css/_auth.scss
@@ -40,7 +40,7 @@ $auth-input-bg: rgb(26 22 16 / 1);
     gap: 0.5rem;
     margin: -0.5em 0 2em 0;
 
-    @media (width >= $large) {
+    @media (min-width: $large) {
       display: none;
     }
 
@@ -93,7 +93,7 @@ $auth-input-bg: rgb(26 22 16 / 1);
     }
   }
 
-  @media (width >= $x-small) {
+  @media (min-width: $x-small) {
     width: 40em;
   }
 

--- a/ui/bits/css/learn/_ribbon.scss
+++ b/ui/bits/css/learn/_ribbon.scss
@@ -8,7 +8,7 @@
   position: absolute;
   top: -4px;
 
-  @media (width < $xx-small) {
+  @media (max-width: $xx-small) {
     @include inline-end(-13px);
 
     scale: 0.75;

--- a/ui/bits/css/practice/_app.scss
+++ b/ui/bits/css/practice/_app.scss
@@ -14,7 +14,7 @@
   .studies {
     ---min-width: 400px;
 
-    @media (width < $xx-small) {
+    @media (max-width: $xx-small) {
       ---min-width: calc(100vw - 2em);
 
       padding: 0 0.5em;
@@ -48,7 +48,7 @@
       }
     }
 
-    @media (width < $xx-small) {
+    @media (max-width: $xx-small) {
       min-height: fit-content;
       padding: 6px 3em 6px 0;
 
@@ -66,7 +66,7 @@
       background-position: center;
       flex-shrink: 0;
 
-      @media (width < $xx-small) {
+      @media (max-width: $xx-small) {
         width: 50px;
         height: 64px;
       }

--- a/ui/bits/css/practice/_side.scss
+++ b/ui/bits/css/practice/_side.scss
@@ -49,7 +49,7 @@
       font-size: 1.3em;
     }
 
-    @media (width < $small) {
+    @media (max-width: $small) {
       flex-flow: row nowrap;
       gap: $block-gap;
       text-align: left;

--- a/ui/bits/css/team/_list.scss
+++ b/ui/bits/css/team/_list.scss
@@ -51,7 +51,7 @@
   .actions {
     width: 0;
 
-    @media (width <= $x-small) {
+    @media (max-width: $x-small) {
       display: none;
     }
   }

--- a/ui/bits/css/ublog/_post.scss
+++ b/ui/bits/css/ublog/_post.scss
@@ -164,7 +164,7 @@
     margin-bottom: 4rem;
     gap: 1rem;
 
-    @media (width <= $xx-small) {
+    @media (max-width: $xx-small) {
       grid-template-columns: 1fr;
     }
 

--- a/ui/learn/css/_layout.scss
+++ b/ui/learn/css/_layout.scss
@@ -43,7 +43,7 @@
       grid-template-areas: 'side main';
       grid-template-columns: 242px auto;
 
-      @media (width > $x-large) {
+      @media (min-width: $x-large) {
         grid-template-columns: 242px minmax(auto, 1028px);
       }
     }

--- a/ui/learn/css/_map.scss
+++ b/ui/learn/css/_map.scss
@@ -12,7 +12,7 @@
   .categ_stages {
     ---min-width: 400px;
 
-    @media (width < $xx-small) {
+    @media (max-width: $xx-small) {
       ---min-width: calc(100vw - 2em);
 
       padding: 0 0.5em;
@@ -46,7 +46,7 @@
       }
     }
 
-    @media (width < $xx-small) {
+    @media (max-width: $xx-small) {
       min-height: fit-content;
       padding: 6px 3em 6px 0;
 
@@ -61,7 +61,7 @@
       margin: 0 1em;
       opacity: 0.6;
 
-      @media (width < $xx-small) {
+      @media (max-width: $xx-small) {
         width: 50px;
         height: 64px;
       }

--- a/ui/learn/css/_side-home.scss
+++ b/ui/learn/css/_side-home.scss
@@ -48,7 +48,7 @@
       font-size: 1.8em;
     }
 
-    @media (width < $small) {
+    @media (max-width: $small) {
       flex-flow: row nowrap;
       gap: $block-gap;
       text-align: left;

--- a/ui/lib/css/component/_mselect.scss
+++ b/ui/lib/css/component/_mselect.scss
@@ -60,7 +60,7 @@ $c-mselect: $c-primary;
     .mselect__toggle:checked ~ & {
       transform: scale(1, 1);
 
-      @media (width <= $small) {
+      @media (max-width: $small) {
         position: fixed;
         top: 50%;
         transform: translateY(-50%) scale(1, 1);

--- a/ui/lib/css/game/_row.scss
+++ b/ui/lib/css/game/_row.scss
@@ -91,7 +91,7 @@
       line-height: 2em;
     }
 
-    @media (width <= $xxx-small) {
+    @media (max-width: $xxx-small) {
       column-gap: 1em;
 
       .swords {

--- a/ui/lib/css/header/_header.scss
+++ b/ui/lib/css/header/_header.scss
@@ -130,11 +130,11 @@ body.zen {
       outline-offset: -2px;
     }
 
-    @media (width <= $x-small) {
+    @media (max-width: $x-small) {
       display: none;
     }
 
-    @media (width <= $small) {
+    @media (max-width: $small) {
       body.clinput & {
         display: none;
       }

--- a/ui/mod/css/_impersonate.scss
+++ b/ui/mod/css/_impersonate.scss
@@ -8,7 +8,7 @@ body {
   #main-wrap .msg-app {
     height: calc(var(---app-height) - $site-header-height - $impersonate-bar-height);
 
-    @media (width >= $small) {
+    @media (min-width: $small) {
       height: calc(var(---app-height) * 0.98 - $site-header-height - $impersonate-bar-height);
     }
   }

--- a/ui/mod/css/_user.scss
+++ b/ui/mod/css/_user.scss
@@ -1,4 +1,4 @@
-@media (width < $xx-large) {
+@media (max-width: $xx-large) {
   #main-wrap.has-mod-zone .page-menu__menu {
     display: none;
   }

--- a/ui/round/css/_control.scss
+++ b/ui/round/css/_control.scss
@@ -179,7 +179,7 @@
       margin-inline-start: 2em;
     }
 
-    @media (width <= $xxx-small) {
+    @media (max-width: $xxx-small) {
       margin-inline-start: 0;
     }
   }

--- a/ui/tournament/css/_app-header.scss
+++ b/ui/tournament/css/_app-header.scss
@@ -81,7 +81,7 @@
         color: #333 !important;
         text-shadow: 0 0 6px #fff;
 
-        @media (width <= $small) {
+        @media (max-width: $small) {
           top: 10px;
         }
       }

--- a/ui/tutor/css/_card.scss
+++ b/ui/tutor/css/_card.scss
@@ -3,7 +3,7 @@
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(380px, 1fr));
 
-    @media (width < $xxx-small) {
+    @media (max-width: $xxx-small) {
       grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
     }
 

--- a/ui/tutor/css/_preview.scss
+++ b/ui/tutor/css/_preview.scss
@@ -34,7 +34,7 @@
   &__perf {
     @extend %flex-center-nowrap, %box-radius;
 
-    @media (width > $xxx-small) {
+    @media (min-width: $xxx-small) {
       padding: 0.5em 1em;
       border: $border;
     }
@@ -49,7 +49,7 @@
     &__data {
       @extend %flex-column;
 
-      @media (width < $x-small) {
+      @media (max-width: $x-small) {
         display: none;
       }
     }

--- a/ui/voice/css/_voiceMove.help.scss
+++ b/ui/voice/css/_voiceMove.help.scss
@@ -29,7 +29,7 @@
       padding-inline-start: 2em;
     }
 
-    @media (width <= 600px) {
+    @media (min-width: 600px) {
       flex-direction: column;
     }
   }


### PR DESCRIPTION
# Why

Since there are some concerns about supporting discontinued, legacy or old browsers, let's enforce context notation for media queries for now.

Refs: 
- https://github.com/lichess-org/lila/pull/20935#discussion_r3587100681
- https://stylelint.io/user-guide/rules/media-feature-range-notation/

Supersedes: #20939

# How

Update Stylelint rule, fix all new warnings.