### PR TITLE
Change FidePlayer inactivity field to be per time control

### DIFF
--- a/bin/mongodb/fide-inactive-per-tc.js
+++ b/bin/mongodb/fide-inactive-per-tc.js
@@ -1,0 +1,3 @@
+// The combined FIDE list has a "inactive" flag iff the player is inactive in the standard time control.
+db.fide_player.updateMany({ inactive: true }, { $set: { inactive: ['standard'] } });
+db.fide_player.updateMany({ inactive: { $not: { $type: 'array' } } }, { $set: { inactive: [] } });

--- a/conf/base.conf
+++ b/conf/base.conf
@@ -128,6 +128,8 @@ relay {
 }
 fide {
   players.url = "https://lichess-asset-mirror.s3.eu-west-3.amazonaws.com/ratings.fide.com/players_list.zip"
+  # Per time-control rating lists url prefix
+  ratings.url = "https://ratings.fide.com/download/"
 }
 storm.secret = "somethingElseInProd"
 coordinate {

--- a/modules/core/src/main/fide.scala
+++ b/modules/core/src/main/fide.scala
@@ -46,6 +46,11 @@ object Tokenize extends FunctionWrapper[Tokenize, String => PlayerToken]
 enum FidePlayerOrder:
   case name, standard, rapid, blitz, year, follow
   def key = toString
+  // which time control activity applies to that ordering
+  def fideTC: FideTC = this match
+    case FidePlayerOrder.rapid => FideTC.rapid
+    case FidePlayerOrder.blitz => FideTC.blitz
+    case _ => FideTC.standard
 
 object FidePlayerOrder:
   def all: List[FidePlayerOrder] = values.toList

--- a/modules/fide/src/main/Env.scala
+++ b/modules/fide/src/main/Env.scala
@@ -65,8 +65,13 @@ final class Env(
 
   given Federation.Guess = lila.fide.Federation.find
 
-  private lazy val fideSync =
-    FidePlayerSync(repo, ws, httpProxy, appConfig.get[Url]("fide.players.url"))
+  private lazy val fideSync = FidePlayerSync(
+    repo,
+    ws,
+    httpProxy,
+    appConfig.get[Url]("fide.players.url"),
+    appConfig.get[Url]("fide.ratings.url")
+  )
 
   if mode.isProd then
     scheduler.scheduleWithFixedDelay(1.hour, 1.hour): () =>

--- a/modules/fide/src/main/FideJson.scala
+++ b/modules/fide/src/main/FideJson.scala
@@ -16,6 +16,8 @@ final class FideJson(picfitUrl: lila.memo.PicfitUrl):
 
   given Writes[FidePlayer.Gender] = writeAs(_.value.toString)
 
+  given Writes[chess.FideTC] = writeAs(_.toString)
+
   def photosJson(photos: Map[chess.FideId, FidePlayer.PlayerPhoto]) = PhotosJson:
     JsObject:
       photos.map: (id, photo) =>
@@ -30,7 +32,7 @@ final class FideJson(picfitUrl: lila.memo.PicfitUrl):
         "year" -> p.year
       )
       .add("title" -> p.title)
-      .add("inactive" -> p.inactive)
+      .add("inactive" -> p.isInactive)
       .add("standard" -> p.standard)
       .add("rapid" -> p.rapid)
       .add("blitz" -> p.blitz)

--- a/modules/fide/src/main/FideJson.scala
+++ b/modules/fide/src/main/FideJson.scala
@@ -16,8 +16,6 @@ final class FideJson(picfitUrl: lila.memo.PicfitUrl):
 
   given Writes[FidePlayer.Gender] = writeAs(_.value.toString)
 
-  given Writes[chess.FideTC] = writeAs(_.toString)
-
   def photosJson(photos: Map[chess.FideId, FidePlayer.PlayerPhoto]) = PhotosJson:
     JsObject:
       photos.map: (id, photo) =>

--- a/modules/fide/src/main/FidePaginator.scala
+++ b/modules/fide/src/main/FidePaginator.scala
@@ -1,5 +1,6 @@
 package lila.fide
 
+import chess.FideTC
 import reactivemongo.api.*
 import scalalib.paginator.{ AdapterLike, Paginator }
 
@@ -36,7 +37,7 @@ final class FidePaginator(repo: FideRepo)(using Executor):
         def nbResults: Fu[Int] = fuccess(100 * maxPerPage.value)
         def slice(offset: Int, length: Int) =
           repo.playerColl
-            .find(repo.player.selectActive ++ repo.player.selectFed(fed.id))
+            .find(repo.player.selectActive(FideTC.standard) ++ repo.player.selectFed(fed.id))
             .sort(repo.player.sortStandard)
             .skip(offset)
             .cursor[FidePlayer](ReadPref.sec)
@@ -88,7 +89,7 @@ final class FidePaginator(repo: FideRepo)(using Executor):
               CachedAdapter(
                 Adapter[FidePlayer](
                   collection = repo.playerColl,
-                  selector = repo.player.selectActive,
+                  selector = repo.player.selectActive(order.fideTC),
                   projection = none,
                   sort = repo.player.sortBy(order),
                   _.sec

--- a/modules/fide/src/main/FidePlayer.scala
+++ b/modules/fide/src/main/FidePlayer.scala
@@ -25,8 +25,14 @@ case class FidePlayer(
     year: Option[Int],
     deceasedYear: Option[Int] = None,
     gender: Option[FidePlayer.Gender] = None,
-    inactive: Boolean
+    // FIDE flags inactivity separately in each rating list
+    inactive: Set[FideTC]
 ) extends lila.core.fide.Player:
+
+  def isInactiveForTc(tc: FideTC): Boolean = inactive(tc)
+
+  // Flagged inactive by FIDE, in every time control they're rated in.
+  def isInactive: Boolean = inactive.nonEmpty && ratingsMap.keys.forall(inactive.contains)
 
   def ratingOf(tc: FideTC): Option[Elo] = tc match
     case FideTC.standard => standard

--- a/modules/fide/src/main/FidePlayerSync.scala
+++ b/modules/fide/src/main/FidePlayerSync.scala
@@ -203,7 +203,7 @@ final private class FidePlayerSync(
 private object FidePlayerSync:
 
   final class InactiveIds(sorted: Array[Int]):
-    def apply(id: Int): Boolean = java.util.Arrays.binarySearch(sorted, id) >= 0
+    def apply(id: FideId): Boolean = java.util.Arrays.binarySearch(sorted, id.value) >= 0
     def size = sorted.length
 
   /* a line of a single time control rating list. The flag column is last,
@@ -226,7 +226,7 @@ private object FidePlayerSync:
     def kFactor(start: Int) = KFactor.from(number(start, start + 2).filter(_ > 0))
     val nowYear = nowDateTime.getYear
     for
-      id <- number(0, 15)
+      id <- number(0, 15).map(FideId(_))
       name1 <- string(15, 76)
       name = name1.trim
       if name.sizeIs > 2
@@ -236,7 +236,7 @@ private object FidePlayerSync:
       token = FidePlayer.tokenize.exec(name)
       if token.sizeIs > 2
     yield FidePlayer(
-      id = FideId(id),
+      id = id,
       name = PlayerName(name),
       token = token,
       photo = none,

--- a/modules/fide/src/main/FidePlayerSync.scala
+++ b/modules/fide/src/main/FidePlayerSync.scala
@@ -8,6 +8,7 @@ import play.api.libs.ws.StandaloneWSClient
 import reactivemongo.api.bson.*
 import java.util.zip.ZipInputStream
 import java.time.YearMonth
+import scala.collection.mutable.ArrayBuilder
 
 import lila.mon.extensions.*
 import lila.core.fide.Federation
@@ -17,28 +18,74 @@ final private class FidePlayerSync(
     repo: FideRepo,
     ws: StandaloneWSClient,
     proxy: lila.memo.HttpProxy,
-    listUrl: Url
+    listUrl: Url,
+    ratingListsUrl: Url
 )(using
     Executor,
     org.apache.pekko.stream.Materializer
 ):
+  import FidePlayerSync.*
 
-  // the file is big. We want to stream the http response into the zip reader,
-  // and stream the zip output into the database as it's being extracted.
-  // Don't load the whole thing in memory.
   def apply(): Funit = {
     for
-      _ <- playersFromHttpFile()
+      inactiveIds <- inactivityFromHttpFiles()
+      _ <- playersFromHttpFile(inactiveIds)
       _ <- federationsFromPlayers()
     yield ()
   }.logFailure(logger)
+
+  // the files are big. We want to stream the http response into the zip reader,
+  // and stream the zip output line by line. Don't load the whole thing in memory.
+  private def lineSource(url: Url): Fu[Source[String, ?]] = for
+    req = ws.url(url.value)
+    proxyServer = proxy.select()
+    _ = logger.info(s"FidePlayerSync connecting to $url through ${proxyServer.map(_.host)}")
+    proxied = proxyServer.foldLeft(req)(_ withProxyServer _)
+    httpStream <- proxied.stream()
+    _ <-
+      if httpStream.status != 200
+      then fufail(s"FidePlayerSync $url ${httpStream.status} ${httpStream.statusText}")
+      else funit
+  yield
+    logger.info(s"FidePlayerSync connected to $url")
+    ZipInputStreamSource: () =>
+      ZipInputStream(httpStream.bodyAsSource.runWith(StreamConverters.asInputStream()))
+    .map(_._2)
+      .via(Framing.delimiter(org.apache.pekko.util.ByteString("\r\n"), maximumFrameLength = 200))
+      .map(_.utf8String)
+      .drop(1) // first line is a header
+
+  private object inactivityFromHttpFiles:
+
+    def apply(): Fu[Map[FideTC, InactiveIds]] =
+      FideTC.values.toList.sequentially(tc => fetch(tc).dmap(tc -> _)).dmap(_.toMap)
+
+    private def fetch(tc: FideTC): Fu[InactiveIds] = for
+      source <- lineSource(Url(s"${ratingListsUrl.value}${tc}_rating_list.zip"))
+      (builder, nbLines) <- source.runFold(ArrayBuilder.ofInt() -> 0):
+        case ((builder, nbLines), line) =>
+          parseInactiveId(line).foreach(builder.addOne)
+          (builder, nbLines + 1)
+      _ <-
+        if nbLines < 100_000
+        then
+          // As of 2026-08-21, the smallest rating list (blitz) has over 300k lines,
+          // so this is a broken download.
+          fufail(s"FidePlayerSync the $tc rating list only has $nbLines lines")
+        else funit
+      ids = builder.result()
+    yield
+      java.util.Arrays.sort(ids)
+      val inactive = InactiveIds(ids)
+      logger.info(s"FidePlayerSync $tc: ${inactive.size} inactive players out of $nbLines")
+      inactive
 
   private object federationsFromPlayers:
     def apply(): Funit = for
       feds <- repo.playerColl
         .aggregateList(500, _.sec): framework =>
           import framework.*
-          Match(repo.player.selectActive) ->
+          Match(repo.player.selectActive(FideTC.standard)) ->
             List(PipelineOperator($doc("$sortByCount" -> "$fed")))
         .map: objs =>
           for
@@ -55,20 +102,23 @@ final private class FidePlayerSync(
             import framework.*
             val facets = for
               tc <- FideTC.values.toList
+              active = Match(repo.player.selectActive(tc))
               facet <- List(
                 "top" -> List(
+                  active,
                   Project($doc("_id" -> 0, tc.toString -> 1)),
                   Sort(Descending(tc.toString)),
                   Limit(10),
                   Group(BSONString(s"$tc-top"))("v" -> AvgField(tc.toString))
                 ),
                 "count" -> List(
+                  active,
                   Match(tc.toString.$exists(true)),
                   Group(BSONString(s"$tc-count"))("v" -> SumAll)
                 )
               )
             yield s"$tc-${facet._1}" -> facet._2
-            Match(repo.player.selectActive ++ $doc("fed" -> code)) ->
+            Match($doc("fed" -> code)) ->
               List(
                 Facet(facets),
                 Project($doc("all" -> $doc("$setUnion" -> facets.map((k, _) => s"$$$k").toList))),
@@ -104,83 +154,22 @@ final private class FidePlayerSync(
     yield ()
 
   private object playersFromHttpFile:
-    def apply(): Funit = for
-      req = ws.url(listUrl.value)
-      proxyServer = proxy.select()
-      _ = logger.info(s"RelayFidePlayerApi.update connecting to $listUrl through ${proxyServer.map(_.host)}")
-      proxied = proxyServer.foldLeft(req)(_ withProxyServer _)
-      httpStream <- proxied.stream()
-      _ <-
-        if httpStream.status != 200 then
-          fufail(s"RelayFidePlayerApi.pull ${httpStream.status} ${httpStream.statusText}")
-        else
-          logger.info(s"RelayFidePlayerApi.update connected to stream")
-          for
-            nbUpdated <-
-              ZipInputStreamSource: () =>
-                ZipInputStream(httpStream.bodyAsSource.runWith(StreamConverters.asInputStream()))
-              .map(_._2)
-                .via(Framing.delimiter(org.apache.pekko.util.ByteString("\r\n"), maximumFrameLength = 200))
-                .map(_.utf8String)
-                .drop(1) // first line is a header
-                .map(parseLine)
-                .mapConcat(_.toList)
-                .filter(validatePlayer)
-                .grouped(200)
-                .map(_.toList)
-                .mapAsync(1)(saveIfChanged)
-                .runWith(lila.common.LilaStream.sinkSum)
-                .monSuccess(lila.mon.fideSync.time)
-            nbAll <- repo.player.countAll
-          yield
-            lila.mon.fideSync.updated.update(nbUpdated)
-            lila.mon.fideSync.players.update(nbAll.toDouble)
-            logger.info(s"RelayFidePlayerApi.update upserted: $nbUpdated, total: $nbAll")
-    yield ()
-
-    /*
-6502938        Acevedo Mendez, Lisseth                                      ISL F   WIM  WIM                     1795  0   20 1767  14  20 1740  0   20 1993  w
-6504450        Acevedo Mendez, Oscar                                        CRC M                                1779  0   40              1640  0   20 1994  i
-     */
-    private def parseLine(line: String): Option[FidePlayer] =
-      def char(at: Int) = line.substring(at, at + 1).headOption
-      def string(start: Int, end: Int) = line.substring(start, end).trim.nonEmptyOption
-      def number(start: Int, end: Int) = string(start, end).flatMap(_.toIntOption)
-      def rating(start: Int) = Elo.from(number(start, start + 4).filter(_ >= 1400))
-      def kFactor(start: Int) = KFactor.from(number(start, start + 2).filter(_ > 0))
-      val nowYear = nowDateTime.getYear
-      for
-        id <- number(0, 15)
-        name1 <- string(15, 76)
-        name = name1.trim
-        if name.sizeIs > 2
-        title = string(84, 89).flatMap(PlayerTitle.get)
-        wTitle = string(89, 105).flatMap(PlayerTitle.get)
-        year = number(152, 156).filter(_ > 1000).filter(_ < nowYear)
-        flags = string(158, 160)
-        token = FidePlayer.tokenize.exec(name)
-        if token.sizeIs > 2
-      yield FidePlayer(
-        id = FideId(id),
-        name = PlayerName(name),
-        token = token,
-        photo = none,
-        fed = Federation.Id.from(string(76, 79).map(_.toUpperCase).filter(_ != "NON")),
-        title = PlayerTitle.mostValuable(title, wTitle),
-        standard = rating(113),
-        standardK = kFactor(123),
-        rapid = rating(126),
-        rapidK = kFactor(136),
-        blitz = rating(139),
-        blitzK = kFactor(149),
-        year = year,
-        gender = FidePlayer.Gender.from(char(80)),
-        inactive = flags.exists(_.contains("i"))
-      )
-
-    private def validatePlayer(p: FidePlayer): Boolean =
-      p.age.exists: age =>
-        age > 9 || (age > 5 && p.ratingsMap.nonEmpty)
+    def apply(inactiveIds: Map[FideTC, InactiveIds]): Funit = for
+      source <- lineSource(listUrl)
+      nbUpdated <- source
+        .map(parseLine(inactiveIds))
+        .mapConcat(_.toList)
+        .filter(validatePlayer)
+        .grouped(200)
+        .map(_.toList)
+        .mapAsync(1)(saveIfChanged)
+        .runWith(lila.common.LilaStream.sinkSum)
+        .monSuccess(lila.mon.fideSync.time)
+      nbAll <- repo.player.countAll
+    yield
+      lila.mon.fideSync.updated.update(nbUpdated)
+      lila.mon.fideSync.players.update(nbAll.toDouble)
+      logger.info(s"FidePlayerSync upserted: $nbUpdated, total: $nbAll")
 
     private def saveIfChanged(players: List[FidePlayer]): Future[Int] =
       repo.player
@@ -210,3 +199,60 @@ final private class FidePlayerSync(
       val now = YearMonth.now
       players.sequentiallyVoid: p =>
         repo.rating.set(p.id, now, p.ratingsMap)
+
+private object FidePlayerSync:
+
+  final class InactiveIds(sorted: Array[Int]):
+    def apply(id: Int): Boolean = java.util.Arrays.binarySearch(sorted, id) >= 0
+    def size = sorted.length
+
+  /* a line of a single time control rating list. The flag column is last,
+   * and holds "", "i" (inactive), "w" (woman) or "wi".
+703303         Leko, Peter                                                  HUN M   GM                           2738  0   10 1979  i
+6502938        Acevedo Mendez, Lisseth                                      ISL F   WIM  WIM                     1740  0   20 1993  wi
+   */
+  def parseInactiveId(line: String): Option[Int] =
+    line.drop(132).contains("i").so(line.take(15).trim.toIntOption)
+
+  /* a line of the combined players list, which holds the three ratings but no usable flag
+6502938        Acevedo Mendez, Lisseth                                      ISL F   WIM  WIM                     1795  0   20 1767  14  20 1740  0   20 1993  w
+6504450        Acevedo Mendez, Oscar                                        CRC M                                1779  0   40              1640  0   20 1994  i
+   */
+  def parseLine(inactiveIds: Map[FideTC, InactiveIds])(line: String): Option[FidePlayer] =
+    def char(at: Int) = line.substring(at, at + 1).headOption
+    def string(start: Int, end: Int) = line.substring(start, end).trim.nonEmptyOption
+    def number(start: Int, end: Int) = string(start, end).flatMap(_.toIntOption)
+    def rating(start: Int) = Elo.from(number(start, start + 4).filter(_ >= 1400))
+    def kFactor(start: Int) = KFactor.from(number(start, start + 2).filter(_ > 0))
+    val nowYear = nowDateTime.getYear
+    for
+      id <- number(0, 15)
+      name1 <- string(15, 76)
+      name = name1.trim
+      if name.sizeIs > 2
+      title = string(84, 89).flatMap(PlayerTitle.get)
+      wTitle = string(89, 105).flatMap(PlayerTitle.get)
+      year = number(152, 156).filter(_ > 1000).filter(_ < nowYear)
+      token = FidePlayer.tokenize.exec(name)
+      if token.sizeIs > 2
+    yield FidePlayer(
+      id = FideId(id),
+      name = PlayerName(name),
+      token = token,
+      photo = none,
+      fed = Federation.Id.from(string(76, 79).map(_.toUpperCase).filter(_ != "NON")),
+      title = PlayerTitle.mostValuable(title, wTitle),
+      standard = rating(113),
+      standardK = kFactor(123),
+      rapid = rating(126),
+      rapidK = kFactor(136),
+      blitz = rating(139),
+      blitzK = kFactor(149),
+      year = year,
+      gender = FidePlayer.Gender.from(char(80)),
+      inactive = FideTC.values.view.filter(tc => inactiveIds(tc)(id)).toSet
+    )
+
+  def validatePlayer(p: FidePlayer): Boolean =
+    p.age.exists: age =>
+      age > 9 || (age > 5 && p.ratingsMap.nonEmpty)

--- a/modules/fide/src/main/FidePlayerSync.scala
+++ b/modules/fide/src/main/FidePlayerSync.scala
@@ -8,7 +8,6 @@ import play.api.libs.ws.StandaloneWSClient
 import reactivemongo.api.bson.*
 import java.util.zip.ZipInputStream
 import java.time.YearMonth
-import scala.collection.mutable.ArrayBuilder
 
 import lila.mon.extensions.*
 import lila.core.fide.Federation
@@ -57,28 +56,23 @@ final private class FidePlayerSync(
 
   private object inactivityFromHttpFiles:
 
-    def apply(): Fu[Map[FideTC, InactiveIds]] =
-      FideTC.values.toList.sequentially(tc => fetch(tc).dmap(tc -> _)).dmap(_.toMap)
+    def apply(): Fu[InactiveIds] =
+      FideTC.values.toList.sequentially(tc => fetch(tc).map(tc -> _)).map(_.toMap)
 
-    private def fetch(tc: FideTC): Fu[InactiveIds] = for
+    private def fetch(tc: FideTC): Fu[Set[Int]] = for
       source <- lineSource(Url(s"${ratingListsUrl.value}${tc}_rating_list.zip"))
-      (builder, nbLines) <- source.runFold(ArrayBuilder.ofInt() -> 0):
-        case ((builder, nbLines), line) =>
-          parseInactiveId(line).foreach(builder.addOne)
-          (builder, nbLines + 1)
+      (inactiveIds, nbLines) <- source.runFold(Set.empty[Int] -> 0):
+        case ((inactiveIds, nbLines), line) =>
+          parseInactiveId(line).foldLeft(inactiveIds)(_ + _) -> (nbLines + 1)
       _ <-
         if nbLines < 100_000
         then
-          // As of 2026-08-21, the smallest rating list (blitz) has over 300k lines,
-          // so this is a broken download.
+          // As of 2026-08-21, the smallest rating list (blitz) has over 300k lines, so this is a broken download.
           fufail(s"FidePlayerSync the $tc rating list only has $nbLines lines")
         else funit
-      ids = builder.result()
     yield
-      java.util.Arrays.sort(ids)
-      val inactive = InactiveIds(ids)
-      logger.info(s"FidePlayerSync $tc: ${inactive.size} inactive players out of $nbLines")
-      inactive
+      logger.info(s"FidePlayerSync $tc: ${inactiveIds.size} inactive players out of $nbLines")
+      inactiveIds
 
   private object federationsFromPlayers:
     def apply(): Funit = for
@@ -154,7 +148,7 @@ final private class FidePlayerSync(
     yield ()
 
   private object playersFromHttpFile:
-    def apply(inactiveIds: Map[FideTC, InactiveIds]): Funit = for
+    def apply(inactiveIds: InactiveIds): Funit = for
       source <- lineSource(listUrl)
       nbUpdated <- source
         .map(parseLine(inactiveIds))
@@ -202,9 +196,7 @@ final private class FidePlayerSync(
 
 private object FidePlayerSync:
 
-  final class InactiveIds(sorted: Array[Int]):
-    def apply(id: FideId): Boolean = java.util.Arrays.binarySearch(sorted, id.value) >= 0
-    def size = sorted.length
+  type InactiveIds = Map[FideTC, Set[Int]]
 
   /* a line of a single time control rating list. The flag column is last,
    * and holds "", "i" (inactive), "w" (woman) or "wi".
@@ -218,7 +210,7 @@ private object FidePlayerSync:
 6502938        Acevedo Mendez, Lisseth                                      ISL F   WIM  WIM                     1795  0   20 1767  14  20 1740  0   20 1993  w
 6504450        Acevedo Mendez, Oscar                                        CRC M                                1779  0   40              1640  0   20 1994  i
    */
-  def parseLine(inactiveIds: Map[FideTC, InactiveIds])(line: String): Option[FidePlayer] =
+  def parseLine(inactiveIds: InactiveIds)(line: String): Option[FidePlayer] =
     def char(at: Int) = line.substring(at, at + 1).headOption
     def string(start: Int, end: Int) = line.substring(start, end).trim.nonEmptyOption
     def number(start: Int, end: Int) = string(start, end).flatMap(_.toIntOption)
@@ -250,7 +242,7 @@ private object FidePlayerSync:
       blitzK = kFactor(149),
       year = year,
       gender = FidePlayer.Gender.from(char(80)),
-      inactive = FideTC.values.view.filter(tc => inactiveIds(tc)(id)).toSet
+      inactive = FideTC.values.view.filter(tc => inactiveIds.get(tc).exists(_.contains(id.value))).toSet
     )
 
   def validatePlayer(p: FidePlayer): Boolean =

--- a/modules/fide/src/main/FidePlayerSync.scala
+++ b/modules/fide/src/main/FidePlayerSync.scala
@@ -60,7 +60,7 @@ final private class FidePlayerSync(
       FideTC.values.toList.sequentially(tc => fetch(tc).map(tc -> _)).map(_.toMap)
 
     private def fetch(tc: FideTC): Fu[Set[Int]] = for
-      source <- lineSource(Url(s"${ratingListsUrl.value}${tc}_rating_list.zip"))
+      source <- lineSource(Url(s"$ratingListsUrl${tc}_rating_list.zip"))
       (inactiveIds, nbLines) <- source.runFold(Set.empty[Int] -> 0):
         case ((inactiveIds, nbLines), line) =>
           parseInactiveId(line).foldLeft(inactiveIds)(_ + _) -> (nbLines + 1)

--- a/modules/fide/src/main/FideRepo.scala
+++ b/modules/fide/src/main/FideRepo.scala
@@ -22,8 +22,10 @@ final private class FideRepo(
       { case BSONString(g) if g.nonEmpty => FidePlayer.Gender(g.head) },
       g => BSONString(g.toString)
     )
+    given BSONHandler[FideTC] = stringAnyValHandler(_.toString, FideTC.valueOf)
     given handler: BSONDocumentHandler[FidePlayer] = Macros.handler
-    val selectActive: Bdoc = $doc("inactive".$ne(true))
+    // players unrated in that time control have no flag, and are active as far as we know
+    def selectActive(tc: FideTC): Bdoc = $doc("inactive".$ne(tc))
     def selectFed(fed: Federation.Id): Bdoc = $doc("fed" -> fed)
     def sortStandard: Bdoc = $sort.desc("standard")
     def sortBy(o: FidePlayerOrder) = o match

--- a/modules/fide/src/test/FidePlayerSyncTest.scala
+++ b/modules/fide/src/test/FidePlayerSyncTest.scala
@@ -1,0 +1,82 @@
+package lila.fide
+
+import chess.{ FideId, FideTC, PlayerTitle }
+import chess.rating.Elo
+
+class FidePlayerSyncTest extends munit.FunSuite:
+
+  import FidePlayerSync.{ InactiveIds, parseInactiveId, parseLine }
+
+  // real lines from the august 2026 blitz_rating_list.txt
+  val blitzInactiveMan =
+    "703303         Leko, Peter                                                  HUN M   GM                           2738  0   10 1979  i   "
+  val blitzInactiveWoman =
+    "700070         Polgar, Judit                                                HUN F   GM                           2736  0   10 1976  wi  "
+  val blitzActiveMan =
+    "537001345      A Arbhin Vanniarajan                                         IND M                                1431  0   40 2018      "
+  val blitzActiveWoman =
+    "48701955       Aadya Gowda                                                  IND F   WCM  WCM                     1807  0   40 2013  w   "
+
+  // real line from the august 2026 players_list.txt, holding the three ratings
+  // This player is inactive in blitz, but active in standard and rapid.
+  val combinedLeko =
+    "703303         Leko, Peter                                                  HUN M   GM                           2676  0   10 2700  0   10 2738  0   10 1979      "
+
+  test("parseInactiveId picks up the i flag"):
+    assertEquals(parseInactiveId(blitzInactiveMan), Some(703303))
+
+  test("parseInactiveId picks up the wi flag"):
+    assertEquals(parseInactiveId(blitzInactiveWoman), Some(700070))
+
+  test("parseInactiveId ignores active players"):
+    assertEquals(parseInactiveId(blitzActiveMan), None)
+    assertEquals(parseInactiveId(blitzActiveWoman), None)
+
+  test("parseInactiveId ignores the header and short lines"):
+    assertEquals(parseInactiveId("ID Number      Name"), None)
+    assertEquals(parseInactiveId(""), None)
+
+  def sync(inactive: Map[FideTC, List[Int]]) = parseLine:
+    FideTC.values.view
+      .map(tc => tc -> InactiveIds(inactive.getOrElse(tc, Nil).toArray.sorted))
+      .toMap
+
+  test("parseLine reads the combined list"):
+    val player = sync(Map.empty)(combinedLeko).get
+    assertEquals(player.id, FideId(703303))
+    assertEquals(player.name.value, "Leko, Peter")
+    assertEquals(player.title, Some(PlayerTitle.GM))
+    assertEquals(player.year, Some(1979))
+    assertEquals(player.standard, Some(Elo(2676)))
+    assertEquals(player.rapid, Some(Elo(2700)))
+    assertEquals(player.blitz, Some(Elo(2738)))
+
+  test("parseLine takes inactivity from the rating lists, not from the combined line"):
+    assertEquals(sync(Map.empty)(combinedLeko).get.inactive, Set.empty[FideTC])
+    val player = sync(Map(FideTC.blitz -> List(1, 703303, 999999)))(combinedLeko).get
+    assertEquals(player.inactive, Set(FideTC.blitz))
+    assert(player.isInactiveForTc(FideTC.blitz))
+    assert(!player.isInactiveForTc(FideTC.standard))
+    assert(!player.isInactiveForTc(FideTC.rapid))
+
+  test("parseLine flags every time control the player is inactive in"):
+    val all = FideTC.values.view.map(_ -> List(703303)).toMap
+    assertEquals(sync(all)(combinedLeko).get.inactive, FideTC.values.toSet)
+
+  val leko = sync(Map.empty)(combinedLeko).get
+
+  test("isInactive needs every rated time control to be flagged"):
+    assert(!leko.copy(inactive = Set.empty).isInactive)
+    assert(!leko.copy(inactive = Set(FideTC.blitz)).isInactive)
+    assert(!leko.copy(inactive = Set(FideTC.blitz, FideTC.rapid)).isInactive)
+    assert(leko.copy(inactive = FideTC.values.toSet).isInactive)
+
+  test("isInactive covers players rated in a single time control"):
+    val standardOnly = leko.copy(rapid = None, blitz = None)
+    assert(standardOnly.copy(inactive = Set(FideTC.standard)).isInactive)
+    assert(!standardOnly.copy(inactive = Set(FideTC.blitz)).isInactive)
+
+  test("isInactive needs a flag, not just an absence of ratings"):
+    val unrated = leko.copy(standard = None, rapid = None, blitz = None)
+    assert(!unrated.copy(inactive = Set.empty).isInactive)
+    assert(unrated.copy(inactive = Set(FideTC.rapid)).isInactive)


### PR DESCRIPTION
Solves #21208 

**What it does:**
- Updates the type of the `inactive` field of `FidePlayer` (from boolean to set of time controls where player is inactive). This means that displaying fide data will be broken until  the `fide-inactive-per-tc.js` migration is run
- Reads inactivity from time control specific FIDE player lists. 

**To be done if merging:**
- Run the migration
- Optionally uploads rating lists to S3 and update the env to fetch from s3 instead of FIDE website

**Screenshots of tests:**

Leko does not appear in the list when sorted by "Blitz"
<img width="1829" height="929" alt="image" src="https://github.com/user-attachments/assets/4c412363-e813-42a4-ab01-37e65e2927c9" />

Leko can still be found
<img width="1776" height="571" alt="image" src="https://github.com/user-attachments/assets/d457c06d-777c-4892-b84c-bcd33063573c" />

Leko appears in the list when sorted by "Rapid"
<img width="1633" height="641" alt="image" src="https://github.com/user-attachments/assets/d62ce087-49c6-4a1b-b033-4a4cf3b0011d" />

**Note on AI use:**
The changes were started using Claude Opus 5 on the prompt "Solve https://github.com/lichess-org/lila/pull/21368". This PR is the result of a human review and editing of the LLM's output.

