### PR TITLE
ui(lib): tweak TS config for test to address in editor warning

### DIFF
--- a/ui/lib/tests/tsconfig.json
+++ b/ui/lib/tests/tsconfig.json
@@ -1,3 +1,6 @@
 {
-  "extends": "../../.test/tsconfig.test.json"
+  "extends": "../../.test/tsconfig.test.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": true
+  }
 }


### PR DESCRIPTION
# Why

@fitztrev spotted that editors warns on direct `.mts` import in lib test files.

# How

Add the flag allowing importing TS files directly to TS config dedicated to tests. Test were passing previously and are passing after the change so it change purely to make the compiler happy (we never compile that code anyway).

# Preview

### Before

<img width="1083" height="156" alt="Screenshot 2026-08-03 at 18 03 00" src="https://github.com/user-attachments/assets/2506a3da-d331-48e2-a4f1-bb26a41b82d3" />

### After

<img width="822" height="431" alt="Screenshot 2026-08-03 at 17 52 21" src="https://github.com/user-attachments/assets/dba4e7c5-fc8e-42db-b06a-a0a31b6ff600" />

### All tests still passing

<img width="503" height="81" alt="Screenshot 2026-08-03 at 18 01 35" src="https://github.com/user-attachments/assets/94d47524-f10b-4473-95fe-94bf9eb3c264" />
<img width="329" height="207" alt="Screenshot 2026-08-03 at 18 01 11" src="https://github.com/user-attachments/assets/5989fd14-870e-4163-8b9f-ec294805e114" />

