### PR TITLE
ui(relay): add players list placeholder

### DIFF
--- a/modules/coreI18n/src/main/key.scala
+++ b/modules/coreI18n/src/main/key.scala
@@ -198,6 +198,7 @@ object I18nKey:
     val `subscribeTitle`: I18nKey = "broadcast:subscribeTitle"
     val `uploadImage`: I18nKey = "broadcast:uploadImage"
     val `noBoardsYet`: I18nKey = "broadcast:noBoardsYet"
+    val `noPlayersYet`: I18nKey = "broadcast:noPlayersYet"
     val `boardsCanBeLoaded`: I18nKey = "broadcast:boardsCanBeLoaded"
     val `startsAfter`: I18nKey = "broadcast:startsAfter"
     val `startVerySoon`: I18nKey = "broadcast:startVerySoon"

--- a/translation/source/broadcast.xml
+++ b/translation/source/broadcast.xml
@@ -58,7 +58,7 @@
   <string name="subscribeTitle">Subscribe to be notified when each round starts. You can toggle bell or push notifications for broadcasts in your account preferences.</string>
   <string name="uploadImage">Upload tournament image</string>
   <string name="noBoardsYet">No boards yet. These will appear once games are uploaded.</string>
-  <string name="noPlayersYet">No players yet. They will appear once first games are uploaded.</string>
+  <string name="noPlayersYet">No players yet. They will appear once games are uploaded.</string>
   <string name="boardsCanBeLoaded" comment="%s is 'Broadcaster App'">Boards can be loaded with a source or via the %s</string>
   <string name="startsAfter">Starts after %s</string>
   <string name="startVerySoon">The broadcast will start very soon.</string>

--- a/translation/source/broadcast.xml
+++ b/translation/source/broadcast.xml
@@ -58,6 +58,7 @@
   <string name="subscribeTitle">Subscribe to be notified when each round starts. You can toggle bell or push notifications for broadcasts in your account preferences.</string>
   <string name="uploadImage">Upload tournament image</string>
   <string name="noBoardsYet">No boards yet. These will appear once games are uploaded.</string>
+  <string name="noPlayersYet">No players yet. They will appear once first games are uploaded.</string>
   <string name="boardsCanBeLoaded" comment="%s is 'Broadcaster App'">Boards can be loaded with a source or via the %s</string>
   <string name="startsAfter">Starts after %s</string>
   <string name="startVerySoon">The broadcast will start very soon.</string>
@@ -109,13 +110,13 @@
   <string name="gameX">Game %s</string>
   <string name="knockouts">Knockouts</string>
   <string name="underXAgeTournament" comment="%s is the maximum age set by the organiser for a tournament. e.g.
-  
+
 'U18' will mean it is an tournament for under-18 years.
-  
+
 Please use your language's conventions in sporting activities for how the 'U' should be translated and keep it short.">U%s</string>
-  <string name="underXEloTournament" comment="%s is the maximum Elo rating set by the organiser for a tournament. 
-  
+  <string name="underXEloTournament" comment="%s is the maximum Elo rating set by the organiser for a tournament.
+
 e.g. 'U2000' will mean it is an tournament for players with Elo under 2000.
-  
+
 Please use your language's conventions in sporting activities for how the 'U' should be translated and keep it short.">U%s</string>
 </resources>

--- a/ui/@types/lichess/i18n.d.ts
+++ b/ui/@types/lichess/i18n.d.ts
@@ -359,6 +359,8 @@ interface I18n {
     newBroadcast: string;
     /** No boards yet. These will appear once games are uploaded. */
     noBoardsYet: string;
+    /** No players yet. They will appear once first games are uploaded. */
+    noPlayersYet: string;
     /** The broadcast has not yet started. */
     notYetStarted: string;
     /** Official standings */

--- a/ui/analyse/src/study/relay/relayPlayers.ts
+++ b/ui/analyse/src/study/relay/relayPlayers.ts
@@ -273,6 +273,10 @@ const playersList = (ctrl: RelayPlayers): VNode =>
     ctrl.players ? renderPlayers(ctrl, ctrl.players) : [spinner()],
   );
 
+const sortByBoth = (x?: number, y?: number) => ({
+  attrs: { 'data-sort': (x || 0) * 100000 + (y || 0) },
+});
+
 export const renderPlayers = (
   ctrl: RelayPlayers,
   players: RelayPlayer[],
@@ -283,9 +287,7 @@ export const renderPlayers = (
   const withRank = players.some(p => defined(p.rank));
   const defaultSort = { attrs: { 'data-sort-default': 1 } };
   const tbs = players?.[0]?.tiebreaks;
-  const sortByBoth = (x?: number, y?: number) => ({
-    attrs: { 'data-sort': (x || 0) * 100000 + (y || 0) },
-  });
+  const hasPlayers = players.length > 0;
   return [
     withRank &&
       hl(
@@ -293,96 +295,100 @@ export const renderPlayers = (
         { attrs: dataIcon(licon.InfoCircle) },
         i18n.broadcast.standingsDisclaimer,
       ),
-    hl(
-      'table.relay-tour__players__table.fide-players-table.slist.slist-invert.slist-pad',
-      {
-        hook: onInsert(tableAugment),
-      },
-      [
-        hl(
-          'thead',
-          hl('tr', [
-            hl('th.pin', defaultSort),
-            withRank && hl('th.rank', { attrs: { ...defaultSort['attrs'], ...dataIcon(licon.Trophy) } }),
-            hl('th.player-name', { attrs: { 'data-sort-reverse': true } }, i18n.site.player),
-            withRating && hl('th', ((!withScores && !withRank) || forceEloSort) && defaultSort, 'Elo'),
-            withScores && hl('th.score', !withRank && !forceEloSort && defaultSort, i18n.broadcast.score),
-            hl('th', i18n.site.games),
-            tbs?.map(tb =>
-              hl(
-                'th.tiebreak',
-                { attrs: { 'data-sort': tb.points, title: tb.description, 'aria-label': tb.description } },
-                tb.extendedCode,
-              ),
-            ),
-          ]),
-        ),
-        hl(
-          'tbody',
-          players.map(player => {
-            const id = playerId(player);
-            const pinned = ctrl.pins.isPinned(id);
-            return hl('tr', [
-              hl(
-                'td.pin',
-                { attrs: { 'data-sort': pinned ? 1 : 0 } },
-                id &&
+    hasPlayers
+      ? hl(
+          'table.relay-tour__players__table.fide-players-table.slist.slist-invert.slist-pad',
+          {
+            hook: onInsert(tableAugment),
+          },
+          [
+            hl(
+              'thead',
+              hl('tr', [
+                hl('th.pin', defaultSort),
+                withRank && hl('th.rank', { attrs: { ...defaultSort['attrs'], ...dataIcon(licon.Trophy) } }),
+                hl('th.player-name', { attrs: { 'data-sort-reverse': true } }, i18n.site.player),
+                withRating && hl('th', ((!withScores && !withRank) || forceEloSort) && defaultSort, 'Elo'),
+                withScores && hl('th.score', !withRank && !forceEloSort && defaultSort, i18n.broadcast.score),
+                hl('th', i18n.site.games),
+                tbs?.map(tb =>
                   hl(
-                    'button',
+                    'th.tiebreak',
                     {
-                      class: { pinned },
-                      attrs: {
-                        title: 'Pin player',
-                      },
-                      on: {
-                        click() {
-                          ctrl.pins.togglePin(id);
+                      attrs: { 'data-sort': tb.points, title: tb.description, 'aria-label': tb.description },
+                    },
+                    tb.extendedCode,
+                  ),
+                ),
+              ]),
+            ),
+            hl(
+              'tbody',
+              players.map(player => {
+                const id = playerId(player);
+                const pinned = ctrl.pins.isPinned(id);
+                return hl('tr', [
+                  hl(
+                    'td.pin',
+                    { attrs: { 'data-sort': pinned ? 1 : 0 } },
+                    id &&
+                      hl(
+                        'button',
+                        {
+                          class: { pinned },
+                          attrs: {
+                            title: 'Pin player',
+                          },
+                          on: {
+                            click() {
+                              ctrl.pins.togglePin(id);
+                            },
+                          },
+                        },
+                        pinIcon(),
+                      ),
+                  ),
+                  withRank &&
+                    hl('td.rank', { attrs: { 'data-sort': player.rank ? -player.rank : 0 } }, player.rank),
+                  playerTd(player, ctrl, true),
+                  withRating &&
+                    hl(
+                      'td',
+                      sortByBoth(player.rating, (player.score || 0) * 10),
+                      player.rating && ratingDiff(player),
+                    ),
+                  withScores &&
+                    hl(
+                      'td.score',
+                      {
+                        attrs: {
+                          'data-sort': player.rank
+                            ? -player.rank // so that I don't have to insert a data-sort-reverse also
+                            : sortByBoth((player.score || 0) * 10, player.rating)['attrs']['data-sort'],
                         },
                       },
-                    },
-                    pinIcon(),
+                      `${player.score ?? 0}`,
+                    ),
+                  hl('td', sortByBoth(player.played, player.rating), `${player.played ?? 0}`),
+                  player.tiebreaks?.map(tb =>
+                    hl(
+                      'td.tiebreak',
+                      {
+                        attrs: {
+                          'data-sort': tb.points,
+                          title: tb.description,
+                          'aria-label': tb.description,
+                        },
+                      },
+                      `${tb.points}`,
+                    ),
                   ),
-              ),
-              withRank &&
-                hl('td.rank', { attrs: { 'data-sort': player.rank ? -player.rank : 0 } }, player.rank),
-              playerTd(player, ctrl, true),
-              withRating &&
-                hl(
-                  'td',
-                  sortByBoth(player.rating, (player.score || 0) * 10),
-                  player.rating && ratingDiff(player),
-                ),
-              withScores &&
-                hl(
-                  'td.score',
-                  {
-                    attrs: {
-                      'data-sort': player.rank
-                        ? -player.rank // so that I don't have to insert a data-sort-reverse also
-                        : sortByBoth((player.score || 0) * 10, player.rating)['attrs']['data-sort'],
-                    },
-                  },
-                  `${player.score ?? 0}`,
-                ),
-              hl('td', sortByBoth(player.played, player.rating), `${player.played ?? 0}`),
-              player.tiebreaks?.map(tb =>
-                hl(
-                  'td.tiebreak',
-                  {
-                    attrs: {
-                      'data-sort': tb.points,
-                      title: tb.description,
-                      'aria-label': tb.description,
-                    },
-                  },
-                  `${tb.points}`,
-                ),
-              ),
-            ]);
-          }),
-        ),
-      ],
-    ),
+                ]);
+              }),
+            ),
+          ],
+        )
+      : hl('div.relay-tour__note', i18n.broadcast.noPlayersYet),
   ];
 };
 


### PR DESCRIPTION
# Why

Spotted that in some upcoming broadcasts the players list is empty due to lack of rounds pre-setup.

# How

Add players list placeholder similar to one we use in games tab.

# Preview

### Before

<img width="1744" height="548" alt="Screenshot 2026-08-02 at 10 14 53" src="https://github.com/user-attachments/assets/838715ba-ab69-4f22-9362-06b03c4cf79e" />

### After

<img width="1744" height="548" alt="Screenshot 2026-08-02 at 10 22 48" src="https://github.com/user-attachments/assets/f4ff6435-f28f-4a04-8bbf-366ac27b5ede" />
