### PR TITLE
Move players download URL to a config value

### DIFF
--- a/conf/base.conf
+++ b/conf/base.conf
@@ -126,6 +126,9 @@ puzzle {
 relay {
   syncOnlyIds = null
 }
+fide {
+  players.url = "https://ratings.fide.com/download/players_list.zip"
+}
 storm.secret = "somethingElseInProd"
 coordinate {
   collection {

--- a/modules/fide/src/main/Env.scala
+++ b/modules/fide/src/main/Env.scala
@@ -1,6 +1,7 @@
 package lila.fide
 
 import com.softwaremill.macwire.*
+import play.api.Configuration
 import play.api.libs.ws.StandaloneWSClient
 import chess.FideId
 
@@ -11,6 +12,7 @@ import scalalib.paginator.Paginator
 
 @Module
 final class Env(
+    appConfig: Configuration,
     db: lila.db.Db,
     cacheApi: CacheApi,
     picfitApi: PicfitApi,
@@ -62,7 +64,8 @@ final class Env(
 
   given Federation.Guess = lila.fide.Federation.find
 
-  private lazy val fideSync = wire[FidePlayerSync]
+  private lazy val fideSync =
+    FidePlayerSync(repo, ws, httpProxy, appConfig.get[String]("fide.players.url"))
 
   if mode.isProd then
     scheduler.scheduleWithFixedDelay(1.hour, 1.hour): () =>

--- a/modules/fide/src/main/Env.scala
+++ b/modules/fide/src/main/Env.scala
@@ -7,6 +7,7 @@ import chess.FideId
 
 import lila.core.config.CollName
 import lila.core.fide.*
+import lila.common.autoconfig.given
 import lila.memo.{ CacheApi, PicfitApi, PicfitUrl }
 import scalalib.paginator.Paginator
 
@@ -65,7 +66,7 @@ final class Env(
   given Federation.Guess = lila.fide.Federation.find
 
   private lazy val fideSync =
-    FidePlayerSync(repo, ws, httpProxy, appConfig.get[String]("fide.players.url"))
+    FidePlayerSync(repo, ws, httpProxy, appConfig.get[Url]("fide.players.url"))
 
   if mode.isProd then
     scheduler.scheduleWithFixedDelay(1.hour, 1.hour): () =>

--- a/modules/fide/src/main/FidePlayerSync.scala
+++ b/modules/fide/src/main/FidePlayerSync.scala
@@ -17,7 +17,7 @@ final private class FidePlayerSync(
     repo: FideRepo,
     ws: StandaloneWSClient,
     proxy: lila.memo.HttpProxy,
-    listUrl: String
+    listUrl: Url
 )(using
     Executor,
     org.apache.pekko.stream.Materializer
@@ -105,7 +105,7 @@ final private class FidePlayerSync(
 
   private object playersFromHttpFile:
     def apply(): Funit = for
-      req = ws.url(listUrl)
+      req = ws.url(listUrl.value)
       proxied = proxy.select().foldLeft(req)(_ withProxyServer _)
       httpStream <- proxied.stream()
       _ <-

--- a/modules/fide/src/main/FidePlayerSync.scala
+++ b/modules/fide/src/main/FidePlayerSync.scala
@@ -13,12 +13,15 @@ import lila.mon.extensions.*
 import lila.core.fide.Federation
 import lila.db.dsl.{ *, given }
 
-final private class FidePlayerSync(repo: FideRepo, ws: StandaloneWSClient, proxy: lila.memo.HttpProxy)(using
+final private class FidePlayerSync(
+    repo: FideRepo,
+    ws: StandaloneWSClient,
+    proxy: lila.memo.HttpProxy,
+    listUrl: String
+)(using
     Executor,
     org.apache.pekko.stream.Materializer
 ):
-
-  private val listUrl = "http://ratings.fide.com/download/players_list.zip"
 
   // the file is big. We want to stream the http response into the zip reader,
   // and stream the zip output into the database as it's being extracted.


### PR DESCRIPTION
Other environments can set the value to a cached copy hosted somewhere else in case requests fail

Also changed from http to https