### PR TITLE
ui(analyse): move embedding tips link to input label

### DIFF
--- a/ui/analyse/css/study/panel/_share.scss
+++ b/ui/analyse/css/study/panel/_share.scss
@@ -35,6 +35,18 @@
       margin: 0 2px 0.5em 2px;
     }
   }
+
+  div.form-label {
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
+    justify-content: space-between;
+    flex-wrap: wrap;
+
+    .form-help {
+      font-weight: normal;
+    }
+  }
 }
 
 .study__share .url-start-at-ply {

--- a/ui/analyse/src/study/studyShare.ts
+++ b/ui/analyse/src/study/studyShare.ts
@@ -207,7 +207,20 @@ export function view(ctrl: StudyShare): VNode {
           ])
         : isPrivate || // study embed
           hl('div.form-group', [
-            hl('label.form-label', i18n.study.embedInYourWebsite),
+            hl('div.form-label', [
+              hl('label', i18n.study.embedInYourWebsite),
+              hl(
+                'a.form-help.text',
+                {
+                  attrs: {
+                    href: '/developers#embed-study',
+                    target: '_blank',
+                    ...dataIcon(licon.InfoCircle),
+                  },
+                },
+                i18n.study.readMoreAboutEmbedding,
+              ),
+            ]),
             copyMeInput(
               !isPrivate
                 ? `<iframe ${
@@ -219,17 +232,6 @@ export function view(ctrl: StudyShare): VNode {
               { inputAttrs: { readonly: true, disabled: isPrivate } },
             ),
             fromPly(ctrl),
-            hl(
-              'a.form-help.text',
-              {
-                attrs: {
-                  href: '/developers#embed-study',
-                  target: '_blank',
-                  ...dataIcon(licon.InfoCircle),
-                },
-              },
-              i18n.study.readMoreAboutEmbedding,
-            ),
           ]),
     ]),
     hl('div.form-group', [


### PR DESCRIPTION
# How

Move study embedding tips link to input label to emphasize the relation to iframe input.

# Preview

# Before

<img width="903" height="169" alt="Screenshot 2026-08-16 at 19 43 28" src="https://github.com/user-attachments/assets/f62b8cdf-8ccf-482c-bedf-998fcc297fd2" />

### After

<img width="918" height="140" alt="Screenshot 2026-08-16 at 20 04 08" src="https://github.com/user-attachments/assets/039738f3-af4c-445e-926c-2eceb0862aa9" />

<img width="419" height="169" alt="Screenshot 2026-08-16 at 20 03 55" src="https://github.com/user-attachments/assets/5f39cc02-c2bb-4119-82e2-d0d729ed6f41" />
