### PR TITLE
Add permissions for Relay Stream

### DIFF
--- a/modules/core/src/main/perm.scala
+++ b/modules/core/src/main/perm.scala
@@ -94,6 +94,7 @@ enum Permission(val key: String, val alsoGrants: List[Permission], val name: Str
   case PayPal extends Permission("PAYPAL", "PayPal")
   // Set the tier of own broadcasts, making them official. Group own broadcasts.
   case Relay extends Permission("RELAY", "Broadcast official")
+  case RelayStream extends Permission("RELAY_STREAM", "Broadcast Live stream")
   case FidePlayer extends Permission("FIDE_PLAYER", "Edit FIDE players")
   case Cli extends Permission("CLI", "Command line")
   case Settings
@@ -105,7 +106,7 @@ enum Permission(val key: String, val alsoGrants: List[Permission], val name: Str
   case MonitoredCheatMod extends Permission("MONITORED_MOD_CHEAT", "Monitored mod: cheat")
   case MonitoredBoostMod extends Permission("MONITORED_MOD_BOOST", "Monitored mod: boost")
   case MonitoredCommMod extends Permission("MONITORED_MOD_COMM", "Monitored mod: comms")
-  case StudyAdmin extends Permission("STUDY_ADMIN", List(Relay), "Study/Broadcast admin")
+  case StudyAdmin extends Permission("STUDY_ADMIN", List(Relay, RelayStream), "Study/Broadcast admin")
   case ApiHog extends Permission("API_HOG", "API hog")
   case ApiChallengeAdmin extends Permission("API_CHALLENGE_ADMIN", "API Challenge admin")
   case LichessTeam extends Permission("LICHESS_TEAM", List(Beta), "Lichess team")

--- a/modules/relay/src/main/RelayTourForm.scala
+++ b/modules/relay/src/main/RelayTourForm.scala
@@ -155,7 +155,7 @@ object RelayTourForm:
           teams = teams,
           showTeamScores = showTeamScores,
           spotlight = if Granter(_.StudyAdmin) then spotlight.filterNot(_.isEmpty) else tour.spotlight,
-          pinnedStream = if Granter(_.StudyAdmin) then pinnedStream else tour.pinnedStream,
+          pinnedStream = if Granter(_.RelayStream) then pinnedStream else tour.pinnedStream,
           note = note,
           orphanWarn = if Granter(_.StudyAdmin) then orphanWarn else tour.orphanWarn
         )
@@ -182,7 +182,7 @@ object RelayTourForm:
         players = players,
         teams = teams,
         spotlight = spotlight.filterNot(_.isEmpty).ifTrue(Granter(_.StudyAdmin)),
-        pinnedStream = pinnedStream.ifTrue(Granter(_.StudyAdmin)),
+        pinnedStream = pinnedStream.ifTrue(Granter(_.RelayStream)),
         note = note,
         orphanWarn = orphanWarn || !Granter(_.StudyAdmin)
       ).giveOfficialToBroadcasterIf(Granter(_.StudyAdmin))

--- a/modules/relay/src/main/ui/RelayFormUi.scala
+++ b/modules/relay/src/main/ui/RelayFormUi.scala
@@ -812,42 +812,43 @@ Team Dogs ; Scooby Doo"""),
                     )
                   )
                 )
-            ),
-            (tg.isDefined && Granter.opt(_.RelayStream)).option:
-              form3.fieldset("Pinned stream", toggle = form("pinnedStream.url").value.isDefined.some)(
-                form3.split(
-                  form3.group(
-                    form("pinnedStream.url"),
-                    "Stream URL",
-                    help = frag(
-                      p("Embed a live stream in the broadcast. Examples:"),
-                      ul(
-                        li("https://www.youtube.com/live/Lg0askmGqvo"),
-                        li("https://www.twitch.tv/tcec_chess_tv")
-                      )
-                    ).some,
-                    half = true
-                  )(form3.input(_)),
-                  form3.group(
-                    form("pinnedStream.name"),
-                    "Stream name",
-                    half = true
-                  )(form3.input(_))
-                ),
-                form3.split(
-                  form3.group(
-                    form("pinnedStream.text"),
-                    "Stream link label",
-                    help = frag(
-                      "Optional. Show a label on the image link to your live stream.",
-                      br,
-                      "Example: 'Watch us live on YouTube!'"
-                    ).some
-                  )(form3.input(_))
-                )
-              )
+            )
           )
         else form3.hidden(form("tier")),
+        (tg.isDefined && Granter.opt(_.RelayStream)).option(
+          form3.fieldset("Pinned stream", toggle = form("pinnedStream.url").value.isDefined.some)(
+            form3.split(
+              form3.group(
+                form("pinnedStream.url"),
+                "Stream URL",
+                help = frag(
+                  p("Embed a live stream in the broadcast. Examples:"),
+                  ul(
+                    li("https://www.youtube.com/live/Lg0askmGqvo"),
+                    li("https://www.twitch.tv/tcec_chess_tv")
+                  )
+                ).some,
+                half = true
+              )(form3.input(_)),
+              form3.group(
+                form("pinnedStream.name"),
+                "Stream name",
+                half = true
+              )(form3.input(_))
+            ),
+            form3.split(
+              form3.group(
+                form("pinnedStream.text"),
+                "Stream link label",
+                help = frag(
+                  "Optional. Show a label on the image link to your live stream.",
+                  br,
+                  "Example: 'Watch us live on YouTube!'"
+                ).some
+              )(form3.input(_))
+            )
+          )
+        ),
         form3.fieldset("Broadcaster note", toggle = tg.flatMap(_.tour.note).isDefined.some)(
           form3.group(
             form("note"),

--- a/modules/relay/src/main/ui/RelayFormUi.scala
+++ b/modules/relay/src/main/ui/RelayFormUi.scala
@@ -813,7 +813,7 @@ Team Dogs ; Scooby Doo"""),
                   )
                 )
             ),
-            (tg.isDefined && Granter.opt(_.StudyAdmin)).option:
+            (tg.isDefined && Granter.opt(_.RelayStream)).option:
               form3.fieldset("Pinned stream", toggle = form("pinnedStream.url").value.isDefined.some)(
                 form3.split(
                   form3.group(

--- a/modules/security/src/main/Permission.scala
+++ b/modules/security/src/main/Permission.scala
@@ -58,6 +58,7 @@ object Permission:
     ),
     "Broadcast" -> List(
       Relay,
+      RelayStream,
       BroadcastTimeout,
       FidePlayer,
       StudyAdmin


### PR DESCRIPTION
Added the Relay Stream permission, which allows adding or editing the "Pinned Stream" without needing to grant full Admin rights.
In some cases, a trusted organizer could even be given certain dependencies for editing the LiveStream.

***
~~*Personal note: unfortunately GitHub Codespaces is acting up and I couldn't open the port to test it, but I managed to compile it.*~~ tested in localhost with low ram ....