### PR TITLE
ui(ublog): fix sticky icon, fix pills roundness

### DIFF
--- a/modules/ublog/src/main/ui/UblogUi.scala
+++ b/modules/ublog/src/main/ui/UblogUi.scala
@@ -58,7 +58,7 @@ final class UblogUi(helpers: Helpers, atomUi: AtomUi, modMenu: Context ?=> Frag)
         if showAuthor != ShowAt.none
         then userIdSpanMini(post.created.by)(cls := s"ublog-post-card__over-image pos-$showAuthor")
         else if ~post.sticky
-        then span(dataIcon := Icon.Star, cls := "user-link ublog-post-card__over-image pos-top")
+        then span(iconTag(Icon.Star))(cls := "user-link ublog-post-card__over-image pos-top")
         else emptyFrag
       ),
       span(cls := "ublog-post-card__content")(

--- a/ui/lib/css/component/_ublog-card.scss
+++ b/ui/lib/css/component/_ublog-card.scss
@@ -75,13 +75,13 @@
   time {
     @include inline-start(0);
 
-    border-radius: $small-box-radius-size 0 $small-box-radius-size 0;
+    border-radius: $box-radius-size 0 $small-box-radius-size 0;
   }
 
   .user-link {
     @include inline-end(0);
 
-    border-radius: 0 $small-box-radius-size 0 $small-box-radius-size;
+    border-radius: 0 $box-radius-size 0 $small-box-radius-size;
   }
 
   &__image {


### PR DESCRIPTION
# Why

Fixes #21313
* #21313

Refs:
* #20881

# How

The mentioned above PR changed how the blur is applied to pills, added pseudo element styles had empty `content` which was overwriting the icon data passed in directly to the element.

This PR changes the icon render to be tag based instead, which fixes the missing icon issue and also ensures better sizing of the container. In the process I have also fixed the pills overflow over border caused by small radius being applied to both opposite corners.

# Preview

### Before

<img width="405" height="436" alt="Screenshot 2026-08-16 at 23 57 55" src="https://github.com/user-attachments/assets/a88f9000-ebd2-46f0-abcf-246ca9f575bf" />

### After

<img width="405" height="436" alt="Screenshot 2026-08-16 at 23 49 07" src="https://github.com/user-attachments/assets/6640adde-ef6d-4c24-8dab-a2e56c628be4" />
