### PR TITLE
Fix overlap of voice input bar and material difference display

### DIFF
--- a/ui/round/css/_app-layout.scss
+++ b/ui/round/css/_app-layout.scss
@@ -114,7 +114,7 @@
       'board .'
       'kb-move .';
     grid-template-columns: var(---col2-uniboard-width) $col2-uniboard-table;
-    grid-template-rows: min-content auto;
+    grid-template-rows: minmax(0, 1fr) 0 repeat(10, auto) minmax(0, 1fr);
     column-gap: $block-gap;
 
     &__table {

--- a/ui/round/css/_app-layout.scss
+++ b/ui/round/css/_app-layout.scss
@@ -114,7 +114,7 @@
       'board .'
       'kb-move .';
     grid-template-columns: var(---col2-uniboard-width) $col2-uniboard-table;
-    grid-template-rows: 0 auto; // 0 to prevent `voice` from moving the table off center
+    grid-template-rows: min-content auto;
     column-gap: $block-gap;
 
     &__table {

--- a/ui/round/css/_app-layout.scss
+++ b/ui/round/css/_app-layout.scss
@@ -121,6 +121,10 @@
       grid-area: 5 / 2 / 11 / 3;
     }
 
+    #voice-bar {
+      margin-block-end: 2px;
+    }
+
     .expiration-top {
       display: flex;
       z-index: 1;

--- a/ui/round/css/_zh.scss
+++ b/ui/round/css/_zh.scss
@@ -30,6 +30,18 @@
   }
 }
 
+.round__app:has(#voice-bar) {
+  @include mq-at-least-col2 {
+    .pocket-top {
+      margin-bottom: 2px;
+    }
+
+    .pocket-bottom {
+      margin-top: 2px;
+    }
+  }
+}
+
 @include mq-at-least-col2 {
   @media (min-height: at-least($short)) {
     #{$moves-tag} {


### PR DESCRIPTION
### Why the change is needed:
The voice input bar overlaps the material difference display and crazyhouse pockets. For example, in a crazyhouse game:
<img width="1053" height="634" alt="overlap_crazyhouse" src="https://github.com/user-attachments/assets/18eafff4-bb8f-497a-a5df-2e40bcdaa2d9" />

<strong>Note: </strong> Since starting this PR, some changes on master moved the voice bar up, fixing most of the originally linked problems. However, that change introduced a new problem with the voice bar overlapping crazyhouse pockets. This PR description keeps the original issue's language for continuity with the original issue.

### Link to issue:
Closes #21034

### Solution:
Move the voice input bar up and size the voice bar row with flexible spacers

### Testing:
Built locally
Before: voice input and material difference and crazyhouse pockets overlapped 
After: voice input and material difference and crazyhouse pockets did not overlap

### AI assistance:
This change was made with AI assistance (Claude Code, Anthropic).
Prompt: "Investigate the cause of issue 21034 and fix it, then write the PR content."
Some AI generated outputs have been modified. The bug was reproduced before modifying code and the fix was verified afterward.

### Pictures:
#### Voice input bar on (crazyhouse)
<img width="1050" height="635" alt="on_crazyhouse" src="https://github.com/user-attachments/assets/0fc38a20-2895-4726-9fd6-1fd249cf41ce" />


#### Voice input bar off (crazyhouse)
<img width="1048" height="631" alt="off_crazyhouse" src="https://github.com/user-attachments/assets/971ff1ef-6bc1-4885-a864-7c5250fccd2f" />

#### Voice input bar on (regular)
<img width="1046" height="630" alt="on_regular" src="https://github.com/user-attachments/assets/733dbcb1-b4c9-4136-a300-8b02e3b5e725" />

#### Voice input bar off (regular)
<img width="1053" height="633" alt="off_regular" src="https://github.com/user-attachments/assets/9f35a1c6-cf3c-425d-8509-fbfa99d2a0a8" />
