### PR TITLE
ui(storm): refactor to use tag helpers, small tweaks

### DIFF
--- a/ui/lib/src/view/snabbdomElements.ts
+++ b/ui/lib/src/view/snabbdomElements.ts
@@ -148,6 +148,7 @@ export const p: TagFunction = makeTag('p');
 export const button: TagFunction = makeTag('button');
 export const span: TagFunction = makeTag('span');
 export const strong: TagFunction = makeTag('strong');
+export const main: TagFunction = makeTag('main');
 export const form: TagFunction = makeTag('form');
 export const h1: TagFunction = makeTag('h1');
 export const h2: TagFunction = makeTag('h2');

--- a/ui/storm/css/_high.scss
+++ b/ui/storm/css/_high.scss
@@ -10,7 +10,7 @@
   }
 
   &__period {
-    @extend %flex-column, %box-neat, %roboto;
+    @extend %flex-column, %box-bordered, %roboto;
 
     align-items: center;
     justify-content: center;

--- a/ui/storm/src/ctrl.ts
+++ b/ui/storm/src/ctrl.ts
@@ -23,6 +23,7 @@ import * as xhr from './xhr';
 export default class StormCtrl implements PuzCtrl {
   private readonly data: StormData;
   private readonly redraw: () => void;
+  readonly duration = 900;
   pref: StormPrefs;
   run: Run;
   vm: StormVm;

--- a/ui/storm/src/view/end.ts
+++ b/ui/storm/src/view/end.ts
@@ -1,11 +1,23 @@
 import { numberSpread } from 'lib/i18n';
 import { getNow } from 'lib/puz/util';
-import renderHistory from 'lib/puz/view/history';
-import { onInsert, type LooseVNodes, hl } from 'lib/view';
+import {
+  onInsert,
+  type MaybeVNodes,
+  div,
+  strong,
+  span,
+  p,
+  table,
+  a,
+  button,
+  tbody,
+  tr,
+  th,
+  td,
+  makeExoticTag,
+} from 'lib/view';
 
 import type StormCtrl from '@/ctrl';
-
-const renderEnd = (ctrl: StormCtrl): LooseVNodes => [renderSummary(ctrl), renderHistory(ctrl)];
 
 const newHighI18n = {
   day: i18n.storm.newDailyHighscore,
@@ -14,57 +26,52 @@ const newHighI18n = {
   allTime: i18n.storm.newAllTimeHighscore,
 };
 
-const renderSummary = (ctrl: StormCtrl): LooseVNodes => {
+const number = makeExoticTag('number');
+
+export default function renderSummary(ctrl: StormCtrl): MaybeVNodes {
   const run = ctrl.runStats();
   const high = ctrl.vm.response?.newHigh;
+  const playAgain = ctrl.run.endAt! < getNow() - ctrl.duration ? a('/storm') : button;
   const accuracy = (100 * (run.moves - run.errors)) / run.moves;
   const scoreSteps = Math.min(run.score, 50);
   return [
-    high &&
-      hl(
-        'div.storm--end__high.storm--end__high-daily.bar-glider',
-        hl('div.storm--end__high__content', [
-          hl('div.storm--end__high__text', [
-            hl('strong', newHighI18n[high.key]),
-            high.prev ? hl('span', i18n.storm.previousHighscoreWasX(high.prev)) : null,
+    high
+      ? div(
+          '.storm--end__high.storm--end__high-daily.bar-glider',
+          div('.storm--end__high__content', [
+            div('.storm--end__high__text', [
+              strong(newHighI18n[high.key]),
+              high.prev ? span(i18n.storm.previousHighscoreWasX(high.prev)) : null,
+            ]),
           ]),
-        ]),
-      ),
-    hl('div.storm--end__score', [
-      hl(
-        'span.storm--end__score__number',
+        )
+      : null,
+    div('.storm--end__score', [
+      span(
+        '.storm--end__score__number',
         { hook: onInsert(el => numberSpread(el, scoreSteps, Math.round(scoreSteps * 50), 0)(run.score)) },
         '0',
       ),
-      hl('p', i18n.storm.puzzlesSolved),
+      p(i18n.storm.puzzlesSolved),
     ]),
-    hl('div.storm--end__stats.box.box-pad', [
-      hl('table.slist', [
-        hl('tbody', [
-          hl('tr', [hl('th', i18n.storm.moves), hl('td', hl('number', `${run.moves}`))]),
-          hl('tr', [
-            hl('th', i18n.storm.accuracy),
-            hl('td', [hl('number', accuracy ? accuracy.toFixed(1) : '-'), '%']),
+    div('.storm--end__stats.box.box-pad', [
+      table('.slist', [
+        tbody([
+          tr([th(i18n.storm.moves), td(number(run.moves))]),
+          tr([
+            th(i18n.storm.accuracy),
+            td([number(accuracy ? accuracy.toFixed(1) : '-'), accuracy ? '%' : '']),
           ]),
-          hl('tr', [hl('th', i18n.storm.combo), hl('td', hl('number', `${ctrl.run.combo.best}`))]),
-          hl('tr', [
-            hl('th', i18n.storm.time),
-            hl('td', [hl('number', run.time ? `${Math.round(run.time)}` : 0), 's']),
+          tr([th(i18n.storm.combo), td(number(ctrl.run.combo.best))]),
+          tr([th(i18n.storm.time), td([number(run.time ? Math.round(run.time) : 0), 's'])]),
+          tr([
+            th(i18n.storm.timePerMove),
+            td([number(run.time ? (run.time / run.moves).toFixed(2) : 0), 's']),
           ]),
-          hl('tr', [
-            hl('th', i18n.storm.timePerMove),
-            hl('td', [hl('number', run.time ? (run.time / run.moves).toFixed(2) : 0), 's']),
-          ]),
-          hl('tr', [hl('th', i18n.storm.highestSolved), hl('td', hl('number', `${run.highest}`))]),
+          tr([th(i18n.storm.highestSolved), td(number(run.highest))]),
         ]),
       ]),
     ]),
-    hl(
-      'a.storm-play-again.button',
-      { attrs: ctrl.run.endAt! < getNow() - 900 ? { href: '/storm' } : {} },
-      i18n.storm.playAgain,
-    ),
+    playAgain('.storm-play-again.button', i18n.storm.playAgain),
   ];
-};
-
-export default renderEnd;
+}

--- a/ui/storm/src/view/main.ts
+++ b/ui/storm/src/view/main.ts
@@ -1,5 +1,4 @@
 import { Chessground as makeChessground } from '@lichess-org/chessground';
-import type { VNode } from 'snabbdom';
 
 import { licon } from 'lib/licon';
 import { pubsub } from 'lib/pubsub';
@@ -7,23 +6,26 @@ import { makeCgOpts, povMessage } from 'lib/puz/run';
 import { getNow } from 'lib/puz/util';
 import { makeConfig as makeCgConfig } from 'lib/puz/view/chessground';
 import renderClock from 'lib/puz/view/clock';
+import renderHistory from 'lib/puz/view/history';
 import { playModifiers, renderCombo } from 'lib/puz/view/util';
-import { onInsert, hl, icon } from 'lib/view';
+import { onInsert, icon, div, main, button, dataIcon, a, strong, span, p, type VNode } from 'lib/view';
 
-import config from '../config';
-import type StormCtrl from '../ctrl';
-import renderEnd from './end';
+import config from '@/config';
+import type StormCtrl from '@/ctrl';
+
+import renderSummary from './end';
 
 export default function (ctrl: StormCtrl): VNode {
   if (ctrl.vm.dupTab) return renderReload(i18n.storm.thisRunWasOpenedInAnotherTab);
   if (ctrl.vm.lateStart) return renderReload(i18n.storm.thisRunHasExpired);
-  if (!ctrl.run.endAt)
-    return hl('div.storm.storm-app.storm--play', { class: playModifiers(ctrl.run) }, renderPlay(ctrl));
-  return hl('main.storm.storm--end', renderEnd(ctrl));
+  if (!ctrl.run.endAt) {
+    return div('.storm.storm-app.storm--play', { class: playModifiers(ctrl.run) }, renderPlay(ctrl));
+  }
+  return main('.storm.storm--end', [renderSummary(ctrl), renderHistory(ctrl)]);
 }
 
 const chessground = (ctrl: StormCtrl): VNode =>
-  hl('div.cg-wrap', {
+  div('.cg-wrap', {
     hook: onInsert(el => {
       ctrl.ground(
         makeChessground(
@@ -45,49 +47,52 @@ const renderBonus = (bonus: number) => `${bonus}s`;
 const renderPlay = (ctrl: StormCtrl): VNode[] => {
   const run = ctrl.run;
   const now = getNow();
+  const start = now - ctrl.duration;
   const { malus, bonus } = run.modifier;
   return [
-    hl('div.puz-board.main-board', [chessground(ctrl), ctrl.promotion.view()]),
-    hl('div.puz-side', [
-      run.clock.startAt ? renderSolved(ctrl) : renderStart(),
-      hl('div.puz-clock', [
+    div('.puz-board.main-board', [chessground(ctrl), ctrl.promotion.view()]),
+    div('.puz-side', [
+      run.clock.startAt ? renderSolved(ctrl) : startNode,
+      div('.puz-clock', [
         renderClock(run, ctrl.endNow, true),
-        !!malus && malus.at > now - 900 && hl('div.puz-clock__malus', '-' + malus.seconds),
-        !!bonus && bonus.at > now - 900 && hl('div.puz-clock__bonus', '+' + bonus.seconds),
-        run.clock.started() || [hl('span.puz-clock__pov', povMessage(run))],
+        !!malus && malus.at > start ? div('.puz-clock__malus', '-' + malus.seconds) : null,
+        !!bonus && bonus.at > start ? div('.puz-clock__bonus', '+' + bonus.seconds) : null,
+        run.clock.started() ? [div('.puz-clock__pov', povMessage(run))] : null,
       ]),
-      hl('div.puz-side__table', [renderControls(ctrl), renderCombo(config, renderBonus)(run)]),
+      div('.puz-side__table', [renderControls(ctrl), renderCombo(config, renderBonus)(run)]),
     ]),
   ];
 };
 
 const renderSolved = ({ countWins }: StormCtrl): VNode =>
-  hl('div.puz-side__top.puz-side__solved', [hl('div.puz-side__solved__text', `${countWins()}`)]);
+  div('.puz-side__top.puz-side__solved', [div('.puz-side__solved__text', `${countWins()}`)]);
 
 const renderControls = (ctrl: StormCtrl): VNode =>
-  hl('div.puz-side__control', [
-    hl('a.puz-side__control__flip.button', {
+  div('.puz-side__control', [
+    button('.puz-side__control__flip.button', {
       class: { active: ctrl.flipped, 'button-empty': !ctrl.flipped },
-      attrs: { 'data-icon': licon.ChasingArrows, title: i18n.site.flipBoard + ' (Keyboard: f)' },
+      ...dataIcon(licon.ChasingArrows),
+      title: i18n.site.flipBoard + ' (Keyboard: f)',
       hook: onInsert(el => el.addEventListener('click', ctrl.flip)),
     }),
-    hl('a.puz-side__control__reload.button.button-empty', {
-      attrs: { href: '/storm', 'data-icon': licon.Trash, title: i18n.storm.newRun },
+    a('/storm')('.puz-side__control__reload.button.button-empty', {
+      ...dataIcon(licon.Trash),
+      title: i18n.storm.newRun,
     }),
-    hl('a.puz-side__control__end.button.button-empty', {
-      attrs: { 'data-icon': licon.FlagOutline, title: i18n.storm.endRun },
+    button('.puz-side__control__end.button.button-empty', {
+      ...dataIcon(licon.FlagOutline),
+      title: i18n.storm.endRun,
       hook: onInsert(el => el.addEventListener('click', ctrl.endNow)),
     }),
   ]);
 
-const renderStart = () =>
-  hl('div.puz-side__top.puz-side__start', [
-    hl('div.puz-side__start__text', [hl('strong', 'Puzzle Storm'), hl('span', i18n.storm.moveToStart)]),
-  ]);
+const startNode = div('.puz-side__top.puz-side__start', [
+  div('.puz-side__start__text', [strong('Puzzle Storm'), span(i18n.storm.moveToStart)]),
+]);
 
 const renderReload = (text: string) =>
-  hl('div.storm.storm--reload.box.box-pad', [
+  div('.storm.storm--reload.box.box-pad', [
     icon(licon.Storm)(),
-    hl('p', text),
-    hl('a.storm--dup__reload.button', { attrs: { href: '/storm' } }, i18n.storm.clickToReload),
+    p(text),
+    a('/storm')('.storm--dup__reload.button', i18n.storm.clickToReload),
   ]);


### PR DESCRIPTION
# Why

An another small module migration to tag helpers to find any issues, or missing usage patterns.

# How

Refactor Storm views to use tag helpers, other small tweaks including game duration inside controller, slight code reorganization and visual tweak.

# Preview

<img width="1801" height="1203" alt="Screenshot 2026-07-29 at 10 18 42" src="https://github.com/user-attachments/assets/462ca1a5-c10d-4693-ae5c-9a4dad04be8a" />
<img width="1801" height="1203" alt="Screenshot 2026-07-29 at 10 07 13" src="https://github.com/user-attachments/assets/d35914a3-6c44-4ff2-82f4-275e22904273" />
