### PR TITLE
ui(bits): apply roundness to shepherd component

### DIFF
--- a/ui/bits/css/build/bits.shepherd.scss
+++ b/ui/bits/css/build/bits.shepherd.scss
@@ -2,6 +2,19 @@
 @import '../../../lib/css/plugin';
 
 .shepherd {
+  &-content,
+  &-element {
+    @extend %box-radius;
+  }
+
+  &-header {
+    @extend %box-radius-top;
+  }
+
+  &-footer {
+    @extend %box-radius-bottom;
+  }
+
   &-element {
     border: $border;
     background-color: rgb(from $c-bg r g b / 0.92);
@@ -17,8 +30,9 @@
   }
 
   &-has-title &-content &-header {
-    @extend %metal;
+    @extend %metal-bg;
 
+    background-color: transparent;
     border-bottom: $border;
 
     h3 {
@@ -34,10 +48,11 @@
 
   &-text {
     color: $c-font;
+    padding-inline: 14px;
   }
 
   &-button {
-    @extend %roboto;
+    @extend %roboto, %box-radius;
 
     background-color: $c-primary;
     color: $c-over;


### PR DESCRIPTION
# How

Apply global roundness to shepherd component (help/guide tooltips) + small visual tweaks and fixes.

# Preview

<img width="464" height="234" alt="Screenshot 2026-08-05 at 10 25 09" src="https://github.com/user-attachments/assets/812a6f77-3149-4a7f-9bb2-626efe123d6f" />
