### PR TITLE
cleanup theme colordefs

### DIFF
--- a/ui/lib/css/build/lib.theme.all.scss
+++ b/ui/lib/css/build/lib.theme.all.scss
@@ -1,10 +1,5 @@
 @import '../theme/font-face';
 @import '../theme/theme.default';
-@import '../theme/pieces';
-
-:root {
-  @include shared-color-defs;
-}
-
 @import '../theme/theme.light';
 @import '../theme/theme.transp';
+@import '../theme/pieces';

--- a/ui/lib/css/build/lib.theme.embed.scss
+++ b/ui/lib/css/build/lib.theme.embed.scss
@@ -1,9 +1,4 @@
 @import '../theme/font-face';
 @import '../theme/theme.default';
-@import '../theme/pieces';
-
-:root {
-  @include shared-color-defs;
-}
-
 @import '../theme/theme.light';
+@import '../theme/pieces';

--- a/ui/lib/css/theme/_theme.default.scss
+++ b/ui/lib/css/theme/_theme.default.scss
@@ -1,7 +1,7 @@
 // ui/build provides an scss form for all variables below in gen/_wrap.scss as::after
 // $c-<color-name>: var(--c-<color-name>);
 
-@mixin shared-color-defs {
+:root {
   ---site-hue: 37deg;
   --c-bg: hsl(var(---site-hue) 7% 14%);
   --c-bg-box: var(--c-bg);
@@ -44,7 +44,7 @@
   --c-fancy: hsl(294 62% 48%);
   --c-border: hsl(0 0% 25%);
   --c-border-page: hsl(0 0% 22%);
-  --c-border-tour: color-mix(in oklab, hsl(0 0% 22%) 50%, var(--c-bg-page));
+  --c-border-tour: color-mix(in oklab, var(--c-border-page) 50%, var(--c-bg-page));
   --c-border-light: hsl(0 0% 40%);
   --c-primary: hsl(209 79% 56%);
   --c-primary-clear: color-mix(in oklab, var(--c-clearer) 20%, var(--c-primary));

--- a/ui/lib/css/theme/_theme.light.scss
+++ b/ui/lib/css/theme/_theme.light.scss
@@ -1,8 +1,4 @@
-@import 'theme.default';
-
 html.light {
-  @include shared-color-defs;
-
   --c-bg: hsl(0 0% 100%);
   --c-bg-page: hsl(var(---site-hue) 10% 92%);
   --c-bg-low: hsl(0 0% 89%);
@@ -31,7 +27,6 @@ html.light {
   --c-bg-input: hsl(from var(--c-bg-page) h s 97);
   --c-bg-variation: var(--c-bg-zebra2);
   --c-bg-header-dropdown: var(--c-bg);
-  --c-header-dropdown: var(--c-font);
   --c-page-input: var(--c-bg-low);
   --c-metal-top: hsl(0 0% 96%);
   --c-metal-bottom: hsl(0 0% 93%);
@@ -48,7 +43,6 @@ html.light {
   --c-chat-mention-bg: rgb(161 194 124 / 0.4);
   --c-fancy: hsl(294 61% 62%);
   --c-border-page: hsl(0 0% 80%);
-  --c-border-tour: color-mix(in oklab, hsl(0 0% 80%) 50%, var(--c-bg-page));
   --c-border-light: hsl(0 0% 80%);
   --c-patron-1: hsl(90 60% 43%);
   --c-patron-2: hsl(120 52% 52%);
@@ -59,5 +53,4 @@ html.light {
   --c-patron-7: hsl(270 62% 67%);
   --c-patron-8: hsl(310 56% 57%);
   --c-patron-9: hsl(0 52% 60%);
-  --c-patron-10: hsl(37 74% 43%);
 }

--- a/ui/lib/css/theme/_theme.transp.scss
+++ b/ui/lib/css/theme/_theme.transp.scss
@@ -1,8 +1,4 @@
-@import 'theme.default';
-
 html.transp {
-  @include shared-color-defs;
-
   --c-bg-font: hsl(0 0% 80%);
   --c-bg: hsl(0 0% 0% / 0.6);
   --c-bg-opaque: hsl(0 0% 0% / 0.9);


### PR DESCRIPTION
Colors are no longer defined in terms of scss variables, which means the mixin is no longer needed, and redundant aliased variable definitions can be culled from the generated css.