### PR TITLE
ui(lib/tree): apply color to inline comments, fix tree interrupt border color

### DIFF
--- a/ui/lib/css/tree/_tree.scss
+++ b/ui/lib/css/tree/_tree.scss
@@ -8,7 +8,7 @@ $disclosure-btn-size: calc(15px + var(---button-size-pointer-adjust, 0px));
 
   .#{$name},
   .#{$name} + lines,
-  .#{$name} + interrupt {
+  &-inline .#{$name} + interrupt {
     --c-annotation-border: rgb(from var(--c-#{$name}) r g b / calc(alpha * 0.6));
   }
 
@@ -413,6 +413,7 @@ $disclosure-btn-size: calc(15px + var(---button-size-pointer-adjust, 0px));
     overflow-wrap: break-word;
     margin: 0 0.2em 0 0.1em;
     font-size: 0.9em;
+    color: var(--c-base);
   }
 
   inline::before,


### PR DESCRIPTION
# How

Apply analysis kind color to tree comments in inline notation view.

Fix tree interrupt node border color, the added selector was aimed for inline display, but due to being too generic, it also matched tree view interrupt blocks when referencing move in second column.

# Preview

<img width="380"  alt="Screenshot 2026-08-16 at 21 13 33" src="https://github.com/user-attachments/assets/bea7b024-f9b8-4949-9eab-73f6845faa5f" />

<img width="380" alt="Screenshot 2026-08-16 at 21 07 55" src="https://github.com/user-attachments/assets/27da94b4-c326-44ae-b469-f17b1e7eb6f5" />

