### PR TITLE
Sort participating appeals to top of queue

### DIFF
--- a/modules/appeal/src/main/AppealApi.scala
+++ b/modules/appeal/src/main/AppealApi.scala
@@ -81,7 +81,12 @@ final class AppealApi(
       $doc("status" -> Appeal.Status.unread) ++
         snoozedIds.nonEmpty.so($doc("_id".$nin(snoozedIds))) ++
         topic.so(t => $doc("topic" -> t))
-    coll.find(selector).sort($sort.asc("firstUnrepliedAt")).cursor[Appeal]().list(nb)
+    coll
+      .find(selector)
+      .sort($sort.asc("firstUnrepliedAt"))
+      .cursor[Appeal]()
+      .list(nb)
+      .map(_.sortBy(a => (!a.modIds.contains(me.userId), a.firstUnrepliedAt)))
 
   def setReadIfUnread(user: UserId, topic: AppealTopic) =
     coll


### PR DESCRIPTION
Closes #20698.

Went with the simpler solution of sorting by participation _after_ finding the 50 oldest appeals in the queue. The downside is that if a user responds right away then that appeal won't resurface again in the queue until it is within the 50 oldest appeals.

We could also fetch all of the unread appeals and do the sorting/limiting in memory before sending on to the client. Maybe with queue sizes of ~200 that's fine?