### PR TITLE
ui(lobby): migrate list view to tag elements, remove unused util

### DIFF
--- a/ui/lobby/css/app/_hook-list.scss
+++ b/ui/lobby/css/app/_hook-list.scss
@@ -49,10 +49,14 @@
       font-weight: normal;
     }
 
-    &.sort .is::before {
+    .is {
+      visibility: hidden;
+    }
+
+    &.sort .is {
       opacity: 0.7;
       margin-inline-end: 3px;
-      content: $licon-DownTriangle;
+      visibility: visible;
     }
 
     &.player {

--- a/ui/lobby/src/view/realTime/list.ts
+++ b/ui/lobby/src/view/realTime/list.ts
@@ -1,39 +1,37 @@
-import { h } from 'snabbdom';
-
 import perfIcons from 'lib/game/perfIcons';
 import { licon } from 'lib/licon';
-import { bind, dataIcon } from 'lib/view';
+import { bind, dataIcon, tr, span, td, button, th, thead, tbody, icon, table } from 'lib/view';
 
 import type LobbyController from '@/ctrl';
 import * as hookRepo from '@/hookRepo';
 import type { Hook } from '@/interfaces';
 
-import { tds, perfNames } from '../util';
+import { perfNames } from '../util';
 
 function renderHook(ctrl: LobbyController, hook: Hook) {
-  return h(
-    'tr.hook.' + hook.action,
+  return tr(
+    `.hook.${hook.action}`,
     {
       key: hook.id,
       class: { disabled: !!hook.disabled },
-      attrs: {
-        role: 'button',
-        title: hook.disabled
-          ? ''
-          : hook.action === 'join'
-            ? i18n.site.joinTheGame + ' | ' + perfNames[hook.perf]
-            : i18n.site.cancel,
-        'data-id': hook.id,
-      },
+      role: 'button',
+      title: hook.disabled
+        ? ''
+        : hook.action === 'join'
+          ? i18n.site.joinTheGame + ' | ' + perfNames[hook.perf]
+          : i18n.site.cancel,
+      'data-id': hook.id,
     },
-    tds([
-      ctrl.me
-        ? h('span.ulink.ulpt.mobile-powertip', { attrs: { 'data-href': '/@/' + hook.u } }, hook.u)
-        : i18n.site.anonymous,
-      ...(!ctrl.me ? [] : !ctrl.opts.showRatings ? [''] : [hook.rating + (hook.prov ? '?' : '')]),
-      hook.clock,
-      h('span', { attrs: dataIcon(perfIcons[hook.perf]) }, i18n.site[hook.ra ? 'rated' : 'casual']),
-    ]),
+    [
+      td(
+        ctrl.me
+          ? span('.ulink.ulpt.mobile-powertip', { 'data-href': '/@/' + hook.u }, hook.u)
+          : i18n.site.anonymous,
+      ),
+      !ctrl.me ? null : td(!ctrl.opts.showRatings ? '' : [hook.rating + (hook.prov ? '?' : '')]),
+      td(hook.clock),
+      td(span({ ...dataIcon(perfIcons[hook.perf]) }, i18n.site[hook.ra ? 'rated' : 'casual'])),
+    ],
   );
 }
 
@@ -44,51 +42,51 @@ const isMine = (hook: Hook) => hook.action === 'cancel';
 const isNotMine = (hook: Hook) => !isMine(hook);
 
 export const toggle = (ctrl: LobbyController) =>
-  h('button.toggle', {
+  button('.toggle', {
     key: 'set-mode-chart',
-    attrs: { title: i18n.site.graph, 'data-icon': licon.LineGraph },
+    title: i18n.site.graph,
+    ...dataIcon(licon.LineGraph),
     hook: bind('click', _ => ctrl.setMode('chart'), ctrl.redraw),
   });
 
 export const render = (ctrl: LobbyController, allHooks: Hook[]) => {
-  const mine = allHooks.find(isMine),
-    max = mine ? 13 : 14,
-    hooks = allHooks.slice(0, max),
-    render = (hook: Hook) => renderHook(ctrl, hook),
-    standards = hooks.filter(isNotMine).filter(isStandard(true));
+  const mine = allHooks.find(isMine);
+  const max = mine ? 13 : 14;
+  const hooks = allHooks.slice(0, max);
+  const render = (hook: Hook) => renderHook(ctrl, hook);
+  const standards = hooks.filter(isNotMine).filter(isStandard(true));
   hookRepo.sort(ctrl, standards);
+
   const variants = hooks
     .filter(isNotMine)
     .filter(isStandard(false))
     .slice(0, Math.max(0, max - standards.length - 1));
   hookRepo.sort(ctrl, variants);
+
   const renderedHooks = [
     ...standards.map(render),
     variants.length
-      ? h('tr.variants', { key: 'variants' }, [
-          h('td', { attrs: { colspan: 5 } }, '— ' + i18n.site.variant + ' —'),
-        ])
+      ? tr('.variants', { key: 'variants' }, td({ attrs: { colspan: 5 } }, '— ' + i18n.site.variant + ' —'))
       : null,
     ...variants.map(render),
   ];
+
   if (mine) renderedHooks.unshift(render(mine));
-  return h('table.hooks__list', [
-    h(
-      'thead',
-      h('tr', [
-        h('th'),
+
+  return table('.hooks__list', [
+    thead(
+      tr([
+        th(),
         ctrl.me
-          ? h(
-              'th',
+          ? th(
               {
                 class: { sortable: true, sort: ctrl.sort === 'rating' },
                 hook: bind('click', _ => ctrl.setSort('rating'), ctrl.redraw),
               },
-              [h('icon.is'), i18n.site.rating],
+              [icon(licon.DownTriangle)('.is'), i18n.site.rating],
             )
           : null,
-        h(
-          'th',
+        th(
           ctrl.me
             ? {
                 key: 'time-header-with-rating',
@@ -98,13 +96,12 @@ export const render = (ctrl: LobbyController, allHooks: Hook[]) => {
             : {
                 key: 'time-header-without-rating',
               },
-          [h('icon.is'), i18n.site.time],
+          [icon(licon.DownTriangle)('.is'), i18n.site.time],
         ),
-        h('th', [h('icon.is'), i18n.site.mode]),
+        th(i18n.site.mode),
       ]),
     ),
-    h(
-      'tbody',
+    tbody(
       {
         class: { stepping: ctrl.stepping },
         hook: bind(

--- a/ui/lobby/src/view/util.ts
+++ b/ui/lobby/src/view/util.ts
@@ -1,11 +1,3 @@
-import { h } from 'snabbdom';
-
-import type { MaybeVNodes } from 'lib/view';
-
-export function tds(bits: MaybeVNodes): MaybeVNodes {
-  return bits.map(bit => h('td', [bit]));
-}
-
 export const perfNames = {
   ultraBullet: i18n.site.ultraBullet,
   bullet: i18n.site.bullet,


### PR DESCRIPTION
# How

Migrate lobby list view to tag elements, refactor sort icons a bit, remove unused util shared by correspondence games view and the list.

Stacked on #21109

> [!note]
> Looks like stacked PRs does not work for `lila` yet:
> <img width="601" height="293" alt="Screenshot 2026-07-31 at 11 45 47" src="https://github.com/user-attachments/assets/2d64eefc-7368-47a0-b921-5a2b18571b6e" />

# Preview

<img width="746" height="198" alt="Screenshot 2026-07-31 at 11 02 24" src="https://github.com/user-attachments/assets/8a6b30c0-7430-4146-ae9b-9a2a074a9359" />
