### PR TITLE
workspace: bump scalafmt to get some recent performance optimizations

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = "3.11.1"
+version = "3.11.4"
 runner.dialect = scala3
 
 align.preset = none

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,5 +4,5 @@ addSbtPlugin("com.github.lichess-org.liplay" % "sbt-plugin" % "3.2.0-RC3")
 
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.11.4")
 
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.6.1")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.6.2")
 addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "2.1.0")


### PR DESCRIPTION
# Why

Bump `scalafmt` and SBT plugin to get some recent performance optimizations from `3.11.2` release. Refs:
* https://github.com/scalameta/scalafmt/releases#release-v3.11.2
* https://github.com/scalameta/sbt-scalafmt/releases#release-v2.6.2

# How

Update version in `plugins.sbt`, match version specified in config with version of `scalafmt` shipped with SBT plugin.