### PR TITLE
ui: add table tag helpers, migrate one example view

### DIFF
--- a/ui/insight/src/table.ts
+++ b/ui/insight/src/table.ts
@@ -1,4 +1,6 @@
-import { h, type VNodeData } from 'snabbdom';
+import { type VNodeData } from 'snabbdom';
+
+import { div, table, tbody, td, th, thead, tr } from 'lib/view';
 
 import type Ctrl from './ctrl';
 
@@ -17,25 +19,19 @@ const formatSerieName = (dt: string, n: number) =>
 export function vert(ctrl: Ctrl, attrs: VNodeData | null = null) {
   const answer = ctrl.vm.answer;
   if (!answer) return null;
-  return h(
-    'div.hscroll',
+  return div(
+    '.hscroll',
     attrs,
-    h('table.slist', [
-      h(
-        'thead',
-        h('tr', [
-          h('th', answer.xAxis.name),
-          ...answer.series.map(serie => h('th', serie.name)),
-          h('th', answer.sizeYaxis.name),
-        ]),
+    table('.slist', [
+      thead(
+        tr([th(answer.xAxis.name), answer.series.map(serie => th(serie.name)), th(answer.sizeYaxis.name)]),
       ),
-      h(
-        'tbody',
+      tbody(
         answer.xAxis.categories.map((c, i) =>
-          h('tr', [
-            h('th', formatSerieName(answer.xAxis.dataType, c)),
-            ...answer.series.map(serie => h('td.data', formatNumber(serie.dataType, serie.data[i]))),
-            h('td.size', formatNumber(answer.sizeSerie.dataType, answer.sizeSerie.data[i])),
+          tr([
+            th(formatSerieName(answer.xAxis.dataType, c)),
+            answer.series.map(serie => td('.data', formatNumber(serie.dataType, serie.data[i]))),
+            td('.size', formatNumber(answer.sizeSerie.dataType, answer.sizeSerie.data[i])),
           ]),
         ),
       ),

--- a/ui/lib/src/view/snabbdomElements.ts
+++ b/ui/lib/src/view/snabbdomElements.ts
@@ -151,6 +151,13 @@ export const strong: TagFunction = makeTag('strong');
 export const h1: TagFunction = makeTag('h1');
 export const h2: TagFunction = makeTag('h2');
 
+export const table: TagFunction = makeTag('table');
+export const thead: TagFunction = makeTag('thead');
+export const tbody: TagFunction = makeTag('tbody');
+export const tr: TagFunction = makeTag('tr');
+export const th: TagFunction = makeTag('th');
+export const td: TagFunction = makeTag('td');
+
 export const a: TagFactory<[href: string]> = href => makeTag('a', { href });
 export const img: TagFactory<[src: string, alt: string]> = (src, alt) => makeTag('img', { alt, src });
 export const optgroup: TagFactory<[label: string]> = label => makeTag('optgroup', { label });


### PR DESCRIPTION
# How

Add table related tag helpers, migrate one example view to test them out.

# Preview

<img width="987" height="260" alt="Screenshot 2026-07-26 at 11 16 45" src="https://github.com/user-attachments/assets/870a818e-8d48-4d22-80ae-d5ee250fcde0" />


