### PR TITLE
ui: apply roundness and global styles to auth, tweak bg-input shades

### DIFF
--- a/ui/bits/css/_auth.scss
+++ b/ui/bits/css/_auth.scss
@@ -23,14 +23,11 @@
   }
 }
 
-$auth-input-radius: 16px;
-$auth-input-bg: rgb(26 22 16 / 1);
-
 .auth {
   width: 100%;
   margin: 0 auto;
   height: min-content;
-  border-radius: $auth-input-radius;
+  border-radius: $box-radius-size;
   border: $border;
 
   &__brand {
@@ -129,13 +126,9 @@ $auth-input-bg: rgb(26 22 16 / 1);
   .form-group input {
     height: 50px;
     font-size: 16px;
-    border: none;
-    border-radius: $auth-input-radius;
-    background: $auth-input-bg;
-
-    @include if-light {
-      background: rgb(245 242 237 / 1);
-    }
+    border: $border;
+    border-radius: $box-radius-size;
+    background: $c-bg-input;
 
     &:focus-visible {
       outline: $outline;
@@ -208,7 +201,7 @@ $auth-input-bg: rgb(26 22 16 / 1);
   .button {
     width: 100%;
     padding: 1.3rem;
-    border-radius: $auth-input-radius;
+    border-radius: $box-radius-size;
   }
 
   .submit.button {

--- a/ui/lib/css/theme/_theme.default.scss
+++ b/ui/lib/css/theme/_theme.default.scss
@@ -14,7 +14,7 @@
   --c-bg-zebra: hsl(var(---site-hue) 5% 19%);
   --c-bg-zebra2: hsl(var(---site-hue) 5% 24%);
   --c-bg-header-dropdown: var(--c-bg-popup);
-  --c-bg-input: hsl(from var(--c-bg-page) h s 13% / alpha);
+  --c-bg-input: hsl(from var(--c-bg-page) h s 12% / alpha);
   --c-bg-variation: hsl(var(---site-hue) 5% 15%);
   --c-bg-opaque: hsl(var(---site-hue) 7% 14%);
   --c-body-gradient: hsl(var(---site-hue) 12% 16%);

--- a/ui/lib/css/theme/_theme.light.scss
+++ b/ui/lib/css/theme/_theme.light.scss
@@ -28,7 +28,7 @@ html.light {
   --c-border: hsl(0 0% 85%);
   --c-dimmer: white;
   --c-clearer: black;
-  --c-bg-input: hsl(from var(--c-bg-page) h s 98);
+  --c-bg-input: hsl(from var(--c-bg-page) h s 97);
   --c-bg-variation: var(--c-bg-zebra2);
   --c-bg-header-dropdown: var(--c-bg);
   --c-header-dropdown: var(--c-font);


### PR DESCRIPTION
# How

Apply roundness and match more closely global styles in auth views, tweak `bg-input` shades slightly.

# Preview

<img width="380" align="left" src="https://github.com/user-attachments/assets/48357f0b-61b0-4405-86b0-a8c592169fbb" />
<img width="380" src="https://github.com/user-attachments/assets/27a290f6-b312-41f7-8202-6d652f046cb5" />
<img width="380" src="https://github.com/user-attachments/assets/8b60c259-734f-4403-8f3f-5bc7fce77255" />
