### PR TITLE
toastui - blog editor bugfixes for the person who makes tables

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
-  '@toast-ui/editor@3.2.2': eabd348377a472431b8d5e878f133ef3f6239e98e83d4e1ca409c8892502cd0a
+  '@toast-ui/editor@3.2.2': 3c9aa5176e0c4e67d96e6cfc8928789dfb22ebcb7db6a5c68f40caf5cc9bbce9
 
 importers:
 
@@ -144,7 +144,7 @@ importers:
         version: 0.1.13(@textcomplete/core@0.1.13)
       '@toast-ui/editor':
         specifier: 3.2.2
-        version: 3.2.2(patch_hash=eabd348377a472431b8d5e878f133ef3f6239e98e83d4e1ca409c8892502cd0a)
+        version: 3.2.2(patch_hash=3c9aa5176e0c4e67d96e6cfc8928789dfb22ebcb7db6a5c68f40caf5cc9bbce9)
       '@types/canvas-confetti':
         specifier: ^1.9.0
         version: 1.9.0
@@ -2674,7 +2674,7 @@ snapshots:
 
   '@textcomplete/utils@0.1.13': {}
 
-  '@toast-ui/editor@3.2.2(patch_hash=eabd348377a472431b8d5e878f133ef3f6239e98e83d4e1ca409c8892502cd0a)':
+  '@toast-ui/editor@3.2.2(patch_hash=3c9aa5176e0c4e67d96e6cfc8928789dfb22ebcb7db6a5c68f40caf5cc9bbce9)':
     dependencies:
       dompurify: 2.5.9
       prosemirror-commands: 1.7.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
-  '@toast-ui/editor@3.2.2': 0a324facc984b3c00201cd2ac957c0e51db9ee66ce33c37306031ca67d5aa7ba
+  '@toast-ui/editor@3.2.2': eabd348377a472431b8d5e878f133ef3f6239e98e83d4e1ca409c8892502cd0a
 
 importers:
 
@@ -144,7 +144,7 @@ importers:
         version: 0.1.13(@textcomplete/core@0.1.13)
       '@toast-ui/editor':
         specifier: 3.2.2
-        version: 3.2.2(patch_hash=0a324facc984b3c00201cd2ac957c0e51db9ee66ce33c37306031ca67d5aa7ba)
+        version: 3.2.2(patch_hash=eabd348377a472431b8d5e878f133ef3f6239e98e83d4e1ca409c8892502cd0a)
       '@types/canvas-confetti':
         specifier: ^1.9.0
         version: 1.9.0
@@ -2674,7 +2674,7 @@ snapshots:
 
   '@textcomplete/utils@0.1.13': {}
 
-  '@toast-ui/editor@3.2.2(patch_hash=0a324facc984b3c00201cd2ac957c0e51db9ee66ce33c37306031ca67d5aa7ba)':
+  '@toast-ui/editor@3.2.2(patch_hash=eabd348377a472431b8d5e878f133ef3f6239e98e83d4e1ca409c8892502cd0a)':
     dependencies:
       dompurify: 2.5.9
       prosemirror-commands: 1.7.1

--- a/ui/bits/patches/@toast-ui__editor.patch
+++ b/ui/bits/patches/@toast-ui__editor.patch
@@ -10,3 +10,33 @@ index 941abe3546bba24c4b0b2851ab0b9d92286aff07..a8abea4a8f30cba512d39c077c5603a6
        "import": "./dist/esm/index.js",
        "require": "./dist/toastui-editor.js"
      },
+diff --git a/dist/esm/index.js b/dist/esm/index.js
+index 195b156..1046e69 100644
+--- a/dist/esm/index.js
++++ b/dist/esm/index.js
+@@ -18272,1 +18272,4 @@
+-    return inFirstRow || inLastRow;
++    const inFirstCell = direction === "left" && rowIdx === 0 && colIdx === 0;
++    const inLastCell = direction === "right" &&
++      rowIdx === map.totalRowCount - 1 && colIdx === map.totalColumnCount - 1;
++    return inFirstRow || inLastRow || inFirstCell || inLastCell;
+@@ -18602,1 +18606,3 @@
+-                    newTr = addParagraphAfterTable(tr, map, schema);
++                    newTr = direction === "left"
++                      ? addParagraphBeforeTable(tr, map, schema)
++                      : addParagraphAfterTable(tr, map, schema);
+diff --git a/dist/toastui-editor.js b/dist/toastui-editor.js
+index b20d9c3..f446f8b 100644
+--- a/dist/toastui-editor.js
++++ b/dist/toastui-editor.js
+@@ -19717,1 +19717,4 @@
+-    return inFirstRow || inLastRow;
++    const inFirstCell = direction === Direction.LEFT && rowIdx === 0 && colIdx === 0;
++    const inLastCell = direction === Direction.RIGHT &&
++      rowIdx === map.totalRowCount - 1 && colIdx === map.totalColumnCount - 1;
++    return inFirstRow || inLastRow || inFirstCell || inLastCell;
+@@ -20064,1 +20068,3 @@
+-                    newTr = addParagraphAfterTable(tr, map, schema);
++                    newTr = direction === Direction.LEFT
++                      ? addParagraphBeforeTable(tr, map, schema)
++                      : addParagraphAfterTable(tr, map, schema);

--- a/ui/bits/patches/@toast-ui__editor.patch
+++ b/ui/bits/patches/@toast-ui__editor.patch
@@ -14,6 +14,9 @@ diff --git a/dist/esm/index.js b/dist/esm/index.js
 index 195b156..1046e69 100644
 --- a/dist/esm/index.js
 +++ b/dist/esm/index.js
+@@ -16279,1 +16279,1 @@
+-        _this = _super.call(this, ranges[0].$from, ranges[0].$to, ranges) || this;
++        _this = Reflect.construct(_super, [ranges[0].$from, ranges[0].$to, ranges], CellSelection);
 @@ -18272,1 +18272,4 @@
 -    return inFirstRow || inLastRow;
 +    const inFirstCell = direction === "left" && rowIdx === 0 && colIdx === 0;
@@ -25,18 +28,6 @@ index 195b156..1046e69 100644
 +                    newTr = direction === "left"
 +                      ? addParagraphBeforeTable(tr, map, schema)
 +                      : addParagraphAfterTable(tr, map, schema);
-diff --git a/dist/toastui-editor.js b/dist/toastui-editor.js
-index b20d9c3..f446f8b 100644
---- a/dist/toastui-editor.js
-+++ b/dist/toastui-editor.js
-@@ -19717,1 +19717,4 @@
--    return inFirstRow || inLastRow;
-+    const inFirstCell = direction === Direction.LEFT && rowIdx === 0 && colIdx === 0;
-+    const inLastCell = direction === Direction.RIGHT &&
-+      rowIdx === map.totalRowCount - 1 && colIdx === map.totalColumnCount - 1;
-+    return inFirstRow || inLastRow || inFirstCell || inLastCell;
-@@ -20064,1 +20068,3 @@
--                    newTr = addParagraphAfterTable(tr, map, schema);
-+                    newTr = direction === Direction.LEFT
-+                      ? addParagraphBeforeTable(tr, map, schema)
-+                      : addParagraphAfterTable(tr, map, schema);
+@@ -18951,1 +18957,1 @@
+-                attrs: __assign$1({ imageUrl: { default: '' }, altText: { default: null }, rawHTML: { default: null } }, getDefaultCustomAttrs()),
++                attrs: __assign$1({ imageUrl: { default: '' }, altText: { default: null }, rawHTML: { default: null }, styleWidth: { default: null } }, getDefaultCustomAttrs()),

--- a/ui/bits/src/toastEditor.ts
+++ b/ui/bits/src/toastEditor.ts
@@ -1,6 +1,6 @@
 import { Editor } from '@toast-ui/editor';
-import type { Node as NodeType, Schema as SchemaType } from 'prosemirror-model';
-import type { EditorState as EditorStateType, Selection as SelectionType } from 'prosemirror-state';
+import type { Node as NodeType } from 'prosemirror-model';
+import type { Selection as SelectionType } from 'prosemirror-state';
 import type { EditorView as EditorViewType } from 'prosemirror-view';
 
 import { currentTheme } from 'lib/device';
@@ -69,45 +69,15 @@ function newToast(el: HTMLElement, initialValue: string, rewire: () => void, edi
 function initProseMirror(view: EditorViewType, rewire: () => void) {
   if (!view) return;
 
-  const old = view.state.schema;
-  const imageSpec = old.nodes['image'].spec;
-  // can't import the ProseMirror javascript because toastui bundles it,
-  // so put on the gloves, reach in, and grab some constructors
-  const Schema = old.constructor as new (cfg: { nodes: any; marks: any }) => SchemaType;
-  const EditorState = view.state.constructor as typeof EditorStateType & {
-    create(cfg: any): EditorStateType;
-  };
-  const Node = view.state.doc.constructor as typeof NodeType & {
-    fromJSON(s: SchemaType, j: any): NodeType;
-  };
-  const nodes = old.spec.nodes.update('image', {
-    ...imageSpec,
-    attrs: { ...imageSpec.attrs, styleWidth: { default: null } },
-  });
-  const schema = new Schema({ nodes, marks: old.spec.marks });
-  const newState = EditorState.create({
-    schema,
-    doc: Node.fromJSON(schema, view.state.doc.toJSON()),
-    plugins: view.state.plugins,
-  });
-
-  view.updateState(newState);
   view.setProps({
     nodeViews: { image: imageNodeView(rewire) },
-    handleDOMEvents: { ...view.props.handleDOMEvents, mousedown: clickOutsideTable },
+    handleClick: clickOutsideTable,
   });
-
-  let transaction = view.state.tr;
-  view.state.doc.descendants((n: NodeType, pos: number) => {
-    if (n.type?.name === 'image') {
-      transaction = transaction.setNodeMarkup(pos, n.type, n.attrs, n.marks);
-    }
-  });
-  if (transaction.docChanged) view.dispatch(transaction);
 }
 
-// interpret clicks outside of a table's inline-end boundary as intent to advance the insertion cursor past it
-function clickOutsideTable(view: EditorViewType, event: MouseEvent) {
+// interpret clicks outside of a document ending table's inline-end boundary as intent to advance the
+// insertion cursor past it, inserting a newline
+function clickOutsideTable(view: EditorViewType, _pos: number, event: MouseEvent) {
   if (event.button !== 0) return false;
   let tablePos: number | undefined;
   view.state.doc.forEach((node: NodeType, pos: number) => {
@@ -123,12 +93,10 @@ function clickOutsideTable(view: EditorViewType, event: MouseEvent) {
   });
   if (tablePos === undefined) return false;
 
-  event.preventDefault();
   const table = view.state.doc.nodeAt(tablePos)!;
   const afterTable = tablePos + table.nodeSize;
-  let transaction = view.state.tr;
-  if (!transaction.doc.resolve(afterTable).nodeAfter)
-    transaction = transaction.insert(afterTable, view.state.schema.nodes.paragraph.create());
+  if (view.state.doc.resolve(afterTable).nodeAfter) return false;
+  const transaction = view.state.tr.insert(afterTable, view.state.schema.nodes.paragraph.create());
   const Selection = view.state.selection.constructor as typeof SelectionType;
   view.dispatch(
     transaction.setSelection(Selection.near(transaction.doc.resolve(afterTable), 1)).scrollIntoView(),

--- a/ui/bits/src/toastEditor.ts
+++ b/ui/bits/src/toastEditor.ts
@@ -1,6 +1,6 @@
 import { Editor } from '@toast-ui/editor';
 import type { Node as NodeType, Schema as SchemaType } from 'prosemirror-model';
-import type { EditorState as EditorStateType } from 'prosemirror-state';
+import type { EditorState as EditorStateType, Selection as SelectionType } from 'prosemirror-state';
 import type { EditorView as EditorViewType } from 'prosemirror-view';
 
 import { currentTheme } from 'lib/device';
@@ -92,7 +92,10 @@ function initProseMirror(view: EditorViewType, rewire: () => void) {
   });
 
   view.updateState(newState);
-  view.setProps({ nodeViews: { image: imageNodeView(rewire) } });
+  view.setProps({
+    nodeViews: { image: imageNodeView(rewire) },
+    handleDOMEvents: { ...view.props.handleDOMEvents, mousedown: clickOutsideTable },
+  });
 
   let transaction = view.state.tr;
   view.state.doc.descendants((n: NodeType, pos: number) => {
@@ -101,6 +104,36 @@ function initProseMirror(view: EditorViewType, rewire: () => void) {
     }
   });
   if (transaction.docChanged) view.dispatch(transaction);
+}
+
+// interpret clicks outside of a table's inline-end boundary as intent to advance the insertion cursor past it
+function clickOutsideTable(view: EditorViewType, event: MouseEvent) {
+  if (event.button !== 0) return false;
+  let tablePos: number | undefined;
+  view.state.doc.forEach((node: NodeType, pos: number) => {
+    if (node.type.name !== 'table') return;
+    const table = view.nodeDOM(pos);
+    if (!(table instanceof HTMLElement)) return;
+    const bounds = table.getBoundingClientRect();
+    const beyondInlineEnd =
+      window.getComputedStyle(table).direction === 'rtl'
+        ? event.clientX < bounds.left
+        : event.clientX > bounds.right;
+    if (beyondInlineEnd && event.clientY >= bounds.top && event.clientY <= bounds.bottom) tablePos = pos;
+  });
+  if (tablePos === undefined) return false;
+
+  event.preventDefault();
+  const table = view.state.doc.nodeAt(tablePos)!;
+  const afterTable = tablePos + table.nodeSize;
+  let transaction = view.state.tr;
+  if (!transaction.doc.resolve(afterTable).nodeAfter)
+    transaction = transaction.insert(afterTable, view.state.schema.nodes.paragraph.create());
+  const Selection = view.state.selection.constructor as typeof SelectionType;
+  view.dispatch(
+    transaction.setSelection(Selection.near(transaction.doc.resolve(afterTable), 1)).scrollIntoView(),
+  );
+  return true;
 }
 
 type ProseMirrorProps = { getPos: () => number | undefined; view: EditorViewType };

--- a/ui/lib/src/view/markdownImgResizer.ts
+++ b/ui/lib/src/view/markdownImgResizer.ts
@@ -134,7 +134,7 @@ export function markdownPicfitRegex(origin = ''): RegExp {
   );
 }
 
-const imageIdRe = /&path=([a-z]\w+:[-_a-z0-9]{12}\.\w{3,4})&/i;
+const imageIdRe = /&path=((?:[a-z]\w+:)?[-_a-z0-9]{12}\.\w{3,4})&/i;
 
 async function urlUpdate(img: HTMLImageElement, update: Extract<UpdateImageHook, { url: unknown }>) {
   const imageId = img.src.match(imageIdRe)?.[1];


### PR DESCRIPTION
Partially address https://github.com/lichess-org/lila/issues/21201

- Clicking outside of a table will now move the insertion cursor outside of the table
- Don't blur the entire editor when tabbing from the first/last table cell. Instead, mimic arrow key navigation.

I did not bring the presentation style to the editor because it would hinder ability to distinguish table cells. A full width table would also mean you can't click outside it.

I could not reproduce the un-selectable table cell in video # 2, but perhaps he could have navigated to it with arrow key or tab.