### PR TITLE
remove unneeded css

### DIFF
--- a/ui/analyse/css/_settings.scss
+++ b/ui/analyse/css/_settings.scss
@@ -74,10 +74,6 @@
   .column {
     justify-content: space-between;
     flex: 40%;
-
-    @media (max-width: at-most(600px)) {
-      flex: 1;
-    }
   }
 
   .setting {
@@ -111,7 +107,6 @@
     font-size: 1.2em;
     color: $c-font-dim;
     outline: none;
-    display: none;
   }
 
   .help-button::before {
@@ -135,21 +130,11 @@
         display: block;
       }
     }
-
-    @media (max-width: at-most(600px)) {
-      .help-button {
-        display: block;
-      }
-    }
   }
 
   @include mq-no-hover {
     legend {
       display: none;
-    }
-
-    .help-button {
-      display: block;
     }
   }
 }


### PR DESCRIPTION
CSS rules with no effect are confusing.

`button.help-button`s are not added if the isTouchDevice() media query returns false at page load. And if you toggle touch simulation and (hover:hover) becomes true, they still won't exist until you reload the page.