### PR TITLE
ui: remove unused piece opacity attribute

### DIFF
--- a/ui/lib/src/game/promotion.ts
+++ b/ui/lib/src/game/promotion.ts
@@ -1,4 +1,3 @@
-import type { DrawShape } from '@lichess-org/chessground/draw';
 import type { MoveMetadata } from '@lichess-org/chessground/types';
 import { opposite, key2pos } from '@lichess-org/chessground/util';
 import { h } from 'snabbdom';
@@ -131,9 +130,9 @@ export class PromotionCtrl {
       g.setAutoShapes([
         {
           orig: dest,
-          piece: { color: opposite(g.state.turnColor), role, opacity: 0.8 },
+          piece: { color: opposite(g.state.turnColor), role },
           brush: '',
-        } as DrawShape,
+        },
       ]),
     );
   }


### PR DESCRIPTION
# Why

While working on previous PR I spotted that we cast pre promotion CG piece shape due to additional `opacity` not defined in CG types:
* https://github.com/lichess-org/chessground/blob/9f5e4bf331e05add8e8ff7da4cdbd4d176b17977/src/draw.ts#L22-L26

# How

After inspecting the code locally, I found that CG sets the opacity for auto pieces via SCSS, and indeed, the `opacity` parameter and related cast were not used/needed:

* https://github.com/lichess-org/chessground/blob/9f5e4bf331e05add8e8ff7da4cdbd4d176b17977/assets/chessground.base.css#L112-L112

# Preview

<img width="844" height="403" alt="Screenshot 2026-07-30 at 11 28 25" src="https://github.com/user-attachments/assets/d26e55bb-65d8-4510-b39b-bf6e18b8d7a4" />
