### PR TITLE
ui(analyse): hide Share tab if sharing is disable, code tweaks

### DIFF
--- a/ui/analyse/src/study/studyShare.ts
+++ b/ui/analyse/src/study/studyShare.ts
@@ -5,22 +5,12 @@ import { type VNode, bind, dataIcon, hl, copyMeInput, type MaybeVNode } from 'li
 import { cmnToggleProp } from 'lib/view/cmn-toggle';
 import { writeTextClipboard, url as xhrUrl } from 'lib/xhr';
 
-import { renderIndexAndMove } from '../view/components';
-import { baseUrl } from '../view/util';
+import { renderIndexAndMove } from '@/view/components';
+import { baseUrl } from '@/view/util';
+
 import type { ChapterPreview, StudyData } from './interfaces';
 import type RelayCtrl from './relay/relayCtrl';
 import { relayIframe } from './relay/relayTourView';
-
-function fromPly(ctrl: StudyShare): MaybeVNode {
-  if (!ctrl.onMainline()) return undefined;
-  const renderedMove = renderIndexAndMove(ctrl.currentNode(), false, false);
-  return hl('label.url-start-at-ply', [
-    cmnToggleProp({ id: 'study-share-start-position', prop: ctrl.withPly, redraw: ctrl.redraw }),
-    ...(renderedMove.length
-      ? i18n.study.startAtX.asArray(hl('strong', renderedMove))
-      : [i18n.study.startAtInitialPosition]),
-  ]);
-}
 
 export class StudyShare {
   withPly = prop(false);
@@ -46,192 +36,205 @@ export class StudyShare {
   gamebook = this.data.chapter.gamebook;
 }
 
-export function view(ctrl: StudyShare): VNode {
-  const studyId = ctrl.studyId,
-    chapter = ctrl.chapter();
-  const isPrivate = ctrl.isPrivate();
-  const addPly = (path: string) =>
-    ctrl.onMainline() ? (ctrl.withPly() ? `${path}#${ctrl.currentNode().ply}` : path) : `${path}#last`;
-  const youCanPasteThis = () =>
-    hl(
-      'p.form-help.text',
-      { attrs: dataIcon(licon.InfoCircle) },
-      i18n.study.youCanPasteThisInTheForumToEmbed,
-    );
-  const copyChapterPgn = (url: string, text: string) =>
-    hl(
-      'a.button.text',
-      {
-        attrs: {
-          ...dataIcon(licon.Clipboard),
-          tabindex: '0',
-          'data-url': url,
-        },
-        hook: bind('click', async event => {
-          const target = event.target as HTMLElement;
-          const url = target.dataset['url']!;
-          const iconFeedback = (success: boolean) => {
-            target.setAttribute('data-icon', success ? licon.Checkmark : licon.X);
-            setTimeout(() => target.setAttribute('data-icon', licon.Clipboard), 1000);
-          };
-          writeTextClipboard(url).then(
-            () => iconFeedback(true),
-            err => {
-              console.log(err);
-              iconFeedback(false);
-            },
-          );
-        }),
-      },
-      text,
-    );
+function fromPly(ctrl: StudyShare): MaybeVNode {
+  if (!ctrl.onMainline()) return undefined;
+  const renderedMove = renderIndexAndMove(ctrl.currentNode(), false, false);
+  return hl('label.url-start-at-ply', [
+    cmnToggleProp({ id: 'study-share-start-position', prop: ctrl.withPly, redraw: ctrl.redraw }),
+    ...(renderedMove.length
+      ? i18n.study.startAtX.asArray(hl('strong', renderedMove))
+      : [i18n.study.startAtInitialPosition]),
+  ]);
+}
+
+function youCanPasteThis() {
   return hl(
-    'div.study__share',
-    ctrl.shareable()
-      ? [
-          hl('div.downloads', [
-            ctrl.cloneable() &&
-              hl(
-                'a.button.text',
-                { attrs: { ...dataIcon(licon.StudyBoard), href: `/study/${studyId}/clone` } },
-                i18n.study.cloneStudy,
-              ),
-            ctrl.relay &&
-              hl(
-                'a.button.text',
-                {
-                  attrs: {
-                    ...dataIcon(licon.Download),
-                    href: `/api/broadcast/${ctrl.relay.data.tour.id}.pgn`,
-                    download: true,
-                  },
-                },
-                i18n.broadcast.downloadAllRounds,
-              ),
-            hl(
-              'a.button.text',
-              {
-                attrs: {
-                  ...dataIcon(licon.Download),
-                  href: ctrl.relay ? `${ctrl.relay.roundPath()}.pgn` : `/study/${studyId}.pgn`,
-                  download: true,
-                },
-              },
-              ctrl.relay ? i18n.site.downloadAllGames : i18n.study.studyPgn,
-            ),
-            hl(
-              'a.button.text',
-              {
-                attrs: {
-                  ...dataIcon(licon.Download),
-                  href: `/study/${studyId}/${chapter.id}.pgn`,
-                  download: true,
-                },
-              },
-              ctrl.relay ? i18n.study.downloadGame : i18n.study.chapterPgn,
-            ),
-            copyChapterPgn(`/study/${studyId}/${ctrl.chapter().id}.pgn`, i18n.study.copyChapterPgn),
-            copyChapterPgn(
-              `/study/${studyId}/${ctrl.chapter().id}.pgn?clocks=false&comments=false&variations=false`,
-              i18n.study.copyRawChapterPgn,
-            ),
-            hl(
-              'a.button.text',
-              {
-                attrs: {
-                  ...dataIcon(licon.Download),
-                  href: xhrUrl(site.asset.baseUrl() + '/export/fen.gif', {
-                    fen: ctrl.currentNode().fen,
-                    color: ctrl.bottomColor(),
-                    lastMove: ctrl.currentNode().uci,
-                    variant: ctrl.variantKey,
-                    theme: document.body.dataset.board,
-                    piece: document.body.dataset.pieceSet,
-                  }),
-                  download: true,
-                },
-              },
-              'Board',
-            ),
-            hl(
-              'a.button.text',
-              {
-                attrs: {
-                  ...dataIcon(licon.Download),
-                  href: xhrUrl(`/study/${studyId}/${chapter.id}.gif`, {
-                    theme: document.body.dataset.board,
-                    piece: document.body.dataset.pieceSet,
-                    showGlyphs: true,
-                  }),
-                  download: true,
-                },
-              },
-              'GIF',
-            ),
-          ]),
-          hl('form.form3', [
-            (ctrl.relay
-              ? [
-                  [ctrl.relay.data.tour.name, ctrl.relay.tourPath()],
-                  [ctrl.data.name, ctrl.relay.roundPath()],
-                  [i18n.broadcast.currentGameUrl, addPly(`${ctrl.relay.roundPath()}/${chapter.id}`), true],
-                ]
-              : [
-                  [i18n.study.studyUrl, `/study/${studyId}`],
-                  [i18n.study.currentChapterUrl, addPly(`/study/${studyId}/${chapter.id}`), true],
-                ]
-            ).map(([text, path, pastable]: [string, string, boolean]) =>
-              hl('div.form-group', [
-                hl('label.form-label', text),
-                copyMeInput(`${baseUrl()}${path}`, { inputAttrs: { readonly: true } }),
-                pastable && fromPly(ctrl),
-                pastable && isPrivate && youCanPasteThis(),
-              ]),
-            ),
-            ctrl.relay
-              ? hl('div.form-group', [
-                  hl('label.form-label', 'Embed this particular game'),
-                  copyMeInput(relayIframe(`${ctrl.relay.roundPath()}/${chapter.id}`), {
-                    inputAttrs: { readonly: true },
-                  }),
-                  hl(
-                    'a.form-help.text',
-                    { attrs: { ...dataIcon(licon.InfoCircle), href: `${ctrl.relay.roundPath()}#overview` } },
-                    'More options for embedding a broadcast',
-                  ),
-                ])
-              : isPrivate || // study embed
-                hl('div.form-group', [
-                  hl('label.form-label', i18n.study.embedInYourWebsite),
-                  copyMeInput(
-                    !isPrivate
-                      ? `<iframe ${
-                          ctrl.gamebook ? 'width="320" height="320"' : 'width="600" height="371"'
-                        } src="${baseUrl()}${addPly(
-                          `/study/embed/${studyId}/${chapter.id}`,
-                        )}" frameborder=0></iframe>`
-                      : i18n.study.onlyPublicStudiesCanBeEmbedded,
-                    { inputAttrs: { readonly: true, disabled: isPrivate } },
-                  ),
-                  fromPly(ctrl),
-                  hl(
-                    'a.form-help.text',
-                    {
-                      attrs: {
-                        href: '/developers#embed-study',
-                        target: '_blank',
-                        ...dataIcon(licon.InfoCircle),
-                      },
-                    },
-                    i18n.study.readMoreAboutEmbedding,
-                  ),
-                ]),
-          ]),
-          hl('div.form-group', [
-            hl('label.form-label', 'FEN'),
-            copyMeInput(ctrl.currentNode().fen, { inputAttrs: { readonly: true } }),
-          ]),
-        ]
-      : hl('div', 'Sharing and exporting were disabled by the study owner.'),
+    'p.form-help.text',
+    { attrs: dataIcon(licon.InfoCircle) },
+    i18n.study.youCanPasteThisInTheForumToEmbed,
   );
+}
+
+function copyChapterPgn(url: string, text: string) {
+  return hl(
+    'a.button.text',
+    {
+      attrs: {
+        ...dataIcon(licon.Clipboard),
+        tabindex: '0',
+        'data-url': url,
+      },
+      hook: bind('click', async event => {
+        const target = event.target as HTMLElement;
+        const url = target.dataset['url']!;
+        const iconFeedback = (success: boolean) => {
+          target.setAttribute('data-icon', success ? licon.Checkmark : licon.X);
+          setTimeout(() => target.setAttribute('data-icon', licon.Clipboard), 1000);
+        };
+        writeTextClipboard(url).then(
+          () => iconFeedback(true),
+          err => {
+            console.log(err);
+            iconFeedback(false);
+          },
+        );
+      }),
+    },
+    text,
+  );
+}
+
+export function view(ctrl: StudyShare): VNode {
+  const { studyId, relay } = ctrl;
+  const chapter = ctrl.chapter();
+  const isPrivate = ctrl.isPrivate();
+  const currentNode = ctrl.currentNode();
+
+  const addPly = (path: string) =>
+    ctrl.onMainline() ? (ctrl.withPly() ? `${path}#${currentNode.ply}` : path) : `${path}#last`;
+
+  return hl('div.study__share', [
+    hl('div.downloads', [
+      ctrl.cloneable() &&
+        hl(
+          'a.button.text',
+          { attrs: { ...dataIcon(licon.StudyBoard), href: `/study/${studyId}/clone` } },
+          i18n.study.cloneStudy,
+        ),
+      relay &&
+        hl(
+          'a.button.text',
+          {
+            attrs: {
+              ...dataIcon(licon.Download),
+              href: `/api/broadcast/${relay.data.tour.id}.pgn`,
+              download: true,
+            },
+          },
+          i18n.broadcast.downloadAllRounds,
+        ),
+      hl(
+        'a.button.text',
+        {
+          attrs: {
+            ...dataIcon(licon.Download),
+            href: relay ? `${relay.roundPath()}.pgn` : `/study/${studyId}.pgn`,
+            download: true,
+          },
+        },
+        relay ? i18n.site.downloadAllGames : i18n.study.studyPgn,
+      ),
+      hl(
+        'a.button.text',
+        {
+          attrs: {
+            ...dataIcon(licon.Download),
+            href: `/study/${studyId}/${chapter.id}.pgn`,
+            download: true,
+          },
+        },
+        relay ? i18n.study.downloadGame : i18n.study.chapterPgn,
+      ),
+      copyChapterPgn(`/study/${studyId}/${chapter.id}.pgn`, i18n.study.copyChapterPgn),
+      copyChapterPgn(
+        `/study/${studyId}/${chapter.id}.pgn?clocks=false&comments=false&variations=false`,
+        i18n.study.copyRawChapterPgn,
+      ),
+      hl(
+        'a.button.text',
+        {
+          attrs: {
+            ...dataIcon(licon.Download),
+            href: xhrUrl(site.asset.baseUrl() + '/export/fen.gif', {
+              fen: currentNode.fen,
+              color: ctrl.bottomColor(),
+              lastMove: currentNode.uci,
+              variant: ctrl.variantKey,
+              theme: document.body.dataset.board,
+              piece: document.body.dataset.pieceSet,
+            }),
+            download: true,
+          },
+        },
+        'Board',
+      ),
+      hl(
+        'a.button.text',
+        {
+          attrs: {
+            ...dataIcon(licon.Download),
+            href: xhrUrl(`/study/${studyId}/${chapter.id}.gif`, {
+              theme: document.body.dataset.board,
+              piece: document.body.dataset.pieceSet,
+              showGlyphs: true,
+            }),
+            download: true,
+          },
+        },
+        'GIF',
+      ),
+    ]),
+    hl('form.form3', [
+      (relay
+        ? [
+            [relay.data.tour.name, relay.tourPath()],
+            [ctrl.data.name, relay.roundPath()],
+            [i18n.broadcast.currentGameUrl, addPly(`${relay.roundPath()}/${chapter.id}`), true],
+          ]
+        : [
+            [i18n.study.studyUrl, `/study/${studyId}`],
+            [i18n.study.currentChapterUrl, addPly(`/study/${studyId}/${chapter.id}`), true],
+          ]
+      ).map(([text, path, pastable]: [string, string, boolean]) =>
+        hl('div.form-group', [
+          hl('label.form-label', text),
+          copyMeInput(`${baseUrl()}${path}`, { inputAttrs: { readonly: true } }),
+          pastable && fromPly(ctrl),
+          pastable && isPrivate && youCanPasteThis(),
+        ]),
+      ),
+      relay
+        ? hl('div.form-group', [
+            hl('label.form-label', 'Embed this particular game'),
+            copyMeInput(relayIframe(`${relay.roundPath()}/${chapter.id}`), {
+              inputAttrs: { readonly: true },
+            }),
+            hl(
+              'a.form-help.text',
+              { attrs: { ...dataIcon(licon.InfoCircle), href: `${relay.roundPath()}#overview` } },
+              'More options for embedding a broadcast',
+            ),
+          ])
+        : isPrivate || // study embed
+          hl('div.form-group', [
+            hl('label.form-label', i18n.study.embedInYourWebsite),
+            copyMeInput(
+              !isPrivate
+                ? `<iframe ${
+                    ctrl.gamebook ? 'width="320" height="320"' : 'width="600" height="371"'
+                  } src="${baseUrl()}${addPly(
+                    `/study/embed/${studyId}/${chapter.id}`,
+                  )}" frameborder=0></iframe>`
+                : i18n.study.onlyPublicStudiesCanBeEmbedded,
+              { inputAttrs: { readonly: true, disabled: isPrivate } },
+            ),
+            fromPly(ctrl),
+            hl(
+              'a.form-help.text',
+              {
+                attrs: {
+                  href: '/developers#embed-study',
+                  target: '_blank',
+                  ...dataIcon(licon.InfoCircle),
+                },
+              },
+              i18n.study.readMoreAboutEmbedding,
+            ),
+          ]),
+    ]),
+    hl('div.form-group', [
+      hl('label.form-label', 'FEN'),
+      copyMeInput(currentNode.fen, { inputAttrs: { readonly: true } }),
+    ]),
+  ]);
 }

--- a/ui/analyse/src/study/studyView.ts
+++ b/ui/analyse/src/study/studyView.ts
@@ -310,13 +310,14 @@ function buttons(root: AnalyseCtrl): VNode {
         icon: icon(licon.Multiboard)(),
         shouldBlurIfPrimaryClick: true,
       }),
-      toolButton({
-        ctrl,
-        tab: 'share',
-        hint: i18n.study.shareAndExport,
-        icon: icon(shareIcon())(),
-        shouldBlurIfPrimaryClick: true,
-      }),
+      ctrl.share.shareable() &&
+        toolButton({
+          ctrl,
+          tab: 'share',
+          hint: i18n.study.shareAndExport,
+          icon: icon(shareIcon())(),
+          shouldBlurIfPrimaryClick: true,
+        }),
       !ctrl.relay &&
         !ctrl.data.chapter.gamebook &&
         hl('button.help', {


### PR DESCRIPTION
# Why

We can spare a bit of vertical space, and spare users few clicks by hiding Share tab in unberboard, when study author disables it.

# How

Hide Share tab if sharing is disable by the study author, small code reorganization/tweaks.

# Preview

<img width="994" height="223" alt="Screenshot 2026-08-12 at 10 15 00" src="https://github.com/user-attachments/assets/cc57e467-08e6-4c14-8be1-2c8d98c7b63f" />
