### PR TITLE
Typecheck sources correctly after .d.ts changes in --watch mode

### DIFF
--- a/ui/.build/src/build.ts
+++ b/ui/.build/src/build.ts
@@ -60,20 +60,22 @@ function monitor(pkgs: string[]) {
     includes: [
       { cwd: env.rootDir, path: 'package.json' },
       { cwd: env.typesDir, path: '*/package.json' },
+      { cwd: env.typesDir, path: 'lichess/*.d.ts' },
       { cwd: env.uiDir, path: '*/package.json' },
       { cwd: env.uiDir, path: '*/tsconfig.json' },
     ],
     debounce: 1000,
     monitorOnly: true,
     execute: async files => {
-      if (files.some(x => x.endsWith('package.json'))) {
+      if (files.some(name => name.endsWith('package.json'))) {
         if (!env.install) env.exit('Exiting due to package.json change');
         await stopBuild();
         if (env.clean) await clean();
         build(pkgs);
-      } else if (files.some(x => x.endsWith('tsconfig.json'))) {
+      } else if (files.some(name => name.endsWith('.d.ts') || name.endsWith('tsconfig.json'))) {
         stopManifest();
         await Promise.allSettled([stopTsc(), stopEsbuild()]);
+        await clean(['ui/*/tsconfig.tsbuildinfo']);
         tsc();
         esbuild();
       }


### PR DESCRIPTION
Incremental (non-watch) builds remain unchecked when global types change. So that's broken. I'd say that's on M$, but maybe these types could be surfaced in a more modern, module friendly way.