### PR TITLE
fix ongoing analysis for correspondence variants

### DIFF
--- a/ui/analyse/src/autoShape.ts
+++ b/ui/analyse/src/autoShape.ts
@@ -128,21 +128,17 @@ export function compute(ctrl: AnalyseCtrl): DrawShape[] {
   if (hovering?.fen === nFen) shapes = shapes.concat(makeShapesFromUci(color, hovering.uci, 'paleBlue'));
   ctrl.fork.hover(hovering?.uci);
 
-  if (ctrl.showBestMoveArrows() && ctrl.showEvaluation()) {
+  if (ctrl.isCevalAllowed() && ctrl.showBestMoveArrows() && ctrl.showEvaluation()) {
     if (isUci(nEval.best)) shapes = shapes.concat(makeShapesFromUci(rcolor, nEval.best, 'paleGreen'));
     if (!hovering && ctrl.ceval.search.multiPv) {
-      const bestPvMoves = ctrl.isCevalAllowed() && nCeval ? nCeval.pvs[0]?.moves : undefined;
+      const bestPvMoves = nCeval ? nCeval.pvs[0]?.moves : undefined;
       const nextBest = bestPvMoves?.[0] || ctrl.nextNodeBest();
 
       if (nextBest) {
         drawManeuver(ctrl, color, bestPvMoves || [nextBest], 'paleBlue', shapes);
       }
 
-      if (
-        ctrl.isCevalAllowed() &&
-        nCeval?.pvs[1] &&
-        !(ctrl.threatMode() && nThreat && nThreat.pvs.length > 2)
-      ) {
+      if (nCeval?.pvs[1] && !(ctrl.threatMode() && nThreat && nThreat.pvs.length > 2)) {
         nCeval.pvs.forEach(function (pv) {
           if (pv.moves[0] === nextBest) return;
           const shift = winningChances.povDiff(color, nCeval.pvs[0], pv);

--- a/ui/lib/src/ceval/ctrl.ts
+++ b/ui/lib/src/ceval/ctrl.ts
@@ -86,12 +86,12 @@ export class CevalCtrl {
   init(opts?: CevalOpts): void {
     if (opts) this.opts = opts;
     this.reset();
+    this.analysable = Boolean(this.engines.getEngine({ variant: this.opts.variant.key }));
     this.rules = lichessRules(this.opts.variant.key);
-    this.analysable =
-      !this.opts.initialFen ||
-      parseFen(this.opts.initialFen).chain(setup => setupPosition(this.rules, setup)).isOk;
+    if (this.analysable && this.opts.initialFen)
+      this.analysable = parseFen(this.opts.initialFen).chain(x => setupPosition(this.rules, x)).isOk;
     this.engines.setActive(this.opts.custom?.engine?.id ?? this.storedEngine());
-    if (this.worker?.getInfo().id !== this.engines.active().id) this.unload();
+    if (this.worker?.getInfo().id !== this.engines.active()?.id) this.unload();
   }
 
   available(): boolean {
@@ -120,19 +120,21 @@ export class CevalCtrl {
 
   setThreads = (threads: number): void => storage.set('ceval.threads', threads.toString());
 
-  info(custom?: CustomSearch): SearchInfo {
+  info(custom?: CustomSearch): SearchInfo | undefined {
     const maybeSearch = custom?.search?.();
-    const maxTime = Number(maybeSearch) || this.engines.active().maxMovetime;
+    const active = this.engines.active();
+    if (!active) return undefined;
+    const maxTime = Number(maybeSearch) || active.maxMovetime;
     return {
       threads: clamp(
         custom?.engine?.threads ?? (Number(storage.get('ceval.threads')) || this.recommendedThreads),
-        { min: this.engines.active().minThreads, max: this.maxThreads },
+        { min: active.minThreads, max: this.maxThreads },
       ),
       hashSize: clamp(custom?.engine?.hashSize ?? Number(storage.get('ceval.hash-size')), {
         min: 16,
-        max: this.engines.active().maxHash,
+        max: active.maxHash,
       }),
-      engine: (custom?.engine && this.engines.getEngine({ id: custom.engine.id })) || this.engines.active(),
+      engine: (custom?.engine && this.engines.getEngine({ id: custom.engine.id })) || active,
       search:
         typeof maybeSearch === 'object'
           ? maybeSearch
@@ -144,14 +146,14 @@ export class CevalCtrl {
   }
 
   get search(): Search {
-    return this.info(this.opts.custom).search;
+    return this.info(this.opts.custom)?.search ?? { by: { movetime: 0 }, multiPv: 0 };
   }
 
   get recommendedThreads(): number {
     return (
       this.engines.external?.maxThreads ??
       clamp(navigator.hardwareConcurrency - (navigator.hardwareConcurrency % 2 ? 0 : 1), {
-        min: this.engines.active().minThreads ?? 1,
+        min: this.engines.active()?.minThreads ?? 1,
         max: this.maxThreads,
       })
     );
@@ -161,15 +163,15 @@ export class CevalCtrl {
     return (
       this.engines.external?.maxThreads ??
       (fewerCores()
-        ? Math.min(this.engines.active().maxThreads ?? 32, navigator.hardwareConcurrency)
-        : (this.engines.active().maxThreads ?? 32))
+        ? Math.min(this.engines.active()?.maxThreads ?? 32, navigator.hardwareConcurrency)
+        : (this.engines.active()?.maxThreads ?? 32))
     );
   }
 
   get isInfinite(): boolean {
     return (
       this.storedMovetime() === Number.POSITIVE_INFINITY &&
-      !Number.isFinite(this.engines.active().maxMovetime)
+      !Number.isFinite(this.engines.active()?.maxMovetime)
     );
   }
 
@@ -186,17 +188,17 @@ export class CevalCtrl {
   }
 
   get isCacheable(): boolean {
-    return !!this.engines.active().capabilities?.includes('cloudEval');
+    return Boolean(this.engines.active()?.capabilities?.includes('cloudEval'));
   }
 
   get wasUnloaded(): boolean {
-    return !this.worker && !!this.lastStarted; // another tab started ceval
+    return !this.worker && Boolean(this.lastStarted); // another tab started ceval
   }
 
   get showingCloud(): boolean {
     if (!this.lastStarted) return false;
     const curr = this.lastStarted.steps[this.lastStarted.steps.length - 1];
-    return !!curr.ceval?.cloud;
+    return Boolean(curr.ceval?.cloud);
   }
 
   setHashSize = (hash: number): void => storage.set('ceval.hash-size', hash.toString());
@@ -214,7 +216,7 @@ export class CevalCtrl {
 
   engineFailed(msg: string): void {
     if (msg.includes('Blocking on the main thread')) return; // mostly harmless
-    showEngineError(this.engines.active().name, msg);
+    showEngineError(String(this.engines.active()?.name), msg);
     this.reset();
     this.unload();
   }
@@ -222,7 +224,7 @@ export class CevalCtrl {
   private readonly doStart = (s: Started) => {
     this.lastStarted = s;
     const step = s.steps[s.steps.length - 1];
-    const { search, threads, hashSize } = this.info(this.opts.custom);
+    const { search, threads, hashSize, engine } = this.info(this.opts.custom)!;
     const lastEvalMillis = (s.threatMode ? step.threat : step.ceval)?.millis ?? 0;
     if (!this.isDeeper() && 'movetime' in search.by && lastEvalMillis >= search.by.movetime) {
       return;
@@ -260,8 +262,8 @@ export class CevalCtrl {
       }
     }
 
-    if (this.worker?.getInfo().id !== this.engines.active().id) this.unload();
-    this.worker ??= this.engines.makeEngine({ id: this.engines.active().id, variant: this.opts.variant.key });
+    if (this.worker?.getInfo().id !== engine.id) this.unload();
+    this.worker ??= this.engines.makeEngine({ id: engine.id, variant: this.opts.variant.key });
     this.worker.start(work);
   };
 

--- a/ui/lib/src/ceval/engines/engines.ts
+++ b/ui/lib/src/ceval/engines/engines.ts
@@ -265,9 +265,9 @@ export class Engines {
     );
   }
 
-  active(): EngineInfo {
+  active(): EngineInfo | undefined {
     this.activeEngine ??= this.getEngine({ variant: this.ctrl.opts.variant.key });
-    return this.activeEngine!;
+    return this.activeEngine;
   }
 
   setActive(id: string): EngineInfo | undefined {

--- a/ui/lib/src/ceval/view/settings.ts
+++ b/ui/lib/src/ceval/view/settings.ts
@@ -17,10 +17,12 @@ export function renderCevalSettings(ctrl: CevalHandler): VNode | null {
     return null;
   }
 
-  const minThreads = ceval.engines.active().minThreads ?? 1;
+  const minThreads = ceval.engines.active()?.minThreads ?? 1;
   const maxThreads = ceval.maxThreads;
+  const threads = ceval.info()?.threads ?? 1;
+  const hashSize = ceval.info()?.hashSize ?? 4;
   const searchTicks = allSearchTicks.filter(
-    x => x * 1000 <= (ceval.engines.active().maxMovetime ?? Infinity),
+    x => x * 1000 <= (ceval.engines.active()?.maxMovetime ?? Infinity),
   );
 
   let observer: ResizeObserver;
@@ -119,7 +121,7 @@ export function renderCevalSettings(ctrl: CevalHandler): VNode | null {
                       max: maxThreads,
                       step: 1,
                     },
-                    hook: rangeConfig(() => ceval.info().threads, clickThreads),
+                    hook: rangeConfig(() => threads, clickThreads),
                   }),
                   hl(
                     'div.tick',
@@ -141,7 +143,7 @@ export function renderCevalSettings(ctrl: CevalHandler): VNode | null {
                     !ceval.engines.external && [threadsTick('up'), threadsTick('down')],
                   ),
                 ]),
-                hl('div.range_value', `${ceval.info().threads} / ${maxThreads}`),
+                hl('div.range_value', `${threads} / ${maxThreads}`),
               ],
             );
           })('analyse-threads'),
@@ -152,12 +154,12 @@ export function renderCevalSettings(ctrl: CevalHandler): VNode | null {
               attrs: {
                 type: 'range',
                 min: 4,
-                max: Math.floor(Math.log2(ceval.engines.active().maxHash ?? 4)),
+                max: Math.floor(Math.log2(ceval.engines.active()?.maxHash ?? 4)),
                 step: 1,
-                'aria-valuetext': formatHashSize(ceval.info().hashSize),
+                'aria-valuetext': formatHashSize(hashSize),
               },
               hook: rangeConfig(
-                () => Math.floor(Math.log2(ceval.info().hashSize)),
+                () => Math.floor(Math.log2(hashSize)),
                 v => {
                   ceval.setHashSize(Math.pow(2, v));
                   ctrl.startCeval();
@@ -166,7 +168,7 @@ export function renderCevalSettings(ctrl: CevalHandler): VNode | null {
               ),
             }),
 
-            hl('div.range_value', formatHashSize(ceval.info().hashSize)),
+            hl('div.range_value', formatHashSize(hashSize)),
           ]))('analyse-memory'),
       ],
     ),
@@ -180,14 +182,14 @@ function formatHashSize(v: number) {
 function setupTick(v: VNode, ceval: CevalCtrl) {
   const tick = v.elm as HTMLElement;
   const parentSpan = tick.parentElement!;
-  const minThreads = ceval.engines.active().minThreads ?? 1;
+  const minThreads = ceval.engines.active()?.minThreads ?? 1;
   const thumbWidth = isChrome() ? 17 : 19; // it is what it is
   const trackWidth = parentSpan.querySelector('input')!.offsetWidth - thumbWidth;
   const tickRatio = (ceval.recommendedThreads - minThreads) / (ceval.maxThreads - minThreads);
   const tickLeft = Math.floor(thumbWidth / 2 + trackWidth * tickRatio);
 
   tick.style.left = `${tickLeft}px`;
-  $(tick).toggleClass('recommended', ceval.info().threads === ceval.recommendedThreads);
+  $(tick).toggleClass('recommended', ceval.info()?.threads === ceval.recommendedThreads);
 }
 
 function engineSelection({ ceval }: CevalHandler) {

--- a/ui/puzzle/src/report.ts
+++ b/ui/puzzle/src/report.ts
@@ -43,7 +43,7 @@ export default class Report {
       ctrl.data.puzzle.themes.some((t: ThemeKey) => t.toLowerCase().includes('mate')) ||
       // positions with 7 pieces or less can be checked with the tablebase
       pieceCount(ev.fen) <= 7 ||
-      !ctrl.ceval.engines.active().capabilities?.includes('puzzleReport') ||
+      !ctrl.ceval.engines.active()?.capabilities?.includes('puzzleReport') ||
       // if the user has chosen to hide the dialog less than a week ago
       this.tsHideReportDialog() > Date.now() - 1000 * 3600 * 24 * 7
     )
@@ -75,7 +75,7 @@ export default class Report {
       if (this.evalsWithMultipleSolutions === 2) {
         // in all case, we do not want to show the dialog more than once
         this.reported = true;
-        const engine = ctrl.ceval.engines.active();
+        const engine = ctrl.ceval.engines.active()!;
         const engineName = engine.short || engine.name;
         const reason = `(v${version}, ${engineName}) after move ${plyToTurn(node.ply)}. ${node.san}, at depth ${ev.depth}, multiple solutions:\n\n${ev.pvs.map(pv => `${pvEvalToStr(pv)}: ${pv.moves.join(' ')}`).join('\n\n')}`;
         this.reportDialog(ctrl.data.puzzle.id, reason);


### PR DESCRIPTION
https://lichess.org/forum/lichess-feedback/analysis-not-working-in-correspondence-matches

Correspondence analysis pages have no embedder/opener policy response header, so shared array buffer is not available. But all variant-capable engines require shared array buffer.

This exposed some unfounded optimism in the engines.ts active() accessor where it was assumed that at least a javascript engine would always be available.

Make active()'s return type `EngineInfo | undefined` and force callsites to gracefully handle undefined.
