### PR TITLE
ui(lib): add background to `copy-me` inputs

### DIFF
--- a/ui/lib/css/component/_copy-me.scss
+++ b/ui/lib/css/component/_copy-me.scss
@@ -2,6 +2,8 @@
   @extend %box-radius, %flex-center-nowrap;
   @include backdrop-blur-if-transparent;
 
+  background: $c-bg-input;
+
   &__target {
     @extend %nowrap-ellipsis, %box-radius-left;
 


### PR DESCRIPTION
# Why

To improve the readability, especially in light and transparent themes.

# How

Add input background to `copy-me` elements to improve redability, and prevent them from inheriting container background color.

# Preview

<img width="808" height="310" alt="Screenshot 2026-08-05 at 13 35 14" src="https://github.com/user-attachments/assets/e5e28d84-debb-48f4-8d0f-e2e94f547487" />
<img width="808" height="310" alt="Screenshot 2026-08-05 at 13 35 03" src="https://github.com/user-attachments/assets/6d859088-851c-4eff-8cdd-07beff15930f" />
<img width="808" height="310" alt="Screenshot 2026-08-05 at 13 34 53" src="https://github.com/user-attachments/assets/8c25d26f-91cc-42ab-ab85-6fc47e64c353" />
<img width="1051" height="348" alt="Screenshot 2026-08-05 at 13 50 07" src="https://github.com/user-attachments/assets/f6fef206-ec95-453b-b51c-75a275194ef1" />

