### PR TITLE
ui: allow adjusting board brightness in transparent theme

### DIFF
--- a/ui/dasher/src/board.ts
+++ b/ui/dasher/src/board.ts
@@ -160,9 +160,8 @@ export class BoardCtrl extends PaneCtrl {
       sliders.push(this.propSlider('zoom', i18n.site.size, { min: 0, max: 100, step: 1 }));
     if (document.body.dataset.theme === 'transp')
       sliders.push(this.propSlider('board-opacity', i18n.site.opacity, { min: 0, max: 100, step: 1 }));
-    else
-      sliders.push(this.propSlider('board-brightness', i18n.site.brightness, { min: 20, max: 140, step: 1 }));
     sliders.push(
+      this.propSlider('board-brightness', i18n.site.brightness, { min: 20, max: 140, step: 1 }),
       this.propSlider('board-contrast', i18n.site.contrast, { min: 40, max: 200, step: 2 }),
       this.propSlider(
         'board-hue',

--- a/ui/lib/css/theme/board/_chessground.scss
+++ b/ui/lib/css/theme/board/_chessground.scss
@@ -3,6 +3,7 @@
 cg-board {
   @extend %box-shadow, %abs-100;
   @include prevent-select;
+  @include backdrop-blur-if-transparent;
 
   top: 0;
   left: 0;
@@ -28,7 +29,6 @@ cg-board::before {
 
     @include if-transp {
       opacity: calc(var(---board-opacity) / 100);
-      filter: hue-rotate(calc(var(---board-hue) * 3.6deg)) contrast(calc(var(---board-contrast) / 100));
     }
   }
 }


### PR DESCRIPTION
# Why

Due to some recent changes related to the picture theme, I feel like it make sense to allow adjusting board brightness also in that theme, since this allows a bit more of customisability, and prevent the board changing appearance when toggling theme.

# How

Append brightness slider non-conditionally, update board filters to include brightness value, add backdrop blur under chessground.

# Preview

<img width="1851" height="1095" alt="Screenshot 2026-08-10 at 13 52 40" src="https://github.com/user-attachments/assets/a3a3bcba-5b45-4b03-9181-7e258da30c24" />

<img width="1851" height="1095" alt="Screenshot 2026-08-10 at 13 40 04" src="https://github.com/user-attachments/assets/472ad72e-d251-4d72-a45c-db360233c26d" />
