### PR TITLE
corrected the positioning of the crosstable to be top aligned with a .5em padding top

### DIFF
--- a/ui/analyse/css/_round-underboard.scss
+++ b/ui/analyse/css/_round-underboard.scss
@@ -67,8 +67,9 @@ $col2-panel-height: 240px;
   }
 
   .ctable {
-    align-items: center;
+    align-items: flex-start;
     justify-content: center;
+    padding: 0.5em 0 0 0;
 
     &.active {
       display: flex;


### PR DESCRIPTION
Fixes this minor layout issue: https://github.com/lichess-org/lila/issues/21263