### PR TITLE
ui(bits): apply roundness to few forum elements, fix lint

### DIFF
--- a/ui/bits/css/_markdown-textarea.scss
+++ b/ui/bits/css/_markdown-textarea.scss
@@ -29,7 +29,7 @@
     align-items: center;
     min-width: 112px;
     height: 40px;
-    border-radius: 6px 6px 0 0;
+    border-radius: $box-radius-size $box-radius-size 0 0;
     border: 1px solid transparent;
     border-bottom: none;
     background: transparent;
@@ -100,7 +100,7 @@
     overflow-x: hidden;
     overflow-y: auto;
     padding: 0.8em 1em 0;
-    border-radius: 6px 6px 24px 6px;
+    border-radius: $box-radius-size;
     background: $c-bg-preview;
   }
 

--- a/ui/bits/css/forum/_topic.scss
+++ b/ui/bits/css/forum/_topic.scss
@@ -8,7 +8,6 @@
     .warning {
       @extend %box-radius;
 
-      border-radius: 20px;
       padding: 1rem;
       background: color-mix(in oklab, $c-bad 15%, $c-bg);
       border: 1px solid $c-error;


### PR DESCRIPTION
# Why

Spotted that forum warning and markdown textarea does not use the global roundness.

# How

Apply roundness to few forum elements (warning, tabs, textarea container), fix stylelint warnings.

# Preview

<img width="955" height="956" alt="Screenshot 2026-08-02 at 21 00 35" src="https://github.com/user-attachments/assets/16876830-8463-45e1-8ae3-a295956194dd" />
