### PR TITLE
app(practice): inject missing keyboard move CSS based on user pref

### DIFF
--- a/modules/practice/src/main/PracticeUi.scala
+++ b/modules/practice/src/main/PracticeUi.scala
@@ -16,6 +16,7 @@ final class PracticeUi(helpers: Helpers)(
   def show(us: UserStudy, data: JsonView.JsData)(using ctx: Context) =
     Page(us.practiceStudy.name.value)
       .css("analyse.practice")
+      .css(ctx.pref.hasKeyboardMove.option("keyboardMove"))
       .i18n(_.study)
       .i18nOpt(ctx.speechSynthesis, _.nvui)
       .i18nOpt(ctx.blind, _.keyboardMove)


### PR DESCRIPTION
# Why

Spotted that keyboard move is rendered incorrectly in practice, when it's enabled in user perferences.

# How

Inject missing keyboard move CSS to practice view based on user pref.

# Preview

### Before

<img width="500" height="208" alt="Screenshot 2026-08-16 at 12 03 51" src="https://github.com/user-attachments/assets/c64b62cc-fe2f-451b-9483-68c43a830df1" />

### After

<img width="500" height="208" alt="Screenshot 2026-08-16 at 12 15 32" src="https://github.com/user-attachments/assets/a324fd48-e6ba-4595-921c-13e909e2dae8" />
