### PR TITLE
use openingexplorer's internal endpoint to access opening data

### DIFF
--- a/modules/opening/src/main/Env.scala
+++ b/modules/opening/src/main/Env.scala
@@ -19,7 +19,7 @@ final class Env(
     ws: StandaloneWSClient
 )(using Executor, lila.core.config.RateLimit):
 
-  private val explorerEndpoint = Url(appConfig.get[String]("explorer.endpoint"))
+  private val explorerEndpoint = Url(appConfig.get[String]("explorer.internal_endpoint"))
   private val oauthToken = appConfig.get[Secret]("explorer.oauth_token")
 
   private lazy val wikiColl = db(CollName("opening_wiki"))


### PR DESCRIPTION
Working on getting openingexplorer working within dev environments, where lila and openingexplorer are in the same bridge network.

If openingexplorer's public endpoint uses `localhost` host, then lila can't access it. Switch to use the internal endpoint.

Similar PRs:
- #13937
- #14051