### PR TITLE
Fix donation button visibility on TV game change

### DIFF
--- a/ui/lobby/src/lobby.ts
+++ b/ui/lobby/src/lobby.ts
@@ -38,7 +38,10 @@ export function initModule(opts: LobbyOpts) {
         });
       },
       featured(o: { html: string }) {
-        $('.lobby__tv').html(o.html);
+        const $tv = $('.lobby__tv'),
+          $game = $tv.find('.mini-game');
+        if ($game.length) $game.replaceWith(o.html);
+        else $tv.append(o.html);
         pubsub.emit('content-loaded');
       },
       redirect(e: RedirectTo) {


### PR DESCRIPTION
### Why the change is needed:
On the homepage, the donation button disappears whenever the TV game changes

This bug was reproducible.

### Link to issue:
Closes #20958

### Solution:
Changed the lobby featured socket handler to replace only the .mini-game element instead of the whole .lobby__tv container. 

### Testing:
Before: observable on lichess.org that the donation button disappears when the TV game changes
After: built locally with 4 accounts running two concurrent games. When TV switched from one game to the other, the donation button stayed in place.

### AI assistance:
This change was made with AI assistance (Claude Code, Anthropic).
Prompt: "Identify the cause of issue 20958, make the fix, and write the PR content."
Some AI generated outputs have been modified. The bug's mechanism was confirmed before modifying code and the fix was verified afterward.

### Video:

https://github.com/user-attachments/assets/29ea86ac-a80a-4f3a-b84d-d72cac3562b7