### PR TITLE
ui: replace `iconCls` and `iconTag` with common `icon` custom element

### DIFF
--- a/ui/analyse/src/explorer/explorerConfig.ts
+++ b/ui/analyse/src/explorer/explorerConfig.ts
@@ -5,7 +5,7 @@ import { myUsername, type Prop, prop } from 'lib';
 import perfIcons from 'lib/game/perfIcons';
 import { licon } from 'lib/licon';
 import { storedProp, storedJsonProp, type StoredProp, storedStringProp } from 'lib/storage';
-import { type Dialog, snabDialog, bind, dataIcon, iconTag, onInsert } from 'lib/view';
+import { type Dialog, snabDialog, bind, dataIcon, icon, onInsert } from 'lib/view';
 import { userComplete } from 'lib/view/userComplete';
 
 import type AnalyseCtrl from '../ctrl';
@@ -229,7 +229,7 @@ const lichessDb = (ctrl: ExplorerConfigCtrl) =>
 const speedSection = (ctrl: ExplorerConfigCtrl) =>
   h('section.speed', [
     h('label', i18n.site.timeControl),
-    h('div.choices', allSpeeds.map(radioButton(ctrl, ctrl.data.speed, s => iconTag(perfIcons[s])))),
+    h('div.choices', allSpeeds.map(radioButton(ctrl, ctrl.data.speed, s => icon(perfIcons[s])()))),
   ]);
 
 const modeSection = (ctrl: ExplorerConfigCtrl) =>

--- a/ui/analyse/src/explorer/explorerView.ts
+++ b/ui/analyse/src/explorer/explorerView.ts
@@ -1,16 +1,7 @@
 import perfIcons from 'lib/game/perfIcons';
 import { displayLocale, numberFormat } from 'lib/i18n';
 import { licon } from 'lib/licon';
-import {
-  bind,
-  dataIcon,
-  type MaybeVNode,
-  type LooseVNodes,
-  type VNode,
-  hl,
-  iconTag,
-  onInsert,
-} from 'lib/view';
+import { bind, dataIcon, type MaybeVNode, type LooseVNodes, type VNode, hl, onInsert, icon } from 'lib/view';
 
 import type AnalyseCtrl from '../ctrl';
 import { view as renderConfig } from './explorerConfig';
@@ -148,7 +139,7 @@ function showGameTable(ctrl: AnalyseCtrl, fen: FEN, title: string, games: Openin
               hl('td', showResult(game.winner)),
               hl('td', game.month || game.year),
               !isMasters &&
-                hl('td', game.speed && iconTag(perfIcons[game.speed], { title: ucfirst(game.speed) })),
+                hl('td', game.speed && icon(perfIcons[game.speed])({ title: ucfirst(game.speed) })),
             ]),
       ),
     ),
@@ -228,7 +219,7 @@ const showEmpty = (ctrl: AnalyseCtrl, data?: OpeningData): VNode => {
 const showGameEnd = (ctrl: AnalyseCtrl, title: string): VNode =>
   hl('div.data.empty', [
     hl('div.title', i18n.site.gameOver),
-    hl('div.message', [iconTag(licon.InfoCircle), hl('h3', title), closeButton(ctrl)]),
+    hl('div.message', [icon(licon.InfoCircle)(), hl('h3', title), closeButton(ctrl)]),
   ]);
 
 const openingTitle = (ctrl: AnalyseCtrl, data?: OpeningData) => {

--- a/ui/analyse/src/retrospect/retroView.ts
+++ b/ui/analyse/src/retrospect/retroView.ts
@@ -1,6 +1,6 @@
 import { licon } from 'lib/licon';
 import type { TreeNode } from 'lib/tree/types';
-import { bind, hl, type VNode, spinnerVdom as spinner, iconTag } from 'lib/view';
+import { bind, hl, type VNode, spinnerVdom as spinner, icon } from 'lib/view';
 
 import type AnalyseCtrl from '../ctrl';
 import { renderIndexAndMove } from '../view/components';
@@ -14,7 +14,7 @@ const skipOrViewSolution = (ctrl: RetroCtrl): VNode =>
 
 const jumpToNext = (ctrl: RetroCtrl): VNode =>
   hl('a.half.continue', { hook: bind('click', ctrl.jumpToNext) }, [
-    iconTag(licon.PlayTriangle),
+    icon(licon.PlayTriangle)(),
     i18n.site.next,
   ]);
 

--- a/ui/analyse/src/study/analyse.study.tour.ts
+++ b/ui/analyse/src/study/analyse.study.tour.ts
@@ -12,7 +12,7 @@ export function initModule(): StudyTour {
     chapter,
   };
 
-  function iconTag(i: string) {
+  function iconI18nTag(i: string) {
     return `<icon data-icon='${i}'></icon>`;
   }
 
@@ -49,7 +49,7 @@ export function initModule(): StudyTour {
       },
       {
         title: i18n.study.studyMembersTitle,
-        text: i18n.study.studyMembersText(iconTag(licon.Eye), iconTag(licon.User)),
+        text: i18n.study.studyMembersText(iconI18nTag(licon.Eye), iconI18nTag(licon.User)),
         attachTo: { element: '.study__members', on: 'right' },
         when: onTab('members'),
       },
@@ -58,7 +58,7 @@ export function initModule(): StudyTour {
     if (ctrl.study?.members.isOwner()) {
       steps.push({
         title: i18n.study.addMembers,
-        text: i18n.study.addMembersText(iconTag(licon.PlusButton)),
+        text: i18n.study.addMembersText(iconI18nTag(licon.PlusButton)),
         attachTo: { element: '.study__members .add', on: 'right' },
         when: onTab('members'),
       });
@@ -74,7 +74,7 @@ export function initModule(): StudyTour {
     if (ctrl.study?.members.canContribute()) {
       steps.push({
         title: i18n.study.commentPositionTitle,
-        text: i18n.study.commentPositionText(iconTag(licon.BubbleSpeech)),
+        text: i18n.study.commentPositionText(iconI18nTag(licon.BubbleSpeech)),
         attachTo: { element: '.study__buttons .left-buttons .comments', on: 'top' },
       });
       steps.push({
@@ -90,7 +90,7 @@ export function initModule(): StudyTour {
       attachTo: { element: helpButtonSelector, on: 'top' },
       buttons: [
         {
-          text: iconTag(licon.Checkmark),
+          text: iconI18nTag(licon.Checkmark),
           action: tourCtrl.tour.next,
         },
       ],
@@ -155,7 +155,7 @@ export function initModule(): StudyTour {
         text: i18n.study.chapterConclusionText,
         buttons: [
           {
-            text: iconTag(licon.Checkmark),
+            text: iconI18nTag(licon.Checkmark),
             action: tourCtrl.tour.next,
           },
         ],

--- a/ui/analyse/src/study/chapterNewForm.ts
+++ b/ui/analyse/src/study/chapterNewForm.ts
@@ -17,7 +17,7 @@ import {
   spinnerVdom,
   type Dialog,
   type VNode,
-  iconCls,
+  icon,
 } from 'lib/view';
 import { json as xhrJson, text as xhrText } from 'lib/xhr';
 
@@ -299,7 +299,7 @@ export function view(ctrl: StudyChapterNewForm): VNode {
                 {
                   hook: bind('click', () => ctrl.tab('edit'), ctrl.root.redraw),
                 },
-                [iconCls(licon.Eye, 'text'), i18n.study.editor],
+                [icon(licon.Eye)('.text'), i18n.study.editor],
               ),
             ]),
           activeTab === 'pgn' &&

--- a/ui/analyse/src/study/gamebook/gamebookEdit.ts
+++ b/ui/analyse/src/study/gamebook/gamebookEdit.ts
@@ -4,7 +4,7 @@ import { requestIdleCallbackSafe } from 'lib';
 import { throttle } from 'lib/async';
 import { licon } from 'lib/licon';
 import type { Gamebook, TreeNode } from 'lib/tree/types';
-import { iconTag, bind, type MaybeVNodes } from 'lib/view';
+import { bind, type MaybeVNodes, icon } from 'lib/view';
 
 import type AnalyseCtrl from '@/ctrl';
 
@@ -42,7 +42,7 @@ export function render(ctrl: AnalyseCtrl): VNode {
     if (isMyMove)
       content = [
         h('div.legend.todo.clickable', { hook: commentHook, class: { done: isCommented } }, [
-          iconTag(licon.BubbleSpeech),
+          icon(licon.BubbleSpeech)(),
           h('p', 'Help the player find the initial move, with a comment.'),
         ]),
         renderHint(ctrl),
@@ -50,11 +50,11 @@ export function render(ctrl: AnalyseCtrl): VNode {
     else
       content = [
         h('div.legend.clickable', { hook: commentHook }, [
-          iconTag(licon.BubbleSpeech),
+          icon(licon.BubbleSpeech)(),
           h('p', 'Introduce the gamebook with a comment'),
         ]),
         h('div.legend.todo', { class: { done: !!ctrl.node.children[0] } }, [
-          iconTag(licon.PlayTriangle),
+          icon(licon.PlayTriangle)(),
           h('p', "Put the opponent's first move on the board."),
         ]),
       ];
@@ -62,7 +62,7 @@ export function render(ctrl: AnalyseCtrl): VNode {
     if (isMyMove)
       content = [
         h('div.legend.todo.clickable', { hook: commentHook, class: { done: isCommented } }, [
-          iconTag(licon.BubbleSpeech),
+          icon(licon.BubbleSpeech)(),
           h('p', 'Explain the opponent move, and help the player find the next move, with a comment.'),
         ]),
         renderHint(ctrl),
@@ -70,7 +70,7 @@ export function render(ctrl: AnalyseCtrl): VNode {
     else
       content = [
         h('div.legend.clickable', { hook: commentHook }, [
-          iconTag(licon.BubbleSpeech),
+          icon(licon.BubbleSpeech)(),
           h(
             'p',
             "You may reflect on the player's correct move, with a comment; or leave empty to jump immediately to the next move.",
@@ -79,7 +79,7 @@ export function render(ctrl: AnalyseCtrl): VNode {
         hasVariation
           ? null
           : h('div.legend.clickable', { hook: bind('click', ctrl.navigate.prev, ctrl.redraw) }, [
-              iconTag(licon.PlayTriangle),
+              icon(licon.PlayTriangle)(),
               h('p', 'Add variation moves to explain why specific other moves are wrong.'),
             ]),
         renderDeviation(ctrl),
@@ -87,7 +87,7 @@ export function render(ctrl: AnalyseCtrl): VNode {
   } else
     content = [
       h('div.legend.todo.clickable', { hook: commentHook, class: { done: isCommented } }, [
-        iconTag(licon.BubbleSpeech),
+        icon(licon.BubbleSpeech)(),
         h('p', 'Explain why this move is wrong in a comment'),
       ]),
       h('div.legend', [h('p', 'Or promote it as the mainline if it is the right move.')]),
@@ -104,7 +104,7 @@ function renderDeviation(ctrl: AnalyseCtrl): VNode {
   const field = 'deviation';
   return h('div.deviation', [
     h('div.legend.todo', { class: { done: nodeGamebookValue(ctrl.node, field).length > 2 } }, [
-      iconTag(licon.BubbleSpeech),
+      icon(licon.BubbleSpeech)(),
       h('p', 'When any other wrong move is played:'),
     ]),
     h('textarea', {
@@ -116,7 +116,7 @@ function renderDeviation(ctrl: AnalyseCtrl): VNode {
 
 const renderHint = (ctrl: AnalyseCtrl): VNode =>
   h('div.hint', [
-    h('div.legend', [iconTag(licon.InfoCircle), h('p', 'Optional, on-demand hint for the player:')]),
+    h('div.legend', [icon(licon.InfoCircle)(), h('p', 'Optional, on-demand hint for the player:')]),
     h('textarea', {
       attrs: { placeholder: 'Give the player a tip so they can find the right move' },
       hook: textareaHook(ctrl, 'hint'),

--- a/ui/analyse/src/study/gamebook/gamebookPlayView.ts
+++ b/ui/analyse/src/study/gamebook/gamebookPlayView.ts
@@ -1,6 +1,6 @@
 import { licon } from 'lib/licon';
 import { richHTML } from 'lib/richText';
-import { type VNode, iconTag, bind, dataIcon, hl, requiresI18n } from 'lib/view';
+import { type VNode, bind, dataIcon, hl, requiresI18n, icon } from 'lib/view';
 
 import GamebookPlayCtrl, { type State } from './gamebookPlayCtrl';
 
@@ -43,7 +43,7 @@ function renderFeedback(ctrl: GamebookPlayCtrl, state: State) {
     return hl(
       'button.feedback.act.bad' + (state.comment ? '.com' : ''),
       { attrs: { type: 'button' }, hook: bind('click', ctrl.retry) },
-      [iconTag(licon.Reload), hl('span', i18n.site.retry)],
+      [icon(licon.Reload)(), hl('span', i18n.site.retry)],
     );
   if (fb === 'good' && state.comment)
     return hl('button.feedback.act.good.com', { attrs: { type: 'button' }, hook: bind('click', ctrl.next) }, [

--- a/ui/analyse/src/study/studyChapters.ts
+++ b/ui/analyse/src/study/studyChapters.ts
@@ -5,7 +5,7 @@ import type Sortable from 'sortablejs';
 import { blurIfPrimaryClick, defined, prop, type Prop, scrollToInnerSelector } from 'lib';
 import { fenColor } from 'lib/game/chess';
 import { licon } from 'lib/licon';
-import { type VNode, bind, iconTag, hl, alert } from 'lib/view';
+import { type VNode, bind, hl, alert, icon } from 'lib/view';
 
 import type AnalyseCtrl from '../ctrl';
 import type { StudySocketSend } from '../socket';
@@ -222,7 +222,7 @@ export function view(ctrl: StudyCtrl): VNode {
             hl('span', i + 1),
             hl('h3', chapter.name),
             chapter.status && hl('res', chapter.status),
-            canContribute && iconTag(licon.Gear, { title: i18n.study.editChapter, cls: 'act' }),
+            canContribute && icon(licon.Gear)('.act', { title: i18n.study.editChapter }),
           ],
         );
       }),
@@ -240,7 +240,7 @@ export function view(ctrl: StudyCtrl): VNode {
             ctrl.redraw,
           ),
         },
-        [iconTag(licon.PlusButton), hl('h3', i18n.study.addNewChapter)],
+        [icon(licon.PlusButton)(), hl('h3', i18n.study.addNewChapter)],
       ),
   ]);
 }

--- a/ui/analyse/src/study/studyMembers.ts
+++ b/ui/analyse/src/study/studyMembers.ts
@@ -2,7 +2,7 @@ import { prop, type Prop, scrollTo } from 'lib';
 import { licon } from 'lib/licon';
 import { pubsub } from 'lib/pubsub';
 import { once } from 'lib/storage';
-import { type VNode, iconTag, bind, onInsert, dataIcon, bindNonPassive, hl } from 'lib/view';
+import { type VNode, bind, onInsert, dataIcon, bindNonPassive, hl, icon } from 'lib/view';
 import { cmnToggleWrap } from 'lib/view/cmn-toggle';
 import { userLink } from 'lib/view/userLink';
 import { textRaw as xhrTextRaw } from 'lib/xhr';
@@ -149,7 +149,7 @@ export function view(ctrl: StudyCtrl): VNode {
         },
         attrs: { title: i18n.study[contrib ? 'contributor' : 'spectator'] },
       },
-      [iconTag(contrib ? licon.User : licon.Eye)],
+      icon(contrib ? licon.User : licon.Eye)(),
     );
   }
 
@@ -218,7 +218,7 @@ export function view(ctrl: StudyCtrl): VNode {
     isOwner &&
       ordered.length < members.max &&
       hl('button.add', { key: 'add', hook: bind('click', members.inviteForm.toggle) }, [
-        iconTag(licon.PlusButton),
+        icon(licon.PlusButton)(),
         hl('h3', i18n.study.addMembers),
       ]),
     !members.canContribute() &&

--- a/ui/analyse/src/study/studyView.ts
+++ b/ui/analyse/src/study/studyView.ts
@@ -6,7 +6,7 @@ import { renderChat } from 'lib/chat/renderChat';
 import { displayColumns, shareIcon } from 'lib/device';
 import { licon } from 'lib/licon';
 import type { TreeNode, TreePath } from 'lib/tree/types';
-import { type VNode, iconTag, bind, dataIcon, type LooseVNodes, onInsert, hl } from 'lib/view';
+import { type VNode, bind, dataIcon, type LooseVNodes, onInsert, hl, icon } from 'lib/view';
 import { verticalResize } from 'lib/view/verticalResize';
 import { watchers } from 'lib/view/watchers';
 
@@ -271,7 +271,7 @@ function buttons(root: AnalyseCtrl): VNode {
         ctrl,
         tab: 'tags',
         hint: i18n.study.pgnTags,
-        icon: iconTag(licon.Tag),
+        icon: icon(licon.Tag)(),
         shouldBlurIfPrimaryClick: true,
       }),
       canContribute &&
@@ -279,7 +279,7 @@ function buttons(root: AnalyseCtrl): VNode {
           ctrl,
           tab: 'comments',
           hint: i18n.study.commentThisPosition,
-          icon: iconTag(licon.BubbleSpeech),
+          icon: icon(licon.BubbleSpeech)(),
           onClick() {
             ctrl.commentForm.start(ctrl.vm.chapterId, root.path, root.node);
           },
@@ -299,7 +299,7 @@ function buttons(root: AnalyseCtrl): VNode {
           ctrl,
           tab: 'serverEval',
           hint: i18n.site.computerAnalysis,
-          icon: iconTag(licon.BarChart),
+          icon: icon(licon.BarChart)(),
           count: root.data.analysis && '✓',
           shouldBlurIfPrimaryClick: true,
         }),
@@ -307,14 +307,14 @@ function buttons(root: AnalyseCtrl): VNode {
         ctrl,
         tab: 'multiBoard',
         hint: 'Multiboard',
-        icon: iconTag(licon.Multiboard),
+        icon: icon(licon.Multiboard)(),
         shouldBlurIfPrimaryClick: true,
       }),
       toolButton({
         ctrl,
         tab: 'share',
         hint: i18n.study.shareAndExport,
-        icon: iconTag(shareIcon()),
+        icon: icon(shareIcon())(),
         shouldBlurIfPrimaryClick: true,
       }),
       !ctrl.relay &&

--- a/ui/analyse/src/view/clocks.ts
+++ b/ui/analyse/src/view/clocks.ts
@@ -5,7 +5,7 @@ import { plyColor } from 'lib/game';
 import { formatClockTimeVerbal } from 'lib/game/clock/clockView';
 import { licon } from 'lib/licon';
 import type { TreePath } from 'lib/tree/types';
-import { iconTag, type MaybeVNode, type MaybeVNodes } from 'lib/view';
+import { icon, type MaybeVNode, type MaybeVNodes } from 'lib/view';
 
 import type AnalyseCtrl from '../ctrl';
 
@@ -82,8 +82,10 @@ function clockContent(opts: ClockOpts): MaybeVNodes {
       : opts.centis >= 6000
         ? [baseStr]
         : [baseStr, h('tenths', '.' + Math.floor(millis / 100).toString())];
-  const pauseNodes = opts.pause ? [iconTag(licon.Pause)] : [];
-  return [...pauseNodes, ...timeNodes];
+  if (opts.pause) {
+    return [icon(licon.Pause)(), ...timeNodes];
+  }
+  return timeNodes;
 }
 
 const clockContentNvui = (opts: ClockOpts): MaybeVNode =>

--- a/ui/botDev/src/devSideView.ts
+++ b/ui/botDev/src/devSideView.ts
@@ -5,7 +5,7 @@ import { Bot } from 'lib/bot/bot';
 import type { LocalSpeed, LocalSetup } from 'lib/bot/types';
 import { licon, type LiconValue } from 'lib/licon';
 import { storedBooleanProp, storedIntProp } from 'lib/storage';
-import { type VNode, hl, onInsert, bind, domDialog, iconTag, dataIcon } from 'lib/view';
+import { type VNode, hl, onInsert, bind, domDialog, dataIcon, icon } from 'lib/view';
 
 import { domIdToUid, uidToDomId } from './devBotCtrl';
 import { env } from './devEnv';
@@ -100,7 +100,7 @@ function ratingText(uid: string, speed: LocalSpeed): string {
 
 function ratingSpan(p: Bot): VNode {
   const glicko = env.dev.getRating(p.uid, env.game.speed);
-  return hl('span.stats', [iconTag(speedIcon(env.game.speed)), `${glicko.r}${glicko.rd > 80 ? '?' : ''}`]);
+  return hl('span.stats', [icon(speedIcon(env.game.speed))(), `${glicko.r}${glicko.rd > 80 ? '?' : ''}`]);
 }
 
 function speedIcon(speed: LocalSpeed = env.game.speed): LiconValue {

--- a/ui/challenge/src/view.ts
+++ b/ui/challenge/src/view.ts
@@ -2,7 +2,7 @@ import { opposite } from '@lichess-org/chessground/util';
 import { h, type VNode } from 'snabbdom';
 
 import { licon } from 'lib/licon';
-import { spinnerVdom, initMiniBoard, dataIcon, iconCls, onInsert } from 'lib/view';
+import { spinnerVdom, initMiniBoard, dataIcon, onInsert, icon } from 'lib/view';
 import { userLink } from 'lib/view/userLink';
 
 import type ChallengeCtrl from './ctrl';
@@ -57,7 +57,7 @@ function challenge(ctrl: ChallengeCtrl, dir: ChallengeDirection) {
               ),
             ]),
           ]),
-          iconCls(c.perf.icon, 'perf'),
+          icon(c.perf.icon)('.perf'),
         ]),
         fromPosition
           ? h('div.position.mini-board.cg-wrap.is2d', {

--- a/ui/insight/src/chart.ts
+++ b/ui/insight/src/chart.ts
@@ -16,7 +16,7 @@ import { h, type VNode } from 'snabbdom';
 
 import { currentTheme } from 'lib/device';
 import { licon } from 'lib/licon';
-import { iconTag, spinnerHtml } from 'lib/view';
+import { icon, spinnerHtml } from 'lib/view';
 
 import type Ctrl from './ctrl';
 import type { InsightChart, InsightData } from './interfaces';
@@ -178,7 +178,7 @@ function scaleBuilder(d: InsightData): ChartOptions<'bar'>['scales'] {
   };
 }
 function empty(txt: string) {
-  return h('div.chart.empty', [iconTag(licon.Target), txt]);
+  return h('div.chart.empty', [icon(licon.Target)(), txt]);
 }
 
 let chart: InsightChart;

--- a/ui/insight/src/view.ts
+++ b/ui/insight/src/view.ts
@@ -2,7 +2,7 @@ import { thunk } from 'snabbdom';
 
 import { debounce } from 'lib/async';
 import { licon } from 'lib/licon';
-import { bind, dataIcon, hl, iconTag } from 'lib/view';
+import { bind, dataIcon, hl, icon } from 'lib/view';
 
 import axis from './axis';
 import boards from './boards';
@@ -48,7 +48,7 @@ const renderMain = (ctrl: Ctrl, _cacheKey: string | boolean) => {
     return hl('div'); // returning undefined breaks snabbdom's thunks
   } else if (ctrl.vm.broken) {
     return hl('div.broken', [
-      iconTag(licon.DiscBig),
+      icon(licon.DiscBig)(),
       'Insights are unavailable.',
       hl('br'),
       'Please try again later.',

--- a/ui/learn/src/progressView.ts
+++ b/ui/learn/src/progressView.ts
@@ -1,5 +1,5 @@
 import { licon } from 'lib/licon';
-import { a, div, iconTag, span } from 'lib/view';
+import { a, div, icon, span } from 'lib/view';
 
 import { hashHref } from './hashRouting';
 import type { RunCtrl } from './run/runCtrl';
@@ -9,7 +9,7 @@ import type { Level } from './stage/list';
 export function makeStars(level: Level, score: number) {
   const rank = getLevelRank(level, score);
   const stars = [];
-  for (let i = 3; i >= rank; i--) stars.push(iconTag(licon.Star));
+  for (let i = 3; i >= rank; i--) stars.push(icon(licon.Star)());
   return span(`.stars.st${stars.length}`, stars);
 }
 

--- a/ui/learn/src/run/stageComplete.ts
+++ b/ui/learn/src/run/stageComplete.ts
@@ -2,7 +2,7 @@ import { h } from 'snabbdom';
 
 import { numberSpread } from 'lib/i18n';
 import { licon } from 'lib/licon';
-import { bind, iconTag, onInsert } from 'lib/view';
+import { bind, icon, onInsert } from 'lib/view';
 
 import { hashNavigate } from '../hashRouting';
 import { getStageRank } from '../score';
@@ -49,11 +49,11 @@ export default function (ctrl: RunCtrl) {
         next
           ? h('button.button', { hook: bind('click', () => hashNavigate(next.id)) }, [
               i18n.learn.nextX(next.title),
-              iconTag(licon.GreaterThan),
+              icon(licon.GreaterThan)(),
             ])
           : null,
         h(`button.button.button-empty`, { hook: bind('click', () => hashNavigate()) }, [
-          iconTag(licon.LessThan),
+          icon(licon.LessThan)(),
           i18n.learn.backToMenu,
         ]),
       ]),

--- a/ui/learn/src/view.ts
+++ b/ui/learn/src/view.ts
@@ -1,7 +1,7 @@
 import { h, type VNode } from 'snabbdom';
 
 import { licon } from 'lib/licon';
-import { iconTag } from 'lib/view';
+import { icon } from 'lib/view';
 
 import type { LearnCtrl } from './ctrl';
 import { hashHref } from './hashRouting';
@@ -45,7 +45,7 @@ const mapView = (ctrl: LearnCtrl) =>
     ]),
   ]);
 
-const makeStars = (rank: scoring.Rank): VNode[] => Array(4 - rank).fill(iconTag(licon.Star));
+const makeStars = (rank: scoring.Rank): VNode[] => Array(4 - rank).fill(icon(licon.Star)());
 
 const ongoingStr = (ctrl: LearnCtrl, s: Stage): string => {
   const progress = ctrl.stageProgress(s);

--- a/ui/lib/src/ceval/view/main.ts
+++ b/ui/lib/src/ceval/view/main.ts
@@ -14,7 +14,7 @@ import { isTouchDevice } from '@/device';
 import { blurIfPrimaryClick, defined, notNull, requestIdleCallbackSafe } from '@/index';
 import { licon } from '@/licon';
 import type { ClientEval, LocalEval, PvData } from '@/tree/types';
-import { type VNode, type LooseVNode, type LooseVNodes, bind, hl, iconCls } from '@/view';
+import { type VNode, type LooseVNode, type LooseVNodes, bind, hl, icon } from '@/view';
 import { cmnToggle } from '@/view/cmn-toggle';
 import stepwiseScroll from '@/view/stepwiseScroll';
 
@@ -174,7 +174,7 @@ export function renderCeval(ctrl: CevalHandler): VNode[] {
   } else {
     if (!enabled) pearl = h('pearl', h('icon'));
     else if (node.outcome() || node.threefold) pearl = h('pearl', '-');
-    else if (ceval.state === CevalState.Failed) pearl = h('pearl', iconCls(licon.CautionCircle, 'is-red'));
+    else if (ceval.state === CevalState.Failed) pearl = h('pearl', icon(licon.CautionCircle)('.is-red'));
     else pearl = h('pearl', h('icon.ddloader'));
     percent = node.outcome() ? 100 : 0;
   }

--- a/ui/lib/src/view/snabbdom.ts
+++ b/ui/lib/src/view/snabbdom.ts
@@ -68,18 +68,6 @@ export const dataIcon = (icon: LiconValue): Attrs => ({
 
 export const testId = (id: string): Attrs => (site.debug ? { 'data-testid': id } : {});
 
-export const iconTag = (icon: LiconValue, attrs?: Attrs & { cls?: string }): VNode => {
-  let sel = 'icon';
-  if (attrs?.cls) {
-    sel += '.' + attrs.cls;
-    delete attrs.cls;
-  }
-  return snabH(sel, { attrs: { ...attrs, ...dataIcon(icon) } });
-};
-
-export const iconCls = (icon: LiconValue, cls: string): VNode =>
-  snabH('icon.' + cls, { attrs: dataIcon(icon) });
-
 export type LooseVNode = VNodeChildElement | boolean;
 export type LooseVNodes = LooseVNode | LooseVNodes[];
 

--- a/ui/lib/src/view/snabbdomElements.ts
+++ b/ui/lib/src/view/snabbdomElements.ts
@@ -1,5 +1,7 @@
 import { type Attrs, h, type VNode, type VNodeChildren, type VNodeData } from 'snabbdom';
 
+import type { LiconValue } from '@/licon';
+
 type RemoveIndexSignature<T> = {
   [K in keyof T as string extends K ? never : number extends K ? never : symbol extends K ? never : K]: T[K];
 };
@@ -133,3 +135,5 @@ export const strong: TagFunction = makeTag('strong');
 export const img: TagFactory<[src: string, alt: string]> = (src, alt) => makeTag('img', { alt, src });
 export const h1: TagFunction = makeTag('h1');
 export const h2: TagFunction = makeTag('h2');
+
+export const icon: TagFactory<[icon: LiconValue]> = icon => makeExoticTag('icon', { 'data-icon': icon });

--- a/ui/lobby/src/view/setup/components/ratingView.ts
+++ b/ui/lobby/src/view/setup/components/ratingView.ts
@@ -1,6 +1,6 @@
 import { h } from 'snabbdom';
 
-import { dataIcon, iconTag, type MaybeVNode } from 'lib/view';
+import { dataIcon, icon, type MaybeVNode } from 'lib/view';
 
 import type LobbyController from '@/ctrl';
 import { speeds, variants } from '@/options';
@@ -17,7 +17,7 @@ export const ratingView = ({ opts, data, setupCtrl }: LobbyController): MaybeVNo
   return h(
     'div.ratings',
     !opts.showRatings
-      ? [iconTag(perfOrSpeed.icon), perfOrSpeed.name]
+      ? [icon(perfOrSpeed.icon)(), perfOrSpeed.name]
       : [
           ...i18n.site.yourRatingIsX.asArray(
             h(

--- a/ui/msg/src/view/contact.ts
+++ b/ui/msg/src/view/contact.ts
@@ -3,7 +3,7 @@ import { h, type VNode } from 'snabbdom';
 import { hookMobileMousedown } from 'lib/device';
 import { timeago } from 'lib/i18n';
 import { licon } from 'lib/licon';
-import { iconCls } from 'lib/view';
+import { icon } from 'lib/view';
 import type { MaybeVNodes } from 'lib/view/snabbdom';
 import { fullName, userLine } from 'lib/view/userLink';
 
@@ -34,7 +34,7 @@ export default function renderContact(ctrl: MsgCtrl, contact: Contact, active?: 
             { class: { 'msg-app__side__contact__msg--new': isNew } },
             msg.text,
           ),
-          isNew ? iconCls(licon.BellOutline, 'msg-app__side__contact__new') : null,
+          isNew ? icon(licon.BellOutline)('.msg-app__side__contact__new') : null,
         ]),
       ]),
     ],

--- a/ui/notify/src/renderers.ts
+++ b/ui/notify/src/renderers.ts
@@ -2,7 +2,7 @@ import { h, type VNode } from 'snabbdom';
 
 import { timeago } from 'lib/i18n';
 import { licon, type LiconValue } from 'lib/licon';
-import { iconTag } from 'lib/view';
+import { icon } from 'lib/view';
 
 import type { Notification, Renderer, Renderers } from './interfaces';
 
@@ -168,14 +168,14 @@ const jobDone = (name: string): Renderer => ({
   text: n => `${n.content.user!.name}: ${name} job complete!`,
 });
 
-function generic(n: Notification, url: string | undefined, icon: LiconValue, content: VNode[]): VNode {
+function generic(n: Notification, url: string | undefined, licon: LiconValue, content: VNode[]): VNode {
   return h(
     url ? 'a' : 'span',
     {
       class: { site_notification: true, [n.type]: true, new: !n.read },
       attrs: { key: n.date, ...(url ? { href: url } : {}) },
     },
-    [iconTag(icon), h('span.content', content)],
+    [icon(licon)(), h('span.content', content)],
   );
 }
 

--- a/ui/puzzle/src/view/after.ts
+++ b/ui/puzzle/src/view/after.ts
@@ -1,5 +1,5 @@
 import { licon } from 'lib/licon';
-import { type VNode, type MaybeVNodes, bind, hl, iconTag } from 'lib/view';
+import { type VNode, type MaybeVNodes, bind, hl, icon } from 'lib/view';
 
 import type PuzzleCtrl from '../ctrl';
 
@@ -31,7 +31,7 @@ const renderStreak = (ctrl: PuzzleCtrl): MaybeVNodes => [
     hl('span', i18n.puzzle.yourStreakX.asArray(hl('strong', `${ctrl.streak?.data.index ?? 0}`))),
   ]),
   hl('a.continue', { attrs: { href: ctrl.routerWithLang('/streak') } }, [
-    iconTag(licon.PlayTriangle),
+    icon(licon.PlayTriangle)(),
     i18n.puzzle.newStreak,
   ]),
 ];
@@ -47,7 +47,7 @@ export default function (ctrl: PuzzleCtrl): VNode {
       : [
           hl('div.complete', i18n.puzzle[win ? 'puzzleSuccess' : 'puzzleComplete']),
           hl('button.continue', { hook: bind('click', ctrl.nextPuzzle) }, [
-            iconTag(licon.PlayTriangle),
+            icon(licon.PlayTriangle)(),
             i18n.puzzle[ctrl.streak ? 'continueTheStreak' : 'continueTraining'],
           ]),
           hl('div.puzzle__more', [

--- a/ui/puzzle/src/view/theme.ts
+++ b/ui/puzzle/src/view/theme.ts
@@ -1,5 +1,5 @@
 import { licon } from 'lib/licon';
-import { type VNode, type MaybeVNode, bind, hl, type VNodeData, iconTag } from 'lib/view';
+import { type VNode, type MaybeVNode, bind, hl, type VNodeData, icon } from 'lib/view';
 
 import type PuzzleCtrl from '@/ctrl';
 import type { ThemeKey, RoundThemes } from '@/interfaces';
@@ -92,7 +92,7 @@ const editor = (ctrl: PuzzleCtrl): VNode[] => {
             hl(
               'div.puzzle__themes__votes',
               allThemes.static.has(key)
-                ? [hl('div.puzzle__themes__lock', iconTag(licon.Padlock))]
+                ? [hl('div.puzzle__themes__lock', icon(licon.Padlock)())]
                 : [
                     hl('button.puzzle__themes__vote.vote-up', {
                       class: { active: !!votedThemes[key] },

--- a/ui/recap/src/slides.ts
+++ b/ui/recap/src/slides.ts
@@ -4,7 +4,7 @@ import { shuffle } from 'lib/algo';
 import perfIcons from 'lib/game/perfIcons';
 import { currencyFormat, numberFormat, percentFormat } from 'lib/i18n';
 import { licon } from 'lib/licon';
-import { onInsert, hl, type LooseVNodes, type VNode, spinnerVdom, iconCls } from 'lib/view';
+import { onInsert, hl, type LooseVNodes, type VNode, spinnerVdom, icon } from 'lib/view';
 import { fullName, userFlair, userTitle } from 'lib/view/userLink';
 
 import { pieceGrams, totalGames } from './constants';
@@ -317,7 +317,7 @@ export const patron = (opts: Opts): VNode =>
       ),
     ),
     hl('p', i18n.recap.patronCharity),
-    iconCls(licon.Wings, 'text'),
+    icon(licon.Wings)('.text'),
 
     opts.user.patron
       ? hl('p', i18n.patron.thankYou)
@@ -331,7 +331,7 @@ export const patron = (opts: Opts): VNode =>
 
 const renderPerf = (perf: RecapPerf): VNode => {
   return hl('span', [
-    iconCls(perfIcons[perf.key], 'text'),
+    icon(perfIcons[perf.key])('.text'),
     !perfIsSpeed(perf.key)
       ? i18n.variant[perf.key]
       : perf.key !== 'ultraBullet'

--- a/ui/storm/src/view/main.ts
+++ b/ui/storm/src/view/main.ts
@@ -8,7 +8,7 @@ import { getNow } from 'lib/puz/util';
 import { makeConfig as makeCgConfig } from 'lib/puz/view/chessground';
 import renderClock from 'lib/puz/view/clock';
 import { playModifiers, renderCombo } from 'lib/puz/view/util';
-import { onInsert, hl, iconTag } from 'lib/view';
+import { onInsert, hl, icon } from 'lib/view';
 
 import config from '../config';
 import type StormCtrl from '../ctrl';
@@ -87,7 +87,7 @@ const renderStart = () =>
 
 const renderReload = (text: string) =>
   hl('div.storm.storm--reload.box.box-pad', [
-    iconTag(licon.Storm),
+    icon(licon.Storm)(),
     hl('p', text),
     hl('a.storm--dup__reload.button', { attrs: { href: '/storm' } }, i18n.storm.clickToReload),
   ]);

--- a/ui/swiss/src/view/header.ts
+++ b/ui/swiss/src/view/header.ts
@@ -2,7 +2,7 @@ import { h, type Hooks, type VNode } from 'snabbdom';
 
 import { setClockWidget } from 'lib/game/clock/clockWidget';
 import { licon } from 'lib/licon';
-import { iconCls, onInsert } from 'lib/view';
+import { icon, onInsert } from 'lib/view';
 
 import type SwissCtrl from '../ctrl';
 
@@ -36,7 +36,7 @@ function ongoing(ctrl: SwissCtrl): VNode | undefined {
 export default function (ctrl: SwissCtrl): VNode {
   const greatPlayer = ctrl.data.greatPlayer;
   return h('div.swiss__main__header', [
-    iconCls(licon.Trophy, 'img'),
+    icon(licon.Trophy)('.img'),
     h(
       'h1',
       greatPlayer

--- a/ui/swiss/src/view/standing.ts
+++ b/ui/swiss/src/view/standing.ts
@@ -1,7 +1,7 @@
 import { h, type VNode } from 'snabbdom';
 
 import { licon } from 'lib/licon';
-import { bind, iconTag, type MaybeVNodes, onInsert } from 'lib/view';
+import { bind, icon, type MaybeVNodes, onInsert } from 'lib/view';
 
 import type SwissCtrl from '../ctrl';
 import type { Player } from '../interfaces';
@@ -20,8 +20,8 @@ function playerTr(ctrl: SwissCtrl, player: Player) {
       h(
         'td.rank',
         player.absent && ctrl.data.status !== 'finished'
-          ? iconTag(licon.Pause, { title: 'Absent' })
-          : [player.rank],
+          ? icon(licon.Pause)({ title: 'Absent' })
+          : player.rank,
       ),
       h('td.player', renderPlayer(player, false, ctrl.opts.showRatings)),
       h(

--- a/ui/tournament/src/view/arena.ts
+++ b/ui/tournament/src/view/arena.ts
@@ -2,7 +2,7 @@ import { h, type VNode } from 'snabbdom';
 
 import { defined } from 'lib';
 import { licon } from 'lib/licon';
-import { bind, dataIcon, iconTag, type MaybeVNodes } from 'lib/view';
+import { bind, dataIcon, icon, type MaybeVNodes } from 'lib/view';
 import { renderPager, searchButton, searchInput } from 'lib/view/pagination';
 import { userLink } from 'lib/view/userLink';
 import { numberRow } from 'lib/view/util';
@@ -49,7 +49,7 @@ function playerTr(ctrl: TournamentController, player: StandingPlayer) {
       hook: bind('click', _ => ctrl.showPlayerInfo(player), ctrl.redraw),
     },
     [
-      h('td.rank', player.withdraw ? iconTag(licon.Pause, { title: i18n.site.pause }) : player.rank),
+      h('td.rank', player.withdraw ? icon(licon.Pause)({ title: i18n.site.pause }) : player.rank),
       h('td.player', [
         renderPlayer(player, false, ctrl.opts.showRatings, userId === ctrl.data.defender),
         ...(battle && player.team ? [' ', teamName(battle, player.team)] : []),

--- a/ui/tournament/src/view/header.ts
+++ b/ui/tournament/src/view/header.ts
@@ -3,7 +3,7 @@ import { h, type Hooks, type VNode } from 'snabbdom';
 import { setClockWidget } from 'lib/game/clock/clockWidget';
 import perfIcons from 'lib/game/perfIcons';
 import { licon } from 'lib/licon';
-import { dataIcon, iconCls, iconTag } from 'lib/view';
+import { dataIcon, icon } from 'lib/view';
 import { userTitle } from 'lib/view/userLink';
 
 import type TournamentController from '../ctrl';
@@ -52,12 +52,12 @@ function image(d: TournamentData): VNode | undefined {
   if (hasFreq('shield', d) || hasFreq('marathon', d)) return;
   const s = d.spotlight;
   if (s?.iconImg) return h('img.img', { attrs: { src: site.asset.url('images/' + s.iconImg) } });
-  return iconCls(s?.iconFont || licon.Trophy, 'img');
+  return icon(s?.iconFont || licon.Trophy)('.img');
 }
 
 function title(ctrl: TournamentController) {
   const d = ctrl.data;
-  if (hasFreq('marathon', d)) return h('h1', [iconTag(licon.Globe, { cls: 'fire-trophy' }), d.fullName]);
+  if (hasFreq('marathon', d)) return h('h1', [icon(licon.Globe)('.fire-trophy'), d.fullName]);
   if (hasFreq('shield', d))
     return h('h1', [
       h('a.shield-trophy', { attrs: { href: '/tournament/shields' } }, perfIcons[d.perf.key]),

--- a/ui/tournament/src/view/scheduleView.ts
+++ b/ui/tournament/src/view/scheduleView.ts
@@ -3,7 +3,7 @@ import { type Classes, h, type VNode } from 'snabbdom';
 
 import perfIcons from 'lib/game/perfIcons';
 import { licon } from 'lib/licon';
-import { dataIcon, iconTag } from 'lib/view';
+import { dataIcon, icon } from 'lib/view';
 
 import type { Tournament, Clock } from '../interfaces';
 import type { Ctrl, Lane } from '../tournament.schedule';
@@ -174,7 +174,7 @@ function renderTournament(tour: Tournament) {
       },
     },
     [
-      iconTag(iconOf(tour)),
+      icon(iconOf(tour))(),
       h('span.body', [
         h('span.name', i18nName(tour)),
         h('span.infos', [

--- a/ui/tournament/src/view/table.ts
+++ b/ui/tournament/src/view/table.ts
@@ -1,7 +1,7 @@
 import { opposite } from '@lichess-org/chessground/util';
 
 import { licon } from 'lib/licon';
-import { type VNode, bind, onInsert, hl, initMiniGames, iconTag } from 'lib/view';
+import { type VNode, bind, onInsert, hl, initMiniGames, icon } from 'lib/view';
 
 import type TournamentController from '../ctrl';
 import type { Duel, DuelPlayer, FeaturedGame, TournamentOpts } from '../interfaces';
@@ -14,7 +14,7 @@ function featuredPlayer(game: FeaturedGame, color: Color, opts: TournamentOpts) 
     hl('span.mini-game__user', [
       hl('strong', '#' + player.rank),
       renderPlayer(player, true, opts.showRatings, false),
-      player.berserk && iconTag(licon.Berserk, { cls: 'berserk', title: 'Berserk' }),
+      player.berserk && icon(licon.Berserk)('.berserk', { title: 'Berserk' }),
     ]),
     game.c
       ? hl(`span.mini-game__clock.mini-game__clock--${color}`, {


### PR DESCRIPTION
# Why

Since the PR introducing a new pattern for Snabbdom element helpers landed, let's clean up some previous attempts with icons.

# How

Replace `iconCls` and `iconTag` helper with common `icon` custom Snabbdom element.
