### PR TITLE
Add logger configs for reactivemongo in dev mode

### DIFF
--- a/conf/logger.dev.xml
+++ b/conf/logger.dev.xml
@@ -30,4 +30,6 @@
   <logger name="org.apache.pekko"><appender-ref ref="STDOUT_INFO" /></logger>
   <logger name="reactivemongo"><appender-ref ref="STDOUT_INFO" /></logger>
 
+  <logger name="reactivemongo.core.nodeset.ChannelFactory" level="INFO"/>
+  <logger name="reactivemongo.core.actors.MongoDBSystem" level="INFO"/>
 </configuration>


### PR DESCRIPTION
Both are set as INFO, so it'll work as before. But it'll make devs
easier to toggle them. Which helps debug reactivemongo from time to
time.
