### PR TITLE
Keep them sliders in the same place

### DIFF
--- a/modules/coreI18n/src/main/key.scala
+++ b/modules/coreI18n/src/main/key.scala
@@ -2295,7 +2295,7 @@ object I18nKey:
     val `deviceTheme`: I18nKey = "deviceTheme"
     val `roundness`: I18nKey = "roundness"
     val `backgroundImageUrl`: I18nKey = "backgroundImageUrl"
-    val `backgroundImageOpacity`: I18nKey = "backgroundImageOpacity"
+    val `pictureBrightness`: I18nKey = "pictureBrightness"
     val `board`: I18nKey = "board"
     val `size`: I18nKey = "size"
     val `opacity`: I18nKey = "opacity"

--- a/modules/coreI18n/src/main/key.scala
+++ b/modules/coreI18n/src/main/key.scala
@@ -2295,7 +2295,7 @@ object I18nKey:
     val `deviceTheme`: I18nKey = "deviceTheme"
     val `roundness`: I18nKey = "roundness"
     val `backgroundImageUrl`: I18nKey = "backgroundImageUrl"
-    val `pictureBrightness`: I18nKey = "pictureBrightness"
+    val `imageOpacity`: I18nKey = "imageOpacity"
     val `board`: I18nKey = "board"
     val `size`: I18nKey = "size"
     val `opacity`: I18nKey = "opacity"

--- a/translation/source/site.xml
+++ b/translation/source/site.xml
@@ -837,7 +837,7 @@
   <string name="deviceTheme">Device theme</string>
   <string name="roundness">Roundness</string>
   <string name="backgroundImageUrl">Background image URL:</string>
-  <string name="backgroundImageOpacity">Background image opacity:</string>
+  <string name="pictureBrightness">Picture brightness</string>
   <string name="board">Board</string>
   <string name="size">Size</string>
   <string name="opacity">Opacity</string>

--- a/translation/source/site.xml
+++ b/translation/source/site.xml
@@ -837,7 +837,7 @@
   <string name="deviceTheme">Device theme</string>
   <string name="roundness">Roundness</string>
   <string name="backgroundImageUrl">Background image URL:</string>
-  <string name="pictureBrightness">Picture brightness</string>
+  <string name="imageOpacity">Image opacity</string>
   <string name="board">Board</string>
   <string name="size">Size</string>
   <string name="opacity">Opacity</string>

--- a/ui/@types/lichess/i18n.d.ts
+++ b/ui/@types/lichess/i18n.d.ts
@@ -3255,8 +3255,6 @@ interface I18n {
     averageRatingX: I18nFormat;
     /** Background */
     background: string;
-    /** Background image opacity: */
-    backgroundImageOpacity: string;
     /** Background image URL: */
     backgroundImageUrl: string;
     /** Back to game */
@@ -4223,6 +4221,8 @@ interface I18n {
     permanentLinkForAnyoneToChallengeYou: string;
     /** Picture */
     picture: string;
+    /** Picture brightness */
+    pictureBrightness: string;
     /** Piece set */
     pieceSet: string;
     /** Pinned pieces */

--- a/ui/@types/lichess/i18n.d.ts
+++ b/ui/@types/lichess/i18n.d.ts
@@ -3769,6 +3769,8 @@ interface I18n {
     ifYouDoNotGetTheEmail: string;
     /** If you don't see the email, check other places it might be, like your junk, spam, social, or other folders. */
     ifYouDoNotSeeTheEmailCheckOtherPlaces: string;
+    /** Image opacity */
+    imageOpacity: string;
     /** Important */
     important: string;
     /** Imported by %s */
@@ -4221,8 +4223,6 @@ interface I18n {
     permanentLinkForAnyoneToChallengeYou: string;
     /** Picture */
     picture: string;
-    /** Picture brightness */
-    pictureBrightness: string;
     /** Piece set */
     pieceSet: string;
     /** Pinned pieces */

--- a/ui/dasher/css/_theme.scss
+++ b/ui/dasher/css/_theme.scss
@@ -6,7 +6,8 @@
     display: block;
   }
 
-  .ui-roundness .slider-label {
+  .ui-roundness .slider-label,
+  .bg-opacity .slider-label {
     @extend %flex-between;
 
     color: $c-font-dim;
@@ -21,6 +22,10 @@
       font-size: 0.9rem;
       font-family: monospace;
     }
+  }
+
+  .bg-opacity .slider-label {
+    border-top: none;
   }
 
   .range {

--- a/ui/dasher/src/theme.ts
+++ b/ui/dasher/src/theme.ts
@@ -62,6 +62,15 @@ export class ThemeCtrl extends PaneCtrl {
           );
         }),
         this.propSlider('ui-roundness', i18n.site.roundness, { min: 0, max: 15, step: 1 }),
+        cur === 'transp'
+          ? this.propSlider(
+              'bg-opacity',
+              i18n.site.pictureBrightness,
+              { min: 5, max: 100, step: 1 },
+              val => `${val}%`,
+              '',
+            )
+          : null,
       ]),
       cur === 'transp' ? (this.backgroundData.gallery ? this.galleryInput() : this.imageInput()) : null,
     ]);
@@ -140,13 +149,6 @@ export class ThemeCtrl extends PaneCtrl {
           );
         }),
       }),
-      this.propSlider(
-        'bg-opacity',
-        i18n.site.backgroundImageOpacity,
-        { min: 5, max: 100, step: 1 },
-        val => `${val}%`,
-        '',
-      ),
     ]);
 
   private readonly galleryInput = () => {

--- a/ui/dasher/src/theme.ts
+++ b/ui/dasher/src/theme.ts
@@ -64,7 +64,7 @@ export class ThemeCtrl extends PaneCtrl {
         cur === 'transp'
           ? this.propSlider(
               'bg-opacity',
-              i18n.site.pictureBrightness,
+              i18n.site.imageOpacity,
               { min: 5, max: 100, step: 1 },
               val => `${val}%`,
               '',

--- a/ui/dasher/src/theme.ts
+++ b/ui/dasher/src/theme.ts
@@ -46,7 +46,6 @@ export class ThemeCtrl extends PaneCtrl {
 
     return div('.sub.theme', [
       header(i18n.site.theme, this.close),
-      label(i18n.site.background),
       div('.selector.large', [
         this.list.map(bg => {
           return button(


### PR DESCRIPTION
Remove the "Background" category header text from dasher's theme pane. Mobile needs that vertical space and it's not needed to understand the options.

Move the bg-opacity slider below roundness and call it "Picture brightness" because there's a black background behind the picture. So it currently behaves like brightness.

Transparent theme users chose their picture based on how it looked at 100%. I would reconsider changing everyone to 50%.

<img width="261" height="520" alt="image" src="https://github.com/user-attachments/assets/436ed898-4c72-439f-9859-82d3721f9bb5" />
