### PR TITLE
ui(bits): user blog calendar select view tweaks

### DIFF
--- a/ui/bits/css/ublog/_ublog.scss
+++ b/ui/bits/css/ublog/_ublog.scss
@@ -98,6 +98,12 @@
     flex: auto;
     padding: 0.2em;
     gap: 0;
+    background: none;
+    border: none;
+
+    a {
+      font-size: 1.25em;
+    }
 
     div {
       gap: 0.5em;

--- a/ui/bits/css/ublog/_ublog.scss
+++ b/ui/bits/css/ublog/_ublog.scss
@@ -95,9 +95,10 @@
   }
 
   .calendar-mselect {
+    justify-content: center;
     flex: auto;
     padding: 0.2em;
-    gap: 0;
+    gap: 1em;
     background: none;
     border: none;
 


### PR DESCRIPTION
# How

Adjust the style of calendar select view when display in user blogs list header.

# Preview

### Before

<img width="1200" height="506" alt="Screenshot 2026-08-07 at 12 50 50" src="https://github.com/user-attachments/assets/023ee3fb-6c48-4f85-ad4f-3cdc7c1c2c7d" />

### After

<img width="1200" height="506" alt="Screenshot 2026-08-07 at 12 48 41" src="https://github.com/user-attachments/assets/cddf595c-7433-4709-952a-1a9149a64947" />
