### PR TITLE
make toast image resize work again

### DIFF
--- a/ui/lib/src/view/markdownImgResizer.ts
+++ b/ui/lib/src/view/markdownImgResizer.ts
@@ -134,7 +134,7 @@ export function markdownPicfitRegex(origin = ''): RegExp {
   );
 }
 
-const imageIdRe = /&path=([a-z]\w+:[-_a-z0-9]{12}\.\w{3,4})&/i;
+const imageIdRe = /&path=((?:[a-z]\w+:)?[-_a-z0-9]{12}\.\w{3,4})&/i;
 
 async function urlUpdate(img: HTMLImageElement, update: Extract<UpdateImageHook, { url: unknown }>) {
   const imageId = img.src.match(imageIdRe)?.[1];


### PR DESCRIPTION
I'm not sure when blog image ids stopped using the xxx:hash.ext form, but resizing has been broken since then. You should probably remove the (?:[a-z]\w+:)? part of these regexes altogether but making it optional is safe for now. Maybe somewhere the extended form is still used.