### PR TITLE
prevent castled king from premoving castling onto rook

### DIFF
--- a/ui/round/src/premove.ts
+++ b/ui/round/src/premove.ts
@@ -178,9 +178,9 @@ export class Premove {
       ((ctx.orig.pos[0] === 4 &&
         this.variant !== 'chess960' &&
         ((ctx.dest.pos[0] === 2 && ctx.rookFilesFriendlies.includes(0)) ||
-          (ctx.dest.pos[0] === 6 && ctx.rookFilesFriendlies.includes(7)))) ||
-        ((this.rookCastle || this.variant === 'chess960') &&
-          ctx.rookFilesFriendlies.includes(ctx.dest.pos[0]))) &&
+          (ctx.dest.pos[0] === 6 && ctx.rookFilesFriendlies.includes(7)) ||
+          (this.rookCastle && ctx.rookFilesFriendlies.includes(ctx.dest.pos[0])))) ||
+        (this.variant === 'chess960' && ctx.rookFilesFriendlies.includes(ctx.dest.pos[0]))) &&
       (this.unrestrictedPremoves ||
         /* The following checks if no non-rook friendly piece is in the way between the king and its castling destination.
          Note that for the Chess960 edge case of Kb1 "long castling", the check passes even if there is a piece in the way

--- a/ui/round/tests/premove.test.ts
+++ b/ui/round/tests/premove.test.ts
@@ -248,4 +248,36 @@ describe('premoves', () => {
       );
     }
   });
+
+  test('castled king cannot premove castling onto rook in standard chess', () => {
+    const kingsideExpectedPremoves = new Map<cg.Key, Set<cg.Key>>([
+      ['g1', new Set(['f2', 'g2', 'h2', 'h1'])],
+      ['f1', new Set(['f2', 'f3', 'f4', 'f5', 'f6', 'f7', 'f8', 'e1', 'd1', 'c1', 'b1'])],
+      ['a1', new Set(['a2', 'a3', 'a4', 'a5', 'a6', 'a7', 'a8', 'b1', 'c1', 'd1', 'e1'])],
+    ]);
+    testPosition(
+      fen.read('4k3/8/8/8/8/8/8/R4RK1 b - - 0 1'),
+      'black',
+      undefined,
+      kingsideExpectedPremoves,
+      true,
+      false,
+      'standard',
+    );
+
+    const queensideExpectedPremoves = new Map<cg.Key, Set<cg.Key>>([
+      ['c1', new Set(['b1', 'b2', 'c2', 'd2'])],
+      ['d1', new Set(['d2', 'd3', 'd4', 'd5', 'd6', 'd7', 'd8', 'e1', 'f1', 'g1'])],
+      ['h1', new Set(['h2', 'h3', 'h4', 'h5', 'h6', 'h7', 'h8', 'g1', 'f1', 'e1'])],
+    ]);
+    testPosition(
+      fen.read('4k3/8/8/8/8/8/8/2KR3R b - - 0 1'),
+      'black',
+      undefined,
+      queensideExpectedPremoves,
+      true,
+      false,
+      'standard',
+    );
+  });
 });


### PR DESCRIPTION
### Problem
In non-Chess960 variants (such as Standard chess), castling is only legal when the king is on its starting square (e-file, ctx.orig.pos[0] === 4).

Previously in ui/round/src/premove.ts, when rookCastle was enabled (default preference allowing king-to-rook castling), the destination check ctx.rookFilesFriendlies.includes(ctx.dest.pos[0]) was not guarded by ctx.orig.pos[0] === 4. As a result, after castling (e.g. White king on g1 or c1), clicking the king still highlighted friendly rooks on the 1st/8th rank as valid premove destinations.

### Solution
- Restrict the rookCastle destination check to ctx.orig.pos[0] === 4 in non-Chess960 variants, while preserving Chess960 back-rank king mobility.
- Add unit tests in ui/round/tests/premove.test.ts for both kingside (g1) and queenside (c1) castled king positions in standard chess.

### AI Assistance Disclosure
Assisted by Antigravity in pair-programming with @dikshyantacharya.