### PR TITLE
ui(lib): fix cnm active toggle background overflow on zoom

### DIFF
--- a/ui/lib/css/form/_cmn-toggle.scss
+++ b/ui/lib/css/form/_cmn-toggle.scss
@@ -13,6 +13,7 @@
 .cmn-toggle label {
   @include prevent-select;
   @include transition(background box-shadow);
+  @extend %box-radius;
 
   display: block;
   position: relative;
@@ -22,7 +23,6 @@
   width: 40px;
   height: 24px;
   border: $border;
-  border-radius: $box-radius-size;
   background-clip: padding-box;
   background-color: $c-font-dimmer;
 
@@ -31,24 +31,23 @@
     display: block;
     position: absolute;
     content: '';
-    width: 22px;
-    height: 22px;
+    width: 23px;
+    height: 23px;
     bottom: 0;
 
     @include inline-start(0);
   }
 
   &::before {
-    @extend %data-icon;
+    @extend %data-icon, %box-radius;
     @include transition(margin color);
 
     font-size: 1em;
     z-index: 1;
     text-align: center;
-    line-height: 22px;
+    line-height: 23px;
     content: $licon-X;
     color: $c-font-dimmer;
-    border-radius: $box-radius-size;
   }
 
   &::after {


### PR DESCRIPTION
# Why

We spotted when looking at the PR on the stream that CNM toggle background can leak around the toggler when user use browser zoom.

# How

Adjust the sizing of the toggle element to prevent background overflow, adjust line hight accordingly.

# Preview

### Before

<img width="501" height="658" alt="Screenshot 2026-08-01 132551" src="https://github.com/user-attachments/assets/c2fe5957-1c5f-4d20-a3cf-56663dce4028" />

### After

<img width="511" height="662" alt="Screenshot 2026-08-01 132341" src="https://github.com/user-attachments/assets/58981f4a-84c8-4239-9c9a-e03c5fe4ec8f" />
