### PR TITLE
ui(game): small visual tweaks for player profile game rows

### DIFF
--- a/modules/game/src/main/ui/GameUi.scala
+++ b/modules/game/src/main/ui/GameUi.scala
@@ -251,7 +251,7 @@ final class GameUi(helpers: Helpers):
 
   object widgets:
 
-    val separator = " • "
+    val separator = span(" • ")(cls := "separator")
 
     def apply(g: Game, user: Option[User], ownerLink: Boolean)(
         contextLink: Option[Tag]
@@ -370,7 +370,7 @@ final class GameUi(helpers: Helpers):
           gameEndStatus(g),
           g.winner.map: winner =>
             frag(
-              " • ",
+              span(" • ")(cls := "separator"),
               winner.color.fold(trans.site.whiteIsVictorious(), trans.site.blackIsVictorious())
             )
         )

--- a/ui/lib/css/game/_row.scss
+++ b/ui/lib/css/game/_row.scss
@@ -53,8 +53,13 @@
 
         font-weight: normal;
         font-size: 1.4em;
+        line-height: 1;
         text-transform: uppercase;
         display: block;
+
+        .separator {
+          color: $c-font-dim;
+        }
       }
     }
   }
@@ -103,6 +108,10 @@
   .result {
     display: block;
     text-align: center;
+
+    .separator {
+      opacity: 0.75;
+    }
   }
 
   .win {


### PR DESCRIPTION
# How

Small visual tweaks for player profile game rows - de-emphasize separators, adjust line height and spacing of few elements.

# Preview

### Before

<img width="1116" height="746" alt="Screenshot 2026-08-18 at 11 04 28" src="https://github.com/user-attachments/assets/b37ca392-fe9b-4f31-b822-90e668286fee" />

### After

<img width="1116" height="748" alt="Screenshot 2026-08-18 at 10 58 14" src="https://github.com/user-attachments/assets/cade6b25-a241-4e26-8b29-ef6edb1d7965" />
