### PR TITLE
ui(round): tweak user tv section alignment

### DIFF
--- a/app/views/game/side.scala
+++ b/app/views/game/side.scala
@@ -111,7 +111,7 @@ def meta(
       ,
       userTv.map: u =>
         st.section(cls := "game__tv"):
-          h2(cls := "top user-tv text", dataUserTv := u.id, dataIcon := Icon.AnalogTv)(u.titleUsername)
+          frag(iconTag(Icon.AnalogTv), h2(cls := "top user-tv text", dataUserTv := u.id)(u.titleUsername))
       ,
       tour
         .map: t =>

--- a/ui/round/css/_meta.scss
+++ b/ui/round/css/_meta.scss
@@ -62,10 +62,21 @@
     }
   }
 
-  .user-tv {
-    @extend %nowrap-ellipsis;
+  .game__tv {
+    @extend %flex-center-nowrap;
 
-    font-size: 1.2em;
+    gap: 8px;
+
+    icon {
+      font-size: 1.2em;
+      margin-top: -4px;
+    }
+
+    .user-tv {
+      @extend %nowrap-ellipsis;
+
+      font-size: 1.2em;
+    }
   }
 }
 


### PR DESCRIPTION
# Why

When looking for some places which still might miss global roundness or have some visual issues related to it, I have spotted that user TV section/label is misaligned slightly.

# How

Slightly alter the DOM, move the icon to a separate tag, adjust styles. Make sure that ellipsis still works.

# Preview

### Before

<img width="376" height="234" alt="Screenshot 2026-08-05 at 10 47 58" src="https://github.com/user-attachments/assets/5f41316c-da5a-4d02-b746-a2a10b95e20d" />

### After

<img width="350" height="234" alt="Screenshot 2026-08-05 at 10 59 57" src="https://github.com/user-attachments/assets/35a4178a-2325-4a65-b334-0c9dbc672be5" />
