### PR TITLE
remove redundant guards

### DIFF
--- a/ui/lib/src/bigFileStorage.ts
+++ b/ui/lib/src/bigFileStorage.ts
@@ -19,29 +19,16 @@ class BigFileStorage {
 
     const fetched = await new Promise<U8>((resolve, reject) => {
       const xhr = new XMLHttpRequest();
-      let settled = false;
-
-      const settle = (value: U8) => {
-        if (settled) return;
-        settled = true;
-        resolve(value);
-      };
-      const fail = (message: string) => {
-        if (settled) return;
-        settled = true;
-        reject(new Error(message));
-      };
 
       xhr.open('GET', assetUrl, true);
       xhr.responseType = 'arraybuffer';
 
       if (onProgress) xhr.onprogress = e => onProgress(e.loaded, e.total);
 
-      xhr.onerror = () => fail(`fetch '${assetUrl}' failed: ${xhr.status}`);
-      xhr.onabort = () => fail(`fetch '${assetUrl}' aborted`);
+      xhr.onerror = () => reject(new Error(`fetch '${assetUrl}' failed: ${xhr.status}`));
       xhr.onload = () => {
-        if (Math.floor(xhr.status / 100) === 2) settle(new Uint8Array(xhr.response));
-        else fail(`fetch '${assetUrl}' failed: ${xhr.status}`);
+        if (Math.floor(xhr.status / 100) === 2) resolve(new Uint8Array(xhr.response));
+        else reject(new Error(`fetch '${assetUrl}' failed: ${xhr.status}`));
       };
 
       xhr.send();


### PR DESCRIPTION
once resolve/reject is called on a Promise, subsequent calls are ignored already. that's built in.

xhr.onabort is not needed because XMLHttpRequest.abort() / AbortSignal are never used.
