### PR TITLE
workspace: add `workspace-check` to CI, fix dependencies order

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,6 +22,7 @@ jobs:
         script:
           - lint
           - check-format
+          - workspace-check
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9

--- a/ui/team/package.json
+++ b/ui/team/package.json
@@ -3,8 +3,8 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "lib": "workspace:*",
-    "bits": "workspace:*"
+    "bits": "workspace:*",
+    "lib": "workspace:*"
   },
   "build": {
     "bundle": "src/team.*ts"


### PR DESCRIPTION
# Why

Spotted an error running `workspace-check` script locally.

# How

Fix dependencies order to address error, add `workspace-check` to lint CI workflow.
