### PR TITLE
ui(voice): fix voice bar moves list shift

### DIFF
--- a/ui/voice/css/_voice.scss
+++ b/ui/voice/css/_voice.scss
@@ -2,7 +2,6 @@
   @include prevent-select;
 
   position: relative;
-  flex: 1 1 auto;
   grid-area: voice;
 }
 


### PR DESCRIPTION
# Why

Spotted that when voice commands are enabled the voice bar grows too much and shifts move list down, creating the gap.

# How

Remove `flex` from voice bar, let the grid control the sizing.

# Preview

### Before

<img width="419" height="558" alt="Screenshot 2026-08-03 at 12 01 47" src="https://github.com/user-attachments/assets/cef30e2d-75f6-4d25-a0fd-2497e9a90d39" />

### After

<img width="419" height="558" alt="Screenshot 2026-08-03 at 12 01 51" src="https://github.com/user-attachments/assets/6d1aef64-b8fa-4d50-9de1-65766a1ed35a" />
