### PR TITLE
Fix Move Numbering When Inserting Transpositions

### DIFF
--- a/modules/study/src/main/ExplorerGame.scala
+++ b/modules/study/src/main/ExplorerGame.scala
@@ -1,10 +1,11 @@
 package lila.study
 
-import chess.format.{ Fen, UciPath }
+import chess.format.{ Fen, Uci, UciPath }
 import chess.format.pgn.{ Parser, Tags, Comment as CommentStr }
+import chess.variant.Variant
 
 import lila.tree.Node.Comment
-import lila.tree.{ Branch, Node, Root }
+import lila.tree.{ Branch, Branches, Node, Root }
 
 final private class ExplorerGameApi(
     explorer: lila.core.game.Explorer,
@@ -30,7 +31,8 @@ final private class ExplorerGameApi(
                 path = UciPath.fromIds(root.mainline.map(_.id))
               )
             .so: gameRoot =>
-              merge(fromNode, position.path, gameRoot).flatMap { (newNode, path) =>
+              val variant = position.chapter.setup.variant
+              merge(fromNode, position.path, gameRoot, variant, gameId).flatMap { (newNode, path) =>
                 position.chapter.addNode(newNode, path).map(_ -> path)
               }
 
@@ -43,23 +45,55 @@ final private class ExplorerGameApi(
       val nodes = game.mainline.dropWhile(n => !compareFens(n.fen, fromNode.fen, firstTry))
       if nodes.nonEmpty || !firstTry then nodes.drop(1) else gameNodes(fromNode, game, false)
 
-  private def merge(fromNode: Node, fromPath: UciPath, game: Root): Option[(Branch, UciPath)] =
-    val (path, foundGameNode) = gameNodes(fromNode, game, true).foldLeft((UciPath.root, none[Branch])):
-      case ((path, None), gameNode) =>
-        val nextPath = path + gameNode.id
-        if fromNode.children.nodeAt(nextPath).isDefined then (nextPath, none)
-        else (path, gameNode.some)
-      case (found, _) => found
-    foundGameNode.map { _ -> fromPath.+(path) }
+  private def merge(
+      fromNode: Node,
+      fromPath: UciPath,
+      game: Root,
+      variant: Variant,
+      gameId: GameId
+  ): Option[(Branch, UciPath)] =
+    @annotation.tailrec
+    def dropKnown(anchor: Node, path: UciPath, nodes: List[Branch]): (Node, UciPath, List[Branch]) =
+      nodes match
+        case gameNode :: rest =>
+          anchor.children.get(gameNode.id) match
+            case Some(child) => dropKnown(child, path + gameNode.id, rest)
+            case None => (anchor, path, nodes)
+        case Nil => (anchor, path, nodes)
+    val (anchor, path, newNodes) = dropKnown(fromNode, UciPath.root, gameNodes(fromNode, game, true))
+    replay(anchor, newNodes, variant, gameId).map { _ -> fromPath.+(path) }
+
+  private def replay(anchor: Node, nodes: List[Branch], variant: Variant, gameId: GameId): Option[Branch] =
+    val setup = chess.Position.AndFullMoveNumber(variant, anchor.fen)
+    val sources = nodes.toVector
+    val (result, error) = setup.position.foldRight(nodes.map(_.move.uci), anchor.ply)(
+      none[Branch],
+      (step, acc) =>
+        val source = sources((step.ply - anchor.ply - 1).value)
+        inline def branch = makeBranch(source, step.move, step.ply)
+        acc.fold(branch)(branch.prependChildUnchecked).some
+    )
+    error.foreach: err =>
+      logger.warn(s"ExplorerGame replay ${gameUrl(gameId)} ${err.value}")
+    result
+
+  private def makeBranch(source: Branch, move: chess.MoveOrDrop, ply: chess.Ply): Branch =
+    source.copy(
+      ply = ply,
+      move = Uci.WithSan(move.toUci, move.toSanStr),
+      fen = Fen.write(move.after, ply.fullMoveNumber),
+      crazyData = move.after.crazyData,
+      children = Branches.empty
+    )
 
   private def gameComment(game: Game) =
     Comment(
       id = Comment.Id.make,
-      text = CommentStr(s"${gameTitle(game)}, ${gameUrl(game)}"),
+      text = CommentStr(s"${gameTitle(game)}, ${gameUrl(game.id)}"),
       by = Comment.Author.Lichess
     )
 
-  private def gameUrl(game: Game) = s"${net.baseUrl}/${game.id}"
+  private def gameUrl(gameId: GameId) = s"${net.baseUrl}/$gameId"
 
   private def gameTitle(g: Game): String =
     val tags = g.pgnImport.flatMap(pgni => Parser.tags(pgni.pgn).toOption).getOrElse(Tags.empty)

--- a/modules/study/src/main/ExplorerGame.scala
+++ b/modules/study/src/main/ExplorerGame.scala
@@ -14,6 +14,8 @@ final private class ExplorerGameApi(
     net: lila.core.config.NetConfig
 )(using Executor):
 
+  import ExplorerGameApi.*
+
   def quote(gameId: GameId): Fu[Option[Comment]] =
     explorer(gameId).map2(gameComment)
 
@@ -36,16 +38,33 @@ final private class ExplorerGameApi(
                 position.chapter.addNode(newNode, path).map(_ -> path)
               }
 
-  private def compareFens(a: Fen.Full, b: Fen.Full, strict: Boolean) =
-    if strict then a == b else a.simple == b.simple
+  private def gameComment(game: Game) =
+    Comment(
+      id = Comment.Id.make,
+      text = CommentStr(s"${gameTitle(game)}, ${gameUrl(game.id)}"),
+      by = Comment.Author.Lichess
+    )
 
-  private def gameNodes(fromNode: Node, game: Root): List[Branch] =
-    val mainline = game.mainline
-    mainline.lastIndexWhere(n => compareFens(n.fen, fromNode.fen, false)) match
-      case -1 => if compareFens(game.fen, fromNode.fen, false) then mainline else Nil
-      case i => mainline.drop(i + 1)
+  private def gameUrl(gameId: GameId) = s"${net.baseUrl}/$gameId"
 
-  private[study] def merge(
+  private def gameTitle(g: Game): String =
+    val tags = g.pgnImport.flatMap(pgni => Parser.tags(pgni.pgn).toOption).getOrElse(Tags.empty)
+    gameTitle(g, tags)
+
+  private def gameTitle(g: Game, tags: Tags): String =
+    val white = tags(_.White) | namer.playerTextBlocking(g.whitePlayer)(using lightUserApi.sync)
+    val black = tags(_.Black) | namer.playerTextBlocking(g.blackPlayer)(using lightUserApi.sync)
+    val result = chess.Outcome.showResult(chess.Outcome(g.winnerColor).some)
+    val event: Option[String] =
+      (tags(_.Event), tags.year.map(_.toString)) match
+        case (Some(event), Some(year)) if event.contains(year) => event.some
+        case (Some(event), Some(year)) => s"$event, $year".some
+        case (eventO, yearO) => eventO.orElse(yearO)
+    s"$white - $black, $result, ${event | "-"}"
+
+private object ExplorerGameApi:
+
+  def merge(
       fromNode: Node,
       fromPath: UciPath,
       game: Root,
@@ -74,8 +93,17 @@ final private class ExplorerGameApi(
         acc.fold(branch)(branch.prependChildUnchecked).some
     )
     error.foreach: err =>
-      logger.warn(s"ExplorerGame replay ${gameUrl(gameId)} ${err.value}")
+      logger.warn(s"ExplorerGame replay /$gameId ${err.value}")
     result
+
+  private def gameNodes(fromNode: Node, game: Root): List[Branch] =
+    val mainline = game.mainline
+    mainline.lastIndexWhere(n => compareFens(n.fen, fromNode.fen, false)) match
+      case -1 => if compareFens(game.fen, fromNode.fen, false) then mainline else Nil
+      case i => mainline.drop(i + 1)
+
+  private def compareFens(a: Fen.Full, b: Fen.Full, strict: Boolean) =
+    if strict then a == b else a.simple == b.simple
 
   private def makeBranch(source: Branch, move: chess.MoveOrDrop, ply: chess.Ply): Branch =
     source.copy(
@@ -85,27 +113,3 @@ final private class ExplorerGameApi(
       crazyData = move.after.crazyData,
       children = Branches.empty
     )
-
-  private def gameComment(game: Game) =
-    Comment(
-      id = Comment.Id.make,
-      text = CommentStr(s"${gameTitle(game)}, ${gameUrl(game.id)}"),
-      by = Comment.Author.Lichess
-    )
-
-  private def gameUrl(gameId: GameId) = s"${net.baseUrl}/$gameId"
-
-  private def gameTitle(g: Game): String =
-    val tags = g.pgnImport.flatMap(pgni => Parser.tags(pgni.pgn).toOption).getOrElse(Tags.empty)
-    gameTitle(g, tags)
-
-  private def gameTitle(g: Game, tags: Tags): String =
-    val white = tags(_.White) | namer.playerTextBlocking(g.whitePlayer)(using lightUserApi.sync)
-    val black = tags(_.Black) | namer.playerTextBlocking(g.blackPlayer)(using lightUserApi.sync)
-    val result = chess.Outcome.showResult(chess.Outcome(g.winnerColor).some)
-    val event: Option[String] =
-      (tags(_.Event), tags.year.map(_.toString)) match
-        case (Some(event), Some(year)) if event.contains(year) => event.some
-        case (Some(event), Some(year)) => s"$event, $year".some
-        case (eventO, yearO) => eventO.orElse(yearO)
-    s"$white - $black, $result, ${event | "-"}"

--- a/modules/study/src/main/ExplorerGame.scala
+++ b/modules/study/src/main/ExplorerGame.scala
@@ -41,7 +41,7 @@ final private class ExplorerGameApi(
 
   private def gameNodes(fromNode: Node, game: Root): List[Branch] =
     val mainline = game.mainline
-    mainline.dropRight(1).lastIndexWhere(n => compareFens(n.fen, fromNode.fen, false)) match
+    mainline.lastIndexWhere(n => compareFens(n.fen, fromNode.fen, false)) match
       case -1 => if compareFens(game.fen, fromNode.fen, false) then mainline else Nil
       case i => mainline.drop(i + 1)
 

--- a/modules/study/src/main/ExplorerGame.scala
+++ b/modules/study/src/main/ExplorerGame.scala
@@ -45,7 +45,7 @@ final private class ExplorerGameApi(
       case -1 => if compareFens(game.fen, fromNode.fen, false) then mainline else Nil
       case i => mainline.drop(i + 1)
 
-  private def merge(
+  private[study] def merge(
       fromNode: Node,
       fromPath: UciPath,
       game: Root,

--- a/modules/study/src/main/ExplorerGame.scala
+++ b/modules/study/src/main/ExplorerGame.scala
@@ -39,11 +39,11 @@ final private class ExplorerGameApi(
   private def compareFens(a: Fen.Full, b: Fen.Full, strict: Boolean) =
     if strict then a == b else a.simple == b.simple
 
-  private def gameNodes(fromNode: Node, game: Root, firstTry: Boolean): List[Branch] =
-    if compareFens(fromNode.fen, game.fen, firstTry) then game.mainline
-    else
-      val nodes = game.mainline.dropWhile(n => !compareFens(n.fen, fromNode.fen, firstTry))
-      if nodes.nonEmpty || !firstTry then nodes.drop(1) else gameNodes(fromNode, game, false)
+  private def gameNodes(fromNode: Node, game: Root): List[Branch] =
+    val mainline = game.mainline
+    mainline.dropRight(1).lastIndexWhere(n => compareFens(n.fen, fromNode.fen, false)) match
+      case -1 => if compareFens(game.fen, fromNode.fen, false) then mainline else Nil
+      case i => mainline.drop(i + 1)
 
   private def merge(
       fromNode: Node,
@@ -60,7 +60,7 @@ final private class ExplorerGameApi(
             case Some(child) => dropKnown(child, path + gameNode.id, rest)
             case None => (anchor, path, nodes)
         case Nil => (anchor, path, nodes)
-    val (anchor, path, newNodes) = dropKnown(fromNode, UciPath.root, gameNodes(fromNode, game, true))
+    val (anchor, path, newNodes) = dropKnown(fromNode, UciPath.root, gameNodes(fromNode, game))
     replay(anchor, newNodes, variant, gameId).map { _ -> fromPath.+(path) }
 
   private def replay(anchor: Node, nodes: List[Branch], variant: Variant, gameId: GameId): Option[Branch] =

--- a/modules/study/src/main/ExplorerGame.scala
+++ b/modules/study/src/main/ExplorerGame.scala
@@ -53,23 +53,23 @@ final private class ExplorerGameApi(
       gameId: GameId
   ): Option[(Branch, UciPath)] =
     @annotation.tailrec
-    def dropKnown(anchor: Node, path: UciPath, nodes: List[Branch]): (Node, UciPath, List[Branch]) =
+    def dropKnown(parent: Node, path: UciPath, nodes: List[Branch]): (Node, UciPath, List[Branch]) =
       nodes match
         case gameNode :: rest =>
-          anchor.children.get(gameNode.id) match
+          parent.children.get(gameNode.id) match
             case Some(child) => dropKnown(child, path + gameNode.id, rest)
-            case None => (anchor, path, nodes)
-        case Nil => (anchor, path, nodes)
-    val (anchor, path, newNodes) = dropKnown(fromNode, UciPath.root, gameNodes(fromNode, game))
-    replay(anchor, newNodes, variant, gameId).map { _ -> fromPath.+(path) }
+            case None => (parent, path, nodes)
+        case Nil => (parent, path, nodes)
+    val (parent, path, newNodes) = dropKnown(fromNode, UciPath.root, gameNodes(fromNode, game))
+    replay(parent, newNodes, variant, gameId).map { _ -> fromPath.+(path) }
 
-  private def replay(anchor: Node, nodes: List[Branch], variant: Variant, gameId: GameId): Option[Branch] =
-    val setup = chess.Position.AndFullMoveNumber(variant, anchor.fen)
+  private def replay(parent: Node, nodes: List[Branch], variant: Variant, gameId: GameId): Option[Branch] =
+    val setup = chess.Position.AndFullMoveNumber(variant, parent.fen)
     val sources = nodes.toVector
-    val (result, error) = setup.position.foldRight(nodes.map(_.move.uci), anchor.ply)(
+    val (result, error) = setup.position.foldRight(nodes.map(_.move.uci), parent.ply)(
       none[Branch],
       (step, acc) =>
-        val source = sources((step.ply - anchor.ply - 1).value)
+        val source = sources((step.ply - parent.ply - 1).value)
         inline def branch = makeBranch(source, step.move, step.ply)
         acc.fold(branch)(branch.prependChildUnchecked).some
     )

--- a/modules/study/src/test/ExplorerGameTest.scala
+++ b/modules/study/src/test/ExplorerGameTest.scala
@@ -1,0 +1,149 @@
+package lila.study
+
+import chess.Ply
+import chess.format.pgn.{ Comment as CommentStr, PgnStr, SanStr }
+import chess.format.UciPath
+import chess.variant.{ Atomic, Crazyhouse, Standard, Variant }
+
+import lila.tree.Node.Comment
+import lila.tree.{ Branch, Node, Root }
+
+class ExplorerGameTest extends LilaTest:
+
+  given Conversion[String, PgnStr] = PgnStr(_)
+  given Executor = scala.concurrent.ExecutionContextOpportunistic
+
+  private val api = new ExplorerGameApi(null, null, null, null)
+
+  private def parse(pgn: PgnStr): Root = StudyPgnImport.result(pgn, Nil).toOption.get.root
+
+  private val emptyChapter: (Node, UciPath) = Root.default(Standard) -> UciPath.root
+
+  private def cursorAtStart(pgn: PgnStr): (Node, UciPath) = parse(pgn) -> UciPath.root
+
+  private def cursorAt(pgn: PgnStr, ply: Int): (Node, UciPath) =
+    val mainline = parse(pgn).mainline.take(ply)
+    mainline.last -> UciPath.fromIds(mainline.map(_.id))
+
+  private def cursorAtEnd(pgn: PgnStr): (Node, UciPath) = cursorAt(pgn, Int.MaxValue)
+
+  private def merge(
+      cursor: (Node, UciPath),
+      game: Root,
+      variant: Variant = Standard
+  ): Option[(Branch, UciPath)] =
+    api.merge(cursor._1, cursor._2, game, variant, GameId("explorerG"))
+
+  private def mergeOrFail(cursor: (Node, UciPath), game: Root, variant: Variant = Standard)(using
+      munit.Location
+  ) =
+    merge(cursor, game, variant).getOrElse(fail("expected the game to be inserted"))
+
+  private val shuffle: PgnStr = "1. Nf3 Nf6 2. Ng1 Ng8"
+
+  private def assertRebuilt(game: Root)(using munit.Location) =
+    val (inserted, _) = mergeOrFail(cursorAtEnd(shuffle), game)
+    assertEquals(inserted.mainline.map(_.move.san), game.mainline.map(_.move.san))
+    assertEquals(inserted.mainline.map(_.id), game.mainline.map(_.id))
+    assertEquals(inserted.mainline.map(_.fen.simple), game.mainline.map(_.fen.simple))
+    assertEquals(inserted.mainline.map(_.ply), game.mainline.map(n => Ply(n.ply.value + 4)))
+
+  test("renumber the inserted moves from the current position"):
+    val chapter = parse(shuffle)
+    val (inserted, path) = mergeOrFail(cursorAtEnd(shuffle), parse("1. Nc3 d5 2. e4"))
+    val played = parse("1. Nf3 Nf6 2. Ng1 Ng8 3. Nc3 d5 4. e4").mainline.drop(4)
+    assertEquals(path, UciPath.fromIds(chapter.mainline.map(_.id)))
+    assertEquals(inserted.mainline.map(_.move.san), played.map(_.move.san))
+    assertEquals(inserted.mainline.map(_.ply), played.map(_.ply))
+    assertEquals(inserted.fen.value, "rnbqkbnr/pppppppp/8/8/8/2N5/PPPPPPPP/R1BQKBNR b KQkq - 5 3")
+    assertEquals(inserted.mainline.map(_.fen), played.map(_.fen))
+    val merged = chapter.withChildren(_.addNodeAt(inserted, path)).getOrElse(fail("expected a valid path"))
+    assertEquals(merged.mainline.map(_.ply), (1 to 7).toList.map(Ply(_)))
+
+  test("insert the game mainline only (avoid inserting the variations)"):
+    val (inserted, _) = mergeOrFail(emptyChapter, parse("1. d4 d5 (1... Nf6) 2. c4"))
+    assertEquals(inserted.mainline.map(_.move.san), List(SanStr("d4"), SanStr("d5"), SanStr("c4")))
+    assertEquals(inserted.mainline.map(_.children.toList.size), List(1, 1, 0))
+
+  test("insert the whole game when it starts on the starting position"):
+    val (inserted, path) = mergeOrFail(emptyChapter, parse("1. e4 e5"))
+    assertEquals(path, UciPath.root)
+    assertEquals(inserted.mainline.map(_.move.san), List(SanStr("e4"), SanStr("e5")))
+    assertEquals(inserted.mainline.map(_.ply), List(Ply(1), Ply(2)))
+
+  test("prefer the last matching position to the start of the game"):
+    val (inserted, path) = mergeOrFail(emptyChapter, parse("1. Nf3 Nf6 2. Ng1 Ng8 3. e4 e5"))
+    assertEquals(path, UciPath.root)
+    assertEquals(inserted.mainline.map(_.move.san), List(SanStr("e4"), SanStr("e5")))
+    assertEquals(inserted.mainline.map(_.ply), List(Ply(1), Ply(2)))
+
+  test("skip the moves the chapter already has"):
+    val chapter = parse("1. d4 d5 2. c4 e6")
+    val (inserted, path) = mergeOrFail(cursorAt("1. d4 d5 2. c4 e6", 2), parse("1. d4 d5 2. c4 e6 3. Nc3"))
+    assertEquals(path, UciPath.fromIds(chapter.mainline.map(_.id)))
+    assertEquals(inserted.move.san, SanStr("Nc3"))
+    assertEquals(inserted.ply, Ply(5))
+
+  test("follow the moves the chapter has as a variation"):
+    val chapter: PgnStr = "1. d4 d5 2. c4 (2. Nf3)"
+    val (inserted, path) = mergeOrFail(cursorAtStart(chapter), parse("1. d4 d5 2. Nf3 Nf6"))
+    assertEquals(path, UciPath.fromIds(parse("1. d4 d5 2. Nf3").mainline.map(_.id)))
+    assertEquals(inserted.move.san, SanStr("Nf6"))
+    assertEquals(inserted.ply, Ply(4))
+
+  test("renumber and skip known moves at the same time"):
+    val chapter: PgnStr = "1. Nf3 Nf6 2. Ng1 Ng8 3. Nc3"
+    val (inserted, path) = mergeOrFail(cursorAt(chapter, 4), parse("1. Nc3 d5 2. e4"))
+    assertEquals(path, UciPath.fromIds(parse(chapter).mainline.map(_.id)))
+    assertEquals(inserted.mainline.map(_.move.san), List(SanStr("d5"), SanStr("e4")))
+    assertEquals(inserted.mainline.map(_.ply), List(Ply(6), Ply(7)))
+    assertEquals(inserted.fen.value, "rnbqkbnr/ppp1pppp/8/3p4/8/2N5/PPPPPPPP/R1BQKBNR w KQkq - 0 4")
+
+  test("insert nothing when the game ends on the current position"):
+    val game = parse("1. d4 d5 2. Nf3 Nf6 3. Ng1 Ng8")
+    assertEquals(merge(cursorAtEnd("1. d4 d5"), game), None)
+
+  test("insert nothing when the game never reaches the current position"):
+    assertEquals(merge(cursorAtEnd("1. d4 d5"), parse("1. e4 e5")), None)
+
+  test("insert nothing when the chapter already has the whole game"):
+    assertEquals(merge(cursorAtStart("1. d4 d5 2. c4"), parse("1. d4 d5 2. c4")), None)
+
+  test("renumber from a chapter that starts on a custom position"):
+    val chapter: PgnStr = """[SetUp "1"]
+[FEN "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1"]
+
+1... Nf6 2. Nf3 Ng8 3. Ng1"""
+    val (inserted, _) = mergeOrFail(cursorAtEnd(chapter), parse("1. e4 e5 2. Nf3"))
+    assertEquals(inserted.mainline.map(_.move.san), List(SanStr("e5"), SanStr("Nf3")))
+    assertEquals(inserted.mainline.map(_.ply), List(Ply(6), Ply(7)))
+    assertEquals(inserted.fen.value, "rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 4")
+
+  test("rebuild promotions, castling and en passant"):
+    assertRebuilt(parse("1. e4 d5 2. exd5 c6 3. dxc6 Nf6 4. cxb7 Ne4 5. bxa8=Q"))
+    assertRebuilt(parse("1. e4 Nf6 2. e5 d5 3. exd6 exd6 4. Nf3 Be7 5. Bc4 O-O"))
+
+  test("replay the game in the variant of the chapter"):
+    val chapter: PgnStr = """[Variant "Crazyhouse"]
+
+1. Nf3 Nf6 2. Ng1 Ng8"""
+    val game = parse("""[Variant "Crazyhouse"]
+
+1. e4 d5 2. exd5 Qxd5 3. P@e4 Qd8""")
+    val (inserted, _) = mergeOrFail(cursorAtEnd(chapter), game, Crazyhouse)
+    assertEquals(inserted.mainline.map(_.move.san), game.mainline.map(_.move.san))
+    assertEquals(inserted.mainline.map(_.ply), (5 to 10).toList.map(Ply(_)))
+    assertEquals(inserted.mainline.map(_.crazyData), game.mainline.map(_.crazyData))
+
+  test("keep the source comments on the renumbered moves"):
+    val game = parse("1. d4 d5 2. c4 e6")
+    val comment = Comment(Comment.Id.make, CommentStr("Carlsen - Nakamura"), Comment.Author.Lichess)
+    val annotated = game.setCommentAt(comment, UciPath.fromIds(game.mainline.map(_.id))).get
+    val (inserted, _) = mergeOrFail(cursorAtEnd(shuffle), annotated)
+    assertEquals(inserted.mainline.last.ply, Ply(8))
+    assertEquals(inserted.mainline.last.comments.value.map(_.text), List(comment.text))
+
+  test("keep the moves a game from another variant was played with".fail):
+    val game = parse("1. e4 e5 2. Nf3 Nc6 3. Nxe5 Nxe5")
+    val (inserted, _) = mergeOrFail(Root.default(Atomic) -> UciPath.root, game, Atomic)
+    assertEquals(inserted.mainline.map(_.move.san), game.mainline.map(_.move.san))

--- a/modules/study/src/test/ExplorerGameTest.scala
+++ b/modules/study/src/test/ExplorerGameTest.scala
@@ -13,8 +13,6 @@ class ExplorerGameTest extends LilaTest:
   given Conversion[String, PgnStr] = PgnStr(_)
   given Executor = scala.concurrent.ExecutionContextOpportunistic
 
-  private val api = new ExplorerGameApi(null, null, null, null)
-
   private def parse(pgn: PgnStr): Root = StudyPgnImport.result(pgn, Nil).toOption.get.root
 
   private val emptyChapter: (Node, UciPath) = Root.default(Standard) -> UciPath.root
@@ -32,7 +30,7 @@ class ExplorerGameTest extends LilaTest:
       game: Root,
       variant: Variant = Standard
   ): Option[(Branch, UciPath)] =
-    api.merge(cursor._1, cursor._2, game, variant, GameId("explorerG"))
+    ExplorerGameApi.merge(cursor._1, cursor._2, game, variant, GameId("explorerG"))
 
   private def mergeOrFail(cursor: (Node, UciPath), game: Root, variant: Variant = Standard)(using
       munit.Location


### PR DESCRIPTION
Closes #18873 

### AI Assistance
Claude Code helped create this PR
Prompt: Please fix 18873 minimally. Present many different solutions and order them by correctness and then least technical debt. Let the user decide before coding a solution. Do not implement extraneous items

### Pictures
#### Before

Move numbers: 1, 2, 1, 2, 3 ...
<img width="388" height="145" alt="before" src="https://github.com/user-attachments/assets/ac90207e-513b-43af-ae92-c69506f789bf" />

#### After

Move numbers: 1, 2, 3, 4, 5
<img width="392" height="146" alt="after" src="https://github.com/user-attachments/assets/d07fc093-d365-49f0-b1b8-fa31f118a268" />