### PR TITLE
Update reporting game link error text in en-US

### DIFF
--- a/translation/dest/site/en-US.xml
+++ b/translation/dest/site/en-US.xml
@@ -590,7 +590,7 @@
   <string name="reportCheatBoostHelp">Paste a link to the game(s) and explain what is wrong with this user\'s behavior. Don\'t just say \"they cheat,\" but tell us how you came to this conclusion.</string>
   <string name="reportUsernameHelp">Explain why this username is offensive. Don\'t just say \"it\'s offensive/inappropriate,\" but tell us how you came to this conclusion, especially if the offense is obscure, not in English, in slang, or a historical/cultural reference.</string>
   <string name="reportProcessedFasterInEnglish">Your report will be processed faster if written in English.</string>
-  <string name="error.provideOneCheatedGameLink">Please provide at least one link to a game with suspected cheating.</string>
+  <string name="error.provideOneCheatedGameLink">Please provide at least one link to a game for review.</string>
   <string name="by">by %s</string>
   <string name="importedByX">Imported by %s</string>
   <string name="thisTopicIsNowClosed">This topic is now closed.</string>


### PR DESCRIPTION
In #19410 and #19483, the error text for reporting a game for cheating or stalling was updated to be more neutral (before it specifically mentioned "suspected cheating" which doesn't necessarily apply to stalling).

This wasn't propagated to, for example, the en-US specific localization, so the old version still shows up on browsers in that locale.

NB: I am not sure about any other translations.