### PR TITLE
Remove reactivemongo shaded dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -63,7 +63,7 @@ libraryDependencies ++= pekko.bundle ++ playWs.bundle ++ macwire.bundle ++ scala
   play.json, play.logback, compression, hasher,
   reactivemongo.driver, /* reactivemongo.kamon, */ maxmind, scalatags,
   kamon.core, kamon.influxdb, kamon.metrics,
-  scaffeine, caffeine, lettuce, uaparser, nettyTransport, reactivemongo.shaded, catsMtl
+  scaffeine, caffeine, lettuce, uaparser, nettyTransport, catsMtl
 ) ++ tests.bundle
 
 // influences the compilation order

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -82,7 +82,6 @@ object Dependencies:
     val driver = ("org.reactivemongo" %% "reactivemongo" % "1.1.0-pekko.noshaded.RC20")
     val actorsPekko = "org.reactivemongo" %% "reactivemongo-actors-pekko" % rmVersion
     val stream = "org.reactivemongo" %% "reactivemongo-pekkostream" % rmVersion
-    val shaded = "org.reactivemongo" % s"reactivemongo-shaded-native-$os-$dashArch" % rmVersion
     def bundle = Seq(driver, actorsPekko, stream)
 
   object play:


### PR DESCRIPTION
As We use reactivemongo noshaded since moving to pekko. This is an
unintentional change, but it works fine. So I guess this is a win.

Note: reactivemongo core depends on netty 4.1 the shaded version is
4.2.
