### PR TITLE
Fix lobby chart plots shifting on first render

### DIFF
--- a/ui/lobby/css/app/_hook-chart.scss
+++ b/ui/lobby/css/app/_hook-chart.scss
@@ -48,6 +48,8 @@
     font-size: 1.6em;
     opacity: 0.7;
     transform: scale(1);
+    margin-inline-start: -0.5em;
+    margin-bottom: -0.5em;
 
     &.rated {
       opacity: 0.9;

--- a/ui/lobby/src/view/realTime/chart.ts
+++ b/ui/lobby/src/view/realTime/chart.ts
@@ -32,9 +32,9 @@ const clockX = (dur: number) => {
   return Math.round((durLog(Math.min(clockMax, dur || clockMax)) / durLog(clockMax)) * 100);
 };
 
-function renderPlot(ctrl: LobbyController, hook: Hook, translate: [number, number]) {
-  const bottom = Math.max(0, ratingY(hook.rating) - translate[1]),
-    left = Math.max(0, clockX(hook.t) - translate[0]),
+function renderPlot(ctrl: LobbyController, hook: Hook) {
+  const bottom = Math.max(0, ratingY(hook.rating)),
+    left = Math.max(0, clockX(hook.t)),
     klass = [
       hook.id,
       'plot.new',
@@ -118,13 +118,6 @@ export function toggle(ctrl: LobbyController) {
 }
 
 export function render(ctrl: LobbyController, hooks: Hook[]) {
-  let translate: [number, number] = [0, 0];
-  const chart = document.querySelector('.hooks__chart') as HTMLElement;
-  if (chart) {
-    const fontSize = parseFloat(window.getComputedStyle(chart).fontSize);
-    translate = [(fontSize / chart.clientWidth) * 95, (fontSize / chart.clientHeight) * 75];
-  }
-
   return h('div.hooks__chart', [
     h(
       'div.canvas',
@@ -138,7 +131,7 @@ export function render(ctrl: LobbyController, hooks: Hook[]) {
           ctrl.redraw,
         ),
       },
-      hooks.map(hook => renderPlot(ctrl, hook, translate)),
+      hooks.map(hook => renderPlot(ctrl, hook)),
     ),
     ...renderYAxis(),
     ...renderXAxis(),


### PR DESCRIPTION
## Summary
Fixes #21101. Plots in the lobby graph view shifted position shortly after opening. Root cause: translate was calculated from `.hooks__chart` DOM dimensions, which didn't exist on first render (returned `[0,0]`), then recalculated correctly on next redraw — causing visible shift.

Removed the DOM-dependent translate calculation. Plot positions are now deterministic from hook data alone.

AI-assisted with Devin (GLM-5.2 High). Human reviewed and tested.
<img width="800" height="383" alt="screenrecording-2026-08-08_23-00-16-ezgif com-video-to-gif-converter" src="https://github.com/user-attachments/assets/56c8e89e-0d3d-43f9-b5c7-87db41fff19b" />