### PR TITLE
ui(opening): roundness related visual tweaks

### DIFF
--- a/ui/opening/css/_next.scss
+++ b/ui/opening/css/_next.scss
@@ -13,6 +13,7 @@
     outline: 3px solid color-mix(in oklab, $c-font 30%, $c-bg);
     cursor: pointer;
     color: $c-font;
+    overflow: hidden;
 
     &:hover {
       outline: 3px solid color-mix(in oklab, $c-primary 60%, $c-bg);
@@ -79,11 +80,10 @@
       flex-flow: row nowrap;
 
       span {
-        @extend %box-radius-bottom-right;
-
+        border-radius: 0 0 $small-box-radius-size 0;
         background: $c-primary;
         color: $c-over;
-        padding-right: 0.5em;
+        padding-inline: 0.5em;
         font-size: 0.8em;
         text-align: right;
       }

--- a/ui/opening/css/_show.scss
+++ b/ui/opening/css/_show.scss
@@ -61,9 +61,14 @@
 
     .lpv {
       flex: 0 0 calc(100% - #{$result-width});
+      border-radius: 0 $box-radius-size $box-radius-size 0;
 
       @include mq-col-many {
         flex: 0 0 300px;
+      }
+
+      cg-board {
+        @extend %box-radius-top-right;
       }
     }
 

--- a/ui/opening/css/_wiki.scss
+++ b/ui/opening/css/_wiki.scss
@@ -3,6 +3,7 @@
 
   background: $c-bg-zebra;
   flex: 2 1 auto;
+  overflow: hidden;
 
   &__markup {
     max-height: 220px;
@@ -16,11 +17,15 @@
 
     @include rendered-markdown(1em);
 
+    &::-webkit-scrollbar-track {
+      background: $c-bg-zebra;
+    }
+
     ul {
       padding: 0;
     }
 
-    h2:not(first-child) {
+    h2:not(:first-child) {
       line-height: 1.3em;
       padding-bottom: 0.4em;
     }


### PR DESCRIPTION
# Why

Spotted some small display issues with new roundness feature on the opening page.

# How

Summary of changes:
* hide eval bar overflow
* reduce popularity bar roundness and fix popularity label trim
* adjust cg-board roundness to better match container
* use the background color for the nested scroll bar in opening box

# Preview

### Before

<img width="1399" height="1106" alt="Screenshot 2026-08-03 at 17 45 43" src="https://github.com/user-attachments/assets/6b9edd17-86d9-4361-8f82-fab2a1305130" />

### After

<img width="1353" height="1143" alt="Screenshot 2026-08-03 at 17 34 25" src="https://github.com/user-attachments/assets/82fd92fb-142a-4365-9085-70cc321378ca" />
