### PR TITLE
relay: fix spotlight calendar dropping non-main tours in a group

### DIFF
--- a/modules/relay/src/main/RelayApi.scala
+++ b/modules/relay/src/main/RelayApi.scala
@@ -506,7 +506,7 @@ final class RelayApi(
       until: Option[Instant]
   ): Source[RelayRound.WithTour, ?] =
     Source.futureSource:
-      listing.active.map: all =>
+      listing.activeTours.map: all =>
         Source(all.map(_.tour).filter(_.spotlight.exists(_.enabled)))
           .mapAsync(1): tour =>
             roundRepo.byTourOrdered(tour.id).map(tour -> _)

--- a/modules/relay/src/main/RelayListing.scala
+++ b/modules/relay/src/main/RelayListing.scala
@@ -19,6 +19,8 @@ private final class RelayListing(
 
   def active: Fu[List[RelayCard]] = activeCache.get({}).recoverDefault
 
+  def activeTours: Fu[List[RelayTour.WithRounds]] = toursWithRounds
+
   val activeCacheTtl = 11.seconds
 
   private enum Spot:


### PR DESCRIPTION
I created 1 group with 2 tournaments, each with 1 round.

```bash
http -b -A bearer -a lip_admin http://localhost:9663/api/broadcast/spotlight-rounds
```

## Before

only 1 tour of the group's spotlight rounds were being returned

```js
{"id":"QMYf9L6A","name":"Round 1","slug":"round-1","createdAt":1785930271884,"rated":true,"startsAt":1786190400000,"url":"http://localhost:9663/broadcast/test-1/round-1/QMYf9L6A","t
our":{"id":"WDy7139l","name":"test 1","slug":"test-1","info":{"fideTC":"standard","timeZone":"America/Detroit"},"createdAt":1785930258387,"url":"http://localhost:9663/broadcast/test
-1/WDy7139l","tier":3,"dates":[1786190400000]},"spotlight":{"language":"en","tier":3}}
```

## After

```js
{"id":"QMYf9L6A","name":"Round 1","slug":"round-1","createdAt":1785930271884,"rated":true,"startsAt":1786190400000,"url":"http://localhost:9663/broadcast/test-1/round-1/QMYf9L6A","t
our":{"id":"WDy7139l","name":"test 1","slug":"test-1","info":{"fideTC":"standard","timeZone":"America/Detroit"},"createdAt":1785930258387,"url":"http://localhost:9663/broadcast/test
-1/WDy7139l","tier":3,"dates":[1786190400000]},"spotlight":{"language":"en","tier":3}}
{"id":"EwbigIJv","name":"Round 1","slug":"round-1","createdAt":1785930414863,"rated":true,"startsAt":1786197600000,"url":"http://localhost:9663/broadcast/test-2/round-1/EwbigIJv","t
our":{"id":"j5gDjYkf","name":"test 2","slug":"test-2","info":{"fideTC":"standard","timeZone":"America/Detroit"},"createdAt":1785930404941,"url":"http://localhost:9663/broadcast/test
-2/j5gDjYkf","tier":3,"dates":[1786197600000]},"spotlight":{"language":"en","tier":3}}
```