### PR TITLE
ui: add `optgroup` tag, replace per module helpers

### DIFF
--- a/ui/editor/src/view.ts
+++ b/ui/editor/src/view.ts
@@ -8,7 +8,7 @@ import { h, type VNode } from 'snabbdom';
 
 import { fenToEpd } from 'lib/game/chess';
 import { licon, type LiconValue } from 'lib/licon';
-import { copyMeInput, dataIcon, domDialog, enter } from 'lib/view';
+import { copyMeInput, dataIcon, domDialog, enter, optgroup } from 'lib/view';
 import { url as xhrUrl } from 'lib/xhr';
 
 import { fenToChess960Id, isValidPositionId } from './chess960';
@@ -31,10 +31,6 @@ function castleCheckBox(ctrl: EditorCtrl, id: CastlingToggle, label: string, rev
     },
   });
   return h('label', reversed ? [input, label] : [label, input]);
-}
-
-function optgroup(name: string, opts: VNode[]): VNode {
-  return h('optgroup', { attrs: { label: name } }, opts);
 }
 
 function studyButton(ctrl: EditorCtrl, state: EditorState): VNode {
@@ -249,8 +245,8 @@ function controls(ctrl: EditorCtrl, state: EditorState): VNode {
               },
               [
                 h('option', { attrs: { value: '' } }, i18n.site.setTheBoard),
-                optgroup(i18n.site.popularOpenings, ctrl.cfg.positions.map(positionOption)),
-                optgroup(i18n.site.endgamePositions, ctrl.cfg.endgamePositions.map(endgamePosition2option)),
+                optgroup(i18n.site.popularOpenings)(ctrl.cfg.positions.map(positionOption)),
+                optgroup(i18n.site.endgamePositions)(ctrl.cfg.endgamePositions.map(endgamePosition2option)),
               ],
             );
           })(),

--- a/ui/insight/src/axis.ts
+++ b/ui/insight/src/axis.ts
@@ -1,9 +1,9 @@
 import { h, type VNodeData } from 'snabbdom';
 
-import type { MaybeVNode } from 'lib/view';
+import { optgroup } from 'lib/view';
 
 import type Ctrl from './ctrl';
-import type { Categ, Dimension, Metric } from './interfaces';
+import type { Dimension, Metric } from './interfaces';
 
 const selectData = (onClick: (v: { value: string }) => void, getValue: () => string): VNodeData => ({
   hook: {
@@ -11,11 +11,6 @@ const selectData = (onClick: (v: { value: string }) => void, getValue: () => str
     update: vnode => $(vnode.elm).multipleSelect('setSelects', [getValue()]),
   },
 });
-
-const optgroup =
-  <T>(callback: (item: T) => MaybeVNode) =>
-  (categ: Categ<T>) =>
-    h('optgroup', { attrs: { label: categ.name } }, categ.items.map(callback));
 
 const option = (ctrl: Ctrl, item: Metric | Dimension, axis: 'metric' | 'dimension') =>
   h(
@@ -43,7 +38,9 @@ export default function (ctrl: Ctrl, attrs: VNodeData | null = null) {
         v => ctrl.setMetric(v.value),
         () => ctrl.vm.metric.key,
       ),
-      ctrl.ui.metricCategs.map(optgroup(y => option(ctrl, y, 'metric'))),
+      ctrl.ui.metricCategs.map(categ =>
+        optgroup(categ.name)(categ.items.map(item => option(ctrl, item, 'metric'))),
+      ),
     ),
     h('span.by', 'by'),
     h(
@@ -52,8 +49,10 @@ export default function (ctrl: Ctrl, attrs: VNodeData | null = null) {
         v => ctrl.setDimension(v.value),
         () => ctrl.vm.dimension.key,
       ),
-      ctrl.ui.dimensionCategs.map(
-        optgroup(x => (x.key !== 'period' ? option(ctrl, x, 'dimension') : undefined)),
+      ctrl.ui.dimensionCategs.map(categ =>
+        optgroup(categ.name)(
+          categ.items.map(item => (item.key !== 'period' ? option(ctrl, item, 'dimension') : undefined)),
+        ),
       ),
     ),
   ]);

--- a/ui/lib/src/view/snabbdomElements.ts
+++ b/ui/lib/src/view/snabbdomElements.ts
@@ -128,12 +128,14 @@ export function makeExoticTag(tag: string, defaultData?: VNodeDataExtended): Tag
 
 export const div: TagFunction = makeTag('div');
 export const p: TagFunction = makeTag('p');
-export const a: TagFactory<[href: string]> = href => makeTag('a', { href });
 export const button: TagFunction = makeTag('button');
 export const span: TagFunction = makeTag('span');
 export const strong: TagFunction = makeTag('strong');
-export const img: TagFactory<[src: string, alt: string]> = (src, alt) => makeTag('img', { alt, src });
 export const h1: TagFunction = makeTag('h1');
 export const h2: TagFunction = makeTag('h2');
+
+export const a: TagFactory<[href: string]> = href => makeTag('a', { href });
+export const img: TagFactory<[src: string, alt: string]> = (src, alt) => makeTag('img', { alt, src });
+export const optgroup: TagFactory<[label: string]> = label => makeTag('optgroup', { label });
 
 export const icon: TagFactory<[icon: LiconValue]> = icon => makeExoticTag('icon', { 'data-icon': icon });


### PR DESCRIPTION
# Why

Spotted that two modules uses their own `optgroup` helpers.

# How

Add `optgroup` tag function, replace per module helpers.

# Preview

<img width="638" height="546" alt="Screenshot 2026-07-25 at 09 28 34" src="https://github.com/user-attachments/assets/40b13455-92c3-41e5-866d-a4c6141460da" />
