### PR TITLE
workspace: prune CodeQL caches earlier

### DIFF
--- a/.github/workflows/codeql-cache-prune.yml
+++ b/.github/workflows/codeql-cache-prune.yml
@@ -1,0 +1,39 @@
+name: Prune CodeQL caches
+
+on:
+  schedule:
+    - cron: '32 3 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: prune-codeql-caches
+  cancel-in-progress: true
+
+permissions:
+  actions: write
+
+jobs:
+  prune:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete CodeQL caches unused for three days
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          cutoff="$(date -u -d "3 days ago" +%s)"
+
+          gh api --paginate \
+            "/repos/$REPOSITORY/actions/caches?per_page=100" \
+            --jq '.actions_caches[]
+              | select(.key | startswith("codeql-"))
+              | select((.last_accessed_at | fromdateiso8601) < '"$cutoff"')
+              | .id' |
+          while read -r cache_id; do
+            echo "Deleting CodeQL cache $cache_id"
+
+            gh api --method DELETE \
+              "/repos/$REPOSITORY/actions/caches/$cache_id"
+          done


### PR DESCRIPTION
# Why

Currently we are almost continuously at 10GB action cache storage limit, due to CodeQL and shear amount of commits pushed and PRs made.

GitHub automatically prune stale CodeQL caches after 7 days, and prunes oldest caches when repository reaches limit, but preferably we should prfioritize removal of CodeQL caches before env ones like Node/Java, since CodeQL ones are basically valid per commit, while evn ones would be used for PRs up for few days with new changes without rebase.

<img width="1312" height="326" alt="Screenshot 2026-08-19 at 10 37 57" src="https://github.com/user-attachments/assets/5e2fad63-f5f9-476a-9dd0-334f70aa6f67" />

# How

Add a custom CodeQL caches workflow, which will run every 3h and delete `codeql-` cache entries unused for more than than 3 days. It can also be manually run by repo maintainers via dispatch.

# Test plan

Run list command locally with small adjustment for macOS `jq`:

<img width="1132" height="208" alt="Screenshot 2026-08-19 at 10 51 02" src="https://github.com/user-attachments/assets/ae57d1f3-8f23-4bb9-be42-b3fc3168a4ba" />

