### PR TITLE
Reduce reactivemongo-pekko max thread count to 16

### DIFF
--- a/conf/base.conf
+++ b/conf/base.conf
@@ -10,7 +10,7 @@ mongodb {
     # uri = "mongodb://127.0.0.1:27010?appName=lila&connectTimeoutMS=800&rm.maxNonQueryableHeartbeats=9999"
   }
   mongo-async-driver.pekko = ${pekko}
-  mongo-async-driver.pekko.actor.default-dispatcher.fork-join-executor.parallelism-max=32
+  mongo-async-driver.pekko.actor.default-dispatcher.fork-join-executor.parallelism-max=16
 }
 net {
   domain = "localhost:9663"


### PR DESCRIPTION
reactivemongo pekko is still the least used FJP's pool with current usage in cpu/cycles profiles is ~ 2.75 percent, while it occupies more than 12 percent in context switches profiles.