### PR TITLE
fix(broadcast): fix team player score when merging multiple games

### DIFF
--- a/modules/relay/src/main/RelayTeams.scala
+++ b/modules/relay/src/main/RelayTeams.scala
@@ -70,7 +70,11 @@ object RelayTeam:
         copy(players =
           players.updated(
             id,
-            players.get(id).fold(player)(rp => rp.copy(games = rp.games ++ player.games))
+            players
+              .get(id)
+              .fold(player)(rp =>
+                rp.copy(games = rp.games ++ player.games, score = rp.score |+| player.score)
+              )
           )
         )
     def points = players.values.toList.foldMap(_.score)


### PR DESCRIPTION
fixes #21242

### Before

<img width="1449" height="636" alt="image" src="https://github.com/user-attachments/assets/dcc36bba-1f20-4510-af48-e5fe32c33775" />


```json
{
  "table": [
    {
      "teams": [
        {
          "players": [ { "played": 2, "score": 0 } ],
          "points": 0
        },
        {
          "players": [ { "played": 2, "score": 1 } ],
          "points": 1
        }
      ],
      "games": [
        { "id": "z96gOFD4", "pov": "white" },
        { "id": "6Wnxbbvb", "pov": "black" }
      ]
    }
  ]
}
```

### After

<img width="1440" height="654" alt="image" src="https://github.com/user-attachments/assets/687aad84-963b-4b11-a80b-ec05ce5dbb9b" />


```json
{
  "table": [
    {
      "teams": [
        {
          "players": [ { "played": 2, "score": 0 } ],
          "points": 0
        },
        {
          "players": [ { "played": 2, "score": 2 } ],
          "points": 2
        }
      ],
      "games": [
        { "id": "z96gOFD4", "pov": "white" },
        { "id": "6Wnxbbvb", "pov": "black" }
      ]
    }
  ]
}
```