### PR TITLE
Copy sub-variations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,7 @@ node_modules/
 ui/lib/css/theme/gen/*.scss
 ui/.build/build
 ui/voice/crowdv
-ui/*/tsconfig.tsbuildinfo
+ui/**/tsconfig.tsbuildinfo
 hs_*.log
 dependency-graph.png
 dump.rdb

--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -130,7 +130,7 @@ export default class AnalyseCtrl implements CevalHandler {
   initialPath: TreePath;
   contextMenuPath?: TreePath;
   gamePath?: TreePath;
-  pendingCopyPath: Prop<TreePath | null>;
+  pendingCopy: Prop<{ eventPath: TreePath; withVariations: boolean } | null>;
   pendingDeletionPath: Prop<TreePath | null>;
 
   // misc
@@ -175,7 +175,7 @@ export default class AnalyseCtrl implements CevalHandler {
 
     this.initialize(this.data, false);
     this.initCeval();
-    this.pendingCopyPath = propWithEffect(null, this.redraw);
+    this.pendingCopy = propWithEffect(null, this.redraw);
     this.pendingDeletionPath = propWithEffect(null, this.redraw);
     this.initialPath = this.makeInitialPath();
     this.setPath(this.initialPath);
@@ -651,6 +651,13 @@ export default class AnalyseCtrl implements CevalHandler {
     else this.jump(this.path);
     if (this.study) this.study.deleteNode(path);
     this.redraw();
+  }
+
+  isPendingCopy(path: TreePath, isMainline: boolean): boolean {
+    const pending = this.pendingCopy();
+    if (!pending) return false;
+    const { eventPath, withVariations } = pending;
+    return withVariations ? treePath.areComparable(path, eventPath) : isMainline;
   }
 
   allowedEval(node: TreeNode = this.node): ClientEval | ServerEval | false | undefined {

--- a/ui/analyse/src/pgnExport.ts
+++ b/ui/analyse/src/pgnExport.ts
@@ -42,20 +42,20 @@ export function renderNodesHtml(nodes: PgnNode[]): MaybeVNodes {
 
 export function renderNodesPgn(game: Game, nodeList: TreeNode[], includeSubVariations: boolean): string {
   const filteredNodeList = nodeList.filter(node => node.san);
-  if (filteredNodeList.length === 0) return '';
-
   let variationPgn = '';
 
-  const first = filteredNodeList[0];
-  variationPgn += `${plyPrefix(first)}${first.san} `;
+  if (filteredNodeList.length) {
+    const first = filteredNodeList[0];
+    variationPgn += `${plyPrefix(first)}${first.san} `;
 
-  for (let i = 1; i < filteredNodeList.length; i++) {
-    const node = filteredNodeList[i];
-    if (node.ply % 2 === 1) {
-      variationPgn += plyToTurn(node.ply) + '. ';
+    for (let i = 1; i < filteredNodeList.length; i++) {
+      const node = filteredNodeList[i];
+      if (node.ply % 2 === 1) {
+        variationPgn += plyToTurn(node.ply) + '. ';
+      }
+
+      variationPgn += fixCrazySan(node.san!) + ' ';
     }
-
-    variationPgn += fixCrazySan(node.san!) + ' ';
   }
 
   variationPgn += renderNodesTxt(

--- a/ui/analyse/src/pgnExport.ts
+++ b/ui/analyse/src/pgnExport.ts
@@ -58,11 +58,7 @@ export function renderNodesPgn(game: Game, nodeList: TreeNode[], includeSubVaria
     }
   }
 
-  pgn += renderNodesTxt(
-    nodeList[nodeList.length - 1],
-    nonRootNodes.length === 0,
-    includeSubVariations,
-  );
+  pgn += renderNodesTxt(nodeList[nodeList.length - 1], nonRootNodes.length === 0, includeSubVariations);
 
   return pgn ? renderPgnTags(game) + pgn : '';
 }

--- a/ui/analyse/src/pgnExport.ts
+++ b/ui/analyse/src/pgnExport.ts
@@ -41,28 +41,28 @@ export function renderNodesHtml(nodes: PgnNode[]): MaybeVNodes {
 }
 
 export function renderNodesPgn(game: Game, nodeList: TreeNode[], includeSubVariations: boolean): string {
-  const filteredNodeList = nodeList.filter(node => node.san);
-  let variationPgn = '';
+  const nonRootNodes = nodeList.filter(node => node.san);
+  let pgn = '';
 
-  if (filteredNodeList.length) {
-    const first = filteredNodeList[0];
-    variationPgn += `${plyPrefix(first)}${first.san} `;
+  if (nonRootNodes.length) {
+    const first = nonRootNodes[0];
+    pgn += `${plyPrefix(first)}${first.san} `;
 
-    for (let i = 1; i < filteredNodeList.length; i++) {
-      const node = filteredNodeList[i];
+    for (let i = 1; i < nonRootNodes.length; i++) {
+      const node = nonRootNodes[i];
       if (node.ply % 2 === 1) {
-        variationPgn += plyToTurn(node.ply) + '. ';
+        pgn += plyToTurn(node.ply) + '. ';
       }
 
-      variationPgn += fixCrazySan(node.san!) + ' ';
+      pgn += fixCrazySan(node.san!) + ' ';
     }
   }
 
-  variationPgn += renderNodesTxt(
+  pgn += renderNodesTxt(
     nodeList[nodeList.length - 1],
-    filteredNodeList.length === 0,
+    nonRootNodes.length === 0,
     includeSubVariations,
   );
 
-  return variationPgn ? renderPgnTags(game) + variationPgn : '';
+  return pgn ? renderPgnTags(game) + pgn : '';
 }

--- a/ui/analyse/src/pgnExport.ts
+++ b/ui/analyse/src/pgnExport.ts
@@ -40,7 +40,7 @@ export function renderNodesHtml(nodes: PgnNode[]): MaybeVNodes {
   return tags;
 }
 
-export function renderVariationPgn(game: Game, nodeList: TreeNode[]): string {
+export function renderNodesPgn(game: Game, nodeList: TreeNode[], includeSubVariations: boolean): string {
   const filteredNodeList = nodeList.filter(node => node.san);
   if (filteredNodeList.length === 0) return '';
 
@@ -58,5 +58,11 @@ export function renderVariationPgn(game: Game, nodeList: TreeNode[]): string {
     variationPgn += fixCrazySan(node.san!) + ' ';
   }
 
-  return renderPgnTags(game) + variationPgn;
+  variationPgn += renderNodesTxt(
+    nodeList[nodeList.length - 1],
+    filteredNodeList.length === 0,
+    includeSubVariations,
+  );
+
+  return variationPgn ? renderPgnTags(game) + variationPgn : '';
 }

--- a/ui/analyse/src/treeView/contextMenu.ts
+++ b/ui/analyse/src/treeView/contextMenu.ts
@@ -4,7 +4,7 @@ import type { TreePath } from 'lib/tree/types';
 import { type VNode, onInsert, hl, dataIcon } from 'lib/view';
 
 import type AnalyseCtrl from '@/ctrl';
-import { renderVariationPgn } from '@/pgnExport';
+import { renderNodesPgn } from '@/pgnExport';
 import * as studyView from '@/study/studyView';
 import { patch, nodeFullName } from '@/view/util';
 
@@ -106,8 +106,7 @@ function view(ctrl: AnalyseCtrl, path: TreePath, coords: Coords): VNode {
   const { tree, idbTree } = ctrl;
   const canPrune = ctrl.ongoing && path.startsWith(ctrl.initialPath); // correspondence
   const node = tree.nodeAtPath(path),
-    onMainline = tree.pathIsMainline(path) && !tree.pathIsForcedVariation(path),
-    extendedPath = tree.extendPath(path, onMainline);
+    onMainline = tree.pathIsMainline(path) && !tree.pathIsForcedVariation(path);
   let canPromote = !onMainline;
   for (let iter = tree.lastMainlineNode(path).children[1]; canPromote && iter; iter = iter.children[0]) {
     if (iter === node) canPromote = false;
@@ -148,10 +147,10 @@ function view(ctrl: AnalyseCtrl, path: TreePath, coords: Coords): VNode {
         onMainline ? i18n.site.copyMainLinePgn : i18n.site.copyVariationPgn,
         () =>
           navigator.clipboard.writeText(
-            renderVariationPgn(ctrl.data.game, ctrl.tree.getNodeList(extendedPath)),
+            renderNodesPgn(ctrl.data.game, ctrl.tree.getNodeList(path), !onMainline),
           ),
-        () => ctrl.pendingCopyPath(extendedPath),
-        () => ctrl.pendingCopyPath(null),
+        () => ctrl.pendingCopy({ eventPath: path, withVariations: !onMainline }),
+        () => ctrl.pendingCopy(null),
       ),
 
       path &&

--- a/ui/analyse/src/treeView/inlineView.ts
+++ b/ui/analyse/src/treeView/inlineView.ts
@@ -165,7 +165,7 @@ export class InlineView {
         !currentPath && !!ctrl.gamePath && treePath.contains(path, ctrl.gamePath) && path !== ctrl.gamePath,
       'context-menu': path === ctrl.contextMenuPath,
       'pending-deletion': path.startsWith(ctrl.pendingDeletionPath() || ' '),
-      'pending-copy': !!ctrl.pendingCopyPath()?.startsWith(path),
+      'pending-copy': ctrl.isPendingCopy(path, isMainline),
     };
     const glyphs = [...(node.glyphs ?? [])];
     const liveGlyph = ctrl.liveAnnotate?.get(path);

--- a/ui/analyse/tests/pgnExport.test.ts
+++ b/ui/analyse/tests/pgnExport.test.ts
@@ -1,11 +1,10 @@
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 
-import { makeTree as makeTreeWrapper } from 'lib/tree';
 import type { TreeNode, TreePath } from 'lib/tree/types';
 
 import type { Game } from '../src/interfaces';
-import { renderVariationPgn } from '../src/pgnExport';
+import { renderNodesPgn } from '../src/pgnExport';
 
 const game = { variant: { key: 'standard', name: 'Standard' } } as Game;
 
@@ -35,18 +34,27 @@ const makeForcedTree = (): TreeNode =>
     children: [node(1, 'e4', node(2, 'e5', forced(node(3, 'Nf3', node(4, 'Nc6')))))],
   }) as TreeNode;
 
-const renderFrom = (root: TreeNode, g: Game, path: TreePath, includeSubVariations: boolean) => {
-  const tree = makeTreeWrapper(root);
-  return renderVariationPgn(g, tree.getNodeList(tree.extendPath(path, !includeSubVariations)));
-};
+function nodeList(root: TreeNode, path: TreePath): TreeNode[] {
+  const nodes = [root];
+  for (let n = root; path; path = path.slice(2)) {
+    n = n.children.find(c => c.id === path.slice(0, 2))!;
+    nodes.push(n);
+  }
+  return nodes;
+}
 
-describe('renderVariationPgn', () => {
+describe('renderNodesPgn', () => {
   const root = makeTree();
   const render = (path: TreePath, includeSubVariations: boolean) =>
-    renderFrom(root, game, path, includeSubVariations).trim();
+    renderNodesPgn(game, nodeList(root, path), includeSubVariations).trim();
 
   test('renders the main line without variations', () => {
     assert.equal(render('e4e5', false), '1. e4 e5 2. Nf3 Nc6');
+  });
+
+  test('appends the sub-variations branching off the last node', () => {
+    assert.equal(render('e4', true), '1. e4 e5 (1... c5 2. Nf3 (2. d4)) 2. Nf3 Nc6');
+    assert.equal(render('e4c5', true), '1. e4 c5 2. Nf3 (2. d4)');
   });
 
   test('leaves the line leading up to the last node linear', () => {
@@ -61,14 +69,14 @@ describe('renderVariationPgn', () => {
   test('renders nothing when there are no moves', () => {
     const empty = { id: '', ply: 0, children: [] } as unknown as TreeNode;
     const fromFen = { ...game, initialFen: '4k3/8/8/8/8/8/8/4K3 w - - 0 1' } as Game;
-    assert.equal(renderFrom(empty, fromFen, '', false), '');
-    assert.equal(renderFrom(empty, fromFen, '', true), '');
+    assert.equal(renderNodesPgn(fromFen, [empty], false), '');
+    assert.equal(renderNodesPgn(fromFen, [empty], true), '');
   });
 
   test('renders the game tags', () => {
     const crazyhouse = { variant: { key: 'crazyhouse', name: 'Crazyhouse' } } as Game;
     assert.equal(
-      renderFrom(root, crazyhouse, 'e4', false).trim(),
+      renderNodesPgn(crazyhouse, nodeList(root, 'e4'), false).trim(),
       '[Variant "Crazyhouse"]\n\n1. e4 e5 2. Nf3 Nc6',
     );
   });
@@ -76,7 +84,7 @@ describe('renderVariationPgn', () => {
   describe('forced variations', () => {
     const forcedRoot = makeForcedTree();
     const renderForced = (path: TreePath, includeSubVariations: boolean) =>
-      renderFrom(forcedRoot, game, path, includeSubVariations).trim();
+      renderNodesPgn(game, nodeList(forcedRoot, path), includeSubVariations).trim();
 
     test('the main line stops before a forced variation', () => {
       assert.equal(renderForced('e4', false), '1. e4 e5');

--- a/ui/analyse/tests/pgnExport.test.ts
+++ b/ui/analyse/tests/pgnExport.test.ts
@@ -81,6 +81,24 @@ describe('renderNodesPgn', () => {
     );
   });
 
+  describe('black to move from the initial fen', () => {
+    const fen = 'rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1';
+    const fromFen = { ...game, initialFen: fen } as Game;
+    const blackFirst = { id: '', ply: 1, children: [node(2, 'e5', node(3, 'Nf3'))] } as TreeNode;
+
+    test('numbers the first move when the path contributes none', () => {
+      assert.equal(
+        renderNodesPgn(fromFen, nodeList(blackFirst, ''), false).trim(),
+        `[FEN "${fen}"]\n\n1... e5 2. Nf3`,
+      );
+    });
+
+    test('the empty path and the full path render the same moves', () => {
+      const render = (path: TreePath) => renderNodesPgn(game, nodeList(blackFirst, path), false).trim();
+      assert.equal(render(''), render('e5'));
+    });
+  });
+
   describe('forced variations', () => {
     const forcedRoot = makeForcedTree();
     const renderForced = (path: TreePath, includeSubVariations: boolean) =>

--- a/ui/analyse/tests/pgnExport.test.ts
+++ b/ui/analyse/tests/pgnExport.test.ts
@@ -1,0 +1,90 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+
+import { makeTree as makeTreeWrapper } from 'lib/tree';
+import type { TreeNode, TreePath } from 'lib/tree/types';
+
+import type { Game } from '../src/interfaces';
+import { renderVariationPgn } from '../src/pgnExport';
+
+const game = { variant: { key: 'standard', name: 'Standard' } } as Game;
+
+const node = (ply: Ply, san: San, ...children: TreeNode[]): TreeNode =>
+  ({ id: san.slice(0, 2), ply, san, children }) as TreeNode;
+
+const forced = (n: TreeNode): TreeNode => ({ ...n, forceVariation: true });
+
+const makeTree = (): TreeNode =>
+  ({
+    id: '',
+    ply: 0,
+    children: [
+      node(
+        1,
+        'e4',
+        node(2, 'e5', node(3, 'Nf3', node(4, 'Nc6'))),
+        node(2, 'c5', node(3, 'Nf3'), node(3, 'd4')),
+      ),
+    ],
+  }) as TreeNode;
+
+const makeForcedTree = (): TreeNode =>
+  ({
+    id: '',
+    ply: 0,
+    children: [node(1, 'e4', node(2, 'e5', forced(node(3, 'Nf3', node(4, 'Nc6')))))],
+  }) as TreeNode;
+
+const renderFrom = (root: TreeNode, g: Game, path: TreePath, includeSubVariations: boolean) => {
+  const tree = makeTreeWrapper(root);
+  return renderVariationPgn(g, tree.getNodeList(tree.extendPath(path, !includeSubVariations)));
+};
+
+describe('renderVariationPgn', () => {
+  const root = makeTree();
+  const render = (path: TreePath, includeSubVariations: boolean) =>
+    renderFrom(root, game, path, includeSubVariations).trim();
+
+  test('renders the main line without variations', () => {
+    assert.equal(render('e4e5', false), '1. e4 e5 2. Nf3 Nc6');
+  });
+
+  test('leaves the line leading up to the last node linear', () => {
+    assert.equal(render('e4e5', true), '1. e4 e5 2. Nf3 Nc6');
+    assert.equal(render('e4c5Nf', true), '1. e4 c5 2. Nf3');
+  });
+
+  test('renders the whole main line for an empty path', () => {
+    assert.equal(render('', false), '1. e4 e5 2. Nf3 Nc6');
+  });
+
+  test('renders nothing when there are no moves', () => {
+    const empty = { id: '', ply: 0, children: [] } as unknown as TreeNode;
+    const fromFen = { ...game, initialFen: '4k3/8/8/8/8/8/8/4K3 w - - 0 1' } as Game;
+    assert.equal(renderFrom(empty, fromFen, '', false), '');
+    assert.equal(renderFrom(empty, fromFen, '', true), '');
+  });
+
+  test('renders the game tags', () => {
+    const crazyhouse = { variant: { key: 'crazyhouse', name: 'Crazyhouse' } } as Game;
+    assert.equal(
+      renderFrom(root, crazyhouse, 'e4', false).trim(),
+      '[Variant "Crazyhouse"]\n\n1. e4 e5 2. Nf3 Nc6',
+    );
+  });
+
+  describe('forced variations', () => {
+    const forcedRoot = makeForcedTree();
+    const renderForced = (path: TreePath, includeSubVariations: boolean) =>
+      renderFrom(forcedRoot, game, path, includeSubVariations).trim();
+
+    test('the main line stops before a forced variation', () => {
+      assert.equal(renderForced('e4', false), '1. e4 e5');
+      assert.equal(renderForced('', false), '1. e4 e5');
+    });
+
+    test('a variation copy runs through a forced variation', () => {
+      assert.equal(renderForced('e4e5Nf', true), '1. e4 e5 2. Nf3 Nc6');
+    });
+  });
+});

--- a/ui/lib/src/game/nodePGN.ts
+++ b/ui/lib/src/game/nodePGN.ts
@@ -5,23 +5,25 @@ import { fixCrazySan } from './chess';
 export const plyPrefix = (node: TreeNode): string =>
   `${Math.floor((node.ply + 1) / 2)}${node.ply % 2 === 1 ? '. ' : '... '}`;
 
-export function renderNodesTxt(node: TreeNode, forcePly: boolean): string {
-  if (node.children.length === 0) return '';
+export function renderNodesTxt(node: TreeNode, forcePly: boolean, includeVariations = true): string {
+  const first = node.children[0];
+  if (!first || (!includeVariations && first.forceVariation)) return '';
 
   let s = '';
-  const first = node.children[0];
   if (forcePly || first.ply % 2 === 1) s += plyPrefix(first);
   s += fixCrazySan(first.san!);
 
-  for (let i = 1; i < node.children.length; i++) {
-    const child = node.children[i];
-    s += ` (${plyPrefix(child)}${fixCrazySan(child.san!)}`;
-    const variation = renderNodesTxt(child, false);
-    if (variation) s += ' ' + variation;
-    s += ')';
+  if (includeVariations) {
+    for (let i = 1; i < node.children.length; i++) {
+      const child = node.children[i];
+      s += ` (${plyPrefix(child)}${fixCrazySan(child.san!)}`;
+      const variation = renderNodesTxt(child, false, includeVariations);
+      if (variation) s += ' ' + variation;
+      s += ')';
+    }
   }
 
-  const mainline = renderNodesTxt(first, node.children.length > 1);
+  const mainline = renderNodesTxt(first, s.endsWith(')'), includeVariations);
   if (mainline) s += ' ' + mainline;
 
   return s;

--- a/ui/lib/src/tree/path.ts
+++ b/ui/lib/src/tree/path.ts
@@ -16,8 +16,7 @@ export const last = (path: TreePath): string => path.slice(-2);
 
 export const contains = (p1: TreePath, p2: TreePath): boolean => p1.startsWith(p2);
 
-export const areComparable = (p1: TreePath, p2: TreePath): boolean =>
-  contains(p1, p2) || contains(p2, p1)
+export const areComparable = (p1: TreePath, p2: TreePath): boolean => contains(p1, p2) || contains(p2, p1);
 
 export const fromNodeList = (nodes: TreeNode[]): TreePath => nodes.map(n => n.id).join('');
 

--- a/ui/lib/src/tree/path.ts
+++ b/ui/lib/src/tree/path.ts
@@ -16,6 +16,9 @@ export const last = (path: TreePath): string => path.slice(-2);
 
 export const contains = (p1: TreePath, p2: TreePath): boolean => p1.startsWith(p2);
 
+export const areComparable = (p1: TreePath, p2: TreePath): boolean =>
+  contains(p1, p2) || contains(p2, p1)
+
 export const fromNodeList = (nodes: TreeNode[]): TreePath => nodes.map(n => n.id).join('');
 
 export const isChildOf = (child: TreePath, parent: TreePath): boolean =>

--- a/ui/lib/src/tree/tree.ts
+++ b/ui/lib/src/tree/tree.ts
@@ -24,7 +24,6 @@ export interface TreeWrapper {
   pathIsMainline(path: TreePath): boolean;
   pathIsForcedVariation(path: TreePath): boolean;
   lastMainlineNode(path: TreePath): TreeNode;
-  extendPath(path: TreePath, isMainline: boolean): TreePath;
   pathExists(path: TreePath): boolean;
   deleteNodeAt(path: TreePath): void;
   promoteAt(path: TreePath, toMainline: boolean): void;
@@ -103,13 +102,6 @@ export function makeTree(root: TreeNode): TreeWrapper {
       path = treePath.tail(path);
       return ops.childById(node, id);
     });
-
-  const extendPath = (path: TreePath, isMainline: boolean): TreePath => {
-    let currNode = nodeAtPath(path);
-    while ((currNode = currNode?.children[0]) && !(isMainline && currNode.forceVariation))
-      path += currNode.id;
-    return path;
-  };
 
   function updateAt(path: TreePath, update: (node: TreeNode) => void): MaybeNode {
     const node = nodeAtPathOrNull(path);
@@ -230,7 +222,6 @@ export function makeTree(root: TreeNode): TreeWrapper {
     pathIsMainline,
     pathIsForcedVariation,
     lastMainlineNode: (path: TreePath): TreeNode => lastMainlineNodeFrom(root, path),
-    extendPath,
     pathExists,
     deleteNodeAt,
     promoteAt,

--- a/ui/lib/tests/nodePGN.test.ts
+++ b/ui/lib/tests/nodePGN.test.ts
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+
+import { renderNodesTxt } from '../src/game/nodePGN';
+import type { TreeNode } from '../src/tree/types';
+
+const node = (ply: Ply, san: San, ...children: TreeNode[]): TreeNode =>
+  ({ id: san.slice(0, 2), ply, san, children }) as TreeNode;
+
+const root = {
+  id: '',
+  ply: 0,
+  children: [
+    node(
+      1,
+      'e4',
+      node(2, 'e5', node(3, 'Nf3', node(4, 'Nc6'))),
+      node(2, 'c5', node(3, 'Nf3'), node(3, 'd4')),
+    ),
+  ],
+} as TreeNode;
+
+describe('renderNodesTxt', () => {
+  test('includes variations by default', () => {
+    assert.equal(renderNodesTxt(root, true), '1. e4 e5 (1... c5 2. Nf3 (2. d4)) 2. Nf3 Nc6');
+  });
+
+  test('renders through a forced variation', () => {
+    const forcedRoot = {
+      id: '',
+      ply: 0,
+      children: [node(1, 'e4', { ...node(2, 'e5', node(3, 'Nf3')), forceVariation: true })],
+    } as TreeNode;
+    assert.equal(renderNodesTxt(forcedRoot, true), '1. e4 e5 2. Nf3');
+  });
+
+  test('returns nothing for a leaf', () => {
+    assert.equal(renderNodesTxt(node(1, 'e4'), true), '');
+  });
+});

--- a/ui/lib/tests/nodePGN.test.ts
+++ b/ui/lib/tests/nodePGN.test.ts
@@ -39,6 +39,16 @@ describe('renderNodesTxt', () => {
     assert.equal(renderNodesTxt(forcedRoot, true), '1. e4 e5 2. Nf3');
   });
 
+  test('numbers a black move only when a variation precedes it', () => {
+    const branchingRoot = {
+      id: '',
+      ply: 0,
+      children: [node(1, 'e4', node(2, 'e5')), node(1, 'd4')],
+    } as TreeNode;
+    assert.equal(renderNodesTxt(branchingRoot, true), '1. e4 (1. d4) 1... e5');
+    assert.equal(renderNodesTxt(branchingRoot, true, false), '1. e4 e5');
+  });
+
   test('returns nothing for a leaf', () => {
     assert.equal(renderNodesTxt(node(1, 'e4'), true), '');
   });

--- a/ui/lib/tests/nodePGN.test.ts
+++ b/ui/lib/tests/nodePGN.test.ts
@@ -25,12 +25,17 @@ describe('renderNodesTxt', () => {
     assert.equal(renderNodesTxt(root, true), '1. e4 e5 (1... c5 2. Nf3 (2. d4)) 2. Nf3 Nc6');
   });
 
-  test('renders through a forced variation', () => {
+  test('omits variations when asked to', () => {
+    assert.equal(renderNodesTxt(root, true, false), '1. e4 e5 2. Nf3 Nc6');
+  });
+
+  test('stops before a forced variation only when omitting variations', () => {
     const forcedRoot = {
       id: '',
       ply: 0,
       children: [node(1, 'e4', { ...node(2, 'e5', node(3, 'Nf3')), forceVariation: true })],
     } as TreeNode;
+    assert.equal(renderNodesTxt(forcedRoot, true, false), '1. e4');
     assert.equal(renderNodesTxt(forcedRoot, true), '1. e4 e5 2. Nf3');
   });
 


### PR DESCRIPTION
Imo it would be more useful (and intuitive) if copying a variation copied all sub-variations too. E.g., yesterday I was working on an opening repertoire file and wanted to split it into two, so I copied one of the mainline's variations (planning to then delete it from the current chapter, and paste it in a new chapter). However, it only copied the main nodes of said variation.

Prod:
<img width="1191" height="747" alt="image" src="https://github.com/user-attachments/assets/e1a0181d-e626-4170-bf5f-0bc7d6d8062d" />

After my changes:
<img width="1339" height="793" alt="image" src="https://github.com/user-attachments/assets/34b58b1d-44e0-48c9-9e87-6237185ab0d3" />

Note that behaviour remains the same if copying from 2.Nf3 in the above screenshots (i.e., the 2.d4 variation remains excluded).

Because there are now multiple paths pending copy (for variations), we can no longer store a single `pendingCopyPath` prop in `analyse/src/ctrl.ts`. Instead, now the path from where the user clicked copy is stored, and it is used to compute whether any given path is pending a copy or not.