### PR TITLE
Only let the board editor draw shapes with the pointer

### DIFF
--- a/ui/editor/src/chessground.ts
+++ b/ui/editor/src/chessground.ts
@@ -85,15 +85,10 @@ function onMouseEvent(ctrl: EditorCtrl): (e: MouchEvent) => void {
       }
       lastKey = key;
     } else if (isRightClick(e)) {
-      if (sel !== 'pointer') {
-        ctrl.chessground!.state.drawable.current = undefined;
-        ctrl.chessground!.state.drawable.shapes = [];
-
-        if (e.type === 'contextmenu' && sel !== 'trash') {
-          ctrl.chessground!.cancelMove();
-          sel[0] = opposite(sel[0]);
-          ctrl.redraw();
-        }
+      if (sel !== 'pointer' && sel !== 'trash' && e.type === 'contextmenu') {
+        ctrl.chessground!.cancelMove();
+        sel[0] = opposite(sel[0]);
+        ctrl.redraw();
       }
     }
   };
@@ -135,7 +130,7 @@ function makeConfig(ctrl: EditorCtrl): CgConfig {
       enabled: false,
     },
     drawable: {
-      enabled: true,
+      enabled: ctrl.selected() === 'pointer',
       defaultSnapToValidMove: storage.boolean('arrow.snap').getOrDefault(true),
     },
     draggable: {

--- a/ui/editor/src/ctrl.ts
+++ b/ui/editor/src/ctrl.ts
@@ -57,7 +57,10 @@ export default class EditorCtrl {
     this.selected = propWithEffect('pointer', selected => {
       // right click paints the opposite color while a piece is selected, so shapes
       // can only be drawn with the pointer
-      if (this.chessground) this.chessground.state.drawable.enabled = selected === 'pointer';
+      if (this.chessground)
+        this.chessground.set({
+          drawable: { enabled: selected === 'pointer' },
+        });
     });
 
     [...(cfg.positions || []), ...(cfg.endgamePositions || [])].forEach(

--- a/ui/editor/src/ctrl.ts
+++ b/ui/editor/src/ctrl.ts
@@ -9,7 +9,7 @@ import { type Setup, Material, RemainingChecks, defaultSetup } from 'chessops/se
 import type { Rules, Square } from 'chessops/types';
 import { Castles, defaultPosition, Position, setupPosition } from 'chessops/variant';
 
-import { defined, prop, type Prop } from 'lib';
+import { defined, propWithEffect, type Prop } from 'lib';
 import { prompt } from 'lib/view';
 
 import {
@@ -54,7 +54,11 @@ export default class EditorCtrl {
   ) {
     this.options = cfg.options || {};
 
-    this.selected = prop('pointer');
+    this.selected = propWithEffect('pointer', selected => {
+      // right click paints the opposite color while a piece is selected, so shapes
+      // can only be drawn with the pointer
+      if (this.chessground) this.chessground.state.drawable.enabled = selected === 'pointer';
+    });
 
     [...(cfg.positions || []), ...(cfg.endgamePositions || [])].forEach(
       p => (p.epd = p.fen.split(' ').slice(0, 4).join(' ')),


### PR DESCRIPTION
Fixes #18884

### Problem

In the board editor, selecting a piece and then right clicking a square makes a circle appear and
disappear again straight away. Same with arrows.

Right click has a meaning while a piece is selected: it paints the opposite color. To keep that
working, the mouse handler cancelled whatever shape chessground had started and cleared the existing
shapes:

```ts
ctrl.chessground!.state.drawable.current = undefined;
ctrl.chessground!.state.drawable.shapes = [];
```

But `drawable` was enabled unconditionally, so chessground still started drawing on mousedown. The
shape was created and then wiped a moment later, which is the flicker.

### Fix

Drawing is enabled only while the pointer is selected. Chessground no longer starts a shape that has
to be undone, so nothing flickers, and the two clearing lines are no longer needed.

A side effect worth pointing out: shapes drawn with the pointer are no longer wiped when you right
click with a piece selected. That clearing looked incidental rather than intended - right click is
meant to flip the piece color, not to erase annotations - but say the word if it should be kept.

`selected` became a `propWithEffect` so the flag follows the tool without having to touch the four
call sites that change it.

### Testing

`pnpm test` is 236 passing, lint, format and tsc clean.

On a local lila I confirmed the behaviour that had to survive the change: selecting the white queen
and right clicking the board still flips it to the black queen.

The flicker itself I could not drive from automation - chessground does not react to synthetic right
clicks - so the before state was confirmed by hand in the editor rather than captured. Happy to add
screenshots if a maintainer wants them.

### AI usage disclosure

Written with Claude Code (Claude Opus 5), driven by me. The AI found the cause, wrote the fix and ran
the checks. I reproduced the bug myself, reviewed the change and approved it before it was pushed.
The prompts used are recorded in the commit message.
