### PR TITLE
Fix ublog automod type errors introduced in "reorganize ublog post quality"

### DIFF
--- a/app/controllers/Ublog.scala
+++ b/app/controllers/Ublog.scala
@@ -266,7 +266,7 @@ final class Ublog(env: Env) extends LilaController(env):
         _ <- logModAction(post, "reassess")
       yield Ok.snip(
         views.ublog.post.modTools(
-          post.copy(automod = mod.orElse(post.automod), featured = none),
+          post.copy(automod = mod.flatMap(_.automod).orElse(post.automod), featured = none),
           isInCarousel = false
         )
       )

--- a/modules/ublog/src/main/UblogApi.scala
+++ b/modules/ublog/src/main/UblogApi.scala
@@ -64,7 +64,7 @@ final class UblogApi(
   yield
     triggerAutomod(post).foreach: newPost =>
       if isFirstPublish && blog.visible
-      then sendPostToZulip(author.light, newPost, blog)
+      then newPost.foreach(sendPostToZulip(author.light, _, blog))
     post
 
   private def onFirstPublish(author: LightUser, blog: UblogBlog, post: UblogPost) =

--- a/modules/ublog/src/main/UblogApi.scala
+++ b/modules/ublog/src/main/UblogApi.scala
@@ -64,7 +64,7 @@ final class UblogApi(
   yield
     triggerAutomod(post).foreach: newPost =>
       if isFirstPublish && blog.visible
-      then newPost.foreach(sendPostToZulip(author.light, _, blog))
+      then sendPostToZulip(author.light, newPost.getOrElse(post), blog)
     post
 
   private def onFirstPublish(author: LightUser, blog: UblogBlog, post: UblogPost) =


### PR DESCRIPTION
## What

Fixes two Scala compile errors ([E007] Type Mismatch Error) introduced by commit b8a390f ("reorganize ublog post quality for #21096"), which changed `UblogApi.triggerAutomod` and `UblogApi.modPost` to return a full `UblogPost` instead of an `Option[UblogAutomod.Assessment]`, but left two call sites still treating the result with the old type.

## Where

1. `modules/ublog/src/main/UblogApi.scala` - `update()` called `sendPostToZulip(author.light, newPost, blog)` where `newPost` is `Option[UblogPost]` returned by `triggerAutomod`, but `sendPostToZulip` expects a plain `UblogPost`.
2. 2. `app/controllers/Ublog.scala` - `modAssess()` built `post.copy(automod = mod.orElse(post.automod), ...)` where `mod` is now `Option[UblogPost]` instead of `Option[Assessment]`, producing a union type that doesn't fit the `automod` field.
## Fix

- `UblogApi.scala`: use `newPost.getOrElse(post)` so the Zulip notification still fires on first publish even if the automod assessment failed, matching pre-refactor behavior (which always notified, falling back to "unknown quality").
- - `Ublog.scala`: extract the `automod` field from the returned post via `mod.flatMap(_.automod).orElse(post.automod)`, preserving the original fallback semantics.
## AI disclosure

This fix was produced with the assistance of Claude (Claude Sonnet 5, Anthropic's browser/Chrome extension agent). I asked it to inspect the failing GitHub Actions run for this commit, locate the compile error, and propose a fix; when a second related compile error surfaced on a follow-up CI run, I asked it to trace and fix that one as well. In both cases I asked it to diff against the pre-refactor code to confirm the fix preserves original behavior rather than just satisfying the compiler.

## Testing

Not yet run locally / manually tested - opening as a draft. Will confirm with a local build and manual check of the Zulip notification and mod-assess flow before marking ready for review.