### PR TITLE
ui(tournament): reorganize and reduce side content, calendar visual tweak

### DIFF
--- a/modules/tournament/src/main/TournamentRepo.scala
+++ b/modules/tournament/src/main/TournamentRepo.scala
@@ -262,7 +262,11 @@ final class TournamentRepo(val coll: Coll, playerCollName: CollName)(using Execu
 
   def allScheduledDedup: Fu[List[Tournament]] =
     coll
-      .find(createdSelect ++ scheduledSelect)
+      .find(
+        createdSelect ++ scheduledButNotHourly ++ $doc(
+          "startsAt".$lt(nowInstant.plusDays(21))
+        )
+      )
       .sort($doc("startsAt" -> 1))
       .cursor[Tournament]()
       .listAll()

--- a/modules/tournament/src/main/ui/TournamentList.scala
+++ b/modules/tournament/src/main/ui/TournamentList.scala
@@ -35,18 +35,6 @@ final class TournamentList(helpers: Helpers, ui: TournamentUi)(
       ):
         main(cls := "tour-home")(
           st.aside(cls := "tour-home__side")(
-            h2(
-              a(href := routes.Tournament.leaderboard)(trans.site.leaderboard())
-            ),
-            ul(cls := "leaderboard")(
-              winners.top.map: w =>
-                li(
-                  userIdLink(w.userId.some),
-                  a(title := w.tourName, href := routes.Tournament.show(w.tourId))(
-                    ui.scheduledTournamentNameShortHtml(w.tourName)
-                  )
-                )
-            ),
             p(cls := "tour__links")(
               ctx.me.map: me =>
                 frag(
@@ -63,6 +51,18 @@ final class TournamentList(helpers: Helpers, ui: TournamentUi)(
                 "Leagues & Streamer Battles"
               )
             ),
+            h2(
+              a(href := routes.Tournament.leaderboard)(trans.site.leaderboard())
+            ),
+            ul(cls := "leaderboard")(
+              winners.top.map: w =>
+                li(
+                  userIdLink(w.userId.some),
+                  a(title := w.tourName, href := routes.Tournament.show(w.tourId))(
+                    ui.scheduledTournamentNameShortHtml(w.tourName)
+                  )
+                )
+            ),
             h2(trans.site.lichessTournaments()),
             div(cls := "scheduled")(
               scheduled.map: tour =>
@@ -73,7 +73,8 @@ final class TournamentList(helpers: Helpers, ui: TournamentUi)(
                       strong(tour.name(full = false)),
                       momentFromNow(tour.startsAt)
                     )
-            )
+            ),
+            a(href := routes.Tournament.calendar)("See more tournaments on the calendar")
           ),
           st.section(cls := "tour-home__schedule box")(
             boxTop(

--- a/ui/tournament/css/_calendar.scss
+++ b/ui/tournament/css/_calendar.scss
@@ -118,7 +118,8 @@
 
     .icon {
       font-size: 1.3em;
-      margin: 2px 1px -1px 3px;
+      line-height: 1;
+      margin: 0 2px 0 4px;
     }
 
     .body {

--- a/ui/tournament/css/schedule/_side.scss
+++ b/ui/tournament/css/schedule/_side.scss
@@ -6,6 +6,7 @@
     margin-top: 30px;
     margin-bottom: 6px;
     border-bottom: $border;
+    padding-bottom: 4px;
 
     a {
       color: $c-font;
@@ -46,6 +47,7 @@
 
 .tour__links {
   margin-top: 1em;
+  line-height: 1.5;
 
   a {
     color: $c-font;
@@ -59,16 +61,17 @@
 }
 
 .scheduled {
+  margin-bottom: 6px;
+
   a {
-    color: $c-font;
-
     @include padding-direction(0.5em, 0, 0.5em, 2.7em);
+    @include transition;
 
+    color: $c-font;
     display: block;
     position: relative;
     line-height: 1.2;
-
-    @include transition;
+    min-height: 48px;
 
     &:hover {
       @extend %box-radius;
@@ -91,12 +94,10 @@
 
   a::before {
     @include transition;
+    @include inline-start(0);
 
     position: absolute;
     top: 0.3rem;
-
-    @include inline-start(0);
-
     font-size: 2.2em;
     opacity: 0.6;
     color: $c-brag;


### PR DESCRIPTION
# Why

Recently spotted that tournament home page (https://lichess.org/tournament) lists almost all scheduled upcoming tournaments in to indefinite future, leading to the page become very lengthy, with just a small portion of content on the left side, when scrolled down.

<img width="645" height="653" alt="Screenshot 2026-08-12 at 15 45 57" src="https://github.com/user-attachments/assets/a24dd09c-8777-4ebc-879c-9dd3ccc77082" />

# How

Summary of changes:
* limit scheduled/upcoming tournaments list to the next 21 days (was thinking about also adding a hard limit, like 50 entries, but time range seems more suitable here, but we can adjust that to whatever filter logic seems more useful)
* add link to calendar page at the end of the list, where all scheduled tournaments can be seen
* move tournament related links above the leaderboard section
* set minimal height for tournament links to avoid content shift due to client side `time` node becoming visible after server render)
* adjust spacing for links and between section. headers and separators
* fix game mode icons alignment in the calendar view

# Preview

<img width="404" height="350" alt="Screenshot 2026-08-12 at 16 15 00" src="https://github.com/user-attachments/assets/154e9b8a-3c1b-450a-878b-7723b91f324d" />

<img width="688" height="621" alt="Screenshot 2026-08-12 at 16 14 51" src="https://github.com/user-attachments/assets/07c355f0-8083-4148-8357-571e4290541c" />

<img width="645" height="649" alt="Screenshot 2026-08-12 at 16 10 18" src="https://github.com/user-attachments/assets/149f6fa2-79eb-4832-a347-72523326f6ea" />
