### PR TITLE
ui: add styles for native selects, if browser supports `base-select`

### DIFF
--- a/ui/lib/css/base/_form.scss
+++ b/ui/lib/css/base/_form.scss
@@ -52,3 +52,108 @@ select:-webkit-autofill {
   -webkit-text-fill-color: $c-font;
   box-shadow: 0 0 0 1000px color-mix(in oklab, $c-secondary 10%, $c-bg) inset;
 }
+
+/* Select (with `base-select` support) */
+
+:root {
+  @supports (appearance: base-select) {
+    --picker-icon-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='m19.5 8.25-7.5 7.5-7.5-7.5' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+    --option-interactive-background: color-mix(in srgb, var(--c-bg-zebra2) 80%, transparent);
+
+    &.light {
+      --option-interactive-background: color-mix(in srgb, var(--c-border) 50%, transparent);
+    }
+  }
+}
+
+select {
+  @supports (appearance: base-select) {
+    align-items: center;
+    appearance: base-select;
+    padding-inline: 8px 6px;
+    mask-image: none;
+    color: var(--c-font);
+
+    &::picker-icon {
+      content: '';
+      width: 14px;
+      height: 14px;
+      background-color: var(--c-font-dim);
+      mask-image: var(--picker-icon-mask);
+      transition: rotate 0.25s ease;
+    }
+
+    &:open::picker-icon {
+      rotate: 180deg;
+      background-color: var(--c-font);
+      mask-image: var(--picker-icon-mask);
+    }
+
+    &::picker(select) {
+      @include backdrop-blur-if-transparent;
+
+      appearance: base-select;
+      flex-direction: column;
+      gap: 2px;
+      padding: 2px;
+      border: 1px solid var(--c-border);
+      background: var(--c-bg-input);
+      border-radius: 6px;
+      font-weight: 400;
+      opacity: 0;
+      overflow: clip;
+      margin: 2px 0;
+      transition:
+        opacity 0.25s ease,
+        display 0.25s allow-discrete,
+        overlay 0.25s allow-discrete;
+      box-shadow:
+        hsl(206 22% 7% / 0.6) 0 10px 24px -8px,
+        hsl(206 22% 7% / 0.4) 0 10px 12px -12px;
+
+      @include if-light {
+        box-shadow:
+          hsl(206 22% 7% / 0.3) 0 10px 24px -8px,
+          hsl(206 22% 7% / 0.15) 0 10px 12px -12px;
+      }
+    }
+
+    &:open::picker(select) {
+      opacity: 1;
+      overflow: hidden;
+      display: flex;
+
+      @starting-style {
+        opacity: 0;
+      }
+    }
+
+    option {
+      display: flex;
+      align-items: center;
+      padding: 2px 8px;
+      cursor: pointer;
+      border-radius: 3.5px;
+      transition: background-color 0.2s ease-out;
+      color: var(--c-font);
+      background-color: var(--c-bg-input);
+
+      &:where(:hover, :focus, :active) {
+        background-color: var(--option-interactive-background);
+      }
+
+      &:checked {
+        background-color: var(--c-primary);
+        color: #fff;
+      }
+
+      &:checked:hover {
+        background-color: color-mix(in srgb, var(--c-primary) 0.8, transparent);
+      }
+
+      &::checkmark {
+        display: none;
+      }
+    }
+  }
+}

--- a/ui/lib/css/base/_form.scss
+++ b/ui/lib/css/base/_form.scss
@@ -70,7 +70,7 @@ select {
   @supports (appearance: base-select) {
     align-items: center;
     appearance: base-select;
-    padding-inline: 8px 6px;
+    padding-inline: 9px 6px;
     mask-image: none;
     color: var(--c-font);
 
@@ -108,13 +108,13 @@ select {
         display 0.25s allow-discrete,
         overlay 0.25s allow-discrete;
       box-shadow:
-        hsl(206 22% 7% / 0.6) 0 10px 24px -8px,
-        hsl(206 22% 7% / 0.4) 0 10px 12px -12px;
+        hsl(206 22% 2% / 0.6) 0 6px 24px -8px,
+        hsl(206 22% 2% / 0.4) 0 6px 12px -12px;
 
       @include if-light {
         box-shadow:
-          hsl(206 22% 7% / 0.3) 0 10px 24px -8px,
-          hsl(206 22% 7% / 0.15) 0 10px 12px -12px;
+          hsl(206 22% 7% / 0.3) 0 6px 24px -8px,
+          hsl(206 22% 7% / 0.15) 0 6px 12px -12px;
       }
     }
 
@@ -148,7 +148,7 @@ select {
       }
 
       &:checked:hover {
-        background-color: color-mix(in srgb, var(--c-primary) 0.8, transparent);
+        background-color: color-mix(in srgb, var(--c-primary) 80%, transparent);
       }
 
       &::checkmark {

--- a/ui/puzzle/css/_side.scss
+++ b/ui/puzzle/css/_side.scss
@@ -119,9 +119,12 @@
 
     &__difficulty {
       margin-top: 1em;
+      display: flex;
+      align-items: center;
+      gap: 1em;
 
-      label {
-        margin-inline-end: 1em;
+      select {
+        flex: 1;
       }
     }
 


### PR DESCRIPTION
# Why

Since support for `appearance: base-select` has crossed 50% of browser share, and we still use native select elements in few places, let's add a simple styling for it, on browser which support that.

Ref: 
* https://caniuse.com/mdn-css_properties_appearance_base-select

# How

Add new CSS styles for `select` and `option` elements when browser supports `base-select` appearance. Add animations, and make sure that on browsers not supporting the feature selects still renders the same.

# Preview

### Chrome (supporting)

<img width="337" height="307" alt="Screenshot 2026-07-20 at 13 12 12" src="https://github.com/user-attachments/assets/c777b172-6f34-445e-b123-6bcefabd14a7" />
<img width="337" height="307" alt="Screenshot 2026-07-20 at 13 12 06" src="https://github.com/user-attachments/assets/d16a1b42-ccd9-4638-a375-0bb8a4377f4f" />
<img width="337" height="307" alt="Screenshot 2026-07-20 at 13 12 19" src="https://github.com/user-attachments/assets/aa4ed5d0-1648-48df-bd0b-26cee43be44a" />

### Firefox (not supporting)

<img width="373" height="299" alt="Screenshot 2026-07-20 at 13 00 25" src="https://github.com/user-attachments/assets/99465165-1ef6-421f-ab19-f7e8608e58c5" />

### Safari (not supporting, but in next release it will)

<img width="337" height="307" alt="Screenshot 2026-07-20 at 13 02 51" src="https://github.com/user-attachments/assets/1c47040b-8b95-4d19-8d6f-8681d8d7c01d" />
