### PR TITLE
Fix AnnotatorTest to pass real opening data (analyse & fishnet)

### DIFF
--- a/modules/analyse/src/test/AnnotatorTest.scala
+++ b/modules/analyse/src/test/AnnotatorTest.scala
@@ -1,5 +1,6 @@
 package lila.analyse
 import chess.format.pgn.{ InitialComments, Move, Parser, Pgn, PgnStr, SanStr, Tag, Tags }
+import chess.opening.OpeningDb
 import chess.{ ByColor, Node, Ply }
 
 import lila.core.LightUser
@@ -70,8 +71,9 @@ class AnnotatorTest extends munit.FunSuite:
       ).some,
       Ply.firstMove
     )
+    val opening = OpeningDb.search(List(SanStr("a3"), SanStr("g6"), SanStr("g4")))
 
     assertEquals(
-      annotator(dumped, makeGame(playedGame), none, none).copy(tags = Tags.empty).render,
+      annotator(dumped, makeGame(playedGame), none, opening).copy(tags = Tags.empty).render,
       PgnStr("""1. a3 { A00 Anderssen's Opening } g6 2. g4""")
     )

--- a/modules/fishnet/src/test/AnnotatorTest.scala
+++ b/modules/fishnet/src/test/AnnotatorTest.scala
@@ -2,6 +2,7 @@ package lila.fishnet
 import chess.format.FullFen
 import chess.format.pgn.{ Parser, PgnStr, SanStr, Tags }
 import chess.variant.{ Standard, Variant }
+import chess.opening.OpeningDb
 import chess.{ ByColor, Ply }
 import play.api.libs.json.Json
 
@@ -53,7 +54,8 @@ object AnnotatorTest:
       val (game, moves) = AnnotatorTest.gameWithMoves(sans, fen, variant)
       val analysis = AnnotatorTest.parse(builder, fishnetInput, fen.some, variant, moves, ply)
       val p1 = annotator.addEvals(dumped, analysis)
-      val p2 = annotator(p1, makeGame(game), analysis.some, none).copy(tags = Tags.empty)
+      val opening = OpeningDb.search(sans)
+      val p2 = annotator(p1, makeGame(game), analysis.some, opening).copy(tags = Tags.empty)
       val output = annotator.toPgnString(p2)
       (output, expected)
 

--- a/modules/insight/src/main/Env.scala
+++ b/modules/insight/src/main/Env.scala
@@ -9,21 +9,22 @@ import lila.common.Bus
 
 @Module
 final class Env(
-    appConfig: Configuration,
-    gameRepo: lila.game.GameRepo,
-    gameApi: lila.core.game.GameApi,
-    analysisRepo: lila.analyse.AnalysisRepo,
-    prefApi: lila.core.pref.PrefApi,
-    relationApi: lila.core.relation.RelationApi,
-    cacheApi: lila.memo.CacheApi,
-    mongo: lila.db.Env
-)(using Executor, Scheduler, akka.stream.Materializer):
+        appConfig: Configuration,
+        gameRepo: lila.game.GameRepo,
+        gameApi: lila.core.game.GameApi,
+        gameOpening: lila.core.game.GameOpening,
+        analysisRepo: lila.analyse.AnalysisRepo,
+        prefApi: lila.core.pref.PrefApi,
+        relationApi: lila.core.relation.RelationApi,
+        cacheApi: lila.memo.CacheApi,
+        mongo: lila.db.Env
+    )(using Executor, Scheduler, akka.stream.Materializer):
 
   lazy val db = mongo
     .asyncDb(
-      "insight",
-      appConfig.get[String]("insight.mongodb.uri")
-    )
+              "insight",
+              appConfig.get[String]("insight.mongodb.uri")
+            )
     .taggedWith[lila.game.core.insight.InsightDb]
 
   lazy val share = wire[Share]

--- a/modules/insight/src/main/Env.scala
+++ b/modules/insight/src/main/Env.scala
@@ -9,22 +9,22 @@ import lila.common.Bus
 
 @Module
 final class Env(
-        appConfig: Configuration,
-        gameRepo: lila.game.GameRepo,
-        gameApi: lila.core.game.GameApi,
-        gameOpening: lila.core.game.GameOpening,
-        analysisRepo: lila.analyse.AnalysisRepo,
-        prefApi: lila.core.pref.PrefApi,
-        relationApi: lila.core.relation.RelationApi,
-        cacheApi: lila.memo.CacheApi,
-        mongo: lila.db.Env
-    )(using Executor, Scheduler, akka.stream.Materializer):
+    appConfig: Configuration,
+    gameRepo: lila.game.GameRepo,
+    gameApi: lila.core.game.GameApi,
+    gameOpening: lila.core.game.GameOpening,
+    analysisRepo: lila.analyse.AnalysisRepo,
+    prefApi: lila.core.pref.PrefApi,
+    relationApi: lila.core.relation.RelationApi,
+    cacheApi: lila.memo.CacheApi,
+    mongo: lila.db.Env
+)(using Executor, Scheduler, akka.stream.Materializer):
 
   lazy val db = mongo
     .asyncDb(
-              "insight",
-              appConfig.get[String]("insight.mongodb.uri")
-            )
+      "insight",
+      appConfig.get[String]("insight.mongodb.uri")
+    )
     .taggedWith[lila.game.core.insight.InsightDb]
 
   lazy val share = wire[Share]


### PR DESCRIPTION
This PR fixes AnnotatorTest in both the analyse and fishnet modules, which previously called annotator(...) with none for the opening argument, and adds the GameOpening dependency that insight/Env.scala was missing.

Changes: modules/analyse/src/test/AnnotatorTest.scala now computes a real opening via OpeningDb.search and passes it to annotator. modules/fishnet/src/test/AnnotatorTest.scala is updated the same way. insight/Env.scala gains the missing GameOpening dependency and a scalafmt formatting fix.

This keeps the tests aligned with the real Annotator signature/behavior instead of stubbing the opening argument with none.

Note: this PR was opened with the help of a browser assistant (Claude) on my behalf; the code changes themselves are my own commits.