### PR TITLE
use enter not space to trigger clean rebuild

### DIFF
--- a/ui/.build/src/env.ts
+++ b/ui/.build/src/env.ts
@@ -132,7 +132,7 @@ export const env = new (class {
     if (this.buildOk()) {
       if (this.startTime) {
         const doneMsg = `Done in ${c.green(String((Date.now() - this.startTime) / 1000))}s`;
-        this.log(doneMsg + (this.stdin ? `. Press ${c.grey('<space>')} to clean and rebuild` : ''));
+        this.log(doneMsg + (this.stdin ? `. Press ${c.grey('<enter>')} to clean and rebuild` : ''));
       }
       this.onSuccess.forEach(yay => yay());
       this.startTime = undefined;

--- a/ui/.build/src/main.ts
+++ b/ui/.build/src/main.ts
@@ -123,7 +123,7 @@ if (env.watch && 'setRawMode' in ps.stdin) {
   ps.stdin.on('data', (key: Buffer) => {
     if (key[0] === 3 || key[0] === 27) {
       ps.exit(0);
-    } else if (key[0] === 32 && tasksIdle()) {
+    } else if ((key[0] === 13 || key[0] === 10) && tasksIdle()) {
       stopBuild().then(() => clean('force').then(() => build(argv.filter(x => !x.startsWith('-')))));
     }
   });


### PR DESCRIPTION
Node's raw mode TTY seems to get partially detached when its vscode embedded terminal loses focus. There's no repair when focus is regained and there's no hook to observe that PTY/input state from within node. So we change the keystroke that triggers rebuilds to `<enter>` because it rides on stdin (which is reacquired on refocus), rather than `<space>` over raw mode (which is not).