### PR TITLE
ui(lib): apply roundness to styled input range sliders

### DIFF
--- a/ui/lib/css/form/_range.scss
+++ b/ui/lib/css/form/_range.scss
@@ -4,7 +4,7 @@
   border: 1px solid $c-font-dimmer;
   height: 1em;
   width: 1.5em;
-  border-radius: 12px;
+  border-radius: $box-radius-size;
   background: $c-bg-box;
   cursor: pointer;
 }
@@ -14,7 +14,7 @@
   height: 1em;
   cursor: pointer;
   background: $c-shade;
-  border-radius: 0.5em;
+  border-radius: $box-radius-size;
 }
 
 input.range {
@@ -50,12 +50,10 @@ input.range {
 
   &::-ms-fill-lower {
     background: rgb(191 191 191 / 0.78);
-    border-radius: 11.8px;
   }
 
   &::-ms-fill-upper {
     background: rgb(214 214 214 / 0.78);
-    border-radius: 11.8px;
   }
 
   &::-ms-thumb {


### PR DESCRIPTION
# Why

One more element which we can apply roundness to seems to be styled input range sliders.

# How

Use roundness variable in the sliders styles, remove Edge overwrites (by 0.2px) - they seems to be not affecting the display even on 4k HDPI display.

# Preview

### Chrome macOS

https://github.com/user-attachments/assets/a1eabcab-4210-4aa1-8a31-d2d1d9d3b19c

### FF macOS

<img width="338" height="561" alt="Screenshot 2026-08-01 at 10 24 28" src="https://github.com/user-attachments/assets/dec4ddb7-aee7-4259-bb23-db7b411e14dd" />

### Edge Win

<img width="535" height="733" alt="Screenshot 2026-08-01 102337" src="https://github.com/user-attachments/assets/798a89f3-eb62-4824-90ff-e0bb0cd8e866" />
