### PR TITLE
ui(editor): move to snabbdom elements, add missing form related ones

### DIFF
--- a/ui/editor/src/view.ts
+++ b/ui/editor/src/view.ts
@@ -4,11 +4,29 @@ import { eventPosition, opposite } from '@lichess-org/chessground/util';
 import { lichessRules } from 'chessops/compat';
 import { parseFen } from 'chessops/fen';
 import { parseSquare, makeSquare } from 'chessops/util';
-import { h, type VNode } from 'snabbdom';
 
 import { fenToEpd } from 'lib/game/chess';
 import { licon, type LiconValue } from 'lib/licon';
-import { copyMeInput, dataIcon, domDialog, enter, optgroup } from 'lib/view';
+import {
+  copyMeInput,
+  dataIcon,
+  domDialog,
+  enter,
+  input,
+  optgroup,
+  label,
+  form,
+  button,
+  option,
+  div,
+  select,
+  strong,
+  a,
+  span,
+  p,
+  makeExoticTag,
+  type VNode,
+} from 'lib/view';
 import { url as xhrUrl } from 'lib/xhr';
 
 import { fenToChess960Id, isValidPositionId } from './chess960';
@@ -16,10 +34,9 @@ import chessground from './chessground';
 import type EditorCtrl from './ctrl';
 import type { Selected, CastlingToggle, EditorState, EndgamePosition, OpeningPosition } from './interfaces';
 
-function castleCheckBox(ctrl: EditorCtrl, id: CastlingToggle, label: string, reversed: boolean): VNode {
-  const input = h('input', {
+function castleCheckBox(ctrl: EditorCtrl, id: CastlingToggle, inputLabel: string, reversed: boolean): VNode {
+  const inputElement = input('checkbox')({
     class: { 'not-allowed': !ctrl.enabledCastlingToggles[id] },
-    attrs: { type: 'checkbox' },
     props: {
       checked: ctrl.castlingToggles[id] && ctrl.enabledCastlingToggles[id],
       disabled: !ctrl.enabledCastlingToggles[id],
@@ -30,18 +47,19 @@ function castleCheckBox(ctrl: EditorCtrl, id: CastlingToggle, label: string, rev
       },
     },
   });
-  return h('label', reversed ? [input, label] : [label, input]);
+  return label(reversed ? [inputElement, inputLabel] : [inputLabel, inputElement]);
 }
 
 function studyButton(ctrl: EditorCtrl, state: EditorState): VNode {
-  return h('form', { attrs: { method: 'post', action: '/study/as' } }, [
-    h('input', { attrs: { type: 'hidden', name: 'orientation', value: ctrl.bottomColor() } }),
-    h('input', { attrs: { type: 'hidden', name: 'variant', value: lichessRules(ctrl.variant) } }),
-    h('input', { attrs: { type: 'hidden', name: 'fen', value: state.legalFen || '' } }),
-    h(
-      'button',
+  return form({ method: 'post', action: '/study/as' }, [
+    input('hidden')({ name: 'orientation', value: ctrl.bottomColor() }),
+    input('hidden')({ name: 'variant', value: lichessRules(ctrl.variant) }),
+    input('hidden')({ name: 'fen', value: state.legalFen || '' }),
+    button(
       {
-        attrs: { type: 'submit', 'data-icon': licon.StudyBoard, disabled: !state.legalFen },
+        type: 'submit',
+        ...dataIcon(licon.StudyBoard),
+        disabled: !state.legalFen,
         class: { button: true, 'button-empty': true, text: true, disabled: !state.legalFen },
       },
       i18n.site.toStudy,
@@ -49,15 +67,22 @@ function studyButton(ctrl: EditorCtrl, state: EditorState): VNode {
   ]);
 }
 
-function variant2option(key: VariantKey, name: string, ctrl: EditorCtrl): VNode {
-  return h(
-    'option',
-    { attrs: { value: key, selected: key === ctrl.variant } },
-    `${i18n.site.variant} | ${name}`,
+function variantOption(key: VariantKey, name: string, ctrl: EditorCtrl): VNode {
+  return option({ value: key, selected: key === ctrl.variant }, `${i18n.site.variant} | ${name}`);
+}
+
+function endgamePositionOption(pos: EndgamePosition): VNode {
+  return option({ value: pos.epd || pos.fen, 'data-fen': pos.fen }, pos.name);
+}
+
+function positionOption(pos: OpeningPosition): VNode {
+  return option(
+    { value: pos.epd || pos.fen, 'data-fen': pos.fen },
+    pos.eco ? `${pos.eco} ${pos.name}` : pos.name,
   );
 }
 
-const allVariants: Array<[VariantKey, string]> = [
+const ALL_VARIANTS: Array<[VariantKey, string]> = [
   ['standard', i18n.variant.standard],
   ['chess960', i18n.variant.chess960],
   ['kingOfTheHill', i18n.variant.kingOfTheHill],
@@ -69,54 +94,52 @@ const allVariants: Array<[VariantKey, string]> = [
   ['racingKings', i18n.variant.racingKings],
 ];
 
+function controlsButtonStart(ctrl: EditorCtrl, icon?: LiconValue) {
+  return button(
+    `.button.button-empty${icon ? '.text' : ''}`,
+    {
+      on: {
+        click(e) {
+          e.preventDefault();
+          ctrl.startPosition();
+        },
+      },
+      type: 'button',
+      ...(icon ? dataIcon(icon) : {}),
+    },
+    i18n.site.startPosition,
+  );
+}
+
+function controlsButtonClear(ctrl: EditorCtrl, icon?: LiconValue) {
+  return button(
+    `.button.button-empty${icon ? '.text' : ''}`,
+    {
+      on: {
+        click(e) {
+          e.preventDefault();
+          ctrl.clearBoard();
+        },
+      },
+      type: 'button',
+      ...(icon ? dataIcon(icon) : {}),
+    },
+    i18n.site.clearBoard,
+  );
+}
+
 function controls(ctrl: EditorCtrl, state: EditorState): VNode {
-  const endgamePosition2option = function (pos: EndgamePosition): VNode {
-    return h('option', { attrs: { value: pos.epd || pos.fen, 'data-fen': pos.fen } }, pos.name);
-  };
-
-  const buttonStart = (icon?: LiconValue) =>
-    h(
-      `button.button.button-empty${icon ? '.text' : ''}`,
-      {
-        on: {
-          click(e) {
-            e.preventDefault();
-            ctrl.startPosition();
-          },
-        },
-        attrs: { type: 'button', ...(icon ? dataIcon(icon) : {}) },
-      },
-      i18n.site.startPosition,
-    );
-  const buttonClear = (icon?: LiconValue) =>
-    h(
-      `button.button.button-empty${icon ? '.text' : ''}`,
-      {
-        on: {
-          click(e) {
-            e.preventDefault();
-            ctrl.clearBoard();
-          },
-        },
-        attrs: { type: 'button', ...(icon ? dataIcon(icon) : {}) },
-      },
-      i18n.site.clearBoard,
-    );
-
   const chess960PositionIdSelector =
     ctrl.variant !== 'chess960'
       ? null
-      : h('div.metadata', [
-          h('div.chess960-position-row', [
-            h(
-              'label.form-label',
-              {
-                attrs: { for: 'chess960-position-id' },
-              },
-              'Chess960 position',
-            ),
-            h('input#chess960-position-id', {
-              attrs: { minlength: 1, maxlength: 3, type: 'number', min: '0', max: '959' },
+      : div('.metadata', [
+          div('.chess960-position-row', [
+            label('.form-label', { for: 'chess960-position-id' }, 'Chess960 position'),
+            input('number')('#chess960-position-id', {
+              minlength: 1,
+              maxlength: 3,
+              min: '0',
+              max: '959',
               props: {
                 value: ctrl.chess960PositionId,
               },
@@ -131,8 +154,10 @@ function controls(ctrl: EditorCtrl, state: EditorState): VNode {
                 keydown: enter(target => target.blur()),
               },
             }),
-            h('button.button.button-empty', {
-              attrs: { type: 'button', title: i18n.site.randomChess960Position, ...dataIcon(licon.DieSix) },
+            button('.button.button-empty', {
+              type: 'button',
+              title: i18n.site.randomChess960Position,
+              ...dataIcon(licon.DieSix),
               on: {
                 click(e) {
                   e.preventDefault();
@@ -143,12 +168,11 @@ function controls(ctrl: EditorCtrl, state: EditorState): VNode {
           ]),
         ]);
 
-  return h('div.board-editor__tools', [
-    h('div.metadata', [
-      h(
-        'div.color',
-        h(
-          'select',
+  return div('.board-editor__tools', [
+    div('.metadata', [
+      div(
+        '.color',
+        select(
           {
             on: {
               change(e) {
@@ -157,35 +181,32 @@ function controls(ctrl: EditorCtrl, state: EditorState): VNode {
             },
             props: { value: ctrl.turn },
           },
-          (['whitePlays', 'blackPlays'] as const).map(function (key) {
-            return h(
-              'option',
+          (['whitePlays', 'blackPlays'] as const).map(key =>
+            option(
               {
-                attrs: {
-                  value: key.startsWith('w') ? 'white' : 'black',
-                  selected: key.startsWith(ctrl.turn[0]),
-                },
+                value: key.startsWith('w') ? 'white' : 'black',
+                selected: key.startsWith(ctrl.turn[0]),
               },
               i18n.site[key],
-            );
-          }),
+            ),
+          ),
         ),
       ),
-      h('div.castling', [
-        h('strong', i18n.site.castling),
-        h('div', [
+      div('.castling', [
+        strong(i18n.site.castling),
+        div([
           castleCheckBox(ctrl, 'K', i18n.site.whiteCastlingKingside, !!ctrl.options.inlineCastling),
           castleCheckBox(ctrl, 'Q', 'O-O-O', true),
         ]),
-        h('div', [
+        div([
           castleCheckBox(ctrl, 'k', i18n.site.blackCastlingKingside, !!ctrl.options.inlineCastling),
           castleCheckBox(ctrl, 'q', 'O-O-O', true),
         ]),
       ]),
-      h('div.enpassant', [
-        h('label', { attrs: { for: 'enpassant-select' } }, i18n.site.enPassant),
-        h(
-          'select#enpassant-select',
+      div('.enpassant', [
+        label({ for: 'enpassant-select' }, i18n.site.enPassant),
+        select(
+          '#enpassant-select',
           {
             on: {
               change(e) {
@@ -196,15 +217,12 @@ function controls(ctrl: EditorCtrl, state: EditorState): VNode {
           },
           ['', ...[ctrl.turn === 'black' ? 3 : 6].flatMap(r => 'abcdefgh'.split('').map(f => f + r))].map(
             key =>
-              h(
-                'option',
+              option(
                 {
-                  attrs: {
-                    value: key,
-                    selected: (key ? parseSquare(key) : undefined) === ctrl.epSquare,
-                    hidden: Boolean(key && !state.enPassantOptions.includes(key)),
-                    disabled: Boolean(key && !state.enPassantOptions.includes(key)) /*Safari*/,
-                  },
+                  value: key,
+                  selected: (key ? parseSquare(key) : undefined) === ctrl.epSquare,
+                  hidden: Boolean(key && !state.enPassantOptions.includes(key)),
+                  disabled: Boolean(key && !state.enPassantOptions.includes(key)) /*Safari*/,
                 },
                 key,
               ),
@@ -216,20 +234,14 @@ function controls(ctrl: EditorCtrl, state: EditorState): VNode {
       ? []
       : [
           (() => {
-            const positionOption = (pos: OpeningPosition): VNode =>
-              h(
-                'option',
-                { attrs: { value: pos.epd || pos.fen, 'data-fen': pos.fen } },
-                pos.eco ? `${pos.eco} ${pos.name}` : pos.name,
-              );
             const epd = fenToEpd(state.fen);
             const value =
               (
                 ctrl.cfg.positions.find(p => p.fen.startsWith(epd)) ||
                 ctrl.cfg.endgamePositions.find(p => p.epd === epd)
               )?.epd || '';
-            return h(
-              'select.positions',
+            return select(
+              '.positions',
               {
                 props: { value },
                 on: {
@@ -244,21 +256,20 @@ function controls(ctrl: EditorCtrl, state: EditorState): VNode {
                 },
               },
               [
-                h('option', { attrs: { value: '' } }, i18n.site.setTheBoard),
+                option({ value: '' }, i18n.site.setTheBoard),
                 optgroup(i18n.site.popularOpenings)(ctrl.cfg.positions.map(positionOption)),
-                optgroup(i18n.site.endgamePositions)(ctrl.cfg.endgamePositions.map(endgamePosition2option)),
+                optgroup(i18n.site.endgamePositions)(ctrl.cfg.endgamePositions.map(endgamePositionOption)),
               ],
             );
           })(),
         ]),
     ...(ctrl.cfg.embed
-      ? [h('div.actions', [chess960PositionIdSelector, buttonStart(), buttonClear()])]
+      ? [div('.actions', [chess960PositionIdSelector, controlsButtonStart(ctrl), controlsButtonClear(ctrl)])]
       : [
-          h('div', [
-            h(
-              'select',
+          div([
+            select(
               {
-                attrs: { id: 'variants' },
+                id: 'variants',
                 on: {
                   change(e) {
                     const value = (e.target as HTMLSelectElement).value;
@@ -267,17 +278,17 @@ function controls(ctrl: EditorCtrl, state: EditorState): VNode {
                   },
                 },
               },
-              allVariants.map(x => variant2option(x[0], x[1], ctrl)),
+              ALL_VARIANTS.map(x => variantOption(x[0], x[1], ctrl)),
             ),
           ]),
           chess960PositionIdSelector,
-          h('div.actions', [
-            buttonStart(licon.Reload),
-            buttonClear(licon.Trash),
-            h(
-              'button.button.button-empty.text',
+          div('.actions', [
+            controlsButtonStart(ctrl, licon.Reload),
+            controlsButtonClear(ctrl, licon.Trash),
+            button(
+              '.button.button-empty.text',
               {
-                attrs: { 'data-icon': licon.ChasingArrows },
+                ...dataIcon(licon.ChasingArrows),
                 on: {
                   click() {
                     ctrl.chessground!.toggleOrientation();
@@ -287,16 +298,10 @@ function controls(ctrl: EditorCtrl, state: EditorState): VNode {
               },
               i18n.site.flipBoard,
             ),
-            h(
-              'a',
+            a(state.legalFen ? ctrl.makeAnalysisUrl(state.legalFen, ctrl.bottomColor()) : '')(
               {
-                attrs: {
-                  'data-icon': licon.Microscope,
-                  rel: 'nofollow',
-                  ...(state.legalFen
-                    ? { href: ctrl.makeAnalysisUrl(state.legalFen, ctrl.bottomColor()) }
-                    : {}),
-                },
+                ...dataIcon(licon.Microscope),
+                rel: 'nofollow',
                 class: {
                   button: true,
                   'button-empty': true,
@@ -306,13 +311,10 @@ function controls(ctrl: EditorCtrl, state: EditorState): VNode {
               },
               i18n.site.analysis,
             ),
-            h(
-              'button',
+            button(
               {
                 class: { button: true, 'button-empty': true, disabled: !state.playable },
-                attrs: {
-                  disabled: !state.playable,
-                },
+                disabled: !state.playable,
                 on: {
                   click: () => {
                     if (state.playable)
@@ -325,19 +327,19 @@ function controls(ctrl: EditorCtrl, state: EditorState): VNode {
                   },
                 },
               },
-              [h('span.text', { attrs: dataIcon(licon.Swords) }, i18n.site.continueFromHere)],
+              [span('.text', dataIcon(licon.Swords), i18n.site.continueFromHere)],
             ),
             studyButton(ctrl, state),
           ]),
-          h('div.continue-with.none', [
-            h(
-              'a.button',
-              { attrs: { href: '/?fen=' + state.legalFen + '#ai', rel: 'nofollow' } },
+          div('.continue-with.none', [
+            a('/?fen=' + state.legalFen + '#ai')(
+              '.button',
+              { rel: 'nofollow' },
               i18n.site.playAgainstComputer,
             ),
-            h(
-              'a.button',
-              { attrs: { href: '/?fen=' + state.legalFen + '#friend', rel: 'nofollow' } },
+            a('/?fen=' + state.legalFen + '#friend')(
+              '.button',
+              { rel: 'nofollow' },
               i18n.site.challengeAFriend,
             ),
           ]),
@@ -348,9 +350,9 @@ function controls(ctrl: EditorCtrl, state: EditorState): VNode {
 function inputs(ctrl: EditorCtrl, fen: FEN): VNode | undefined {
   if (ctrl.cfg.embed) return undefined;
 
-  return h('div.copyables', [
-    h('p', [
-      h('strong', 'FEN'),
+  return div('.copyables', [
+    p([
+      strong('FEN'),
       copyMeInput(fen, {
         inputAttrs: { enterkeyhint: 'done' },
         on: {
@@ -379,22 +381,20 @@ function inputs(ctrl: EditorCtrl, fen: FEN): VNode | undefined {
         },
       }),
     ]),
-    h('p', [
-      h('strong.name', 'URL'),
+    p([
+      strong('.name', 'URL'),
       copyMeInput(ctrl.makeEditorUrl(fen, ctrl.bottomColor()), { inputAttrs: { readonly: true } }),
     ]),
-    h(
-      'a',
+    a(
+      xhrUrl(`${site.asset.baseUrl()}/export/fen.gif`, {
+        fen: ctrl.urlFen(fen),
+        color: ctrl.bottomColor(),
+        theme: document.body.dataset.board,
+        piece: document.body.dataset.pieceSet,
+      }),
+    )(
       {
-        attrs: {
-          href: xhrUrl(`${site.asset.baseUrl()}/export/fen.gif`, {
-            fen: ctrl.urlFen(fen),
-            color: ctrl.bottomColor(),
-            theme: document.body.dataset.board,
-            piece: document.body.dataset.pieceSet,
-          }),
-          download: true,
-        },
+        download: true,
       },
       'SCREENSHOT',
     ),
@@ -407,17 +407,17 @@ function selectedToClass(s: Selected): string {
 }
 
 let lastTouchMovePos: NumberPair | undefined;
+const piece = makeExoticTag('piece');
 
-function sparePieces(ctrl: EditorCtrl, color: Color, _orientation: Color, position: 'top' | 'bottom'): VNode {
+function sparePieces(ctrl: EditorCtrl, color: Color, position: 'top' | 'bottom'): VNode {
   const selectedClass = selectedToClass(ctrl.selected());
 
   const pieces = ['king', 'queen', 'rook', 'bishop', 'knight', 'pawn'].map(function (role) {
     return [color, role];
   });
 
-  return h(
-    'div',
-    { attrs: { class: ['spare', 'spare-' + position, 'spare-' + color].join(' ') } },
+  return div(
+    `.spare.spare-${position}.spare-${color}`,
     ['pointer', ...pieces, 'trash'].map((s: Selected) => {
       const className = selectedToClass(s);
       const attrs = {
@@ -431,8 +431,7 @@ function sparePieces(ctrl: EditorCtrl, color: Color, _orientation: Color, positi
       };
       const selectedSquare =
         selectedClass === className && !ctrl.chessground?.state.draggable.current?.newPiece;
-      return h(
-        'div',
+      return div(
         {
           class: {
             'no-square': true,
@@ -448,7 +447,7 @@ function sparePieces(ctrl: EditorCtrl, color: Color, _orientation: Color, positi
             },
           },
         },
-        [h('div', [h('piece', { attrs })])],
+        div(piece({ attrs })),
       );
     }),
   );
@@ -492,10 +491,10 @@ export default function (ctrl: EditorCtrl): VNode {
   const state = ctrl.getState();
   const color = ctrl.bottomColor();
 
-  return h(`div.board-editor.board-editor--${ctrl.variant}`, [
-    sparePieces(ctrl, opposite(color), color, 'top'),
-    h('div.main-board', { attrs: { style: `cursor: ${makeCursor(ctrl.selected())}` } }, [chessground(ctrl)]),
-    sparePieces(ctrl, color, color, 'bottom'),
+  return div(`.board-editor.board-editor--${ctrl.variant}`, [
+    sparePieces(ctrl, opposite(color), 'top'),
+    div('.main-board', { attrs: { style: `cursor: ${makeCursor(ctrl.selected())}` } }, chessground(ctrl)),
+    sparePieces(ctrl, color, 'bottom'),
     controls(ctrl, state),
     inputs(ctrl, state.legalFen || state.fen),
   ]);

--- a/ui/editor/src/view.ts
+++ b/ui/editor/src/view.ts
@@ -26,6 +26,7 @@ import {
   p,
   makeExoticTag,
   type VNode,
+  type MaybeVNode,
 } from 'lib/view';
 import { url as xhrUrl } from 'lib/xhr';
 
@@ -347,7 +348,7 @@ function controls(ctrl: EditorCtrl, state: EditorState): VNode {
   ]);
 }
 
-function inputs(ctrl: EditorCtrl, fen: FEN): VNode | undefined {
+function inputs(ctrl: EditorCtrl, fen: FEN): MaybeVNode {
   if (ctrl.cfg.embed) return undefined;
 
   return div('.copyables', [
@@ -411,13 +412,16 @@ const piece = makeExoticTag('piece');
 
 function sparePieces(ctrl: EditorCtrl, color: Color, position: 'top' | 'bottom'): VNode {
   const selectedClass = selectedToClass(ctrl.selected());
-
-  const pieces = ['king', 'queen', 'rook', 'bishop', 'knight', 'pawn'].map(function (role) {
-    return [color, role];
-  });
+  const pieces = ['king', 'queen', 'rook', 'bishop', 'knight', 'pawn'].map(role => [color, role]);
 
   return div(
-    `.spare.spare-${position}.spare-${color}`,
+    {
+      class: {
+        spare: true,
+        ['spare-' + position]: true,
+        ['spare-' + color]: true,
+      },
+    },
     ['pointer', ...pieces, 'trash'].map((s: Selected) => {
       const className = selectedToClass(s);
       const attrs = {

--- a/ui/lib/src/view/snabbdomElements.ts
+++ b/ui/lib/src/view/snabbdomElements.ts
@@ -150,6 +150,8 @@ export const span: TagFunction = makeTag('span');
 export const strong: TagFunction = makeTag('strong');
 export const time: TagFunction = makeTag('time');
 export const label: TagFunction = makeTag('label');
+export const select: TagFunction = makeTag('select');
+export const option: TagFunction = makeTag('option');
 export const main: TagFunction = makeTag('main');
 export const form: TagFunction = makeTag('form');
 export const h1: TagFunction = makeTag('h1');
@@ -164,6 +166,8 @@ export const td: TagFunction = makeTag('td');
 
 export const a: TagFactory<[href: string]> = href => makeTag('a', { href });
 export const img: TagFactory<[src: string, alt: string]> = (src, alt) => makeTag('img', { alt, src });
+export const input: TagFactory<[type: HTMLInputElement['type']]> = (type = 'text') =>
+  makeTag('input', { type });
 export const optgroup: TagFactory<[label: string]> = label => makeTag('optgroup', { label });
 
 export const icon: TagFactory<[icon: LiconValue]> = icon => makeExoticTag('icon', { 'data-icon': icon });


### PR DESCRIPTION
# How

Move editor view code to use snabbdom elements, add missing form-related element tags.

# Preview

<img width="1123" height="1137" alt="Screenshot 2026-08-10 at 12 52 02" src="https://github.com/user-attachments/assets/2d4fc10a-aaab-4060-9487-5ab12e4f8bc8" />

