### PR TITLE
fixed off-center loading spinner on table pagers

### DIFF
--- a/ui/bits/src/bits.infiniteScroll.ts
+++ b/ui/bits/src/bits.infiniteScroll.ts
@@ -9,7 +9,7 @@ export function initModule(selector = '.infinite-scroll'): void {
 }
 
 function register(el: HTMLElement, selector: string, backoff = 500) {
-  const nav = el.querySelector<HTMLAnchorElement>('.pager');
+  const nav = el.querySelector<HTMLElement>('.pager');
   const next = nav?.querySelector<HTMLAnchorElement>('a');
   const nextUrl = next?.href;
   const scrollSelector = el.dataset.scrollSelector;
@@ -31,7 +31,11 @@ function register(el: HTMLElement, selector: string, backoff = 500) {
         );
     })
       .then(() => {
-        nav.innerHTML = spinnerHtml;
+        // in tables .pager is the <tr> - writing into it drops the cell and the spinner lands in an
+        // anonymous single-column cell
+        const cell = nav.querySelector<HTMLTableCellElement>(':scope > th, :scope > td');
+        if (cell) cell.colSpan = renderedColumns(nav);
+        (cell ?? nav).innerHTML = spinnerHtml;
         return xhr.text(nextUrl);
       })
       .then(
@@ -47,6 +51,14 @@ function register(el: HTMLElement, selector: string, backoff = 500) {
           nav.remove();
         },
       );
+}
+
+// count the cells css actually renders - several tables drop columns at narrow widths and spanning
+// the dropped ones adds empty phantom columns that squeeze the visible ones
+function renderedColumns(pagerRow: HTMLElement) {
+  const cells = (pagerRow.previousElementSibling as HTMLTableRowElement | null)?.cells;
+  if (!cells) return 1;
+  return [...cells].reduce((n, cell) => n + (cell.getClientRects().length ? cell.colSpan : 0), 0) || 1;
 }
 
 function isVisible(el: HTMLElement) {

--- a/ui/bits/src/bits.infiniteScroll.ts
+++ b/ui/bits/src/bits.infiniteScroll.ts
@@ -9,7 +9,7 @@ export function initModule(selector = '.infinite-scroll'): void {
 }
 
 function register(el: HTMLElement, selector: string, backoff = 500) {
-  const nav = el.querySelector<HTMLElement>('.pager');
+  const nav = el.querySelector<HTMLAnchorElement>('.pager');
   const next = nav?.querySelector<HTMLAnchorElement>('a');
   const nextUrl = next?.href;
   const scrollSelector = el.dataset.scrollSelector;
@@ -31,11 +31,7 @@ function register(el: HTMLElement, selector: string, backoff = 500) {
         );
     })
       .then(() => {
-        // in tables .pager is the <tr> - writing into it drops the cell and the spinner lands in an
-        // anonymous single-column cell
-        const cell = nav.querySelector<HTMLTableCellElement>(':scope > th, :scope > td');
-        if (cell) cell.colSpan = renderedColumns(nav);
-        (cell ?? nav).innerHTML = spinnerHtml;
+        if (nav.tagName !== 'TR') nav.innerHTML = spinnerHtml;
         return xhr.text(nextUrl);
       })
       .then(
@@ -51,14 +47,6 @@ function register(el: HTMLElement, selector: string, backoff = 500) {
           nav.remove();
         },
       );
-}
-
-// count the cells css actually renders - several tables drop columns at narrow widths and spanning
-// the dropped ones adds empty phantom columns that squeeze the visible ones
-function renderedColumns(pagerRow: HTMLElement) {
-  const cells = (pagerRow.previousElementSibling as HTMLTableRowElement | null)?.cells;
-  if (!cells) return 1;
-  return [...cells].reduce((n, cell) => n + (cell.getClientRects().length ? cell.colSpan : 0), 0) || 1;
 }
 
 function isVisible(el: HTMLElement) {


### PR DESCRIPTION
fixes #20240 

#20241 alr tried adding a colspan and @ornicar pointed out it does nothing and it took me a while to understand why

`bits.infiniteScroll.ts` looks up `.pager` which in a table is the `<tr>` itself then assigns to its `innerHTML` so the `<th>` gets thrown away along with whatever colspan was on it. what's left is the spinner `<div>` sitting directly inside a `<tr>` and the browser sticks that in an anonymous cell that only ever spans one column
`.spinner` is `margin: auto` so it centres in that column instead of the whole table and that's the shift
(tldr - its that its alr gone by the time anything gets laid out)

So the spinner has to go into the cell rather than the row and the cell has to span the table

My first go at the span was a column 

count on `pagerNextTable` passed in from every call site. it worked on desktop but it breaks the table at narrow widths (gemini was just bs-ing me there) `_table.scss` drops forum columns with `display: none` under a couple of breakpoints and `.slist.topics` is `table-layout: fixed` a cell that's `display: none` doesn't create a column at all so down there the topics table really is one or two columns wide and not three. a hardcoded `colspan="3"` forces the missing ones back into existence, fixed layout then splits the width evenly between them and the subject column collapses to a third of the table with every topic title wrapping over three lines (same underlying thing as the `colspan="100%"` in the first attempt you end up with columns that nothing else is in) - the storm dashboard hides five of its eight columns on a phone so it would have gone the same way

So the number can't come from the template because the template has no idea which columns CSS is going to render and the js counts the cells that actually got rendered in the row above the pager and spans that many instead, on the forum topic list that lands on 1, 2 or 3 depending on width and it can't go stale if someone adds a column later.

The lookup falls back to the row itself for `pagerNext` which renders a div and has no cell to find

I guess a nice side effect of doing it there is that `pagerNextTable` alr emits a bare `<th>`

I used antigravity (used gemini 3.7 flash) - he found the innerHTML on the row being why the colspan disappears(after hallucinating and bs-ing me)

https://github.com/user-attachments/assets/eb953487-7c5b-4160-898e-ca9a568c7e88

_the video is a desktop window being resized and not an actual phone (the breakpoints here are plain css media queries so it comes out the same)_