### PR TITLE
ui(lib): display fixes for button racks

### DIFF
--- a/ui/lib/css/component/_btn-rack.scss
+++ b/ui/lib/css/component/_btn-rack.scss
@@ -23,6 +23,7 @@
     border-inline-end: $border;
     color: $c-font;
     white-space: nowrap;
+    overflow: hidden;
 
     &:hover {
       color: $c-font;
@@ -38,11 +39,21 @@
       border: 0;
     }
 
+    &:first-child:last-child {
+      @extend %box-radius;
+    }
+
     icon {
       @extend %roboto;
 
       letter-spacing: -1px;
     }
+  }
+
+  > form .btn-rack__btn {
+    border-radius: 0 !important;
+    border: 0;
+    box-shadow: none;
   }
 
   &__btn {

--- a/ui/lib/css/component/_btn-rack.scss
+++ b/ui/lib/css/component/_btn-rack.scss
@@ -23,7 +23,6 @@
     border-inline-end: $border;
     color: $c-font;
     white-space: nowrap;
-    overflow: hidden;
 
     &:hover {
       color: $c-font;
@@ -50,10 +49,14 @@
     }
   }
 
-  > form .btn-rack__btn {
-    border-radius: 0 !important;
-    border: 0;
-    box-shadow: none;
+  > form {
+    overflow: hidden;
+
+    .btn-rack__btn {
+      border-radius: 0 !important;
+      border: 0;
+      box-shadow: none;
+    }
   }
 
   &__btn {


### PR DESCRIPTION
# Why

There was a report about button racks used in mods pages which does not display correctly with UI roundness.

# How

Fix single button in rack case, adjust styles for rack with forms inside.

# Preview

### Before

<img width="1312" height="407" alt="Screenshot 2026-08-03 at 11 55 14" src="https://github.com/user-attachments/assets/d9daa3d0-54b0-4609-a44f-11dfac4b395f" />

### After

<img width="1312" height="407" alt="Screenshot 2026-08-03 at 11 54 53" src="https://github.com/user-attachments/assets/c5f99333-5496-4ddb-8942-5f025d9d1b01" />
