### PR TITLE
ui: appearance tweaks and fixes for native styled selects

### DIFF
--- a/ui/analyse/css/study/_modal.scss
+++ b/ui/analyse/css/study/_modal.scss
@@ -89,16 +89,22 @@
     }
   }
 
-  &.study-edit .flair-and-name {
-    gap: 4%;
-
-    .form-group:last-child {
-      flex: 1 1 auto;
+  &.study-edit {
+    @media (min-width: at-least($x-small)) {
+      min-width: 600px;
     }
 
-    .uflair {
-      margin: 0;
-      font-size: 1.3em;
+    .flair-and-name {
+      gap: 4%;
+
+      .form-group:last-child {
+        flex: 1 1 auto;
+      }
+
+      .uflair {
+        margin: 0;
+        font-size: 1.3em;
+      }
     }
   }
 }

--- a/ui/analyse/css/study/panel/_metadata.scss
+++ b/ui/analyse/css/study/panel/_metadata.scss
@@ -82,10 +82,13 @@
   }
 
   select {
-    cursor: pointer;
     border: none;
-    background: none;
-    padding: 0;
+    padding-block: 4px;
+    min-width: 120px;
+
+    @supports (appearance: base-select) {
+      padding-inline-end: 24px;
+    }
   }
 }
 

--- a/ui/lib/css/base/_form.scss
+++ b/ui/lib/css/base/_form.scss
@@ -70,17 +70,26 @@ select {
   @supports (appearance: base-select) {
     align-items: center;
     appearance: base-select;
-    padding-inline: 9px 6px;
+    padding-inline: 9px 24px;
     mask-image: none;
     color: var(--c-font);
+    position: relative;
 
     &::picker-icon {
+      position: absolute;
       content: '';
       width: 14px;
       height: 14px;
       background-color: var(--c-font-dim);
       mask-image: var(--picker-icon-mask);
       transition: rotate 0.25s ease;
+      right: 8px;
+      top: calc(50% - 7px);
+
+      @include if-rtl {
+        right: unset;
+        left: 8px;
+      }
     }
 
     &:open::picker-icon {
@@ -120,7 +129,8 @@ select {
 
     &:open::picker(select) {
       opacity: 1;
-      overflow: hidden;
+      overflow-x: clip;
+      overflow-y: auto;
       display: flex;
 
       @starting-style {


### PR DESCRIPTION
# Why

Refs:
* https://github.com/lichess-org/lila/pull/20982#issuecomment-5031394572

# How

Appearance tweaks and fixes for native styled selects based on the feedback. Summary of changes:
- fix select popover container with a lot of options being not scrollable
- change the chevron placement approach to be more flexible and support custom sized selects (+ RTL support)
- small tweaks for study tags select, which has the `button` class and some overwrites

Known issues:
- when option has a very long label it will overflow the select container (not the popover container tho), still looking for a solution for that

# Preview

https://github.com/user-attachments/assets/2d98da13-2af5-4453-bce9-8898883b1aa8

<img width="664" height="794" alt="Screenshot 2026-07-21 at 11 03 12" src="https://github.com/user-attachments/assets/8c65fdfd-2961-4f80-8701-8ab0bb734728" />
