### PR TITLE
Remove Unused SCSS Mixins and Placeholders

### DIFF
--- a/ui/lib/css/abstract/_box.scss
+++ b/ui/lib/css/abstract/_box.scss
@@ -59,10 +59,6 @@
   border-radius: 0 0 0 $box-radius-size;
 }
 
-%box-radius-bottom-right {
-  border-radius: 0 0 $box-radius-size 0;
-}
-
 %box-shadow {
   @include box-shadow;
 }

--- a/ui/lib/css/abstract/_extends.scss
+++ b/ui/lib/css/abstract/_extends.scss
@@ -102,24 +102,6 @@
   text-shadow: 0 1px 0 $c-clearer;
 }
 
-%metal-light {
-  background: linear-gradient(to bottom, hsl(0 0% 90%), hsl(0 0% 80%));
-  text-shadow: 0 1px 0 #fff;
-}
-
-%metal-light-hover {
-  background: linear-gradient(to bottom, hsl(0 0% 95%), hsl(0 0% 85%));
-  text-shadow: 0 1px 0 #fff;
-}
-
-%metal-dark {
-  background: linear-gradient(to bottom, hsl(37 7% 22%), hsl(37 5% 19%));
-}
-
-%metal-dark-hover {
-  background: linear-gradient(to bottom, hsl(37 7% 25%), hsl(37 5% 22%));
-}
-
 %active-inset-shadow {
   box-shadow: 0 3px 4px hsl(0 0% 0% / 0.15) inset !important;
 }

--- a/ui/lib/css/abstract/_mixins.scss
+++ b/ui/lib/css/abstract/_mixins.scss
@@ -13,26 +13,6 @@
     0 1px 5px 0 rgb(0 0 0 / 0.1);
 }
 
-@mixin box-neat {
-  @include box-radius;
-  @include box-shadow;
-}
-
-@mixin debug-zoom-input {
-  #zoom-input {
-    display: none;
-
-    @include mq-zoom-enabled {
-      @include inline-end(3px);
-
-      display: block;
-      position: fixed;
-      bottom: 3px;
-      width: 10vw;
-    }
-  }
-}
-
 @mixin transition($prop: all, $dur: $transition-duration, $timing: ease) {
   @if type-of($prop) == 'list' and length($prop) > 1 {
     $out: ();

--- a/ui/lib/css/abstract/_theme.scss
+++ b/ui/lib/css/abstract/_theme.scss
@@ -23,12 +23,6 @@ $outline: 2px solid $c-primary;
   }
 }
 
-@mixin if-not-transp {
-  html:not(.transp) & {
-    @content;
-  }
-}
-
 @mixin theme-style {
   html.transp::before {
     content: ' ';


### PR DESCRIPTION
## Why
Removes 8 unused mixins and placeholders from `ui/lib/css/abstract/`

## Testing

Nothing includes or extends these mixins and placeholders

``` shell
git grep -nE "debug-zoom-input|if-not-transp|metal-light|metal-dark|box-radius-bottom-right"
git grep -nE "@include +box-neat"
```

Outputs nothing after deletion

Builds successfully in lila-docker