### PR TITLE
ui(lib): reduce header cut-off visibility on quite uniform background

### DIFF
--- a/ui/lib/css/header/_header.scss
+++ b/ui/lib/css/header/_header.scss
@@ -41,7 +41,7 @@
       @include back-blur(6px);
 
       border: none;
-      background: hsl(0 0% 20% / 0.15);
+      background: linear-gradient(180deg, hsl(0 0% 20% / 0.25) 10%, transparent 90%);
     }
 
     .dropdown {


### PR DESCRIPTION
# How

Reduce header cut-off visibility in transparent them, when picture have a quite uniform background, but relaying on linear gradient, instead of solid color for header background.

On pictures with way more details at top, when blur is immediately visible there should be not much noticeable difference.

# Preview

### Before

<img width="1345" height="306" alt="Screenshot 2026-08-10 at 14 26 49" src="https://github.com/user-attachments/assets/a198a52e-a176-4550-bb4b-7fcd11b21ff9" />

### After

<img width="1345" height="306" alt="Screenshot 2026-08-10 at 14 26 57" src="https://github.com/user-attachments/assets/19ccdcfc-5ad2-42ca-8bab-cbea50404316" />
