### PR TITLE
fix text alignment in analysis settings dialog

### DIFF
--- a/ui/analyse/css/_settings.scss
+++ b/ui/analyse/css/_settings.scss
@@ -40,6 +40,7 @@
   -webkit-tap-highlight-color: transparent;
   gap: 2em;
   height: 100%;
+  text-align: start;
 
   @media (max-width: at-most(600px)) {
     flex-direction: column;


### PR DESCRIPTION
Localized text combined with tiny viewports (under 360px width) could be misaligned. Fixes #21007