### PR TITLE
ui(analyse): blur explorer sticky elements background in picture mode

### DIFF
--- a/ui/analyse/css/explorer/_explorer.scss
+++ b/ui/analyse/css/explorer/_explorer.scss
@@ -45,6 +45,7 @@
 
   .explorer-title {
     @extend %flex-center-nowrap;
+    @include backdrop-blur-if-transparent;
 
     align-items: stretch;
     font-size: 0.9rem;
@@ -148,7 +149,6 @@
     }
 
     tbody tr.sum {
-      /* sum row */
       background: color-mix(in oklab, $c-primary 25%, $c-bg);
       font-weight: bold;
 
@@ -160,6 +160,8 @@
       }
 
       td {
+        @include backdrop-blur-if-transparent;
+
         cursor: default;
       }
     }


### PR DESCRIPTION
# How

Spotted this while testing the picture mode (transparent theme) locally.

Blur explorer sticky elements background in picture mode to ensure content readability.

# Preview

<img width="333" height="404" alt="Screenshot 2026-08-08 at 16 39 11" src="https://github.com/user-attachments/assets/f7374712-b522-4987-9046-273263abed23" />

