### PR TITLE
Add scss watch for sources outside of 'ui' directory

### DIFF
--- a/ui/.build/src/sass.ts
+++ b/ui/.build/src/sass.ts
@@ -8,7 +8,7 @@ import { c, env, errorMark, trimLines } from './env.ts';
 import { hashedBasename, symlinkTargetHashes } from './hash.ts';
 import { updateManifest } from './manifest.ts';
 import { glob, readable } from './parse.ts';
-import { makeTask, runTask } from './task.ts';
+import { makeTask, runTask, addIncludes } from './task.ts';
 
 const importMap = new Map<string, Set<string>>();
 
@@ -29,7 +29,6 @@ export async function sass(): Promise<string | undefined> {
     fs.promises.mkdir(env.themeGenDir),
     fs.promises.mkdir(join(env.buildTempDir, 'css')),
   ]);
-
   let remaining: Set<string> | undefined;
 
   makeTask({
@@ -121,7 +120,7 @@ async function compile(sources: string[], logAll = true): Promise<string[]> {
   });
 }
 
-// recursively parse scss file and its imports to build dependency and color maps
+// recursively parse scss file and its imports to build dependency maps
 async function parseScss(src: string, processed: Set<string>) {
   if (dirname(src).endsWith('/gen')) return;
   if (processed.has(src)) return;
@@ -151,6 +150,7 @@ async function parseScss(src: string, processed: Set<string>) {
 
     const dep = relative(env.rootDir, absDep);
     if (!importMap.get(dep)?.add(src)) importMap.set(dep, new Set<string>([src]));
+    addIncludes([{ cwd: dirname(dep), path: '*.scss' }], 'sass'); // could be outside of ui/** glob
     await parseScss(dep, processed);
   }
 }
@@ -254,6 +254,6 @@ const absTempCss = (scss: string): string => join(env.cssTempDir, `${basename(sc
 
 const isConcrete = (src: string): boolean => src.startsWith('ui/') && !basename(src).startsWith('_');
 
-const isPartial = (src: string): boolean => src.startsWith('ui/') && basename(src).startsWith('_');
+const isPartial = (src: string): boolean => basename(src).startsWith('_');
 
 const isUrlTarget = (src: string): boolean => src.startsWith('public/');

--- a/ui/.build/src/task.ts
+++ b/ui/.build/src/task.ts
@@ -23,7 +23,7 @@ type Debounce = {
   rename: boolean;
   files: Set<AbsPath>;
 };
-type Task = Omit<TaskOpts, 'glob' | 'debounce'> & {
+type Task = Omit<TaskOpts, 'glob' | 'debounce' | 'includes' | 'excludes'> & {
   includes: CwdPath[];
   excludes: Path[];
   key: TaskKey;
@@ -93,6 +93,20 @@ export function taskOk(ctx?: Context): boolean {
 }
 
 export const tasksIdle = (): boolean => activeTaskCount === 0;
+
+export function addIncludes(includes: CwdPath | CwdPath[], key: TaskKey): void {
+  const t = tasks.get(key);
+  if (!t) return;
+
+  const existing = t.includes.map(i => relative(t.root!, join(i.cwd, i.path)));
+
+  for (const include of Array.isArray(includes) ? includes : [includes]) {
+    if (mm.isMatch(join(include.cwd, include.path), existing)) continue;
+
+    t.includes.push(include);
+    if (env.watch) watchGlob(include, key);
+  }
+}
 
 async function execute(t: Task, firstRun = false): Promise<void> {
   const makeRelative = (files: AbsPath[]) => (t.root ? files.map(f => relative(t.root!, f)) : files);


### PR DESCRIPTION
The practical upshot is direct watching of pnpm linked pgn-viewer sources such as _lichess-pgn-viewer.lib.scss and its imports.

Such node_modules fall outside our initial glob, are linked from the project root (rather than ui/**), and require special handling