### PR TITLE
Puzzle Storm: add "unfinished" puzzles

### DIFF
--- a/ui/lib/css/puz/_history.scss
+++ b/ui/lib/css/puz/_history.scss
@@ -56,6 +56,10 @@
       outline-color: $c-bad;
     }
 
+    .unfinished cg-container {
+      outline-color: $c-font-dim;
+    }
+
     &:hover .puz-history__round__id {
       font-family: monospace;
       color: $c-font;
@@ -65,7 +69,8 @@
   }
 
   good,
-  bad {
+  bad,
+  unfinished {
     @extend %flex-center, %box-radius-bottom;
 
     &::before {
@@ -88,6 +93,14 @@
 
     &::before {
       content: $licon-X;
+    }
+  }
+
+  unfinished {
+    color: $c-font-dim;
+
+    &::before {
+      content: $licon-Clock;
     }
   }
 }

--- a/ui/lib/src/puz/interfaces.ts
+++ b/ui/lib/src/puz/interfaces.ts
@@ -41,6 +41,7 @@ export interface Run {
   modifier: Modifier;
   endAt?: number;
   skipId?: string;
+  unfinishedId?: string;
 }
 
 export interface Round {

--- a/ui/lib/src/puz/view/history.ts
+++ b/ui/lib/src/puz/view/history.ts
@@ -5,7 +5,7 @@ import { parseUci } from 'chessops/util';
 import { h, type VNode } from 'snabbdom';
 
 import type { Toggle } from '@/index';
-import type { PuzCtrl } from '@/puz/interfaces';
+import type { PuzCtrl, Round } from '@/puz/interfaces';
 import { initMiniBoardWith, onInsert } from '@/view';
 
 const slowPuzzleIds = (ctrl: PuzCtrl): Set<string> | undefined => {
@@ -28,6 +28,8 @@ const toggleButton = (prop: Toggle, title: string): VNode =>
 export default (ctrl: PuzCtrl): VNode => {
   const slowIds = slowPuzzleIds(ctrl),
     filters = ctrl.filters,
+    unfinishedId = ctrl.run.unfinishedId,
+    klass = (r: Round) => (r.puzzle.id === unfinishedId ? 'unfinished' : r.win ? 'good' : 'bad'),
     buttons: VNode[] = [
       toggleButton(filters.fail, i18n.storm.failedPuzzles),
       toggleButton(filters.slow, i18n.storm.slowPuzzles),
@@ -40,13 +42,13 @@ export default (ctrl: PuzCtrl): VNode => {
       ctrl.run.history
         .filter(
           r =>
-            (!r.win || !filters.fail()) &&
+            ((!r.win && r.puzzle.id !== unfinishedId) || !filters.fail()) &&
             (!slowIds || slowIds.has(r.puzzle.id)) &&
             (!filters.skip || !filters.skip() || r.puzzle.id === ctrl.run.skipId),
         )
         .map(round =>
           h('div.puz-history__round', { key: round.puzzle.id }, [
-            h(`a.puz-history__round__puzzle.mini-board.cg-wrap.is2d.${round.win ? 'good' : 'bad'}`, {
+            h(`a.puz-history__round__puzzle.mini-board.cg-wrap.is2d.${klass(round)}`, {
               attrs: {
                 href: `/training/${round.puzzle.id}`,
                 target: '_blank',
@@ -64,7 +66,7 @@ export default (ctrl: PuzCtrl): VNode => {
             }),
             h('span.puz-history__round__meta', [
               h('span.puz-history__round__result', [
-                h(round.win ? 'good' : 'bad', Math.round(round.millis / 1000) + 's'),
+                h(klass(round), Math.round(round.millis / 1000) + 's'),
                 ctrl.pref.ratings ? h('rating', round.puzzle.rating) : '',
               ]),
               h('span.puz-history__round__id', '#' + round.puzzle.id),

--- a/ui/racer/src/ctrl.ts
+++ b/ui/racer/src/ctrl.ts
@@ -143,6 +143,7 @@ export default class RacerCtrl implements PuzCtrl {
       : undefined;
 
   end = (): void => {
+    this.run.unfinishedId = this.run.current.puzzle.id;
     this.pushToHistory(false); // add last unsolved puzzle
     this.setGround();
     this.redraw();

--- a/ui/storm/src/ctrl.ts
+++ b/ui/storm/src/ctrl.ts
@@ -88,6 +88,7 @@ export default class StormCtrl implements PuzCtrl {
   };
 
   endNow = (): void => {
+    this.run.unfinishedId = this.run.current.puzzle.id;
     this.pushToHistory(false);
     this.end();
   };


### PR DESCRIPTION
When a Storm or Racer run ends with a puzzle still on the board, that puzzle is recorded as a loss and shown in red. Show it in gray with a clock icon instead, and leave it out of the "failed puzzles" filter.

**Why it isn't simply "the last round".** In Storm a wrong move costs 10 seconds, and that malus can be what flags the clock — the round is pushed as a loss *before* the clock is checked, and `end()` doesn't push again, so that round is a puzzle you genuinely got wrong and stays red. Racer has no malus, so its last puzzle really is always unfinished; Storm's isn't.

The run knows which case it is at the moment it ends, so it records the id there — the same way `run.skipId` already marks the skipped puzzle. No new state on `Round`, no inference from the history.

# Rules about AI-assisted code contributions
Model: Fable 5, Opus 5
```
Hi. On puzzle storm it marks puzzles as wrong when I merely didn't finish it yet.
Is there not the option for green, red, and a gray or something?
```
Rewritten three times after review: first to drop the flag and infer the unfinished round from the error count, then back to an explicit marker once the -10s case showed the inference was wrong, then onto `run.unfinishedId` to match the `skipId` that was already there.
