### PR TITLE
group tv channels into collapsible sections

### DIFF
--- a/modules/tv/src/main/Tv.scala
+++ b/modules/tv/src/main/Tv.scala
@@ -211,6 +211,11 @@ object Tv:
   object Channel:
     val list = values.toList
     val byKey = values.mapBy(_.key)
+    val featured: List[Channel] = list.filter(c => c.speed.isEmpty && c.variant.isEmpty)
+    val grouped: List[(String, List[Channel])] = List(
+      "Speeds" -> list.filter(_.speed.isDefined),
+      "Variants" -> list.filter(_.variant.isDefined)
+    ).filter(_._2.nonEmpty)
 
   private def rated(min: Int) = (c: Candidate) => c.game.rated.yes && hasMinRating(c.game, IntRating(min))
   private def speed(speed: chess.Speed) = (c: Candidate) => c.game.speed == speed

--- a/modules/tv/src/main/TvUi.scala
+++ b/modules/tv/src/main/TvUi.scala
@@ -106,32 +106,49 @@ final class TvUi(helpers: lila.ui.Helpers)(
       )
 
     def channels(channel: Tv.Channel, champions: Tv.Champions, baseUrl: String)(using Context): Frag =
-      lila.ui.bits.subnav:
-        Tv.Channel.list.map: c =>
-          a(
-            href := s"$baseUrl/${c.key}",
+      lila.ui.bits.subnav(
+        Tv.Channel.featured.map(channelLink(channel, champions, baseUrl)),
+        Tv.Channel.grouped.map: (groupName, chans) =>
+          fieldset(
             cls := List(
-              "tv-channel" -> true,
-              c.key -> true,
-              "active" -> (c == channel)
+              "tv-channel-group" -> true,
+              "toggle-box" -> true,
+              "toggle-box--toggle" -> true,
+              "toggle-box--toggle-off" -> !chans.contains(channel)
             )
-          ):
-            span(dataIcon := c.icon):
-              span(
-                strong(c.translate),
-                span(cls := "champion")(
-                  champions
-                    .get(c)
-                    .fold[Frag](raw(" - ")): p =>
-                      frag(
-                        p.user.title.fold[Frag](p.user.name)(t => frag(t, nbsp, p.user.name)),
-                        ratingTag(
-                          " ",
-                          p.rating
-                        )
-                      )
-                )
-              )
+          )(
+            legend(tabindex := 0)(groupName),
+            chans.map(channelLink(channel, champions, baseUrl))
+          )
+      )
+
+    private def channelLink(active: Tv.Channel, champions: Tv.Champions, baseUrl: String)(
+        c: Tv.Channel
+    )(using Context): Frag =
+      a(
+        href := s"$baseUrl/${c.key}",
+        cls := List(
+          "tv-channel" -> true,
+          c.key -> true,
+          "active" -> (c == active)
+        )
+      ):
+        span(dataIcon := c.icon):
+          span(
+            strong(c.translate),
+            span(cls := "champion")(
+              champions
+                .get(c)
+                .fold[Frag](raw(" - ")): p =>
+                  frag(
+                    p.user.title.fold[Frag](p.user.name)(t => frag(t, nbsp, p.user.name)),
+                    ratingTag(
+                      " ",
+                      p.rating
+                    )
+                  )
+            )
+          )
 
     def sides(
         pov: Pov,

--- a/ui/bits/css/build/bits.tv.games.scss
+++ b/ui/bits/css/build/bits.tv.games.scss
@@ -1,3 +1,4 @@
 @import '../../../lib/css/plugin';
 @import '../../../lib/css/component/now-playing';
+@import '../../../lib/css/component/toggle-box';
 @import '../tv/games';

--- a/ui/bits/css/build/bits.tv.single.scss
+++ b/ui/bits/css/build/bits.tv.single.scss
@@ -1,2 +1,3 @@
 @import '../../../lib/css/plugin';
+@import '../../../lib/css/component/toggle-box';
 @import '../tv/single';

--- a/ui/bits/css/tv/_side.scss
+++ b/ui/bits/css/tv/_side.scss
@@ -35,6 +35,49 @@
   }
 }
 
+.tv-channel-group {
+  margin: 0;
+  padding: 0;
+  border: none;
+  background: none;
+
+  legend {
+    width: 100%;
+    background: none;
+    border: none;
+    border-top: $border;
+    font-size: 0.9em;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    color: $c-font-dim;
+    text-align: end;
+    padding: 0.5rem 2em 0.5rem 0;
+    margin-top: 0.5rem;
+
+    &:hover {
+      background: none;
+    }
+
+    &::after {
+      font-size: 12px;
+    }
+  }
+}
+
+@include mq-subnav-top {
+  .tv-channel-group {
+    display: contents;
+
+    legend {
+      display: none;
+    }
+
+    > a {
+      display: flex;
+    }
+  }
+}
+
 @include mq-subnav-top {
   .round__side {
     overflow: hidden;


### PR DESCRIPTION
# Why
The TV Channel UI is a bit busy with all the channel types listed in a row.

# How
1. Grouped channels by their filter (if time control filter is defined or if variant filter is defined)
2. Use existing toggle box for collapse sections based on these groups

# Preview
Images showing ui:
<img width="2880" height="1881" alt="open" src="https://github.com/user-attachments/assets/1b44b6f4-9c27-4c7d-be95-f54b6c38403b" />
<img width="2880" height="1881" alt="closed" src="https://github.com/user-attachments/assets/9df04817-76b3-4703-bd78-9ab90a6e6ae9" />

Video showing ui:
https://github.com/user-attachments/assets/0b54f77a-ee9c-42d2-b17e-3b018efdb4e8

I was working on adding opening-based tv channels - but this seemed like a good change regardless of that idea. 

I am a bit new here, so please let me know if I can do anything differently / better. Thanks! 