### PR TITLE
ui(puzzle): allow wrapping of difficulty form layout

### DIFF
--- a/ui/puzzle/css/_side.scss
+++ b/ui/puzzle/css/_side.scss
@@ -122,6 +122,7 @@
       display: flex;
       align-items: center;
       gap: 1em;
+      flex-wrap: wrap;
 
       select {
         flex: 1;


### PR DESCRIPTION
# Why

Fixes #21093
* #21093

# How

Allow wrapping of difficulty form layout in puzzle view, to avoid overflow for languages with lengthy select label and options (like German). If elements fit the width, the will be rendered in the same row.

# Preview

### German

<img width="487" height="387" alt="Screenshot 2026-07-30 at 23 25 38" src="https://github.com/user-attachments/assets/8e8c32ee-3d43-4fd1-8120-670d2c2d0aba" />

### English

<img width="487" height="387" alt="Screenshot 2026-07-30 at 23 25 54" src="https://github.com/user-attachments/assets/aee5470a-cca8-4441-bb2c-5c0934680c4a" />
