### PR TITLE
workspace: enable consistent returns lint rule

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -6,6 +6,7 @@
   },
   "ignorePatterns": ["**/dist/", "**/public"],
   "rules": {
+    "consistent-return": "error",
     "default-param-last": "error",
     "eqeqeq": [
       "error",
@@ -264,6 +265,7 @@
       "files": ["bin/**", "cron/**"],
       "rules": {
         "await-thenable": "off",
+        "consistent-return": "off",
         "no-unused-vars": "off",
         "prefer-const": "off",
         "unicorn/prefer-set-has": "off"

--- a/ui/.build/src/build.ts
+++ b/ui/.build/src/build.ts
@@ -55,7 +55,7 @@ export function stopBuild(): Promise<any> {
 }
 
 function monitor(pkgs: string[]) {
-  if (!env.watch) return;
+  if (!env.watch) return undefined;
   return makeTask({
     key: 'monitor',
     includes: [

--- a/ui/.build/src/console.ts
+++ b/ui/.build/src/console.ts
@@ -21,7 +21,7 @@ export async function startConsole() {
     let body = '';
 
     req.on('data', chunk => (body += chunk.toString()));
-    req.on('end', () => {
+    return req.on('end', () => {
       try {
         const [levelAndVal] = Object.entries<string>(JSON.parse(body));
         const level = levelAndVal[0];
@@ -35,11 +35,11 @@ export async function startConsole() {
         if (typeof val !== 'string') val = stringify(val, { indent: 2, maxLength: 80 });
 
         env.log(`${mark}${c.grey(val)}`, ip);
-        res
+        return res
           .writeHead(200, { 'Access-Control-Allow-Origin': '*', 'Access-Control-Allow-Methods': 'POST' })
           .end();
       } catch (_) {
-        res.writeHead(400).end();
+        return res.writeHead(400).end();
       }
     });
   }).listen(8666);

--- a/ui/.build/src/esbuild.ts
+++ b/ui/.build/src/esbuild.ts
@@ -10,7 +10,7 @@ import { makeTask, stopTask } from './task.ts';
 let esbuildCtx: es.BuildContext | undefined;
 
 export async function esbuild(): Promise<[string, string] | undefined> {
-  if (!env.begin('esbuild')) return;
+  if (!env.begin('esbuild')) return undefined;
 
   const options: es.BuildOptions = {
     bundle: true,
@@ -193,6 +193,7 @@ function condenseLiterals(text: string) {
       if (text.startsWith('html', i + 1)) return [i + 6, true];
       if (text.startsWith('trim', i + 1)) return [i + 6, false];
     }
+    return undefined;
   };
   const condense = (str: string, isHtml: boolean) =>
     isHtml

--- a/ui/.build/src/sass.ts
+++ b/ui/.build/src/sass.ts
@@ -22,7 +22,7 @@ export function stopSass(): void {
 }
 
 export async function sass(): Promise<string | undefined> {
-  if (!env.begin('sass')) return;
+  if (!env.begin('sass')) return undefined;
 
   await Promise.allSettled([
     fs.promises.mkdir(env.cssOutDir),

--- a/ui/.build/src/sync.ts
+++ b/ui/.build/src/sync.ts
@@ -7,7 +7,7 @@ import { isGlob, isFolder, isClose } from './parse.ts';
 import { makeTask } from './task.ts';
 
 export async function sync(): Promise<void[] | undefined> {
-  if (!env.begin('sync')) return;
+  if (!env.begin('sync')) return undefined;
   return Promise.all(
     [...env.tasks('sync')].map(async ([pkg, sync]) => {
       const { root, exact } = await srcRoot(env.rootDir, sync.src);

--- a/ui/analyse/src/crazy/crazyView.ts
+++ b/ui/analyse/src/crazy/crazyView.ts
@@ -11,7 +11,7 @@ const oKeys = ['pawn', 'knight', 'bishop', 'rook', 'queen'] as const;
 type Position = 'top' | 'bottom';
 
 export default function (ctrl: AnalyseCtrl, color: Color, position: Position) {
-  if (!ctrl.node.crazy || ctrl.data.game.variant.key !== 'crazyhouse') return;
+  if (!ctrl.node.crazy || ctrl.data.game.variant.key !== 'crazyhouse') return undefined;
   const pocket = ctrl.node.crazy.pockets[color === 'white' ? 0 : 1];
   const dropped = ctrl.justDropped;
   const captured = ctrl.justCaptured;

--- a/ui/analyse/src/explorer/explorerView.ts
+++ b/ui/analyse/src/explorer/explorerView.ts
@@ -396,7 +396,7 @@ let lastFen: FEN = '';
 export default function (ctrl: AnalyseCtrl): MaybeVNode {
   const { explorer } = ctrl;
 
-  if (!explorer.enabled()) return;
+  if (!explorer.enabled()) return undefined;
 
   const data = explorer.current();
   const configOpened = explorer.config.data.open();

--- a/ui/analyse/src/forecast/forecastView.ts
+++ b/ui/analyse/src/forecast/forecastView.ts
@@ -12,9 +12,9 @@ import type { ForecastStep } from './interfaces';
 
 function onMyTurn(fctrl: ForecastCtrl, cNodes: ForecastStep[]): VNode | undefined {
   const firstNode = cNodes[0];
-  if (!firstNode) return;
+  if (!firstNode) return undefined;
   const fcs = fctrl.findStartingWithNode(firstNode);
-  if (!fcs.length) return;
+  if (!fcs.length) return undefined;
   const lines = fcs.filter(fc => fc.length > 1);
   return h(
     'button.on-my-turn.button.text',

--- a/ui/analyse/src/fork.ts
+++ b/ui/analyse/src/fork.ts
@@ -81,9 +81,9 @@ const eventToIndex = (e: MouseEvent): number | undefined => {
 };
 
 export function view(ctrl: AnalyseCtrl, concealOf?: ConcealOf) {
-  if (ctrl.retro?.isSolving() || ctrl.study?.hideMoves()) return;
+  if (ctrl.retro?.isSolving() || ctrl.study?.hideMoves()) return undefined;
   ctrl.fork.update();
-  if (!ctrl.fork.isVisible) return;
+  if (!ctrl.fork.isVisible) return undefined;
   const isMainline = concealOf && ctrl.onMainline;
   return hl(
     'div.analyse__fork',

--- a/ui/analyse/src/idbTree.ts
+++ b/ui/analyse/src/idbTree.ts
@@ -93,7 +93,7 @@ export class IdbTree {
   };
 
   async saveMoves(force = false): Promise<IDBValidKey | undefined> {
-    if (this.noop || this.ctrl.study || !(this.cache.movesDirty || force)) return;
+    if (this.noop || this.ctrl.study || !(this.cache.movesDirty || force)) return undefined;
     return this.moveDb().then(db =>
       db.put(this.id, { root: treeOps.structuredCloneLite(this.ctrl.tree.root) }),
     );

--- a/ui/analyse/src/keyboard.ts
+++ b/ui/analyse/src/keyboard.ts
@@ -47,6 +47,7 @@ export const bind = (ctrl: AnalyseCtrl) => {
     else if (ctrl.practice || ctrl.study?.practice || ctrl.retro?.isSolving()) return undefined;
     else if (ctrl.cevalEnabled()) ctrl.playBestMove();
     else if (ctrl.isCevalAllowed() && ctrl.ceval.analysable) ctrl.cevalEnabled(!ctrl.cevalEnabled());
+    return undefined;
   });
 
   if (ctrl.study?.practice) return;

--- a/ui/analyse/src/practice/practiceView.ts
+++ b/ui/analyse/src/practice/practiceView.ts
@@ -101,7 +101,7 @@ export const renderCustomStatus = ({ ceval }: AnalyseCtrl, hardMode: Prop<boolea
 
 export default function (root: AnalyseCtrl): VNode | undefined {
   const ctrl = root.practice;
-  if (!ctrl) return;
+  if (!ctrl) return undefined;
   const comment: Comment | null = ctrl.comment();
   const isFiftyMoves = ctrl.currentNode().fen.split(' ')[4] === '100';
   const running: boolean = ctrl.running();

--- a/ui/analyse/src/retrospect/nvuiRetroView.ts
+++ b/ui/analyse/src/retrospect/nvuiRetroView.ts
@@ -12,7 +12,7 @@ import type { RetroCtrl } from '@/retrospect/retroCtrl';
 export function renderRetro(nvuiCtx: AnalyseNvuiContext): LooseVNodes {
   const ctx = makeContext(nvuiCtx);
   const { ctrl } = ctx;
-  if (ctrl.ongoing || ctrl.synthetic || !ctrl.hasFullComputerAnalysis()) return;
+  if (ctrl.ongoing || ctrl.synthetic || !ctrl.hasFullComputerAnalysis()) return undefined;
   const current = ctrl.retro?.current();
   const mistakes = ctrl.retro?.completion();
 

--- a/ui/analyse/src/retrospect/retroView.ts
+++ b/ui/analyse/src/retrospect/retroView.ts
@@ -180,7 +180,7 @@ function renderFeedback(root: AnalyseCtrl, fb: Exclude<keyof typeof feedback, 'e
 
 export default function (root: AnalyseCtrl): VNode | undefined {
   const ctrl = root.retro;
-  if (!ctrl) return;
+  if (!ctrl) return undefined;
   const fb = ctrl.feedback(),
     completion = ctrl.completion();
   return hl('div.retro-box.training-box.sub-box', [

--- a/ui/analyse/src/study/description.ts
+++ b/ui/analyse/src/study/description.ts
@@ -33,7 +33,7 @@ export function view(study: StudyCtrl, chapter: boolean): VNode | undefined {
     contrib = study.members.canContribute() && !study.gamebookPlay;
   if (desc.edit) return edit(desc, chapter ? study.data.chapter.id : study.data.id, chapter);
   const isEmpty = desc.text === '-';
-  if (!desc.text || (isEmpty && !contrib)) return;
+  if (!desc.text || (isEmpty && !contrib)) return undefined;
   return hl(`div.study-desc${chapter ? '.chapter-desc' : ''}${isEmpty ? '.empty' : ''}`, [
     contrib &&
       !isEmpty &&

--- a/ui/analyse/src/study/gamebook/gamebookButtons.ts
+++ b/ui/analyse/src/study/gamebook/gamebookButtons.ts
@@ -8,7 +8,7 @@ import type StudyCtrl from '../studyCtrl';
 export function playButtons(root: AnalyseCtrl): VNode | undefined {
   const study = root.study!,
     ctrl = study.gamebookPlay;
-  if (!ctrl) return;
+  if (!ctrl) return undefined;
   const state = ctrl.state,
     fb = state.feedback,
     myTurn = fb === 'play';

--- a/ui/analyse/src/study/playerBars.ts
+++ b/ui/analyse/src/study/playerBars.ts
@@ -25,7 +25,7 @@ import { resultTag } from './studyView';
 
 export default function (ctrl: AnalyseCtrl): VNode[] | undefined {
   const study = ctrl.study;
-  if (!study) return;
+  if (!study) return undefined;
   const relayPlayers = study.relay?.players;
   const showTeamLeaderboard = !!study.relay?.data.tour.showTeamScores;
   const relayTeamLeaderboard = study.relay?.teamLeaderboard;

--- a/ui/analyse/src/study/relay/relayGames.ts
+++ b/ui/analyse/src/study/relay/relayGames.ts
@@ -40,57 +40,60 @@ const gamesList = (study: StudyCtrl, relay: RelayCtrl, pinned: boolean, cloudEva
   const roundPath = relay.roundPath();
   const showResults = study.multiBoard.showResults();
   const round = study.relay?.round;
-  return chapters.length === 1 && chapters[0].name === 'Chapter 1'
-    ? []
-    : chapters.map((c, i) => {
-        if (relay.players.pins.isChapterPinned(c) !== pinned) return;
-        const clocks = renderClocks(c);
-        const players = [c.players?.black, c.players?.white];
-        if (c.orientation === 'black') {
-          players.reverse();
-          clocks.reverse();
-        }
-        const current = c.id === study.data.chapter.id && !relay.tourShow();
-        return hl(
-          `a.relay-game.relay-game--${c.id}`,
-          {
-            attrs: {
-              ...gameLinkAttrs(roundPath, c),
-              'data-n': i + 1,
-            },
-            class: { 'relay-game--current': current },
-          },
-          [
-            showResults && cloudEval && verticalEvalGauge(c, c.orientation, cloudEval),
-            hl(
-              'span.relay-game__players',
-              players.map((p, i) => {
-                const playerColor: Color = (c.orientation === 'black' ? COLORS : COLORS.slice().reverse())[i];
-                const coloredResult =
-                  showResults &&
-                  c.status &&
-                  c.status !== '*' &&
-                  playerColoredResult(c.status, playerColor, round?.customScoring);
-                return hl(
-                  'span.relay-game__player',
-                  p
-                    ? [
-                        hl('span.mini-game__user', [
-                          playerFedFlag(p.fed),
-                          hl('span.name', [userTitle(p), p.name]),
-                          pinned && relay.players.pins.isPlayerPinned(p) ? pinIcon() : undefined,
-                        ]),
-                        coloredResult
-                          ? hl(coloredResult.tag, [coloredResult.points])
-                          : showResults && hl('span', clocks[i]),
-                      ]
-                    : [hl('span.mini-game__user', hl('span.name', 'Unknown player'))],
-                );
-              }),
-            ),
-          ],
-        );
-      });
+
+  if (chapters.length === 1 && chapters[0].name === 'Chapter 1') {
+    return [];
+  }
+
+  return chapters.map((c, i) => {
+    if (relay.players.pins.isChapterPinned(c) !== pinned) return undefined;
+    const clocks = renderClocks(c);
+    const players = [c.players?.black, c.players?.white];
+    if (c.orientation === 'black') {
+      players.reverse();
+      clocks.reverse();
+    }
+    const current = c.id === study.data.chapter.id && !relay.tourShow();
+    return hl(
+      `a.relay-game.relay-game--${c.id}`,
+      {
+        attrs: {
+          ...gameLinkAttrs(roundPath, c),
+          'data-n': i + 1,
+        },
+        class: { 'relay-game--current': current },
+      },
+      [
+        showResults && cloudEval && verticalEvalGauge(c, c.orientation, cloudEval),
+        hl(
+          'span.relay-game__players',
+          players.map((p, i) => {
+            const playerColor: Color = (c.orientation === 'black' ? COLORS : COLORS.slice().reverse())[i];
+            const coloredResult =
+              showResults &&
+              c.status &&
+              c.status !== '*' &&
+              playerColoredResult(c.status, playerColor, round?.customScoring);
+            return hl(
+              'span.relay-game__player',
+              p
+                ? [
+                    hl('span.mini-game__user', [
+                      playerFedFlag(p.fed),
+                      hl('span.name', [userTitle(p), p.name]),
+                      pinned && relay.players.pins.isPlayerPinned(p) ? pinIcon() : undefined,
+                    ]),
+                    coloredResult
+                      ? hl(coloredResult.tag, [coloredResult.points])
+                      : showResults && hl('span', clocks[i]),
+                  ]
+                : [hl('span.mini-game__user', hl('span.name', 'Unknown player'))],
+            );
+          }),
+        ),
+      ],
+    );
+  });
 };
 
 const renderClocks = (chapter: ChapterPreview) =>

--- a/ui/analyse/src/study/relay/relayTeams.ts
+++ b/ui/analyse/src/study/relay/relayTeams.ts
@@ -147,7 +147,7 @@ const renderTeams = (
         row.games.map(game => {
           const chap = chapters.get(game.id);
           const players = chap?.players;
-          if (!players) return;
+          if (!players) return undefined;
           const sortedPlayers =
             game.pov === 'white' ? [players.white, players.black] : [players.black, players.white];
           return (

--- a/ui/analyse/src/study/studyComments.ts
+++ b/ui/analyse/src/study/studyComments.ts
@@ -26,18 +26,18 @@ export const authorText = (author?: Author): string =>
   !author ? 'Unknown' : typeof author === 'string' ? author : author.name;
 
 export function currentComments(ctrl: AnalyseCtrl, includingMine: boolean): VNode | undefined {
-  if (!ctrl.node.comments) return;
+  if (!ctrl.node.comments) return undefined;
   const node = ctrl.node,
     study: StudyCtrl = ctrl.study!,
     chapter = study.currentChapter(),
     comments = node.comments!;
-  if (!comments.length) return;
+  if (!comments.length) return undefined;
   return h(
     'div',
     comments.map(comment => {
       const by: Author = comment.by;
       const isMine = isAuthorObj(by) && by.id === ctrl.opts.userId;
-      if (!includingMine && isMine) return;
+      if (!includingMine && isMine) return undefined;
       return h('div.study__comment.' + comment.id, [
         study.members.canContribute() && study.vm.mode.write
           ? h('a.edit', {

--- a/ui/analyse/src/study/studyCtrl.ts
+++ b/ui/analyse/src/study/studyCtrl.ts
@@ -443,7 +443,7 @@ export default class StudyCtrl {
       n.gamebook = n.gamebook || {};
       if (n.shapes) n.gamebook.shapes = n.shapes.slice(0);
     });
-    if (this.gamebookPlay?.chapterId === this.vm.chapterId) return;
+    if (this.gamebookPlay?.chapterId === this.vm.chapterId) return undefined;
     this.gamebookPlay = new GamebookPlayCtrl(this.ctrl, this.vm.chapterId, this.redraw);
     this.vm.mode.sticky = false;
     return undefined;

--- a/ui/analyse/src/study/studyShare.ts
+++ b/ui/analyse/src/study/studyShare.ts
@@ -12,7 +12,7 @@ import type RelayCtrl from './relay/relayCtrl';
 import { relayIframe } from './relay/relayTourView';
 
 function fromPly(ctrl: StudyShare): MaybeVNode {
-  if (!ctrl.onMainline()) return;
+  if (!ctrl.onMainline()) return undefined;
   const renderedMove = renderIndexAndMove(ctrl.currentNode(), false, false);
   return hl('label.url-start-at-ply', [
     cmnToggleProp({ id: 'study-share-start-position', prop: ctrl.withPly, redraw: ctrl.redraw }),

--- a/ui/analyse/src/treeView/columnView.ts
+++ b/ui/analyse/src/treeView/columnView.ts
@@ -34,11 +34,11 @@ class ColumnView extends InlineView {
   }
 
   renderNodes([child, ...siblings]: TreeNode[], opts: Args): LooseVNodes {
-    if (!child) return;
+    if (!child) return undefined;
     const { parentPath, parentDisclose } = opts;
     const childPath = parentPath + child.id;
     const conceal = opts.conceal ?? this.concealOf(true)(childPath, child);
-    if (conceal === 'hide') return;
+    if (conceal === 'hide') return undefined;
     const emptyMove = () => hl('move.empty', { class: { conceal: conceal === 'conceal' } }, '...');
     const isWhite = child.ply % 2 === 1;
     const comments = this.commentNodes(child, { conceal: conceal === 'conceal' });

--- a/ui/analyse/src/treeView/inlineView.ts
+++ b/ui/analyse/src/treeView/inlineView.ts
@@ -49,7 +49,7 @@ export class InlineView {
   constructor(readonly ctrl: AnalyseCtrl) {}
 
   renderNodes([child, ...siblings]: TreeNode[], args: Args): LooseVNodes {
-    if (!child) return;
+    if (!child) return undefined;
     const { isMainline, parentDisclose } = args;
     return child.forceVariation && isMainline
       ? hl('interrupt', this.lines([child, ...siblings], args))
@@ -93,7 +93,7 @@ export class InlineView {
 
   protected lines(lines: TreeNode[], args: Args): LooseVNodes {
     const { parentDisclose, parentPath, parentNode, isMainline } = args;
-    if (!lines.length || parentDisclose === 'collapsed') return;
+    if (!lines.length || parentDisclose === 'collapsed') return undefined;
     const anchor = parentDisclose === 'expanded' && (this.inline || !isMainline);
     const lineArgs = { parentPath, parentNode, isMainline: false };
 
@@ -108,7 +108,7 @@ export class InlineView {
   }
 
   private sidelineNodes([child, ...siblings]: TreeNode[], args: Args): LooseVNodes {
-    if (!child) return;
+    if (!child) return undefined;
     const childArgs = this.childArgs(child, args, false);
     const sideline = [
       this.moveNode(child, args),

--- a/ui/analyse/src/view/actionMenu.ts
+++ b/ui/analyse/src/view/actionMenu.ts
@@ -56,7 +56,7 @@ function autoplayButtons(ctrl: AnalyseCtrl): VNode {
 const hiddenInput = (name: string, value: string) => hl('input', { attrs: { type: 'hidden', name, value } });
 
 function studyButton(ctrl: AnalyseCtrl) {
-  if (ctrl.study || ctrl.ongoing) return;
+  if (ctrl.study || ctrl.ongoing) return undefined;
   return hl(
     'form',
     {

--- a/ui/analyse/src/view/clocks.ts
+++ b/ui/analyse/src/view/clocks.ts
@@ -26,7 +26,7 @@ export default function renderClocks(ctrl: AnalyseCtrl, path: TreePath): [VNode,
       isWhiteTurn ? [parentClock, node.clock] : [node.clock, parentClock]
     ).map(c => (defined(c) && c < 0 ? undefined : c));
 
-  if (!centis.some(notNull)) return;
+  if (!centis.some(notNull)) return undefined;
 
   const study = ctrl.study;
 

--- a/ui/analyse/src/view/components.ts
+++ b/ui/analyse/src/view/components.ts
@@ -165,7 +165,7 @@ export const renderUnderboard = ({ ctrl, deps, study }: ViewContext): VNode =>
   );
 
 export function renderInputs(ctrl: AnalyseCtrl): VNode | undefined {
-  if (ctrl.ongoing || !ctrl.data.userAnalysis) return;
+  if (ctrl.ongoing || !ctrl.data.userAnalysis) return undefined;
   if (ctrl.redirecting) return spinner();
   return hl('div.copyables', [
     hl('div.pair', [
@@ -211,6 +211,7 @@ export function renderInputs(ctrl: AnalyseCtrl): VNode | undefined {
                 if (e.key !== 'Enter' || e.shiftKey || e.ctrlKey || e.altKey || e.metaKey || isMobile())
                   return undefined;
                 else if (changePgnIfDifferent()) e.preventDefault();
+                return undefined;
               });
               if (isMobile()) el.addEventListener('focusout', changePgnIfDifferent);
             }),

--- a/ui/bits/src/bits.auth.ts
+++ b/ui/bits/src/bits.auth.ts
@@ -90,9 +90,11 @@ function signupStart() {
 
   $form.on('submit', () => {
     const responseEl = $form.find('[name="cf-turnstile-response"]');
-    if (!responseEl.length || responseEl.val())
+    if (!responseEl.length || responseEl.val()) {
       $form.find('button.submit').prop('disabled', true).addClass('button-empty').html(spinnerHtml);
-    else return false;
+      return true;
+    }
+    return false;
   });
 
   $form.find('.password-generator button').on('click', () => {

--- a/ui/bits/src/bits.broadcastForm.i18nCheck.ts
+++ b/ui/bits/src/bits.broadcastForm.i18nCheck.ts
@@ -50,6 +50,7 @@ export default function initModule(): void {
           : nameInput.value
         : false;
     if (name) return name.trim();
+    return undefined;
   };
   // Initial load
   const shortName = getShortName();

--- a/ui/bits/src/bits.checkout.ts
+++ b/ui/bits/src/bits.checkout.ts
@@ -121,6 +121,7 @@ export function initModule({
     $(this).text(currencyFormat(amount, pricing.currency));
     ($(this).siblings('input').data('amount', amount)[0] as HTMLInputElement).checked = true;
     updateFeeLabel();
+    return true;
   });
 
   const $userInput = $checkout.find('input.user-autocomplete');
@@ -225,7 +226,7 @@ function payPalOrderStart($checkout: Cash, pricing: Pricing, getAmount: () => nu
       style: payPalStyle,
       createOrder: (_data: any, _actions: any) => {
         const amount = getAmount();
-        if (!amount) return;
+        if (!amount) return undefined;
         return xhr
           .jsonAnyResponse(`/patron/paypal/checkout?currency=${pricing.currency}`, {
             method: 'post',
@@ -236,6 +237,7 @@ function payPalOrderStart($checkout: Cash, pricing: Pricing, getAmount: () => nu
             if (data.error) showErrorThenReload(data.error);
             else if (data.order?.id) return data.order.id;
             else location.assign('/patron');
+            return undefined;
           });
       },
       onApprove: (data: any, _actions: any) => {
@@ -254,7 +256,7 @@ function payPalSubscriptionStart($checkout: Cash, pricing: Pricing, getAmount: (
       style: payPalStyle,
       createSubscription: (_data: any, _actions: any) => {
         const amount = getAmount();
-        if (!amount) return;
+        if (!amount) return undefined;
         return xhr
           .jsonAnyResponse(`/patron/paypal/checkout?currency=${pricing.currency}`, {
             method: 'post',
@@ -265,6 +267,7 @@ function payPalSubscriptionStart($checkout: Cash, pricing: Pricing, getAmount: (
             if (data.error) showErrorThenReload(data.error);
             else if (data.subscription?.id) return data.subscription.id;
             else location.assign('/patron');
+            return undefined;
           });
       },
       onApprove: (data: any, _actions: any) => {

--- a/ui/bits/src/bits.expandText.ts
+++ b/ui/bits/src/bits.expandText.ts
@@ -16,20 +16,19 @@ interface Candidate {
 
 function toYoutubeEmbedUrl(url: string): string | undefined {
   const result = parseYoutubeUrl(url);
-  if (result) {
-    return embedYoutubeUrl(result);
-  }
+  if (!result) return undefined;
+  return embedYoutubeUrl(result);
 }
 
 site.load.then(() => {
   function parseLink(a: HTMLAnchorElement): Parsed | undefined {
-    if (a.href.replace(/^https?:\/\//, '') !== a.textContent?.replace(/^https?:\/\//, '')) return;
+    if (a.href.replace(/^https?:\/\//, '') !== a.textContent?.replace(/^https?:\/\//, '')) return undefined;
     const yt = toYoutubeEmbedUrl(a.href);
-    if (yt)
-      return {
-        type: 'youtube',
-        src: yt,
-      };
+    if (!yt) return undefined;
+    return {
+      type: 'youtube',
+      src: yt,
+    };
   }
 
   function expandYoutube(a: Candidate) {

--- a/ui/bits/src/bits.forum.ts
+++ b/ui/bits/src/bits.forum.ts
@@ -206,7 +206,7 @@ site.load.then(() => {
   });
 
   $('form.reply').on('submit', () => {
-    if (submittingReply) return false;
+    if (submittingReply) return;
     replyStorage.remove();
     submittingReply = true;
   });

--- a/ui/bits/src/bits.voiceChat.ts
+++ b/ui/bits/src/bits.voiceChat.ts
@@ -35,7 +35,7 @@ export function initModule(opts: VoiceChatOpts): VoiceChat | undefined {
   const devices = navigator.mediaDevices;
   if (!devices) {
     alert('Voice chat requires navigator.mediaDevices');
-    return;
+    return undefined;
   }
 
   let state: State = 'off';
@@ -218,29 +218,29 @@ export function initModule(opts: VoiceChatOpts): VoiceChat | undefined {
   return {
     render: () => {
       const connections = allOpenConnections();
-      return devices
-        ? hl(
-            'button.mchat__tab.voicechat.data-count.voicechat-' + state,
-            {
-              attrs: {
-                'data-icon': licon.Handset,
-                title: `Voice chat: ${state}`,
-                'data-count': state === 'on' ? connections.length + 1 : 0,
-              },
-              hook: onInsert(el => el.addEventListener('click', () => (peer ? stop() : start()))),
-            },
-            state === 'on'
-              ? connections.map(c =>
-                  hl('audio.voicechat__audio.' + c.peer, {
-                    attrs: { autoplay: true },
-                    hook: onInsert<HTMLAudioElement>(el => {
-                      el.srcObject = c.remoteStream;
-                    }),
-                  }),
-                )
-              : [],
-          )
-        : undefined;
+      if (!devices) return undefined;
+
+      return hl(
+        'button.mchat__tab.voicechat.data-count.voicechat-' + state,
+        {
+          attrs: {
+            'data-icon': licon.Handset,
+            title: `Voice chat: ${state}`,
+            'data-count': state === 'on' ? connections.length + 1 : 0,
+          },
+          hook: onInsert(el => el.addEventListener('click', () => (peer ? stop() : start()))),
+        },
+        state === 'on'
+          ? connections.map(c =>
+              hl('audio.voicechat__audio.' + c.peer, {
+                attrs: { autoplay: true },
+                hook: onInsert<HTMLAudioElement>(el => {
+                  el.srcObject = c.remoteStream;
+                }),
+              }),
+            )
+          : [],
+      );
     },
   };
 }

--- a/ui/bits/src/crop.ts
+++ b/ui/bits/src/crop.ts
@@ -39,6 +39,7 @@ export function wireCropDialog(
         }
       }
     }
+    return undefined;
   });
 }
 

--- a/ui/bits/src/youtubeLinkProcessor.ts
+++ b/ui/bits/src/youtubeLinkProcessor.ts
@@ -13,7 +13,7 @@ const videoIdRegex = /^[a-zA-Z0-9_-]{11}$/;
 export function parseYoutubeUrl(url: string): YoutubeMatch | undefined {
   const youtubeUrl = toURL(url);
   if (!youtubeUrl) {
-    return;
+    return undefined;
   }
 
   switch (getDomainType(youtubeUrl.hostname)) {
@@ -21,6 +21,8 @@ export function parseYoutubeUrl(url: string): YoutubeMatch | undefined {
       return handleYoutuBe(youtubeUrl);
     case 'youtube.com':
       return handleYoutubeCom(youtubeUrl);
+    default:
+      return undefined;
   }
 }
 
@@ -51,6 +53,8 @@ function getDomainType(hostname: string): DomainType | undefined {
   if ('youtu.be' === hostname) {
     return 'youtu.be';
   }
+
+  return undefined;
 }
 
 function handleYoutubeCom(url: URL): YoutubeMatch | undefined {
@@ -61,7 +65,7 @@ function handleYoutubeCom(url: URL): YoutubeMatch | undefined {
   let { videoId } = parsedResult;
 
   if (!videoType) {
-    return;
+    return undefined;
   }
 
   let startTimeParamName = 't';
@@ -81,7 +85,7 @@ function handleYoutubeCom(url: URL): YoutubeMatch | undefined {
     case 'playlist':
       const playlistId = searchParams.get('list');
       if (!playlistId || !isPlaylistIdValid(playlistId)) {
-        return;
+        return undefined;
       }
 
       return {
@@ -92,7 +96,7 @@ function handleYoutubeCom(url: URL): YoutubeMatch | undefined {
   }
 
   if (!isVideoIdValid(videoId) || !videoId) {
-    return;
+    return undefined;
   }
   const startTime = extractStartTime(searchParams.get(startTimeParamName) ?? '');
 
@@ -108,7 +112,7 @@ function handleYoutuBe(url: URL): YoutubeMatch | undefined {
 
   const [videoId] = getPathSegments(pathname);
   if (!isVideoIdValid(videoId) || !videoId) {
-    return;
+    return undefined;
   }
 
   const startTimeParamName = 't';
@@ -133,12 +137,10 @@ function parseVideoPath(path: string): {
   videoId?: string | null;
 } {
   const [type, id] = getPathSegments(path);
-
-  const videoType = supportedVideoTypes.includes(type) ? (type as VideoType) : undefined;
-
-  const videoId = isVideoIdValid(id) ? id : undefined;
-
-  return { videoType, videoId };
+  return {
+    videoType: supportedVideoTypes.includes(type) ? (type as VideoType) : undefined,
+    videoId: isVideoIdValid(id) ? id : undefined,
+  };
 }
 
 const isVideoIdValid = (id?: string | null) =>

--- a/ui/botDev/src/devSideView.ts
+++ b/ui/botDev/src/devSideView.ts
@@ -105,8 +105,6 @@ function ratingSpan(p: Bot): VNode {
 
 function speedIcon(speed: LocalSpeed = env.game.speed): LiconValue {
   switch (speed) {
-    case 'classical':
-      return licon.Turtle;
     case 'rapid':
       return licon.Rabbit;
     case 'blitz':
@@ -114,6 +112,9 @@ function speedIcon(speed: LocalSpeed = env.game.speed): LiconValue {
     case 'bullet':
     case 'ultraBullet':
       return licon.Bullet;
+    case 'classical':
+    default:
+      return licon.Turtle;
   }
 }
 

--- a/ui/botDev/src/historyDialog.ts
+++ b/ui/botDev/src/historyDialog.ts
@@ -109,7 +109,7 @@ class HistoryDialog {
   }
 
   version(version: string | number | undefined): BotVersionInfo | undefined {
-    if (!version) return;
+    if (!version) return undefined;
     return this.versions.find(b => String(b.version) === String(version));
   }
 

--- a/ui/botPlay/src/clock.ts
+++ b/ui/botPlay/src/clock.ts
@@ -5,7 +5,7 @@ import type { DateMillis } from './interfaces';
 
 export const computeClockState = (g: Game): ClockState | undefined => {
   const config = g.clockConfig;
-  if (!config) return;
+  if (!config) return undefined;
   const initial = config.initial || 5;
   const state = {
     white: initial,

--- a/ui/botPlay/src/game.ts
+++ b/ui/botPlay/src/game.ts
@@ -85,7 +85,7 @@ export class Game {
     this.data.end = endOnTheBoard(chess);
     if (this.end) return this.end;
     const clock = this.clockState();
-    if (!clock) return;
+    if (!clock) return undefined;
     const flag = (color: Color): GameEnd => ({
       winner: opposite(color),
       status: 'outoftime',
@@ -122,7 +122,7 @@ export class Game {
 }
 
 const endOnTheBoard = (chess: Chess): GameEnd | undefined => {
-  if (!chess.isEnd()) return;
+  if (!chess.isEnd()) return undefined;
   return {
     winner: chess.outcome()?.winner,
     status: chess.isCheckmate() ? 'mate' : chess.isStalemate() ? 'stalemate' : 'draw',

--- a/ui/botPlay/src/play/view/playView.ts
+++ b/ui/botPlay/src/play/view/playView.ts
@@ -75,7 +75,7 @@ const viewActions = (ctrl: PlayCtrl) =>
 
 const viewResult = (ctrl: PlayCtrl) => {
   const end = ctrl.game.end;
-  if (!end) return;
+  if (!end) return undefined;
   const result = end.winner === 'white' ? '1-0' : end.winner === 'black' ? '0-1' : '½-½';
   const statusData: StatusData = {
     winner: end.winner,

--- a/ui/botPlay/src/setup/setupCtrl.ts
+++ b/ui/botPlay/src/setup/setupCtrl.ts
@@ -78,9 +78,9 @@ export default class SetupCtrl {
 
   ongoingGameWorthResuming = () => {
     const game = this.ongoing();
-    if (!game?.worthResuming()) return;
+    if (!game?.worthResuming()) return undefined;
     const bot = this.opts.bots.find(b => b.key === game.botKey);
-    if (!bot) return;
+    if (!bot) return undefined;
     return { game, board: game.lastBoard(), bot };
   };
 }

--- a/ui/botPlay/src/setup/view/setupDialog.ts
+++ b/ui/botPlay/src/setup/view/setupDialog.ts
@@ -9,7 +9,7 @@ import type SetupCtrl from '../setupCtrl';
 
 export const setupDialog = (ctrl: SetupCtrl) => {
   const bot = ctrl.selectedBot;
-  if (!bot) return;
+  if (!bot) return undefined;
   return snabDialog({
     class: `bot-setup__dialog bot-color--${bot.key}`,
     onClose: ctrl.cancel,

--- a/ui/challenge/src/view.ts
+++ b/ui/challenge/src/view.ts
@@ -131,6 +131,8 @@ function timeControl(c: TimeControl): string {
       return c.daysPerTurn + ' days';
     case 'clock':
       return c.show || '-';
+    default:
+      return '-';
   }
 }
 

--- a/ui/chart/src/movetime.ts
+++ b/ui/chart/src/movetime.ts
@@ -40,7 +40,7 @@ export default async function (
   const possibleChart = maybeChart(el);
   if (possibleChart) return possibleChart as PlyChart;
   const moveCentis = data.game.moveCentis;
-  if (!moveCentis) return; // imported games
+  if (!moveCentis) return undefined; // imported games
   type PlotSeries = { white: MovePoint[]; black: MovePoint[] };
   const moveSeries: PlotSeries = {
     white: [],

--- a/ui/dasher/src/sound.ts
+++ b/ui/dasher/src/sound.ts
@@ -78,9 +78,9 @@ export class SoundCtrl extends PaneCtrl {
   };
 
   private readonly voiceSelectionDialog = () => {
-    if (!this.showVoiceSelection) return;
+    if (!this.showVoiceSelection) return undefined;
     const content = this.renderVoiceSelection();
-    if (!content) return;
+    if (!content) return undefined;
     return snabDialog({
       onClose: () => {
         if (!i18n.nvui) return site.reload();

--- a/ui/editor/src/view.ts
+++ b/ui/editor/src/view.ts
@@ -346,7 +346,7 @@ function controls(ctrl: EditorCtrl, state: EditorState): VNode {
 }
 
 function inputs(ctrl: EditorCtrl, fen: FEN): VNode | undefined {
-  if (ctrl.cfg.embed) return;
+  if (ctrl.cfg.embed) return undefined;
 
   return h('div.copyables', [
     h('p', [

--- a/ui/insight/src/boards.ts
+++ b/ui/insight/src/boards.ts
@@ -31,7 +31,7 @@ const miniGame = (game: Game) =>
   ]);
 
 export default function (ctrl: Ctrl, attrs: VNodeData | null = null) {
-  if (!ctrl.vm.answer || ctrl.vm.answer.games.length === 0) return;
+  if (!ctrl.vm.answer || ctrl.vm.answer.games.length === 0) return undefined;
 
   return h('div.game-sample.box.hscroll', attrs, [
     h('div.top', 'Some of the games used to generate this insight'),

--- a/ui/insight/src/filters.ts
+++ b/ui/insight/src/filters.ts
@@ -6,7 +6,7 @@ import type Ctrl from './ctrl';
 import type { Dimension } from './interfaces';
 
 const select = (ctrl: Ctrl) => (dimension: Dimension) => {
-  if (dimension.key === 'date') return;
+  if (dimension.key === 'date') return undefined;
   const single = dimension.key === 'period';
   return h(
     'select',

--- a/ui/keyboardMove/src/keyboardMove.ts
+++ b/ui/keyboardMove/src/keyboardMove.ts
@@ -5,7 +5,7 @@ import type { KeyboardMoveHandler, Opts, ArrowKey } from '@/exports';
 import { type Submit, makeSubmit } from '@/keyboardSubmit';
 
 export function initModule(opts: Opts): KeyboardMoveHandler | undefined {
-  if (opts.input.classList.contains('ready')) return;
+  if (opts.input.classList.contains('ready')) return undefined;
   opts.input.classList.add('ready');
 
   const clear = makeClear(opts);

--- a/ui/learn/src/ctrl.ts
+++ b/ui/learn/src/ctrl.ts
@@ -39,9 +39,9 @@ export class LearnCtrl {
       levelId ||
       // otherwise find a level id based on the last completed level
       (() => {
-        if (!stageId) return;
+        if (!stageId) return null;
         const stage = stageById[stageId];
-        if (!stage) return;
+        if (!stage) return null;
         const result = this.data.stages[stage.key];
         let it = 0;
         if (result) while (result.scores[it]) it++;

--- a/ui/learn/src/promotionView.ts
+++ b/ui/learn/src/promotionView.ts
@@ -12,7 +12,7 @@ export function promotionView(ctrl: RunCtrl) {
   const { promotionCtrl } = ctrl.levelCtrl;
   const { promoting } = promotionCtrl;
   const { chessground: ground } = ctrl;
-  if (!promoting || !ground) return;
+  if (!promoting || !ground) return undefined;
 
   const color = opposite(ground.state.turnColor);
   const orientation = ground.state.orientation;

--- a/ui/learn/src/scenario.ts
+++ b/ui/learn/src/scenario.ts
@@ -38,7 +38,7 @@ export default function (blueprint: ScenarioLevel | undefined, opts: ScenarioOpt
 
   const opponent = () => {
     const step = steps[it];
-    if (!step) return;
+    if (!step) return undefined;
     const move = decomposeUci(step.move);
     const res = opts.chess.move(move[0], move[1], move[2]);
     if (!res) return fail();

--- a/ui/lib/src/async.ts
+++ b/ui/lib/src/async.ts
@@ -185,6 +185,7 @@ export function throttleWithFlush<T extends (...args: any[]) => void>(
     queued = undefined;
     wrapped.apply(thisArg, args);
     timerId = setTimeout(runNext, interval);
+    return timerId;
   };
 
   const throttled = function (this: any, ...args: Parameters<T>) {

--- a/ui/lib/src/bot/filter.ts
+++ b/ui/lib/src/bot/filter.ts
@@ -111,5 +111,7 @@ export function combine(v: FilterFacetValue, by: FilterBy): number {
       return Math.min(...Object.values(v));
     case 'avg':
       return Object.values(v).reduce((sum, w) => sum + w, 0) / Object.keys(v).length;
+    default:
+      return 0;
   }
 }

--- a/ui/lib/src/ceval/view/main.ts
+++ b/ui/lib/src/ceval/view/main.ts
@@ -125,7 +125,7 @@ let gaugeLast = 0;
 let gaugeTicks: VNode[];
 
 export function renderGauge(ctrl: CevalHandler): VNode | undefined {
-  if (ctrl.ongoing || !ctrl.showEvalGauge()) return;
+  if (ctrl.ongoing || !ctrl.showEvalGauge()) return undefined;
   gaugeTicks ??= [...Array(8).keys()].map(i =>
     hl(i === 3 ? 'tick.zero' : 'tick', { attrs: { style: `height: ${(i + 1) * 12.5}%` } }),
   );
@@ -318,7 +318,7 @@ function setHovering(ceval: CevalCtrl, fen: FEN | null, uci?: Uci): void {
 }
 
 export function renderPvs(ctrl: CevalHandler): VNode | undefined {
-  if (!ctrl.cevalEnabled()) return;
+  if (!ctrl.cevalEnabled()) return undefined;
   const ceval = ctrl.ceval;
   const multiPv = ceval.search.multiPv,
     node = ctrl.getNode(),
@@ -456,7 +456,7 @@ function renderPvMoves(pos: Position, pv: Uci[]): VNode[] {
 function renderPvBoard(ctrl: CevalHandler): VNode | undefined {
   const ceval = ctrl.ceval;
   const pvBoard = ceval.pvBoard();
-  if (!pvBoard) return;
+  if (!pvBoard) return undefined;
   const { fen, uci } = pvBoard;
   const orientation = ctrl.getOrientation();
   const cgConfig = {

--- a/ui/lib/src/chat/discussion.ts
+++ b/ui/lib/src/chat/discussion.ts
@@ -86,7 +86,7 @@ export default function (ctrl: ChatCtrl): Array<VNode | undefined> {
 }
 
 function renderInput(ctrl: ChatCtrl): VNode | undefined {
-  if (!ctrl.vm.writeable) return;
+  if (!ctrl.vm.writeable) return undefined;
   if ((ctrl.data.loginRequired && !ctrl.data.userId) || ctrl.data.restricted)
     return h('input.mchat__say', {
       attrs: { placeholder: i18n.site.loginToChat, disabled: true },

--- a/ui/lib/src/chat/moderation.ts
+++ b/ui/lib/src/chat/moderation.ts
@@ -75,10 +75,10 @@ async function reportUserText(resourceId: string, username: string, text: string
 export const lineAction = (): VNode => h('action.mod', { attrs: dataIcon(licon.Agent) });
 
 export function moderationView(ctrl?: ModerationCtrl): VNode[] | undefined {
-  if (!ctrl) return;
+  if (!ctrl) return undefined;
   if (ctrl.loading()) return [h('div.loading')];
   const data = ctrl.data();
-  if (!data) return;
+  if (!data) return undefined;
   const perms = ctrl.opts.permissions;
 
   const infos = data.history

--- a/ui/lib/src/chat/preset.ts
+++ b/ui/lib/src/chat/preset.ts
@@ -60,7 +60,7 @@ export function presetCtrl(opts: PresetOpts): PresetCtrl {
 
 export function presetView(ctrl: PresetCtrl): VNode | undefined {
   const group = ctrl.group();
-  if (!group) return;
+  if (!group) return undefined;
   const sets = groups[group];
   const said = ctrl.said();
   return sets && said.length < 2

--- a/ui/lib/src/chat/renderChat.ts
+++ b/ui/lib/src/chat/renderChat.ts
@@ -20,7 +20,7 @@ export function renderChat(ctrl: ChatCtrl, hook: Hooks = {}): VNode {
 
 function renderVoiceChat(ctrl: ChatCtrl) {
   const p = ctrl.voiceChat;
-  if (!p.enabled()) return;
+  if (!p.enabled()) return undefined;
   return p.instance
     ? p.instance.render()
     : hl('button.mchat__tab.voicechat.voicechat-slot', {

--- a/ui/lib/src/game/promotion.ts
+++ b/ui/lib/src/game/promotion.ts
@@ -94,7 +94,7 @@ export class PromotionCtrl {
 
   view = (antichess?: boolean): MaybeVNode => {
     const promoting = this.promoting;
-    if (!promoting) return;
+    if (!promoting) return undefined;
     promoting.hooks.show?.(this, antichess ? [...PROMOTABLE_ROLES, 'king'] : PROMOTABLE_ROLES);
 
     return (

--- a/ui/lib/src/nvui/handler.ts
+++ b/ui/lib/src/nvui/handler.ts
@@ -275,7 +275,7 @@ export type DropMove = { role: Role; key: Key };
 
 export function inputToMove(input: string, fen: string, chessground: CgApi): Uci | DropMove | undefined {
   const dests = chessground.state.movable.dests;
-  if (!dests || input.length < 1) return;
+  if (!dests || input.length < 1) return undefined;
   const legalUcis = destsToUcis(dests),
     legalSans = sanWriter(fen, legalUcis),
     cleanedMixedCase = input[0] + input.slice(1).replace(/\+|#/g, '').toLowerCase();

--- a/ui/lib/src/tree/tree.ts
+++ b/ui/lib/src/tree/tree.ts
@@ -97,9 +97,9 @@ export function makeTree(root: TreeNode): TreeWrapper {
   }
 
   const getNodeList = (path: TreePath): TreeNode[] =>
-    ops.collect(root, function (node: TreeNode) {
+    ops.collect(root, (node: TreeNode) => {
       const id = treePath.head(path);
-      if (id === '') return;
+      if (id === '') return undefined;
       path = treePath.tail(path);
       return ops.childById(node, id);
     });

--- a/ui/lib/src/view/complete.ts
+++ b/ui/lib/src/view/complete.ts
@@ -30,7 +30,7 @@ export function complete<Result>(opts: CompleteOpts<Result>): void {
       });
     },
     selectedResult = (): Result | undefined => {
-      if (selectedIndex === null) return;
+      if (selectedIndex === null) return undefined;
       return renderedResults[selectedIndex];
     },
     moveSelection = (offset: number) => {
@@ -69,7 +69,7 @@ export function complete<Result>(opts: CompleteOpts<Result>): void {
       return true;
     },
     keydown(e: KeyboardEvent) {
-      if ($container.hasClass('none')) return;
+      if ($container.hasClass('none')) return undefined;
       if (e.code === 'ArrowDown') {
         moveSelection(1);
         return false;

--- a/ui/puzzle/src/moveTest.ts
+++ b/ui/puzzle/src/moveTest.ts
@@ -21,11 +21,11 @@ function isAltCastle(str: string): str is AltCastle {
 }
 
 export default function moveTest(ctrl: PuzzleCtrl): MoveTestReturn {
-  if (ctrl.mode === 'view') return;
-  if (!pathOps.contains(ctrl.path, ctrl.initialPath)) return;
+  if (ctrl.mode === 'view') return undefined;
+  if (!pathOps.contains(ctrl.path, ctrl.initialPath)) return undefined;
 
   const playedByColor = plyOpponentColor(ctrl.node.ply);
-  if (playedByColor !== ctrl.pov) return;
+  if (playedByColor !== ctrl.pov) return undefined;
 
   const nodes = ctrl.nodeList.slice(pathOps.size(ctrl.initialPath) + 1).map(node => ({
     uci: node.uci,

--- a/ui/puzzle/src/moveTree.ts
+++ b/ui/puzzle/src/moveTree.ts
@@ -54,11 +54,11 @@ const makeNode = (pos: Position, move: Move, ply: number, san: San): TreeNode =>
   });
 
 export function nextCorrectMove(ctrl: PuzzleCtrl): NormalMove | undefined {
-  if (ctrl.mode === 'view') return;
-  if (!pathOps.contains(ctrl.path, ctrl.initialPath)) return;
+  if (ctrl.mode === 'view') return undefined;
+  if (!pathOps.contains(ctrl.path, ctrl.initialPath)) return undefined;
 
   const playedByColor = plyOpponentColor(ctrl.node.ply);
-  if (playedByColor === ctrl.pov) return;
+  if (playedByColor === ctrl.pov) return undefined;
 
   const nodes = ctrl.nodeList.slice(pathOps.size(ctrl.initialPath) + 1);
   const nextUci = ctrl.data.puzzle.solution[nodes.length];

--- a/ui/puzzle/src/view/side.ts
+++ b/ui/puzzle/src/view/side.ts
@@ -149,7 +149,7 @@ const colors = [
 
 export function replay(ctrl: PuzzleCtrl): MaybeVNode {
   const { replay, angle } = ctrl.data;
-  if (!replay) return;
+  if (!replay) return undefined;
   const i = replay.i + (ctrl.mode === 'play' ? 0 : 1);
   const text = i18n.puzzleTheme[angle.key];
   return hl('div.puzzle__side__replay', [

--- a/ui/racer/src/view/main.ts
+++ b/ui/racer/src/view/main.ts
@@ -80,6 +80,8 @@ const selectScreen = (ctrl: RacerCtrl): MaybeVNodes => {
         ? [playerScore(ctrl), div('.racer__post', [raceComplete, yourRank(ctrl), nextRace]), combo]
         : [spectating, div('.racer__post', [raceComplete, nextRace]), combo];
     }
+    default:
+      return [];
   }
 };
 

--- a/ui/recap/src/slides.ts
+++ b/ui/recap/src/slides.ts
@@ -144,7 +144,7 @@ export const firstMoves = (r: Recap, firstMove: Counted<string>): VNode => {
 
 export const openingColor = (os: ByColor<Counted<Opening>>, color: Color): VNode | undefined => {
   const o = os[color];
-  if (!o.count) return;
+  if (!o.count) return undefined;
   return slideTag('openings')([
     hl('div.lpv.lpv--todo.lpv--moves-bottom.is2d', {
       hook: onInsert(el => loadOpeningLpv(el, color, o.value)),

--- a/ui/round/src/crazy/crazyView.ts
+++ b/ui/round/src/crazy/crazyView.ts
@@ -12,7 +12,7 @@ const eventNames = ['mousedown', 'touchstart'];
 
 export default function pocket(ctrl: RoundController, color: Color, position: TopOrBottom): LooseVNode {
   const step = plyStep(ctrl.data, ctrl.ply);
-  if (!step.crazy) return;
+  if (!step.crazy) return undefined;
   const droppedRole = ctrl.justDropped,
     preDropRole = ctrl.preDrop,
     pocket = step.crazy.pockets[color === 'white' ? 0 : 1],

--- a/ui/round/src/view/clock.ts
+++ b/ui/round/src/view/clock.ts
@@ -34,7 +34,7 @@ const onTheSide = (round: RoundController) => (color: Color, position: TopOrBott
 
 function whosTurn(ctrl: RoundController, color: Color, position: TopOrBottom) {
   const d = ctrl.data;
-  if (finished(d) || aborted(d)) return;
+  if (finished(d) || aborted(d)) return undefined;
   return hl(
     'div.rclock.rclock-turn.rclock-' + position,
     d.game.player === color &&

--- a/ui/round/src/view/expiration.ts
+++ b/ui/round/src/view/expiration.ts
@@ -9,7 +9,7 @@ let rang = false;
 
 export default function (ctrl: RoundController): MaybeVNode {
   const d = playable(ctrl.data) && ctrl.data.expiration;
-  if (!d) return;
+  if (!d) return undefined;
   const timeLeft = Math.max(0, d.movedAt - Date.now() + d.millisToMove),
     secondsLeft = Math.floor(timeLeft / 1000),
     myTurn = isPlayerTurn(ctrl.data),

--- a/ui/simul/src/socket.ts
+++ b/ui/simul/src/socket.ts
@@ -9,7 +9,7 @@ type SimulMessage =
 export type SimulTpe = SimulMessage['tpe'];
 export type SimulSocket = {
   send: SocketSend;
-  receive(message: SimulMessage): void | false;
+  receive(message: SimulMessage): void;
 };
 
 export function makeSocket(send: SocketSend, ctrl: SimulCtrl): SimulSocket {
@@ -27,9 +27,6 @@ export function makeSocket(send: SocketSend, ctrl: SimulCtrl): SimulSocket {
         case 'hostGame':
           ctrl.data.host.gameId = message.data;
           ctrl.redraw();
-          return;
-        default:
-          return false;
       }
     },
   };

--- a/ui/site/src/sound.ts
+++ b/ui/site/src/sound.ts
@@ -43,7 +43,7 @@ export default new (class implements SoundI {
     const ctx = await this.ctxPromise;
     if (path) this.paths.set(name, path);
     else path = this.paths.get(name) ?? this.resolvePath(name);
-    if (!path) return;
+    if (!path) return undefined;
     if (this.sounds.has(path)) return this.sounds.get(path);
 
     const result = await fetch(path);
@@ -60,10 +60,10 @@ export default new (class implements SoundI {
   }
 
   resolvePath(name: Name): string | undefined {
-    if (!this.enabled()) return;
+    if (!this.enabled()) return undefined;
     let dir = this.theme;
     if (this.theme === 'music' || this.speech()) {
-      if (['move', 'capture', 'check', 'checkmate'].includes(name)) return;
+      if (['move', 'capture', 'check', 'checkmate'].includes(name)) return undefined;
       dir = 'standard';
     }
     return this.url(`${dir}/${name[0].toUpperCase() + name.slice(1)}.mp3`);

--- a/ui/swiss/src/view/header.ts
+++ b/ui/swiss/src/view/header.ts
@@ -14,7 +14,7 @@ const oneDayInSeconds = 60 * 60 * 24;
 
 function clock(ctrl: SwissCtrl): VNode | undefined {
   const next = ctrl.data.nextRound;
-  if (!next) return;
+  if (!next) return undefined;
   if (next.in > oneDayInSeconds)
     return h('div.clock', [
       h('time.timeago.shy', {

--- a/ui/swiss/src/view/main.ts
+++ b/ui/swiss/src/view/main.ts
@@ -95,7 +95,7 @@ function controls(ctrl: SwissCtrl): VNode {
 }
 
 function nextRound(ctrl: SwissCtrl): VNode | undefined {
-  if (!ctrl.opts.schedule || ctrl.data.nbOngoing || ctrl.data.round === 0) return;
+  if (!ctrl.opts.schedule || ctrl.data.nbOngoing || ctrl.data.round === 0) return undefined;
   return hl(
     'form.schedule-next-round',
     {
@@ -141,7 +141,7 @@ function joinButton(ctrl: SwissCtrl): VNode | undefined {
       i18n.team.joinTeam,
     );
 
-  if (!d.canJoin && (d.me?.absent || !d.me)) return;
+  if (!d.canJoin && (d.me?.absent || !d.me)) return undefined;
 
   if (ctrl.joinSpinner) return spinnerVdom();
 

--- a/ui/swiss/src/view/playerInfo.ts
+++ b/ui/swiss/src/view/playerInfo.ts
@@ -11,7 +11,7 @@ import { isOutcome } from '../util';
 import { player as renderPlayer } from './util';
 
 export default function (ctrl: SwissCtrl): VNode | undefined {
-  if (!ctrl.playerInfoId) return;
+  if (!ctrl.playerInfoId) return undefined;
   const data = ctrl.data.playerInfo;
   const tag = 'div.swiss__player-info.swiss__table';
   if (data?.user.id !== ctrl.playerInfoId)

--- a/ui/tournament/src/view/header.ts
+++ b/ui/tournament/src/view/header.ts
@@ -19,7 +19,7 @@ const hasFreq = (freq: 'shield' | 'marathon', d: TournamentData) => d.schedule?.
 
 function clock(ctrl: TournamentController): VNode | undefined {
   const d = ctrl.data;
-  if (d.isFinished) return;
+  if (d.isFinished) return undefined;
   if (d.secondsToFinish) return h('div.clock', [h('div.time', { hook: startClock(d.secondsToFinish) })]);
   if (d.secondsToStart) {
     if (d.secondsToStart > oneDayInSeconds)
@@ -43,8 +43,8 @@ function clock(ctrl: TournamentController): VNode | undefined {
 }
 
 function image(d: TournamentData): VNode | undefined {
-  if (d.isFinished) return;
-  if (hasFreq('shield', d) || hasFreq('marathon', d)) return;
+  if (d.isFinished) return undefined;
+  if (hasFreq('shield', d) || hasFreq('marathon', d)) return undefined;
   const s = d.spotlight;
   if (s?.iconImg) return h('img.img', { attrs: { src: site.asset.url('images/' + s.iconImg) } });
   return icon(s?.iconFont || licon.Trophy)('.img');

--- a/ui/voice/src/voice.vosk.ts
+++ b/ui/voice/src/voice.vosk.ts
@@ -38,7 +38,7 @@ export function initModule(): VoskModule {
   function initRecognizer(opts: RecognizerOpts): AudioNode | undefined {
     if (!opts.words?.length || !voskClient) {
       recs.remove(opts.recId);
-      return;
+      return undefined;
     }
     const kaldi = new voskClient.KaldiRecognizer(opts.audioCtx.sampleRate, JSON.stringify(opts.words));
 


### PR DESCRIPTION
# How

Enable consistent returns lint rule to avoid mixing value-returning and non-value-returning code (`void` !== `undefined`).

In contradiction to the warning on rule page, in our case the rule has found few more cases, even with `noImplicitReturns` TS flag enabled. The `bin` and `cron` scripts has been excluded from the checks since there is no much benefit from the rule in there.

Refs:
* https://oxc.rs/docs/guide/usage/linter/rules/typescript/consistent-return.html