### PR TITLE
ui(lib): small tweak for sizing/aligment of buttons with icon

### DIFF
--- a/ui/lib/css/base/_data-icon.scss
+++ b/ui/lib/css/base/_data-icon.scss
@@ -7,6 +7,7 @@
 .is.text::before,
 .text[data-icon]::before {
   margin-inline: 0 0.4em;
+  line-height: 1;
 }
 
 .is-green::before {

--- a/ui/user/css/_show.scss
+++ b/ui/user/css/_show.scss
@@ -67,7 +67,7 @@
             color: $c-header-dropdown;
 
             &::before {
-              margin-inline: 0 1rem;
+              margin-inline: 0 0.5rem;
               font-size: 1.4em;
             }
           }


### PR DESCRIPTION
# Why

Due to usage of font icon instead of SVG elements directly we often have some slight misalignment when icons are injected on the side of text via shadow DOM elements.

# How

This changeset does not eliminate/fix the all issues, but it's a small generalized tweak which improves the icon display, especially for buttons using text and icon together.

During testing I have also caught up that user provide page button rack have quite large spacing between icon and text, almost 2.5x the default value, so I reduced it a bit.

# Preview

### Screen recording showing elements changes/move while toggling the `line-height`

https://github.com/user-attachments/assets/b3f20da6-3303-464b-b6ea-cbd4cf51c625

https://github.com/user-attachments/assets/7049f5c9-ff58-470a-81c6-b499980f2632

https://github.com/user-attachments/assets/b8dc8985-c04f-4f7a-8987-acd36fc09790

### User profile rack tweak

<img width="761" height="197" alt="Screenshot 2026-08-16 at 20 08 19" src="https://github.com/user-attachments/assets/b11a9a9c-610b-4306-8d59-a7ecb6441eae" />
