### PR TITLE
workspace: update pnpm to the latest version available for NixOS

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -19,13 +19,13 @@ Lila (li[chess in sca]la) is the free, open-source chess server powering lichess
 
 - **Java 21** (JDK, not JRE - needs jdk.compiler module)
 - **Node.js 24.14.0+** (specified in `.node-version`)
-- **PNPM 11.5.1+** (specified in `package.json`)
+- **PNPM 11.15.0+** (specified in `package.json`)
 
 **Installation:**
 
 ```bash
 # Install PNPM globally
-npm install -g pnpm@11.5.1
+npm install -g pnpm@11.15.0
 
 # Install dependencies (always run this first)
 pnpm install

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lila",
   "private": true,
-  "packageManager": "pnpm@11.9.0",
+  "packageManager": "pnpm@11.15.0",
   "engines": {
     "node": ">=24",
     "pnpm": "11"

--- a/ui/.build/package.json
+++ b/ui/.build/package.json
@@ -1,7 +1,7 @@
 {
   "name": "build",
   "type": "module",
-  "packageManager": "pnpm@11.5.1",
+  "packageManager": "pnpm@11.15.0",
   "engines": {
     "node": ">=24",
     "pnpm": "11"


### PR DESCRIPTION
# Why

Update pnpm across workspace to the latest version available for NixOS.

Refs:
* https://search.nixos.org/packages?channel=unstable&query=pnpm#show=pnpm
* https://github.com/pnpm/pnpm/releases