### PR TITLE
workspace: cache XMLLint APT packages to avoid installation each run

### DIFF
--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -21,8 +21,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Install xmllint
-        run: sudo apt-get update && sudo apt-get install -y libxml2-utils
+      - name: Cache APT packages
+        uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # 1.6.3
+        with:
+          packages: libxml2-utils
+          version: 1.0
       - name: Validate translation files
         run: xmllint --noout --dtdvalid translation/resources.dtd translation/**/*.xml
 


### PR DESCRIPTION
# Why

XMLLint installation could take a lot of CI run time, especially on PRs, since we also run `update` before.

<img width="1312" height="486" alt="Screenshot 2026-08-19 at 10 01 33" src="https://github.com/user-attachments/assets/61254f54-b547-406b-b4d2-9981d8698485" />

# How

Test out the `awalsh128/cache-apt-pkgs-action` to avoid updating APT and installing packages each time action runs.