### PR TITLE
Offload redis messages processing from IO threads

### DIFF
--- a/modules/socket/src/main/Env.scala
+++ b/modules/socket/src/main/Env.scala
@@ -10,7 +10,10 @@ import lila.core.socket.{ SocketRequester as _, * }
 @Module
 final class Env(appConfig: Configuration, shutdown: CoordinatedShutdown)(using Executor, Scheduler):
 
-  private val redisClient = RedisClient.create(RedisURI.create(appConfig.get[String]("socket.redis.uri")))
+  private val redisClient =
+    val client = RedisClient.create(RedisURI.create(appConfig.get[String]("socket.redis.uri")))
+    client.setOptions(ClientOptions.builder().publishOnScheduler(true).build())
+    client
 
   val userLag = new UserLagCache
   export userLag.{ getLagRating, put as putLag }


### PR DESCRIPTION
To avoid some big context switching in epollEventLoop:
- https://stackoverflow.com/questions/53001283/reactive-redis-lettuce-always-publishing-to-single-thread
- https://redis.github.io/lettuce/faq/#performance-degradation-using-the-reactive-api-with-a-single-connection