### PR TITLE
ui(analyse): use i18n instead of hardcoded label

### DIFF
--- a/ui/analyse/src/study/studyShare.ts
+++ b/ui/analyse/src/study/studyShare.ts
@@ -156,7 +156,7 @@ export function view(ctrl: StudyShare): VNode {
             download: true,
           },
         },
-        'Board',
+        i18n.site.board,
       ),
       hl(
         'a.button.text',


### PR DESCRIPTION
# Why

Fixes #21307
* #21307

# How

Use i18n instead of hardcoded label for study board export.