### PR TITLE
ui(analyse): detach eval bar from sibling components, spacing tweaks

### DIFF
--- a/ui/analyse/css/_layout.scss
+++ b/ui/analyse/css/_layout.scss
@@ -16,7 +16,7 @@ body {
 .analyse {
   grid-area: main;
   display: grid;
-  gap: $analyse-block-gap;
+  gap: $block-gap $analyse-block-gap;
 
   ---analyse-gauge-col: #{$analyse-block-gap};
   ---analyse-gauge-offset: calc(var(---analyse-gauge-col) - #{$analyse-block-gap});
@@ -67,8 +67,6 @@ body {
   }
 
   .eval-gauge {
-    @extend %box-radius;
-
     grid-area: gauge;
     display: none;
   }
@@ -140,8 +138,8 @@ body {
     .keyboard-move {
       display: block;
       grid-area: kb-move;
-      margin: $analyse-block-gap;
-      margin: calc($analyse-block-gap / 2) 0 0 0;
+      margin: $block-gap;
+      margin: calc($block-gap / 2) 0 0 0;
     }
   }
 

--- a/ui/analyse/css/_layout.scss
+++ b/ui/analyse/css/_layout.scss
@@ -1,4 +1,4 @@
-$analyse-block-gap: $block-gap;
+$analyse-block-gap: 4px;
 
 body {
   /* prevents scroll bar flicker on page height changes */
@@ -16,6 +16,14 @@ body {
 .analyse {
   grid-area: main;
   display: grid;
+  gap: $analyse-block-gap;
+
+  ---analyse-gauge-col: #{$analyse-block-gap};
+  ---analyse-gauge-offset: calc(var(---analyse-gauge-col) - #{$analyse-block-gap});
+
+  &.gauge-on {
+    ---analyse-gauge-col: calc(#{$analyse-block-gap} * 3.75);
+  }
 
   &__side {
     grid-area: side;
@@ -59,6 +67,8 @@ body {
   }
 
   .eval-gauge {
+    @extend %box-radius;
+
     grid-area: gauge;
     display: none;
   }
@@ -90,7 +100,12 @@ body {
     'uchat';
 
   @include mq-at-least-col2 {
-    grid-template-columns: var(---col2-uniboard-width) $analyse-block-gap $col2-uniboard-table;
+    grid-template-columns:
+      var(---col2-uniboard-width) var(---analyse-gauge-col)
+      minmax(
+        calc(#{$col3-uniboard-table-min} - var(---analyse-gauge-offset)),
+        calc(#{$col3-uniboard-table-max} - var(---analyse-gauge-offset))
+      );
     grid-template-rows: fit-content(0);
     grid-template-areas:
       'board      gauge tools'
@@ -131,13 +146,22 @@ body {
   }
 
   @include mq-is-col2-squeeze {
-    grid-template-columns: $col2-uniboard-squeeze-width $analyse-block-gap $col2-uniboard-squeeze-table;
+    grid-template-columns:
+      $col2-uniboard-squeeze-width var(---analyse-gauge-col)
+      minmax(
+        calc(#{$col2-uniboard-squeeze-table-min} - var(---analyse-gauge-offset)),
+        calc(#{$col2-uniboard-squeeze-table-max} - var(---analyse-gauge-offset))
+      );
   }
 
   @include mq-at-least-col3 {
     grid-template-columns:
       $col3-uniboard-side $analyse-block-gap var(---col3-uniboard-width)
-      $analyse-block-gap $col3-uniboard-table;
+      var(---analyse-gauge-col)
+      minmax(
+        calc(#{$col3-uniboard-table-min} - var(---analyse-gauge-offset)),
+        calc(#{$col3-uniboard-table-max} - var(---analyse-gauge-offset))
+      );
     grid-template-rows: auto $chat-height auto 2.5em 1fr;
     grid-template-areas:
       'side    . board   gauge tools'

--- a/ui/analyse/css/_tools.scss
+++ b/ui/analyse/css/_tools.scss
@@ -4,10 +4,6 @@
   position: relative;
   background: $c-bg-box;
 
-  .gauge-on & {
-    @extend %box-radius-right;
-  }
-
   .ceval {
     flex: 0 0 44px;
   }

--- a/ui/analyse/css/study/_chapters.scss
+++ b/ui/analyse/css/study/_chapters.scss
@@ -18,10 +18,6 @@ $span-width: 1.5em;
   > button {
     width: 100%;
 
-    &:first-child {
-      @extend %box-radius-top;
-    }
-
     &.active,
     &:active {
       opacity: 1;

--- a/ui/analyse/css/study/_chapters.scss
+++ b/ui/analyse/css/study/_chapters.scss
@@ -18,6 +18,10 @@ $span-width: 1.5em;
   > button {
     width: 100%;
 
+    &:first-child {
+      @extend %box-radius-top;
+    }
+
     &.active,
     &:active {
       opacity: 1;

--- a/ui/analyse/css/study/_layout.scss
+++ b/ui/analyse/css/study/_layout.scss
@@ -1,10 +1,10 @@
 .analyse__underboard {
-  margin-top: calc($analyse-block-gap / 2);
+  margin-top: calc($block-gap / 2);
 }
 
 .analyse .keyboard-move {
-  margin-top: calc($analyse-block-gap * 2);
-  margin-bottom: calc($analyse-block-gap * -1);
+  margin-top: calc($block-gap * 2);
+  margin-bottom: calc($block-gap * -1);
 }
 
 @include mq-at-least-col3 {

--- a/ui/analyse/css/study/_list.scss
+++ b/ui/analyse/css/study/_list.scss
@@ -3,6 +3,7 @@
   @include prevent-select;
 
   background: $c-bg-box;
+  overflow: hidden;
 
   .study-list > div,
   button {

--- a/ui/analyse/css/study/_members.scss
+++ b/ui/analyse/css/study/_members.scss
@@ -78,8 +78,14 @@
     opacity: 0.7;
   }
 
-  .study-list > div:hover .leave:hover {
-    background-color: $c-bad;
+  .study-list > div {
+    &:first-child {
+      @extend %box-radius-top;
+    }
+
+    &:hover .leave:hover {
+      background-color: $c-bad;
+    }
   }
 
   .add {
@@ -89,12 +95,12 @@
     }
   }
 
-  .admin {
-    text-align: center;
+  .admin button {
+    @extend %box-radius-bottom;
 
-    button {
-      margin-bottom: 0.5em;
-    }
+    justify-content: center;
+    margin-bottom: 0.5em;
+    padding-block: 2px;
   }
 
   m-config,

--- a/ui/analyse/css/study/_members.scss
+++ b/ui/analyse/css/study/_members.scss
@@ -78,14 +78,8 @@
     opacity: 0.7;
   }
 
-  .study-list > div {
-    &:first-child {
-      @extend %box-radius-top;
-    }
-
-    &:hover .leave:hover {
-      background-color: $c-bad;
-    }
+  .study-list > div:hover .leave:hover {
+    background-color: $c-bad;
   }
 
   .add {
@@ -99,7 +93,6 @@
     @extend %box-radius-bottom;
 
     justify-content: center;
-    margin-bottom: 0.5em;
     padding-block: 2px;
   }
 

--- a/ui/analyse/css/study/relay/_embed.scss
+++ b/ui/analyse/css/study/relay/_embed.scss
@@ -1,6 +1,6 @@
 $vp-min-width: 320px;
 $vp-max-width: 1200px;
-$embed-uniboard-table: minmax(#{$col3-uniboard-table-min}, 800px);
+$embed-uniboard-table-max: 800px;
 
 body {
   ---site-header-height: 0px;
@@ -24,7 +24,12 @@ body {
 main.analyse.is-relay:not(.has-relay-tour) {
   /* In embed mode we don't want any space on the sides. Make the table expand to the full width */
   @include mq-at-least-col2 {
-    grid-template-columns: var(---col2-board-width) $analyse-block-gap $embed-uniboard-table;
+    grid-template-columns:
+      var(---col2-board-width) var(---analyse-gauge-col)
+      minmax(
+        calc(#{$col3-uniboard-table-min} - var(---analyse-gauge-offset)),
+        calc(#{$embed-uniboard-table-max} - var(---analyse-gauge-offset))
+      );
     grid-template-rows: repeat(2, calc(50vh - 1.5rem)) 3rem;
     grid-template-areas:
       'board gauge side'
@@ -72,7 +77,9 @@ main.is-relay.has-relay-tour {
 
   @include mq-at-least-col2 {
     /* Same column layout as in the game view */
-    grid-template-columns: var(---col2-board-width) $analyse-block-gap $embed-uniboard-table;
+    grid-template-columns:
+      var(---col2-board-width) $analyse-block-gap
+      minmax(#{$col3-uniboard-table-min}, #{$embed-uniboard-table-max});
     grid-template-rows: 100vh;
     grid-template-areas: 'relay-tour . side';
   }

--- a/ui/lib/css/abstract/_uniboard.scss
+++ b/ui/lib/css/abstract/_uniboard.scss
@@ -3,8 +3,9 @@
 $scrollbar-width: 20px;
 $col3-uniboard-side-min: var(---col3-uniboard-side-min, 250px);
 $col3-uniboard-table-min: 240px;
+$col3-uniboard-table-max: 400px;
 $col3-uniboard-side: minmax(#{$col3-uniboard-side-min}, 350px);
-$col3-uniboard-table: minmax(#{$col3-uniboard-table-min}, 400px);
+$col3-uniboard-table: minmax(#{$col3-uniboard-table-min}, #{$col3-uniboard-table-max});
 $col3-uniboard-controls: 3rem;
 $col3-min-bottom-margin: 1rem;
 $col3-uniboard-max-width: calc(
@@ -42,7 +43,12 @@ $col2-uniboard-default-width: minmax(
   #{$col3-uniboard-default-min-width},
   #{$col2-uniboard-default-max-width}
 );
-$col2-uniboard-squeeze-table: minmax(200px, 240px);
+$col2-uniboard-squeeze-table-min: 200px;
+$col2-uniboard-squeeze-table-max: 240px;
+$col2-uniboard-squeeze-table: minmax(
+  #{$col2-uniboard-squeeze-table-min},
+  #{$col2-uniboard-squeeze-table-max}
+);
 $col2-uniboard-squeeze-width: minmax(
   calc(55vmin),
   calc(100vh - #{$site-header-outer-height} - #{$block-gap})

--- a/ui/lib/css/ceval/_eval-gauge.scss
+++ b/ui/lib/css/ceval/_eval-gauge.scss
@@ -1,4 +1,6 @@
 .eval-gauge {
+  @extend %box-radius;
+
   width: $block-gap;
   height: var(---cg-height, 100%);
   position: relative;
@@ -22,6 +24,8 @@
   }
 
   &::after {
+    @extend %box-radius;
+
     content: '';
     display: block;
     position: absolute;

--- a/ui/lib/css/component/_board.scss
+++ b/ui/lib/css/component/_board.scss
@@ -32,7 +32,3 @@ cg-board {
 .mini-game .cg-wrap {
   @extend %square;
 }
-
-.gauge-on .main-board cg-board {
-  @extend %box-radius-left;
-}

--- a/ui/puzzle/css/_layout.scss
+++ b/ui/puzzle/css/_layout.scss
@@ -1,4 +1,4 @@
-$puzzle-block-gap: $block-gap;
+$puzzle-block-gap: 4px;
 
 #main-wrap {
   ---main-max-width: calc(100vh - #{$site-header-outer-height} - #{$col1-uniboard-controls});
@@ -18,6 +18,14 @@ $puzzle-block-gap: $block-gap;
 .puzzle {
   grid-area: main;
   display: grid;
+  gap: $block-gap $puzzle-block-gap;
+
+  ---puzzle-gauge-col: #{$puzzle-block-gap};
+  ---puzzle-gauge-offset: calc(var(---puzzle-gauge-col) - #{$puzzle-block-gap});
+
+  &.gauge-on {
+    ---puzzle-gauge-col: calc(#{$puzzle-block-gap} * 3.75);
+  }
 
   &--nvui {
     display: block;
@@ -60,14 +68,18 @@ $puzzle-block-gap: $block-gap;
   }
 
   grid-template-areas: 'board' 'controls' 'tools' 'session' 'side' 'kb-move';
-  row-gap: $puzzle-block-gap;
 
   &__moves {
     display: none;
   }
 
   @include mq-at-least-col2 {
-    grid-template-columns: var(---col2-uniboard-width) $puzzle-block-gap $col2-uniboard-table;
+    grid-template-columns:
+      var(---col2-uniboard-width) var(---puzzle-gauge-col)
+      minmax(
+        calc(#{$col3-uniboard-table-min} - var(---puzzle-gauge-offset)),
+        calc(#{$col3-uniboard-table-max} - var(---puzzle-gauge-offset))
+      );
     grid-template-rows: fit-content(0);
     grid-template-areas:
       'board   gauge tools'
@@ -85,7 +97,12 @@ $puzzle-block-gap: $block-gap;
   }
 
   @include mq-is-col2-squeeze {
-    grid-template-columns: $col2-uniboard-squeeze-width $puzzle-block-gap $col2-uniboard-squeeze-table;
+    grid-template-columns:
+      $col2-uniboard-squeeze-width var(---puzzle-gauge-col)
+      minmax(
+        calc(#{$col2-uniboard-squeeze-table-min} - var(---puzzle-gauge-offset)),
+        calc(#{$col2-uniboard-squeeze-table-max} - var(---puzzle-gauge-offset))
+      );
   }
 
   @include mq-at-least-col3 {
@@ -96,12 +113,16 @@ $puzzle-block-gap: $block-gap;
       'side    . .       .     .';
     grid-template-columns:
       $col3-uniboard-side $puzzle-block-gap var(---col3-uniboard-width)
-      $puzzle-block-gap $col3-uniboard-table;
+      var(---puzzle-gauge-col)
+      minmax(
+        calc(#{$col3-uniboard-table-min} - var(---puzzle-gauge-offset)),
+        calc(#{$col3-uniboard-table-max} - var(---puzzle-gauge-offset))
+      );
   }
 
   &__side {
     display: grid;
-    gap: $puzzle-block-gap;
+    gap: $block-gap;
     grid-template-areas: 'user' 'theme' 'metas' 'config';
 
     .puzzle-replay & {

--- a/ui/puzzle/css/_tools.scss
+++ b/ui/puzzle/css/_tools.scss
@@ -3,10 +3,6 @@
 
   background: $c-bg-box;
 
-  .gauge-on & {
-    @extend %box-radius-right;
-  }
-
   .ceval-wrap {
     flex: 0 0 38px;
   }


### PR DESCRIPTION
# Why

The eval bar might be a bit hard to spot/read when it's attached on both sides to the board and the analyse tools container.

This has been mentioned in some feedback videos/threads before, and we already detached the eval bar from miniboards for better readability.

# How

Add global gap for the analyse layout, adjust how grids are sets, define variable for few uniboard static values, so we can adjust them automatically, so only the tools cell/column resizes when eval bar visibility is toggled. Apply roundness to the eval bard and sibling container.

# Preview

<img width="1803" height="1136" alt="Screenshot 2026-08-16 at 10 30 48" src="https://github.com/user-attachments/assets/372007cd-326d-4175-9d79-dfb6695615ac" />

<img width="1803" height="1136" alt="Screenshot 2026-08-16 at 10 18 54" src="https://github.com/user-attachments/assets/de583fb9-7ed9-4df1-b6be-e515f5bb7b9c" />
