### PR TITLE
powertip fixes

### DIFF
--- a/ui/@types/lichess/index.d.ts
+++ b/ui/@types/lichess/index.d.ts
@@ -266,7 +266,7 @@ declare namespace PowerTip {
   type BasePlacement = 'n' | 'e' | 's' | 'w' | 'nw' | 'ne' | 'sw' | 'se';
   type Placement = BasePlacement | 'n-alt' | 'e-alt' | 's-alt' | 'w-alt';
   interface Options {
-    preRender?: (el: HTMLElement) => void;
+    render?: (el: HTMLElement) => Promise<void>;
     placement?: Placement;
     smartPlacement?: boolean;
     popupId?: string;

--- a/ui/analyse/src/study/relay/relayPlayers.ts
+++ b/ui/analyse/src/study/relay/relayPlayers.ts
@@ -408,11 +408,11 @@ export const playerLinkHook = (ctrl: RelayPlayers, player: RelayPlayer, withTip:
           closeDelay: 200,
           popupId: playerTipId,
           defaultSize: [420, 150],
-          preRender() {
+          render() {
             const tipEl = document.getElementById(playerTipId) as HTMLElement;
             const patch = initSnabbdom([attributesModule]);
             tipEl.style.visibility = 'hidden';
-            ctrl.loadPlayerWithGames(id).then(p => {
+            return ctrl.loadPlayerWithGames(id).then(p => {
               const vdom = renderPlayerTipWithGames(ctrl, p);
               tipEl.innerHTML = '';
               patch(tipEl, hl(`div#${playerTipId}`, vdom));

--- a/ui/lobby/src/view/realTime/chart.ts
+++ b/ui/lobby/src/view/realTime/chart.ts
@@ -51,7 +51,7 @@ function renderPlot(ctrl: LobbyController, hook: Hook) {
           closeDelay: 200,
           defaultSize: [120, 80],
           popupId: 'hook',
-          preRender() {
+          async render() {
             $('#hook')
               .html(renderHook(ctrl, hook))
               .find('.inner-clickable')

--- a/ui/puzzle/src/puzzle.opening.ts
+++ b/ui/puzzle/src/puzzle.opening.ts
@@ -21,7 +21,7 @@ const makeBoardTip = (el: HTMLElement, e: Event) => {
     .removeClass('blpt')
     .powerTip({
       popupId: 'miniBoard',
-      preRender(el) {
+      async render(el) {
         const tipEl = document.getElementById('miniBoard') as HTMLDivElement;
         tipEl.innerHTML = `<div class="mini-board mini-board--init cg-wrap standard is2d"/>`;
         initMiniBoardWith(tipEl.querySelector('.cg-wrap')!, {

--- a/ui/site/src/powertip.ts
+++ b/ui/site/src/powertip.ts
@@ -1,43 +1,25 @@
 import { requestIdleCallbackSafe } from 'lib';
-import { licon } from 'lib/licon';
 import { pubsub } from 'lib/pubsub';
-import { spinnerHtml } from 'lib/view';
 import { text as xhrText } from 'lib/xhr';
 
 // Thanks Steven Benner! - adapted from https://github.com/stevenbenner/jquery-powertip
 
 const inCrosstable = (el: HTMLElement) => document.querySelector('.crosstable')?.contains(el);
 
-const onPowertipPreRender = (id: string, preload?: (url: string) => void) => (el: HTMLAnchorElement) => {
+const makeRender = (id: string) => async (el: HTMLAnchorElement) => {
   const url = (el.dataset.href || el.href).replace(/\?.+$/, '');
-  if (preload) preload(url);
-  xhrText(url + '/mini').then(html => {
+  return xhrText(url + '/mini').then(html => {
     const el = document.getElementById(id) as HTMLElement;
     el.innerHTML = html;
     pubsub.emit('content-loaded', el);
   });
 };
 
-const uptA = (url: string, icon: string) => `<a class="btn-rack__btn" href="${url}" data-icon="${icon}"></a>`;
-
 const userPowertip = (el: HTMLElement, pos?: PowerTip.Placement) =>
   $(el)
     .removeClass('ulpt')
     .powerTip({
-      preRender: onPowertipPreRender('powerTip', (url: string) => {
-        const u = url.split('@/')[1];
-        if (!u) return;
-        const name = el.dataset.name || $(el).html();
-        $('#powerTip').html(
-          '<div class="upt__info"><div class="upt__info__top"><span class="user-link offline">' +
-            name +
-            '</span></div></div><div class="upt__actions btn-rack">' +
-            uptA('/@/' + u + '/tv', licon.AnalogTv) +
-            uptA('/inbox/new?user=' + u, licon.BubbleSpeech) +
-            uptA('/?user=' + u + '#friend', licon.Swords) +
-            '<a class="btn-rack__btn relation-button" disabled></a></div>',
-        );
-      }),
+      render: makeRender('powerTip'),
       placement:
         pos || (el.getAttribute('data-pt-pos') as PowerTip.Placement) || (inCrosstable(el) ? 'n' : 's'),
     });
@@ -46,7 +28,7 @@ const gamePowertip = (el: HTMLElement) =>
   $(el)
     .removeClass('glpt')
     .powerTip({
-      preRender: onPowertipPreRender('miniGame', () => spinnerHtml),
+      render: makeRender('miniGame'),
       placement: inCrosstable(el) ? 'n' : 'w',
       defaultSize: [264, 264],
       popupId: 'miniGame',
@@ -182,14 +164,15 @@ const defaults: Options = {
 };
 
 const smartPlacementLists: Record<PowerTip.BasePlacement, string[]> = {
-  n: ['n', 'ne', 'nw', 's', 'se', 'sw', 'e', 'w'],
-  e: ['e', 'ne', 'se', 'w', 'nw', 'sw', 'n', 's'],
-  s: ['s', 'se', 'sw', 'n', 'ne', 'nw', 'e', 'w'],
-  w: ['w', 'nw', 'sw', 'e', 'ne', 'se', 'n', 's'],
-  nw: ['nw', 'w', 'sw', 'n', 's', 'se', 'nw', 'e'],
-  ne: ['ne', 'e', 'se', 'n', 's', 'sw', 'ne', 'w'],
-  sw: ['sw', 'w', 'nw', 's', 'n', 'ne', 'sw', 'e'],
-  se: ['se', 'e', 'ne', 's', 'n', 'nw', 'se', 'w'],
+  // alternating clockwise then counter-clockwise steps away from preferred placement for maximum befuddlement
+  n: ['n', 'ne', 'nw', 'e', 'w', 's', 'n'],
+  e: ['e', 'se', 'ne', 's', 'n', 'w', 'e'],
+  s: ['s', 'sw', 'se', 'w', 'e', 'n', 's'],
+  w: ['w', 'nw', 'sw', 'n', 's', 'e', 'w'],
+  nw: ['nw', 'n', 'w', 'ne', 'sw', 'e', 's', 'se', 'nw'],
+  ne: ['ne', 'e', 'n', 'se', 'nw', 's', 'w', 'sw', 'ne'],
+  sw: ['sw', 'w', 's', 'nw', 'se', 'n', 'e', 'ne', 'sw'],
+  se: ['se', 's', 'e', 'sw', 'nw', 'w', 'n', 'nw', 'se'],
 };
 
 /**
@@ -227,14 +210,14 @@ $.powerTip = {
 // csscoordinates.js
 
 type Coords = {
-  left: number | 'auto';
-  right: number | 'auto';
-  top: number | 'auto';
-  bottom: number | 'auto';
+  left: number;
+  top: number;
+  right: 'auto';
+  bottom: 'auto';
 };
 
 function cssCoordinates(): Coords {
-  return { left: 'auto', top: 'auto', right: 'auto', bottom: 'auto' };
+  return { left: 0, top: 0, right: 'auto', bottom: 'auto' };
 }
 
 // displaycontroller.js
@@ -338,7 +321,7 @@ function placementCalculator() {
       switch (placement) {
         case 'n':
           coords.left = position.left - tipWidth / 2;
-          coords.bottom = session.windowHeight - position.top + offset;
+          coords.top = position.top - tipHeight - offset;
           break;
         case 'e':
           coords.left = position.left + offset;
@@ -349,20 +332,20 @@ function placementCalculator() {
           coords.top = position.top + offset;
           break;
         case 'w':
+          coords.left = position.left - tipWidth - offset;
           coords.top = position.top - tipHeight / 2;
-          coords.right = session.windowWidth - position.left + offset;
           break;
         case 'nw':
-          coords.bottom = session.windowHeight - position.top + offset;
-          coords.right = session.windowWidth - position.left - 20;
+          coords.left = position.left + 20 - tipWidth;
+          coords.top = position.top - tipHeight - offset;
           break;
         case 'ne':
           coords.left = position.left - 20;
-          coords.bottom = session.windowHeight - position.top + offset;
+          coords.top = position.top - tipHeight - offset;
           break;
         case 'sw':
+          coords.left = position.left + 20 - tipWidth;
           coords.top = position.top + offset;
-          coords.right = session.windowWidth - position.left - 20;
           break;
         case 'se':
           coords.left = position.left - 20;
@@ -461,7 +444,7 @@ class TooltipController {
     this.doShowTip(element);
   }
 
-  doShowTip(element: Cash) {
+  async doShowTip(element: Cash) {
     // it is possible, especially with keyboard navigation, to move on to
     // another element with a tooltip during the queue to get to this point
     // in the code. if that happens then we need to not proceed or we may
@@ -480,15 +463,10 @@ class TooltipController {
       }, 100);
       return;
     }
+    await this.options.render?.($as(element));
 
     // set tooltip position
     this.resetPosition(element);
-
-    // trigger powerTipPreRender event
-    if (this.options.preRender) {
-      this.tipElement.empty();
-      this.options.preRender($as(element));
-    }
 
     this.scoped.activeHover = element;
     this.scoped.isTipOpen = true;
@@ -547,7 +525,10 @@ class TooltipController {
         const coords = this.placeTooltip(element, pos);
         const collisions = getViewportCollisions(coords, elementWidth, elementHeight);
         // only attempt to nudge when the issue is horizontal overflow
-        if (collisions & (Collision.left | Collision.right)) {
+        if (
+          (collisions === Collision.left || collisions === Collision.right) &&
+          (pos === 'n' || pos === 's')
+        ) {
           const nudged = nudgeToFit(coords, collisions, elementWidth);
           if (nudged) {
             this.tipElement.css(nudged);


### PR DESCRIPTION
- Dont calculate position or draw until there is something to draw
- Dont involve viewport when measuring document offsets. I have no clue what the original intent was here: https://github.com/stevenbenner/jquery-powertip/blob/0f7cd704c56d4618ea37c9a0166191e4700a5dde/src/placementcalculator.js#L42
- Only nudge horizontal offsets on north/south placements so as not to cover the hovered element.

fix #21282