### PR TITLE
mobile login with email code

### DIFF
--- a/app/controllers/Account.scala
+++ b/app/controllers/Account.scala
@@ -380,7 +380,7 @@ final class Account(
                 env.security.reopen
                   .prepare(data.username, data.email, env.mod.logApi.closedByMod)
                   .flatMap: user =>
-                    env.security.loginToken.rateLimit[Result](user, data.email, ctx.req, rateLimited):
+                    env.security.loginToken.rateLimit[Result](data.email.normalize, rateLimited):
                       lila.mon.user.auth.reopenRequest("success").increment()
                       env.security.reopen
                         .send(user, data.email)

--- a/app/controllers/Auth.scala
+++ b/app/controllers/Auth.scala
@@ -1,7 +1,9 @@
 package controllers
+
 import play.api.data.Form
 import play.api.libs.json.*
 import play.api.mvc.*
+import scalalib.net.Bearer
 
 import lila.app.{ *, given }
 import lila.common.HTTPRequest
@@ -96,7 +98,7 @@ final class Auth(env: Env, accountC: => Account) extends LilaController(env):
 
   private def withTakex3Referrer(fallback: Call, requireSimpleSignup: Boolean = false)(run: => Fu[Result])(
       using Option[ValidReferrer]
-  ) =
+  ): Fu[Result] =
     val allowed =
       if requireSimpleSignup then simpleSignup.exists(_.client == takex3Client)
       else signedClient.contains(takex3Client)
@@ -682,13 +684,20 @@ final class Auth(env: Env, accountC: => Account) extends LilaController(env):
 
   def mobileCodeEmail = Anon:
     Firewall:
-      for
-        limit <- env.security.loginToken.storedCode.createAndSend()
-        res <- if limit.ok then NoContent.toFuccess else rateLimited
-      yield res
+      NoTor:
+        for
+          limit <- env.security.loginToken.storedCode.createAndSend()
+          res <- if limit.ok then NoContent.toFuccess else rateLimited
+        yield res
 
   def mobileCodeBearer = Anon:
-    ???
+    Firewall:
+      NoTor:
+        env.security.loginToken.storedCode
+          .consume()
+          .flatMap:
+            case limit: RateLimit.LimitResult => if limit.ok then notFound else rateLimited
+            case token: lila.oauth.AccessToken => Ok(token.plain).toFuccess
 
   def check = OpenOrScoped() { ctx ?=>
     ctx.me match

--- a/app/controllers/Auth.scala
+++ b/app/controllers/Auth.scala
@@ -100,7 +100,7 @@ final class Auth(env: Env, accountC: => Account) extends LilaController(env):
     val allowed =
       if requireSimpleSignup then simpleSignup.exists(_.client == takex3Client)
       else signedClient.contains(takex3Client)
-    if allowed then run else Redirect(fallback).toFuccess
+    if allowed then run else Redirect(fallback)
 
   private def authCustomUi(variant: AuthVariant)(using
       Option[ValidReferrer]
@@ -639,13 +639,10 @@ final class Auth(env: Env, accountC: => Account) extends LilaController(env):
             .fold(
               err => BadRequest.async(renderMagicLink(err.some, fail = true)),
               data =>
-                env.user.repo.notClosedForeverWithEmail(data.email.normalize).flatMap {
-                  case Some(user, storedEmail) =>
-                    env.security.loginToken.rateLimit[Result](user, storedEmail, ctx.req, rateLimited):
-                      for _ <- env.security.loginToken.send(user, storedEmail)
-                      yield Redirect(routes.Auth.magicLinkSent)
-                  case _ => Redirect(routes.Auth.magicLinkSent)
-                }
+                for
+                  accept <- env.security.loginToken.magicLink.send(data.email)
+                  res <- if accept then Redirect(routes.Auth.magicLinkSent).toFuccess else rateLimited
+                yield res
             )
         else BadRequest.async(renderMagicLink(none, fail = true))
       }
@@ -653,9 +650,9 @@ final class Auth(env: Env, accountC: => Account) extends LilaController(env):
   def magicLinkSent = Open:
     Ok.page(views.auth.magicLinkSent)
 
-  def makeLoginToken = Auth { ctx ?=> me ?=>
+  def makeLoginTokenLichobile = Auth { ctx ?=> me ?=>
     JsonOk:
-      env.security.loginToken
+      env.security.loginToken.magicLink
         .generate(me)
         .map: token =>
           Json.obj(
@@ -670,7 +667,7 @@ final class Auth(env: Env, accountC: => Account) extends LilaController(env):
       Firewall:
         consumingToken(token): user =>
           Ok.async:
-            env.security.loginToken
+            env.security.loginToken.magicLink
               .generate(user)
               .map(views.auth.tokenLoginConfirmation(user, _))
 
@@ -682,6 +679,13 @@ final class Auth(env: Env, accountC: => Account) extends LilaController(env):
           consumingToken(token): user =>
             if user.enabled.yes then authenticateUser(user, remember = true, pwned = IsPwned.No)
             else authenticateAppealUser(user, Redirect(_))
+
+  def mobileCodeEmail = Anon:
+    Firewall:
+      for
+        access <- env.security.loginToken.storedCode.createAndSend()
+        res <- if access then NoContent.toFuccess else rateLimited
+      yield res
 
   def check = OpenOrScoped() { ctx ?=>
     ctx.me match
@@ -703,7 +707,7 @@ final class Auth(env: Env, accountC: => Account) extends LilaController(env):
   }
 
   private def consumingToken(token: String)(f: UserModel => Fu[Result])(using Context) =
-    env.security.loginToken
+    env.security.loginToken.magicLink
       .consume(token)
       .flatMap:
         case None =>

--- a/app/controllers/Auth.scala
+++ b/app/controllers/Auth.scala
@@ -640,8 +640,8 @@ final class Auth(env: Env, accountC: => Account) extends LilaController(env):
               err => BadRequest.async(renderMagicLink(err.some, fail = true)),
               data =>
                 for
-                  accept <- env.security.loginToken.magicLink.send(data.email)
-                  res <- if accept then Redirect(routes.Auth.magicLinkSent).toFuccess else rateLimited
+                  limit <- env.security.loginToken.magicLink.send(data.email)
+                  res <- if limit.ok then Redirect(routes.Auth.magicLinkSent).toFuccess else rateLimited
                 yield res
             )
         else BadRequest.async(renderMagicLink(none, fail = true))
@@ -683,9 +683,12 @@ final class Auth(env: Env, accountC: => Account) extends LilaController(env):
   def mobileCodeEmail = Anon:
     Firewall:
       for
-        access <- env.security.loginToken.storedCode.createAndSend()
-        res <- if access then NoContent.toFuccess else rateLimited
+        limit <- env.security.loginToken.storedCode.createAndSend()
+        res <- if limit.ok then NoContent.toFuccess else rateLimited
       yield res
+
+  def mobileCodeBearer = Anon:
+    ???
 
   def check = OpenOrScoped() { ctx ?=>
     ctx.me match

--- a/conf/routes
+++ b/conf/routes
@@ -590,12 +590,14 @@ POST  /password/reset/takex3/confirm/:token controllers.Auth.passwordResetConfir
 GET   /password/reset/confirm/:token   controllers.Auth.passwordResetConfirm(token)
 POST  /password/reset/confirm/:token   controllers.Auth.passwordResetConfirmApply(token)
 POST  /auth/set-fp/:fp/:ms             controllers.Auth.setFingerPrint(fp, ms: Int)
-POST  /auth/token                      controllers.Auth.makeLoginToken
+POST  /auth/token                      controllers.Auth.makeLoginTokenLichobile
 GET   /auth/token/:token               controllers.Auth.loginWithToken(token)
 POST  /auth/token/:token               controllers.Auth.loginWithTokenPost(token)
 GET   /auth/magic-link                 controllers.Auth.magicLink
 POST  /auth/magic-link/send            controllers.Auth.magicLinkApply
 GET   /auth/magic-link/sent            controllers.Auth.magicLinkSent
+POST  /auth/mobile-code/email          controllers.Auth.mobileCodeEmail
+POST  /auth/mobile-code/bearer         controllers.Auth.mobileCodeBearer
 GET   /auth/check                      controllers.Auth.check
 POST  /auth/validate-new-email         controllers.Auth.apiEmailValidate
 

--- a/modules/mailer/src/main/Mailer.scala
+++ b/modules/mailer/src/main/Mailer.scala
@@ -146,6 +146,7 @@ $serviceNote"""
 
     val emailMessage = div(itemscope, itemtype := "http://schema.org/EmailMessage")
     val pDesc = p(itemprop := "description")
+    val loginCode = div(itemprop := "identifier", itemscope, itemtype := "http://schema.org/ViewAction")
     val potentialAction =
       div(itemprop := "potentialAction", itemscope, itemtype := "http://schema.org/ViewAction")
     def metaName(cont: String) = meta(itemprop := "name", content := cont)

--- a/modules/memo/src/main/RateLimit.scala
+++ b/modules/memo/src/main/RateLimit.scala
@@ -70,6 +70,7 @@ object RateLimit:
 
   enum LimitResult:
     case Through, Limited
+    def ok = this == Through
 
   case class Limited(key: String, msg: String, until: Instant)
 

--- a/modules/mon/src/main/mon.scala
+++ b/modules/mon/src/main/mon.scala
@@ -343,6 +343,7 @@ object email:
     private val c = counter("email.send")
     val resetPassword = c.withTag("type", "resetPassword")
     val magicLink = c.withTag("type", "magicLink")
+    val storedCode = c.withTag("type", "storedCode")
     val reopen = c.withTag("type", "reopen")
     val fix = c.withTag("type", "fix")
     val change = c.withTag("type", "change")

--- a/modules/oauth/src/main/AccessTokenApi.scala
+++ b/modules/oauth/src/main/AccessTokenApi.scala
@@ -60,16 +60,19 @@ final class AccessTokenApi(
     yield res
 
   def create(granted: AccessTokenRequest.Granted)(using ua: UserAgent): Fu[AccessToken] =
+    create(granted.userId, granted.scopes, granted.redirectUri.origin)
+
+  def create(userId: UserId, scopes: TokenScopes, origin: Origin)(using ua: UserAgent): Fu[AccessToken] =
     val plain = Bearer.random()
     createAndRotate:
       AccessToken(
         id = AccessToken.idFrom(plain),
         plain = plain,
-        userId = granted.userId,
+        userId = userId,
         description = None,
         created = nowInstant.some,
-        scopes = granted.scopes,
-        clientOrigin = granted.redirectUri.origin.some,
+        scopes = scopes,
+        clientOrigin = origin.some,
         userAgent = ua.some,
         expires = nowInstant.plusMonths(12).some
       )

--- a/modules/security/src/main/Env.scala
+++ b/modules/security/src/main/Env.scala
@@ -10,7 +10,7 @@ import lila.core.config.*
 import lila.core.data.Strings
 import lila.memo.SettingStore
 import lila.memo.SettingStore.Strings.given
-import lila.oauth.OAuthServer
+import lila.oauth.{ OAuthServer, AccessTokenApi }
 import lila.common.config.GetRelativeFile
 
 @Module
@@ -25,6 +25,7 @@ final class Env(
     cacheApi: lila.memo.CacheApi,
     settingStore: lila.memo.SettingStore.Builder,
     oAuthServer: OAuthServer,
+    accessTokenApi: AccessTokenApi,
     mongoCache: lila.memo.MongoCache.Api,
     canSendEmails: SettingStore[Boolean] @@ lila.mailer.CanSendEmails,
     cookieBaker: play.api.mvc.SessionCookieBaker,

--- a/modules/security/src/main/LoginToken.scala
+++ b/modules/security/src/main/LoginToken.scala
@@ -2,7 +2,7 @@ package lila.security
 
 import play.api.mvc.RequestHeader
 import play.api.i18n.Lang
-import scalalib.net.{ Bearer, UserAgent }
+import scalalib.net.UserAgent
 
 import lila.core.config.*
 import lila.core.i18n.I18nKey.emails as trans
@@ -10,7 +10,7 @@ import lila.core.net.{ Origin, ValidReferrer }
 import lila.core.email.NormalizedEmailAddress
 import lila.mailer.Mailer
 import lila.user.{ User, UserRepo }
-import lila.oauth.{ AccessTokenApi, OAuthScope, TokenScopes }
+import lila.oauth.{ AccessTokenApi, AccessToken, OAuthScope, TokenScopes }
 import lila.common.HTTPRequest
 import lila.memo.RateLimit.LimitResult
 
@@ -38,14 +38,14 @@ final class LoginToken(
     private def reqEmail(using RequestHeader): Option[NormalizedEmailAddress] =
       HTTPRequest.queryStringGet("email").flatMap(EmailAddress.from).map(_.normalize)
 
-    def consume()(using RequestHeader, UserAgent): Fu[LimitResult | Bearer] =
+    def consume()(using RequestHeader, UserAgent): Fu[LimitResult | AccessToken] =
       (reqEmail, HTTPRequest.queryStringGet("code")).tupled.fold(notRateLimited): pair =>
         limitAndFind(pair._1, cost = 1): (user, _) =>
           if store.getIfPresent(pair).exists(_.is(user))
           then
             store.invalidate(pair)
             val scopes = TokenScopes(List(OAuthScope.Web.Mobile))
-            accessTokenApi.create(user.id, scopes, Origin("org.lichess.mobile://")).map(_.plain)
+            accessTokenApi.create(user.id, scopes, Origin("org.lichess.mobile://"))
           else notRateLimited
 
     def createAndSend()(using RequestHeader): Fu[LimitResult] =

--- a/modules/security/src/main/LoginToken.scala
+++ b/modules/security/src/main/LoginToken.scala
@@ -1,51 +1,134 @@
 package lila.security
 
-import scalatags.Text.all.*
+import play.api.mvc.RequestHeader
+import play.api.i18n.Lang
+import scalalib.net.{ Bearer, UserAgent }
 
 import lila.core.config.*
 import lila.core.i18n.I18nKey.emails as trans
-import lila.core.net.ValidReferrer
+import lila.core.net.{ Origin, ValidReferrer }
 import lila.mailer.Mailer
 import lila.user.{ User, UserRepo }
+import lila.oauth.{ AccessTokenApi, OAuthScope, TokenScopes }
+import lila.common.HTTPRequest
 
 final class LoginToken(
     mailer: Mailer,
     userRepo: UserRepo,
     routeUrl: RouteUrl,
-    tokenerSecret: Secret
+    tokenerSecret: Secret,
+    cacheApi: lila.memo.CacheApi,
+    accessTokenApi: AccessTokenApi
 )(using Executor, lila.core.i18n.Translator, lila.core.config.RateLimit):
 
-  private val tokener = StringToken.withLifetime[UserId](tokenerSecret, 10.minutes)
+  object storedCode:
 
-  def generate[U: UserIdOf](user: U): Fu[String] = tokener.make(user.id)
+    private type Code = String
 
-  def send(user: User, email: EmailAddress)(using referrer: Option[ValidReferrer]): Funit =
-    generate(user).flatMap { token =>
-      lila.mon.email.send.magicLink.increment()
-      val url = referrer.foldLeft(routeUrl(routes.Auth.loginWithToken(token))): (url, ref) =>
-        ref.propagate(url)
-      given play.api.i18n.Lang = user.realLang | lila.core.i18n.defaultLang
-      import Mailer.html.*
-      mailer.sendOrFail:
-        Mailer.Message(
-          to = email,
-          subject = trans.logInToLichess.txt(user.username),
-          text = Mailer.txt.addServiceNote(s"""
+    private val store = cacheApi.notLoadingSync[(EmailAddress, Code), UserId](64, "loginToken.storedCode"):
+      _.expireAfterWrite(5.minutes).build()
+
+    private val chars = (('2' to '9') ++ (('a' to 'z').toSet - 'l')).mkString
+    private val nbChars = chars.length
+    private def secureChar = chars(scalalib.SecureRandom.nextInt(nbChars))
+
+    private def reqEmail(using req: RequestHeader): Option[EmailAddress] =
+      HTTPRequest.queryStringGet("email").flatMap(EmailAddress.from)
+
+    def consume()(using RequestHeader, UserAgent): Fu[Option[Bearer]] =
+      (reqEmail, HTTPRequest.queryStringGet("code")).tupled.so: pair =>
+        findAndLimit(rawEmail, cost = 1): (user, email) =>
+          store
+            .getIfPresent(pair)
+            .so: userId =>
+              store.invalidate(pair)
+              userRepo
+                .notForeverClosedById(userId)
+                .flatMapz: user =>
+                  val scopes = TokenScopes(List(OAuthScope.Web.Mobile))
+                  accessTokenApi
+                    .create(user.id, scopes, Origin("org.lichess.mobile://"))
+                    .map: token =>
+                      token.plain.some
+
+    def createAndSend()(using req: RequestHeader): Fu[Boolean] =
+      reqEmail.so: rawEmail =>
+        findAndLimit(rawEmail, cost = 1): (user, email) =>
+          val code = String(Array.fill(6)(secureChar))
+          store.put(rawEmail -> code, user.id)
+          lila.mon.email.send.storedCode.increment()
+          import scalatags.Text.all.*
+          import Mailer.html.*
+          sendEmail(user, email)(
+            Mailer.txt.addServiceNote(s"""
+Enter this code to log in with your Lichess account:
+
+$code
+
+This code expires in 5 minutes. If you didn’t request it, you can safely ignore this email.
+"""),
+            emailMessage(
+              p("Enter this code to log in with your Lichess account:"),
+              loginCode(metaName("Log in code"), code),
+              p(
+                "This code expires in 5 minutes. If you didn’t request it, you can safely ignore this email."
+              ),
+              serviceNote
+            )
+          )
+
+  object magicLink:
+
+    private val tokener = StringToken.withLifetime[UserId](tokenerSecret, 10.minutes)
+
+    def generate[U: UserIdOf](user: U): Fu[String] = tokener.make(user.id)
+
+    def send(reqEmail: EmailAddress)(using req: RequestHeader, referrer: Option[ValidReferrer]): Fu[Boolean] =
+      findAndLimit(reqEmail, cost = 2): (user, email) =>
+        generate(user).flatMap { token =>
+          lila.mon.email.send.magicLink.increment()
+          val url = referrer.foldLeft(routeUrl(routes.Auth.loginWithToken(token))): (url, ref) =>
+            ref.propagate(url)
+          import scalatags.Text.all.*
+          import Mailer.html.*
+          sendEmail(user, email)(
+            Mailer.txt.addServiceNote(s"""
 ${trans.passwordReset_clickOrIgnore.txt()}
 
 $url
 
 ${trans.common_orPaste.txt()}"""),
-          htmlBody = emailMessage(
-            p(trans.passwordReset_clickOrIgnore()),
-            potentialAction(metaName("Log in"), Mailer.html.url(url)),
-            serviceNote
-          ).some
-        )
-    }
+            emailMessage(
+              p(trans.passwordReset_clickOrIgnore()),
+              potentialAction(metaName("Log in"), Mailer.html.url(url)),
+              serviceNote
+            )
+          )
+        }
 
-  def consume(token: String): Fu[Option[User]] =
-    tokener.read(token).flatMapz(userRepo.notForeverClosedById)
+    def consume(token: String): Fu[Option[User]] =
+      tokener.read(token).flatMapz(userRepo.notForeverClosedById)
+
+  private def findAndLimit(reqEmail: EmailAddress, cost: Int)(f: (User, EmailAddress) => Funit)(using
+      req: RequestHeader
+  ): Fu[Boolean] =
+    userRepo
+      .notClosedForeverWithEmail(reqEmail.normalize)
+      .flatMapz: (user, email) =>
+        rateLimit(user, email, cost = cost, fuFalse)(f(user, email).inject(true))
+
+  private def sendEmail(user: User, email: EmailAddress)(
+      makeText: Lang ?=> String,
+      makeHtml: Lang ?=> scalatags.Text.all.Frag
+  ): Funit =
+    given play.api.i18n.Lang = user.realLang | lila.core.i18n.defaultLang
+    mailer.sendOrFail:
+      Mailer.Message(
+        to = email,
+        subject = trans.logInToLichess.txt(user.username),
+        text = makeText,
+        htmlBody = makeHtml.some
+      )
 
   object rateLimit:
 
@@ -55,26 +138,26 @@ ${trans.common_orPaste.txt()}"""),
     import lila.core.net.IpAddress
 
     private lazy val rateLimitPerIP = RateLimit[IpAddress](
-      credits = 5,
+      credits = 10 * 2,
       duration = 1.hour,
       key = "login.magicLink.ip"
     )
 
     private lazy val rateLimitPerUser = RateLimit[UserId](
-      credits = 3,
+      credits = 3 * 2,
       duration = 1.hour,
       key = "login.magicLink.user"
     )
 
     private lazy val rateLimitPerEmail = RateLimit[String](
-      credits = 3,
+      credits = 3 * 2,
       duration = 1.hour,
       key = "login.magicLink.email"
     )
 
-    def apply[A](user: User, email: EmailAddress, req: RequestHeader, default: => Fu[A])(
+    def apply[A](user: User, email: EmailAddress, cost: Int, default: => Fu[A])(
         run: => Fu[A]
-    ): Fu[A] =
+    )(using req: RequestHeader): Fu[A] =
       rateLimitPerUser(user.id, default):
         rateLimitPerEmail(email.value, default):
           rateLimitPerIP(HTTPRequest.ipAddress(req), default):

--- a/modules/security/src/main/LoginToken.scala
+++ b/modules/security/src/main/LoginToken.scala
@@ -7,10 +7,12 @@ import scalalib.net.{ Bearer, UserAgent }
 import lila.core.config.*
 import lila.core.i18n.I18nKey.emails as trans
 import lila.core.net.{ Origin, ValidReferrer }
+import lila.core.email.NormalizedEmailAddress
 import lila.mailer.Mailer
 import lila.user.{ User, UserRepo }
 import lila.oauth.{ AccessTokenApi, OAuthScope, TokenScopes }
 import lila.common.HTTPRequest
+import lila.memo.RateLimit.LimitResult
 
 final class LoginToken(
     mailer: Mailer,
@@ -25,48 +27,43 @@ final class LoginToken(
 
     private type Code = String
 
-    private val store = cacheApi.notLoadingSync[(EmailAddress, Code), UserId](64, "loginToken.storedCode"):
-      _.expireAfterWrite(5.minutes).build()
+    private val store =
+      cacheApi.notLoadingSync[(NormalizedEmailAddress, Code), UserId](64, "loginToken.storedCode"):
+        _.expireAfterWrite(5.minutes).build()
 
     private val chars = (('2' to '9') ++ (('a' to 'z').toSet - 'l')).mkString
     private val nbChars = chars.length
     private def secureChar = chars(scalalib.SecureRandom.nextInt(nbChars))
 
-    private def reqEmail(using req: RequestHeader): Option[EmailAddress] =
-      HTTPRequest.queryStringGet("email").flatMap(EmailAddress.from)
+    private def reqEmail(using RequestHeader): Option[NormalizedEmailAddress] =
+      HTTPRequest.queryStringGet("email").flatMap(EmailAddress.from).map(_.normalize)
 
-    def consume()(using RequestHeader, UserAgent): Fu[Option[Bearer]] =
-      (reqEmail, HTTPRequest.queryStringGet("code")).tupled.so: pair =>
-        findAndLimit(rawEmail, cost = 1): (user, email) =>
-          store
-            .getIfPresent(pair)
-            .so: userId =>
-              store.invalidate(pair)
-              userRepo
-                .notForeverClosedById(userId)
-                .flatMapz: user =>
-                  val scopes = TokenScopes(List(OAuthScope.Web.Mobile))
-                  accessTokenApi
-                    .create(user.id, scopes, Origin("org.lichess.mobile://"))
-                    .map: token =>
-                      token.plain.some
+    def consume()(using RequestHeader, UserAgent): Fu[LimitResult | Bearer] =
+      (reqEmail, HTTPRequest.queryStringGet("code")).tupled.fold(notRateLimited): pair =>
+        limitAndFind(pair._1, cost = 1): (user, _) =>
+          if store.getIfPresent(pair).exists(_.is(user))
+          then
+            store.invalidate(pair)
+            val scopes = TokenScopes(List(OAuthScope.Web.Mobile))
+            accessTokenApi.create(user.id, scopes, Origin("org.lichess.mobile://")).map(_.plain)
+          else notRateLimited
 
-    def createAndSend()(using req: RequestHeader): Fu[Boolean] =
-      reqEmail.so: rawEmail =>
-        findAndLimit(rawEmail, cost = 1): (user, email) =>
+    def createAndSend()(using RequestHeader): Fu[LimitResult] =
+      reqEmail.fold(notRateLimited): rawEmail =>
+        limitAndFind(rawEmail, cost = 1): (user, email) =>
           val code = String(Array.fill(6)(secureChar))
           store.put(rawEmail -> code, user.id)
           lila.mon.email.send.storedCode.increment()
           import scalatags.Text.all.*
           import Mailer.html.*
           sendEmail(user, email)(
-            Mailer.txt.addServiceNote(s"""
-Enter this code to log in with your Lichess account:
-
-$code
-
-This code expires in 5 minutes. If you didn’t request it, you can safely ignore this email.
-"""),
+            List(
+              "Enter this code to log in with your Lichess account:",
+              "",
+              code,
+              "",
+              "This code expires in 5 minutes. If you didn’t request it, you can safely ignore this email."
+            ),
             emailMessage(
               p("Enter this code to log in with your Lichess account:"),
               loginCode(metaName("Log in code"), code),
@@ -75,7 +72,7 @@ This code expires in 5 minutes. If you didn’t request it, you can safely ignor
               ),
               serviceNote
             )
-          )
+          ).inject(LimitResult.Through)
 
   object magicLink:
 
@@ -83,8 +80,10 @@ This code expires in 5 minutes. If you didn’t request it, you can safely ignor
 
     def generate[U: UserIdOf](user: U): Fu[String] = tokener.make(user.id)
 
-    def send(reqEmail: EmailAddress)(using req: RequestHeader, referrer: Option[ValidReferrer]): Fu[Boolean] =
-      findAndLimit(reqEmail, cost = 2): (user, email) =>
+    def send(
+        reqEmail: EmailAddress
+    )(using req: RequestHeader, referrer: Option[ValidReferrer]): Fu[LimitResult] =
+      limitAndFind(reqEmail.normalize, cost = 2): (user, email) =>
         generate(user).flatMap { token =>
           lila.mon.email.send.magicLink.increment()
           val url = referrer.foldLeft(routeUrl(routes.Auth.loginWithToken(token))): (url, ref) =>
@@ -92,33 +91,30 @@ This code expires in 5 minutes. If you didn’t request it, you can safely ignor
           import scalatags.Text.all.*
           import Mailer.html.*
           sendEmail(user, email)(
-            Mailer.txt.addServiceNote(s"""
-${trans.passwordReset_clickOrIgnore.txt()}
-
-$url
-
-${trans.common_orPaste.txt()}"""),
+            List(trans.passwordReset_clickOrIgnore.txt(), "", url.value, "", trans.common_orPaste.txt()),
             emailMessage(
               p(trans.passwordReset_clickOrIgnore()),
               potentialAction(metaName("Log in"), Mailer.html.url(url)),
               serviceNote
             )
-          )
+          ).inject(LimitResult.Through)
         }
 
     def consume(token: String): Fu[Option[User]] =
       tokener.read(token).flatMapz(userRepo.notForeverClosedById)
 
-  private def findAndLimit(reqEmail: EmailAddress, cost: Int)(f: (User, EmailAddress) => Funit)(using
-      req: RequestHeader
-  ): Fu[Boolean] =
-    userRepo
-      .notClosedForeverWithEmail(reqEmail.normalize)
-      .flatMapz: (user, email) =>
-        rateLimit(user, email, cost = cost, fuFalse)(f(user, email).inject(true))
+  private def limitAndFind[A](email: NormalizedEmailAddress, cost: Int)(f: (User, EmailAddress) => Fu[A])(
+      using req: RequestHeader
+  ): Fu[LimitResult | A] =
+    rateLimit(email, fuccess(LimitResult.Limited), cost):
+      userRepo
+        .notClosedForeverWithEmail(email)
+        .flatMap(_.fold(notRateLimited)(f.tupled))
+
+  private val notRateLimited = fuccess(LimitResult.Through) // but we don't tell what was wrong
 
   private def sendEmail(user: User, email: EmailAddress)(
-      makeText: Lang ?=> String,
+      makeText: Lang ?=> List[String],
       makeHtml: Lang ?=> scalatags.Text.all.Frag
   ): Funit =
     given play.api.i18n.Lang = user.realLang | lila.core.i18n.defaultLang
@@ -126,7 +122,7 @@ ${trans.common_orPaste.txt()}"""),
       Mailer.Message(
         to = email,
         subject = trans.logInToLichess.txt(user.username),
-        text = makeText,
+        text = Mailer.txt.addServiceNote(makeText.mkString("\n")),
         htmlBody = makeHtml.some
       )
 
@@ -137,28 +133,23 @@ ${trans.common_orPaste.txt()}"""),
     import lila.common.HTTPRequest
     import lila.core.net.IpAddress
 
+    private val defaultCost = 2
+
     private lazy val rateLimitPerIP = RateLimit[IpAddress](
-      credits = 10 * 2,
+      credits = 10 * defaultCost,
       duration = 1.hour,
       key = "login.magicLink.ip"
     )
 
-    private lazy val rateLimitPerUser = RateLimit[UserId](
-      credits = 3 * 2,
-      duration = 1.hour,
-      key = "login.magicLink.user"
-    )
-
     private lazy val rateLimitPerEmail = RateLimit[String](
-      credits = 3 * 2,
+      credits = 3 * defaultCost,
       duration = 1.hour,
       key = "login.magicLink.email"
     )
 
-    def apply[A](user: User, email: EmailAddress, cost: Int, default: => Fu[A])(
-        run: => Fu[A]
-    )(using req: RequestHeader): Fu[A] =
-      rateLimitPerUser(user.id, default):
-        rateLimitPerEmail(email.value, default):
-          rateLimitPerIP(HTTPRequest.ipAddress(req), default):
-            run
+    def apply[A](email: NormalizedEmailAddress, default: => Fu[A], cost: Int = defaultCost)(run: => Fu[A])(
+        using req: RequestHeader
+    ): Fu[A] =
+      rateLimitPerEmail(email.value, default, cost):
+        rateLimitPerIP(HTTPRequest.ipAddress(req), default, cost):
+          run


### PR DESCRIPTION
alternative login for mobile app. here's the protocol:

1. App user selects "Login by email" option on the app login screen.
2. The app shows an email form input.
3. The user enters their email address and submits the form.
4. The app sends a request to lichess:
`POST https://lichess.org/auth/mobile-code/email?email=thibault@lichess.org`
The server responds with `204 No Content` and maybe sends an email* containing a 6 digit verification code `pscc2e`.
5. The app shows a 6 digit code input form, and prompts the user to check their email for the code.
6. The user gets the code from the email and enters it into the app.
7. The app sends a request to lichess:
`POST https://lichess.org/auth/mobile-code/bearer email==thibault@lichess.org code==pscc2e`
8. Lichess responds with `200` and the text body just contains an oauth token bearer `lio_537SlblTonkK8iqi8k8CVgYUMO2OFKA6`.
9. The app uses the token bearer.


* if a user matches the email. It won't reveal if there's one.

The server can return `429` in both requests. It can return `404` if the code is expired or invalid.
A code lives for 5 minutes only and can only be used once.