### PR TITLE
ui(lib): fix simuls top nav entry overflowing container

### DIFF
--- a/ui/lib/css/header/_topnav-visible.scss
+++ b/ui/lib/css/header/_topnav-visible.scss
@@ -81,10 +81,7 @@
           border-radius: 0 $menu-radius 0 0;
         }
 
-        &:last-child:not(.mobile-only) {
-          border-radius: 0 0 $menu-radius $menu-radius;
-        }
-
+        &:last-child:not(.mobile-only),
         &:has(+ .mobile-only:last-child) {
           border-radius: 0 0 $menu-radius $menu-radius;
         }

--- a/ui/lib/css/header/_topnav-visible.scss
+++ b/ui/lib/css/header/_topnav-visible.scss
@@ -81,7 +81,11 @@
           border-radius: 0 $menu-radius 0 0;
         }
 
-        &:last-child {
+        &:last-child:not(.mobile-only) {
+          border-radius: 0 0 $menu-radius $menu-radius;
+        }
+
+        &:has(+ .mobile-only:last-child) {
           border-radius: 0 0 $menu-radius $menu-radius;
         }
 


### PR DESCRIPTION
# Why

After shipping the roundness feature I have spotted one more issue with top nav.

# How

Fix simuls top nav entry overflowing container due to not visible on desktop `.mobile-only` donate link, which is acctually the last child in the container.

# Preview

<img width="292" height="312" alt="Screenshot 2026-08-01 at 09 53 08" src="https://github.com/user-attachments/assets/db2595b1-2780-4175-b904-c49c9817440a" />
