### PR TITLE
Fixed takeback point

### DIFF
--- a/modules/round/src/main/Takebacker.scala
+++ b/modules/round/src/main/Takebacker.scala
@@ -182,4 +182,4 @@ final private class Takebacker(
 private object Takebacker:
   def acceptedPlies(currentPly: Ply, proposedAt: Ply, accepter: Color, playedPlies: Ply): Int =
     val proposedPlies = if accepter == proposedAt.turn then 1 else 2
-    (currentPly.value - proposedAt.value + proposedPlies).atLeast(1).atMost(playedPlies.value)
+    (currentPly - proposedAt + proposedPlies).atLeast(1).atMost(playedPlies).value

--- a/modules/round/src/main/Takebacker.scala
+++ b/modules/round/src/main/Takebacker.scala
@@ -1,7 +1,6 @@
 package lila.round
 
-import chess.ByColor
-import chess.Ply
+import chess.{ ByColor, Color, Ply }
 import alleycats.Zero
 import scalalib.data.Preload
 
@@ -47,21 +46,25 @@ final private class Takebacker(
       pov match
         case Pov(game, color) if pov.opponent.isProposingTakeback =>
           for
-            events <-
-              if pov.opponent.proposeTakebackAt == pov.game.ply &&
-                color == pov.opponent.proposeTakebackAt.turn
-              then single(pov)
-              else double(pov)
+            events <- rewind(
+              pov,
+              Takebacker.acceptedPlies(
+                currentPly = game.ply,
+                proposedAt = pov.opponent.proposeTakebackAt,
+                accepter = color,
+                playedPlies = game.playedPlies
+              )
+            )
             _ = publishTakeback(pov)
           yield events -> takebackBoardZero.zero
         case Pov(game, _) if pov.game.playableByAi =>
           for
-            events <- single(pov)
+            events <- rewind(pov, 1)
             _ = publishTakeback(pov)
           yield events -> board
         case Pov(game, _) if pov.opponent.isAi =>
           for
-            events <- double(pov)
+            events <- rewind(pov, 2)
             _ = publishTakeback(pov)
           yield events -> board
         case pov if canProposeTakeback(pov) && board(pov.color).offerable =>
@@ -137,21 +140,14 @@ final private class Takebacker(
         if _ then f
         else fufail(ClientError("[takebacker] disallowed by preferences " + game.id))
 
-  private def single(pov: Pov)(using GameProxy): Fu[Events] =
+  private def rewind(pov: Pov, plies: Int)(using GameProxy): Fu[Events] =
     for
       fen <- gameRepo.initialFen(pov.game)
-      progress <- Rewind(pov.game, fen).toFuture
-      _ <- fuccess(uciMemo.drop(pov.game, 1))
+      progress <- (1 to plies).foldLeft(fuccess(Progress(pov.game))): (prev, _) =>
+        prev.flatMap: prog =>
+          Rewind(prog.game, fen).toFuture.dmap(rewinded => prog.withGame(rewinded.game))
+      _ <- fuccess(uciMemo.drop(pov.game, plies))
       events <- saveAndNotify(progress, pov)
-    yield events
-
-  private def double(pov: Pov)(using GameProxy): Fu[Events] =
-    for
-      fen <- gameRepo.initialFen(pov.game)
-      prog1 <- Rewind(pov.game, fen).toFuture
-      prog2 <- Rewind(prog1.game, fen).toFuture.dmap(progress => prog1.withGame(progress.game))
-      _ <- fuccess(uciMemo.drop(pov.game, 2))
-      events <- saveAndNotify(prog2, pov)
     yield events
 
   private def saveAndNotify(p1: Progress, pov: Pov)(using proxy: GameProxy): Fu[Events] =
@@ -182,3 +178,8 @@ final private class Takebacker(
             lila.game.actorApi.BoardTakeback(p.game),
             lila.game.actorApi.BoardTakeback.makeChan(prevPov.gameId)
           )
+
+private object Takebacker:
+  def acceptedPlies(currentPly: Ply, proposedAt: Ply, accepter: Color, playedPlies: Ply): Int =
+    val proposedPlies = if accepter == proposedAt.turn then 1 else 2
+    (currentPly.value - proposedAt.value + proposedPlies).atLeast(1).atMost(playedPlies.value)

--- a/modules/round/src/test/TakebackerTest.scala
+++ b/modules/round/src/test/TakebackerTest.scala
@@ -1,0 +1,55 @@
+package lila.round
+
+import chess.{ Color, Ply }
+
+import Takebacker.*
+
+class TakebackerTest extends munit.FunSuite:
+
+  test("proposed on the proposer's own turn"):
+    assertEquals(
+      acceptedPlies(currentPly = Ply(4), proposedAt = Ply(4), Color.Black, playedPlies = Ply(4)),
+      2
+    )
+
+  test("proposed right after the proposer's move"):
+    assertEquals(
+      acceptedPlies(currentPly = Ply(3), proposedAt = Ply(3), Color.Black, playedPlies = Ply(3)),
+      1
+    )
+
+  test("proposer moved again while the offer was pending"):
+    assertEquals(
+      acceptedPlies(currentPly = Ply(5), proposedAt = Ply(4), Color.Black, playedPlies = Ply(5)),
+      3
+    )
+
+  test("proposer moved again while the offer was pending, black proposing"):
+    assertEquals(
+      acceptedPlies(currentPly = Ply(6), proposedAt = Ply(5), Color.White, playedPlies = Ply(6)),
+      3
+    )
+
+  test("rewinds at most to game start"):
+    assertEquals(
+      acceptedPlies(currentPly = Ply(3), proposedAt = Ply(2), Color.White, playedPlies = Ply(2)),
+      2
+    )
+
+  test("never rewinds further back than the game start"):
+    assertEquals(
+      acceptedPlies(currentPly = Ply(3), proposedAt = Ply(2), Color.Black, playedPlies = Ply(2)),
+      2
+    )
+
+  test("never rewinds a non-positive number of plies"):
+    assertEquals(
+      acceptedPlies(currentPly = Ply(4), proposedAt = Ply(6), Color.Black, playedPlies = Ply(4)),
+      1
+    )
+
+  test("from position"):
+    assertEquals(
+      acceptedPlies(currentPly = Ply(25), proposedAt = Ply(24), Color.Black, playedPlies = Ply(5)),
+      3
+    )


### PR DESCRIPTION
If player A offers a takeback at ply X and B accepts, the game will rewind to ply X - 2. However, if player A makes a move after offering, and then B accepts, the game rewinds to ply X - 1. This PR fixes this by making the rewind point X - 2 no matter what.