### PR TITLE
ui(msg): apply roundness to few elements, fix submit button styling

### DIFF
--- a/ui/msg/css/_convo.scss
+++ b/ui/msg/css/_convo.scss
@@ -110,7 +110,7 @@
         @extend %msg-input-focus;
 
         flex: 1 1 100%;
-        border-radius: 1.5em;
+        border-radius: calc($box-radius-size * 2);
         background: $c-bg-box;
         resize: none;
       }
@@ -118,12 +118,10 @@
       &__submit {
         outline: 0;
         margin-inline-start: 1em;
-        border-radius: 99px;
-        background: $c-font-dimmer;
+        border-radius: calc($box-radius-size * 2);
 
-        &.connected,
-        &.connected:hover {
-          background: $c-secondary;
+        &:disabled {
+          background: $c-font-dimmer;
         }
       }
     }

--- a/ui/msg/css/_side.scss
+++ b/ui/msg/css/_side.scss
@@ -40,7 +40,7 @@
 
         width: 100%;
         margin: auto 2em;
-        border-radius: 99px;
+        border-radius: calc($box-radius-size * 2);
         background: $c-bg-box;
         padding: 0.6em 1.2em;
       }

--- a/ui/msg/src/view/interact.ts
+++ b/ui/msg/src/view/interact.ts
@@ -24,7 +24,7 @@ export default function renderInteract(ctrl: MsgCtrl, user: User): VNode {
     [
       renderTextarea(ctrl, user),
       h('button.msg-app__convo__post__submit.button', {
-        class: { connected },
+        class: { 'button-green': connected, disabled: !connected },
         attrs: {
           type: 'submit',
           'data-icon': licon.PlayTriangle,


### PR DESCRIPTION
# Why

Spotted that few inbox elements have hardcoded roundness, and the fact that submit button still uses blue box shadow over green background.

# How

Use roundness variable for inbox elements like inputs and buttons, multiply default value by two to mimic more the previous appearance, but still make elements to fit better with lower roundness values.

Update submit button styling approach, use `.button-green` instead of manual color overwrite, which also handles shadows and disabled state/class.

# Preview

<img width="1787" height="1190" alt="Screenshot 2026-08-01 at 13 48 34" src="https://github.com/user-attachments/assets/d2105bab-83c4-41cd-8d06-2db1285a732f" />
