### PR TITLE
Keep the keyboard move input clear of outer coordinates

### DIFF
--- a/ui/keyboardMove/css/_keyboardMove.scss
+++ b/ui/keyboardMove/css/_keyboardMove.scss
@@ -27,6 +27,13 @@
   }
 }
 
+// outer coordinates hang 15px below the board, see lib/css/theme/board/_coords.scss
+@include mq-at-least-col2 {
+  .coords-out .keyboard-move {
+    margin-block-start: calc(15px + 0.5rem);
+  }
+}
+
 .keyboard-move-help {
   td.tips li {
     list-style: disc;


### PR DESCRIPTION
Fixes #19755

### Problem

With "Board coordinates" set to outside the board, the keyboard move input box is laid out into the
file letters below the board - its outline touches the `a` under the a1 square.

`coords.files` is placed at `bottom: -15px` (`lib/css/theme/board/_coords.scss`), so it hangs below
the board container rather than taking up room in the layout. The input is spaced from that
container, so it ends up 4px inside the coordinates.

Measured on the analysis board before the change:

| | y |
| --- | --- |
| board container bottom | 841 |
| file coordinates | 839 - 856 |
| input top | 852 |

so the input starts 4px above where the coordinates end.

### Fix

Add the overhang to the input's top margin when the coordinates are outside. Afterwards the input
starts at 866, a 10px gap below the coordinates.

The rule is scoped to `.coords-out`, so the inside case keeps its existing 7.5px margin unchanged,
and to `mq-at-least-col2`, which is the breakpoint where outer coordinates are drawn at all.

The 15px is written out rather than shared with `_coords.scss`. Happy to lift it into a variable if
you would rather have one, it just seemed a big change to make for a spacing fix.

### Testing

Checked by hand on a local lila, coordinates outside and keyboard input on:

| case | margin | gap |
| --- | --- | --- |
| outside, before | 7.5px | -4px, overlapping |
| outside, after | 22px | +10px |
| inside, after | 7.5px | unchanged from master |

Stylelint and the formatter pass.

I could only exercise the analysis board. The issue also links a game, and `.keyboard-move` has no
top margin at all in the round layout, so the overlap there is the full 15px - this fix lives in the
shared keyboardMove stylesheet so it covers both, but I have not run it in a game.

### AI usage disclosure

Written with Claude Code (Claude Opus 5), driven by me. The AI reproduced the overlap, measured it,
wrote the fix and verified the result against the rendered page through browser automation. I set up
the account and preferences it needed, reviewed the change and approved it before it was pushed. The
prompts used are recorded in the commit message.
