### PR TITLE
ui(analyse): remove redundant gaps on mobile (1 column) view

### DIFF
--- a/ui/analyse/css/_layout.scss
+++ b/ui/analyse/css/_layout.scss
@@ -16,7 +16,6 @@ body {
 .analyse {
   grid-area: main;
   display: grid;
-  gap: $block-gap $analyse-block-gap;
 
   ---analyse-gauge-col: #{$analyse-block-gap};
   ---analyse-gauge-offset: calc(var(---analyse-gauge-col) - #{$analyse-block-gap});
@@ -144,6 +143,7 @@ body {
   }
 
   @include mq-is-col2-squeeze {
+    gap: $block-gap $analyse-block-gap;
     grid-template-columns:
       $col2-uniboard-squeeze-width var(---analyse-gauge-col)
       minmax(
@@ -153,6 +153,7 @@ body {
   }
 
   @include mq-at-least-col3 {
+    gap: $block-gap $analyse-block-gap;
     grid-template-columns:
       $col3-uniboard-side $analyse-block-gap var(---col3-uniboard-width)
       var(---analyse-gauge-col)


### PR DESCRIPTION
# Why

When working on detached eval bar I have added gaps to the base layout. Unfortunately, the gaps does not look good on mobile (1 column) view.

# How

Move gaps to styles blocks applied for two and three columns layouts.

# Preview

### Before

<img width="447" height="791" alt="Screenshot 2026-08-17 at 11 45 03" src="https://github.com/user-attachments/assets/a4a7e063-8263-4138-9705-1225b0f19e15" />

### After

<img width="447" height="791" alt="Screenshot 2026-08-17 at 11 44 46" src="https://github.com/user-attachments/assets/283532ad-6438-41f1-be88-cc5b7766dfdb" />
