### PR TITLE
ui: change <h3> to <p> on bots page for better visuals and readability

### DIFF
--- a/modules/user/src/main/ui/UserList.scala
+++ b/modules/user/src/main/ui/UserList.scala
@@ -146,14 +146,14 @@ final class UserList(helpers: Helpers, bits: UserBits):
           div(cls := "bots page-menu__content")(
             div(cls := "box box-pad bots__categ")(
               boxTop(h1("Featured bots")),
-              h3("Try playing these innovative chess engines! These are our favourites."),
+              p("Try playing these innovative chess engines! These are our favourites."),
               div(cls := "bots__featured")(
                 botGrid(featured, bestPerfs)
               )
             ),
             div(cls := "box box-pad bots__categ")(
               boxTop(h1("Community bots"), aboutLink),
-              h3(
+              p(
                 "More chess engines created by the Lichess community. They are hosted by their creators, and as such might not always be online."
               ),
               botGrid(community, bestPerfs)

--- a/ui/user/css/_list-bot.scss
+++ b/ui/user/css/_list-bot.scss
@@ -12,7 +12,7 @@
       padding-bottom: 0.5em;
     }
 
-    h3 {
+    p {
       margin-bottom: 2em;
     }
   }


### PR DESCRIPTION
Updated text markup on the `/player/bots` page, mainly because the text of which appeared quite thin (esp. in the transparent theme) making it harder to read.

This looks better and is more readable, while also being more semantically appropriate (as it jumped from `<h1>` to `<h3>`, and arguably was `<p>`aragraph text anyway).

| Theme | Before | After |
|--------|--------|--------|
| Dark | <img width="3838" height="1871" alt="before-dark" src="https://github.com/user-attachments/assets/52fc3df3-b98e-4610-ab48-d36d9036bd2b" /> | <img width="3839" height="1875" alt="after-dark" src="https://github.com/user-attachments/assets/784c8fc4-b661-4fbd-b00b-cad2516f9b16" /> |
| Light | <img width="3839" height="1879" alt="before-light" src="https://github.com/user-attachments/assets/a6f3c37b-7275-4db4-a8e9-cf73ba5a9fe8" /> | <img width="3838" height="1881" alt="after-light" src="https://github.com/user-attachments/assets/b4603cf2-1aa8-489b-812f-2482fe0d1bd8" /> |
| Transparent | <img width="3839" height="1882" alt="before-transparent" src="https://github.com/user-attachments/assets/992c3498-6133-48c8-b95f-870287d56029" /> | <img width="3838" height="1878" alt="after-transparent" src="https://github.com/user-attachments/assets/5e6920ac-6615-4a04-b76f-bd3e76e8262d" /> |