### PR TITLE
ui(lib): fix button racks in power tips

### DIFF
--- a/ui/lib/css/component/_power-tip.scss
+++ b/ui/lib/css/component/_power-tip.scss
@@ -105,6 +105,11 @@
     border: 0;
     border-radius: 0;
 
+    .btn-rack__btn:first-child,
+    .btn-rack__btn:last-child {
+      border-radius: 0;
+    }
+
     a {
       flex: 0 0 18%;
 


### PR DESCRIPTION
# Why

Ornicar spotted an issue during https://github.com/lichess-org/lila/pull/21158 review.

# How

Besides rack container, nullify radius for children too.

# Preview

### Before

<img width="349" height="190" alt="Screenshot 2026-08-03 at 12 26 06" src="https://github.com/user-attachments/assets/06b9e4e3-964b-4ed8-934e-73fecd8e9b39" />

### After

<img width="349" height="190" alt="Screenshot 2026-08-03 at 12 24 06" src="https://github.com/user-attachments/assets/47a9f2c2-7530-443e-acab-be85b6f2d9ff" />


