### PR TITLE
Changes to Remember last completed chapter in Study

### DIFF
--- a/app/controllers/Study.scala
+++ b/app/controllers/Study.scala
@@ -237,7 +237,7 @@ final class Study(
 
   def show(id: StudyId) = OpenOrScoped(_.Study.Read, _.Web.Mobile):
     orRelayRedirect(id):
-      env.study.api.byIdWithChapter(id).flatMap(showQuery)
+      env.study.api.byIdWithChapterForUser(id, ctx.me.map(_.userId)).flatMap(showQuery)
 
   def chapter(id: StudyId, chapterId: StudyChapterId) = OpenOrScoped(_.Study.Read, _.Web.Mobile):
     orRelayRedirect(id, chapterId.some):

--- a/bin/mongodb/indexes.js
+++ b/bin/mongodb/indexes.js
@@ -320,6 +320,7 @@ db.study_chapter_flat.createIndex(
   { 'relay.fideIds': 1 },
   { partialFilterExpression: { 'relay.fideIds': { $exists: true } } },
 );
+db.study_view.createIndex({ d: 1 }, { expireAfterSeconds: 7776000 }); // 90 days
 db.title_request.createIndex({ userId: 1 });
 db.title_request.createIndex({ 'history.0.status.n': 1, 'history.0.at': 1 });
 db.title_request.createIndex(

--- a/modules/study/src/main/BSONHandlers.scala
+++ b/modules/study/src/main/BSONHandlers.scala
@@ -341,7 +341,7 @@ object BSONHandlers:
     { case BSONString(v) => StudyMember.Role.byId.get(v).toTry(s"Invalid role $v") },
     x => BSONString(x.id)
   )
-  private[study] case class DbMember(role: StudyMember.Role)
+  private[study] case class DbMember(role: StudyMember.Role, lastChapterId: Option[StudyChapterId] = None)
   private[study] given dbMemberHandler: BSONDocumentHandler[DbMember] = Macros.handler
   private[study] given BSONDocumentWriter[StudyMember] with
     def writeTry(x: StudyMember) = Success($doc("role" -> x.role))
@@ -350,9 +350,9 @@ object BSONHandlers:
     handler.as[StudyMembers](
       members =>
         StudyMembers(members.map { (id, dbMember) =>
-          UserId(id) -> StudyMember(UserId(id), dbMember.role)
+          UserId(id) -> StudyMember(UserId(id), dbMember.role, dbMember.lastChapterId)
         }),
-      _.members.view.map((id, m) => id.value -> DbMember(m.role)).toMap
+      _.members.view.map((id, m) => id.value -> DbMember(m.role, m.lastChapterId)).toMap
     )
 
   import lila.core.study.Visibility

--- a/modules/study/src/main/Env.scala
+++ b/modules/study/src/main/Env.scala
@@ -58,6 +58,7 @@ final class Env(
   val chapterRepo = ChapterRepo(studyDb(CollName("study_chapter_flat")))
   private val topicRepo = StudyTopicRepo(studyDb(CollName("study_topic")))
   private val userTopicRepo = StudyUserTopicRepo(studyDb(CollName("study_user_topic")))
+  private val viewRepo = StudyViewRepo(studyDb(CollName("study_view")))
 
   lazy val jsonView = wire[JsonView]
 

--- a/modules/study/src/main/StudyApi.scala
+++ b/modules/study/src/main/StudyApi.scala
@@ -79,6 +79,12 @@ final class StudyApi(
   def byIdWithChapterOrFallback(id: StudyId, chapterId: StudyChapterId): Fu[Option[Study.WithChapter]] =
     byIdWithChapter(id, chapterId).orElse(byIdWithChapter(id))
 
+  def byIdWithChapterForUser(id: StudyId, userId: Option[UserId]): Fu[Option[Study.WithChapter]] =
+    byId(id).flatMapz: study =>
+      val resumeChapterId =
+        (!study.settings.sticky).so(userId.flatMap(study.members.get).flatMap(_.lastChapterId))
+      resumeChapterId.fold(byIdWithChapter(id))(byIdWithChapterOrFallback(id, _))
+
   def byIdWithFirstChapter(id: StudyId): Fu[Option[Study.WithChapter]] =
     byIdWithChapterFinder(id, chapterRepo.firstByStudy(id))
 
@@ -224,6 +230,11 @@ final class StudyApi(
           publicSource = study.isPublic.option(lila.core.chat.PublicSource.Study(studyId)),
           busChan = _.study
         )
+
+  // private per-member bookmark, not broadcast to other clients
+  def setMemberLastChapter(studyId: StudyId, chapterId: StudyChapterId)(who: Who): Funit =
+    byId(studyId).flatMapz: study =>
+      study.isMember(who.u).so(studyRepo.setMemberLastChapter(study, who.u, chapterId))
 
   def setPath(studyId: StudyId, position: Position.Ref)(who: Who): Funit =
     sequenceStudy(studyId): study =>

--- a/modules/study/src/main/StudyApi.scala
+++ b/modules/study/src/main/StudyApi.scala
@@ -19,6 +19,7 @@ import cats.mtl.Handle.*
 final class StudyApi(
     studyRepo: StudyRepo,
     chapterRepo: ChapterRepo,
+    viewRepo: StudyViewRepo,
     sequencer: StudySequencer,
     studyMaker: StudyMaker,
     chapterMaker: ChapterMaker,
@@ -81,9 +82,14 @@ final class StudyApi(
 
   def byIdWithChapterForUser(id: StudyId, userId: Option[UserId]): Fu[Option[Study.WithChapter]] =
     byId(id).flatMapz: study =>
-      val resumeChapterId =
-        (!study.settings.sticky).so(userId.flatMap(study.members.get).flatMap(_.lastChapterId))
-      resumeChapterId.fold(byIdWithChapter(id))(byIdWithChapterOrFallback(id, _))
+      val resumeChapterId: Fu[Option[StudyChapterId]] =
+        if study.settings.sticky then fuccess(none)
+        else
+          userId.so: u =>
+            study.members.get(u) match
+              case Some(member) => fuccess(member.lastChapterId)
+              case None => viewRepo.lastChapter(id, u)
+      resumeChapterId.flatMap(_.fold(byIdWithChapter(id))(byIdWithChapterOrFallback(id, _)))
 
   def byIdWithFirstChapter(id: StudyId): Fu[Option[Study.WithChapter]] =
     byIdWithChapterFinder(id, chapterRepo.firstByStudy(id))
@@ -231,10 +237,11 @@ final class StudyApi(
           busChan = _.study
         )
 
-  // private per-member bookmark, not broadcast to other clients
-  def setMemberLastChapter(studyId: StudyId, chapterId: StudyChapterId)(who: Who): Funit =
+  // private per-user bookmark, not broadcast to other clients
+  def setViewedChapter(studyId: StudyId, chapterId: StudyChapterId)(who: Who): Funit =
     byId(studyId).flatMapz: study =>
-      study.isMember(who.u).so(studyRepo.setMemberLastChapter(study, who.u, chapterId))
+      if study.isMember(who.u) then studyRepo.setMemberLastChapter(study, who.u, chapterId)
+      else viewRepo.setLastChapter(studyId, who.u, chapterId)
 
   def setPath(studyId: StudyId, position: Position.Ref)(who: Who): Funit =
     sequenceStudy(studyId): study =>
@@ -431,7 +438,13 @@ final class StudyApi(
             (isAdmin && !study.isOwner(userId)) || (study.isOwner(who) ^ (who.is(userId)))
           }
           allowed.so:
-            for _ <- studyRepo.removeMember(study.id, userId)
+            for
+              // preserve the bookmark across the member -> viewer transition
+              _ <- study.members
+                .get(userId)
+                .flatMap(_.lastChapterId)
+                .so(viewRepo.setLastChapter(study.id, userId, _))
+              _ <- studyRepo.removeMember(study.id, userId)
             yield onMembersChange(study, (study.members - userId), study.members.ids)
 
   export studyRepo.{ isMember, isContributor }

--- a/modules/study/src/main/StudyMember.scala
+++ b/modules/study/src/main/StudyMember.scala
@@ -1,6 +1,6 @@
 package lila.study
 
-case class StudyMember(id: UserId, role: StudyMember.Role):
+case class StudyMember(id: UserId, role: StudyMember.Role, lastChapterId: Option[StudyChapterId] = None):
 
   def canContribute = role.canWrite
 

--- a/modules/study/src/main/StudyRepo.scala
+++ b/modules/study/src/main/StudyRepo.scala
@@ -208,6 +208,14 @@ final class StudyRepo(private[study] val coll: AsyncColl)(using
     _ <- coll(_.update.one($id(study), $set("ownerId" -> userId)))
   yield ()
 
+  def setMemberLastChapter(study: Study, userId: UserId, chapterId: StudyChapterId): Funit =
+    coll:
+      _.update.one(
+        $id(study.id),
+        $set(s"members.$userId.lastChapterId" -> chapterId)
+      )
+    .void
+
   def membersDoc(id: StudyId): Fu[Option[Bdoc]] =
     coll(_.primitiveOne[Bdoc]($id(id), "members"))
 

--- a/modules/study/src/main/StudySocket.scala
+++ b/modules/study/src/main/StudySocket.scala
@@ -143,6 +143,11 @@ final private class StudySocket(
             .foreach: chapterId =>
               applyWho(api.setChapter(studyId, chapterId))
 
+        case "setViewedChapter" =>
+          o.get[StudyChapterId]("d")
+            .foreach: chapterId =>
+              applyWho(api.setMemberLastChapter(studyId, chapterId))
+
         case "editChapter" =>
           reading[ChapterMaker.EditData](o): data =>
             applyWho(api.editChapter(studyId, data))

--- a/modules/study/src/main/StudySocket.scala
+++ b/modules/study/src/main/StudySocket.scala
@@ -146,7 +146,7 @@ final private class StudySocket(
         case "setViewedChapter" =>
           o.get[StudyChapterId]("d")
             .foreach: chapterId =>
-              applyWho(api.setMemberLastChapter(studyId, chapterId))
+              applyWho(api.setViewedChapter(studyId, chapterId))
 
         case "editChapter" =>
           reading[ChapterMaker.EditData](o): data =>

--- a/modules/study/src/main/StudyViewRepo.scala
+++ b/modules/study/src/main/StudyViewRepo.scala
@@ -3,7 +3,6 @@ package lila.study
 import lila.db.AsyncColl
 import lila.db.dsl.{ *, given }
 
-
 final private[study] class StudyViewRepo(private val coll: AsyncColl)(using Executor):
 
   private def makeId(studyId: StudyId, userId: UserId) = s"$studyId/$userId"

--- a/modules/study/src/main/StudyViewRepo.scala
+++ b/modules/study/src/main/StudyViewRepo.scala
@@ -1,0 +1,21 @@
+package lila.study
+
+import lila.db.AsyncColl
+import lila.db.dsl.{ *, given }
+
+
+final private[study] class StudyViewRepo(private val coll: AsyncColl)(using Executor):
+
+  private def makeId(studyId: StudyId, userId: UserId) = s"$studyId/$userId"
+
+  def lastChapter(studyId: StudyId, userId: UserId): Fu[Option[StudyChapterId]] =
+    coll(_.primitiveOne[StudyChapterId]($id(makeId(studyId, userId)), "c"))
+
+  def setLastChapter(studyId: StudyId, userId: UserId, chapterId: StudyChapterId): Funit =
+    coll:
+      _.update.one(
+        $id(makeId(studyId, userId)),
+        $doc("c" -> chapterId, "d" -> nowInstant),
+        upsert = true
+      )
+    .void

--- a/ui/analyse/src/socket.ts
+++ b/ui/analyse/src/socket.ts
@@ -36,6 +36,7 @@ export interface StudySocketSendParams {
   toggleGlyph: (d: ReqPosition & { id: number }) => void;
   explorerGame: (d: ReqPosition & { gameId: string; insert: boolean }) => void;
   setChapter: (chapterId: string) => void;
+  setViewedChapter: (chapterId: string) => void;
   setRole: (d: { userId: string; role: string }) => void;
   addChapter: (d: ChapterData & { sticky?: boolean; showRatings?: boolean }) => void;
   editChapter: (d: EditChapterData) => void;

--- a/ui/analyse/src/study/studyCtrl.ts
+++ b/ui/analyse/src/study/studyCtrl.ts
@@ -513,6 +513,7 @@ export default class StudyCtrl {
       this.vm.mode.sticky = false;
       if (!this.vm.behind) this.vm.behind = 1;
       this.vm.chapterId = id;
+      if (this.members.myMember()) this.send('setViewedChapter', id);
       this.chapters.scroller.request('smooth'); // sticky scroll request is set in `changeChapter`
       await this.xhrReload(false, () => componentCallbacks(id));
     }

--- a/ui/analyse/src/study/studyCtrl.ts
+++ b/ui/analyse/src/study/studyCtrl.ts
@@ -513,7 +513,7 @@ export default class StudyCtrl {
       this.vm.mode.sticky = false;
       if (!this.vm.behind) this.vm.behind = 1;
       this.vm.chapterId = id;
-      if (this.members.myMember()) this.send('setViewedChapter', id);
+      if (this.members.opts.myId) this.send('setViewedChapter', id);
       this.chapters.scroller.request('smooth'); // sticky scroll request is set in `changeChapter`
       await this.xhrReload(false, () => componentCallbacks(id));
     }


### PR DESCRIPTION
- Studies now reopen to the chapter you personally last looked at, instead of
  always jumping to the study's current chapter.
- Only applies to non-sticky studies — sticky studies keep following the
  live/current chapter for everyone, as before.
- The last-viewed chapter is stored per-member and never broadcast to other
  viewers
- #20633 
