### PR TITLE
ui: blur feed icons background in transparent theme

### DIFF
--- a/ui/bits/css/_dailyFeed.scss
+++ b/ui/bits/css/_dailyFeed.scss
@@ -42,6 +42,8 @@ $marker-margin-top: -14px;
       border-radius: 50%;
 
       &.nobg {
+        @include backdrop-blur-if-transparent;
+
         background: $c-bg-box;
         border: 2px solid $c-contours;
       }

--- a/ui/lobby/css/_feed.scss
+++ b/ui/lobby/css/_feed.scss
@@ -33,6 +33,8 @@
       border-radius: 50%;
 
       &.nobg {
+        @include backdrop-blur-if-transparent;
+
         background: $c-bg-box;
         border: 2px solid $c-contours;
       }


### PR DESCRIPTION
# How

Add blur to the feed icons background in transparent theme, to prevent border/line poking through.

The changes applies for the main feed page and the feed section on the home page.

# Preview

### Before

<img width="649" height="617" alt="Screenshot 2026-08-08 at 16 23 18" src="https://github.com/user-attachments/assets/34e47bad-7b35-4fc6-b4f3-55eb55aee918" />

### After

<img width="649" height="617" alt="Screenshot 2026-08-08 at 16 24 42" src="https://github.com/user-attachments/assets/48730f16-4533-4a33-b413-964228e8c074" />
