### PR TITLE
Analysis settings: Help videos are now mandatory for all citizens

### DIFF
--- a/ui/analyse/src/view/settingsView.ts
+++ b/ui/analyse/src/view/settingsView.ts
@@ -104,7 +104,7 @@ export async function showSettingsDialog(ctrl: AnalyseCtrl): Promise<Dialog> {
   return domDialog({
     class: 'analysis-settings-dialog',
     htmlText: '<h2>Analysis settings</h2>',
-    insert: [{ node: settingsView(ctrl.settings) }],
+    insert: [{ nodes: settingsView(ctrl.settings) }],
     modal: !isTouchDevice(),
     easyClose: 'clickOutside',
     show: true,
@@ -170,7 +170,7 @@ function setupTouchHelp(view: HTMLElement) {
     el.addEventListener('click', () =>
       domDialog({
         class: 'setting-popup',
-        insert: [{ node: nodes }],
+        insert: [{ nodes }],
         noCloseButton: true,
         show: true,
         easyClose: 'anyClick',

--- a/ui/analyse/src/view/settingsView.ts
+++ b/ui/analyse/src/view/settingsView.ts
@@ -270,33 +270,29 @@ function imageHtml(path: string) {
   return `<img src="${site.asset.url('images/help/' + path + '.webp')}" alt=""><br>`;
 }
 
-async function preload(htmlWithMedia: string): Promise<Node[]> {
+async function preload(html: string): Promise<Node[]> {
   const loader = frag<HTMLElement>(
     `<div style="position: fixed; left: -100000px; top: 0; visibility: hidden"></div>`,
   );
-
-  loader.append(frag(htmlWithMedia));
+  loader.append(frag(html));
   document.body.append(loader);
 
   await Promise.all([
     ...[...loader.querySelectorAll('img')].map(img =>
       img.complete
         ? img.decode().catch(() => {})
-        : new Promise<void>(resolve => {
-            img.addEventListener('load', () => resolve(), { once: true });
-            img.addEventListener('error', () => resolve(), { once: true });
-          }),
+        : new Promise<void>(resolve =>
+            ['load', 'error'].forEach(e => img.addEventListener(e, () => resolve(), { once: true })),
+          ),
     ),
     ...[...loader.querySelectorAll<HTMLMediaElement>('audio, video')].map(media => {
       media.preload = 'auto';
       media.load();
-
       return media.readyState >= HTMLMediaElement.HAVE_CURRENT_DATA
         ? Promise.resolve()
-        : new Promise<void>(resolve => {
-            media.addEventListener('loadeddata', () => resolve(), { once: true });
-            media.addEventListener('error', () => resolve(), { once: true });
-          });
+        : new Promise<void>(resolve =>
+            ['loadeddata', 'error'].forEach(e => media.addEventListener(e, () => resolve(), { once: true })),
+          );
     }),
   ]);
   loader.remove();

--- a/ui/analyse/src/view/settingsView.ts
+++ b/ui/analyse/src/view/settingsView.ts
@@ -162,52 +162,52 @@ export function settingsView(ctrl: SettingsCtrl): HTMLElement {
 }
 
 function setupTouchHelp(view: HTMLElement) {
-  view.querySelectorAll<HTMLElement>('.help-button').forEach(el => {
+  view.querySelectorAll<HTMLElement>('.help-button').forEach(async el => {
     const key = el.dataset.key as SettingKey;
-    if (!settings[key]) return;
-    const htmlText = settings[key].helpHtml;
+    if (!settings[key]?.helpHtml) return;
+    const nodes = await preload(settings[key].helpHtml);
 
     el.addEventListener('click', () =>
-      domDialog({ htmlText, class: 'setting-popup', noCloseButton: true, show: true, easyClose: 'anyClick' }),
+      domDialog({
+        class: 'setting-popup',
+        insert: [{ node: nodes }],
+        noCloseButton: true,
+        show: true,
+        easyClose: 'anyClick',
+      }),
     );
   });
 }
 
 function setupHoverHelp(view: HTMLElement) {
   const helpEl = () => view.querySelector<HTMLElement>('.help-container')!.firstElementChild!;
-  const helpPanes: Record<string, Element> = { keyboardHelp: helpEl() };
+  const keyboardHelp = helpEl();
+  let resetTimeout: number | undefined;
 
-  let hoverTimeout: number;
   view.querySelectorAll<HTMLElement>('.hover-help').forEach(el => {
     const key = el.dataset.key as SettingKey;
     const setting = settings[key];
     if (!setting?.helpHtml) return;
 
-    el.addEventListener('mouseenter', () => {
-      clearTimeout(hoverTimeout);
-      hoverTimeout = setTimeout(
-        () => {
-          const helpPaneEl =
-            helpPanes[key] ??
-            frag<HTMLElement>($html`
-              <fieldset class="help-pane" data-key="${key}">
-                <legend>${setting.label}</legend>
-                ${setting.helpHtml}
-              </fieldset>`);
-          helpEl().replaceWith(helpPaneEl);
-          if (helpPanes[key]) helpPaneEl.querySelector<HTMLVideoElement>('video')?.play();
-          helpPanes[key] = helpPaneEl;
-        },
-        helpEl() === helpPanes.keyboardHelp ? 400 : 0,
+    el.addEventListener('mouseenter', async () => {
+      const fieldset = frag<HTMLElement>(
+        `<fieldset class="help-pane" data-key="${key}"><legend>${setting.label}</legend></fieldset>`,
       );
+      clearTimeout(resetTimeout);
+      fieldset.append(...(await preload(setting.helpHtml!)));
+      if (!el.matches(':hover')) return;
+
+      helpEl().replaceWith(fieldset);
+      fieldset.querySelector<HTMLVideoElement>('video')?.play();
     });
     el.addEventListener('mouseleave', () => {
-      clearTimeout(hoverTimeout);
-      hoverTimeout = setTimeout(() => helpEl().replaceWith(helpPanes.keyboardHelp), 700);
+      resetTimeout = setTimeout(() => {
+        if (!view.querySelector('.hover-help:hover')) helpEl().replaceWith(keyboardHelp);
+      }, 300);
     });
   });
   if (document.querySelector('main.analyse')) return; // keyboard help is triggered by analyse snabbdom
-  helpPanes.keyboardHelp.querySelector('button')!.addEventListener('click', () =>
+  keyboardHelp.querySelector('button')!.addEventListener('click', () =>
     domDialog({
       class: 'help.keyboard-help',
       htmlUrl: '/analysis/help',
@@ -220,13 +220,12 @@ function setupHoverHelp(view: HTMLElement) {
 
 function defaultToggleHtml(ctrl: SettingsCtrl, key: SettingKey) {
   const setting = settings[key];
-  const label = setting.helpHtml
-    ? isTouchDevice()
+  const label =
+    setting.helpHtml && isTouchDevice()
       ? `<button class="help-button" data-key="${key}" data-icon="${licon.InfoCircle}">${setting.label}</button>`
-      : `<span class="hover-help" data-key="${key}">${setting.label}</span>`
-    : setting.label;
+      : `<span>${setting.label}</span>`;
   return $html`
-    <span class="setting">
+    <span class="setting${setting.helpHtml ? ' hover-help' : ''}" data-key="${key}">
       ${label}
       <span class="form-check__input">
         <input data-key="${key}" id="${key}" type="checkbox" ${ctrl[key] ? 'checked' : ''}>
@@ -253,8 +252,7 @@ function helpHtml() {
         ${settingShortcutsHtml}
         <button class="button button-empty button-dim show-all">Show all</button>
       </fieldset>
-    </div>
-    <div class="hover-hint">${i18n.preferences.hoverOverSettingLabelsForHelp}</div>`;
+    </div>`;
 }
 
 // iOS Safari has trouble rendering HTMLDialogElement content with replaced elements (i.e. <video>). It
@@ -270,4 +268,37 @@ function videoHtml(path: string) {
 
 function imageHtml(path: string) {
   return `<img src="${site.asset.url('images/help/' + path + '.webp')}" alt=""><br>`;
+}
+
+async function preload(htmlWithMedia: string): Promise<Node[]> {
+  const loader = frag<HTMLElement>(
+    `<div style="position: fixed; left: -100000px; top: 0; visibility: hidden"></div>`,
+  );
+
+  loader.append(frag(htmlWithMedia));
+  document.body.append(loader);
+
+  await Promise.all([
+    ...[...loader.querySelectorAll('img')].map(img =>
+      img.complete
+        ? img.decode().catch(() => {})
+        : new Promise<void>(resolve => {
+            img.addEventListener('load', () => resolve(), { once: true });
+            img.addEventListener('error', () => resolve(), { once: true });
+          }),
+    ),
+    ...[...loader.querySelectorAll<HTMLMediaElement>('audio, video')].map(media => {
+      media.preload = 'auto';
+      media.load();
+
+      return media.readyState >= HTMLMediaElement.HAVE_CURRENT_DATA
+        ? Promise.resolve()
+        : new Promise<void>(resolve => {
+            media.addEventListener('loadeddata', () => resolve(), { once: true });
+            media.addEventListener('error', () => resolve(), { once: true });
+          });
+    }),
+  ]);
+  loader.remove();
+  return [...loader.childNodes];
 }

--- a/ui/bits/src/bits.cropDialog.ts
+++ b/ui/bits/src/bits.cropDialog.ts
@@ -76,7 +76,7 @@ export async function initModule(o?: CropOpts): Promise<void> {
         <button class="button button-empty cancel">cancel</button>
         <button class="button submit">submit</button>
       </span>`,
-    insert: [{ selector: '.crop-view', node: container }],
+    insert: [{ selector: '.crop-view', nodes: container }],
     actions: [
       { selector: '.dialog-actions > .cancel', listener: (_, d) => d.close() },
       { selector: '.dialog-actions > .submit', listener: crop },

--- a/ui/botDev/src/editDialog.ts
+++ b/ui/botDev/src/editDialog.ts
@@ -60,7 +60,7 @@ export class EditDialog {
 
   async show(): Promise<Dialog> {
     this.dlg = await domDialog({
-      insert: [{ node: this.view }],
+      insert: [{ nodes: this.view }],
       actions: this.actions,
       onClose: () => this.janitor.cleanup(),
       onShow: () => this.deck.resize(),
@@ -229,8 +229,8 @@ export class EditDialog {
       class: 'dev-view',
       htmlText: `<h2>Choose a user id</h2><p>must be unique and begin with #</p><span></span>`,
       insert: [
-        { node: input, selector: 'span' },
-        { node: ok, selector: 'span' },
+        { nodes: input, selector: 'span' },
+        { nodes: ok, selector: 'span' },
       ],
       focus: 'input',
       modal: true,
@@ -289,7 +289,7 @@ export class EditDialog {
           </div>
       </div>`);
     const dlg = await domDialog({
-      insert: [{ node: view }],
+      insert: [{ nodes: view }],
       easyClose: 'clickOutside',
       show: true,
       actions: [
@@ -315,7 +315,7 @@ export class EditDialog {
           </div>
       </div>`);
     const dlg = await domDialog({
-      insert: [{ node: view }],
+      insert: [{ nodes: view }],
       easyClose: 'clickOutside',
       show: true,
       actions: [

--- a/ui/botDev/src/historyDialog.ts
+++ b/ui/botDev/src/historyDialog.ts
@@ -43,7 +43,7 @@ class HistoryDialog {
       </div>`);
     await this.updateHistory();
     this.dlg = await domDialog({
-      insert: [{ node: this.view }],
+      insert: [{ nodes: this.view }],
       easyClose: 'clickOutside',
       actions: [
         { selector: '[data-action="pull"]', listener: this.pull },

--- a/ui/lib/src/view/dialog.ts
+++ b/ui/lib/src/view/dialog.ts
@@ -27,7 +27,7 @@ export interface DialogOpts<Ctx = undefined> {
   htmlText?: string; // content, htmlText is inserted as fragment into DOM
   cash?: Cash; // content, precedence over htmlText, cash will be cloned and any 'none' class removed
   htmlUrl?: string; // content, precedence over htmlText and cash, url will be xhr'd
-  insert?: { node: Node | Node[]; selector?: string; position?: 'child' | 'before' | 'after' }[]; // ??= 'child'
+  insert?: { nodes: Node | Node[]; selector?: string; position?: 'child' | 'before' | 'after' }[]; // 'child'
   attrs?: { dialog?: Attrs; view?: Attrs }; // optional attrs for dialog and view div
   focus?: string; // query selector for focus on show
   actions?: Action<Ctx> | Action<Ctx>[]; // add listeners to controls, call updateActions() to reattach
@@ -217,8 +217,8 @@ class DialogWrapper<Ctx = undefined> implements Dialog<Ctx> {
         () => this.close('cancel'),
       );
     for (const app of o.insert ?? []) {
-      if (app.node === view) break;
-      const nodes = Array.isArray(app.node) ? app.node : [app.node];
+      if (app.nodes === view) break;
+      const nodes = Array.isArray(app.nodes) ? app.nodes : [app.nodes];
       const target = (app.selector ? view.querySelector(app.selector) : view)!;
       if (app.position === 'before') target.before(...nodes);
       else if (app.position === 'after') target.after(...nodes);

--- a/ui/lib/src/view/dialog.ts
+++ b/ui/lib/src/view/dialog.ts
@@ -27,7 +27,7 @@ export interface DialogOpts<Ctx = undefined> {
   htmlText?: string; // content, htmlText is inserted as fragment into DOM
   cash?: Cash; // content, precedence over htmlText, cash will be cloned and any 'none' class removed
   htmlUrl?: string; // content, precedence over htmlText and cash, url will be xhr'd
-  insert?: { node: Node; selector?: string; position?: 'child' | 'before' | 'after' }[]; // default is 'child'
+  insert?: { node: Node | Node[]; selector?: string; position?: 'child' | 'before' | 'after' }[]; // ??= 'child'
   attrs?: { dialog?: Attrs; view?: Attrs }; // optional attrs for dialog and view div
   focus?: string; // query selector for focus on show
   actions?: Action<Ctx> | Action<Ctx>[]; // add listeners to controls, call updateActions() to reattach
@@ -218,10 +218,11 @@ class DialogWrapper<Ctx = undefined> implements Dialog<Ctx> {
       );
     for (const app of o.insert ?? []) {
       if (app.node === view) break;
+      const nodes = Array.isArray(app.node) ? app.node : [app.node];
       const target = (app.selector ? view.querySelector(app.selector) : view)!;
-      if (app.position === 'before') target.before(app.node);
-      else if (app.position === 'after') target.after(app.node);
-      else target.appendChild(app.node);
+      if (app.position === 'before') target.before(...nodes);
+      else if (app.position === 'after') target.after(...nodes);
+      else target.append(...nodes);
     }
     this.updateActions();
     this.dialogEvents.addListener(this.dialog, 'keydown', this.onKeydown);


### PR DESCRIPTION
Allan Joseph was right (as usual).

fully load media elements within html before tooltip/popup rendering. `preload` will also grab audio elements in case it's promoted to lib one day. but there's no audio in the current pile of help.