### PR TITLE
Fix broadcast forced variations again

### DIFF
--- a/modules/relay/src/main/RelaySync.scala
+++ b/modules/relay/src/main/RelaySync.scala
@@ -101,27 +101,20 @@ final private class RelaySync(
 
   private type NbMoves = Int
 
-  private def forceBranchesAsVariations(chapter: Chapter, game: RelayGame)(using by: Who): Fu[Unit] =
-    // moves that are not in the source but are in the study chapter,
+  private def forceTailMovesAsVariations(chapter: Chapter, gameMainline: UciPath)(using
+      by: Who
+  ): Fu[Unit] =
+    // tail moves that are not in the source but are in the study chapter,
     // should become forced variations in the study chapter
-    game.root.mainline
-      .foldLeft(List.empty[UciPath] -> UciPath.root):
-        case ((acc, parentPath), gameNode) =>
-          val nodePath = parentPath + gameNode.id
-          val localPaths = chapter.root
-            .nodeAt(parentPath)
-            .so: parentNode =>
-              parentNode.children.toList.collect:
-                case child if child.id != gameNode.id && !child.forceVariation =>
-                  parentPath + child.id
-          (acc ::: localPaths, nodePath)
-      ._1
-      .sequentiallyVoid: childPath =>
+    chapter.root
+      .nodeAt(gameMainline)
+      .map(_.children.toList.map(gameMainline + _.id))
+      .foldMap(_.sequentiallyVoid: childPath =>
         studyApi.forceVariation(
           studyId = chapter.studyId,
           position = Position(chapter, childPath).ref,
           force = true
-        )(by)
+        )(by))
 
   private def sendLastNode(study: Study, chapter: Chapter, game: RelayGame, gameMainlinePath: UciPath)(using
       Who,
@@ -201,7 +194,7 @@ final private class RelaySync(
     for
       gameMainlinePath = game.root.mainlinePath
       (path, newNodeOpt) = getNewNodeOrSetClockOfExisting(chapter, study, game)
-      _ <- forceBranchesAsVariations(chapter, game)
+      _ <- forceTailMovesAsVariations(chapter, gameMainlinePath)
       _ <- newNodeOpt.fold(sendLastNode(study, chapter, game, gameMainlinePath)): newNode =>
         addNode(study, chapter, game, path, newNode)
     yield newNodeOpt.so(_.mainline.size)

--- a/modules/relay/src/main/RelaySync.scala
+++ b/modules/relay/src/main/RelaySync.scala
@@ -150,24 +150,6 @@ final private class RelaySync(
                 relay = makeRelayFor(game, gameMainlinePath).some
               )
 
-  /* oldChapter doesn't yet contain the new nodes from the game,
-   * but we can get a newChapter from the DB which does. */
-  private def maybePromoteToMainline(study: Study, oldChapter: Chapter, gameMainline: UciPath)(using
-      Who
-  ): Funit =
-    // First we check if we need to load
-    (!gameMainline.isMainline(oldChapter.root)).so:
-      // then we check again with the new chapter.
-      chapterRepo
-        .byId(oldChapter.id)
-        .flatMapz: newChapter =>
-          (!gameMainline.isMainline(newChapter.root)).so:
-            logger.info(s"Change mainline ${showSC(study, newChapter)} $gameMainline")
-            for
-              _ <- studyApi.promote(study.id, Position(newChapter, gameMainline).ref, toMainline = true)
-              _ <- chapterRepo.setRelayPath(newChapter.id, gameMainline)
-            yield ()
-
   private def addNode(study: Study, chapter: Chapter, game: RelayGame, path: UciPath, node: Branch)(using
       Who,
       RelayTour
@@ -222,7 +204,6 @@ final private class RelaySync(
       _ <- forceBranchesAsVariations(chapter, game)
       _ <- newNodeOpt.fold(sendLastNode(study, chapter, game, gameMainlinePath)): newNode =>
         addNode(study, chapter, game, path, newNode)
-      _ <- maybePromoteToMainline(study, chapter, gameMainlinePath)
     yield newNodeOpt.so(_.mainline.size)
 
   private def updateChapterTags(


### PR DESCRIPTION
1. We don't need to explicitly promote to mainline again at the end because `addNode` (and `sendLastNode`) both call `promote` if it's not the mainline. https://github.com/lichess-org/lila/blob/aabf0bfbba8830fe94f41e2577c2719878e8c187/modules/study/src/main/StudyApi.scala#L298
2. We don't need to force variations for all nodes not on the mainline because promoting already does that. The only case that `promote` does not handle is nodes extending beyond the mainline path.  i.e. The game went from `A->B->C` to `A->B`. So I've changed the function to only force variation for children of the last mainline node.

Scenarios tested
- [x] Alternating between lines does not force variation but correctly promotes to mainline (https://github.com/lichess-org/lila/issues/21059)
- [x] Broadcast does not jump to the new position on receiving new moves if on a previous move (https://github.com/lichess-org/lila/issues/21036)
- [x] Local moves at the tail end of the broadcast should be forced variations (https://github.com/lichess-org/lila/issues/20818)


Closes https://github.com/lichess-org/lila/issues/21059