### PR TITLE
Don't prevent team battle updates that don't change the start date

### DIFF
--- a/modules/tournament/src/main/TournamentForm.scala
+++ b/modules/tournament/src/main/TournamentForm.scala
@@ -85,7 +85,8 @@ final class TournamentForm:
           )
           .verifying(
             "Can't change start date of a team battle after 10 players have joined",
-            _.startDate.contains(tour.startsAt) ||
+            _.startDate.isEmpty ||
+              _.startDate.contains(tour.startsAt) ||
               tour.nbPlayers < 10 ||
               tour.teamBattle.isEmpty ||
               Granter(_.ManageTournament)

--- a/modules/tournament/src/main/TournamentForm.scala
+++ b/modules/tournament/src/main/TournamentForm.scala
@@ -85,11 +85,12 @@ final class TournamentForm:
           )
           .verifying(
             "Can't change start date of a team battle after 10 players have joined",
-            _.startDate.isEmpty ||
-              _.startDate.contains(tour.startsAt) ||
-              tour.nbPlayers < 10 ||
-              tour.teamBattle.isEmpty ||
-              Granter(_.ManageTournament)
+            d =>
+              d.startDate.isEmpty ||
+                d.startDate.contains(tour.startsAt) ||
+                tour.nbPlayers < 10 ||
+                tour.teamBattle.isEmpty ||
+                Granter(_.ManageTournament)
           )
 
   private def makeMapping(leaderTeams: List[LightTeam], prev: Option[Tournament])(using me: Me) =


### PR DESCRIPTION
7fc03a085249192c2bc0f6e2316a460658e628a3 added a validation to prevent changing the start date of team battles with 10 or more players but it currently also prevents API requests that don't set the start date, which would leave the start date unchanged.