### PR TITLE
do not persist FEN from "Continue from here"

### DIFF
--- a/ui/lobby/src/setupCtrl.ts
+++ b/ui/lobby/src/setupCtrl.ts
@@ -122,10 +122,11 @@ export default class SetupController {
     if (!this.gameType) return;
 
     // Don't persist position passed through URL
-    const storedPosition = this.forced?.fen ? this.store[this.gameType]() : undefined;
+    const prevSetup = this.forced?.fen ? this.store[this.gameType]() : undefined;
+
     this.store[this.gameType]({
-      variant: storedPosition?.variant ?? this.variant(),
-      fen: storedPosition?.fen ?? this.fen(),
+      variant: prevSetup?.variant ?? this.variant(),
+      fen: prevSetup?.fen ?? this.fen(),
       timeMode: this.timeControl.mode(),
       time: this.timeControl.time(),
       increment: this.timeControl.increment(),

--- a/ui/lobby/src/setupCtrl.ts
+++ b/ui/lobby/src/setupCtrl.ts
@@ -118,11 +118,14 @@ export default class SetupController {
     }
   };
 
-  private readonly savePropsToStore = (override: Partial<SetupStore> = {}) =>
-    this.gameType &&
+  private readonly savePropsToStore = (override: Partial<SetupStore> = {}) => {
+    if (!this.gameType) return;
+
+    // Don't persist position passed through URL
+    const storedPosition = this.forced?.fen ? this.store[this.gameType]() : undefined;
     this.store[this.gameType]({
-      variant: this.variant(),
-      fen: this.fen(),
+      variant: storedPosition?.variant ?? this.variant(),
+      fen: storedPosition?.fen ?? this.fen(),
       timeMode: this.timeControl.mode(),
       time: this.timeControl.time(),
       increment: this.timeControl.increment(),
@@ -134,6 +137,7 @@ export default class SetupController {
       aiLevel: this.aiLevel(),
       ...override,
     });
+  };
 
   private readonly savePropsToStoreExceptRating = () =>
     this.gameType &&


### PR DESCRIPTION
Closes #13668 

## Problem

Opening a game setup through "Continue from here" passes a FEN and variant into the setup dialog. However, these values were also being saved in local storage, so the next regular setup reused the forced position and variant (see the videos attached below). 

## Solution

When the setup dialog has a forced FEN, the stored FEN and variant are preserved instead of being replaced with the forced values. Significantly, note that other setup preferences continue to be saved normally.

## Testing

Issue was successfully reproduced locally and a fix was applied, verifying that the forced FEN and variant no longer persist in both the computer and friend setup dialogs.

### Before Fix

https://github.com/user-attachments/assets/88adbf9f-c5d1-4470-a95d-0b628392155c

### After Fix

https://github.com/user-attachments/assets/73ebce69-41a8-46d6-82c1-e0448cd0a066