### PR TITLE
Fix: chapter settings button click

### DIFF
--- a/ui/analyse/src/study/studyChapters.ts
+++ b/ui/analyse/src/study/studyChapters.ts
@@ -182,18 +182,6 @@ export function view(ctrl: StudyCtrl): VNode {
       {
         hook: {
           insert(vnode) {
-            (vnode.elm as HTMLElement).addEventListener('click', async e => {
-              const target = e.target as HTMLElement;
-              const id = (target.parentNode as HTMLElement).dataset['id'] || target.dataset['id'];
-              if (!id) return;
-              if (target.className === 'act') {
-                const chapter = ctrl.chapters.list.get(id);
-                if (chapter) ctrl.chapters.editForm.toggle(chapter);
-              } else {
-                await ctrl.setChapter(id);
-              }
-              blurIfPrimaryClick(e);
-            });
             vnode.data!.li = {};
             ctrl.chapters.scroller.request('instant');
             onListUpdate(ctrl, vnode);
@@ -217,12 +205,31 @@ export function view(ctrl: StudyCtrl): VNode {
             key: chapter.id,
             attrs: { 'data-id': chapter.id },
             class: { active, editing, draggable: canContribute },
+            on: {
+              click: e => {
+                ctrl.setChapter(chapter.id);
+                blurIfPrimaryClick(e);
+              },
+            },
           },
           [
             hl('span', i + 1),
             hl('h3', chapter.name),
             chapter.status && hl('res', chapter.status),
-            canContribute && button('.act', icon(licon.Gear)({ title: i18n.study.editChapter })),
+            canContribute &&
+              button(
+                '.act',
+                {
+                  on: {
+                    click: e => {
+                      ctrl.chapters.editForm.toggle(chapter);
+                      e.stopPropagation();
+                      blurIfPrimaryClick(e);
+                    },
+                  },
+                },
+                icon(licon.Gear)({ title: i18n.study.editChapter }),
+              ),
           ],
         );
       }),


### PR DESCRIPTION
Regression of 074e3065f95cf5e6fdb4f06e93d34b1a00df7475

The event listeners relied on the `className`s of elements and their parents to trigger. That broke when changing the tree structure.

Instead of adding yet another parentNode check I've switched to snabbdom event listeners. So we go from 1 event listener for the entire chapter list to `nbChapters * 2`. 