### PR TITLE
ui(puzzle): migrate after game view, add missing translation

### DIFF
--- a/ui/puzzle/css/_after.scss
+++ b/ui/puzzle/css/_after.scss
@@ -36,6 +36,7 @@
       border-bottom: $border;
       padding-bottom: 0.5em;
       margin-bottom: 0.5em;
+      text-transform: uppercase;
     }
 
     .puzzle--streak & {

--- a/ui/puzzle/src/view/after.ts
+++ b/ui/puzzle/src/view/after.ts
@@ -1,67 +1,64 @@
 import { licon } from 'lib/licon';
-import { type VNode, type MaybeVNodes, bind, hl, icon } from 'lib/view';
+import { type VNode, bind, icon, div, button, span, strong, a, type MaybeVNode } from 'lib/view';
 
 import type PuzzleCtrl from '../ctrl';
 
-const renderVote = (ctrl: PuzzleCtrl): VNode =>
-  hl(
-    'div.puzzle__vote',
-    !ctrl.autoNexting() && [
-      ctrl.session.isNew() &&
-        ctrl.data.user?.provisional &&
-        hl('div.puzzle__vote__help', i18n.puzzle.didYouLikeThisPuzzle),
-      hl('div.puzzle__vote__buttons', [
-        hl('button.button.button-empty.vote-up', {
-          class: { active: ctrl.voted === true },
-          attrs: { title: i18n.puzzle.upVote },
-          hook: bind('click', () => ctrl.vote(true)),
-        }),
-        hl('button.button.button-empty.vote-down', {
-          class: { active: ctrl.voted === false },
-          attrs: { title: i18n.puzzle.downVote },
-          hook: bind('click', () => ctrl.vote(false)),
-        }),
-      ]),
-    ],
-  );
+const renderVote = (ctrl: PuzzleCtrl): MaybeVNode => {
+  if (!ctrl.data.user) return null;
+  if (ctrl.autoNexting()) return div('.puzzle__vote');
 
-const renderStreak = (ctrl: PuzzleCtrl): MaybeVNodes => [
-  hl('div.complete', [
-    hl('span.game-over', 'GAME OVER'),
-    hl('span', i18n.puzzle.yourStreakX.asArray(hl('strong', `${ctrl.streak?.data.index ?? 0}`))),
+  return div('.puzzle__vote', [
+    ctrl.session.isNew() && ctrl.data.user?.provisional
+      ? div('.puzzle__vote__help', i18n.puzzle.didYouLikeThisPuzzle)
+      : null,
+    div('.puzzle__vote__buttons', [
+      button('.button.button-empty.vote-up', {
+        class: { active: ctrl.voted === true },
+        title: i18n.puzzle.upVote,
+        hook: bind('click', () => ctrl.vote(true)),
+      }),
+      button('.button.button-empty.vote-down', {
+        class: { active: ctrl.voted === false },
+        title: i18n.puzzle.downVote,
+        hook: bind('click', () => ctrl.vote(false)),
+      }),
+    ]),
+  ]);
+};
+
+const renderStreak = (ctrl: PuzzleCtrl): VNode[] => [
+  div('.complete', [
+    span('.game-over', i18n.site.gameOver),
+    span(i18n.puzzle.yourStreakX.asArray(strong(ctrl.streak?.data.index ?? 0))),
   ]),
-  hl('a.continue', { attrs: { href: ctrl.routerWithLang('/streak') } }, [
-    icon(licon.PlayTriangle)(),
-    i18n.puzzle.newStreak,
-  ]),
+  a(ctrl.routerWithLang('/streak'))('.continue', [icon(licon.PlayTriangle)(), i18n.puzzle.newStreak]),
 ];
 
 export default function (ctrl: PuzzleCtrl): VNode {
-  const { data } = ctrl;
   const win = ctrl.lastFeedback === 'win';
   const canPlayComputer = !ctrl.node.san?.includes('#');
-  return hl(
-    'div.puzzle__feedback.after',
+  return div(
+    '.puzzle__feedback.after',
     ctrl.streak && !win
       ? renderStreak(ctrl)
       : [
-          hl('div.complete', i18n.puzzle[win ? 'puzzleSuccess' : 'puzzleComplete']),
-          hl('button.continue', { hook: bind('click', ctrl.nextPuzzle) }, [
+          div('.complete', i18n.puzzle[win ? 'puzzleSuccess' : 'puzzleComplete']),
+          button('.continue', { hook: bind('click', ctrl.nextPuzzle) }, [
             icon(licon.PlayTriangle)(),
             i18n.puzzle[ctrl.streak ? 'continueTheStreak' : 'continueTraining'],
           ]),
-          hl('div.puzzle__more', [
+          div('.puzzle__more', [
             canPlayComputer
-              ? hl('a.practice.button.button-empty', {
-                  attrs: {
+              ? a(`/analysis/${ctrl.node.fen.replace(/ /g, '_')}?color=${ctrl.pov}#practice`)(
+                  '.practice.button.button-empty',
+                  {
                     'data-icon': licon.Bullseye,
-                    href: `/analysis/${ctrl.node.fen.replace(/ /g, '_')}?color=${ctrl.pov}#practice`,
                     title: i18n.site.playAgainstComputer,
                     target: '_blank',
                   },
-                })
-              : hl('a'),
-            data.user ? renderVote(ctrl) : undefined,
+                )
+              : null,
+            renderVote(ctrl),
           ]),
         ],
   );


### PR DESCRIPTION
# How

An another test for element helpers, this time in migration of puzzle after game view.

In the process I have also replaced hardcoded string with an existing translation, and move the `renderVote` logic together, inside of the function.

# Preview

<img width="479" height="447" alt="Screenshot 2026-08-06 at 14 26 30" src="https://github.com/user-attachments/assets/231934a8-8785-42dd-9565-67ce0cb35fd3" />

<img width="479" height="447" alt="Screenshot 2026-08-06 at 14 33 14" src="https://github.com/user-attachments/assets/60c6c8f6-bc60-405d-859f-03c02c2364c9" />
