### PR TITLE
ui(dasher): fix boards/picies toggle button label, regenerate i18n keys

### DIFF
--- a/modules/coreI18n/src/main/key.scala
+++ b/modules/coreI18n/src/main/key.scala
@@ -1970,6 +1970,7 @@ object I18nKey:
     val `blocked`: I18nKey = "blocked"
     val `unblock`: I18nKey = "unblock"
     val `xStartedFollowingY`: I18nKey = "xStartedFollowingY"
+    val `less`: I18nKey = "less"
     val `more`: I18nKey = "more"
     val `memberSince`: I18nKey = "memberSince"
     val `lastSeenActive`: I18nKey = "lastSeenActive"

--- a/translation/source/site.xml
+++ b/translation/source/site.xml
@@ -485,6 +485,7 @@
     <item quantity="one">%s following</item>
     <item quantity="other">%s following</item>
   </plurals>
+  <string name="less">Less</string>
   <string name="more">More</string>
   <string name="memberSince">Member since</string>
   <string name="lastSeenActive">Active %s</string>

--- a/ui/@types/lichess/i18n.d.ts
+++ b/ui/@types/lichess/i18n.d.ts
@@ -359,7 +359,7 @@ interface I18n {
     newBroadcast: string;
     /** No boards yet. These will appear once games are uploaded. */
     noBoardsYet: string;
-    /** No players yet. They will appear once first games are uploaded. */
+    /** No players yet. They will appear once games are uploaded. */
     noPlayersYet: string;
     /** The broadcast has not yet started. */
     notYetStarted: string;
@@ -3871,6 +3871,8 @@ interface I18n {
     learnFromYourMistakes: string;
     /** Learn */
     learnMenu: string;
+    /** Less */
+    less: string;
     /** Let other players challenge you */
     letOtherPlayersChallengeYou: string;
     /** Let other players follow you */

--- a/ui/dasher/src/util.ts
+++ b/ui/dasher/src/util.ts
@@ -13,7 +13,7 @@ export const moreButton = (toggle: Toggle): VNode =>
   hl(
     'button.button.more',
     {
-      attrs: { title: i18n.site.more },
+      attrs: { title: toggle() ? i18n.site.less : i18n.site.more },
       hook: bind('click', toggle.toggle),
     },
     toggle() ? '-' : '+',


### PR DESCRIPTION
# Why

Spotted that dasher board/pieces options list toggle button have the hardcoded label, which is not always correct.

# How

Add i18n key for "Less", update the board/pieces options list  toggle button title. (Also, maybe we should replace "+" and "-" with those labels, and remove title anyway?)

Also fix CI failure after merging in #21140 with a word change.

# Preview

<img width="332" height="516" alt="Screenshot 2026-08-02 at 11 57 31" src="https://github.com/user-attachments/assets/d4a60014-5788-404a-b0f8-95279bc03b81" />
