### PR TITLE
ui: tweaks and fixes related to global roundness

### DIFF
--- a/ui/bits/css/ublog/_post.scss
+++ b/ui/bits/css/ublog/_post.scss
@@ -213,7 +213,8 @@
   }
 
   fieldset {
-    border: $border-width $border-style $c-border;
+    border: $border;
+    border-radius: $box-radius-size;
     padding: 1rem 1.5rem 1.5rem;
   }
 

--- a/ui/lib/css/component/_friend-box.scss
+++ b/ui/lib/css/component/_friend-box.scss
@@ -8,7 +8,7 @@
   background: $c-bg-popup;
   overflow: hidden;
   border-inline-start: $border;
-  border-top-left-radius: $box-radius-size;
+  border-top-left-radius: $small-box-radius-size;
   font-size: 0.9rem;
   min-width: 150px;
   max-height: 95%;

--- a/ui/lib/css/component/_reconnecting.scss
+++ b/ui/lib/css/component/_reconnecting.scss
@@ -26,7 +26,7 @@ $recon-height: 2.5rem;
 
   height: $recon-height;
   padding: 0 1rem;
-  border-top-right-radius: 3px;
+  border-top-right-radius: $box-radius-size;
   z-index: $z-network-status-105;
   opacity: 0;
   transform: translateY($recon-height);

--- a/ui/lib/css/component/_tagify.scss
+++ b/ui/lib/css/component/_tagify.scss
@@ -232,7 +232,7 @@
       color: $tag-text-color;
       color: var(--tag-text-color, $tag-text-color);
       line-height: inherit;
-      border-radius: 3px;
+      border-radius: $small-box-radius-size;
       white-space: nowrap;
       transition: 0.13s ease-out;
 

--- a/ui/lobby/css/_setup.scss
+++ b/ui/lobby/css/_setup.scss
@@ -265,7 +265,7 @@ $c-slider: $c-setup;
           .val-box {
             background: $c-font-dim;
             padding: 0.1rem 0.5rem;
-            border-radius: $box-radius-size / 2;
+            border-radius: $small-box-radius-size;
             font-weight: bold;
             color: $c-bg;
           }

--- a/ui/opening/css/_search.scss
+++ b/ui/opening/css/_search.scss
@@ -42,12 +42,13 @@
       @extend %flex-column, %box-neat;
 
       background: $c-bg-zebra;
-      outline: 3px solid color-mix(in oklab, $c-font 30%, $c-bg);
+      outline: 1px solid color-mix(in oklab, $c-font 30%, $c-bg);
       cursor: pointer;
       color: $c-font;
+      overflow: hidden;
 
       &:hover {
-        outline: 3px solid color-mix(in oklab, $c-primary 60%, $c-bg);
+        outline: 1px solid color-mix(in oklab, $c-primary 60%, $c-bg);
         background: color-mix(in oklab, $c-primary 10%, $c-bg-zebra);
         box-shadow: 0 0 30px color-mix(in oklab, $c-primary 50%, $c-bg);
       }
@@ -57,7 +58,7 @@
 
         flex: 1 1 100%;
         font-size: 1.3em;
-        padding: 0.4em 0.7em 0.3em 1em;
+        padding: 0.4em 0.5em 0.3em 0.8em;
 
         .opening-name {
           &__variation {


### PR DESCRIPTION
# How

Assortment of small fixes and tweaks related to global roundness.

Changes includes:
* fixed openings search display (with ported border change made to main list)
* fixed lobby value roundness broken due to lack of `calc`
* replacement of custom roundness for few elements including network error container, fieldests and tagify elements

# Preview

<img width="566" height="197" alt="Screenshot 2026-08-05 at 14 07 07" src="https://github.com/user-attachments/assets/66a5d2bb-5082-402d-82b6-798d2d755b02" />

<img width="817" height="257" alt="Screenshot 2026-08-05 at 14 03 59" src="https://github.com/user-attachments/assets/0641cd4a-a581-410b-8c88-2f354e37b9f5" />

<img width="1250" height="453" alt="Screenshot 2026-08-05 at 14 12 33" src="https://github.com/user-attachments/assets/63095341-603c-4e1c-aa6e-905c4ec2599d" />

<img width="634" height="264" alt="Screenshot 2026-08-05 at 14 01 17" src="https://github.com/user-attachments/assets/567bbf33-de16-451f-a2c9-96d6b6c1e338" />

<img width="2056" height="116" alt="Screenshot 2026-08-05 at 13 58 01" src="https://github.com/user-attachments/assets/a0f05012-b7e2-42ef-83ba-3ea53cdb8de9" />
