### PR TITLE
Rated/casual buttons not highlighted in green after mobile press

### DIFF
--- a/ui/lib/css/abstract/_extends.scss
+++ b/ui/lib/css/abstract/_extends.scss
@@ -133,6 +133,7 @@
 
   &:not(.disabled):hover {
     @extend %active-inset-shadow;
+
     @media (hover: hover) {
       background: hsl(from $c-accent h s calc(l + 5));
     }

--- a/ui/lib/css/abstract/_extends.scss
+++ b/ui/lib/css/abstract/_extends.scss
@@ -133,8 +133,9 @@
 
   &:not(.disabled):hover {
     @extend %active-inset-shadow;
-
-    background: hsl(from $c-accent h s calc(l + 5));
+    @media (hover: hover) {
+      background: hsl(from $c-accent h s calc(l + 5));
+    }
   }
 }
 

--- a/ui/lobby/css/_setup.scss
+++ b/ui/lobby/css/_setup.scss
@@ -100,8 +100,10 @@ $c-slider: $c-setup;
   group.radio input:checked + label {
     background: $c-setup;
 
-    &:hover {
-      background: hsl(from $c-secondary h s calc(l + 5));
+    @media (hover: hover) {
+      &:hover {
+        background: hsl(from $c-secondary h s calc(l + 5));
+      }
     }
   }
 


### PR DESCRIPTION
In this use case:

- On phone (for me, iPhone 8 ios 16.7.15, safari & chrome), open the form to make a lobby challenge.
- Tap on rated/casual.
- You should notice it doesn't get highlighted green until you tap somewhere else.

Bug appears to have been introduced in #20848.