### PR TITLE
Broadcasts: Don't force variations at the chapter root

### DIFF
--- a/modules/relay/src/main/RelaySync.scala
+++ b/modules/relay/src/main/RelaySync.scala
@@ -106,15 +106,16 @@ final private class RelaySync(
   ): Fu[Unit] =
     // tail moves that are not in the source but are in the study chapter,
     // should become forced variations in the study chapter
-    chapter.root
-      .nodeAt(gameMainline)
-      .map(_.children.toList.map(gameMainline + _.id))
-      .foldMap(_.sequentiallyVoid: childPath =>
-        studyApi.forceVariation(
-          studyId = chapter.studyId,
-          position = Position(chapter, childPath).ref,
-          force = true
-        )(by))
+    gameMainline.nonEmpty.so:
+      chapter.root
+        .nodeAt(gameMainline)
+        .map(_.children.toList.map(gameMainline + _.id))
+        .foldMap(_.sequentiallyVoid: childPath =>
+          studyApi.forceVariation(
+            studyId = chapter.studyId,
+            position = Position(chapter, childPath).ref,
+            force = true
+          )(by))
 
   private def sendLastNode(study: Study, chapter: Chapter, game: RelayGame, gameMainlinePath: UciPath)(using
       Who,


### PR DESCRIPTION
Closes https://github.com/lichess-org/lila/issues/21059

https://github.com/lichess-org/lila/pull/21067 fixed the case where the nodes diverge somewhere down the mainline.

The way to reproduce the remaining buggy scenario is: 
1. Push node `A`
2. Push an empty PGN. This sets the `gameMainline` path to be empty and forces `A` as a variation.
3. Push node `B`. Node B is treated as mainline because `isMainline` only checks nodes that aren't forced variations. So no promotion happens because `isMainline` returns true.

The fix is to not force variations at the chapter root.