### PR TITLE
ui(lib): apply analysis result color to the annotation guide

### DIFF
--- a/ui/lib/css/tree/_tree.scss
+++ b/ui/lib/css/tree/_tree.scss
@@ -7,7 +7,8 @@ $disclosure-btn-size: calc(15px + var(---button-size-pointer-adjust, 0px));
   }
 
   .#{$name},
-  .#{$name} + lines {
+  .#{$name} + lines,
+  .#{$name} + interrupt {
     --c-annotation-border: rgb(from var(--c-#{$name}) r g b / calc(alpha * 0.6));
   }
 
@@ -417,6 +418,12 @@ $disclosure-btn-size: calc(15px + var(---button-size-pointer-adjust, 0px));
   inline::before,
   inline::after {
     vertical-align: 0.7em;
+  }
+
+  .disclosure {
+    width: 13px;
+    height: 13px;
+    margin-inline-start: 2px;
   }
 }
 

--- a/ui/lib/css/tree/_tree.scss
+++ b/ui/lib/css/tree/_tree.scss
@@ -1,5 +1,20 @@
-$c-transp-border: rgb(from $c-font r g b / calc(alpha * 0.12));
+$c-annotation-border: var(--c-annotation-border, rgb(from $c-font r g b / calc(alpha * 0.12)));
 $disclosure-btn-size: calc(15px + var(---button-size-pointer-adjust, 0px));
+
+@mixin annotation-color($name) {
+  .#{$name} {
+    --c-base: var(--c-#{$name});
+  }
+
+  .#{$name},
+  .#{$name} + lines {
+    --c-annotation-border: rgb(from var(--c-#{$name}) r g b / calc(alpha * 0.6));
+  }
+
+  .#{$name}.active {
+    --c-annotation-border: var(--c-#{$name});
+  }
+}
 
 .tview2 {
   white-space: normal;
@@ -10,29 +25,12 @@ $disclosure-btn-size: calc(15px + var(---button-size-pointer-adjust, 0px));
     --c-base: var(--c-primary);
   }
 
-  .inaccuracy {
-    --c-base: var(--c-inaccuracy);
-  }
-
-  .mistake {
-    --c-base: var(--c-mistake);
-  }
-
-  .blunder {
-    --c-base: var(--c-blunder);
-  }
-
-  .good {
-    --c-base: var(--c-good);
-  }
-
-  .brilliant {
-    --c-base: var(--c-brilliant);
-  }
-
-  .interesting {
-    --c-base: var(--c-interesting);
-  }
+  @include annotation-color(inaccuracy);
+  @include annotation-color(mistake);
+  @include annotation-color(blunder);
+  @include annotation-color(good);
+  @include annotation-color(brilliant);
+  @include annotation-color(interesting);
 
   .anchor {
     position: relative;
@@ -71,7 +69,7 @@ $disclosure-btn-size: calc(15px + var(---button-size-pointer-adjust, 0px));
     }
 
     .disclosure {
-      background-color: $c-font-dimmer;
+      background-color: white;
     }
   }
 
@@ -179,7 +177,7 @@ $disclosure-btn-size: calc(15px + var(---button-size-pointer-adjust, 0px));
   }
 
   > branch {
-    border-inline-start: 2px solid $c-transp-border;
+    border-inline-start: 2px solid $c-annotation-border;
     margin-inline-start: -9px;
     position: absolute;
     width: 8px;
@@ -187,23 +185,22 @@ $disclosure-btn-size: calc(15px + var(---button-size-pointer-adjust, 0px));
   }
 
   > branch::after {
-    margin-top: 0.8em;
+    margin-top: calc(1.15em - 2px);
     content: ' ';
-    border-top: 2px solid $c-transp-border;
+    border-top: 2px solid $c-annotation-border;
     position: absolute;
     width: 7px;
     height: 2px;
   }
 
   &:last-child > branch {
-    height: calc(0.8em + 2px) !important;
+    height: 1.15em;
   }
 }
 
 .tview2 lines {
   display: block;
   margin-block: 2px;
-  margin-inline-start: 1px;
   padding-inline-start: 2px;
   overflow-x: clip;
 
@@ -258,7 +255,7 @@ $disclosure-btn-size: calc(15px + var(---button-size-pointer-adjust, 0px));
 
 .tview2 .disclosure {
   display: inline-block;
-  background-color: $c-transp-border;
+  background-color: $c-annotation-border;
   vertical-align: -2px;
   align-self: center;
   width: $disclosure-btn-size;
@@ -277,7 +274,7 @@ $disclosure-btn-size: calc(15px + var(---button-size-pointer-adjust, 0px));
 
   + san::before,
   + index::before {
-    color: $c-transp-border;
+    color: $c-annotation-border;
   }
 }
 
@@ -285,8 +282,8 @@ $disclosure-btn-size: calc(15px + var(---button-size-pointer-adjust, 0px));
   position: absolute;
   pointer-events: none;
   inset-inline-start: 0;
-  border-inline-start: 2px solid $c-transp-border;
-  border-top: 2px solid $c-transp-border;
+  border-inline-start: 2px solid $c-annotation-border;
+  border-top: 2px solid $c-annotation-border;
 }
 
 .tview2 .disclosure-connector.riser {
@@ -346,7 +343,7 @@ $disclosure-btn-size: calc(15px + var(---button-size-pointer-adjust, 0px));
   color: $c-font-dimmer;
 
   + move {
-    border-inline-end: $c-transp-border;
+    border-inline-end: $c-annotation-border;
   }
 }
 
@@ -377,8 +374,8 @@ $disclosure-btn-size: calc(15px + var(---button-size-pointer-adjust, 0px));
   flex: 0 0 100%;
   max-width: 100%;
   background: $c-bg-zebra;
-  border-top: 1px solid $c-transp-border;
-  border-bottom: 1px solid $c-transp-border;
+  border-top: 1px solid $c-annotation-border;
+  border-bottom: 1px solid $c-annotation-border;
 
   > comment {
     @extend %break-word;
@@ -386,7 +383,7 @@ $disclosure-btn-size: calc(15px + var(---button-size-pointer-adjust, 0px));
     color: var(--c-base);
     display: block;
     padding: 3px 5px;
-    border-inline-start: 2px solid $c-transp-border;
+    border-inline-start: 2px solid $c-annotation-border;
   }
 }
 


### PR DESCRIPTION
# Why

To improve the interrupts visual connection to a move.

# How

Apply analysis result color to the annotation guide, small shade and spacing/placement tweaks for the guides.

> [!note]
> Also spotted that some moves are marked as mistake for example, but they interrupt is not. Will try to address this in a follow up PR.
>
> <img width="427" height="137" alt="Screenshot 2026-08-15 at 11 01 41" src="https://github.com/user-attachments/assets/84bbe4e6-52f9-434c-949f-0339bd6bf786" />


# Preview

### Hiding variations enabled

<img width="427" height="999" alt="Screenshot 2026-08-15 at 10 54 18" src="https://github.com/user-attachments/assets/f1a23e82-fd16-4e79-8e4f-2cd1ec310803" />

### Hiding variations disabled

<img width="427" height="999" alt="Screenshot 2026-08-15 at 10 59 52" src="https://github.com/user-attachments/assets/178821a5-3677-4c3f-8b9e-ff898551547f" />

### Inline display mode

<img width="442" height="647" alt="Screenshot 2026-08-15 at 11 23 43" src="https://github.com/user-attachments/assets/c48a132e-2423-478f-8364-6e1916cea7ed" />

