### PR TITLE
Remove unused TypeScript exports

### DIFF
--- a/ui/analyse/src/util.ts
+++ b/ui/analyse/src/util.ts
@@ -3,10 +3,6 @@ import { Position } from 'chessops';
 import { completeNode } from 'lib/tree/node';
 import type { TreeNode, TreeNodeBase } from 'lib/tree/types';
 
-export function readOnlyProp<A>(value: A): () => A {
-  return () => value;
-}
-
 export function treeReconstruct(
   parts: TreeNodeBase[],
   variant: VariantKey,

--- a/ui/keyboardMove/src/exports.ts
+++ b/ui/keyboardMove/src/exports.ts
@@ -60,10 +60,6 @@ export interface KeyboardMoveRootCtrl extends MoveRootCtrl {
   data: RootData;
 }
 
-export function loadKeyboardMove(opts: Opts): Promise<KeyboardMoveHandler> {
-  return site.asset.loadEsm('keyboardMove', { init: opts });
-}
-
 export function render(ctrl?: KeyboardMove): VNode {
   if (!ctrl) return h('div.keyboard-move');
   return h('div.keyboard-move', [

--- a/ui/lib/src/chessgroundResize.ts
+++ b/ui/lib/src/chessgroundResize.ts
@@ -9,15 +9,6 @@ type MouchEvent = Event & Partial<MouseEvent & TouchEvent>;
 
 type Visible = (ply: Ply) => boolean;
 
-let boundChessgroundResize = false;
-
-export const bindChessgroundResizeOnce = (f: () => void): void => {
-  if (!boundChessgroundResize) {
-    boundChessgroundResize = true;
-    bindChessgroundResize(f);
-  }
-};
-
 export const dispatchChessgroundResize = (): boolean =>
   document.body.dispatchEvent(new Event('chessground.resize'));
 

--- a/ui/lib/src/objectStorage.ts
+++ b/ui/lib/src/objectStorage.ts
@@ -142,36 +142,6 @@ export function deleteObjectStorage(info: DbInfo): IDBOpenDBRequest | undefined 
     : undefined;
 }
 
-export async function nonEmptyStore(info: DbInfo): Promise<boolean> {
-  const dbName = info.db ?? info.store;
-  if (window.indexedDB.databases) {
-    const dbs = await window.indexedDB.databases();
-    if (dbs.every(db => db.name !== dbName)) return false;
-  }
-
-  return new Promise<boolean>(resolve => {
-    const request = window.indexedDB.open(dbName);
-
-    request.onerror = () => resolve(false);
-    request.onsuccess = (e: Event) => {
-      const db = (e.target as IDBOpenDBRequest).result;
-      if (!db.objectStoreNames.contains(info.store)) {
-        db.close();
-        resolve(false);
-      }
-      const cursorReq = db.transaction(info.store, 'readonly').objectStore(info.store).openCursor();
-      cursorReq.onsuccess = () => {
-        db.close();
-        resolve(Boolean(cursorReq.result));
-      };
-      cursorReq.onerror = () => {
-        db.close();
-        resolve(false);
-      };
-    };
-  });
-}
-
 export interface DbInfo {
   /** name of the object store */
   store: string;

--- a/ui/lib/src/tree/ops.ts
+++ b/ui/lib/src/tree/ops.ts
@@ -35,9 +35,6 @@ export const childById = <T extends TreeNodeBase>(node: T, id: string): T | unde
 
 export const last = <T extends TreeNodeBase>(nodeList: T[]): T | undefined => nodeList[nodeList.length - 1];
 
-export const nodeAtPly = <T extends TreeNodeBase>(nodeList: T[], ply: number): T | undefined =>
-  nodeList.find(node => node.ply === ply);
-
 export function takePathWhile<T extends TreeNodeBase>(
   nodeList: T[],
   predicate: (node: T) => boolean,

--- a/ui/lib/src/tree/path.ts
+++ b/ui/lib/src/tree/path.ts
@@ -20,9 +20,6 @@ export const areComparable = (p1: TreePath, p2: TreePath): boolean => contains(p
 
 export const fromNodeList = (nodes: TreeNode[]): TreePath => nodes.map(n => n.id).join('');
 
-export const isChildOf = (child: TreePath, parent: TreePath): boolean =>
-  !!child && child.slice(0, -2) === parent;
-
 export const intersection = (p1: TreePath, p2: TreePath): TreePath => {
   const head1 = head(p1),
     head2 = head(p2);

--- a/ui/puzzle/src/control.ts
+++ b/ui/puzzle/src/control.ts
@@ -2,10 +2,6 @@ import { path as treePath } from 'lib/tree/tree';
 
 import type PuzzleCtrl from './ctrl';
 
-export function canGoForward(ctrl: PuzzleCtrl): boolean {
-  return ctrl.node.children.length > 0;
-}
-
 export function next(ctrl: PuzzleCtrl): void {
   const child = ctrl.node.children[0];
   if (!child) return;

--- a/ui/round/src/xhr.ts
+++ b/ui/round/src/xhr.ts
@@ -1,4 +1,4 @@
-import { text, json, form } from 'lib/xhr';
+import { json } from 'lib/xhr';
 
 import type RoundController from './ctrl';
 import type { RoundData } from './interfaces';
@@ -7,9 +7,6 @@ export const reload = (d: RoundData): Promise<RoundData> => {
   const url = d.player.spectator ? `/${d.game.id}/${d.player.color}` : `/${d.game.id}${d.player.id}`;
   return json(url);
 };
-
-export const setPreference = (key: string, value: string): Promise<string> =>
-  text(`/pref/${key}`, { method: 'post', body: form({ [key]: value }) });
 
 export const whatsNext = (ctrl: RoundController): Promise<{ next?: string }> =>
   json(`/whats-next/${ctrl.data.game.id}${ctrl.data.player.id}`);


### PR DESCRIPTION
## Why
Removes some dead code

## Testing

Nothing references them:

```shell
git grep -nwE "loadKeyboardMove|canGoForward|setPreference|bindChessgroundResizeOnce|nonEmptyStore|isChildOf|nodeAtPly|readOnlyProp"
```
Outputs nothing

Builds in lila-docker