### PR TITLE
Fix broken CSS bundle keys

### DIFF
--- a/app/views/base/notFound.scala
+++ b/app/views/base/notFound.scala
@@ -34,7 +34,7 @@ def notFound(msg: Option[String]) =
     )
 
 def notFoundEmbed(msg: Option[String])(using EmbedContext) =
-  views.base.embed.site(title = msg | "Page not found", cssKeys = List("bits.embed-not-found"))(
+  views.base.embed.site(title = msg | "Page not found", cssKeys = List("bits.not-found-embed"))(
     main(cls := "not-found page-small box box-pad")(
       header(
         h1("404"),

--- a/modules/security/src/main/ui/AccountSecurity.scala
+++ b/modules/security/src/main/ui/AccountSecurity.scala
@@ -140,7 +140,7 @@ final class AccountSecurity(helpers: Helpers)(
 
   import lila.security.EmailConfirm.Help.Status
   def emailConfirmHelp(form: Form[?], status: Option[Status])(using Context) =
-    Page(trans.site.emailConfirmHelp.txt()).css("email-confirm"):
+    Page(trans.site.emailConfirmHelp.txt()).css("bits.email-confirm"):
       frag(
         main(cls := "page-small box box-pad email-confirm-help")(
           h1(cls := "box__top")(trans.site.emailConfirmHelp()),


### PR DESCRIPTION
## Why
Two pages request a CSS bundle key that doesn't exist:

https://lichess.org/embed/broadcast/x/00000000
https://lichess.org/contact/email-confirm/help (logged out)

## Before
<img width="1470" height="484" alt="Screenshot 2026-08-18 at 12 21 54 AM" src="https://github.com/user-attachments/assets/6f9daf48-928b-42ef-8259-eb4db3aca390" />
<img width="985" height="241" alt="Screenshot 2026-08-18 at 12 21 44 AM" src="https://github.com/user-attachments/assets/0e4278ea-6a70-45ae-aaba-44c4e0fe9edd" />

## After
<img width="1313" height="468" alt="Screenshot 2026-08-18 at 12 23 07 AM" src="https://github.com/user-attachments/assets/15bc09da-afdb-4619-8f6c-ee16276d9c0f" />
<img width="973" height="301" alt="Screenshot 2026-08-18 at 12 23 17 AM" src="https://github.com/user-attachments/assets/bf7eb603-2912-40e8-827b-cbccd3b87996" />