### PR TITLE
lint: add consistent type assertions rule, avoid casting

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -48,6 +48,7 @@
     "promise/no-callback-in-promise": "error",
     "promise/no-multiple-resolved": "error",
     "promise/no-return-wrap": "error",
+    "typescript/consistent-type-assertions": "error",
     "typescript/consistent-indexed-object-style": "error",
     "typescript/no-empty-interface": "error",
     "typescript/no-empty-object-type": "error",

--- a/ui/.build/src/hash.ts
+++ b/ui/.build/src/hash.ts
@@ -64,7 +64,7 @@ export async function hash(): Promise<void> {
 }
 
 export async function symlinkTargetHashes(newLinks?: string[]) {
-  const targetHashes = {} as Record<string, string>;
+  const targetHashes: Record<string, string> = {};
   if (newLinks?.length === 0) return targetHashes;
 
   await fs.promises.readdir(env.hashOutDir).then(files =>

--- a/ui/analyse/src/explorer/explorerView.ts
+++ b/ui/analyse/src/explorer/explorerView.ts
@@ -44,7 +44,7 @@ function showMoveTable(ctrl: AnalyseCtrl, data: OpeningData): MaybeVNode {
             draws: data.draws,
             uci: '',
             san: 'Σ',
-          } as OpeningMoveStats,
+          },
         ]
       : data.moves;
 

--- a/ui/analyse/src/view/settingsView.ts
+++ b/ui/analyse/src/view/settingsView.ts
@@ -175,7 +175,7 @@ function setupTouchHelp(view: HTMLElement) {
 
 function setupHoverHelp(view: HTMLElement) {
   const helpEl = () => view.querySelector<HTMLElement>('.help-container')!.firstElementChild!;
-  const helpPanes = { keyboardHelp: helpEl() } as Record<string, Element>;
+  const helpPanes: Record<string, Element> = { keyboardHelp: helpEl() };
 
   let hoverTimeout: number;
   view.querySelectorAll<HTMLElement>('.hover-help').forEach(el => {

--- a/ui/dgt/src/play.ts
+++ b/ui/dgt/src/play.ts
@@ -542,7 +542,7 @@ export default function (token: string): void {
       for (let i = 0; i < moves.length; i++) {
         if (moves[i] !== '') {
           //Make any move that may have been already played on the ChessBoard. Useful when reconnecting
-          const uciMove = <NormalMove>parseUci(moves[i]);
+          const uciMove = parseUci(moves[i]) as NormalMove;
           const normalizedMove = normalizeMove(chess, uciMove); //This is because chessops uses UCI_960
           if (normalizedMove && chess.isLegal(normalizedMove)) chess.play(normalizedMove);
         }
@@ -580,7 +580,7 @@ export default function (token: string): void {
         for (let i = 0; i < moves.length; i++) {
           if (moves[i] !== '') {
             //Make the new move
-            const uciMove = <NormalMove>parseUci(moves[i]);
+            const uciMove = parseUci(moves[i]) as NormalMove;
             const normalizedMove = normalizeMove(chess, uciMove); //This is because chessops uses UCI_960
             if (normalizedMove && chess.isLegal(normalizedMove)) {
               //This is a good chance to get the move in SAN format
@@ -927,7 +927,7 @@ export default function (token: string): void {
             //Get first move to process, usually the last since movesToProcess is usually 1
             SANMove = String(message.param.san[message.param.san.length - i]).trim();
             if (verbose) console.info('onmessage - SANMove = ' + SANMove);
-            const moveObject = <NormalMove | undefined>parseSan(localBoard, SANMove); //get move from DGT LiveChess
+            const moveObject = parseSan(localBoard, SANMove) as NormalMove | undefined; //get move from DGT LiveChess
             //if valid move on local chessops
             if (moveObject && localBoard.isLegal(moveObject)) {
               if (verbose) console.info('onmessage - Move is legal');

--- a/ui/lobby/src/store.ts
+++ b/ui/lobby/src/store.ts
@@ -18,24 +18,36 @@ interface Config<A> {
   fix(v: string | null): A;
 }
 
+function isTab(value: string | null): value is Tab {
+  return value === 'pools' || value === 'real_time' || value === 'seeks' || value === 'now_playing';
+}
+
+function isMode(value: string | null): value is Mode {
+  return value === 'list' || value === 'chart';
+}
+
+function isSort(value: string | null): value is Sort {
+  return value === 'rating' || value === 'time';
+}
+
 const tab: Config<Tab> = {
   key: 'lobby.tab',
   fix(t: string | null): Tab {
-    if (<Tab>t) return t as Tab;
+    if (isTab(t)) return t;
     return 'pools';
   },
 };
 const mode: Config<Mode> = {
   key: 'lobby.mode',
   fix(m: string | null): Mode {
-    if (<Mode>m) return m as Mode;
+    if (isMode(m)) return m;
     return 'list';
   },
 };
 const sort: Config<Sort> = {
   key: 'lobby.sort',
   fix(s: string | null): Sort {
-    if (<Sort>s) return s as Sort;
+    if (isSort(s)) return s;
     return 'rating';
   },
 };

--- a/ui/msg/src/network.ts
+++ b/ui/msg/src/network.ts
@@ -25,11 +25,11 @@ export async function loadMoreContacts(before: Date): Promise<Contact[]> {
 }
 
 export async function search(q: string): Promise<SearchResult> {
-  const res = await json(`/inbox/search?q=${q}`);
+  const res: SearchResult = await json(`/inbox/search?q=${q}`);
   return {
     ...res,
     contacts: res.contacts.map(upgradeContact),
-  } as SearchResult;
+  };
 }
 
 export function block(u: string) {

--- a/ui/tournament/src/view/calendarView.ts
+++ b/ui/tournament/src/view/calendarView.ts
@@ -14,12 +14,12 @@ import type { Tournament } from '../interfaces';
 import type { Ctrl, Lanes } from '../tournament.calendar';
 
 function tournamentClass(tour: Tournament, day: Date): Classes {
-  const classes = {
+  const classes: Classes = {
     rated: tour.rated,
     casual: !tour.rated,
     'max-rating': tour.hasMaxRating,
     yesterday: tour.bounds.start < day,
-  } as Classes;
+  };
   if (tour.schedule) classes[tour.schedule.freq] = true;
   return classes;
 }

--- a/ui/tournament/src/view/scheduleView.ts
+++ b/ui/tournament/src/view/scheduleView.ts
@@ -114,19 +114,19 @@ function splitOverlapping(lanes: Lane[]): Lane[] {
 }
 
 function tournamentClass(tour: Tournament): Classes {
-  const finished = tour.status === 30,
-    userCreated = tour.createdBy !== 'lichess',
-    classes = {
-      'tsht-rated': tour.rated,
-      'tsht-casual': !tour.rated,
-      'tsht-finished': finished,
-      'tsht-joinable': !finished,
-      'tsht-user-created': userCreated,
-      'tsht-thematic': !!tour.position,
-      'tsht-short': tour.minutes <= 30,
-      'tsht-max-rating': !userCreated && tour.hasMaxRating,
-      'tsht-variant': tour.variant.key !== 'standard' && tour.variant.key !== 'fromPosition',
-    } as Classes;
+  const finished = tour.status === 30;
+  const userCreated = tour.createdBy !== 'lichess';
+  const classes: Classes = {
+    'tsht-rated': tour.rated,
+    'tsht-casual': !tour.rated,
+    'tsht-finished': finished,
+    'tsht-joinable': !finished,
+    'tsht-user-created': userCreated,
+    'tsht-thematic': !!tour.position,
+    'tsht-short': tour.minutes <= 30,
+    'tsht-max-rating': !userCreated && tour.hasMaxRating,
+    'tsht-variant': tour.variant.key !== 'standard' && tour.variant.key !== 'fromPosition',
+  };
   if (tour.schedule) classes['tsht-' + tour.schedule.freq] = true;
   return classes;
 }


### PR DESCRIPTION
# Why

Add consistent type assertions rule, avoid casting when not needed, improve lobby store fixers.

For the second commit changes I have disabled `objectLiteralTypeAssertions` locally, and addressed few valid warnings. There are more of them, but addressing them would requite some potentially logic changing refactors, so I opt out doing it for now, and left to option with default value (`allow`).

Refs:
* https://oxc.rs/docs/guide/usage/linter/rules/typescript/consistent-type-assertions.html