### PR TITLE
add study visibility to study json view

### DIFF
--- a/modules/study/src/main/JsonView.scala
+++ b/modules/study/src/main/JsonView.scala
@@ -89,7 +89,8 @@ final class JsonView(
         "owner" -> lightUserApi.sync(s.study.ownerId),
         "chapters" -> s.chapters.take(Study.previewNbChapters),
         "topics" -> s.study.topicsOrEmpty,
-        "members" -> s.study.members.members.values.take(Study.previewNbMembers)
+        "members" -> s.study.members.members.values.take(Study.previewNbMembers),
+        "visibility" -> s.study.visibility
       )
       .add("flair", s.study.flair)
 


### PR DESCRIPTION
To let the mobile app show a "lock" icon for private and unlisted studies, like on the website.

Tested with lila-docker + local branch of the mobile app.

AI Tools: Deep Wiki to quickly find the place that needed to be changed
