### PR TITLE
Add Firefox version 115 requirement to browserslist

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   "browserslist": [
     "defaults",
     "not op_mini all",
-    "not kaios <= 4"
+    "not kaios <= 4",
+    "firefox >= 115"
   ]
 }


### PR DESCRIPTION
used to see https://browsersl.ist/#q=defaults%2C+not+op_mini+all%2C+not+kaios+%3C%3D+4%2C+firefox+%3E%3D+115

and due https://github.com/lichess-org/lila/issues/21223