### PR TITLE
ui(round): post match buttons visual alignment

### DIFF
--- a/ui/round/css/_control.scss
+++ b/ui/round/css/_control.scss
@@ -7,7 +7,8 @@
     margin: 0;
   }
 
-  button {
+  button,
+  a.fbt {
     @extend %box-radius;
 
     &.resign,
@@ -131,6 +132,8 @@
 
     border-bottom: $border;
     position: relative;
+    padding: 0 8px 8px;
+    gap: 4px;
 
     /* for rematch-decline */
     .fbt {
@@ -187,11 +190,10 @@
   .rematch {
     &.fbt {
       @extend %metal;
+      @include transition;
 
       font-size: 1.2em;
       height: 6rem;
-
-      @include transition;
     }
 
     &.me {
@@ -270,28 +272,31 @@
     }
 
     &.fbt:not(.disabled):hover {
-      background: color-mix(in oklab, $c-primary 70%, $c-bg);
+      @include with-button-shadow(
+        hsl(from $c-primary h s calc(l + 32)),
+        hsl(from $c-primary h s calc(l - 18)),
+        hsl(from $c-primary h s calc(l + 44)),
+        hsl(from $c-primary h s calc(l - 14))
+      );
+
+      background: $c-primary;
       color: #fff;
       animation: none;
     }
 
     &-decline {
       @extend %flex-center-nowrap, %box-radius-right, %box-shadow;
+      @include inline-end(-25px);
+      @include transition;
 
       justify-content: center;
       position: absolute;
       top: 0;
-
-      @include inline-end(-25px);
-
       width: 25px;
       height: 6rem;
       border: 0;
       opacity: 0.7;
       background: color-mix(in oklab, $c-bad 50%, $c-bg);
-
-      @include transition;
-
       display: none;
 
       @include mq-at-least-col2 {
@@ -301,10 +306,9 @@
       &:hover {
         background: $c-bad;
         color: $c-over;
+        width: 35px;
 
         @include inline-end(-36px);
-
-        width: 35px;
       }
     }
   }

--- a/ui/round/css/_moves-col1.scss
+++ b/ui/round/css/_moves-col1.scss
@@ -1,5 +1,7 @@
 /* context: .rmoves */
 @include mq-is-col1 {
+  @include backdrop-blur-if-transparent;
+
   overflow: hidden;
 
   .col1-moves {
@@ -24,10 +26,10 @@
     white-space: nowrap;
     overflow-x: scroll;
     color: $c-font-page;
-    box-shadow: 0 4px 12px #000 inset;
+    box-shadow: 0 4px 16px #0006 inset;
 
     @include if-light {
-      box-shadow: 0 4px 4px #aaa inset;
+      box-shadow: 0 4px 16px #aaa6 inset;
     }
 
     &::-webkit-scrollbar {


### PR DESCRIPTION
# Why

* https://hq.lichess.ovh/#narrow/channel/8-dev/topic/custom.20user.20UI.20roundness/near/4287056

# How

Add roundness to analyse (and other `a.fbt` buttons), tweak spacing and correct rematch button colors.

Improve moves node visibility in one column layout, especially in transparent theme.

# Preview

https://github.com/user-attachments/assets/1f3ddfb3-e378-4f39-bbd0-e5ce52817463

