### PR TITLE
Relay http code: Show a message about the error instead of the raw code

### DIFF
--- a/modules/relay/src/main/HttpClient.scala
+++ b/modules/relay/src/main/HttpClient.scala
@@ -128,15 +128,15 @@ private object HttpClient:
   type Body = String
   case class Status(code: Int, host: String) extends LilaExceptionNoStack:
     override val message = code match
-      case 204 | 404  => s"${host} games not found"
-      case 301 | 302  => s"${host} trying redirect, please fix the URL"
-      case 429        => s"${host} rate limited"
-      case 400        => s"${host} bad request, please fix the URL"
-      case 500        => s"${host} internal server error"
-      case 502        => s"${host} bad gateway"
-      case 503        => s"${host} service unavailable or rate limited" // some sites return 503 instead of 429
-      case 407        => s"${host} connection problem - call a sysadmin" // proxy auth required
-      case _          => s"$code: $host"
+      case 204 | 404 => s"${host} games not found"
+      case 301 | 302 => s"${host} trying redirect, please fix the URL"
+      case 429 => s"${host} rate limited"
+      case 400 => s"${host} bad request, please fix the URL"
+      case 500 => s"${host} internal server error"
+      case 502 => s"${host} bad gateway"
+      case 503 => s"${host} service unavailable or rate limited" // some sites return 503 instead of 429
+      case 407 => s"${host} connection problem - call a sysadmin" // proxy auth required
+      case _ => s"$code: $host"
 
   case class SourceTimeout(host: String) extends LilaExceptionNoStack:
     override val message = s"$host is not responding"

--- a/modules/relay/src/main/HttpClient.scala
+++ b/modules/relay/src/main/HttpClient.scala
@@ -82,7 +82,7 @@ private final class HttpClient(
             )
           .flatMap: res =>
             if res.status == 200 || res.status == 304 then fuccess(res)
-            else fufail(Status(res.status, url))
+            else fufail(Status(res.status, url.host.toString))
           .recoverWith:
             case _: java.util.concurrent.TimeoutException =>
               fufail(SourceTimeout(url.host.toString))
@@ -126,8 +126,17 @@ private object charsetGuess:
 private object HttpClient:
   type Etag = String
   type Body = String
-  case class Status(code: Int, url: URL) extends LilaExceptionNoStack:
-    override val message = s"$code: $url"
+  case class Status(code: Int, host: String) extends LilaExceptionNoStack:
+    override val message = code match
+      case 204 | 404  => s"${host} games not found"
+      case 301 | 302  => s"${host} trying redirect, please fix the URL"
+      case 429        => s"${host} rate limited"
+      case 400        => s"${host} bad request, please fix the URL"
+      case 500        => s"${host} internal server error"
+      case 502        => s"${host} bad gateway"
+      case 503        => s"${host} service unavailable or rate limited" // some sites return 503 instead of 429
+      case 407        => s"${host} connection problem - call a sysadmin" // proxy auth required
+      case _          => s"$code: $host"
 
   case class SourceTimeout(host: String) extends LilaExceptionNoStack:
     override val message = s"$host is not responding"


### PR DESCRIPTION
Many organizers might not know what each number means, so it's better to explain.