### PR TITLE
add client context to dialog opts, accessible as dlg.ctx

### DIFF
--- a/ui/analyse/src/view/settingsView.ts
+++ b/ui/analyse/src/view/settingsView.ts
@@ -104,7 +104,7 @@ export async function showSettingsDialog(ctrl: AnalyseCtrl): Promise<Dialog> {
   return domDialog({
     class: 'analysis-settings-dialog',
     htmlText: '<h2>Analysis settings</h2>',
-    append: [{ node: settingsView(ctrl.settings) }],
+    insert: [{ node: settingsView(ctrl.settings) }],
     modal: !isTouchDevice(),
     easyClose: 'clickOutside',
     show: true,

--- a/ui/bits/src/bits.cropDialog.ts
+++ b/ui/bits/src/bits.cropDialog.ts
@@ -76,7 +76,7 @@ export async function initModule(o?: CropOpts): Promise<void> {
         <button class="button button-empty cancel">cancel</button>
         <button class="button submit">submit</button>
       </span>`,
-    append: [{ where: '.crop-view', node: container }],
+    insert: [{ selector: '.crop-view', node: container }],
     actions: [
       { selector: '.dialog-actions > .cancel', listener: (_, d) => d.close() },
       { selector: '.dialog-actions > .submit', listener: crop },

--- a/ui/botDev/src/editDialog.ts
+++ b/ui/botDev/src/editDialog.ts
@@ -60,7 +60,7 @@ export class EditDialog {
 
   async show(): Promise<Dialog> {
     this.dlg = await domDialog({
-      append: [{ node: this.view }],
+      insert: [{ node: this.view }],
       actions: this.actions,
       onClose: () => this.janitor.cleanup(),
       onShow: () => this.deck.resize(),
@@ -228,9 +228,9 @@ export class EditDialog {
     domDialog({
       class: 'dev-view',
       htmlText: `<h2>Choose a user id</h2><p>must be unique and begin with #</p><span></span>`,
-      append: [
-        { node: input, where: 'span' },
-        { node: ok, where: 'span' },
+      insert: [
+        { node: input, selector: 'span' },
+        { node: ok, selector: 'span' },
       ],
       focus: 'input',
       modal: true,
@@ -289,7 +289,7 @@ export class EditDialog {
           </div>
       </div>`);
     const dlg = await domDialog({
-      append: [{ node: view }],
+      insert: [{ node: view }],
       easyClose: 'clickOutside',
       show: true,
       actions: [
@@ -315,7 +315,7 @@ export class EditDialog {
           </div>
       </div>`);
     const dlg = await domDialog({
-      append: [{ node: view }],
+      insert: [{ node: view }],
       easyClose: 'clickOutside',
       show: true,
       actions: [

--- a/ui/botDev/src/historyDialog.ts
+++ b/ui/botDev/src/historyDialog.ts
@@ -43,7 +43,7 @@ class HistoryDialog {
       </div>`);
     await this.updateHistory();
     this.dlg = await domDialog({
-      append: [{ node: this.view }],
+      insert: [{ node: this.view }],
       easyClose: 'clickOutside',
       actions: [
         { selector: '[data-action="pull"]', listener: this.pull },

--- a/ui/lib/src/view/dialog.ts
+++ b/ui/lib/src/view/dialog.ts
@@ -9,28 +9,30 @@ import * as xhr from '@/xhr';
 
 import { onInsert, hl, type VNode, type Attrs, type LooseVNodes } from './snabbdom';
 
-export interface Dialog {
+export interface Dialog<Ctx = undefined> {
+  ctx: Ctx;
   readonly view: HTMLElement; // your content div
   readonly dialog: HTMLDialogElement; // the dialog element
   readonly returnValue?: 'ok' | 'cancel' | string; // how did we close?
 
-  show(): Promise<Dialog>; // promise resolves on close
-  updateActions(actions?: Action | Action[]): void; // set new actions or reattach existing if no args
+  show(): Promise<Dialog<Ctx>>; // promise resolves on close
+  updateActions(actions?: Action<Ctx> | Action<Ctx>[]): void; // set new actions or reattach existing if no args
   close(returnValue?: string): void;
 }
 
-export interface DialogOpts {
+export interface DialogOpts<Ctx = undefined> {
+  ctx?: Ctx;
   class?: string; // classes for your view div
   css?: ({ url: string } | { hashed: string })[]; // hashed or full url css
   htmlText?: string; // content, htmlText is inserted as fragment into DOM
   cash?: Cash; // content, precedence over htmlText, cash will be cloned and any 'none' class removed
   htmlUrl?: string; // content, precedence over htmlText and cash, url will be xhr'd
-  append?: { node: HTMLElement; where?: string; how?: 'after' | 'before' | 'child' }[]; // default is 'child'
+  insert?: { node: Node; selector?: string; position?: 'child' | 'before' | 'after' }[]; // default is 'child'
   attrs?: { dialog?: Attrs; view?: Attrs }; // optional attrs for dialog and view div
   focus?: string; // query selector for focus on show
-  actions?: Action | Action[]; // add listeners to controls, call updateActions() to reattach
-  onShow?: (dialog: Dialog) => void; // called after dialog is shown
-  onClose?: (dialog: Dialog) => void; // always called when dialog closes
+  actions?: Action<Ctx> | Action<Ctx>[]; // add listeners to controls, call updateActions() to reattach
+  onShow?: (dialog: Dialog<Ctx>) => void; // called after dialog is shown
+  onClose?: (dialog: Dialog<Ctx>) => void; // always called when dialog closes
   noCloseButton?: boolean; // if true, no upper right corner close button
   noScrollable?: boolean; // if true, no scrollable div container. Fixes dialogs containing an auto-completer
   modal?: boolean; // if true, show as modal (darken everything else)
@@ -38,34 +40,37 @@ export interface DialogOpts {
 }
 
 // show is an explicit property for domDialog.
-export interface DomDialogOpts extends DialogOpts {
+export interface DomDialogOpts<Ctx = undefined> extends DialogOpts<Ctx> {
   parent?: Element; // for centering and dom placement, otherwise fixed on document.body
   show?: boolean; // show dialog immediately after construction
 }
 
-// for snabDialog, show is inferred from !onInsert
-export interface SnabDialogOpts extends DialogOpts {
+export interface SnabDialogOpts<Ctx = undefined> extends DialogOpts<Ctx> {
   vnodes?: LooseVNodes; // content, overrides all other content properties
-  onInsert?: (dialog: Dialog) => void; // if provided you must call show
+  onInsert?: (dialog: Dialog<Ctx>) => void; // if provided you must call show
 }
 
-export type ActionListener = (e: Event, dialog: Dialog, action: Action) => void;
+export type ActionListener<T extends Event = Event, Ctx = undefined> = (
+  e: T,
+  dialog: Dialog<Ctx>,
+  action: Action<Ctx>,
+) => void;
 
 // Actions are listeners / results for controls
 // if no event is specified, then 'click' is assumed
 // if no selector is given, the handler is attached to the dialog-content view div
-export type Action =
-  | { selector?: string; event?: string | string[]; listener: ActionListener }
+export type Action<Ctx = undefined> =
+  | { selector?: string; event?: string | string[]; listener: ActionListener<any, Ctx> }
   | { selector?: string; event?: string | string[]; result: string };
 
 // when opts contains 'show', domDialog function's result promise resolves on dialog closure.
 // otherwise, the promise resolves once assets are loaded and it is safe to call show
-export async function domDialog(o: DomDialogOpts): Promise<Dialog> {
-  const [html] = await loadAssets(o);
+export async function domDialog<Ctx = undefined>(o: DomDialogOpts<Ctx>): Promise<Dialog<Ctx>> {
+  const html = await loadAssets(o);
 
   const dialog = document.createElement('dialog');
   for (const [k, v] of Object.entries(o.attrs?.dialog ?? {})) dialog.setAttribute(k, String(v));
-  if (isTouchDevice() && o.actions) dialog.classList.add('touch-scroll');
+  if (isTouchDevice()) dialog.classList.add('touch-scroll');
   if (o.parent) dialog.style.position = 'absolute';
 
   if (!o.noCloseButton) {
@@ -86,17 +91,17 @@ export async function domDialog(o: DomDialogOpts): Promise<Dialog> {
 
   (o.parent ?? document.body).appendChild(dialog);
 
-  const wrapper = new DialogWrapper(dialog, view, o);
+  const wrapper = new DialogWrapper<Ctx>(dialog, view, o);
   return o.show ? wrapper.show() : wrapper;
 }
 
-export function snabDialog(o: SnabDialogOpts): VNode {
-  const assets = loadAssets(o);
+export function snabDialog<Ctx = undefined>(o: SnabDialogOpts<Ctx>): VNode {
   let dialog: HTMLDialogElement;
-
+  const classes = o.class?.split(/[. ]/).filter(Boolean) ?? [];
   const dialogVNode = hl(
-    `dialog${isTouchDevice() ? '.touch-scroll' : ''}`,
+    'dialog',
     {
+      class: { 'touch-scroll': isTouchDevice() },
       key: o.class ?? 'dialog',
       attrs: o.attrs?.dialog,
       hook: onInsert(el => (dialog = el as HTMLDialogElement)),
@@ -108,15 +113,17 @@ export function snabDialog(o: SnabDialogOpts): VNode {
           hl('button.close-button', { attrs: { 'data-icon': licon.X, 'aria-label': i18n.site.close } }),
         ),
       hl(
-        `div.${o.noScrollable ? 'not-' : ''}scrollable`,
+        'div',
+        { class: { scrollable: !o.noScrollable } },
         hl(
-          'div.dialog-content' + (o.class ? '.' + o.class.split(/[. ]/).filter(Boolean).join('.') : ''),
+          'div.dialog-content',
           {
+            class: Object.fromEntries(classes.map(c => [c, true])),
             attrs: o.attrs?.view,
             hook: onInsert(async view => {
-              const [html] = await assets;
+              const html = await loadAssets(o);
               if (!o.vnodes && html) view.innerHTML = html;
-              const dlg = new DialogWrapper(dialog, view, o);
+              const dlg = new DialogWrapper<Ctx>(dialog, view, o);
               if (o.onInsert) o.onInsert(dlg);
               else dlg.show();
             }),
@@ -127,20 +134,20 @@ export function snabDialog(o: SnabDialogOpts): VNode {
     ],
   );
   if (!o.modal) return dialogVNode;
-  return hl('div.snab-modal-mask' + (o.onInsert ? '.none' : ''), dialogVNode);
+  return hl('div.snab-modal-mask', { class: { none: Boolean(o.onInsert) } }, dialogVNode);
 }
 
 const easyCloseHandler = new (class {
   private stack: DialogWrapper[] = [];
 
-  push(dlg: DialogWrapper) {
+  push(dlg: DialogWrapper<any>) {
     if (!dlg.o.easyClose) return;
     if (this.stack.length === 0)
       document.addEventListener('pointerdown', this.pointerdown, { capture: true });
     this.stack.push(dlg);
   }
 
-  remove(dlg: DialogWrapper): void {
+  remove(dlg: DialogWrapper<any>): void {
     this.stack = this.stack.filter(d => d !== dlg);
     if (this.stack.length === 0)
       document.removeEventListener('pointerdown', this.pointerdown, { capture: true });
@@ -154,11 +161,17 @@ const easyCloseHandler = new (class {
       const bounds = this.top.dialog.getBoundingClientRect();
       if (x >= bounds.left && x <= bounds.right && y >= bounds.top && y <= bounds.bottom) return;
     }
+    if (e.pointerType === 'touch' || !this.top.o.modal)
+      window.addEventListener(
+        'click',
+        e => {
+          e.preventDefault();
+          e.stopImmediatePropagation();
+        },
+        { once: true, capture: true },
+      );
     this.top.close('cancel');
-
     e.stopPropagation();
-    if (!this.top.o.modal)
-      document.addEventListener('click', e => e.stopPropagation(), { once: true, capture: true });
   };
 
   private get top(): DialogWrapper | undefined {
@@ -166,10 +179,10 @@ const easyCloseHandler = new (class {
   }
 })();
 
-class DialogWrapper implements Dialog {
+class DialogWrapper<Ctx = undefined> implements Dialog<Ctx> {
   private readonly dialogEvents = new Janitor();
   private readonly actionEvents = new Janitor();
-  private resolve?: (dialog: Dialog) => void;
+  private resolve?: (dialog: Dialog<Ctx>) => void;
   private readonly observer: MutationObserver = new MutationObserver(list => {
     for (const m of list)
       if (m.type === 'childList')
@@ -180,15 +193,14 @@ class DialogWrapper implements Dialog {
           }
         }
   });
-  private readonly focusQuery = ['button', 'input', 'select', 'textarea']
-    .map(sel => `${sel}:not(:disabled)`)
-    .concat(['[href]', '[tabindex]', '[role="tab"]'])
-    .join(',');
+  private readonly focusQuery =
+    'button, input, select, textarea, [href], [tabindex], [role="tab"], [role="button"], [role="link"]';
 
   constructor(
     readonly dialog: HTMLDialogElement,
     readonly view: HTMLElement,
-    readonly o: DialogOpts,
+    readonly o: DialogOpts<Ctx>,
+    public ctx: Ctx = o.ctx as Ctx,
   ) {
     this.observer.observe(document.body, { childList: true, subtree: true });
     document.body.style.setProperty('---viewport-height', `${window.innerHeight}px`);
@@ -204,12 +216,12 @@ class DialogWrapper implements Dialog {
         'click',
         () => this.close('cancel'),
       );
-    for (const app of o.append ?? []) {
+    for (const app of o.insert ?? []) {
       if (app.node === view) break;
-      const where = (app.where ? view.querySelector(app.where) : view)!;
-      if (app.how === 'before') where.before(app.node);
-      else if (app.how === 'after') where.after(app.node);
-      else where.appendChild(app.node);
+      const target = (app.selector ? view.querySelector(app.selector) : view)!;
+      if (app.position === 'before') target.before(app.node);
+      else if (app.position === 'after') target.after(app.node);
+      else target.appendChild(app.node);
     }
     this.updateActions();
     this.dialogEvents.addListener(this.dialog, 'keydown', this.onKeydown);
@@ -219,7 +231,7 @@ class DialogWrapper implements Dialog {
     return this.dialog.returnValue;
   }
 
-  show = async (): Promise<Dialog> => {
+  show = async (): Promise<Dialog<Ctx>> => {
     (await pubsub.after('polyfill.dialog'))?.(this.dialog);
     const snabModal = this.dialog.parentElement === this.dialog.closest('.snab-modal-mask');
     if (this.o.modal) this.view.scrollTop = 0;
@@ -242,6 +254,7 @@ class DialogWrapper implements Dialog {
 
   updateActions = (actions = this.o.actions) => {
     this.actionEvents.cleanup();
+    this.o.actions = actions;
     if (!actions) return;
     for (const a of Array.isArray(actions) ? actions : [actions]) {
       for (const event of Array.isArray(a.event) ? a.event : a.event ? [a.event] : ['click']) {
@@ -260,14 +273,18 @@ class DialogWrapper implements Dialog {
       e.preventDefault();
     } else if (e.key === 'Tab') {
       const focii = [...this.dialog.querySelectorAll<HTMLElement>(this.focusQuery)].filter(
-        el => el.getAttribute('tabindex') !== '-1',
+        el =>
+          el.tabIndex !== -1 &&
+          el.checkVisibility({ visibilityProperty: true }) &&
+          !el.matches(':disabled') &&
+          !el.closest('[inert]'),
       );
       focii.sort((a, b) => {
         const ati = Number(a.getAttribute('tabindex') ?? '0');
         const bti = Number(b.getAttribute('tabindex') ?? '0');
         if (ati > 0 && (bti === 0 || ati < bti)) return -1;
         else if (bti > 0 && ati !== bti) return 1;
-        else return a.compareDocumentPosition(b) & 2 ? 1 : -1;
+        else return a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_PRECEDING ? 1 : -1;
       });
       const first = focii[0],
         last = focii[focii.length - 1],
@@ -278,7 +295,8 @@ class DialogWrapper implements Dialog {
       else return;
       e.preventDefault();
     }
-    if (['Escape', 'Enter', 'Tab'].includes(e.key)) e.stopPropagation();
+
+    if (['Escape', 'Tab'].includes(e.key)) e.stopPropagation(); // trap 'Enter' for modals here or?
   };
 
   private autoFocus() {
@@ -307,8 +325,8 @@ class DialogWrapper implements Dialog {
   };
 }
 
-async function loadAssets(o: DialogOpts) {
-  return Promise.all([
+async function loadAssets<Ctx>(o: DialogOpts<Ctx>): Promise<string> {
+  const results = await Promise.allSettled([
     o.htmlUrl
       ? xhr.text(o.htmlUrl)
       : Promise.resolve(o.cash?.clone().removeClass('none')[0]?.outerHTML ?? o.htmlText),
@@ -317,4 +335,5 @@ async function loadAssets(o: DialogOpts) {
       'hashed' in css ? site.asset.loadCssPath(css.hashed) : site.asset.loadCss(css.url),
     ),
   ]);
+  return (results[0]?.status === 'fulfilled' && results[0].value) || '';
 }


### PR DESCRIPTION
There are some other changes as well, but they are minor:

- a tweak to easy close handler
- use standard DOM language for node insertion dialog opts
- fix focus bugs when elements are invisible
- use allSettled rather than all for loadAssets

I plan to use the context parameter to simplify some existing dialog usages in cleanup PRs