### PR TITLE
ui: add alwaysShowVariationTree preference option

### DIFF
--- a/modules/coreI18n/src/main/key.scala
+++ b/modules/coreI18n/src/main/key.scala
@@ -1291,6 +1291,7 @@ object I18nKey:
     val `blindfold`: I18nKey = "preferences:blindfold"
     val `showClockOnTheLeft`: I18nKey = "preferences:showClockOnTheLeft"
     val `inlineNotation`: I18nKey = "preferences:inlineNotation"
+    val `alwaysShowVariationTree`: I18nKey = "preferences:alwaysShowVariationTree"
     val `showServerAnalysis`: I18nKey = "preferences:showServerAnalysis"
     val `showBestMoveArrows`: I18nKey = "preferences:showBestMoveArrows"
     val `showManeuverArrows`: I18nKey = "preferences:showManeuverArrows"

--- a/translation/source/preferences.xml
+++ b/translation/source/preferences.xml
@@ -77,6 +77,7 @@ This setting only affects what you see. Rated games will still impact your ratin
   <string name="blindfold" comment="As in Blindfold chess">Blindfold</string>
   <string name="showClockOnTheLeft" comment="During the game on a mobile device, show the clock on the left side of the screen. Only applies to mobile devices.">Show on the left on mobile devices</string>
   <string name="inlineNotation">Inline notation</string>
+  <string name="alwaysShowVariationTree">Always show variation tree</string>
   <string name="showServerAnalysis">Show server analysis</string>
   <string name="showBestMoveArrows">Show best move arrows</string>
   <string name="showManeuverArrows">Show maneuver arrows</string>

--- a/ui/@types/lichess/i18n.d.ts
+++ b/ui/@types/lichess/i18n.d.ts
@@ -2349,6 +2349,8 @@ interface I18n {
     winningStreak: string;
   };
   preferences: {
+    /** Always show variation tree */
+    alwaysShowVariationTree: string;
     /** Analysis settings */
     analysisSettings: string;
     /** Bell notification sound */

--- a/ui/analyse/src/settingsCtrl.ts
+++ b/ui/analyse/src/settingsCtrl.ts
@@ -15,6 +15,7 @@ export class Settings {
     public readonly showUndefendedPieces = false,
     public readonly showPinnedPieces = false,
     public readonly showCheckableKing = false,
+    public readonly alwaysTree = false,
   ) {}
 }
 

--- a/ui/analyse/src/treeView/inlineView.ts
+++ b/ui/analyse/src/treeView/inlineView.ts
@@ -136,6 +136,7 @@ export class InlineView {
   }
 
   private parenthetical(node: TreeNode): boolean {
+    if (this.ctrl.settings.alwaysTree) return false;
     const [, second, third] = node.children;
     return !third && second && !treeOps.hasBranching(second, 6);
   }

--- a/ui/analyse/src/treeView/inlineView.ts
+++ b/ui/analyse/src/treeView/inlineView.ts
@@ -50,16 +50,17 @@ export class InlineView {
   renderNodes([child, ...siblings]: TreeNode[], args: Args): LooseVNodes {
     if (!child) return undefined;
     const { isMainline, parentDisclose } = args;
-    return child.forceVariation && isMainline
-      ? hl('interrupt', this.lines([child, ...siblings], args))
-      : [
-          this.moveNode(child, args),
-          parentDisclose !== 'collapsed' && [
-            this.commentNodes(child),
-            siblings[0] && hl('interrupt', this.lines(siblings, args)),
-          ],
-          this.renderNodes(this.ctrl.visibleChildren(child), this.childArgs(child, args, true)),
-        ];
+    if (isMainline && (child.forceVariation || this.ctrl.settings.alwaysTree)) {
+      return hl('interrupt', this.lines([child, ...siblings], args));
+    }
+    return [
+      this.moveNode(child, args),
+      parentDisclose !== 'collapsed' && [
+        this.commentNodes(child),
+        siblings[0] && hl('interrupt', this.lines(siblings, args)),
+      ],
+      this.renderNodes(this.ctrl.visibleChildren(child), this.childArgs(child, args, true)),
+    ];
   }
 
   commentNodes(node: TreeNode, classes: Classes = {}): LooseVNodes[] {

--- a/ui/analyse/src/view/settingsView.ts
+++ b/ui/analyse/src/view/settingsView.ts
@@ -35,6 +35,11 @@ const settings: Record<SettingKey, Setting> = {
     group: i18n.preferences.moveListSettings,
     helpHtml: videoHtml('info-inline-notation'),
   },
+  alwaysTree: {
+    label: i18n.preferences.alwaysShowVariationTree,
+    group: i18n.preferences.moveListSettings,
+    helpHtml: videoHtml('info-always-tree'),
+  },
   disclosureMode: {
     label: i18n.preferences.disclosureMode,
     group: i18n.preferences.moveListSettings,

--- a/ui/analyse/src/view/settingsView.ts
+++ b/ui/analyse/src/view/settingsView.ts
@@ -38,7 +38,6 @@ const settings: Record<SettingKey, Setting> = {
   alwaysTree: {
     label: i18n.preferences.alwaysShowVariationTree,
     group: i18n.preferences.moveListSettings,
-    helpHtml: videoHtml('info-always-tree'),
   },
   disclosureMode: {
     label: i18n.preferences.disclosureMode,


### PR DESCRIPTION
Adds a new user preference option `alwaysShowVariationTree` to allow users to toggle the visibility of the variation tree.
