### PR TITLE
Keep chess960 castling rights for rooks off the corner

### DIFF
--- a/ui/editor/src/chess960.ts
+++ b/ui/editor/src/chess960.ts
@@ -1,6 +1,8 @@
 // Best description is found at https://fr.wikipedia.org/wiki/%C3%89checs_al%C3%A9atoires_Fischer#Identification_des_positions_initiales
 
-import { FILE_NAMES } from 'chessops';
+import { FILE_NAMES, SquareSet } from 'chessops';
+import type { Board } from 'chessops/board';
+import type { Square } from 'chessops/types';
 
 // Square on rank 1
 const darkSquares = [0, 2, 4, 6];
@@ -48,6 +50,25 @@ export function chess960CastlingSquares(id: number | undefined): ByColor<Castlin
       rookK: FILE_NAMES[rookKFile] + '8',
       rookQ: FILE_NAMES[rookQFile] + '8',
     },
+  };
+}
+
+export interface CastlingRooks {
+  rookQ?: Square;
+  rookK?: Square;
+}
+
+export function castlingRooksFromBoard(board: Board, color: Color): CastlingRooks {
+  const backRank = SquareSet.fromRank(color === 'white' ? 0 : 7),
+    king = board.king.intersect(board[color]).intersect(backRank).singleSquare();
+  if (king === undefined) return {};
+
+  const rooks = board.rook.intersect(board[color]).intersect(backRank),
+    queenside = rooks.first(),
+    kingside = rooks.last();
+  return {
+    rookQ: queenside !== undefined && queenside < king ? queenside : undefined,
+    rookK: kingside !== undefined && kingside > king ? kingside : undefined,
   };
 }
 

--- a/ui/editor/src/ctrl.ts
+++ b/ui/editor/src/ctrl.ts
@@ -13,6 +13,7 @@ import { defined, prop, type Prop } from 'lib';
 import { prompt } from 'lib/view';
 
 import {
+  castlingRooksFromBoard,
   chess960CastlingSquares,
   chess960IdToFEN,
   fenToChess960Id,
@@ -139,9 +140,20 @@ export default class EditorCtrl {
   }
 
   private computeCastlingToggles(): CastlingToggles<boolean> {
+    const board = this.getBoard();
+    if (this.variant === 'chess960') {
+      const white = castlingRooksFromBoard(board, 'white'),
+        black = castlingRooksFromBoard(board, 'black');
+      return {
+        K: defined(white.rookK),
+        Q: defined(white.rookQ),
+        k: defined(black.rookK),
+        q: defined(black.rookQ),
+      };
+    }
+
     const chess960Castling = chess960CastlingSquares(this.chess960PositionId);
-    const board = this.getBoard(),
-      whiteKingOnE1 = board.king.intersect(board.white).has(parseSquare(chess960Castling.white.king)!),
+    const whiteKingOnE1 = board.king.intersect(board.white).has(parseSquare(chess960Castling.white.king)!),
       blackKingOnE8 = board.king.intersect(board.black).has(parseSquare(chess960Castling.black.king)!),
       whiteRooks = board.rook.intersect(board.white),
       blackRooks = board.rook.intersect(board.black);

--- a/ui/editor/tests/chess960.test.ts
+++ b/ui/editor/tests/chess960.test.ts
@@ -1,0 +1,69 @@
+import { parseSquare } from 'chessops';
+import { parseFen } from 'chessops/fen';
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+
+import { castlingRooksFromBoard } from '../src/chess960';
+
+const boardOf = (boardFen: string) => parseFen(`${boardFen} w - - 0 1`).unwrap().board;
+
+describe('castling rooks from board', () => {
+  test('standard back rank uses the corner rooks', () => {
+    const board = boardOf('rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR');
+
+    assert.deepEqual(castlingRooksFromBoard(board, 'white'), {
+      rookQ: parseSquare('a1'),
+      rookK: parseSquare('h1'),
+    });
+    assert.deepEqual(castlingRooksFromBoard(board, 'black'), {
+      rookQ: parseSquare('a8'),
+      rookK: parseSquare('h8'),
+    });
+  });
+
+  test('a rook off the corner is still a castling rook', () => {
+    const board = boardOf('rnbqk1r1/pppppppp/8/8/8/8/PPPPPPPP/RNBQK1R1');
+
+    assert.deepEqual(castlingRooksFromBoard(board, 'white'), {
+      rookQ: parseSquare('a1'),
+      rookK: parseSquare('g1'),
+    });
+    assert.deepEqual(castlingRooksFromBoard(board, 'black'), {
+      rookQ: parseSquare('a8'),
+      rookK: parseSquare('g8'),
+    });
+  });
+
+  test('the outermost rook on each side is picked', () => {
+    const board = boardOf('8/8/8/8/8/8/8/RR2K1RR');
+
+    assert.deepEqual(castlingRooksFromBoard(board, 'white'), {
+      rookQ: parseSquare('a1'),
+      rookK: parseSquare('h1'),
+    });
+  });
+
+  test('rooks on one side only grant that side', () => {
+    const board = boardOf('8/8/8/8/8/8/8/RR2K3');
+
+    assert.deepEqual(castlingRooksFromBoard(board, 'white'), {
+      rookQ: parseSquare('a1'),
+      rookK: undefined,
+    });
+  });
+
+  test('a king off the back rank has no castling rooks', () => {
+    const board = boardOf('8/8/8/8/8/8/4K3/R6R');
+
+    assert.deepEqual(castlingRooksFromBoard(board, 'white'), {});
+  });
+
+  test('rooks off the back rank are ignored', () => {
+    const board = boardOf('8/8/8/8/8/8/R6R/4K3');
+
+    assert.deepEqual(castlingRooksFromBoard(board, 'white'), {
+      rookQ: undefined,
+      rookK: undefined,
+    });
+  });
+});


### PR DESCRIPTION
Fixes #17919

### Problem

In the board editor set to chess960, castling rights are lost for any rook that is not on a1/h1.

Following the steps in the issue - remove the f1 bishop and g1 knight, put the rook on g1 - the
kingside toggle disappears and the right is dropped from the FEN. Loading
`rnbqk1r1/pppppppp/8/8/8/8/PPPPPPPP/RNBQK1R1 w KQkq - 0 1` into the chess960 editor gives back
`... w Qq - 0 1`, and white can no longer castle kingside.

<img width="1456" height="836" alt="1-before-rights-dropped" src="https://github.com/user-attachments/assets/53e5ebe3-5b36-4988-a163-e177e0bf53d0" />

### Cause

`computeCastlingToggles` asks `chess960CastlingSquares` for the squares of the current position id,
and that helper falls back to the standard position when the id is undefined:

```ts
const rank1 = chess960IdToRank(id ?? 518); // default to standard chess
```

`boardFenToChess960Id` only returns an id for a recognised chess960 starting arrangement, so as soon
as the board is edited into something else the toggles require rooks on a1/h1.

### Fix

For chess960 the castling rooks are now read off the board: the outermost rook on each side of the
king, on its back rank. That is the X-FEN reading, and the same rook `parseCastlingFen` resolves `K`
and `Q` to further down, so the toggles and the FEN the editor emits now agree.

Other variants are untouched and still require the usual squares - a rook on g1 in standard chess
still loses the kingside right.

### Testing

`ui/editor/tests/chess960.test.ts` covers the corner rooks, a rook off the corner, picking the
outermost of several rooks, one-sided rooks, and a king or rooks off the back rank. `pnpm test` is
221 passing; lint, format and tsc are clean.

Checked by hand on a local lila (lila-docker):

| Case | Expected | Result |
| --- | --- | --- |
| chess960, rook on g1 | rights kept | FEN keeps `KQkq`, all four toggles shown |
| chess960, castle kingside | allowed | `O-O` plays, king to g1 and rook to f1 |
| standard, rook on g1 | right dropped | `Qq`, unchanged from master |
<img width="1456" height="836" alt="2-after-rights-kept" src="https://github.com/user-attachments/assets/e41be0c3-87cf-483a-bbb5-7acbbbb35dd6" />

<img width="1456" height="836" alt="3-after-kingside-castling-works" src="https://github.com/user-attachments/assets/2292ad14-c5ce-496b-9fef-5b4c7c725c50" />

### AI usage disclosure

Written with Claude Code (Claude Opus 5), driven by me. The AI reproduced the issue, found the cause,
wrote the fix and the tests, and drove the local lila used for the checks above through browser
automation. I reviewed and directed the work, and approved the change before it was pushed. The
prompts used are recorded in the commit message.
