### PR TITLE
Fix study chapter default name numbering after deletions

### DIFF
--- a/modules/study/src/main/ChapterMaker.scala
+++ b/modules/study/src/main/ChapterMaker.scala
@@ -20,14 +20,21 @@ final private class ChapterMaker(
 
   import ChapterMaker.*
 
-  def apply(study: Study, data: Data, order: Int, userId: UserId, withRatings: Boolean): Fu[Chapter] =
+  def apply(
+      study: Study,
+      data: Data,
+      order: Int,
+      userId: UserId,
+      withRatings: Boolean,
+      nameOrder: Option[Int] = None
+  ): Fu[Chapter] =
     data.game
       .so(parseGame)
       .flatMap:
         case None => fromFenOrPgnOrBlank(study, data, order, userId)
         case Some(game) => fromGame(study, game, data, order, userId, withRatings)
       .map: c =>
-        if c.name.value.isEmpty then c.copy(name = Chapter.defaultName(order)) else c
+        if c.name.value.isEmpty then c.copy(name = Chapter.defaultName(nameOrder | order)) else c
 
   def fromFenOrPgnOrBlank(study: Study, data: Data, order: Int, userId: UserId): Fu[Chapter] =
     data.pgn.filter(_.value.trim.nonEmpty) match

--- a/modules/study/src/main/StudyApi.scala
+++ b/modules/study/src/main/StudyApi.scala
@@ -611,7 +611,7 @@ final class StudyApi(
             .flatMap:
               _.filter(_.isEmptyInitial).so(chapterRepo.delete)
         order <- chapterRepo.nextOrderByStudy(study.id)
-        chapter <- chapterMaker(study, data, order, who.u, withRatings)
+        chapter <- chapterMaker(study, data, order, who.u, withRatings, nameOrder = (count + 1).some)
           .recoverWith:
             case StudyValidationException(error) =>
               sendTo(study.id)(_.validationError(error, who.sri))


### PR DESCRIPTION
### Why the change is needed:
When adding a chapter to an existing study from the board editor, the new chapter's default name reflected a stale number rather than the current chapter count. This bug was reproducible.

### Link to issue:
Closes #18969

### Solution:
Made new chapters added from the board editor use the current chapter count for their default name, so they're numbered correctly even after earlier chapters have been deleted.

### Testing:
Before: create a study, add chapters up to "Chapter 3", delete Chapters 1–2, rename the remaining chapter to "Chapter 1", then use the board editor's "Study" button to add a chapter to it. The new chapter was named "Chapter 4".

After: built locally and repeated the steps; the new chapter is correctly named "Chapter 2". 

### AI assistance:
This change was made with AI assistance (Claude Code, Anthropic).
Prompt: "Identify the cause of issue 18969, make the fix, and write the PR content."
Some AI generated outputs have been modified. The bug was reproduced before modifying code and the fix was verified afterward.

### Video

https://github.com/user-attachments/assets/e7eb4570-a06a-4bb7-8be3-07a2597acff2

