### PR TITLE
ui(fide): reduce slightly the follow/fav icon size

### DIFF
--- a/ui/lib/css/form/_cmn-favourite.scss
+++ b/ui/lib/css/form/_cmn-favourite.scss
@@ -9,7 +9,7 @@
   }
 }
 
-$star-width: 1.8rem;
+$star-width: 1.4rem;
 
 .cmn-favourite label {
   @include prevent-select;


### PR DESCRIPTION
# Why

Spotted that the follow/fav icon is quite large, and it looks a bit off especially in button with label on the player profile page.

# How

Slightly reduce the star icon size.

# Preview

<img width="595" height="321" alt="Screenshot 2026-07-21 at 11 43 42" src="https://github.com/user-attachments/assets/0683ec4d-45d6-41e0-8577-6cc751fc9c15" />
<img width="1024" height="272" alt="Screenshot 2026-07-21 at 11 43 19" src="https://github.com/user-attachments/assets/cc84cf98-cabc-485a-8ca4-dfaff03b129e" />
