### PR TITLE
ui(lib): small visual tweaks for select search, fix light theme hover

### DIFF
--- a/ui/lib/css/abstract/_extends.scss
+++ b/ui/lib/css/abstract/_extends.scss
@@ -178,9 +178,7 @@
 }
 
 %popup-shadow {
-  @include if-transp {
-    @include back-blur;
-  }
+  @include backdrop-blur-if-transparent;
 
   box-shadow:
     0 14px 28px rgb(0 0 0 / 0.15),

--- a/ui/lib/css/form/_select-search.scss
+++ b/ui/lib/css/form/_select-search.scss
@@ -18,15 +18,16 @@
   }
 
   &__menu {
-    @extend %box-radius-bottom, %popup-shadow;
+    @extend %box-radius, %popup-shadow;
 
     display: none;
     position: absolute;
     z-index: $z-dropdown-109;
     width: 100%;
-    background: $c-bg-popup;
+    background: $c-bg-zebra;
     border: $border;
     margin-top: -1px;
+    overflow: hidden;
   }
 
   &--open &__menu {
@@ -47,6 +48,12 @@
   &__list {
     max-height: 250px;
     overflow-y: auto;
+    border-top: $border;
+    background: $c-bg-popup;
+
+    &::-webkit-scrollbar-track {
+      background: $c-bg-popup;
+    }
   }
 
   &__item {
@@ -56,7 +63,7 @@
 
     &:hover,
     &.focus {
-      background: $c-bg-high;
+      background: $c-bg-zebra;
     }
 
     &.selected {


### PR DESCRIPTION
# Why

While inspecting pages for some roundness related issues spotted that select search item highlight is not visible in light mode, and its the appearance can be improved a bit overall.

# How

Fix item hover in light mode, add border dividing list from sticky search part, adjust background colors, tweak roundness and fix overflow in Picture theme.

# Preview

https://github.com/user-attachments/assets/72d0a6e7-1783-4539-ab26-f71bd1bfdda9

<img width="459" height="413" alt="Screenshot 2026-08-01 at 11 04 54" src="https://github.com/user-attachments/assets/4a2925ef-8b83-4338-a752-56eb0c54a807" />
