### PR TITLE
ui(analyse): stretch server-side analyse message in tab

### DIFF
--- a/ui/analyse/css/study/panel/_message.scss
+++ b/ui/analyse/css/study/panel/_message.scss
@@ -4,6 +4,7 @@
   background: $c-bg-box;
   padding: 3em;
   text-align: center;
+  width: 100%;
 
   .button {
     display: inline-block;

--- a/ui/analyse/src/view/roundTraining.ts
+++ b/ui/analyse/src/view/roundTraining.ts
@@ -141,8 +141,10 @@ export function render(ctrl: AnalyseCtrl): VNode | undefined {
     !ctrl.data.analysis ||
     !ctrl.settings.showStaticAnalysis ||
     (ctrl.study && ctrl.study.vm.toolTab() !== 'serverEval')
-  )
+  ) {
+    if (!ctrl.data.puzzle) return undefined;
     return h('div.analyse__round-training', puzzleLink(ctrl));
+  }
 
   // don't cache until the analysis is complete!
   const buster = ctrl.data.analysis.partial ? Math.random() : '';


### PR DESCRIPTION
# Why

Spotted that before the server-side analysis has been requested we render an empty div leading to request message taking only part of horizontal space in the tab.

# How

Avoid rendering empty round data div, make sure that initial container with request message stretches in the container.


# Preview

### Before

<img width="1031" height="350" alt="Screenshot 2026-08-15 at 09 36 09" src="https://github.com/user-attachments/assets/23287937-9adb-4ccd-8691-d2b9463350d1" />

### After

<img width="1031" height="350" alt="Screenshot 2026-08-15 at 09 39 54" src="https://github.com/user-attachments/assets/7baaa57f-7871-401a-aa68-7622e590a8e0" />
<img width="1031" height="350" alt="Screenshot 2026-08-15 at 09 44 07" src="https://github.com/user-attachments/assets/07c8a296-c800-4b90-98c3-ffc4fb9d897a" />
