### PR TITLE
app: hide studies and forum posts links in user profile when there is none

### DIFF
--- a/app/views/user/show/header.scala
+++ b/app/views/user/show/header.scala
@@ -101,10 +101,12 @@ object header:
               splitNumber(trans.broadcast.nbBroadcasts.pluralSame(info.nbRelays))
             )
           ),
-          a(href := routes.Study.byOwnerDefault(u.username), cls := "nm-item")(
-            splitNumber(trans.site.`nbStudies`.pluralSame(info.nbStudies))
+          (info.nbStudies > 0).option(
+            a(href := routes.Study.byOwnerDefault(u.username), cls := "nm-item")(
+              splitNumber(trans.site.`nbStudies`.pluralSame(info.nbStudies))
+            )
           ),
-          ctx.kid.no.option(
+          (ctx.kid.no && info.nbForumPosts > 0).option(
             a(
               cls := "nm-item",
               href := routes.ForumPost.search("user:" + u.username, 1).url


### PR DESCRIPTION
# Why

They lead to empty pages anyway, and take a space for action buttons, which dynamically fill out the remaining space in the header.

# How

Hide studies and forum posts links in user profile when there is none.

# Preview

<img width="1084" height="239" alt="Screenshot 2026-08-07 at 13 35 53" src="https://github.com/user-attachments/assets/164c1201-c4f7-475f-bbca-ba9664b2e4d5" />
<img width="1084" height="239" alt="Screenshot 2026-08-07 at 13 36 23" src="https://github.com/user-attachments/assets/71d9e2cc-dde3-4e04-8c8f-1c3b0277e0f3" />
<img width="1084" height="239" alt="Screenshot 2026-08-07 at 13 38 12" src="https://github.com/user-attachments/assets/dd11639a-c462-463b-90aa-fb84a2cfa35f" />
