### PR TITLE
ui(dasher): fix dropdown roundness in transparent theme

### DIFF
--- a/ui/dasher/css/_dasher.scss
+++ b/ui/dasher/css/_dasher.scss
@@ -6,11 +6,13 @@
 #dasher_app {
   @extend %box-radius-left;
 
-  #top.scrolled & {
-    border-radius: 0 0 0 $box-radius-size;
-  }
-
   width: 225px;
+
+  @include if-transp {
+    &::before {
+      @extend %box-radius-left;
+    }
+  }
 
   .spinner {
     margin: 20px auto;


### PR DESCRIPTION
# How

Apply roundness to the dasher dropdown `:before` blur overlay, so rounded corners are properly visible. Remove style overwrite when scrolling, so radius does not changes based on state.

# Preview

### Before

<img width="260" height="464" alt="Screenshot 2026-08-08 at 10 24 06" src="https://github.com/user-attachments/assets/9f902df5-1e89-4556-9841-0f771602b07f" />

### After

<img width="260" height="464" alt="Screenshot 2026-08-08 at 10 24 13" src="https://github.com/user-attachments/assets/0fee89e4-3e7e-4131-94d4-da7d33716d31" />
