### PR TITLE
Have delays for takeback offers be separate for both players

### DIFF
--- a/modules/round/src/main/RoundAsyncActor.scala
+++ b/modules/round/src/main/RoundAsyncActor.scala
@@ -1,6 +1,5 @@
 package lila.round
 
-import alleycats.Zero
 import chess.{ ByColor, Centis, Color }
 import play.api.libs.json.*
 import scalalib.actor.AsyncActor
@@ -471,18 +470,6 @@ object RoundAsyncActor:
 
   private val monitor =
     AsyncActor.Monitor(msg => logger.warn(s"round.asyncActor unhandled msg: $msg"))
-
-  private[round] final class TakebackState(nbDeclined: Int, lastDeclined: Option[Instant]):
-
-    def decline = TakebackState(nbDeclined + 1, nowInstant.some)
-
-    def delaySeconds = (math.pow(nbDeclined.min(10), 2) * 10).toInt
-
-    def offerable = lastDeclined.forall { _.isBefore(nowInstant.minusSeconds(delaySeconds)) }
-
-  private[round] type TakebackBoard = ByColor[TakebackState]
-
-  private[round] given takebackBoardZero: Zero[TakebackBoard] = Zero(ByColor.fill(TakebackState(0, none)))
 
   private[round] class Dependencies(
       val gameRepo: GameRepo,

--- a/modules/round/src/main/RoundAsyncActor.scala
+++ b/modules/round/src/main/RoundAsyncActor.scala
@@ -472,18 +472,25 @@ object RoundAsyncActor:
   private val monitor =
     AsyncActor.Monitor(msg => logger.warn(s"round.asyncActor unhandled msg: $msg"))
 
-  private[round] case class TakebackBoard(nbDeclined: Int, lastDeclined: Option[Instant]):
+  private[round] case class TakebackState(nbDeclined: Int, lastDeclined: Option[Instant]):
 
-    def decline = TakebackBoard(nbDeclined + 1, nowInstant.some)
+    def decline = TakebackState(nbDeclined + 1, nowInstant.some)
 
     def delaySeconds = (math.pow(nbDeclined.min(10), 2) * 10).toInt
 
     def offerable = lastDeclined.forall { _.isBefore(nowInstant.minusSeconds(delaySeconds)) }
 
+  private[round] case class TakebackBoard(states: ByColor[TakebackState]):
+
+    // `color` is the side whose takeback offer was just declined (or cancelled)
+    def decline(color: Color) = TakebackBoard(states.update(color, _.decline))
+
+    def offerable(color: Color) = states(color).offerable
+
     def reset = takebackBoardZero.zero
 
   private[round] given takebackBoardZero: Zero[TakebackBoard] =
-    Zero(TakebackBoard(0, none))
+    Zero(TakebackBoard(ByColor.fill(TakebackState(0, none))))
 
   private[round] class Dependencies(
       val gameRepo: GameRepo,

--- a/modules/round/src/main/RoundAsyncActor.scala
+++ b/modules/round/src/main/RoundAsyncActor.scala
@@ -472,7 +472,7 @@ object RoundAsyncActor:
   private val monitor =
     AsyncActor.Monitor(msg => logger.warn(s"round.asyncActor unhandled msg: $msg"))
 
-  private[round] case class TakebackState(nbDeclined: Int, lastDeclined: Option[Instant]):
+  private[round] final class TakebackState(nbDeclined: Int, lastDeclined: Option[Instant]):
 
     def decline = TakebackState(nbDeclined + 1, nowInstant.some)
 
@@ -480,17 +480,9 @@ object RoundAsyncActor:
 
     def offerable = lastDeclined.forall { _.isBefore(nowInstant.minusSeconds(delaySeconds)) }
 
-  private[round] case class TakebackBoard(states: ByColor[TakebackState]):
+  private[round] type TakebackBoard = ByColor[TakebackState]
 
-    // `color` is the side whose takeback offer was just declined (or cancelled)
-    def decline(color: Color) = TakebackBoard(states.update(color, _.decline))
-
-    def offerable(color: Color) = states(color).offerable
-
-    def reset = takebackBoardZero.zero
-
-  private[round] given takebackBoardZero: Zero[TakebackBoard] =
-    Zero(TakebackBoard(ByColor.fill(TakebackState(0, none))))
+  private[round] given takebackBoardZero: Zero[TakebackBoard] = Zero(ByColor.fill(TakebackState(0, none)))
 
   private[round] class Dependencies(
       val gameRepo: GameRepo,

--- a/modules/round/src/main/Takebacker.scala
+++ b/modules/round/src/main/Takebacker.scala
@@ -55,7 +55,7 @@ final private class Takebacker(
             events <- double(pov)
             _ = publishTakeback(pov)
           yield events -> board
-        case pov if canProposeTakeback(pov) && board.offerable =>
+        case pov if canProposeTakeback(pov) && board.offerable(pov.color) =>
           messenger.volatile(pov.game, offerTakebackMessage(pov))
           val progress = Progress(pov.game).map: g =>
             g.updatePlayer(pov.color, _.copy(proposeTakebackAt = g.ply))
@@ -79,7 +79,7 @@ final private class Takebacker(
           _ <- proxy.save(progress)
           _ = publishTakebackOffer(progress.game)
           events = List(Event.TakebackOffers(white = false, black = false))
-        yield events -> board.decline
+        yield events -> board.decline(color)
       case Pov(game, color) if pov.opponent.isProposingTakeback =>
         messenger.volatile(
           game,
@@ -91,7 +91,7 @@ final private class Takebacker(
           _ <- proxy.save(progress)
           _ = publishTakebackOffer(progress.game)
           events = List(Event.TakebackOffers(white = false, black = false))
-        yield events -> board.decline
+        yield events -> board.decline(!color)
       case _ => fufail(ClientError("[takebacker] invalid no " + pov))
 
   def isAllowedIn(game: Game, prefs: Preload[ByColor[Pref]]): Fu[Boolean] =

--- a/modules/round/src/main/Takebacker.scala
+++ b/modules/round/src/main/Takebacker.scala
@@ -1,6 +1,8 @@
 package lila.round
 
 import chess.ByColor
+import chess.Ply
+import alleycats.Zero
 import scalalib.data.Preload
 
 import lila.common.Bus
@@ -8,9 +10,16 @@ import lila.core.i18n.{ I18nKey as trans, Translator, defaultLang }
 import lila.core.round.*
 import lila.game.{ Event, GameRepo, Progress, Rewind, UciMemo }
 import lila.pref.{ Pref, PrefApi }
-import lila.round.RoundAsyncActor.TakebackBoard
 import lila.round.RoundGame.playableByAi
-import chess.Ply
+
+private final class TakebackState(nbDeclined: Int, lastDeclined: Option[Instant]):
+  def decline = TakebackState(nbDeclined + 1, nowInstant.some)
+  def offerable = lastDeclined.forall { _.isBefore(nowInstant.minusSeconds(delaySeconds)) }
+  private def delaySeconds = (math.pow(nbDeclined.min(10), 2) * 10).toInt
+
+private type TakebackBoard = ByColor[TakebackState]
+
+private given takebackBoardZero: Zero[TakebackBoard] = Zero(ByColor.fill(TakebackState(0, none)))
 
 final private class Takebacker(
     messenger: Messenger,
@@ -44,7 +53,7 @@ final private class Takebacker(
               then single(pov)
               else double(pov)
             _ = publishTakeback(pov)
-          yield events -> RoundAsyncActor.takebackBoardZero.zero
+          yield events -> takebackBoardZero.zero
         case Pov(game, _) if pov.game.playableByAi =>
           for
             events <- single(pov)

--- a/modules/round/src/main/Takebacker.scala
+++ b/modules/round/src/main/Takebacker.scala
@@ -44,7 +44,7 @@ final private class Takebacker(
               then single(pov)
               else double(pov)
             _ = publishTakeback(pov)
-          yield events -> board.reset
+          yield events -> RoundAsyncActor.takebackBoardZero.zero
         case Pov(game, _) if pov.game.playableByAi =>
           for
             events <- single(pov)
@@ -55,7 +55,7 @@ final private class Takebacker(
             events <- double(pov)
             _ = publishTakeback(pov)
           yield events -> board
-        case pov if canProposeTakeback(pov) && board.offerable(pov.color) =>
+        case pov if canProposeTakeback(pov) && board(pov.color).offerable =>
           messenger.volatile(pov.game, offerTakebackMessage(pov))
           val progress = Progress(pov.game).map: g =>
             g.updatePlayer(pov.color, _.copy(proposeTakebackAt = g.ply))
@@ -79,7 +79,7 @@ final private class Takebacker(
           _ <- proxy.save(progress)
           _ = publishTakebackOffer(progress.game)
           events = List(Event.TakebackOffers(white = false, black = false))
-        yield events -> board.decline(color)
+        yield events -> board.update(color, _.decline)
       case Pov(game, color) if pov.opponent.isProposingTakeback =>
         messenger.volatile(
           game,
@@ -91,7 +91,7 @@ final private class Takebacker(
           _ <- proxy.save(progress)
           _ = publishTakebackOffer(progress.game)
           events = List(Event.TakebackOffers(white = false, black = false))
-        yield events -> board.decline(!color)
+        yield events -> board.update(!color, _.decline)
       case _ => fufail(ClientError("[takebacker] invalid no " + pov))
 
   def isAllowedIn(game: Game, prefs: Preload[ByColor[Pref]]): Fu[Boolean] =


### PR DESCRIPTION
Currently, if Player A offers a number of takebacks (all declined), B gets penalized for this by having to wait just as long as A, if they want to offer a takeback themselves.

A concrete example:

Player A offers a takeback, B doesn't see it (or initially decides not to give one) and makes their move. If B then decides to give A a takeback, they have to wait a minimum of 10 seconds.

This PR changes this behaviour by making takeback delays separate for both players, based off their own histories (or lack thereof) of takebacks being declined.