### PR TITLE
ui(analyse): small visual tweaks for the opening explorer view

### DIFF
--- a/ui/analyse/css/explorer/_explorer.scss
+++ b/ui/analyse/css/explorer/_explorer.scss
@@ -51,6 +51,9 @@
     line-height: 1.9em;
     padding: 0;
     background: color-mix(in oklab, $c-secondary 30%, $c-bg);
+    position: sticky;
+    top: 0;
+    z-index: 10;
 
     .ddloader {
       padding-inline-start: 7px;

--- a/ui/analyse/css/explorer/_explorer.scss
+++ b/ui/analyse/css/explorer/_explorer.scss
@@ -53,7 +53,7 @@
     background: color-mix(in oklab, $c-secondary 30%, $c-bg);
     position: sticky;
     top: 0;
-    z-index: 10;
+    z-index: $z-link-overlay-2;
 
     .ddloader {
       padding-inline-start: 7px;
@@ -323,16 +323,28 @@
 
     position: absolute;
     top: 0;
+    right: 0;
     cursor: pointer;
     display: block;
     font-size: 1.2em;
     width: 1.5em;
-    line-height: 1.5em;
+    height: 100%;
     text-align: center;
     opacity: 0.8;
+    z-index: $z-above-link-overlay-3;
 
     &:hover {
       opacity: 1;
+    }
+
+    &::before {
+      position: relative;
+      top: -1px;
+      margin: 0 0 0 -2px;
+
+      @include if-rtl {
+        margin: 0 -2px 0 0;
+      }
     }
   }
 
@@ -383,7 +395,6 @@
 
   .explorer-box button.toconf {
     font-size: 1.5em;
-    margin-top: 2px;
     margin-inline-end: 8px;
   }
 }

--- a/ui/analyse/css/explorer/_explorer.scss
+++ b/ui/analyse/css/explorer/_explorer.scss
@@ -245,16 +245,22 @@
     td {
       @include padding-direction(5px, 0, 5px, 7px);
 
-      max-width: 110px;
-
-      &:nth-child(2) {
-        max-width: none;
-      }
-
       span {
         @extend %ellipsis;
 
         display: block;
+      }
+
+      &.game-rating {
+        width: 40px;
+      }
+
+      &.game-type {
+        width: 28px;
+      }
+
+      &.game-date {
+        width: 60px;
       }
     }
 

--- a/ui/analyse/css/explorer/_explorer.scss
+++ b/ui/analyse/css/explorer/_explorer.scss
@@ -265,10 +265,11 @@
     }
 
     result {
+      @extend %box-radius;
+
       display: block;
       text-align: center;
       padding: 3px 5px;
-      border-radius: 3px;
       font-size: 0.9em;
     }
   }

--- a/ui/analyse/src/explorer/explorerView.ts
+++ b/ui/analyse/src/explorer/explorerView.ts
@@ -5,7 +5,6 @@ import { bind, dataIcon, type MaybeVNode, type LooseVNodes, type VNode, hl, onIn
 
 import type AnalyseCtrl from '../ctrl';
 import { view as renderConfig } from './explorerConfig';
-import type ExplorerCtrl from './explorerCtrl';
 import { MAX_ANALYSE_DEPTH, moveArrowAttributes, ucfirst } from './explorerUtil';
 import {
   isOpening,
@@ -204,7 +203,7 @@ const closeButton = (ctrl: AnalyseCtrl): VNode =>
 const showEmpty = (ctrl: AnalyseCtrl, data?: OpeningData): VNode => {
   const isTooDeep = ctrl.explorer.root.node.ply >= MAX_ANALYSE_DEPTH;
   return hl('div.data.empty', [
-    explorerTitle(ctrl.explorer),
+    explorerTitle(ctrl),
     openingTitle(ctrl, data),
     hl('div.message', [
       hl('strong', isTooDeep ? i18n.site.maxDepthReached : i18n.site.noGameFound),
@@ -249,7 +248,7 @@ function show(ctrl: AnalyseCtrl): MaybeVNode {
     const topTable = showGameTable(ctrl, data.fen, i18n.site.topGames, data.topGames || []);
     if (moveTable || recentTable || topTable)
       lastShow = hl('div.data', [
-        explorerTitle(ctrl.explorer),
+        explorerTitle(ctrl),
         data?.opening && openingTitle(ctrl, data),
         moveTable,
         topTable,
@@ -286,7 +285,9 @@ function show(ctrl: AnalyseCtrl): MaybeVNode {
   return lastShow;
 }
 
-const explorerTitle = (explorer: ExplorerCtrl) => {
+const explorerTitle = (ctrl: AnalyseCtrl) => {
+  const explorer = ctrl.explorer;
+  const configOpened = explorer.config.data.open();
   const db = explorer.db();
   const otherLink = (name: string, title: string) =>
     hl(
@@ -294,7 +295,7 @@ const explorerTitle = (explorer: ExplorerCtrl) => {
       {
         key: name,
         attrs: { title },
-        hook: bind('click', () => explorer.config.data.db(name.toLowerCase() as ExplorerDb), explorer.reload),
+        hook: bind('click', () => explorer.config.data.db(name.toLowerCase() as ExplorerDb), ctrl.redraw),
       },
       name,
     );
@@ -357,6 +358,13 @@ const explorerTitle = (explorer: ExplorerCtrl) => {
           },
           i18n.site.player,
         ),
+    hl('button.fbt.toconf', {
+      attrs: {
+        'aria-label': configOpened ? 'Close configuration' : 'Open configuration',
+        ...dataIcon(configOpened ? licon.X : licon.Gear),
+      },
+      hook: bind('click', () => explorer.config.toggleOpen(), ctrl.redraw),
+    }),
   ]);
 };
 
@@ -366,7 +374,7 @@ const showTitle = (variant: Variant) =>
     : i18n.site.xOpeningExplorer(variant.name);
 
 const showConfig = (ctrl: AnalyseCtrl): VNode =>
-  hl('div.config', [explorerTitle(ctrl.explorer), renderConfig(ctrl.explorer.config)]);
+  hl('div.config', [explorerTitle(ctrl), renderConfig(ctrl.explorer.config)]);
 
 const showFailing = (ctrl: AnalyseCtrl) =>
   hl('div.data.empty', [
@@ -419,16 +427,6 @@ export default function (ctrl: AnalyseCtrl): MaybeVNode {
         },
       },
     },
-    [
-      hl('div.overlay'),
-      content,
-      hl('button.fbt.toconf', {
-        attrs: {
-          'aria-label': configOpened ? 'Close configuration' : 'Open configuration',
-          ...dataIcon(configOpened ? licon.X : licon.Gear),
-        },
-        hook: bind('click', () => explorer.config.toggleOpen(), ctrl.redraw),
-      }),
-    ],
+    [hl('div.overlay'), content],
   );
 }

--- a/ui/analyse/src/explorer/explorerView.ts
+++ b/ui/analyse/src/explorer/explorerView.ts
@@ -287,15 +287,21 @@ function show(ctrl: AnalyseCtrl): MaybeVNode {
 
 const explorerTitle = (ctrl: AnalyseCtrl) => {
   const explorer = ctrl.explorer;
-  const configOpened = explorer.config.data.open();
+  const config = explorer.config;
+  const configOpened = config.data.open();
+  const playerName = config.data.playerName.value();
+  const masterDbExplanation = i18n.site.masterDbExplanation(2200, '1952', '2026-01');
   const db = explorer.db();
+  const data = explorer.current();
+  const queuePosition = data && isOpening(data) && data.queuePosition;
+
   const otherLink = (name: string, title: string) =>
     hl(
       'button.button-link',
       {
         key: name,
         attrs: { title },
-        hook: bind('click', () => explorer.config.data.db(name.toLowerCase() as ExplorerDb), ctrl.redraw),
+        hook: bind('click', () => config.data.db(name.toLowerCase() as ExplorerDb), ctrl.redraw),
       },
       name,
     );
@@ -304,30 +310,26 @@ const explorerTitle = (ctrl: AnalyseCtrl) => {
       'span.active.text.' + db,
       {
         attrs: { title, ...dataIcon(icon) },
-        hook: db === 'player' ? bind('click', explorer.config.toggleColor, explorer.reload) : undefined,
+        hook: db === 'player' ? bind('click', config.toggleColor, explorer.reload) : undefined,
       },
       nodes,
     );
-  const playerName = explorer.config.data.playerName.value();
-  const masterDbExplanation = i18n.site.masterDbExplanation(2200, '1952', '2026-01'),
-    lichessDbExplanation = i18n.site.lichessDbExplanation;
-  const data = explorer.current();
-  const queuePosition = data && isOpening(data) && data.queuePosition;
+
   return hl('div.explorer-title', [
     db === 'masters'
       ? active([hl('strong', 'Masters'), ' database'], masterDbExplanation, licon.Book)
       : explorer.config.allDbs.includes('masters') && otherLink('Masters', masterDbExplanation),
     db === 'lichess'
-      ? active([hl('strong', 'Lichess'), ' database'], lichessDbExplanation, licon.Logo)
-      : otherLink('Lichess', lichessDbExplanation),
+      ? active([hl('strong', 'Lichess'), ' database'], i18n.site.lichessDbExplanation, licon.Logo)
+      : otherLink('Lichess', i18n.site.lichessDbExplanation),
     db === 'player'
       ? playerName
         ? active(
             [
               hl(`strong${playerName.length > 14 ? '.long' : ''}`, playerName),
-              ` ${i18n.site[explorer.config.data.color() === 'white' ? 'asWhite' : 'asBlack']}`,
+              ` ${i18n.site[config.data.color() === 'white' ? 'asWhite' : 'asBlack']}`,
               explorer.isIndexing() &&
-                !explorer.config.data.open() &&
+                !configOpened &&
                 hl('icon.ddloader', {
                   attrs: {
                     title: queuePosition
@@ -347,10 +349,10 @@ const explorerTitle = (ctrl: AnalyseCtrl) => {
             hook: bind(
               'click',
               () => {
-                explorer.config.selectPlayer(playerName || 'me');
+                config.selectPlayer(playerName || 'me');
                 if (explorer.db() !== 'player') {
-                  explorer.config.data.db('player');
-                  explorer.config.data.open(true);
+                  config.data.db('player');
+                  config.data.open(true);
                 }
               },
               explorer.reload,
@@ -363,7 +365,7 @@ const explorerTitle = (ctrl: AnalyseCtrl) => {
         'aria-label': configOpened ? 'Close configuration' : 'Open configuration',
         ...dataIcon(configOpened ? licon.X : licon.Gear),
       },
-      hook: bind('click', () => explorer.config.toggleOpen(), ctrl.redraw),
+      hook: bind('click', () => config.toggleOpen(), ctrl.redraw),
     }),
   ]);
 };

--- a/ui/analyse/src/explorer/explorerView.ts
+++ b/ui/analyse/src/explorer/explorerView.ts
@@ -301,7 +301,16 @@ const explorerTitle = (ctrl: AnalyseCtrl) => {
       {
         key: name,
         attrs: { title },
-        hook: bind('click', () => config.data.db(name.toLowerCase() as ExplorerDb), explorer.reload),
+        hook: bind(
+          'click',
+          () => {
+            config.data.db(name.toLowerCase() as ExplorerDb);
+            document.querySelector('.explorer-box')?.scrollTo({
+              top: 0,
+            });
+          },
+          explorer.reload,
+        ),
       },
       name,
     );

--- a/ui/analyse/src/explorer/explorerView.ts
+++ b/ui/analyse/src/explorer/explorerView.ts
@@ -128,7 +128,7 @@ function showGameTable(ctrl: AnalyseCtrl, fen: FEN, title: string, games: Openin
           : hl('tr', { key: game.id, attrs: { 'data-id': game.id, 'data-uci': game.uci || '' } }, [
               ctrl.explorer.opts.showRatings &&
                 hl(
-                  'td',
+                  'td.game-rating',
                   [game.white, game.black].map(p => hl('span', p.rating)),
                 ),
               hl(
@@ -136,9 +136,9 @@ function showGameTable(ctrl: AnalyseCtrl, fen: FEN, title: string, games: Openin
                 [game.white, game.black].map(p => hl('span', p.name)),
               ),
               hl('td', showResult(game.winner)),
-              hl('td', game.month || game.year),
+              hl('td.game-date', game.month || game.year),
               !isMasters &&
-                hl('td', game.speed && icon(perfIcons[game.speed])({ title: ucfirst(game.speed) })),
+                hl('td.game-type', game.speed && icon(perfIcons[game.speed])({ title: ucfirst(game.speed) })),
             ]),
       ),
     ),

--- a/ui/analyse/src/explorer/explorerView.ts
+++ b/ui/analyse/src/explorer/explorerView.ts
@@ -389,7 +389,7 @@ const showConfig = (ctrl: AnalyseCtrl): VNode =>
 
 const showFailing = (ctrl: AnalyseCtrl) =>
   hl('div.data.empty', [
-    hl('div.title', showTitle(ctrl.data.game.variant)),
+    explorerTitle(ctrl),
     hl('div.message', [
       hl('h3', 'Oops, sorry!'),
       hl('p.explanation', ctrl.explorer.failing()?.toString()),

--- a/ui/analyse/src/explorer/explorerView.ts
+++ b/ui/analyse/src/explorer/explorerView.ts
@@ -1,6 +1,6 @@
 import perfIcons from 'lib/game/perfIcons';
 import { displayLocale, numberFormat } from 'lib/i18n';
-import { licon } from 'lib/licon';
+import { licon, type LiconValue } from 'lib/licon';
 import { bind, dataIcon, type MaybeVNode, type LooseVNodes, type VNode, hl, onInsert, icon } from 'lib/view';
 
 import type AnalyseCtrl from '../ctrl';
@@ -298,11 +298,11 @@ const explorerTitle = (explorer: ExplorerCtrl) => {
       },
       name,
     );
-  const active = (nodes: LooseVNodes, title: string) =>
+  const active = (nodes: LooseVNodes, title: string, icon: LiconValue) =>
     hl(
       'span.active.text.' + db,
       {
-        attrs: { title, ...dataIcon(licon.Book) },
+        attrs: { title, ...dataIcon(icon) },
         hook: db === 'player' ? bind('click', explorer.config.toggleColor, explorer.reload) : undefined,
       },
       nodes,
@@ -314,10 +314,10 @@ const explorerTitle = (explorer: ExplorerCtrl) => {
   const queuePosition = data && isOpening(data) && data.queuePosition;
   return hl('div.explorer-title', [
     db === 'masters'
-      ? active([hl('strong', 'Masters'), ' database'], masterDbExplanation)
+      ? active([hl('strong', 'Masters'), ' database'], masterDbExplanation, licon.Book)
       : explorer.config.allDbs.includes('masters') && otherLink('Masters', masterDbExplanation),
     db === 'lichess'
-      ? active([hl('strong', 'Lichess'), ' database'], lichessDbExplanation)
+      ? active([hl('strong', 'Lichess'), ' database'], lichessDbExplanation, licon.Logo)
       : otherLink('Lichess', lichessDbExplanation),
     db === 'player'
       ? playerName
@@ -336,8 +336,9 @@ const explorerTitle = (explorer: ExplorerCtrl) => {
                 }),
             ],
             i18n.site.switchSides,
+            licon.User,
           )
-        : active([hl('strong', 'Player'), ' database'], '')
+        : active([hl('strong', 'Player'), ' database'], '', licon.User)
       : hl(
           'button.button-link.player',
           {

--- a/ui/analyse/src/explorer/explorerView.ts
+++ b/ui/analyse/src/explorer/explorerView.ts
@@ -301,7 +301,7 @@ const explorerTitle = (ctrl: AnalyseCtrl) => {
       {
         key: name,
         attrs: { title },
-        hook: bind('click', () => config.data.db(name.toLowerCase() as ExplorerDb), ctrl.redraw),
+        hook: bind('click', () => config.data.db(name.toLowerCase() as ExplorerDb), explorer.reload),
       },
       name,
     );


### PR DESCRIPTION
# How

Small visual tweaks for the opening explorer view in the game analyse sidebar.

Summary of changes:
* make opening explorer view header sticky
* move setting/close button inside title container, tweak sizing and position
* alter icons per database, so it's easier to spot different mode
* ensure same cell distribution in Lichess DB sections

# Preview

https://github.com/user-attachments/assets/0164d2b6-1117-49df-a2b6-8a175351483f

<img width="342" height="496" alt="Screenshot 2026-08-04 at 10 52 53" src="https://github.com/user-attachments/assets/90fc51e1-0ec5-4f0c-9807-a697b98af757" />


