### PR TITLE
Fix first move countdown spacing

### DIFF
--- a/ui/round/css/_table.scss
+++ b/ui/round/css/_table.scss
@@ -27,6 +27,6 @@
 
   strong {
     font-size: 1rem;
-    margin-inline-end: 0.3em;
+    margin-inline: 0.3em;
   }
 }


### PR DESCRIPTION
## Summary

- add inline spacing on both sides of the emphasized first-move countdown value
- fix merged text in translations that place the value after a prefix, such as Turkish: `son17 saniye`

## Why

The translated string already contains spaces around `%s`, but its fragments are rendered as direct children of a flex container. The trailing space before the `<strong>` becomes part of an anonymous flex item and is not rendered. The existing CSS only supplied spacing after the value.

## Testing

- `pnpm exec oxfmt --check ui/round/css/_table.scss`
- `pnpm exec stylelint ui/round/css/_table.scss`
- compared the old and new rules in headless Chrome; the new rule renders `İlk hamle için son 17 saniye`

This is a draft because I could not run the full round build locally: this Windows checkout materialized `ui/.build/src/algo.ts` as a symlink target text file, so Node fails before asset compilation.

## AI disclosure

OpenAI Codex was used to inspect the repository, trace the issue to whitespace handling between translated text fragments in a flex container, propose and apply the one-line SCSS change, and run the checks above. Prompt summary: investigate the Turkish first-move countdown rendering as `son17 saniye`, fix it, and open a PR. I reviewed the resulting diff and render comparison.
