### PR TITLE
Fix computer analysis for games of 300 plies or more

### DIFF
--- a/modules/fishnet/src/main/Analyser.scala
+++ b/modules/fishnet/src/main/Analyser.scala
@@ -20,7 +20,7 @@ final class Analyser(
 )(using Executor, Scheduler)
     extends lila.core.fishnet.FishnetRequest:
 
-  private val maxPlies = 300
+  import Analyser.maxPlies
 
   private val dedup = OnceEvery[String](2.seconds)
 
@@ -171,6 +171,8 @@ final class Analyser(
     )
 
 object Analyser:
+
+  private[fishnet] val maxPlies = 300
 
   enum Result(val error: Option[String]):
     def ok = error.isEmpty

--- a/modules/fishnet/src/main/JsonApi.scala
+++ b/modules/fishnet/src/main/JsonApi.scala
@@ -15,7 +15,7 @@ object JsonApi:
 
   object Request:
 
-    def isValid(js: JsValue): Boolean = js.arr("analysis").forall(_.value.sizeIs <= 301)
+    def isValid(js: JsValue): Boolean = js.arr("analysis").forall(_.value.sizeIs <= Analyser.maxPlies + 1)
 
     case class Stockfish(
         flavor: Option[String]

--- a/modules/fishnet/src/main/JsonApi.scala
+++ b/modules/fishnet/src/main/JsonApi.scala
@@ -15,7 +15,7 @@ object JsonApi:
 
   object Request:
 
-    def isValid(js: JsValue): Boolean = js.arr("analysis").forall(_.value.sizeIs <= 300)
+    def isValid(js: JsValue): Boolean = js.arr("analysis").forall(_.value.sizeIs <= 301)
 
     case class Stockfish(
         flavor: Option[String]


### PR DESCRIPTION
### Why the change is needed:
A computer analysis never finishes on games of 300 plies or more. The user also cannot request analysis for other games.

Lichess sends fishnet at most the first 300 plies of a game. Fishnet sends back one evaluation for each board position. A game has one more position than it has plies, so fishnet sends back 301 evaluations. A size check constraint limits fishnet's reply to 300 evaluations. Every reply for a a game longer than that is rejected, and the work is lost. Fishnet's progress updates are the same length, so those are rejected too and the analysis bar never moves.

### Link to issue:
Closes #21284

### Solution:
Increase the size check from `300` to `300 + 1 (= 301)`

### Testing:
Before: on lichess.org, asked for a computer check on a 158 move game and nothing happened.
After: built it in lila-docker with fishnet running. Brought in the same 158 move game and asked for computer analysis, which was successful

### AI Assistance
Claude Code prompt: Fix issue 21284 and write the PR content
Some AI generated output has been refactored/edited.

### Screenshots
[
<img width="1046" height="631" alt="analysis" src="https://github.com/user-attachments/assets/1c8877f4-aa85-4478-ac21-c7d3056f7236" />
](url)