### PR TITLE
Add pairing sequencer to TournamentApi

### DIFF
--- a/modules/tournament/src/main/TournamentApi.scala
+++ b/modules/tournament/src/main/TournamentApi.scala
@@ -54,6 +54,14 @@ final class TournamentApi(
     lila.core.config.RateLimit
 ):
 
+  private val pairingSequencer = scalalib.actor.AsyncActorSequencers[TourId](
+    maxSize = Max(256),
+    expiration = 1.minute,
+    timeout = 20.seconds,
+    name = "tournament.pairing",
+    lila.mon.asyncActorMonitor.full
+  )
+
   export tournamentRepo.byId as get
 
   def createTournament(
@@ -147,37 +155,42 @@ final class TournamentApi(
       !hadPairings.get(forTour.id) ||
         users.haveWaitedEnough ||
         smallTourNbActivePlayers.exists(_ <= users.size * 1.5)
-    )).so(Parallel(forTour.id, "makePairings")(cached.tourCache.started): tour =>
-      cached
-        .ranking(tour)
-        .mon(lila.mon.tournament.pairing.createRanking)
-        .flatMap: ranking =>
-          pairingSystem
-            .createPairings(tour, users, ranking, smallTourNbActivePlayers)
-            .mon(lila.mon.tournament.pairing.createPairings)
-            .flatMap:
-              case Nil => funit
-              case pairings =>
-                pairingRepo.insert(pairings.map(_.pairing)) >>
-                  pairings
-                    .parallelVoid: pairing =>
-                      autoPairing(tour, pairing, ranking.ranking)
-                        .mon(lila.mon.tournament.pairing.createAutoPairing)
-                        .map { socket.startGame(tour.id, _) }
-                    .mon(lila.mon.tournament.pairing.createInserts)
-                    .andDo:
-                      lila.mon.tournament.pairing.batchSize.record(pairings.size)
-                      waitingUsers.registerPairedUsers(
-                        tour.id,
-                        pairings.view.flatMap(_.pairing.users).toSet
-                      )
-                      socket.reload(tour.id)
-                      hadPairings.put(tour.id)
-                      featureOneOf(tour, pairings, ranking.ranking) // do outside of queue
-        .monSuccess(lila.mon.tournament.pairing.create)
-        .chronometer
-        .logIfSlow(100, logger)(_ => s"Pairings for https://lichess.org/tournament/${tour.id}")
-        .result)
+    )).so(pairingSequencer(forTour.id):
+      Parallel(forTour.id, "makePairings")(cached.tourCache.started): tour =>
+        // snapshot is taken outside the sequencer; exclude anyone who started playing since then
+        pairingRepo.playingUserIds(tour.id).flatMap: playing =>
+          val idle = users.removePairedUsers(playing)
+          (idle.size > 1).so:
+            cached
+              .ranking(tour)
+              .mon(lila.mon.tournament.pairing.createRanking)
+              .flatMap: ranking =>
+                pairingSystem
+                  .createPairings(tour, idle, ranking, smallTourNbActivePlayers)
+                  .mon(lila.mon.tournament.pairing.createPairings)
+                  .flatMap:
+                    case Nil => funit
+                    case pairings =>
+                      pairingRepo.insert(pairings.map(_.pairing)) >>
+                        pairings
+                          .parallelVoid: pairing =>
+                            autoPairing(tour, pairing, ranking.ranking)
+                              .mon(lila.mon.tournament.pairing.createAutoPairing)
+                              .map { socket.startGame(tour.id, _) }
+                          .mon(lila.mon.tournament.pairing.createInserts)
+                          .andDo:
+                            lila.mon.tournament.pairing.batchSize.record(pairings.size)
+                            waitingUsers.registerPairedUsers(
+                              tour.id,
+                              pairings.view.flatMap(_.pairing.users).toSet
+                            )
+                            socket.reload(tour.id)
+                            hadPairings.put(tour.id)
+                            featureOneOf(tour, pairings, ranking.ranking) // do outside of queue
+              .monSuccess(lila.mon.tournament.pairing.create)
+              .chronometer
+              .logIfSlow(100, logger)(_ => s"Pairings for https://lichess.org/tournament/${tour.id}")
+              .result)
 
   private def featureOneOf(tour: Tournament, pairings: List[Pairing.WithPlayers], ranking: Ranking): Funit =
     tour.featured

--- a/modules/tournament/src/main/TournamentApi.scala
+++ b/modules/tournament/src/main/TournamentApi.scala
@@ -158,39 +158,41 @@ final class TournamentApi(
     )).so(pairingSequencer(forTour.id):
       Parallel(forTour.id, "makePairings")(cached.tourCache.started): tour =>
         // snapshot is taken outside the sequencer; exclude anyone who started playing since then
-        pairingRepo.playingUserIds(tour.id).flatMap: playing =>
-          val idle = users.removePairedUsers(playing)
-          (idle.size > 1).so:
-            cached
-              .ranking(tour)
-              .mon(lila.mon.tournament.pairing.createRanking)
-              .flatMap: ranking =>
-                pairingSystem
-                  .createPairings(tour, idle, ranking, smallTourNbActivePlayers)
-                  .mon(lila.mon.tournament.pairing.createPairings)
-                  .flatMap:
-                    case Nil => funit
-                    case pairings =>
-                      pairingRepo.insert(pairings.map(_.pairing)) >>
-                        pairings
-                          .parallelVoid: pairing =>
-                            autoPairing(tour, pairing, ranking.ranking)
-                              .mon(lila.mon.tournament.pairing.createAutoPairing)
-                              .map { socket.startGame(tour.id, _) }
-                          .mon(lila.mon.tournament.pairing.createInserts)
-                          .andDo:
-                            lila.mon.tournament.pairing.batchSize.record(pairings.size)
-                            waitingUsers.registerPairedUsers(
-                              tour.id,
-                              pairings.view.flatMap(_.pairing.users).toSet
-                            )
-                            socket.reload(tour.id)
-                            hadPairings.put(tour.id)
-                            featureOneOf(tour, pairings, ranking.ranking) // do outside of queue
-              .monSuccess(lila.mon.tournament.pairing.create)
-              .chronometer
-              .logIfSlow(100, logger)(_ => s"Pairings for https://lichess.org/tournament/${tour.id}")
-              .result)
+        pairingRepo
+          .playingUserIds(tour.id)
+          .flatMap: playing =>
+            val idle = users.removePairedUsers(playing)
+            (idle.size > 1).so:
+              cached
+                .ranking(tour)
+                .mon(lila.mon.tournament.pairing.createRanking)
+                .flatMap: ranking =>
+                  pairingSystem
+                    .createPairings(tour, idle, ranking, smallTourNbActivePlayers)
+                    .mon(lila.mon.tournament.pairing.createPairings)
+                    .flatMap:
+                      case Nil => funit
+                      case pairings =>
+                        pairingRepo.insert(pairings.map(_.pairing)) >>
+                          pairings
+                            .parallelVoid: pairing =>
+                              autoPairing(tour, pairing, ranking.ranking)
+                                .mon(lila.mon.tournament.pairing.createAutoPairing)
+                                .map { socket.startGame(tour.id, _) }
+                            .mon(lila.mon.tournament.pairing.createInserts)
+                            .andDo:
+                              lila.mon.tournament.pairing.batchSize.record(pairings.size)
+                              waitingUsers.registerPairedUsers(
+                                tour.id,
+                                pairings.view.flatMap(_.pairing.users).toSet
+                              )
+                              socket.reload(tour.id)
+                              hadPairings.put(tour.id)
+                              featureOneOf(tour, pairings, ranking.ranking) // do outside of queue
+                .monSuccess(lila.mon.tournament.pairing.create)
+                .chronometer
+                .logIfSlow(100, logger)(_ => s"Pairings for https://lichess.org/tournament/${tour.id}")
+                .result)
 
   private def featureOneOf(tour: Tournament, pairings: List[Pairing.WithPlayers], ranking: Ranking): Funit =
     tour.featured


### PR DESCRIPTION
See [this zulip topic](https://hq.lichess.ovh/#narrow/channel/58-dev-bug/topic/2.20Titled.20Arena.20games.20started.20at.20the.20same.20time/with/4269861) for the discussion about this bug. TL;DR a user was paired into two separate games in a titled arena, 3.5 seconds apart, end there is evidence for this occasionally happening other times as well.

I got AI assistance with this fix, with the prompt "<full text of user's email, omitted here but available in zulip> we have verified with server logs that this issue did occur with one game having started ~3 seconds after the first game. user was using google chrome. the order of the games issue that they mention is not the main concern, just how two games could have started at the same time"

Basically, overlapping attempts at making pairings for waiting users can end up racing, with the end result being users paired in both consecutive attempts. So we'd like to sequentially make pairings to prevent overlap, as well as check just before making a given pairing that the users in question are still waiting to be paired and haven't been paired in the meantime.