### PR TITLE
switch fishnet auth from body to bearer

### DIFF
--- a/app/controllers/Fishnet.scala
+++ b/app/controllers/Fishnet.scala
@@ -64,7 +64,7 @@ final class Fishnet(env: Env) extends LilaController(env):
   )(using Reads[A]) =
     AnonBodyOf(parse.tolerantJson): body =>
       (HTTPRequest.bearer(req), Client.Version.readFromUA).tupled.so: (bearer, version) =>
-        api.authenticateClient(Client.Key(bearer.value), version, req.ipAddress).flatMap {
+        api.authenticateClient(bearer.into(Client.Key), version, req.ipAddress).flatMap {
           case Failure(msg) => Unauthorized(jsonError(msg.getMessage))
           case Success(client) =>
             if !JsonApi.Request.isValid(body) then BadRequest

--- a/app/controllers/Fishnet.scala
+++ b/app/controllers/Fishnet.scala
@@ -7,17 +7,18 @@ import play.api.mvc.*
 
 import scala.util.{ Failure, Success }
 
-import lila.app.*
+import lila.app.{ *, given }
+import lila.common.HTTPRequest
 import lila.fishnet.JsonApi.readers.given
 import lila.fishnet.JsonApi.writers.given
-import lila.fishnet.{ JsonApi, Work }
+import lila.fishnet.{ Client, JsonApi, Work }
 
 final class Fishnet(env: Env) extends LilaController(env):
 
   private def api = env.fishnet.api
 
   def acquire(slow: Boolean = false) =
-    ClientAction[JsonApi.Request.Acquire] { _ => client =>
+    ClientAction[JsonApi.Request.Acquire] { client => _ =>
       api
         .acquire(client, slow)
         .addEffect: jobOpt =>
@@ -25,7 +26,7 @@ final class Fishnet(env: Env) extends LilaController(env):
     }
 
   def analysis(workId: String, slow: Boolean = false, stop: Boolean = false) =
-    ClientAction[JsonApi.Request.PostAnalysis] { data => client =>
+    ClientAction[JsonApi.Request.PostAnalysis] { client => data =>
       import lila.fishnet.FishnetApi.*
       def onComplete =
         if stop then NoContent.raise
@@ -45,7 +46,7 @@ final class Fishnet(env: Env) extends LilaController(env):
     }
 
   def abort(workId: String) =
-    ClientAction[JsonApi.Request.Acquire] { _ => client =>
+    ClientAction[JsonApi.Request.Acquire] { client => _ =>
       api.abort(Work.Id(workId), client).inject(none)
     }
 
@@ -59,25 +60,31 @@ final class Fishnet(env: Env) extends LilaController(env):
     api.status.map { JsonStrOk(_) }
 
   private def ClientAction[A <: JsonApi.Request](
-      f: A => lila.fishnet.Client => FuRaise[Result, Option[JsonApi.Work]]
+      f: lila.fishnet.Client => A => FuRaise[Result, Option[JsonApi.Work]]
   )(using Reads[A]) =
     AnonBodyOf(parse.tolerantJson): body =>
-      if !JsonApi.Request.isValid(body) then BadRequest
-      else
-        body
-          .validate[A]
-          .fold(
-            err =>
-              lila.fishnet.logger.warn(s"Malformed request: $err\n${body}")
-              BadRequest(jsonError(JsError.toJson(err)))
-            ,
-            data =>
-              api.authenticateClient(data, req.ipAddress).flatMap {
-                case Failure(msg) => Unauthorized(jsonError(msg.getMessage))
-                case Success(client) =>
-                  allow:
-                    f(data)(client).map:
-                      _.map(Json.toJson).fold(NoContent)(Accepted(_))
-                  .rescue(identity)
-              }
+      HTTPRequest
+        .bearer(req)
+        .fold(fuccess(Unauthorized(jsonError("Missing bearer")))): bearer =>
+          val version = Client.Version(
+            ~HTTPRequest.userAgent(req).value.split("/", 2).lift(1) // fishnet-<os>-<arch>/<version>
           )
+          api.authenticateClient(Client.Key(bearer.value), version, req.ipAddress).flatMap {
+            case Failure(msg) => Unauthorized(jsonError(msg.getMessage))
+            case Success(client) =>
+              if !JsonApi.Request.isValid(body) then BadRequest
+              else
+                body
+                  .validate[A]
+                  .fold(
+                    err =>
+                      lila.fishnet.logger.warn(s"Malformed request: $err\n${body}")
+                      BadRequest(jsonError(JsError.toJson(err)))
+                    ,
+                    data =>
+                      allow:
+                        f(client)(data).map:
+                          _.map(Json.toJson).fold(NoContent)(Accepted(_))
+                      .rescue(identity)
+                  )
+          }

--- a/app/controllers/Fishnet.scala
+++ b/app/controllers/Fishnet.scala
@@ -63,28 +63,23 @@ final class Fishnet(env: Env) extends LilaController(env):
       f: lila.fishnet.Client => A => FuRaise[Result, Option[JsonApi.Work]]
   )(using Reads[A]) =
     AnonBodyOf(parse.tolerantJson): body =>
-      HTTPRequest
-        .bearer(req)
-        .fold(fuccess(Unauthorized(jsonError("Missing bearer")))): bearer =>
-          val version = Client.Version(
-            ~HTTPRequest.userAgent(req).value.split("/", 2).lift(1) // fishnet-<os>-<arch>/<version>
-          )
-          api.authenticateClient(Client.Key(bearer.value), version, req.ipAddress).flatMap {
-            case Failure(msg) => Unauthorized(jsonError(msg.getMessage))
-            case Success(client) =>
-              if !JsonApi.Request.isValid(body) then BadRequest
-              else
-                body
-                  .validate[A]
-                  .fold(
-                    err =>
-                      lila.fishnet.logger.warn(s"Malformed request: $err\n${body}")
-                      BadRequest(jsonError(JsError.toJson(err)))
-                    ,
-                    data =>
-                      allow:
-                        f(client)(data).map:
-                          _.map(Json.toJson).fold(NoContent)(Accepted(_))
-                      .rescue(identity)
-                  )
-          }
+      (HTTPRequest.bearer(req), Client.Version.readFromUA).tupled.so: (bearer, version) =>
+        api.authenticateClient(Client.Key(bearer.value), version, req.ipAddress).flatMap {
+          case Failure(msg) => Unauthorized(jsonError(msg.getMessage))
+          case Success(client) =>
+            if !JsonApi.Request.isValid(body) then BadRequest
+            else
+              body
+                .validate[A]
+                .fold(
+                  err =>
+                    lila.fishnet.logger.warn(s"Malformed request: $err\n${body}")
+                    BadRequest(jsonError(JsError.toJson(err)))
+                  ,
+                  data =>
+                    allow:
+                      f(client)(data).map:
+                        _.map(Json.toJson).fold(NoContent)(Accepted(_))
+                    .rescue(identity)
+                )
+        }

--- a/modules/fishnet/src/main/Client.scala
+++ b/modules/fishnet/src/main/Client.scala
@@ -49,7 +49,9 @@ object Client:
   opaque type Key = String
   object Key extends OpaqueString[Key]
   opaque type Version = String
-  object Version extends OpaqueString[Version]
+  object Version extends OpaqueString[Version]:
+    def readFromUA(using ua: scalalib.net.UserAgent): Option[Client.Version] =
+      ua.value.split("/", 2).lift(1) // fishnet-<os>-<arch>/<version>
 
   case class Instance(version: Version, ip: IpAddress, seenAt: Instant):
 
@@ -88,4 +90,4 @@ object Client:
           )
         case Failure(error) => Failure(error)
 
-  def makeKey = Key(SecureRandom.nextString(8))
+  private[fishnet] def makeKey = Key(SecureRandom.nextString(8))

--- a/modules/fishnet/src/main/FishnetApi.scala
+++ b/modules/fishnet/src/main/FishnetApi.scala
@@ -36,14 +36,15 @@ final class FishnetApi(
 
   def keyExists(key: Client.Key) = repo.getEnabledClient(key).map(_.isDefined)
 
-  def authenticateClient(req: JsonApi.Request, ip: IpAddress): Fu[Try[Client]] = {
+  def authenticateClient(key: Client.Key, version: Client.Version, ip: IpAddress): Fu[Try[Client]] = {
     if config.offlineMode then repo.getOfflineClient.map(some)
-    else repo.getEnabledClient(req.fishnet.apikey)
+    else repo.getEnabledClient(key)
   }.map {
     case None => Failure(LilaNoStackTrace("Can't authenticate: invalid key or disabled client"))
-    case Some(client) => clientVersion.accept(req.fishnet.version).map(_ => client)
+    case Some(client) => clientVersion.accept(version).map(_ => client)
   }.flatMap:
-    case Success(client) => repo.updateClientInstance(client, req.instance(ip)).map(Success.apply)
+    case Success(client) =>
+      repo.updateClientInstance(client, Client.Instance(version, ip, nowInstant)).map(Success.apply)
     case invalid => fuccess(invalid)
 
   def acquire(client: Client, slow: Boolean): Fu[Option[JsonApi.Work]] =

--- a/modules/fishnet/src/main/JsonApi.scala
+++ b/modules/fishnet/src/main/JsonApi.scala
@@ -7,46 +7,33 @@ import play.api.libs.json.*
 
 import lila.common.Json.{ *, given }
 import lila.core.chess.Depth
-import lila.core.net.IpAddress
 import lila.fishnet.Work as W
 
 object JsonApi:
 
-  sealed trait Request:
-    val fishnet: Request.Fishnet
-
-    def instance(ip: IpAddress) = Client.Instance(fishnet.version, ip, nowInstant)
+  sealed trait Request
 
   object Request:
 
     def isValid(js: JsValue): Boolean = js.arr("analysis").forall(_.value.sizeIs <= 300)
-
-    case class Fishnet(
-        version: Client.Version,
-        apikey: Client.Key
-    )
 
     case class Stockfish(
         flavor: Option[String]
     ):
       def isNnue = flavor.has("nnue")
 
-    case class Acquire(
-        fishnet: Fishnet
-    ) extends Request
+    case class Acquire() extends Request
 
     case class PostAnalysis(
-        fishnet: Fishnet,
         stockfish: Stockfish,
         analysis: List[Option[Evaluation.EvalOrSkip]]
     ) extends Request:
 
       def completeOrPartial =
-        if analysis.headOption.so(_.isDefined) then CompleteAnalysis(fishnet, stockfish, analysis.flatten)
-        else PartialAnalysis(fishnet, stockfish, analysis)
+        if analysis.headOption.so(_.isDefined) then CompleteAnalysis(stockfish, analysis.flatten)
+        else PartialAnalysis(stockfish, analysis)
 
     case class CompleteAnalysis(
-        fishnet: Fishnet,
         stockfish: Stockfish,
         analysis: List[Evaluation.EvalOrSkip]
     ):
@@ -60,7 +47,6 @@ object JsonApi:
           .flatMap(_.nodes)
 
     case class PartialAnalysis(
-        fishnet: Fishnet,
         stockfish: Stockfish,
         analysis: List[Option[Evaluation.EvalOrSkip]]
     )
@@ -131,7 +117,6 @@ object JsonApi:
     import play.api.libs.functional.syntax.*
     import Request.Evaluation.EvalOrSkip
     given Reads[Request.Stockfish] = Json.reads
-    given Reads[Request.Fishnet] = Json.reads
     given Reads[Request.Acquire] = Json.reads
     given Reads[Request.Evaluation.Score] = Json.reads
     given Reads[List[Uci]] = Reads.of[String].map(Uci.readList(_).getOrElse(Nil))


### PR DESCRIPTION
doing less before authentication. all supported fishnet versions already send the headers.