### PR TITLE
Fix redundant explorer redraw

### DIFF
--- a/ui/analyse/src/explorer/explorerCtrl.ts
+++ b/ui/analyse/src/explorer/explorerCtrl.ts
@@ -135,7 +135,7 @@ export default class ExplorerCtrl {
             .catch(onError)
             .then(_ => true),
         );
-        this.lastStream.promise.then(() => this.root.redraw());
+        if (this.db() === 'player') this.lastStream.promise.then(() => this.root.redraw());
       }
     },
     250,


### PR DESCRIPTION
Closes #20535

`processData` already redraws, so the redraw after `lastStream` is redundant, except for the player DB

#### Testing
Build locally and observed no noticeable visual changes