### PR TITLE
ui(racer): refactor views to use element tags

### DIFF
--- a/ui/lib/src/view/snabbdomElements.ts
+++ b/ui/lib/src/view/snabbdomElements.ts
@@ -148,6 +148,7 @@ export const p: TagFunction = makeTag('p');
 export const button: TagFunction = makeTag('button');
 export const span: TagFunction = makeTag('span');
 export const strong: TagFunction = makeTag('strong');
+export const form: TagFunction = makeTag('form');
 export const h1: TagFunction = makeTag('h1');
 export const h2: TagFunction = makeTag('h2');
 

--- a/ui/racer/src/view/board.ts
+++ b/ui/racer/src/view/board.ts
@@ -1,16 +1,15 @@
 import { Chessground as makeChessground } from '@lichess-org/chessground';
 import { INITIAL_BOARD_FEN } from 'chessops/fen';
-import { h, type VNode } from 'snabbdom';
 
 import { pubsub } from 'lib/pubsub';
 import { makeCgOpts } from 'lib/puz/run';
 import { makeConfig as makeCgConfig } from 'lib/puz/view/chessground';
-import { onInsert } from 'lib/view';
+import { div, makeExoticTag, onInsert, type VNode } from 'lib/view';
 
 import type RacerCtrl from '@/ctrl';
 
 export const renderBoard = (ctrl: RacerCtrl) => {
-  return h('div.puz-board.main-board', [
+  return div('.puz-board.main-board', [
     renderGround(ctrl),
     ctrl.promotion.view(),
     renderCountdown(ctrl.countdownSeconds()),
@@ -18,7 +17,7 @@ export const renderBoard = (ctrl: RacerCtrl) => {
 };
 
 const renderGround = (ctrl: RacerCtrl): VNode =>
-  h('div.cg-wrap', {
+  div('.cg-wrap', {
     hook: onInsert(el => {
       ctrl.ground(
         makeChessground(
@@ -41,14 +40,16 @@ const renderGround = (ctrl: RacerCtrl): VNode =>
     }),
   });
 
+const light = makeExoticTag('light');
+
 const renderCountdown = (seconds?: number) => {
   if (!seconds) return undefined;
-  return h('div.racer__countdown', [
-    h('div.racer__countdown__lights', [
-      h('light.red', { class: { active: seconds > 4 } }),
-      h('light.orange', { class: { active: seconds === 3 || seconds === 4 } }),
-      h('light.green', { class: { active: seconds <= 2 } }),
+  return div('.racer__countdown', [
+    div('.racer__countdown__lights', [
+      light('.red', { class: { active: seconds > 4 } }),
+      light('.orange', { class: { active: seconds === 3 || seconds === 4 } }),
+      light('.green', { class: { active: seconds <= 2 } }),
     ]),
-    h('div.racer__countdown__seconds', seconds),
+    div('.racer__countdown__seconds', seconds),
   ]);
 };

--- a/ui/racer/src/view/main.ts
+++ b/ui/racer/src/view/main.ts
@@ -3,7 +3,7 @@ import { povMessage } from 'lib/puz/run';
 import renderClock from 'lib/puz/view/clock';
 import renderHistory from 'lib/puz/view/history';
 import { playModifiers, renderCombo } from 'lib/puz/view/util';
-import { copyMeInput, type VNode, type MaybeVNodes, bind, hl } from 'lib/view';
+import { copyMeInput, type MaybeVNodes, bind, div, p, button, strong, span, a, form, h2 } from 'lib/view';
 
 import config from '@/config';
 import type RacerCtrl from '@/ctrl';
@@ -11,13 +11,13 @@ import type RacerCtrl from '@/ctrl';
 import { renderBoard } from './board';
 import { renderRace } from './race';
 
-export default function (ctrl: RacerCtrl): VNode {
-  return hl(
-    'div.racer.racer-app.racer--play',
+export default function (ctrl: RacerCtrl) {
+  return div(
+    '.racer.racer-app.racer--play',
     { class: { ...playModifiers(ctrl.run), [`racer--${ctrl.status()}`]: true } },
     [
       renderBoard(ctrl),
-      hl('div.puz-side', selectScreen(ctrl)),
+      div('.puz-side', selectScreen(ctrl)),
       renderRace(ctrl),
       ctrl.status() === 'post' && ctrl.run.history.length > 0 ? renderHistory(ctrl) : null,
     ],
@@ -25,141 +25,135 @@ export default function (ctrl: RacerCtrl): VNode {
 }
 
 const selectScreen = (ctrl: RacerCtrl): MaybeVNodes => {
+  const combo = comboZone(ctrl);
   switch (ctrl.status()) {
     case 'pre': {
-      const povMsg = hl('p.racer__pre__message__pov', povMessage(ctrl.run));
+      const povMsg = p('.racer__pre__message__pov', povMessage(ctrl.run));
       return ctrl.race.lobby
         ? [
-            waitingToStart(),
-            hl('div.racer__pre__message.racer__pre__message--with-skip', [
-              hl('div.racer__pre__message__text', [
-                hl(
-                  'p',
+            waitingToStart,
+            div('.racer__pre__message.racer__pre__message--with-skip', [
+              div('.racer__pre__message__text', [
+                p(
                   ctrl.knowsSkip()
                     ? i18n.storm[ctrl.vm.startsAt ? 'getReady' : 'waitingForMorePlayers']
-                    : skipHelp(),
+                    : skipHelp,
                 ),
                 povMsg,
               ]),
-              !ctrl.knowsSkip() && renderSkip(ctrl),
+              !ctrl.knowsSkip() ? renderSkip(ctrl) : null,
             ]),
-            comboZone(ctrl),
+            combo,
           ]
         : [
-            waitingToStart(),
-            hl('div.racer__pre__message', [
+            waitingToStart,
+            div('.racer__pre__message', [
               ctrl.raceFull()
                 ? ctrl.isPlayer()
                   ? [renderStart(ctrl)]
-                  : []
+                  : null
                 : ctrl.isPlayer()
                   ? [renderLink(ctrl), renderStart(ctrl)]
                   : [renderJoin(ctrl)],
               povMsg,
             ]),
-            comboZone(ctrl),
+            combo,
           ];
     }
     case 'racing': {
       const clock = renderClock(ctrl.run, ctrl.end, false);
       return ctrl.isPlayer()
-        ? [playerScore(ctrl), hl('div.puz-clock', [clock, renderSkip(ctrl)]), comboZone(ctrl)]
+        ? [playerScore(ctrl), div('.puz-clock', [clock, renderSkip(ctrl)]), combo]
         : [
-            spectating(),
-            hl('div.racer__spectating', [
-              hl('div.puz-clock', clock),
-              ctrl.race.lobby ? lobbyNext(ctrl) : waitForRematch(),
+            spectating,
+            div('.racer__spectating', [
+              div('.puz-clock', clock),
+              ctrl.race.lobby ? lobbyNext(ctrl) : waitForRematch,
             ]),
-            comboZone(ctrl),
+            combo,
           ];
     }
     case 'post': {
       const nextRace = ctrl.race.lobby ? lobbyNext(ctrl) : friendNext(ctrl);
-      const raceComplete = hl('h2', i18n.storm.raceComplete);
+      const raceComplete = h2(i18n.storm.raceComplete);
       return ctrl.isPlayer()
-        ? [
-            playerScore(ctrl),
-            hl('div.racer__post', [raceComplete, yourRank(ctrl), nextRace]),
-            comboZone(ctrl),
-          ]
-        : [spectating(), hl('div.racer__post', [raceComplete, nextRace]), comboZone(ctrl)];
+        ? [playerScore(ctrl), div('.racer__post', [raceComplete, yourRank(ctrl), nextRace]), combo]
+        : [spectating, div('.racer__post', [raceComplete, nextRace]), combo];
     }
   }
 };
 
 const renderSkip = (ctrl: RacerCtrl) =>
-  hl(
-    'button.racer__skip.button.button-red',
+  button(
+    '.racer__skip.button.button-red',
     {
       class: { disabled: !ctrl.canSkip() },
-      attrs: { title: i18n.storm.skipExplanation },
+      title: i18n.storm.skipExplanation,
       hook: bind('click', ctrl.skip),
     },
     i18n.storm.skip,
   );
 
-const skipHelp = () => hl('p', i18n.storm.skipHelp);
+const skipHelp = p(i18n.storm.skipHelp);
+const puzzleRacer = strong('Puzzle Racer');
 
-const puzzleRacer = () => hl('strong', 'Puzzle Racer');
+const waitingToStart = div(
+  '.puz-side__top.puz-side__start',
+  div('.puz-side__start__text', [puzzleRacer, span(i18n.storm.waitingToStart)]),
+);
 
-const waitingToStart = () =>
-  hl(
-    'div.puz-side__top.puz-side__start',
-    hl('div.puz-side__start__text', [puzzleRacer(), hl('span', i18n.storm.waitingToStart)]),
-  );
-
-const spectating = () =>
-  hl(
-    'div.puz-side__top.puz-side__start',
-    hl('div.puz-side__start__text', [puzzleRacer(), hl('span', i18n.storm.spectating)]),
-  );
+const spectating = div(
+  '.puz-side__top.puz-side__start',
+  div('.puz-side__start__text', [puzzleRacer, span(i18n.storm.spectating)]),
+);
 
 const renderBonus = (bonus: number) => `+${bonus}`;
 
-const renderControls = (ctrl: RacerCtrl): VNode =>
-  hl(
-    'div.puz-side__control',
-    hl('a.puz-side__control__flip.button', {
+const renderControls = (ctrl: RacerCtrl) =>
+  div(
+    '.puz-side__control',
+    button('.puz-side__control__flip.button', {
       class: { active: ctrl.flipped, 'button-empty': !ctrl.flipped },
-      attrs: { 'data-icon': licon.ChasingArrows, title: i18n.site.flipBoard + ' (Keyboard: f)' },
+      'data-icon': licon.ChasingArrows,
+      title: i18n.site.flipBoard + ' (Keyboard: f)',
       hook: bind('click', ctrl.flip),
     }),
   );
 
 const comboZone = (ctrl: RacerCtrl) =>
-  hl('div.puz-side__table', [renderControls(ctrl), renderCombo(config, renderBonus)(ctrl.run)]);
+  div('.puz-side__table', [renderControls(ctrl), renderCombo(config, renderBonus)(ctrl.run)]);
 
-const playerScore = (ctrl: RacerCtrl): VNode =>
-  hl('div.puz-side__top.puz-side__solved', [hl('div.puz-side__solved__text', `${ctrl.myScore() || 0}`)]);
+const playerScore = ({ myScore }: RacerCtrl) =>
+  div('.puz-side__top.puz-side__solved', [div('.puz-side__solved__text', `${myScore() || 0}`)]);
 
-const renderLink = (ctrl: RacerCtrl) =>
-  hl('div.puz-side__link', [
-    hl('p', i18n.site.toInviteSomeoneToPlayGiveThisUrl),
-    copyMeInput(`${window.location.protocol}//${window.location.host}/racer/${ctrl.race.id}`, {
+const renderLink = ({ race }: RacerCtrl) =>
+  div('.puz-side__link', [
+    p(i18n.site.toInviteSomeoneToPlayGiveThisUrl),
+    copyMeInput(`${window.location.protocol}//${window.location.host}/racer/${race.id}`, {
       inputAttrs: { readonly: true },
     }),
   ]);
 
-const renderStart = (ctrl: RacerCtrl) =>
-  ctrl.isOwner() &&
-  !ctrl.vm.startsAt &&
-  hl(
-    'div.puz-side__start',
-    hl(
-      'button.button.button-fat',
+const renderStart = (ctrl: RacerCtrl) => {
+  if (!ctrl.isOwner() || ctrl.vm.startsAt) return null;
+  return div(
+    '.puz-side__start',
+    button(
+      '.button.button-fat',
       {
         class: { disabled: ctrl.players().length < 2 },
         hook: bind('click', ctrl.start),
-        attrs: { disabled: ctrl.players().length < 2 },
+        disabled: ctrl.players().length < 2,
       },
       i18n.storm.startTheRace,
     ),
   );
+};
 
 const renderJoin = (ctrl: RacerCtrl) =>
-  hl(
-    'div.puz-side__join',
-    hl('button.button.button-fat', { hook: bind('click', ctrl.join) }, i18n.storm.joinTheRace),
+  div(
+    '.puz-side__join',
+    button('.button.button-fat', { hook: bind('click', ctrl.join) }, i18n.storm.joinTheRace),
   );
 
 const yourRank = (ctrl: RacerCtrl) => {
@@ -167,38 +161,32 @@ const yourRank = (ctrl: RacerCtrl) => {
   if (!score) return undefined;
   const players = ctrl.players();
   const rank = players.filter(p => p.score > score).length + 1;
-  return hl('strong.race__post__rank', i18n.storm.yourRankX(`${rank}/${players.length}`));
+  return strong('.race__post__rank', i18n.storm.yourRankX(`${rank}/${players.length}`));
 };
 
-const waitForRematch = () =>
-  hl(
-    `a.racer__new-race.button.button-fat.button-navaway.disabled`,
-    { attrs: { disabled: true } },
-    i18n.storm.waitForRematch,
-  );
+const waitForRematch = button(
+  '.racer__new-race.button.button-fat.button-navaway.disabled',
+  { disabled: true },
+  i18n.storm.waitForRematch,
+);
 
-const lobbyNext = (ctrl: RacerCtrl) =>
-  hl('form', { attrs: { action: '/racer/lobby', method: 'post' } }, [
-    hl(
-      `button.racer__new-race.button.button-navaway${ctrl.race.lobby ? '.button-fat' : '.button-empty'}`,
+const lobbyNext = ({ race }: RacerCtrl) =>
+  form({ action: '/racer/lobby', method: 'post' }, [
+    button(
+      `.racer__new-race.button.button-navaway${race.lobby ? '.button-fat' : '.button-empty'}`,
       i18n.storm.nextRace,
     ),
   ]);
 
-const friendNext = (ctrl: RacerCtrl) =>
-  hl('div.racer__post__next', [
-    hl(
-      `a.racer__rematch.button.button-fat.button-navaway`,
-      { attrs: { href: `/racer/${ctrl.race.id}/rematch` } },
+const friendNext = ({ race }: RacerCtrl) =>
+  div('.racer__post__next', [
+    a(`/racer/${race.id}/rematch`)(
+      `.racer__rematch.button.button-fat.button-navaway`,
       i18n.storm.joinRematch,
     ),
-    hl(
-      'form.racer__post__next__new',
-      { attrs: { action: '/racer', method: 'post' } },
-      hl(
-        'button.racer__post__next__button.button.button-empty',
-        { attrs: { type: 'submit' } },
-        i18n.storm.createNewGame,
-      ),
+    form(
+      '.racer__post__next__new',
+      { action: '/racer', method: 'post' },
+      button('.racer__post__next__button.button.button-empty', { type: 'submit' }, i18n.storm.createNewGame),
     ),
   ]);

--- a/ui/racer/src/view/race.ts
+++ b/ui/racer/src/view/race.ts
@@ -1,15 +1,13 @@
-import { h, type VNodes } from 'snabbdom';
-
+import { div, makeExoticTag, span, type VNode } from 'lib/view';
 import { userLink } from 'lib/view/userLink';
 
-import type { Boost } from '@/boost';
 import type RacerCtrl from '@/ctrl';
 import type { PlayerWithScore } from '@/interfaces';
 
 // to [0,1]
 type RelativeScore = (score: number) => number;
 
-const trackHeight = 25;
+const TRACK_HEIGHT = 25;
 
 export const renderRace = (ctrl: RacerCtrl) => {
   const players = ctrl.players();
@@ -19,17 +17,17 @@ export const renderRace = (ctrl: RacerCtrl) => {
   const relative: RelativeScore = score => (score - minMoves) / delta;
   const bestScore = players.reduce((b, p) => (p.score > b ? p.score : b), 0);
   const myName = ctrl.player().name;
-  const tracks: VNodes = [];
+  const tracks: VNode[] = [];
   players.forEach((p, i) => {
     const isMe = p.name === myName;
-    const track = renderTrack(relative, isMe, bestScore, ctrl.boost, p, i, ctrl.vehicle[i]);
+    const track = renderTrack(relative, isMe, bestScore, ctrl, p, i);
     if (isMe) tracks.unshift(track);
     else tracks.push(track);
   });
-  return h(
-    'div.racer__race',
-    { attrs: { style: `height:${players.length * trackHeight + 14}px` } },
-    h('div.racer__race__tracks', tracks),
+  return div(
+    '.racer__race',
+    { style: { height: `${players.length * TRACK_HEIGHT + 14}px` } },
+    div('.racer__race__tracks', tracks),
   );
 };
 
@@ -37,41 +35,38 @@ const renderTrack = (
   relative: RelativeScore,
   isMe: boolean,
   bestScore: number,
-  boost: Boost,
+  ctrl: RacerCtrl,
   player: PlayerWithScore,
   index: number,
-  vehicle: number,
 ) => {
-  return h(
-    'div.racer__race__track',
+  return div(
+    '.racer__race__track',
     {
       class: {
         'racer__race__track--me': isMe,
         'racer__race__track--first': !!player.score && player.score === bestScore,
-        'racer__race__track--boost': boost.isBoosting(index),
+        'racer__race__track--boost': ctrl.boost.isBoosting(index),
       },
     },
     [
-      h(
-        'div.racer__race__player',
+      div(
+        '.racer__race__player',
         {
-          attrs: {
-            style: `transform:translateX(${
-              relative(player.score) * 95 * (document.dir === 'rtl' ? -1 : 1)
-            }%)`,
+          style: {
+            transform: `translateX(${relative(player.score) * 95 * (document.dir === 'rtl' ? -1 : 1)}%)`,
           },
         },
         [
-          h(`div.racer__race__player__car.car-${index}.vehicle${vehicle}`, [vehicle]),
-          h('span.racer__race__player__name', playerLink(player, isMe)),
+          div(`.racer__race__player__car.car-${index}.vehicle${ctrl.vehicle[index]}`, ctrl.vehicle[index]),
+          span('.racer__race__player__name', playerLink(player, isMe)),
         ],
       ),
-      h('div.racer__race__score', player.score),
+      div('.racer__race__score', player.score),
     ],
   );
 };
 
+const anonymous = makeExoticTag('anonymous', { title: 'Anonymous player' });
+
 export const playerLink = (player: PlayerWithScore, isMe: boolean) =>
-  player.id
-    ? userLink({ ...player, line: false })
-    : h('anonymous', { attrs: { title: 'Anonymous player' } }, [player.name, isMe ? ' (you)' : undefined]);
+  player.id ? userLink({ ...player, line: false }) : anonymous([player.name, isMe ? ' (you)' : undefined]);


### PR DESCRIPTION
# Why

An another in-field verification for the new tag elements.

# How

Refactor racer views to use element tags, add missing `form` tag, replace few `a` without `href` with `button`s, small DOM/code tweaks.

# Preview

<img width="1801" height="1153" alt="Screenshot 2026-07-27 at 11 45 05" src="https://github.com/user-attachments/assets/ff3b23fc-b9cb-4c45-89f8-d955d961314b" />
