### PR TITLE
automod health and ublog tweaks

### DIFF
--- a/app/controllers/Report.scala
+++ b/app/controllers/Report.scala
@@ -214,3 +214,26 @@ final class Report(env: Env, userC: => User, modC: => Mod) extends LilaControlle
             .map:
               views.report.ui.thanks(reported.id, _)
   }
+
+  def automodStatus = Secure(_.SeeReport) { _ ?=> me ?=>
+    env.report.automodRepo
+      .statusJson(adminLinks)
+      .flatMap: health =>
+        Ok.page:
+          views.report.ui.automodStatus(health)(views.mod.ui.menu("automod"))
+  }
+
+  def automodStatusXhr = Secure(_.SeeReport) { _ ?=> _ ?=>
+    env.report.automodRepo
+      .statusJson(adminLinks)
+      .map(JsonOk.apply)
+  }
+
+  private def adminLinks(using Me) =
+    isGranted(_.ModerateBlog)
+      .option:
+        lila.report.AutomodRepo.AdminLink(
+          jobType = lila.report.Automod.JobType.blog,
+          url = routes.Ublog.failedAutomod().url
+        )
+      .toList

--- a/app/controllers/Ublog.scala
+++ b/app/controllers/Ublog.scala
@@ -12,6 +12,7 @@ import lila.report.Suspect
 import lila.ublog.{ UblogBlog, UblogPost, UblogByMonth }
 import lila.core.ublog.{ BlogsBy, Quality, QualityFilter }
 import lila.core.i18n.toLanguage
+import lila.core.perm.Granter
 import lila.ublog.UblogForm.{ ModPostData, UblogPostData }
 import lila.common.HTTPRequest
 
@@ -243,7 +244,8 @@ final class Ublog(env: Env) extends LilaController(env):
             featured <- env.ublog.api.setFeatured(modPost, data)
             newPost = modPost.copy(featured = featured.orElse(modPost.featured))
             carousel <- env.ublog.api.fetchCarouselFromDb()
-            next <- (newPost.modQuality.isDefined && post.isPendingQuality).so(env.ublog.api.nextToReview)
+            next <- (newPost.approval == UblogPost.Approval.verified && post.isPendingQuality)
+              .so(env.ublog.api.nextToReview)
           yield
             if data.hasUpdates then logModAction(newPost, data.diff(post))
             next match
@@ -366,6 +368,25 @@ final class Ublog(env: Env) extends LilaController(env):
         posts <- ids.mapFutureList(env.ublog.api.postPreviews)
         page <- renderPage(views.ublog.ui.search(queryText, by, posts.some))
       yield Ok(page)
+
+  def failedAutomod(page: Int) = Secure(_.ModerateBlog) { _ ?=> me ?=>
+    env.ublog.paginator
+      .failedAutomod(page)
+      .flatMap: posts =>
+        Ok.page(views.ublog.ui.failedAutomod(posts)(views.mod.ui.menu("automod")))
+  }
+
+  def retryFailedAutomod(postId: Option[UblogPostId]) = Secure(_.ModerateBlog) { _ ?=> me ?=>
+    if postId.nonEmpty || Granter(_.Admin) then
+      env.ublog.api.retryFailedAutomod(postId).inject(Redirect(routes.Ublog.failedAutomod()))
+    else authorizationFailed
+  }
+
+  def clearFailedAutomod(postId: Option[UblogPostId]) = Secure(_.ModerateBlog) { _ ?=> me ?=>
+    if postId.nonEmpty || Granter(_.Admin) then
+      env.ublog.api.clearFailedAutomod(postId).inject(Redirect(routes.Ublog.failedAutomod()))
+    else authorizationFailed
+  }
 
   private def isBlogVisible(user: UserModel, blog: UblogBlog) = user.enabled.yes && blog.visible
 

--- a/app/views/base/page.scala
+++ b/app/views/base/page.scala
@@ -70,6 +70,7 @@ object page:
           pref.is3d.option(cssTag("lib.board-3d")),
           ctx.data.inquiry.isDefined.option(cssTag("mod.inquiry")),
           ctx.impersonatedBy.isDefined.option(cssTag("mod.impersonate")),
+          lila.security.Granter.opt(_.SeeReport).option(cssTag("mod.badges")),
           ctx.blind.option(cssTag("bits.blind")),
           p.cssKeys.map(cssTag),
           meta(

--- a/app/views/mod/ui.scala
+++ b/app/views/mod/ui.scala
@@ -6,7 +6,7 @@ import lila.shutup.Analyser.highlightBad
 import lila.core.chat.PublicSource
 import lila.common.ClientName
 
-lazy val ui = ModUi(helpers)
+lazy val ui = ModUi(helpers, () => env.report.automod.health)
 lazy val userTable = ModUserTableUi(helpers, ui)
 lazy val user = ModUserUi(helpers, ui, env.mod.mailerEventsUrl)
 lazy val gamify = GamifyUi(helpers)(views.mod.ui.menu("gamify"))

--- a/bin/mongodb/indexes.js
+++ b/bin/mongodb/indexes.js
@@ -4,6 +4,9 @@ db.picfit_image.createIndex(
   { 'automod.flagged': 1 },
   { partialFilterExpression: { 'automod.flagged': { $exists: true } } },
 );
+db.automod.createIndex({ createdAt: -1 });
+db.automod.createIndex({ jobType: 1, 'response.result': 1, 'response.date': -1 });
+db.automod.createIndex({ jobType: 1, 'response.result': 1, source: 1 });
 db.swiss_pairing.createIndex({ s: 1, p: 1, r: 1 });
 db.swiss_pairing.createIndex({ t: 1 }, { partialFilterExpression: { t: true } });
 db.oauth2_authorization.createIndex({ expires: 1 }, { expireAfterSeconds: 0 });
@@ -18,8 +21,9 @@ db.ublog_post.createIndex({ rank: -1 }, { partialFilterExpression: { live: true 
 db.ublog_post.createIndex({ likers: 1, rank: -1 }, { partialFilterExpression: { live: true } });
 db.ublog_post.createIndex({ language: 1, rank: -1 }, { partialFilterExpression: { live: true } });
 db.ublog_post.createIndex({ topics: 1, rank: -1 }, { partialFilterExpression: { live: true } });
-db.ublog_post.createIndex({ topics: 1, 'lived.at': -1 }, { partialFilterExpression: { live: true } });
+db.ublog_post.createIndex({ topics: 1, listedAt: -1 }, { partialFilterExpression: { live: true } });
 db.ublog_post.createIndex({ likers: 1, 'lived.at': -1 }, { partialFilterExpression: { live: true } });
+db.ublog_post.createIndex({ listedAt: -1 }, { partialFilterExpression: { live: true } });
 db.ublog_post.createIndex({ prismicId: 1 }, { partialFilterExpression: { prismicId: { $exists: 1 } } });
 db.ublog_post.createIndex(
   { 'lived.at': -1 },

--- a/bin/mongodb/indexes.js
+++ b/bin/mongodb/indexes.js
@@ -4,7 +4,7 @@ db.picfit_image.createIndex(
   { 'automod.flagged': 1 },
   { partialFilterExpression: { 'automod.flagged': { $exists: true } } },
 );
-db.automod.createIndex({ createdAt: -1 });
+db.automod.createIndex({ updated: -1 });
 db.automod.createIndex({ jobType: 1, 'response.result': 1, 'response.date': -1 });
 db.automod.createIndex({ jobType: 1, 'response.result': 1, source: 1 });
 db.swiss_pairing.createIndex({ s: 1, p: 1, r: 1 });

--- a/bin/mongodb/ublog-post-quality.js
+++ b/bin/mongodb/ublog-post-quality.js
@@ -1,7 +1,15 @@
 db.ublog_post.find({ automod: { $exists: 1 } }).forEach(p => {
-  const set = {
-    quality: p.automod.quality || 0,
-  };
-  if (p.automod.lockedBy) set['modQuality'] = set.quality;
-  db.ublog_post.updateOne({ _id: p._id }, { $set: set });
+  db.ublog_post.updateOne(
+    { _id: p._id },
+    { $set: { quality: p.quality ?? p.modQuality ?? p.automod.quality ?? 0 } },
+  );
 });
+
+db.ublog_post.updateMany({ approval: { $exists: false } }, { $set: { approval: 'verified' } });
+
+db.ublog_post.updateMany({ modQuality: { $exists: true } }, { $unset: { modQuality: '' } });
+
+db.ublog_post.updateMany(
+  { quality: { $gt: 0 }, listedAt: { $exists: false }, 'lived.at': { $exists: true } },
+  [{ $set: { listedAt: '$lived.at' } }],
+);

--- a/bin/ublog-automod.mjs
+++ b/bin/ublog-automod.mjs
@@ -28,7 +28,7 @@ overview:
     in assessment mode:      
       - if no --out option is given, results are incrementally stored in db.ublog_post
       - provide post ids, --[to/from] filters, or process all of db.ublog_post
-      - stored hashes will prevent reprocessing posts in both --out and direct db mode.
+      - existing automod jobs will prevent reprocessing posts in both --out and direct db mode.
         progress is saved and resumeable on abort. to force reprocessing, use --force
 
 required (one of these):
@@ -50,7 +50,7 @@ optional (with --key only):
   --out=<ndjson file>    # output file for { _id, automod } objects, otherwise assessments go in ublog_post
   --log=<log file>       # append errors to log file (default silent)
   --ppm=<int>            # throttle posts per minute (default 500 - https://docs.together.ai/docs/rate-limits)
-  --force                # retrieve new automod data even if hashes and versions match
+  --force                # retrieve new automod data even if an automod job or current assessment exists
 
 examples:
   ./ublog-automod.mjs --dry-run --from=2024-01-01 --print-ids
@@ -62,10 +62,10 @@ examples:
 
   ./ublog-automod.mjs --key=xyzabc1234 --force ublogId1 ublogId2
     fetches automod assessments for ublogId1 & ublogId2 and force update ublog_post
-    regardless of hashes\n`;
+    regardless of existing automod jobs or assessments\n`;
 
 const qualities = { spam: 0, weak: 1, good: 2, great: 3 }; // in sync with UblogAutomod.scala
-const schemaVersion = 1;
+const schemaVersion = 2;
 const flushEvery = 100; // bulk write after every <flushEvery> assessments
 const concurrentRequests = 32;
 
@@ -109,7 +109,7 @@ async function worker() {
     if (automod) {
       if (args.out) {
         await fs.promises.appendFile(args.out, JSON.stringify({ _id: post._id, automod }) + '\n');
-      } else if (needsUpdate(post.automod, automod.hash)) {
+      } else if (await needsUpdate(post.automod, automodId(post))) {
         bulkOps.push({ updateOne: { filter: { _id: post._id }, update: { $set: { automod } } } });
       }
     }
@@ -132,13 +132,13 @@ async function worker() {
 
 async function assess(post) {
   const content = `${post.title} ${post.intro} ${post.markdown}`.slice(0, 40_000); // UblogAutomod.scala
-  const hash = crypto.createHash('sha256').update(content).digest('hex').slice(0, 12);
+  const jobId = automodId(post);
   const id = post._id;
   const existing = previous[id] ?? post.automod;
   const backoff = retry[id].result !== 'network' ? 0 : 5_000 * 2 ** (retry[id].count - 1);
   const sleepTime = Math.max(0, nextAllowedAfter - Date.now()) + backoff;
 
-  if (!needsUpdate(existing, hash)) return existing;
+  if (!(await needsUpdate(existing, jobId))) return existing;
   if (args.dryRun) {
     retry[id].result = 'dirty';
     return false;
@@ -175,7 +175,6 @@ async function assess(post) {
   try {
     const data = JSON.parse(body).choices[0].message.content;
     const automod = normalize(JSON.parse(/\{[^}]+\}/.exec(data)[0]));
-    automod.hash = hash;
     retry[id].result = 'success';
     return automod;
   } catch {
@@ -204,11 +203,15 @@ function previousAutomods() {
 
 // ===========================================================================================================
 
-function needsUpdate(automod, hash) {
-  if (!automod || args.force) return true;
-  if (automod.version !== schemaVersion) return true;
-  if (automod.hash !== hash) return true;
-  return false;
+async function needsUpdate(automod, id) {
+  if (args.force) return true;
+  if (await db.collection('automod').findOne({ _id: id }, { projection: { _id: 1 } })) return false;
+  return !automod || automod.version !== schemaVersion;
+}
+
+function automodId(post) {
+  const content = `${post.title} ${post.intro} ${post.markdown}`.slice(0, 40_000); // UblogAutomod.scala
+  return `blog:${crypto.createHash('sha256').update(`blog::${content}`).digest('hex').slice(0, 16)}`; // Automod.jobId
 }
 
 // ===========================================================================================================

--- a/conf/report.routes
+++ b/conf/report.routes
@@ -11,3 +11,5 @@ POST  /report/:id/process              controllers.report.Report.process(id: Rep
 POST  /report/:id/xfiles               controllers.report.Report.xfiles(id: ReportId)
 POST  /report/:id/snooze/:dur          controllers.report.Report.snooze(id: ReportId, dur: String)
 GET   /report/:user/cheat-inquiry  controllers.report.Report.currentCheatInquiry(user: UserStr)
+GET   /report/automod                  controllers.report.Report.automodStatus
+GET   /report/automod.json             controllers.report.Report.automodStatusXhr

--- a/conf/routes
+++ b/conf/routes
@@ -137,6 +137,9 @@ POST  /ublog/$id<\w{8}>/adjust         controllers.Ublog.modPost(id: UblogPostId
 POST  /ublog/$id<\w{8}>/pull           controllers.Ublog.modPull(id: UblogPostId)
 POST  /ublog/carousel/size             controllers.Ublog.modSetCarouselSize
 GET   /ublog/carousel                  controllers.Ublog.modShowCarousel
+GET   /ublog/automod/failed            controllers.Ublog.failedAutomod(page: Int ?= 1)
+POST  /ublog/automod/retry             controllers.Ublog.retryFailedAutomod(postId: Option[UblogPostId] ?= None)
+POST  /ublog/automod/clear             controllers.Ublog.clearFailedAutomod(postId: Option[UblogPostId] ?= None)
 POST  /upload/image/ublog/$id<\w{8}>   controllers.Ublog.image(id: UblogPostId)
 
 # Feed

--- a/modules/mod/src/main/ui/ModUi.scala
+++ b/modules/mod/src/main/ui/ModUi.scala
@@ -11,7 +11,7 @@ import lila.report.Mod
 
 import ScalatagsTemplate.{ *, given }
 
-final class ModUi(helpers: Helpers):
+final class ModUi(helpers: Helpers, automodStatus: () => lila.report.Automod.Status):
   import helpers.{ *, given }
 
   def impersonate(user: User)(using Translate) =
@@ -267,6 +267,15 @@ final class ModUi(helpers: Helpers):
         .option(a(cls := itemCls(active, "ip-tiers"), href := routes.Dev.ipTiers)("IP limit tiers")),
       Granter(_.Settings)
         .option(a(cls := itemCls(active, "setting"), href := routes.Dev.settings)("Settings")),
+      Granter(_.SeeReport).option:
+        val status = automodStatus()
+        a(cls := itemCls(active, "automod"), href := routes.Report.automodStatus)(
+          "Automod",
+          (status != lila.report.Automod.Status.green).option(
+            span(cls := s"automod-status-badge ${status.toString}")
+          )
+        )
+      ,
       Granter(_.Cli).option(a(cls := itemCls(active, "cli"), href := routes.Dev.cli)("CLI"))
     )
 

--- a/modules/report/src/main/Automod.scala
+++ b/modules/report/src/main/Automod.scala
@@ -1,147 +1,109 @@
 package lila.report
 
-import play.api.{ ConfigLoader, Configuration }
-import play.api.libs.json.*
-import play.api.libs.ws.{ StandaloneWSClient, StandaloneWSResponse }
-import play.api.libs.ws.JsonBodyWritables.*
-import play.api.libs.ws.JsonBodyReadables.*
+import com.roundeights.hasher.Algo
+import play.api.ConfigLoader
+import reactivemongo.api.bson.Macros.Annotations.Key
 
 import lila.common.autoconfig.AutoConfig
 import lila.common.config.given
-import lila.common.Json.given
 import lila.core.config.Secret
 import lila.core.data.Text
-import lila.core.id.ImageId
-import lila.mon.extensions.*
-import lila.memo.{ ImageAutomod, ImageAutomodRequest, Dimensions }
-import lila.memo.SettingStore.Text.given
+object Automod:
+  enum JobType:
+    case blog, comms, image
 
-final class Automod(
-    ws: StandaloneWSClient,
-    appConfig: Configuration,
-    settingStore: lila.memo.SettingStore.Builder,
-    picfitApi: lila.memo.PicfitApi
-)(using Executor):
+  case class Source(id: Option[String] = none, name: Option[String] = none, url: Option[String] = none)
 
-  private val config = appConfig.get[Automod.Config]("automod")
-
-  val imagePromptSetting = settingStore[Text](
-    "imageAutomodPrompt",
-    text = "Image automod prompt".some,
-    default = Text("")
+  case class Job(
+      jobType: JobType,
+      source: Source,
+      config: String = "",
+      hash: Option[String] = none
   )
 
-  val imageModelSetting = settingStore[String](
-    "imageAutomodModel",
-    text = "Image automod model".some,
-    default = "Qwen/Qwen2.5-VL-72B-Instruct"
-  )
+  enum Input:
+    case Text(value: String)
+    case Image(url: String)
 
-  lila.common.Bus.sub[ImageAutomodRequest]: req =>
-    imageFlagReason(req.id, req.dim.some)
-      .map: flagged =>
-        picfitApi.setAutomod(req.id, ImageAutomod(flagged))
+    def hashInput: String = this match
+      case Text(value) => value
+      case Image(url) => url
 
-  def text(
-      userText: String,
-      systemPrompt: Text,
+  case class Request(
+      job: Job,
+      prompt: Text,
       model: String,
+      input: Input,
       temperature: Double = 0,
-      maxTokens: Int = 4096
-  ): Fu[JsObject] =
-    List(config.apiKey.value, systemPrompt.value, userText)
-      .forall(_.nonEmpty)
-      .so:
-        val body = Json
-          .obj(
-            "model" -> model,
-            "temperature" -> temperature,
-            "max_tokens" -> maxTokens,
-            "messages" -> Json.arr(
-              Json.obj("role" -> "system", "content" -> systemPrompt.value),
-              Json.obj("role" -> "user", "content" -> userText)
-            ),
-            "reasoning" -> Json.obj("enabled" -> false),
-            "response_format" -> Json.obj("type" -> "json_object")
-          )
-        ws.url(config.url)
-          .withHttpHeaders(
-            "Authorization" -> s"Bearer ${config.apiKey.value}",
-            "Content-Type" -> "application/json"
-          )
-          .post(body)
-          .map(extractJsonFromResponse)
-          .flatMap(_.toFuture)
+      reasoning: Boolean = false,
+      timeout: Option[scala.concurrent.duration.FiniteDuration] = none
+  ):
+    def hash: String = job.hash.getOrElse(defaultHash(job, input.hashInput))
 
-  def markdownImages(markdown: Markdown): Fu[Seq[lila.memo.PicfitImage]] =
-    val ids = picfitApi.imageIds(markdown)
-    picfitApi
-      .byIds(ids)
-      .flatMap:
-        _.map: pic =>
-          if pic.automod.isDefined then fuccess(pic)
-          else
-            for
-              flagged <- imageFlagReason(pic.id, pic.dimensions)
-              automod = ImageAutomod(flagged)
-              _ <- picfitApi.setAutomod(pic.id, automod)
-            yield pic.copy(automod = automod.some)
-        .toSeq.parallel
+  object Request:
+    def text(
+        job: Job,
+        userText: String,
+        prompt: Text,
+        model: String,
+        temperature: Double = 0,
+        reasoning: Boolean = false
+    ) = Request(job, prompt, model, Input.Text(userText), temperature, reasoning)
 
-  private def imageFlagReason(id: ImageId, dim: Option[Dimensions]): Fu[Option[String]] =
-    val (apiKey, model, prompt) =
-      (config.apiKey.value, imageModelSetting.get(), imagePromptSetting.get().value)
-    List(apiKey, model, prompt)
-      .forall(_.nonEmpty)
-      .so:
-        val imageUrl = picfitApi.url.automod(id, dim)
-        val body = Json
-          .obj(
-            "model" -> model,
-            "temperature" -> 0,
-            "messages" -> Json.arr(
-              Json.obj(
-                "role" -> "user",
-                "content" -> Json.arr(
-                  Json.obj("type" -> "text", "text" -> prompt),
-                  Json.obj("type" -> "image_url", "image_url" -> Json.obj("url" -> imageUrl))
-                )
-              )
-            ),
-            "reasoning" -> Json.obj("enabled" -> false),
-            "response_format" -> Json.obj("type" -> "json_object")
-          )
-        ws.url(config.url)
-          .withHttpHeaders(
-            "Authorization" -> s"Bearer $apiKey",
-            "Content-Type" -> "application/json"
-          )
-          .withRequestTimeout(10.minutes) // I saw it timeout with the default 5min
-          .post(body)
-          .map(extractJsonFromResponse)
-          .flatMap(_.toFuture)
-          .prefixFailure(s"Automod image $id request failed")
-          .map: res =>
-            val flagged = ~res.boolean("flag")
-            lila.mon.mod.report.automod.imageFlagged(flagged).increment()
-            flagged.option:
-              res.str("reason") | "No reason provided"
-          .monSuccess(lila.mon.mod.report.automod.imageRequest)
-          .recover:
-            case err =>
-              logger.error(err.getMessage, err)
-              none
+    def image(job: Job, imageUrl: String, prompt: Text, model: String) =
+      Request(job, prompt, model, Input.Image(imageUrl), timeout = 10.minutes.some)
 
-  private def extractJsonFromResponse(rsp: StandaloneWSResponse): Either[String, JsObject] =
-    for
-      _ <- Either.cond(rsp.status == 200, (), s"API error ${rsp.status}")
-      choices <- (rsp.body \ "choices").asOpt[List[JsObject]].toRight("No choices in response")
-      best <- choices.headOption.toRight("Empty choices in response")
-      msg <- (best \ "message" \ "content").validate[String].asEither.left.map(_.toString)
-      trimmed = msg.slice(msg.indexOf('{', msg.indexOf("</think>")), msg.lastIndexOf('}') + 1)
-      res <- Json.parse(trimmed).asOpt[JsObject].toRight("Invalid JSON in response")
-    yield res
+  extension (request: Request) def id: String = jobId(request.job, request.input.hashInput)
 
-private object Automod:
+  case class Usage(
+      inputTokens: Int,
+      outputTokens: Int
+  ):
+    def totalTokens: Int = inputTokens + outputTokens
+
+  case class Response(
+      date: Instant,
+      result: Response.Result,
+      output: Option[String] = none,
+      error: Option[String] = none,
+      usage: Option[Usage] = none
+  )
+
+  object Response:
+    enum Result:
+      case success, failed, cleared
+
+    def success(date: Instant, output: String, usage: Option[Usage]) =
+      Response(date, Result.success, output.some, usage = usage)
+    def failed(date: Instant, error: String) = Response(date, Result.failed, error = error.some)
+
+  case class Transaction(
+      @Key("_id") id: String,
+      jobType: JobType,
+      config: String,
+      source: Source,
+      model: String,
+      updated: Instant,
+      response: Option[Response] = none,
+      failures: Int = 0
+  )
+
+  def defaultHash(job: Job, input: String): String =
+    Algo.sha256(s"${job.jobType}:${job.config}:$input").hex.take(16)
+
+  def jobId(job: Job, input: String): String =
+    s"${job.jobType}:${job.hash.getOrElse(defaultHash(job, input))}"
+
+  enum Status:
+    case green, yellow, red
+
+  case class Health(recent: List[Boolean] = Nil):
+    def record(success: Boolean): Health = copy(recent = (success :: recent).take(10))
+
+    def status: Status =
+      if recent.size > 0 && recent.take(5).forall(!_) then Status.red
+      else if recent.contains(false) then Status.yellow
+      else Status.green
+
   case class Config(val url: String, val apiKey: Secret)
   given ConfigLoader[Config] = AutoConfig.loader[Config]

--- a/modules/report/src/main/AutomodApi.scala
+++ b/modules/report/src/main/AutomodApi.scala
@@ -1,0 +1,218 @@
+package lila.report
+
+import java.util.Base64
+import java.util.concurrent.atomic.AtomicReference
+
+import play.api.Configuration
+import play.api.libs.json.*
+import play.api.libs.ws.{ StandaloneWSClient, StandaloneWSResponse }
+import play.api.libs.ws.DefaultBodyReadables.*
+import play.api.libs.ws.JsonBodyWritables.*
+
+import lila.core.data.Text
+import lila.core.id.ImageId
+import lila.mon.extensions.*
+import lila.memo.{ Dimensions, ImageAutomod, ImageAutomodRequest }
+import lila.memo.SettingStore.Text.given
+
+final class AutomodApi(
+    ws: StandaloneWSClient,
+    appConfig: Configuration,
+    settingStore: lila.memo.SettingStore.Builder,
+    picfitApi: lila.memo.PicfitApi,
+    repo: AutomodRepo
+)(using Executor):
+
+  private case class ParsedResponse(data: JsObject, usage: Option[Automod.Usage])
+
+  private val config = appConfig.get[Automod.Config]("automod")
+  private val healthState = AtomicReference(Automod.Health())
+
+  def health: Automod.Status = healthState.get.status
+
+  def failed(jobType: Automod.JobType, offset: Int, limit: Int): Fu[List[Automod.Transaction]] =
+    repo.failed(jobType, offset, limit)
+
+  def failedCount(jobType: Automod.JobType): Fu[Int] = repo.failedCount(jobType)
+
+  def failedSourceIds(jobType: Automod.JobType): Fu[List[String]] = repo.failedSourceIds(jobType)
+
+  def clear(jobType: Automod.JobType, sourceId: String): Funit = repo.clear(jobType, sourceId)
+
+  def clearAll(jobType: Automod.JobType): Funit = repo.clearAll(jobType)
+
+  val imagePromptSetting = settingStore[Text](
+    "imageAutomodPrompt",
+    text = "Image automod prompt".some,
+    default = Text("")
+  )
+
+  val imageModelSetting = settingStore[String](
+    "imageAutomodModel",
+    text = "Image automod model".some,
+    default = "Qwen/Qwen3.5-9B"
+  )
+
+  lila.common.Bus.sub[ImageAutomodRequest]: req =>
+    imageFlagReason(req.id, req.dim.some)
+      .map: flagged =>
+        picfitApi.setAutomod(req.id, ImageAutomod(flagged))
+
+  def apply(request: Automod.Request): Fu[JsObject] =
+    List(config.apiKey.value, request.prompt.value, request.input.hashInput)
+      .forall(_.nonEmpty)
+      .so:
+        track(request)(
+          request.timeout
+            .fold(
+              ws.url(config.url)
+                .withHttpHeaders(
+                  "Authorization" -> s"Bearer ${config.apiKey.value}",
+                  "Content-Type" -> "application/json"
+                )
+            ):
+              ws.url(config.url)
+                .withHttpHeaders(
+                  "Authorization" -> s"Bearer ${config.apiKey.value}",
+                  "Content-Type" -> "application/json"
+                )
+                .withRequestTimeout(_)
+            .post(requestBody(request))
+            .flatMap: rsp =>
+              extractJsonFromResponse(rsp)
+                .toTry(s"Automod ${request.model} invalid response: ${rsp.body[String].takeRight(200)}")
+                .toFuture
+        ).map(_.data)
+
+  def markdownImages(markdown: Markdown): Fu[Seq[lila.memo.PicfitImage]] =
+    val ids = picfitApi.imageIds(markdown)
+    picfitApi
+      .byIds(ids)
+      .flatMap:
+        _.map: pic =>
+          if pic.automod.isDefined then fuccess(pic)
+          else
+            for
+              flagged <- imageFlagReason(pic.id, pic.dimensions)
+              automod = ImageAutomod(flagged)
+              _ <- picfitApi.setAutomod(pic.id, automod)
+            yield pic.copy(automod = automod.some)
+        .toSeq.parallel
+
+  private def imageFlagReason(id: ImageId, dim: Option[Dimensions]): Fu[Option[String]] =
+    val (apiKey, model, prompt) =
+      (config.apiKey.value, imageModelSetting.get(), imagePromptSetting.get().value)
+    List(apiKey, model, prompt)
+      .forall(_.nonEmpty)
+      .so:
+        val imageUrl = picfitApi.url.automod(id, dim)
+        ws.url(imageUrl.value)
+          .get()
+          .flatMap: imageRsp =>
+            if imageRsp.status != 200 then
+              fufail(s"Picfit image $id returned ${imageRsp.status} ${imageRsp.statusText}")
+            else
+              val contentType = if id.value.endsWith(".png") then "image/png" else "image/webp"
+              val encoded = Base64.getEncoder.encodeToString(imageRsp.bodyAsBytes.toArray)
+              apply(
+                Automod.Request.image(
+                  job = Automod.Job(Automod.JobType.image, Automod.Source(id = id.value.some)),
+                  imageUrl = s"data:$contentType;base64,$encoded",
+                  prompt = Text(prompt),
+                  model = model
+                )
+              )
+          .prefixFailure(s"Automod image $id request failed")
+          .map: res =>
+            val flagged = ~res.boolean("flag")
+            lila.mon.mod.report.automod.imageFlagged(flagged).increment()
+            flagged.option:
+              res.str("reason") | "No reason provided"
+          .monSuccess(lila.mon.mod.report.automod.imageRequest)
+          .recover:
+            case err =>
+              logger.error(err.getMessage, err)
+              none
+
+  private def extractJsonFromResponse(rsp: StandaloneWSResponse): Option[ParsedResponse] =
+    if rsp.status != 200 then none
+    else
+      scala.util
+        .Try:
+          val body = rsp.body[String]
+          val streamed = body.linesIterator
+            .collect:
+              case s"data:$event" if event.trim != "[DONE]" =>
+                Json.parse(event)
+            .toList
+          val response = streamed.headOption.getOrElse(Json.parse(body))
+          val content = streamed.flatMap: event =>
+            (event \ "choices")
+              .as[List[JsObject]]
+              .flatMap(choice => (choice \ "delta" \ "content").asOpt[String])
+          val msg = if streamed.nonEmpty then content.mkString
+          else ((response \ "choices").as[List[JsObject]].head \ "message" \ "content").as[String]
+          val usage = (streamed :+ response).reverseIterator.collectFirst:
+            case event if (event \ "usage").asOpt[JsObject].isDefined =>
+              val tokens = (event \ "usage").as[JsObject]
+              Automod.Usage(
+                (tokens \ "input_tokens").asOpt[Int].orElse((tokens \ "prompt_tokens").asOpt[Int]).get,
+                (tokens \ "output_tokens").asOpt[Int].orElse((tokens \ "completion_tokens").asOpt[Int]).get
+              )
+          ParsedResponse(
+            Json
+              .parse(msg.slice(msg.indexOf('{', msg.indexOf("</think>")), msg.lastIndexOf('}') + 1))
+              .as[JsObject],
+            usage
+          )
+        .toOption
+
+  private def requestBody(request: Automod.Request): JsObject =
+    val messages = request.input match
+      case Automod.Input.Text(userText) =>
+        Json.arr(
+          Json.obj("role" -> "system", "content" -> request.prompt.value),
+          Json.obj("role" -> "user", "content" -> userText)
+        )
+      case Automod.Input.Image(imageUrl) =>
+        Json.arr(
+          Json.obj(
+            "role" -> "user",
+            "content" -> Json.arr(
+              Json.obj("type" -> "text", "text" -> request.prompt.value),
+              Json.obj("type" -> "image_url", "image_url" -> Json.obj("url" -> imageUrl))
+            )
+          )
+        )
+    Json.obj(
+      "model" -> request.model,
+      "temperature" -> request.temperature,
+      "max_tokens" -> 4096,
+      "messages" -> messages,
+      "stream" -> true,
+      "stream_options" -> Json.obj("include_usage" -> true),
+      "reasoning" -> Json.obj("enabled" -> request.reasoning),
+      "enable_thinking" -> request.reasoning,
+      "response_format" -> Json.obj("type" -> "json_object")
+    )
+
+  private def track(request: Automod.Request)(f: Fu[ParsedResponse]): Fu[ParsedResponse] =
+    repo
+      .create(request)
+      .flatMap: transaction =>
+        f.transformWith:
+          case scala.util.Success(rsp) =>
+            repo
+              .respond(transaction, Automod.Response.success(nowInstant, Json.stringify(rsp.data), rsp.usage))
+              .inject(rsp)
+          case scala.util.Failure(error) =>
+            val message =
+              Option(error.getMessage).filter(_.nonEmpty).map(_.take(500)) | error.getClass.getSimpleName
+            repo
+              .respond(transaction, Automod.Response.failed(nowInstant, message))
+              .flatMap(_ => fufail(error))
+      .andThen:
+        case scala.util.Success(_) => healthState.getAndUpdate(_.record(success = true))
+        case scala.util.Failure(error) =>
+          healthState.getAndUpdate(_.record(success = false))
+          logger.warn(s"Automod ${request.model} failed", error)

--- a/modules/report/src/main/AutomodRepo.scala
+++ b/modules/report/src/main/AutomodRepo.scala
@@ -1,0 +1,162 @@
+package lila.report
+
+import play.api.libs.json.*
+import reactivemongo.api.bson.*
+
+import lila.db.dsl.{ *, given }
+
+final class AutomodRepo(val coll: Coll)(using Executor):
+
+  import Automod.*
+
+  private given BSONHandler[JobType] = tryHandler(
+    _.asOpt[String]
+      .flatMap(name => JobType.values.find(_.toString == name))
+      .toTry("bad jobType"),
+    jobType => BSONString(jobType.toString)
+  )
+  private given BSONHandler[Response.Result] = tryHandler(
+    _.asOpt[String]
+      .flatMap(name => Response.Result.values.find(_.toString == name))
+      .toTry("bad response result"),
+    result => BSONString(result.toString)
+  )
+  private given BSONDocumentHandler[Source] = Macros.handler
+  private given BSONDocumentHandler[Usage] = Macros.handler
+  private given BSONDocumentHandler[Response] = Macros.handler
+  private given BSONDocumentHandler[Transaction] = Macros.handler
+
+  def create(request: Request): Fu[Transaction] =
+    val transaction = Transaction(
+      id = request.id,
+      jobType = request.job.jobType,
+      config = request.job.config,
+      source = request.job.source,
+      model = request.model,
+      updated = nowInstant
+    )
+    coll.update
+      .one(
+        bdoc("_id" -> transaction.id),
+        bset(
+          "jobType" -> transaction.jobType,
+          "config" -> transaction.config,
+          "source" -> transaction.source,
+          "model" -> transaction.model,
+          "updated" -> transaction.updated
+        ) ++ unset("response") ++ inc("failures" -> 0),
+        upsert = true
+      )
+      .inject(transaction)
+
+  def respond(transaction: Transaction, response: Response): Funit =
+    coll.update
+      .one(
+        bdoc("_id" -> transaction.id),
+        bset("response" -> response, "updated" -> nowInstant) ++ response.result.match
+          case Response.Result.failed => inc("failures" -> 1)
+          case _ => emptyBdoc
+      )
+      .void
+
+  def failed(jobType: JobType, offset: Int, limit: Int): Fu[List[Transaction]] =
+    coll
+      .find(activeFailures(jobType), Option.empty[Bdoc])
+      .sort(sort.desc("response.date"))
+      .skip(offset)
+      .cursor[Transaction]()
+      .list(limit)
+
+  def failedCount(jobType: JobType): Fu[Int] = coll.countSel(activeFailures(jobType))
+
+  def failedSourceIds(jobType: JobType): Fu[List[String]] =
+    coll.distinctEasy[String, List]("source.id", activeFailures(jobType) ++ bdoc("source.id".exists(true)))
+
+  def clear(jobType: JobType, sourceId: String): Funit =
+    clear(activeFailures(jobType) ++ bdoc("source.id" -> sourceId))
+
+  def clearAll(jobType: JobType): Funit = clear(activeFailures(jobType))
+
+  def statusJson(adminLinks: List[AutomodRepo.AdminLink], recent: Int = 10): Fu[JsObject] =
+    for
+      transactions <- coll
+        .find(emptyBdoc, Option.empty[Bdoc])
+        .sort(sort.desc("updated"))
+        .cursor[Transaction]()
+        .list(recent)
+      jobStats <- coll.aggregateList(Int.MaxValue): framework =>
+        import framework.*
+        Match(bdoc("updated".gte(nowInstant.minusDays(30)))) -> List(
+          Sort(Descending("updated")),
+          PipelineOperator(
+            bdoc(
+              "$group" -> bdoc(
+                "_id" -> bdoc("jobType" -> "$jobType", "model" -> "$model"),
+                "responses" -> bdoc("$push" -> "$response.result"),
+                "inputTokens" -> bdoc("$sum" -> "$response.usage.inputTokens"),
+                "outputTokens" -> bdoc("$sum" -> "$response.usage.outputTokens")
+              )
+            )
+          ),
+          Project(
+            bdoc(
+              "responses" -> bdoc("$slice" -> barr("$responses", recent)),
+              "inputTokens" -> 1,
+              "outputTokens" -> 1
+            )
+          )
+        )
+      pending <- coll.countSel(bdoc("response".exists(false)))
+    yield
+      val jobsByTypeAndModel = jobStats.flatMap: stat =>
+        for
+          id <- stat.getAsOpt[Bdoc]("_id")
+          jobType <- id.getAsOpt[String]("jobType")
+          model <- id.getAsOpt[String]("model")
+          responses <- stat.getAsOpt[BSONArray]("responses")
+        yield Json.obj(
+          "jobType" -> jobType,
+          "model" -> model,
+          "inputTokens" -> stat.getAsOpt[Long]("inputTokens").getOrElse(0L),
+          "outputTokens" -> stat.getAsOpt[Long]("outputTokens").getOrElse(0L),
+          "recent" -> responses.size,
+          "failures" -> responses.values.count(_ == BSONString(Response.Result.failed.toString))
+        )
+      Json.obj(
+        "recentJobs" -> transactions.map(transactionJson),
+        "jobsByTypeAndModel" -> jobsByTypeAndModel,
+        "pending" -> pending,
+        "adminLinks" -> Json.obj(adminLinks.map(link => link.jobType.toString -> link.url)*)
+      )
+
+  private def clear(selector: Bdoc): Funit =
+    coll.update
+      .one(
+        selector,
+        bset("response.result" -> Response.Result.cleared, "response.date" -> nowInstant),
+        multi = true
+      )
+      .void
+
+  private def activeFailures(jobType: JobType) =
+    bdoc("jobType" -> jobType, "response.result" -> Response.Result.failed)
+
+  private def transactionJson(transaction: Transaction): JsObject = Json.obj(
+    "jobType" -> transaction.jobType.toString,
+    "model" -> transaction.model,
+    "source" -> Json
+      .obj()
+      .add("id" -> transaction.source.id)
+      .add("name" -> transaction.source.name)
+      .add("url" -> transaction.source.url),
+    "updated" -> transaction.updated.toMillis,
+    "response" -> transaction.response.map: response =>
+      Json.obj(
+        "date" -> response.date.toMillis,
+        "result" -> response.result.toString,
+        "error" -> response.error
+      )
+  )
+
+object AutomodRepo:
+  case class AdminLink(jobType: Automod.JobType, url: String)

--- a/modules/report/src/main/Env.scala
+++ b/modules/report/src/main/Env.scala
@@ -43,7 +43,8 @@ final class Env(
   private given UserIdOf[Report.SnoozeKey] = _.snoozerId
   private lazy val snoozer = lila.memo.Snoozer[Report.SnoozeKey]("report.snooze", cacheApi)
 
-  lazy val automod = wire[Automod]
+  lazy val automodRepo = new AutomodRepo(db(CollName("automod")))
+  lazy val automod = wire[AutomodApi]
   lazy val api = wire[ReportApi]
 
   lazy val modFilters = new ModReportFilter

--- a/modules/report/src/main/ReportApi.scala
+++ b/modules/report/src/main/ReportApi.scala
@@ -26,7 +26,7 @@ final class ReportApi(
     cacheApi: lila.memo.CacheApi,
     snoozer: lila.memo.Snoozer[Report.SnoozeKey],
     thresholds: Thresholds,
-    automodApi: Automod,
+    automodApi: AutomodApi,
     settingStore: lila.memo.SettingStore.Builder
 )(using Executor, Scheduler, lila.core.config.NetDomain)
     extends lila.core.report.ReportApi:
@@ -47,7 +47,7 @@ final class ReportApi(
   val commsModelSetting = settingStore[String](
     "commsAutomodModel",
     text = "Comms automod model".some,
-    default = "Qwen/Qwen3-235B-A22B-Instruct-2507-tput"
+    default = "Qwen/Qwen3.5-9B"
   )
 
   def create(data: ReportSetup, reporter: Reporter, msgs: List[String]): Funit =
@@ -333,10 +333,13 @@ final class ReportApi(
   )(using me: Me): Funit =
     userText.trim.nonEmpty.so:
       val assessText = automodApi
-        .text(
-          userText,
-          systemPrompt = commsPromptSetting.get(),
-          model = commsModelSetting.get()
+        .apply(
+          Automod.Request.text(
+            job = Automod.Job(Automod.JobType.comms, Automod.Source(url = url.some)),
+            userText = userText,
+            prompt = commsPromptSetting.get(),
+            model = commsModelSetting.get()
+          )
         )
         .monSuccess(lila.mon.mod.report.automod.request)
       val candidate = for

--- a/modules/report/src/main/ui/ReportUi.scala
+++ b/modules/report/src/main/ui/ReportUi.scala
@@ -2,6 +2,7 @@ package lila.report
 package ui
 
 import play.api.data.Form
+import play.api.libs.json.JsObject
 
 import lila.core.i18n.{ I18nKey as trans, Translate }
 import lila.ui.*
@@ -180,6 +181,18 @@ final class ReportUi(helpers: Helpers)(menu: Context ?=> Frag):
           br,
           br,
           p(a(href := routes.Lobby.home)("Return to Lichess homepage"))
+        )
+
+  def automodStatus(health: JsObject)(menu: Context ?=> Frag)(using Context, Me) =
+    Page("Automod health")
+      .css("mod.automod-status")
+      .js(PageModule("mod.automodStatus", health)):
+        main(cls := "page-menu")(
+          menu,
+          div(
+            cls := "box box-pad page-small automod-status",
+            data("url") := routes.Report.automodStatusXhr.url
+          )
         )
 
   object list:

--- a/modules/ublog/src/main/Env.scala
+++ b/modules/ublog/src/main/Env.scala
@@ -6,7 +6,7 @@ import lila.core.config.*
 import lila.db.dsl.Coll
 import lila.common.autoconfig.{ *, given }
 import lila.common.Bus
-import lila.report.Automod
+import lila.report.AutomodApi
 
 @Module
 final private class UblogConfig(
@@ -32,7 +32,7 @@ final class Env(
     settingStore: lila.memo.SettingStore.Builder,
     client: lila.search.client.SearchClient,
     lightUser: lila.core.LightUser.GetterSync,
-    automod: lila.report.Automod
+    automod: AutomodApi
 )(using Executor, Scheduler, play.api.Mode):
 
   export net.{ assetBaseUrl, baseUrl, domain, assetDomain }

--- a/modules/ublog/src/main/UblogApi.scala
+++ b/modules/ublog/src/main/UblogApi.scala
@@ -24,6 +24,7 @@ final class UblogApi(
     shutupApi: ShutupApi,
     irc: lila.core.irc.IrcApi,
     ublogAutomod: UblogAutomod,
+    automod: lila.report.AutomodApi,
     config: UblogConfig,
     settingStore: lila.memo.SettingStore.Builder,
     cacheApi: lila.memo.CacheApi
@@ -52,6 +53,7 @@ final class UblogApi(
     post = data.update(me.value, prev)
     isFirstPublish = prev.lived.isEmpty && post.live
     _ <- colls.post.update.one(bid(prev.id), set(bsonWriteObjTry[UblogPost](post).get))
+    _ <- automod.clear(lila.report.Automod.JobType.blog, post.id.value)
     _ <- picfitApi.addRef(post.markdown, s"ublog:${post.id}", routes.Ublog.redirect(post.id).url.some)
     _ = if isFirstPublish then onFirstPublish(author.light, blog, post)
   yield
@@ -208,19 +210,84 @@ final class UblogApi(
     def attempt(n: Int): Fu[Option[UblogPost]] =
       ublogAutomod(post, n * 0.1)
         .flatMapz: llm =>
-          val result = post.automod.foldLeft(llm): (llm, prev) =>
-            prev.updateByLLM(llm)
-          for
-            trustedAuthor <- isAuthorTrusted(post.created.by)
-            newPost = post.copy(automod = result.some).computeEffectiveQuality(trustedAuthor)
-            _ <- updateQualityFields(newPost)
-          yield newPost.some
+          getPost(post.id).flatMapz: current =>
+            val result = current.automod.foldLeft(llm): (llm, prev) =>
+              prev.updateByLLM(llm)
+            for
+              trustedAuthor <- isAuthorTrusted(current.created.by)
+              newPost = current.copy(automod = result.some).computeEffectiveQuality(trustedAuthor)
+              _ <- updateQualityFields(newPost, current.quality)
+            yield newPost.some
         .recoverWith: e =>
           if n < retries then delay((30 * math.pow(2, n).toInt).seconds)(attempt(n + 1))
           else
-            lila.log.system.warn(s"ublog automod ${post.id} failed after $retries retry attempts", e)
+            lila.log.system.warn(s"blog automod ${post.id} failed after $retries retry attempts", e)
             fuccess(none)
     attempt(0)
+
+  def failedAutomod(offset: Int, limit: Int): Fu[List[UblogAutomod.Failed]] =
+    val fetchLimit = offset + limit
+    for
+      failedSourceIds <- automod.failedSourceIds(lila.report.Automod.JobType.blog)
+      failures <- failedAutomodTransactions(fetchLimit)
+      unprocessed <- colls.post
+        .find(unprocessedAutomodSelector(failedSourceIds), postProjection.some)
+        .sort(sort.desc("updated.at"))
+        .cursor[UblogPost]()
+        .list(fetchLimit)
+    yield (failures ++ unprocessed.map(post => UblogAutomod.Failed(post)))
+      .sortBy(_.at)(using Ordering[Instant].reverse)
+      .slice(offset, fetchLimit)
+
+  private def failedAutomodTransactions(limit: Int): Fu[List[UblogAutomod.Failed]] =
+    automod
+      .failed(lila.report.Automod.JobType.blog, 0, limit)
+      .flatMap: transactions =>
+        val postIds = transactions.flatMap(_.source.id).map(UblogPostId.apply)
+        colls.post
+          .byIds[UblogPost, UblogPostId](postIds)
+          .flatMap: posts =>
+            val postsById = posts.map(post => post.id.value -> post).toMap
+            val failed = transactions.flatMap: transaction =>
+              transaction.source.id.flatMap(postsById.get).map(UblogAutomod.Failed(_, transaction.some))
+            transactions
+              .flatMap(_.source.id)
+              .filterNot(postsById.contains)
+              .distinct
+              .sequentiallyVoid(sourceId => automod.clear(lila.report.Automod.JobType.blog, sourceId))
+              .inject(failed)
+
+  def failedAutomodCount(): Fu[Int] =
+    for
+      failedSourceIds <- automod.failedSourceIds(lila.report.Automod.JobType.blog)
+      failures <- automod.failedCount(lila.report.Automod.JobType.blog)
+      unprocessed <- colls.post.countSel(unprocessedAutomodSelector(failedSourceIds))
+    yield failures + unprocessed
+
+  private def unprocessedAutomodSelector(failedSourceIds: List[String]) =
+    bdoc(
+      "live" -> true,
+      "automod".exists(false),
+      "approval".neq(UblogPost.Approval.verified),
+      "lived.at".gt(nowInstant.minusMonths(3)),
+      expr(bdoc("$gte" -> barr(bdoc("$strLenBytes" -> "$markdown"), 200)))
+    ) ++ failedSourceIds.nonEmpty.option(bdoc("_id".nin(failedSourceIds))).getOrElse(emptyBdoc)
+
+  def retryFailedAutomod(postId: Option[UblogPostId]): Funit = postId match
+    case Some(id) =>
+      automod.clear(lila.report.Automod.JobType.blog, id.value) >>
+        getPost(id).flatMapz(triggerAutomod).void
+    case _ =>
+      automod
+        .failedSourceIds(lila.report.Automod.JobType.blog)
+        .flatMap(
+          _.parallelN(4)(sourceId => retryFailedAutomod(UblogPostId(sourceId).some).recover(_ => ())).void
+        )
+        .recover(_ => ())
+
+  def clearFailedAutomod(postId: Option[UblogPostId]): Funit = postId match
+    case Some(id) => automod.clear(lila.report.Automod.JobType.blog, id.value)
+    case _ => automod.clearAll(lila.report.Automod.JobType.blog)
 
   def nextToReview: Fu[Option[UblogPost]] =
     colls.post
@@ -308,13 +375,19 @@ final class UblogApi(
 
   def modPost(post: UblogPost, d: UblogForm.ModPostData): Fu[UblogPost] =
     val newPost = post.moderate(d)
-    updateQualityFields(newPost).inject(newPost)
+    updateQualityFields(newPost, post.quality).inject(newPost)
 
-  private def updateQualityFields(post: UblogPost): Funit =
-    val sets = bdoc("quality" -> post.quality) ++
-      post.automod.so(a => bdoc("automod" -> a)) ++
-      post.modQuality.so(mq => bdoc("modQuality" -> mq))
-    colls.post.update.one(bid(post.id), set(sets)).void
+  private def updateQualityFields(
+      post: UblogPost,
+      previousQuality: Quality
+  ): Funit =
+    val updated = post.refreshListedAt(previousQuality)
+    val sets = bdoc("quality" -> updated.quality, "approval" -> updated.approval) ++
+      updated.listedAt.so(at => bdoc("listedAt" -> at)) ++
+      updated.automod.so(a => bdoc("automod" -> a))
+    colls.post.update
+      .one(bid(post.id), set(sets))
+      .void
 
   private def isAuthorTrusted(userId: UserId): Fu[Boolean] =
     val nbPosts = 4
@@ -387,9 +460,9 @@ final class UblogApi(
       .aggregateList(length, _.sec): framework =>
         import framework.*
         val aggSort = sort match
-          case BlogsBy.oldest => Ascending("lived.at")
+          case BlogsBy.oldest => Ascending("listedAt")
           case BlogsBy.likes => Descending("likes")
-          case _ => Descending("lived.at")
+          case _ => Descending("listedAt")
         Match(select ++ bdoc("live" -> true)) -> {
           Sort(aggSort) ::
             removeUnlistedOrClosedAndProjectForPreview(colls.post, framework) :::

--- a/modules/ublog/src/main/UblogAutomod.scala
+++ b/modules/ublog/src/main/UblogAutomod.scala
@@ -1,7 +1,6 @@
 package lila.ublog
 
 import play.api.libs.json.*
-import com.roundeights.hasher.Algo
 
 import lila.core.data.Text
 import lila.core.ublog.Quality
@@ -16,7 +15,14 @@ import lila.mon.extensions.*
 
 object UblogAutomod:
 
-  private val schemaVersion = 1
+  case class Failed(post: UblogPost, transaction: Option[Automod.Transaction] = none):
+    def at: Instant =
+      transaction
+        .flatMap(_.response.map(_.date))
+        .orElse(post.updated.orElse(post.lived).map(_.at))
+        .getOrElse(post.created.at)
+
+  private val schemaVersion = 2
 
   // not actually an automod assessment, as mods can edit it :-/
   // except for the quality which now lives in UblogPost
@@ -25,7 +31,6 @@ object UblogAutomod:
       flagged: Option[String] = none,
       commercial: Option[String] = none,
       evergreen: Option[Boolean] = none,
-      hash: Option[String] = none,
       version: Int = schemaVersion
   ):
     def updateByLLM(llm: Assessment): Assessment =
@@ -43,7 +48,7 @@ object UblogAutomod:
   private given Reads[FuzzyResult] = Json.reads[FuzzyResult]
 
 private final class UblogAutomod(
-    automod: lila.report.Automod,
+    automod: lila.report.AutomodApi,
     settingStore: lila.memo.SettingStore.Builder,
     picfitApi: lila.memo.PicfitApi
 )(using Executor):
@@ -60,7 +65,7 @@ private final class UblogAutomod(
   val modelSetting = settingStore[String](
     "ublogAutomodModel",
     text = "Ublog automod model".some,
-    default = "Qwen/Qwen3-235B-A22B-Thinking-2507",
+    default = "Qwen/Qwen3.7-Max",
     _.ModerateBlog
   )
 
@@ -70,19 +75,29 @@ private final class UblogAutomod(
         val mainImageAsMarkdown = post.image.so(i => s"![](${picfitApi.url.automod(i.id, none)})\n")
         mainImageAsMarkdown + markdown
     val assessText =
-      val userText = post.allText.take(40_000) // match bin/ublog-automod.mjs hash
+      val userText = post.allText.take(40_000)
       automod
-        .text(
-          userText = userText,
-          systemPrompt = promptSetting.get(),
-          model = modelSetting.get(),
-          temperature = temperature
+        .apply(
+          Automod.Request.text(
+            job = Automod.Job(
+              jobType = Automod.JobType.blog,
+              source = Automod.Source(
+                id = post.id.value.some,
+                name = post.title.some,
+                url = routes.Ublog.redirect(post.id).url.some
+              )
+            ),
+            userText = userText,
+            prompt = promptSetting.get(),
+            model = modelSetting.get(),
+            temperature = temperature
+          )
         )
         .map: res =>
           normalize(res).so: res =>
             lila.mon.ublog.automod.quality(res.quality.toString).increment()
             lila.mon.ublog.automod.flagged(res.flagged.isDefined).increment()
-            res.copy(hash = Algo.sha256(userText).hex.take(12).some).some // match bin/ublog-automod.mjs hash
+            res.some
         .monSuccess(lila.mon.ublog.automod.request)
     assessImages
       .zip(assessText)

--- a/modules/ublog/src/main/UblogBsonHandlers.scala
+++ b/modules/ublog/src/main/UblogBsonHandlers.scala
@@ -8,7 +8,7 @@ import lila.db.dsl.{ *, given }
 
 private object UblogBsonHandlers:
 
-  import UblogPost.{ LightPost, PreviewPost, Recorded, Featured }
+  import UblogPost.{ Approval, LightPost, PreviewPost, Recorded, Featured }
   import UblogAutomod.Assessment
   import lila.core.ublog.Quality
 
@@ -29,6 +29,10 @@ private object UblogBsonHandlers:
     v => v.asOpt[Int].flatMap(Quality.values.lift).toTry(s"bad quality $v"),
     quality => BSONInteger(quality.ordinal)
   )
+  given BSONHandler[Approval] = tryHandler(
+    v => v.asOpt[String].flatMap(Approval.apply).toTry(s"bad approval $v"),
+    approval => BSONString(approval.toString)
+  )
   given BSONDocumentHandler[UblogAutomod.Assessment] = Macros.handler
 
   val postProjection = bdoc("likers" -> false)
@@ -41,6 +45,7 @@ private object UblogBsonHandlers:
       "image" -> true,
       "created" -> true,
       "lived" -> true,
+      "listedAt" -> true,
       "featured" -> true,
       "topics" -> true,
       "sticky" -> true
@@ -51,7 +56,7 @@ private object UblogBsonHandlers:
   def pendingReviewSelect = bdoc(
     "automod.quality" -> Quality.good,
     "quality" -> Quality.weak,
-    "modQuality".exists(false),
+    "approval" -> Approval.unverified,
     "live" -> true,
     "lived.at".gt(nowInstant.minusMonths(1))
   )

--- a/modules/ublog/src/main/UblogPaginator.scala
+++ b/modules/ublog/src/main/UblogPaginator.scala
@@ -73,6 +73,16 @@ final class UblogPaginator(
       maxPerPage = maxPerPage
     )
 
+  def failedAutomod(page: Int): Fu[Paginator[UblogAutomod.Failed]] =
+    Paginator(
+      adapter = new AdapterLike[UblogAutomod.Failed]:
+        def nbResults = ublogApi.failedAutomodCount()
+        def slice(offset: Int, length: Int) = ublogApi.failedAutomod(offset, length)
+      ,
+      currentPage = page,
+      maxPerPage = maxPerPage
+    )
+
   def liveByTopic(
       topic: UblogTopic,
       filter: QualityFilter,
@@ -121,10 +131,10 @@ final class UblogPaginator(
 
   private def selectQuality(filter: QualityFilter, offTopic: Boolean = false): Bdoc =
     filter match
-      case QualityFilter.all => bdoc("automod.quality".gte(if offTopic then Quality.spam else Quality.weak))
-      case QualityFilter.best => bdoc("automod.quality".gte(if offTopic then Quality.weak else Quality.good))
-      case QualityFilter.weak => bdoc("automod.quality" -> Quality.weak)
-      case QualityFilter.spam => bdoc("automod.quality" -> Quality.spam)
+      case QualityFilter.all => bdoc("quality".gte(if offTopic then Quality.spam else Quality.weak))
+      case QualityFilter.best => bdoc("quality".gte(if offTopic then Quality.weak else Quality.good))
+      case QualityFilter.weak => bdoc("quality" -> Quality.weak)
+      case QualityFilter.spam => bdoc("quality" -> Quality.spam)
       case QualityFilter.pending => pendingReviewSelect
 
   object liveByFollowed:

--- a/modules/ublog/src/main/UblogPost.scala
+++ b/modules/ublog/src/main/UblogPost.scala
@@ -28,9 +28,10 @@ case class UblogPost(
     likes: UblogPost.Likes,
     views: UblogPost.Views,
     quality: Quality = Quality.spam, // effective quality used for filtering and ordering
+    listedAt: Option[Instant] = none, // this is the sort key because lived.at is unfair to untrusteds
     similar: Option[List[UblogSimilar]] = none,
     automod: Option[UblogAutomod.Assessment] = none,
-    modQuality: Option[Quality] = none
+    approval: UblogPost.Approval = UblogPost.Approval.unverified
 ) extends UblogPost.BasePost
     with lila.core.ublog.UblogPost:
 
@@ -40,7 +41,7 @@ case class UblogPost(
   def indexable = live && (
     topics.exists(UblogTopic.chessExists) || featured.isDefined || isBy(UserId.lichess)
   )
-  def visibleByCrawlers = indexable && automod.exists(_.quality != Quality.spam)
+  def visibleByCrawlers = indexable && quality != Quality.spam
   def allText = s"$title $intro $markdown"
   def isEmpty = title.isEmpty && intro.isEmpty && markdown.value.isEmpty && image.isEmpty
 
@@ -57,21 +58,31 @@ case class UblogPost(
     )
     copy(
       automod = assessment.some,
-      modQuality = d.quality.orElse(modQuality),
-      quality = d.quality | quality
+      quality = d.quality | quality,
+      approval = d.quality.fold(approval)(_ => UblogPost.Approval.verified)
     )
 
   def isPendingQuality =
-    modQuality.isEmpty && automod.exists(_.quality == Quality.good) && quality == Quality.weak
+    approval == UblogPost.Approval.unverified &&
+      automod.exists(_.quality == Quality.good) &&
+      quality == Quality.weak
 
   private[ublog] def computeEffectiveQuality(trustedAuthor: Boolean): UblogPost =
-    val q = modQuality | automod
-      .map(_.quality)
-      .match
-        case None => if trustedAuthor then Quality.good else Quality.spam // shouldn't happen
-        case Some(Quality.good) => if trustedAuthor then Quality.good else Quality.weak
-        case Some(auto) => auto
-    copy(quality = q)
+    if approval == UblogPost.Approval.verified then this
+    else
+      automod
+        .map(_.quality)
+        .match
+          case None =>
+            copy(quality = if trustedAuthor then Quality.good else Quality.spam) // shouldn't happen
+          case Some(Quality.good) if trustedAuthor =>
+            copy(quality = Quality.good, approval = UblogPost.Approval.trusted)
+          case Some(Quality.good) =>
+            copy(quality = Quality.weak, approval = UblogPost.Approval.unverified)
+          case Some(notGood) => copy(quality = notGood, approval = UblogPost.Approval.unverified)
+
+  private[ublog] def refreshListedAt(previous: Quality): UblogPost =
+    if listedAt.isEmpty && quality.ordinal > previous.ordinal then copy(listedAt = nowInstant.some) else this
 
 case class UblogImage(id: ImageId, alt: Option[String] = None, credit: Option[String] = None)
 
@@ -103,6 +114,12 @@ object UblogPost:
       views = Views(0)
     )
 
+  enum Approval:
+    case unverified, trusted, verified
+    def key = toString
+  object Approval:
+    def apply(key: String) = values.find(_.key == key)
+
   def slug(title: String) =
     val s = scalalib.StringOps.slug(title)
     if s.isEmpty then "-" else s
@@ -120,6 +137,7 @@ object UblogPost:
     val created: Recorded
     val updated: Option[Recorded]
     val lived: Option[Recorded]
+    val listedAt: Option[Instant]
     val featured: Option[Featured]
     val sticky: Option[Boolean]
     def slug = UblogPost.slug(title)
@@ -134,6 +152,7 @@ object UblogPost:
       created: Recorded,
       updated: Option[Recorded],
       lived: Option[Recorded],
+      listedAt: Option[Instant],
       featured: Option[Featured],
       sticky: Option[Boolean],
       topics: List[UblogTopic]

--- a/modules/ublog/src/main/UblogTopic.scala
+++ b/modules/ublog/src/main/UblogTopic.scala
@@ -50,18 +50,18 @@ final class UblogTopicApi(colls: UblogColls, cacheApi: CacheApi)(using Executor,
           .map: topic =>
             for
               count <- colls.post.secondary.countSel:
-                bdoc("live" -> true, "topics" -> topic, "automod.quality" -> neq(0))
+                bdoc("live" -> true, "topics" -> topic, "quality" -> neq(Quality.spam))
               posts <- colls.post
                 .find(
                   bdoc(
                     "live" -> true,
                     "topics" -> topic,
-                    "automod.quality" -> gte(Quality.good.ordinal),
+                    "quality" -> gte(Quality.good.ordinal),
                     "likes" -> gt(50)
                   ),
                   previewPostProjection.some
                 )
-                .sort(bdoc("lived.at" -> -1))
+                .sort(bdoc("listedAt" -> -1))
                 .cursor[UblogPost.PreviewPost](ReadPref.sec)
                 .list(16)
             yield UblogTopic.WithPosts(topic, shuffle(posts).take(4), count)

--- a/modules/ublog/src/main/ui/UblogPostUi.scala
+++ b/modules/ublog/src/main/ui/UblogPostUi.scala
@@ -198,10 +198,13 @@ final class UblogPostUi(helpers: Helpers, ui: UblogUi)(connectLinks: Frag):
                 value := q.name
               )(q.name.capitalize)
           ),
-          post.automod
-            .ifTrue(post.modQuality.isEmpty)
-            .map: auto =>
-              span("AI thought it was ", auto.quality.name, ".")
+          post.automod match
+            case Some(auto) if auto.quality != post.quality =>
+              span(s"AI thought it was ${auto.quality.name}")
+            case None if post.approval != UblogPost.Approval.verified =>
+              span("No assessment yet")
+            case _ =>
+              emptyFrag
         ),
         fieldset(cls := "carousel-fields")(
           legend(a(href := routes.Ublog.modShowCarousel)("Edit Carousel"), isInCarousel.option("(live)")),

--- a/modules/ublog/src/main/ui/UblogUi.scala
+++ b/modules/ublog/src/main/ui/UblogUi.scala
@@ -50,9 +50,9 @@ final class UblogUi(helpers: Helpers, atomUi: AtomUi, modMenu: Context ?=> Frag)
         )
       )(
         thumbnail(post, _.Size.Small)(cls := "ublog-post-card__image"),
-        post.lived.map { live =>
-          if strictDate || DAYS.between(live.at, nowInstant) < 30 then
-            semanticDate(live.at)(cls := "ublog-post-card__over-image")
+        post.listedAt.orElse(post.lived.map(_.at)).map { at =>
+          if strictDate || DAYS.between(at, nowInstant) < 30 then
+            semanticDate(at)(cls := "ublog-post-card__over-image")
           else span(cls := "ublog-post-card__over-image")("Timeless")
         },
         if showAuthor != ShowAt.none
@@ -428,6 +428,56 @@ final class UblogUi(helpers: Helpers, atomUi: AtomUi, modMenu: Context ?=> Frag)
         button(cls := "carousel__next", dataIcon := Icon.GreaterThan)
       )
     )
+
+  def failedAutomod(posts: Paginator[UblogAutomod.Failed])(menu: Context ?=> Frag)(using Context, Me) =
+    Page("Failed blog automod jobs")
+      .css("mod.user")
+      .css("mod.automod-status"):
+        main(cls := "page-menu")(
+          menu,
+          div(cls := "box")(
+            div(cls := "box__top")(
+              h1("Failed automod jobs"),
+              Granter(_.Admin).option:
+                div(cls := "button-group")(
+                  postForm(action := routes.Ublog.clearFailedAutomod(none))(
+                    submitButton(cls := "button button-empty button-red yes-no-confirm")("Clear all")
+                  ),
+                  postForm(action := routes.Ublog.retryFailedAutomod(none))(
+                    submitButton(cls := "button button-empty yes-no-confirm")("Retry all")
+                  )
+                )
+            ),
+            table(cls := "slist slist-pad")(
+              thead(tr(th("Blog"), th("Author"), th("Published"), th("Status"), th("Error"), th("Actions"))),
+              tbody(
+                posts.currentPageResults.map: failed =>
+                  val post = failed.post
+                  tr(
+                    td(a(href := routes.Ublog.redirect(post.id))(post.title)),
+                    td(userIdLink(post.created.by.some)),
+                    td(post.lived.map(record => momentFromNow(record.at))),
+                    td(failed.transaction.fold[Frag]("Unprocessed")(_ => "Failed")),
+                    td(title := failed.transaction.flatMap(_.response.flatMap(_.error)))(
+                      failed.transaction
+                        .flatMap(_.response.flatMap(_.error))
+                        .fold[Frag]("No automod assessment")(_.take(120))
+                    ),
+                    td(cls := "button-group")(
+                      failed.transaction.map: _ =>
+                        postForm(action := routes.Ublog.clearFailedAutomod(post.id.some))(
+                          submitButton(cls := "button button-empty button-red", dataIcon := Icon.X)
+                        ),
+                      postForm(action := routes.Ublog.retryFailedAutomod(post.id.some))(
+                        submitButton(cls := "button button-empty", dataIcon := Icon.ChasingArrows)
+                      )
+                    )
+                  )
+              )
+            ),
+            pagerNext(posts, page => routes.Ublog.failedAutomod(page).url)
+          )
+        )
 
   private def list(
       title: String,

--- a/ui/mod/css/_automod-status.scss
+++ b/ui/mod/css/_automod-status.scss
@@ -1,0 +1,107 @@
+.automod-status {
+  display: flex;
+  flex-direction: column;
+  gap: 2em;
+
+  fieldset {
+    padding: 1em 2em 2em 2em;
+    border-radius: $box-radius-size;
+    border: none; // $border;
+
+    legend {
+      font-size: 2.5em;
+      color: $c-font-dim;
+      padding-inline: 8px;
+
+      span {
+        font-size: 14px;
+        color: $c-font-dim;
+      }
+    }
+  }
+
+  td {
+    max-width: 30vw;
+  }
+
+  td.error,
+  td.source {
+    overflow-wrap: anywhere;
+  }
+
+  .grid {
+    display: grid;
+    gap: 1em;
+    grid-template-columns: repeat(3, 1fr);
+    grid-auto-rows: min-content;
+
+    p,
+    a {
+      margin: 0;
+      padding: 1em;
+      background: $c-bg-zebra;
+      border-radius: $box-radius-size;
+    }
+
+    a.admin {
+      text-decoration: underline;
+    }
+
+    .pending {
+      background: color-mix(in oklab, $c-brag 12%, $c-bg);
+    }
+  }
+
+  .green {
+    color: $c-good;
+  }
+
+  .red {
+    color: $c-bad;
+  }
+
+  .yellow {
+    color: $c-brag;
+  }
+
+  .dim {
+    color: $c-font-dimmer;
+    font-weight: bold;
+  }
+
+  @media (max-width: $small) {
+    .grid {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  .proportion {
+    position: relative;
+  }
+
+  .proportion::before {
+    content: '';
+    border-radius: $box-radius-size;
+    position: absolute;
+    inset: 0;
+    width: var(--input-percentage);
+    background: hsl(from $c-clearer h s l / 0.05);
+    pointer-events: none;
+  }
+
+  .fail::before {
+    background: hsl(from $c-bad h s l / 0.08);
+  }
+
+  .fail[style='--input-percentage:0%;']::before {
+    width: 100%;
+    background: hsl(from $c-good h s l / 0.1);
+  }
+}
+
+.button-group {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.5em;
+}

--- a/ui/mod/css/_badges.scss
+++ b/ui/mod/css/_badges.scss
@@ -1,0 +1,14 @@
+// styles preloaded by app/views/base/page.scala for any mod with SeeReport, for menu or tab badges
+
+.automod-status-badge {
+  display: inline-block;
+  width: 0.55em;
+  height: 0.55em;
+  margin-inline-start: 0.45em;
+  border-radius: 50%;
+  background: $c-warn;
+
+  &.red {
+    background: $c-bad;
+  }
+}

--- a/ui/mod/css/build/mod.automod-status.scss
+++ b/ui/mod/css/build/mod.automod-status.scss
@@ -1,0 +1,3 @@
+@import '../../../lib/css/plugin';
+@import '../../../lib/css/component/slist';
+@import '../automod-status';

--- a/ui/mod/css/build/mod.badges.scss
+++ b/ui/mod/css/build/mod.badges.scss
@@ -1,3 +1,2 @@
 @import '../../../lib/css/plugin';
 @import '../badges';
-@import '../impersonate';

--- a/ui/mod/src/mod.automodStatus.ts
+++ b/ui/mod/src/mod.automodStatus.ts
@@ -1,0 +1,178 @@
+import { attributesModule, classModule, init, type VNode } from 'snabbdom';
+
+import { displayColumns } from 'lib/device';
+import { hl } from 'lib/view';
+import { jsonSimple } from 'lib/xhr';
+
+const patch = init([classModule, attributesModule]);
+const dateTime = new Intl.DateTimeFormat('en', { dateStyle: 'medium', timeStyle: 'short', timeZone: 'UTC' });
+
+interface Result {
+  date: number;
+  result: 'success' | 'failed' | 'cleared';
+  error?: string;
+}
+
+interface Transaction {
+  jobType: string;
+  model: string;
+  source: Source;
+  updated: number;
+  response?: Result;
+}
+
+interface Source {
+  id?: string;
+  name?: string;
+  url?: string;
+}
+
+interface JobHealth {
+  jobType: string;
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  recent: number;
+  failures: number;
+}
+
+interface AutomodStatus {
+  recentJobs: Transaction[];
+  pending: number;
+  jobsByTypeAndModel: JobHealth[];
+  adminLinks?: Record<string, string>;
+}
+
+export function initModule(data: AutomodStatus): void {
+  const el = document.querySelector<HTMLElement>('.automod-status');
+  const url = el?.dataset.url;
+  if (!url) return;
+  let vnode = patch(el, view(data));
+
+  const update = async () => {
+    try {
+      vnode = patch(vnode, view(await jsonSimple(url)));
+    } catch {}
+  };
+  update();
+  setInterval(update, 3000);
+}
+
+function view(status: AutomodStatus): VNode {
+  const failed = (transaction: Transaction) => transaction.response?.result === 'failed';
+  const lastSuccess = status.recentJobs.find(transaction => transaction.response && !failed(transaction));
+  const lastFailure = status.recentJobs.find(failed);
+  const recentFails = status.recentJobs.filter(failed).length;
+  const inputPercentage =
+    status.recentJobs.length === 0 ? 0 : Math.round((recentFails / status.recentJobs.length) * 100);
+  return hl('div.box.box-pad.page-small.automod-status', [
+    hl('fieldset', [
+      hl('legend', 'Automod status'),
+      hl('div.grid', [
+        hl(
+          `p.proportion.fail.${lastFailure ? 'yellow' : 'green'}`,
+          { attrs: { style: `--input-percentage:${inputPercentage}%` } },
+          [hl('strong', recentFails), ' failed / ', hl('strong', status.recentJobs.length), ' recent'],
+        ),
+        hl('p', [
+          lastSuccess && ['Last success: ', dateTime.format(lastSuccess.response!.date), hl('br')],
+          lastFailure &&
+            hl('span', { attrs: { title: lastFailure.response?.error ?? '' } }, [
+              'Last failed: ',
+              dateTime.format(lastFailure.response!.date),
+            ]),
+        ]),
+        hl('p.pending', `${status.pending} pending`),
+      ]),
+    ]),
+    status.jobsByTypeAndModel.length > 0 &&
+      hl('fieldset', [
+        hl('legend', ['Model usage ', hl('span', '(in past 30 days)')]),
+        hl('div.grid', [
+          displayColumns() > 1 && [
+            hl('label'),
+            hl('label', ['tokens (', hl('span.dim', 'input'), ' / ', hl('span.dim', 'output'), ' / total)']),
+            hl('label', 'failures'),
+          ],
+          status.jobsByTypeAndModel
+            .sort(
+              (left, right) =>
+                left.jobType.localeCompare(right.jobType) || left.model.localeCompare(right.model),
+            )
+            .flatMap(job => [
+              status.adminLinks?.[job.jobType]
+                ? hl('a.admin', { attrs: { href: status.adminLinks[job.jobType] } }, job.jobType)
+                : hl('p', job.jobType),
+              usageTokens(job),
+              past30days(job),
+            ]),
+        ]),
+      ]),
+    status.recentJobs.length > 0 &&
+      hl('fieldset', [
+        hl('legend', 'Recent jobs'),
+        hl('table.slist', hl('tbody', status.recentJobs.map(transactionRow))),
+      ]),
+  ]);
+}
+
+function transactionRow(transaction: Transaction): VNode {
+  const { id, name, url } = transaction.source;
+  const label = name ?? id ?? url ?? '';
+  const title = name && id ? id : undefined;
+  const source = url
+    ? hl('a', title ? { attrs: { href: url, title } } : { attrs: { href: url } }, label)
+    : hl('span', title ? { attrs: { title } } : {}, label);
+  return hl('tr', [
+    hl('td', transaction.jobType),
+    hl('td.source', [
+      source,
+      transaction.response?.error && hl('span', { attrs: { title: transaction.response.error } }, ' failed'),
+    ]),
+    hl('td', transaction.model),
+    hl(
+      'td',
+      transaction.response
+        ? dateTime.format(transaction.response.date)
+        : dateTime.format(transaction.updated),
+    ),
+    hl(
+      'td' +
+        (transaction.response?.result === 'success'
+          ? '.green'
+          : transaction.response?.result === 'failed'
+            ? '.red'
+            : '.yellow'),
+      transaction.response?.result ?? 'pending',
+    ),
+  ]);
+}
+
+function usageTokens(job: JobHealth): VNode {
+  const [input, output, total] = [job.inputTokens, job.outputTokens, job.inputTokens + job.outputTokens];
+  const inputPercentage = total === 0 ? 0 : Math.round((100 * input) / total);
+  const friendly = (n: number) =>
+    n > 1_000_000
+      ? `${Math.round(n / 100_000) / 10}M`
+      : n > 1000
+        ? `${Math.round(n / 100) / 10}k`
+        : n.toString();
+  return hl('p.proportion', { attrs: { style: `--input-percentage:${inputPercentage}%;` } }, [
+    `${job.model} `,
+    hl('span.dim', friendly(input)),
+    ' / ',
+    hl('span.dim', friendly(output)),
+    ' / ',
+    friendly(total),
+  ]);
+}
+
+function past30days(job: JobHealth): VNode {
+  const failures = job.failures;
+  const recent = job.recent;
+  const percentage = recent === 0 ? 0 : Math.round((100 * failures) / recent);
+  const color = job.failures ? 'yellow' : 'green';
+  return hl(`p.proportion.fail.${color}`, { attrs: { style: `--input-percentage:${percentage}%;` } }, [
+    `${failures} failed / ${recent} total`,
+  ]);
+}


### PR DESCRIPTION
## automod status
<img width="672" height="516" alt="image" src="https://github.com/user-attachments/assets/3047d38b-2dee-4a77-b9a5-7de4d8fb0041" />

## blog page
<img width="653" height="224" alt="image" src="https://github.com/user-attachments/assets/33c13eb4-8640-44b0-8362-0dba2f856b87" />

mod frontend
- add basic automod health page, viewable by anyone with SeeReport
- add a page listing failed/unprocessed blog jobs which can be restarted/cleared
- add a mod menu badge to alert when automod is having trouble

automod backend
- automod status gets a light collection to support job tracking
- refactor into the familiar Automod/AutomodApi/AutomodRepo pattern

ublog tweaks
- always use quality (not automod.quality).
- remove modQuality (there were too many)
- add automod.approval field in attempt to clarify the quality situation further
- add listedAt date, set it when a mod confirms good, and use that for sorting. the reason is that the lived.at date will frequently result in new (untrusted) authors arriving beneath the fold on community listing due to trusted bloggers posts building up during the time elapsed while the curator is away/offline. a new field seems safer than bumping lived.at.
