### PR TITLE
ui(lib): remove eval gauge tick at 100% height

### DIFF
--- a/ui/lib/src/ceval/view/main.ts
+++ b/ui/lib/src/ceval/view/main.ts
@@ -126,7 +126,7 @@ let gaugeTicks: VNode[];
 
 export function renderGauge(ctrl: CevalHandler): VNode | undefined {
   if (ctrl.ongoing || !ctrl.showEvalGauge()) return undefined;
-  gaugeTicks ??= [...Array(8).keys()].map(i =>
+  gaugeTicks ??= [...Array(7).keys()].map(i =>
     hl(i === 3 ? 'tick.zero' : 'tick', { attrs: { style: `height: ${(i + 1) * 12.5}%` } }),
   );
   const bestEv = getBestEval(ctrl);


### PR DESCRIPTION
# How

Remove tick at 100% from eval gauge. We don't use one at 0% and it looks like an additional border at the bottom of the bar.

# Preview

### Before

<img width="816" height="784" alt="Screenshot 2026-08-18 at 09 01 14" src="https://github.com/user-attachments/assets/e21a3df2-2203-42d5-885c-c8261822e399" />

### After

<img width="816" height="784" alt="Screenshot 2026-08-18 at 09 00 49" src="https://github.com/user-attachments/assets/96587d34-cef9-4c2e-ab93-a3f7e8fc5657" />