### PR TITLE
ui: fix mousetrap stealing events from styled selects

### DIFF
--- a/ui/site/src/mousetrap.ts
+++ b/ui/site/src/mousetrap.ts
@@ -173,9 +173,7 @@ export default class Mousetrap {
     for (const binding of this.getMatches(e)) {
       if (
         binding.combination === 'esc' ||
-        (el.tagName !== 'INPUT' &&
-          el.tagName !== 'SELECT' &&
-          el.tagName !== 'TEXTAREA' &&
+        (!['INPUT', 'SELECT', 'OPTION', 'TEXTAREA'].includes(el.tagName) &&
           !el.isContentEditable &&
           !el.hasAttribute('trap-bypass'))
       ) {


### PR DESCRIPTION
# Why

Refs:
* https://github.com/lichess-org/lila/pull/20982#issuecomment-5031394572

# How

Add missing "OPTION" element tag to the mousetrap check. Looks like for styled element options not the whole select are event targets.

# Preview

https://github.com/user-attachments/assets/9926cda5-e15a-4621-ae1e-812199b9b60f

