### PR TITLE
ui(lib): fix chat message input clip

### DIFF
--- a/ui/lib/css/chat/_discussion.scss
+++ b/ui/lib/css/chat/_discussion.scss
@@ -123,11 +123,12 @@
 
   &__say {
     @include padding-direction(3px, 20px, 3px, 4px);
+    @extend %box-radius-bottom;
 
     flex: 0 0 auto;
     border: 0;
+    padding-inline: 6px;
     border-top: $border;
-    border-radius: 0;
 
     &:focus {
       outline: 1px solid $c-primary;


### PR DESCRIPTION
# Why

Spotted that with global roundness set to higher values the the chat message input corder and content is a bit clipped.

# How

Apply roundness to the message input itself, add a bit of inline padding to avoid characters clip.

# Preview

### Before

<img width="342" height="194" alt="Screenshot 2026-08-04 at 11 48 16" src="https://github.com/user-attachments/assets/155eedbb-18c7-4d2b-807d-25b4b071bc27" />

### After

<img width="342" height="194" alt="Screenshot 2026-08-04 at 11 57 49" src="https://github.com/user-attachments/assets/2c7da32e-7b7f-49aa-9ef3-334aaaf6d13d" />
