### PR TITLE
prevent deploy of workflow_dispatch run

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -202,10 +202,10 @@ def find_workflow_run(repo, session, workflow_url, wanted_commits, *, stage):
                 if run["head_commit"]["id"] not in wanted_commits or run["_workflow_url"] != workflow_url:
                     continue
 
-                if run["event"] == "pull_request" and not stage:
+                if run["event"] in ("pull_request", "workflow_dispatch") and not stage:
                     # Not accepted in production, because pull request builds
                     # do not have access to the secret store. Hence no ab.
-                    print(f"- {run['html_url']} PULL REQUEST (no ab)")
+                    print(f"- {run['html_url']} NOT PROD-ELIGIBLE ({run['event']})")
                 elif run["status"] != "completed":
                     print(f"- {run['html_url']} PENDING (waiting {backoff}s)")
                     pending = True


### PR DESCRIPTION
The server build github action can run on workflow_dispatch on non-master branches. This marks those as not eligible for deploy.
