### PR TITLE
Fix scope of apiMany, integer division in apiBatchSelect

### DIFF
--- a/app/controllers/Puzzle.scala
+++ b/app/controllers/Puzzle.scala
@@ -377,11 +377,11 @@ final class Puzzle(env: Env, apiC: => Api) extends LilaController(env):
   }
 
   def apiBatchSelect(angleStr: String) = AnonOrScoped(_.Puzzle.Read, _.Web.Mobile): ctx ?=>
-    val nb = getInt("nb") | 15
+    val nb = (getInt("nb") | 15).atLeast(1).atMost(50)
     val cost =
       if ctx.isMobileOauth then 0
-      else if HTTPRequest.isLichessMobile(ctx.req) then nb / 5
-      else if ctx.isAuth then nb / 3
+      else if HTTPRequest.isLichessMobile(ctx.req) then (nb / 5).atLeast(1)
+      else if ctx.isAuth then (nb / 3).atLeast(1)
       else nb
     fetchRateLimit(rateLimited, cost = cost):
       PuzzleAngle

--- a/app/controllers/Puzzle.scala
+++ b/app/controllers/Puzzle.scala
@@ -74,10 +74,10 @@ final class Puzzle(env: Env, apiC: => Api) extends LilaController(env):
   def apiMany(idsStr: String) = AnonOrScoped(_.Web.Mobile): ctx ?=>
     val ids = idsStr.split(',').take(50).flatMap(Puz.toId).toList
     val cost =
-      if ctx.isMobileOauth then 0
-      else if HTTPRequest.isLichessMobile(ctx.req) then (ids.length / 5).atLeast(1)
-      else ids.length.atLeast(1)
-    fetchRateLimit(rateLimited, cost = cost):
+      if ctx.isMobileOauth then ids.length / 10
+      else if HTTPRequest.isLichessMobile(ctx.req) then ids.length / 5
+      else ids.length
+    fetchRateLimit(rateLimited, cost = cost.atLeast(1)):
       WithPuzzlePerf:
         for
           puzzles <- env.puzzle.api.puzzle.findMany(ids)

--- a/app/controllers/Puzzle.scala
+++ b/app/controllers/Puzzle.scala
@@ -71,9 +71,13 @@ final class Puzzle(env: Env, apiC: => Api) extends LilaController(env):
   def apiSinglePuzzle(puzzle: Puz)(using Context, Perf) =
     JsonOk(env.puzzle.jsonView(puzzle, none, none, withInitialPos = true))
 
-  def apiMany(idsStr: String) = Scoped(_.Web.Mobile): ctx ?=>
+  def apiMany(idsStr: String) = AnonOrScoped(_.Web.Mobile): ctx ?=>
     val ids = idsStr.split(',').take(50).flatMap(Puz.toId).toList
-    fetchRateLimit(rateLimited, cost = ids.length / 10):
+    val cost =
+      if ctx.isMobileOauth then 0
+      else if HTTPRequest.isLichessMobile(ctx.req) then (ids.length / 5).atLeast(1)
+      else ids.length.atLeast(1)
+    fetchRateLimit(rateLimited, cost = cost):
       WithPuzzlePerf:
         for
           puzzles <- env.puzzle.api.puzzle.findMany(ids)


### PR DESCRIPTION
When implementing this feature in Mobile, I realized I should make changes to my earlier PR #20779.

1. Signed-out puzzle-streak prefetches should be supported in the mobile app, so change it from `Scoped` to `AnonOrScoped`

2. Cost was computed with integer division. So any request with fewer than 10 ids cost 0 and was unmetered (can poll 9 at a time indefinitely).

3. I also found an issue in ApiBatchSelect, where because of integer division, the API is not adding cost. 

`mobileBcBatchSelect` clamps nb in both directions, I feel batchSelect should do that too.  
Internally, batchSelect is already truncating to 50 puzzles. So, add an `atMost(50)`  
Due to integer division, `nb=2` signed in will be `2/3 = 0` and not add cost. So, add an `atLeast(1)`  

---
# AI Usage
I used Fable 5 & Opus 5.

When I had the AI write the mobile code, it was super convoluted. I asked it why, and it pointed out how changing the API to `AnonOrScoped` would let it simplify its code.

```
Please change apiMany to use AnonOrScoped like apiBatchSelect. Fix the integer division problem in the same way as mobileBcBatchSelect
```

Doing that, it also noticed the integer division problem in `apiBatchSelect`

```
Please fix the integer division problems in apiBatchSelect
```