### PR TITLE
docs: update mobile repository link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ Some issues that need artwork and documentation to be resolved are tagged [`nont
 2. Search to make sure it isn't a duplicate. [The advanced search syntax](https://help.github.com/articles/searching-issues/) may come in handy.
 3. It is not a trivial problem or demands unrealistic dev time to fix. Such issues may be closed.
 
-Report mobile-only bugs to [Lichess mobile](https://github.com/lichess-org/lichobile).
+Report mobile-only bugs to [Lichess mobile](https://github.com/lichess-org/mobile).
 
 ## I want to suggest a feature for Lichess
 


### PR DESCRIPTION
## Summary

Updates the mobile repository link in `CONTRIBUTING.md`.

The current documentation points contributors to the archived `lichess-org/lichobile` repository. This PR updates the link to `lichess-org/mobile`, which is the actively maintained repository for the Lichess mobile app.

## Testing

* Verified that the updated link points to the active repository.
* Documentation-only change; no code or runtime behavior is affected.