### PR TITLE
ui: do not convert numbers to strings for snabbdom render

### DIFF
--- a/ui/analyse/src/study/playerBars.ts
+++ b/ui/analyse/src/study/playerBars.ts
@@ -127,7 +127,7 @@ function renderPlayer(
                   )
                 : undefined,
               playerFedFlag(player?.fed),
-              player.rating && hl('span.elo', `${player.rating}`),
+              player.rating && hl('span.elo', player.rating),
             ]),
           ]),
           resultNode,
@@ -148,7 +148,7 @@ function renderPlayer(
                 { attrs: fidePageLinkAttrs(player, ctrl.isEmbed) },
                 player.name,
               ),
-            player.rating && hl('span.elo', `${player.rating}`),
+            player.rating && hl('span.elo', player.rating),
           ]),
         ]),
         materialDiffs[top ? 0 : 1],

--- a/ui/analyse/src/study/relay/relayPlayers.ts
+++ b/ui/analyse/src/study/relay/relayPlayers.ts
@@ -364,9 +364,9 @@ export const renderPlayers = (
                         : sortByBoth((player.score || 0) * 10, player.rating)['attrs']['data-sort'],
                     },
                   },
-                  `${player.score ?? 0}`,
+                  player.score ?? 0,
                 ),
-              hl('td', sortByBoth(player.played, player.rating), `${player.played ?? 0}`),
+              hl('td', sortByBoth(player.played, player.rating), player.played ?? 0),
               player.tiebreaks?.map(tb =>
                 hl(
                   'td.tiebreak',
@@ -377,7 +377,7 @@ export const renderPlayers = (
                       'aria-label': tb.description,
                     },
                   },
-                  `${tb.points}`,
+                  tb.points,
                 ),
               ),
             ]);
@@ -481,7 +481,7 @@ const renderPlayerGames = (ctrl: RelayPlayers, p: RelayPlayerWithGames, withTips
           hl(
             'a.game-link.is.color-icon.text.' + game.color,
             { attrs: { href: `/broadcast/-/-/${game.round}/${game.id}` } },
-            `${i + 1}`,
+            i + 1,
           ),
         ),
         playerTd(game.opponent, ctrl, withTips),

--- a/ui/analyse/src/study/relay/relayTeamLeaderboard.ts
+++ b/ui/analyse/src/study/relay/relayTeamLeaderboard.ts
@@ -89,9 +89,9 @@ export default class RelayTeamLeaderboard {
                   hl(
                     'td',
                     { attrs: { 'data-sort': entry.mp * 1000 + entry.gp, title: i18n.broadcast.matchPoints } },
-                    `${entry.mp}`,
+                    entry.mp,
                   ),
-                  hl('td', { attrs: { title: i18n.broadcast.gamePoints } }, `${entry.gp}`),
+                  hl('td', { attrs: { title: i18n.broadcast.gamePoints } }, entry.gp),
                 ]),
               ),
             ),
@@ -115,14 +115,11 @@ export default class RelayTeamLeaderboard {
         hl(
           'table.relay-tour__team-summary__header__stats',
           hl('tbody', [
-            hl('tr', [
-              hl('th', i18n.broadcast.matches),
-              hl('td', `${finishedTeamMatchCount(foundTeam.matches)}`),
-            ]),
-            hl('tr', [hl('th', i18n.broadcast.matchPoints), hl('td', `${foundTeam.mp}`)]),
-            hl('tr', [hl('th', i18n.broadcast.gamePoints), hl('td', `${foundTeam.gp}`)]),
+            hl('tr', [hl('th', i18n.broadcast.matches), hl('td', finishedTeamMatchCount(foundTeam.matches))]),
+            hl('tr', [hl('th', i18n.broadcast.matchPoints), hl('td', foundTeam.mp)]),
+            hl('tr', [hl('th', i18n.broadcast.gamePoints), hl('td', foundTeam.gp)]),
             foundTeam.averageRating &&
-              hl('tr', [hl('th', i18n.site.averageElo), hl('td', `${foundTeam.averageRating}`)]),
+              hl('tr', [hl('th', i18n.site.averageElo), hl('td', foundTeam.averageRating)]),
           ]),
         ),
       ]),
@@ -151,7 +148,7 @@ export default class RelayTeamLeaderboard {
                     {
                       attrs: { ...dataIcon(licon.StudyBoard), href: `/broadcast/-/-/${match.roundId}#teams` },
                     },
-                    `${i + 1}`,
+                    i + 1,
                   ),
                 ),
                 hl(

--- a/ui/analyse/src/study/relay/relayTeams.ts
+++ b/ui/analyse/src/study/relay/relayTeams.ts
@@ -171,7 +171,7 @@ const playerView = (players: RelayPlayers, p: StudyPlayer) =>
       playerFedFlag(p.fed),
       hl('span.name', [userTitle(p), p.name]),
     ]),
-    !!p.rating && hl('rating', `${p.rating}`),
+    !!p.rating && hl('rating', p.rating),
   ]);
 
 const statusView = (

--- a/ui/puzzle/src/view/after.ts
+++ b/ui/puzzle/src/view/after.ts
@@ -28,7 +28,7 @@ const renderVote = (ctrl: PuzzleCtrl): VNode =>
 const renderStreak = (ctrl: PuzzleCtrl): MaybeVNodes => [
   hl('div.complete', [
     hl('span.game-over', 'GAME OVER'),
-    hl('span', i18n.puzzle.yourStreakX.asArray(hl('strong', `${ctrl.streak?.data.index ?? 0}`))),
+    hl('span', i18n.puzzle.yourStreakX.asArray(hl('strong', ctrl.streak?.data.index ?? 0))),
   ]),
   hl('a.continue', { attrs: { href: ctrl.routerWithLang('/streak') } }, [
     iconTag(licon.PlayTriangle),

--- a/ui/storm/src/view/end.ts
+++ b/ui/storm/src/view/end.ts
@@ -41,21 +41,21 @@ const renderSummary = (ctrl: StormCtrl): LooseVNodes => {
     hl('div.storm--end__stats.box.box-pad', [
       hl('table.slist', [
         hl('tbody', [
-          hl('tr', [hl('th', i18n.storm.moves), hl('td', hl('number', `${run.moves}`))]),
+          hl('tr', [hl('th', i18n.storm.moves), hl('td', hl('number', run.moves))]),
           hl('tr', [
             hl('th', i18n.storm.accuracy),
             hl('td', [hl('number', accuracy ? accuracy.toFixed(1) : '-'), '%']),
           ]),
-          hl('tr', [hl('th', i18n.storm.combo), hl('td', hl('number', `${ctrl.run.combo.best}`))]),
+          hl('tr', [hl('th', i18n.storm.combo), hl('td', hl('number', ctrl.run.combo.best))]),
           hl('tr', [
             hl('th', i18n.storm.time),
-            hl('td', [hl('number', run.time ? `${Math.round(run.time)}` : 0), 's']),
+            hl('td', [hl('number', run.time ? Math.round(run.time) : 0), 's']),
           ]),
           hl('tr', [
             hl('th', i18n.storm.timePerMove),
             hl('td', [hl('number', run.time ? (run.time / run.moves).toFixed(2) : 0), 's']),
           ]),
-          hl('tr', [hl('th', i18n.storm.highestSolved), hl('td', hl('number', `${run.highest}`))]),
+          hl('tr', [hl('th', i18n.storm.highestSolved), hl('td', hl('number', run.highest))]),
         ]),
       ]),
     ]),

--- a/ui/storm/src/view/main.ts
+++ b/ui/storm/src/view/main.ts
@@ -62,7 +62,7 @@ const renderPlay = (ctrl: StormCtrl): VNode[] => {
 };
 
 const renderSolved = ({ countWins }: StormCtrl): VNode =>
-  hl('div.puz-side__top.puz-side__solved', [hl('div.puz-side__solved__text', `${countWins()}`)]);
+  hl('div.puz-side__top.puz-side__solved', [hl('div.puz-side__solved__text', countWins())]);
 
 const renderControls = (ctrl: StormCtrl): VNode =>
   hl('div.puz-side__control', [


### PR DESCRIPTION
# Why

As tested in #20925, Snabbdom handles the number render correctly, internally converting numbers to strings, so we don't need to do this manually.

# How

I have written small regex to find other cases of manual number conversion on render, and simplified them to avoid manual conversion.