### PR TITLE
ui(lib): fix sticky header overlap over popover boards

### DIFF
--- a/ui/lib/css/abstract/_z-index.scss
+++ b/ui/lib/css/abstract/_z-index.scss
@@ -27,6 +27,7 @@ $z-above-dialog-12: 12;
 $z-dialog-11: 11;
 $z-cg__board_resize-10: 10;
 $z-above-pieces-9: 9;
+$z-board-popover: 5;
 $z-cg__svg_cg-custom-svgs-4: 4;
 $z-mz-menu-4: 4;
 $z-above-link-overlay-3: 3;

--- a/ui/lib/css/ceval/_pv.scss
+++ b/ui/lib/css/ceval/_pv.scss
@@ -58,7 +58,7 @@
     inset-block-start: 100%;
     width: min(80%, 240px, 40vmin);
     margin-block-start: 4px;
-    z-index: 2;
+    z-index: $z-board-popover;
 
     .pv-board-square {
       @extend %square;


### PR DESCRIPTION
# Why

Fixes #21196
* #21196

# How

Modify popover boards `z-index` slightly after introduction of openings sticky header, add a variable for readability.

# Preview

<img width="334" height="479" alt="Screenshot 2026-08-06 at 08 46 44" src="https://github.com/user-attachments/assets/0fdedd15-7a3a-43e7-b89f-f911b7c377d9" />
