### PR TITLE
dasher: key the svg board thumbnail on the extension, not the name

### DIFF
--- a/ui/dasher/css/_board.scss
+++ b/ui/dasher/css/_board.scss
@@ -86,7 +86,9 @@
         $name-override: map-get($theme, name-override);
         $file-name: if($name-override, $name-override, $name);
 
-        @if $file-name == 'newspaper' {
+        // svg boards live in a subdirectory and ship no thumbnail, so they scale the
+        // board itself. Keyed on the extension, as in _board-2d.scss.
+        @if $file-ext == 'svg' {
           background-image: url(../images/board/svg/#{$file-name}.svg);
           background-size: 256px;
         } @else {


### PR DESCRIPTION
The dasher picks a board thumbnail like this:

```scss
@if $file-name == 'newspaper' {
  background-image: url(../images/board/svg/#{$file-name}.svg);
  background-size: 256px;
} @else {
  background-image: url(../images/board/#{$file-name}.thumbnail.#{$file-ext});
}
```

The branch it wants is "is this board an svg", since svg boards live in a
subdirectory and ship no `.thumbnail.` file. What it tests instead is a single
board's name. Those coincide today because newspaper is the only svg board, so
nothing is broken right now.

They stop coinciding the moment a second one is added: the new board falls into
the else branch, asks for `<name>.thumbnail.svg`, and shows an empty tile in the
picker. The board itself renders fine, which makes it a slightly confusing one to
chase — `_board-2d.scss` already derives its directory from the extension:

```scss
$dir-name: 'board#{if($file-ext == "svg", "/svg", "")}';
```

So this just brings the thumbnail rule in line with the rule next to it. No
change in output for the current set of boards.

I hit this adding an svg board downstream; happy to close it if you would rather
keep the special case until a second svg board actually lands.
