### PR TITLE
ui(lib): use small radius for tree move pills

### DIFF
--- a/ui/lib/css/tree/_tree.scss
+++ b/ui/lib/css/tree/_tree.scss
@@ -352,7 +352,7 @@ $disclosure-btn-size: calc(15px + var(---button-size-pointer-adjust, 0px));
 
 .tview2-column line {
   move {
-    @extend %box-radius;
+    border-radius: $small-box-radius-size;
   }
 
   comment {
@@ -399,8 +399,7 @@ $disclosure-btn-size: calc(15px + var(---button-size-pointer-adjust, 0px));
   }
 
   move {
-    @extend %box-radius;
-
+    border-radius: $small-box-radius-size;
     margin-inline-end: 2px;
     font-size: 13px;
     font-weight: bold;


### PR DESCRIPTION
# Why

Spotted on the stream that tree move pills does not look that good with fully rounded corners, leading to character inside in some cases being too close to the container boundaries.

# How

Use small radius for tree move pills.

# Preview

### Before

<img width="342" align="left" height="194" alt="Screenshot 2026-08-04 at 11 41 39" src="https://github.com/user-attachments/assets/168dd9c8-f34e-4f6e-973a-a99db34bbe64" />
<img width="342" height="194" alt="Screenshot 2026-08-04 at 11 44 12" src="https://github.com/user-attachments/assets/bd8e89db-93ae-4042-86a5-ca3312f83b42" />


### After

<img width="342" align="left" height="194" alt="Screenshot 2026-08-04 at 11 40 22" src="https://github.com/user-attachments/assets/0802cd2d-63c0-444b-9b57-93e921c3c65f" />
<img width="342" height="194" alt="Screenshot 2026-08-04 at 11 44 29" src="https://github.com/user-attachments/assets/f4e7bae6-5666-41b1-88eb-e5ab62a291e9" />
