### PR TITLE
learn: guard the board.change handler against a missing ground

### DIFF
--- a/ui/learn/src/run/runCtrl.ts
+++ b/ui/learn/src/run/runCtrl.ts
@@ -32,8 +32,10 @@ export class RunCtrl {
     // Helpful for debugging:
     // site.mousetrap.bind(['shift+enter'], this.levelCtrl.complete);
     pubsub.on('board.change', (is3d: boolean) => {
-      this.chessground!.state.addPieceZIndex = is3d;
-      this.chessground!.redrawAll();
+      this.withGround(g => {
+        g.state.addPieceZIndex = is3d;
+        g.redrawAll();
+      });
     });
   }
 


### PR DESCRIPTION
Changing the board theme from the Learn page throws:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'state')
    at learn.js
    at Pubsub.emit
    at BoardCtrl.apply
    at BoardCtrl.setBoard
```

`RunCtrl` declares `chessground?: CgApi`, so it is genuinely optional — it is only
populated later by `setChessground`. The `board.change` handler nevertheless reaches
for it through a non-null assertion:

```ts
pubsub.on('board.change', (is3d: boolean) => {
  this.chessground!.state.addPieceZIndex = is3d;
  this.chessground!.redrawAll();
});
```

The assertion is what keeps this quiet at compile time, so it only shows up at runtime.
Opening the board settings dialog before a level has mounted its ground is enough to
hit it: `setBoard` emits `board.change`, the handler runs, and there is no ground yet.

The same class already has `withGround` for exactly this, so the handler now uses it
instead of asserting.

## To reproduce

1. Open /learn
2. Open the board settings (the cog, then Board)
3. Change any board setting

The error appears in the console and the setting does not apply until reload.
