### PR TITLE
ui(analyse): visual tweaks for transparent theme

### DIFF
--- a/ui/analyse/css/gamebook/_common.scss
+++ b/ui/analyse/css/gamebook/_common.scss
@@ -3,6 +3,7 @@
 
   .right {
     @extend %flex-center;
+    @include backdrop-blur-if-transparent;
 
     align-items: stretch;
     justify-content: flex-end;

--- a/ui/analyse/css/gamebook/_play.scss
+++ b/ui/analyse/css/gamebook/_play.scss
@@ -43,33 +43,36 @@
 
   .comment {
     @extend %flex-column, %box-shadow;
+    @include backdrop-blur-if-transparent;
 
     font-size: 1.1em;
     background: $c-bg-box;
-    border-radius: 1rem;
+    border-radius: $box-radius-size;
     position: relative;
+    border: 1px solid $c-border;
 
     /* fixes firefox overflow when comment is long https://stackoverflow.com/questions/28636832/firefox-overflow-y-not-working-with-nested-flexbox */
     min-height: 0;
 
-    @include if-not-light {
-      border: 1px solid $c-font-dimmer;
-    }
-
     &::after {
+      @include inline-end(20%);
+      @include backdrop-blur-if-transparent;
+
       position: absolute;
       content: '';
-      bottom: -9px;
-
-      @include inline-end(20%);
-
+      bottom: -8px;
       width: 15px;
       height: 15px;
       background: $c-bg-box;
-      border-inline-end: 1px solid $c-font-dimmer;
-      border-bottom: 1.5px solid $c-font-dimmer;
+      border-inline-end: 1px solid $c-border;
+      border-bottom: 1.5px solid $c-border;
       transform: skew(45deg) rotate(45deg);
       z-index: 1;
+
+      @include if-transp {
+        clip-path: polygon(100% 0%, 100% 0%, 100% 100%, 0% 100%);
+        opacity: 0.8;
+      }
     }
 
     &.hinted::after {
@@ -208,6 +211,7 @@
 
       button {
         @extend %flex-column;
+        @include transition;
 
         flex: 1 1 100%;
         background: color-mix(in oklab, $c-primary 80%, $c-bg);
@@ -217,10 +221,11 @@
         justify-content: center;
         text-align: center;
         padding: 0.5em;
-        border-inline-start: 1px solid rgb(255 255 255 / 0.3);
         line-height: 1.2em;
 
-        @include transition;
+        &:not(:first-child) {
+          border-inline-start: 1px solid rgb(255 255 255 / 0.3);
+        }
 
         &::before {
           font-size: 2.2em;

--- a/ui/analyse/css/study/_desc.scss
+++ b/ui/analyse/css/study/_desc.scss
@@ -51,6 +51,8 @@
   }
 
   textarea {
+    @include backdrop-blur-if-transparent;
+
     width: 100%;
     height: 12em;
   }

--- a/ui/analyse/css/study/_player.scss
+++ b/ui/analyse/css/study/_player.scss
@@ -23,6 +23,7 @@ $player-height: 1.6rem;
 .study__player {
   @extend %flex-between-nowrap, %metal-bg, %box-shadow;
   @include inline-end(0);
+  @include backdrop-blur-if-transparent;
 
   position: absolute;
   font-weight: bold;

--- a/ui/analyse/css/study/panel/_comment.scss
+++ b/ui/analyse/css/study/panel/_comment.scss
@@ -13,6 +13,7 @@
 
   #comment-text {
     @extend %box-shadow;
+    @include backdrop-blur-if-transparent;
 
     height: 12em;
   }

--- a/ui/analyse/css/study/relay/_board-player.scss
+++ b/ui/analyse/css/study/relay/_board-player.scss
@@ -10,6 +10,7 @@
   @extend %flex-between-nowrap;
   @include inline-end(0);
   @include with-metal-shadow(hsl(0 0% 0% / 0.2), hsl(0 0% 0% / 0.18));
+  @include backdrop-blur-if-transparent;
 
   background-image: linear-gradient(to bottom, $c-metal-top, $c-metal-bottom);
   overflow: hidden;

--- a/ui/analyse/css/study/relay/_tour.scss
+++ b/ui/analyse/css/study/relay/_tour.scss
@@ -26,6 +26,7 @@
     &__header {
       @extend %flex-center-nowrap, %box-radius-top;
       @include prevent-select;
+      @include backdrop-blur-if-transparent;
 
       position: relative;
       overflow: hidden;
@@ -821,6 +822,7 @@
 
 .relay-games {
   @extend %flex-column, %box-radius-bottom, %box-shadow;
+  @include backdrop-blur-if-transparent;
 
   background: $c-bg-box;
   flex: 1 1 auto;


### PR DESCRIPTION
# Why

Spotted that some analyse elements misses backdrop blur in transparent (picture) theme.

# How

Summary of changes:
* add missing backdrop blur to few analyse elements
* fix interactive lesson bubble chat arrow overlap box
* skip border on first item in interactive lesson rack

# Preview

<img width="707" height="473" alt="Screenshot 2026-08-06 at 13 41 05" src="https://github.com/user-attachments/assets/89129d23-fbb0-4b0e-b36f-ba16c3bbcdb6" />
<img width="707" height="392" alt="Screenshot 2026-08-06 at 13 47 21" src="https://github.com/user-attachments/assets/d507a8f6-9816-4ae3-9a44-06f6793d55d9" />
<img width="346" align="left" height="259" alt="Screenshot 2026-08-06 at 14 10 22" src="https://github.com/user-attachments/assets/e9065f64-4fa3-4245-bdfc-61ed7d79bcac" />
<img width="343" height="248" alt="Screenshot 2026-08-06 at 14 02 59" src="https://github.com/user-attachments/assets/236f01fb-f42a-4240-a2e7-3903be1b5af3" />
