### PR TITLE
ui: drop vertical gaps in analyse and puzzle layouts

### DIFF
--- a/ui/analyse/css/_layout.scss
+++ b/ui/analyse/css/_layout.scss
@@ -137,13 +137,12 @@ body {
     .keyboard-move {
       display: block;
       grid-area: kb-move;
-      margin: $block-gap;
-      margin: calc($block-gap / 2) 0 0 0;
+      margin: $block-gap 0;
     }
   }
 
   @include mq-is-col2-squeeze {
-    gap: $block-gap $analyse-block-gap;
+    gap: 0 $analyse-block-gap;
     grid-template-columns:
       $col2-uniboard-squeeze-width var(---analyse-gauge-col)
       minmax(
@@ -153,7 +152,7 @@ body {
   }
 
   @include mq-at-least-col3 {
-    gap: $block-gap $analyse-block-gap;
+    gap: 0 $analyse-block-gap;
     grid-template-columns:
       $col3-uniboard-side $analyse-block-gap var(---col3-uniboard-width)
       var(---analyse-gauge-col)

--- a/ui/puzzle/css/_layout.scss
+++ b/ui/puzzle/css/_layout.scss
@@ -18,7 +18,7 @@ $puzzle-block-gap: 4px;
 .puzzle {
   grid-area: main;
   display: grid;
-  gap: $block-gap $puzzle-block-gap;
+  gap: calc($block-gap / 2) $puzzle-block-gap;
 
   ---puzzle-gauge-col: #{$puzzle-block-gap};
   ---puzzle-gauge-offset: calc(var(---puzzle-gauge-col) - #{$puzzle-block-gap});


### PR DESCRIPTION
# Why

They unfortunately create more spacing issues than they solve.

# How

Drop vertical gaps added with eval bar detach in analyse and puzzle layouts.

# PReview

### Before

<img width="1141" height="289" alt="Screenshot 2026-08-19 at 08 42 43" src="https://github.com/user-attachments/assets/88a0ef35-c2f7-4e97-8f12-1b04cbaaad46" />

### After

<img width="1282" height="316" alt="Screenshot 2026-08-19 at 08 50 19" src="https://github.com/user-attachments/assets/83325527-5217-4abf-9196-f79a40ffc6f2" />
