### PR TITLE
ui: update puzzle history appearance for Storme and Racer

### DIFF
--- a/ui/lib/css/puz/_history.scss
+++ b/ui/lib/css/puz/_history.scss
@@ -68,8 +68,6 @@
   bad {
     @extend %flex-center, %box-radius-bottom;
 
-    text-transform: uppercase;
-
     &::before {
       @extend %data-icon;
 

--- a/ui/lib/css/puz/_history.scss
+++ b/ui/lib/css/puz/_history.scss
@@ -22,6 +22,8 @@
 
     &__meta {
       @extend %flex-between;
+
+      padding-top: 3px;
     }
 
     &__result {
@@ -31,6 +33,7 @@
         @extend %page-text;
 
         font-size: 0.9em;
+        margin-left: 0.5em;
       }
     }
 
@@ -40,21 +43,32 @@
       visibility: hidden;
     }
 
+    cg-container {
+      outline: 3px solid transparent;
+      border-radius: $miniboard-radius-size;
+    }
+
+    .good cg-container {
+      outline-color: $c-good;
+    }
+
+    .bad cg-container {
+      outline-color: $c-bad;
+    }
+
     &:hover .puz-history__round__id {
+      font-family: monospace;
       color: $c-font;
       visibility: visible;
+      font-size: 0.9em;
     }
   }
 
   good,
   bad {
-    @extend %flex-center;
+    @extend %flex-center, %box-radius-bottom;
 
-    color: white;
-    padding: 0 0.5em 0.1em 0.3em;
-    margin-inline-end: 1ch;
-    font-size: 0.9em;
-    opacity: 0.7;
+    text-transform: uppercase;
 
     &::before {
       @extend %data-icon;
@@ -64,7 +78,7 @@
   }
 
   good {
-    background: $c-good;
+    color: $c-good;
 
     &::before {
       content: $licon-Checkmark;
@@ -72,7 +86,7 @@
   }
 
   bad {
-    background: $c-bad;
+    color: $c-bad;
 
     &::before {
       content: $licon-X;

--- a/ui/lib/src/puz/view/history.ts
+++ b/ui/lib/src/puz/view/history.ts
@@ -46,7 +46,7 @@ export default (ctrl: PuzCtrl): VNode => {
         )
         .map(round =>
           h('div.puz-history__round', { key: round.puzzle.id }, [
-            h('a.puz-history__round__puzzle.mini-board.cg-wrap.is2d', {
+            h(`a.puz-history__round__puzzle.mini-board.cg-wrap.is2d.${round.win ? 'good' : 'bad'}`, {
               attrs: {
                 href: `/training/${round.puzzle.id}`,
                 target: '_blank',


### PR DESCRIPTION
# How

Update puzzle history appearance for Storme and Racer modes, to match the appearance on the main puzzle history page:
* https://lichess.org/training/history

# Preview

<img width="746" height="424" alt="Screenshot 2026-07-30 at 09 44 48" src="https://github.com/user-attachments/assets/b6832111-a133-4f9f-9db6-75192476f732" />

<img width="1028" height="395" alt="Screenshot 2026-07-30 at 09 47 34" src="https://github.com/user-attachments/assets/581862cd-60e3-4812-bae4-fe34b3ba274a" />
