### PR TITLE
web: add spacing between section on /source page

### DIFF
--- a/modules/web/src/main/ui/SitePages.scala
+++ b/modules/web/src/main/ui/SitePages.scala
@@ -251,6 +251,7 @@ final class SitePages(helpers: Helpers):
               )
             )
           ),
+          br,
           st.section(cls := "box box-pad body")(rendered)
         )
 


### PR DESCRIPTION
# Why

@fitztrev spotted the lack of spacing between sections on the `/source` page.

# How

Add `<br />`, just like we do on `/developers` page to separate box sections.

# Preview

### Before

<img width="816" height="784" alt="Screenshot 2026-08-18 at 09 07 32" src="https://github.com/user-attachments/assets/baab235e-fbcb-48f1-be29-eda7c91f287d" />

### After

<img width="816" height="784" alt="Screenshot 2026-08-18 at 09 17 59" src="https://github.com/user-attachments/assets/98b45bdd-96e3-4d18-9a37-861e5d97d6d9" />