### PR TITLE
ui: allow nested children arrays in tag helpers

### DIFF
--- a/ui/lib/src/view/snabbdomElements.ts
+++ b/ui/lib/src/view/snabbdomElements.ts
@@ -1,4 +1,11 @@
-import { type Attrs, h, type VNode, type VNodeChildren, type VNodeData } from 'snabbdom';
+import {
+  type Attrs,
+  h,
+  type VNode,
+  type VNodeChildElement,
+  type VNodeChildren,
+  type VNodeData,
+} from 'snabbdom';
 
 import type { LiconValue } from '@/licon';
 
@@ -7,6 +14,7 @@ type RemoveIndexSignature<T> = {
 };
 type StrictVNodeData = RemoveIndexSignature<VNodeData>;
 type VNodeDataExtended = StrictVNodeData & Record<string, unknown>;
+type NestedVNodeChildren = VNodeChildElement | NestedVNodeChildren[];
 
 type Selector = `.${string}` | `#${string}` | `[${string}`;
 type TagData = VNodeDataExtended | null;
@@ -14,11 +22,11 @@ type TagFunction = {
   (): VNode;
   (selector: Selector): VNode;
   (data: TagData): VNode;
-  (children: VNodeChildren): VNode;
+  (children: NestedVNodeChildren): VNode;
   (selector: Selector, data: TagData): VNode;
-  (selector: Selector, children: VNodeChildren): VNode;
-  (selector: Selector, data: TagData, children: VNodeChildren): VNode;
-  (data: TagData, children: VNodeChildren): VNode;
+  (selector: Selector, children: NestedVNodeChildren): VNode;
+  (selector: Selector, data: TagData, children: NestedVNodeChildren): VNode;
+  (data: TagData, children: NestedVNodeChildren): VNode;
 };
 type TagFactory<Args extends unknown[]> = (...args: Args) => TagFunction;
 
@@ -36,6 +44,8 @@ const VNODE_DATA_KEYS = new Set<keyof StrictVNodeData>([
   'fn',
   'args',
 ]);
+
+const MAX_CHILDREN_NEST_LEVEL = 5;
 
 function movePropsToAttrs(data: TagData): VNodeData | null {
   if (data == null) return null;
@@ -81,7 +91,10 @@ function isSelector(value: unknown): value is Selector {
   );
 }
 
-function normalizeArgs(a?: TagData | VNodeChildren, b?: VNodeChildren): [TagData, VNodeChildren] {
+function normalizeArgs(
+  a?: TagData | NestedVNodeChildren,
+  b?: NestedVNodeChildren,
+): [TagData, NestedVNodeChildren] {
   if (b !== undefined) {
     if (!isVNodeData(a) && a !== null) {
       throw new TypeError(
@@ -106,21 +119,25 @@ export function makeExoticTag(tag: string, defaultData?: VNodeDataExtended): Tag
   function tagFn(): VNode;
   function tagFn(selector: Selector): VNode;
   function tagFn(data: TagData): VNode;
-  function tagFn(children: VNodeChildren): VNode;
+  function tagFn(children: NestedVNodeChildren): VNode;
   function tagFn(selector: Selector, data: TagData): VNode;
-  function tagFn(selector: Selector, children: VNodeChildren): VNode;
-  function tagFn(selector: Selector, data: TagData, children: VNodeChildren): VNode;
-  function tagFn(data: TagData, children: VNodeChildren): VNode;
+  function tagFn(selector: Selector, children: NestedVNodeChildren): VNode;
+  function tagFn(selector: Selector, data: TagData, children: NestedVNodeChildren): VNode;
+  function tagFn(data: TagData, children: NestedVNodeChildren): VNode;
   function tagFn(
-    a?: Selector | TagData | VNodeChildren,
-    b?: TagData | VNodeChildren,
-    c?: VNodeChildren,
+    a?: Selector | TagData | NestedVNodeChildren,
+    b?: TagData | NestedVNodeChildren,
+    c?: NestedVNodeChildren,
   ): VNode {
     const [sel, data, children] = isSelector(a)
       ? [`${tag}${a}`, ...normalizeArgs(b, c)]
-      : [tag, ...normalizeArgs(a, b as VNodeChildren)];
+      : [tag, ...normalizeArgs(a, b as NestedVNodeChildren)];
 
-    return h(sel, movePropsToAttrs({ ...defaultData, ...data }), children);
+    return h(
+      sel,
+      movePropsToAttrs({ ...defaultData, ...data }),
+      Array.isArray(children) ? (children.flat(MAX_CHILDREN_NEST_LEVEL) as VNodeChildren) : children,
+    );
   }
 
   return tagFn;


### PR DESCRIPTION
# Why

To mimic `hl` feature, and to allow less constrained construction on of Snabbdom views, let's add a children flattening to the custom tag helpers.

# How

Adjust the typings, check if children are an array, if so call `.flat()` on it. Since TS complains about `.flat(Infinity)` I had to introduce the reasonable limit of nesting, which has been set to `5`, but can be changed to anything we deem fitting.

# Test plan

Tested the change locally, on artificially altered nodes in one of migrated already views. Then confirmed that DOM looks as expected, and TS is happy.

<img width="839" height="211" alt="Screenshot 2026-07-25 at 10 22 47" src="https://github.com/user-attachments/assets/565b1e07-3adc-44ff-b25d-7f17560b8911" />
