### PR TITLE
ui: bump `pgn-viewer`, update styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@lichess-org/chessground": "^10.1.1",
-    "@lichess-org/pgn-viewer": "^2.6.1",
+    "@lichess-org/pgn-viewer": "^2.6.2",
     "@playwright/test": "^1.60.0",
     "@types/lichess": "workspace:*",
     "@types/node": "^24.13.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^10.1.1
         version: 10.1.1
       '@lichess-org/pgn-viewer':
-        specifier: ^2.6.1
-        version: 2.6.1
+        specifier: ^2.6.2
+        version: 2.6.2
       '@playwright/test':
         specifier: ^1.60.0
         version: 1.60.0
@@ -34,7 +34,7 @@ importers:
         version: 0.15.1
       jsdom:
         specifier: ^27.4.0
-        version: 27.4.0
+        version: 27.4.0(supports-color@10.2.2)
       lint-staged:
         specifier: ^16.4.0
         version: 16.4.0
@@ -52,13 +52,13 @@ importers:
         version: 3.5.1
       stylelint:
         specifier: ^17.11.1
-        version: 17.13.0(typescript@6.0.3)
+        version: 17.13.0(supports-color@10.2.2)(typescript@6.0.3)
       stylelint-config-standard-scss:
         specifier: ^17.0.0
-        version: 17.0.0(postcss@8.5.15)(stylelint@17.13.0(typescript@6.0.3))
+        version: 17.0.0(postcss@8.5.15)(stylelint@17.13.0(supports-color@10.2.2)(typescript@6.0.3))
       stylelint-scss:
         specifier: ^7.1.1
-        version: 7.2.0(stylelint@17.13.0(typescript@6.0.3))
+        version: 7.2.0(stylelint@17.13.0(supports-color@10.2.2)(typescript@6.0.3))
       svgo:
         specifier: ^4.0.2
         version: 4.0.2
@@ -892,8 +892,8 @@ packages:
   '@lichess-org/chessground@10.1.1':
     resolution: {integrity: sha512-IBEs8+J64/zE8QB4NXxsvpjm/tHRjfQAdWwUh4xzqqN+RValgthWHemLnxsmtHFwuxvO4lHd+crp1ecgZxKVoQ==}
 
-  '@lichess-org/pgn-viewer@2.6.1':
-    resolution: {integrity: sha512-LUgSeICEC5M62B01PMMYgOBybjcHCOKei4vD6dbiCFro8Bp1O4Q/vdvVn7OxiGZIpAVsvRaBZMZOv7iHz/N+uA==}
+  '@lichess-org/pgn-viewer@2.6.2':
+    resolution: {integrity: sha512-QZNKVarNiuEkRGf8pM1upN9x0bMxOMeZBxYkYTBLOn7GknGNgxLhMYMQnSIS3CjOJKApv6dvXW+0VvMgnFP9lA==}
 
   '@lichess-org/stockfish-web@0.4.2':
     resolution: {integrity: sha512-qVboc1DNDNRg/ZTu5YlgiiWmxyVZcF4u2nkx0rNzQvh/y/LiH4qz4+aG4mLoSyVWt8u39JdmzIyJFn8wJ2IXNw==}
@@ -2537,7 +2537,7 @@ snapshots:
 
   '@lichess-org/chessground@10.1.1': {}
 
-  '@lichess-org/pgn-viewer@2.6.1':
+  '@lichess-org/pgn-viewer@2.6.2':
     dependencies:
       '@lichess-org/chessground': 10.1.1
       chessops: 0.15.1
@@ -2920,9 +2920,11 @@ snapshots:
 
   debounce-promise@3.1.2: {}
 
-  debug@4.4.3:
+  debug@4.4.3(supports-color@10.2.2):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 10.2.2
 
   decamelize@1.2.0: {}
 
@@ -3134,17 +3136,17 @@ snapshots:
       domutils: 3.2.2
       entities: 7.0.1
 
-  http-proxy-agent@7.0.2:
+  http-proxy-agent@7.0.2(supports-color@10.2.2):
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
-  https-proxy-agent@7.0.6:
+  https-proxy-agent@7.0.6(supports-color@10.2.2):
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -3195,7 +3197,7 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  jsdom@27.4.0:
+  jsdom@27.4.0(supports-color@10.2.2):
     dependencies:
       '@acemir/cssom': 0.9.31
       '@asamuzakjp/dom-selector': 6.8.1
@@ -3204,8 +3206,8 @@ snapshots:
       data-urls: 6.0.1
       decimal.js: 10.6.0
       html-encoding-sniffer: 6.0.0
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
+      http-proxy-agent: 7.0.2(supports-color@10.2.2)
+      https-proxy-agent: 7.0.6(supports-color@10.2.2)
       is-potential-custom-element-name: 1.0.1
       parse5: 8.0.1
       saxes: 6.0.0
@@ -3631,33 +3633,33 @@ snapshots:
 
   strnum@2.3.0: {}
 
-  stylelint-config-recommended-scss@17.0.1(postcss@8.5.15)(stylelint@17.13.0(typescript@6.0.3)):
+  stylelint-config-recommended-scss@17.0.1(postcss@8.5.15)(stylelint@17.13.0(supports-color@10.2.2)(typescript@6.0.3)):
     dependencies:
       postcss-scss: 4.0.9(postcss@8.5.15)
-      stylelint: 17.13.0(typescript@6.0.3)
-      stylelint-config-recommended: 18.0.0(stylelint@17.13.0(typescript@6.0.3))
-      stylelint-scss: 7.2.0(stylelint@17.13.0(typescript@6.0.3))
+      stylelint: 17.13.0(supports-color@10.2.2)(typescript@6.0.3)
+      stylelint-config-recommended: 18.0.0(stylelint@17.13.0(supports-color@10.2.2)(typescript@6.0.3))
+      stylelint-scss: 7.2.0(stylelint@17.13.0(supports-color@10.2.2)(typescript@6.0.3))
     optionalDependencies:
       postcss: 8.5.15
 
-  stylelint-config-recommended@18.0.0(stylelint@17.13.0(typescript@6.0.3)):
+  stylelint-config-recommended@18.0.0(stylelint@17.13.0(supports-color@10.2.2)(typescript@6.0.3)):
     dependencies:
-      stylelint: 17.13.0(typescript@6.0.3)
+      stylelint: 17.13.0(supports-color@10.2.2)(typescript@6.0.3)
 
-  stylelint-config-standard-scss@17.0.0(postcss@8.5.15)(stylelint@17.13.0(typescript@6.0.3)):
+  stylelint-config-standard-scss@17.0.0(postcss@8.5.15)(stylelint@17.13.0(supports-color@10.2.2)(typescript@6.0.3)):
     dependencies:
-      stylelint: 17.13.0(typescript@6.0.3)
-      stylelint-config-recommended-scss: 17.0.1(postcss@8.5.15)(stylelint@17.13.0(typescript@6.0.3))
-      stylelint-config-standard: 40.0.0(stylelint@17.13.0(typescript@6.0.3))
+      stylelint: 17.13.0(supports-color@10.2.2)(typescript@6.0.3)
+      stylelint-config-recommended-scss: 17.0.1(postcss@8.5.15)(stylelint@17.13.0(supports-color@10.2.2)(typescript@6.0.3))
+      stylelint-config-standard: 40.0.0(stylelint@17.13.0(supports-color@10.2.2)(typescript@6.0.3))
     optionalDependencies:
       postcss: 8.5.15
 
-  stylelint-config-standard@40.0.0(stylelint@17.13.0(typescript@6.0.3)):
+  stylelint-config-standard@40.0.0(stylelint@17.13.0(supports-color@10.2.2)(typescript@6.0.3)):
     dependencies:
-      stylelint: 17.13.0(typescript@6.0.3)
-      stylelint-config-recommended: 18.0.0(stylelint@17.13.0(typescript@6.0.3))
+      stylelint: 17.13.0(supports-color@10.2.2)(typescript@6.0.3)
+      stylelint-config-recommended: 18.0.0(stylelint@17.13.0(supports-color@10.2.2)(typescript@6.0.3))
 
-  stylelint-scss@7.2.0(stylelint@17.13.0(typescript@6.0.3)):
+  stylelint-scss@7.2.0(stylelint@17.13.0(supports-color@10.2.2)(typescript@6.0.3)):
     dependencies:
       '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
@@ -3670,9 +3672,9 @@ snapshots:
       postcss-resolve-nested-selector: 0.1.6
       postcss-selector-parser: 7.1.2
       postcss-value-parser: 4.2.0
-      stylelint: 17.13.0(typescript@6.0.3)
+      stylelint: 17.13.0(supports-color@10.2.2)(typescript@6.0.3)
 
-  stylelint@17.13.0(typescript@6.0.3):
+  stylelint@17.13.0(supports-color@10.2.2)(typescript@6.0.3):
     dependencies:
       '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
@@ -3685,7 +3687,7 @@ snapshots:
       cosmiconfig: 9.0.2(typescript@6.0.3)
       css-functions-list: 3.3.3
       css-tree: 3.2.1
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       fast-glob: 3.3.3
       fastest-levenshtein: 1.0.16
       file-entry-cache: 11.1.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -26,5 +26,5 @@ patchedDependencies:
   '@toast-ui/editor@3.2.2': ui/bits/patches/@toast-ui__editor.patch
 minimumReleaseAgeExclude:
   - '@lichess-org/stockfish-web@0.4.0 || 0.4.2'
-  - '@lichess-org/pgn-viewer@2.6.1'
+  - '@lichess-org/pgn-viewer@2.6.1 || 2.6.2'
   - chessops@0.15.1

--- a/ui/lib/css/component/_pgn-viewer.scss
+++ b/ui/lib/css/component/_pgn-viewer.scss
@@ -33,9 +33,24 @@
   --c-lpv-bg-good-hover: #{color-mix(in oklab, $c-good 30%, $c-bg)};
   --c-lpv-bg-brilliant-hover: #{color-mix(in oklab, $c-brilliant 30%, $c-bg)};
   --c-lpv-bg-interesting-hover: #{color-mix(in oklab, $c-interesting 30%, $c-bg)};
+  --c-lpv-bg-inaccuracy-current: #{color-mix(in oklab, $c-inaccuracy 50%, $c-bg)};
+  --c-lpv-bg-mistake-current: #{color-mix(in oklab, $c-mistake 50%, $c-bg)};
+  --c-lpv-bg-blunder-current: #{color-mix(in oklab, $c-blunder 50%, $c-bg)};
+  --c-lpv-bg-good-current: #{color-mix(in oklab, $c-good 50%, $c-bg)};
+  --c-lpv-bg-brilliant-current: #{color-mix(in oklab, $c-brilliant 50%, $c-bg)};
+  --c-lpv-bg-interesting-current: #{color-mix(in oklab, $c-interesting 50%, $c-bg)};
 
   @include if-transp {
     --c-lpv-bg-pane: #{rgb(from $c-body-gradient r g b / calc(alpha * 0.85))};
+  }
+
+  @include if-light {
+    --c-lpv-bg-inaccuracy-current: #{color-mix(in oklab, $c-inaccuracy 70%, $c-bg)};
+    --c-lpv-bg-mistake-current: #{color-mix(in oklab, $c-mistake 70%, $c-bg)};
+    --c-lpv-bg-blunder-current: #{color-mix(in oklab, $c-blunder 70%, $c-bg)};
+    --c-lpv-bg-good-current: #{color-mix(in oklab, $c-good 70%, $c-bg)};
+    --c-lpv-bg-brilliant-current: #{color-mix(in oklab, $c-brilliant 70%, $c-bg)};
+    --c-lpv-bg-interesting-current: #{color-mix(in oklab, $c-interesting 70%, $c-bg)};
   }
 
   @extend %box-neat-force;


### PR DESCRIPTION
# Why

Update `pgn-viewer` to address the readability issues with moves with type assigned.

<img width="472" height="268" alt="Screenshot 2026-07-25 at 11 45 36" src="https://github.com/user-attachments/assets/df0a70e0-55fe-4660-a116-6022aa853159" />
<img width="481" height="177" alt="Screenshot 2026-07-25 at 11 50 10" src="https://github.com/user-attachments/assets/d17257d6-c624-46b2-b699-687aa1b66f34" />
<img width="477" height="194" alt="Screenshot 2026-07-25 at 12 24 35" src="https://github.com/user-attachments/assets/6d0e8c0f-e5d8-4e71-b33b-f8f787fb1bfc" />
<img width="477" height="194" alt="Screenshot 2026-07-25 at 12 24 40" src="https://github.com/user-attachments/assets/38f38098-01b7-4dba-b018-6cc84af83e93" />


# How

Bump `pgn-viewer` to the latest release, update related styles, adjust contrast for light theme.

# Preview

<img width="477" height="194" alt="Screenshot 2026-07-25 at 12 07 36" src="https://github.com/user-attachments/assets/596e6914-8680-4cb5-9935-18b7c0ba2a15" />
<img width="477" height="194" alt="Screenshot 2026-07-25 at 12 07 32" src="https://github.com/user-attachments/assets/eabe47c6-2dc8-4774-9a7c-77aec53e034d" />
<img width="477" height="194" alt="Screenshot 2026-07-25 at 12 20 47" src="https://github.com/user-attachments/assets/e5f66c71-be13-4645-b2de-56034e172820" />
<img width="477" height="194" alt="Screenshot 2026-07-25 at 12 20 40" src="https://github.com/user-attachments/assets/d10fc8ce-aadd-4201-9709-b68220650a38" />
