### PR TITLE
ui(dasher): visual tweaks for Zen mode toggler

### DIFF
--- a/ui/dasher/css/_dasher.scss
+++ b/ui/dasher/css/_dasher.scss
@@ -155,8 +155,6 @@
       &::before {
         opacity: 0.5;
         font-size: 18px;
-        position: relative;
-        top: -1px;
         margin-inline: 0 0.4em;
       }
     }

--- a/ui/dasher/css/_dasher.scss
+++ b/ui/dasher/css/_dasher.scss
@@ -147,8 +147,18 @@
   }
 
   .zen {
-    button::before {
-      opacity: 0.5;
+    margin: 0;
+
+    button {
+      padding: 0.5rem 1rem;
+
+      &::before {
+        opacity: 0.5;
+        font-size: 18px;
+        position: relative;
+        top: -1px;
+        margin-inline: 0 0.4em;
+      }
     }
 
     &:hover button::before {


### PR DESCRIPTION
# How

Adjust size and spacing of Zen mode toggler in Dasher to match better other links and menu togglers.

# Preview

### Before

<img width="291" height="504" alt="Screenshot 2026-08-07 at 09 47 52" src="https://github.com/user-attachments/assets/9b6fe310-b508-4601-9b01-4eb020f8dc5e" />

### After

<img width="291" height="504" alt="Screenshot 2026-08-07 at 09 44 55" src="https://github.com/user-attachments/assets/f20d601a-cb5a-4029-af3f-d1b4f01bc6aa" />
