### PR TITLE
ui(lib): apply roundness to Markdown editor UI

### DIFF
--- a/ui/bits/css/_markdown-toastui.scss
+++ b/ui/bits/css/_markdown-toastui.scss
@@ -26,6 +26,10 @@
         padding: 0 6px;
         border-bottom: $border;
         flex-flow: row wrap;
+
+        button {
+          @extend %box-radius;
+        }
       }
     }
 
@@ -94,6 +98,7 @@
       border: $border;
       background-color: $c-bg-page;
       margin-left: 0;
+      overflow: hidden;
 
       @include if-light {
         background-color: $c-bg;
@@ -102,6 +107,28 @@
       button {
         text-align: center;
       }
+    }
+
+    &-popup-add-image {
+      padding-top: 20px;
+
+      &::before {
+        padding-inline: 20px;
+        content: 'Drag an edge to resize your image.';
+      }
+
+      .toastui-editor-file-name,
+      .toastui-editor-file-select-button {
+        @extend %box-radius;
+      }
+
+      .toastui-editor-file-name {
+        min-height: 32px;
+      }
+    }
+
+    &-button-container button {
+      @extend %box-radius;
     }
 
     &-ok-button {
@@ -237,14 +264,5 @@
     &-tooltip {
       @extend %base-font;
     }
-  }
-}
-
-.toastui-editor-popup-add-image {
-  padding-top: 20px;
-
-  &::before {
-    padding-inline: 20px;
-    content: 'Drag an edge to resize your image.';
   }
 }


### PR DESCRIPTION
# Why

An another small set of changes related to added roundness, this time for Markdown editor.

# How

Apply roundness to toolbar buttons and popups content, fix header popup hover overflow, merge styles in one place.

# Preview

<img width="1103" height="413" alt="Screenshot 2026-08-01 at 11 18 07" src="https://github.com/user-attachments/assets/9a25db3b-2db7-4586-b395-8980ceaf9213" />

<img width="516" height="375" alt="Screenshot 2026-08-01 at 11 29 09" src="https://github.com/user-attachments/assets/de70b3ac-179b-4b58-8b6f-3808ad8f71d0" />
