### PR TITLE
Center eval and logo on mobile analysis

### DIFF
--- a/ui/analyse/css/_tools-mobile.scss
+++ b/ui/analyse/css/_tools-mobile.scss
@@ -82,6 +82,7 @@
       display: flex;
       align-items: center;
       text-shadow: none;
+      justify-content: center;
 
       .cmn-toggle {
         margin-inline-start: 10px;


### PR DESCRIPTION
## What does this change do?

Centers the evaluation and logo elements in the mobile analysis interface.

## Why is this change needed?

On mobile screen sizes, the evaluation and logo elements were not properly centered. This change adjusts the CSS so they are centered in the intended layout.

## Relevant discussion

https://github.com/lichess-org/lila/issues/20429
