### PR TITLE
ui: small tweaks and fixes for transparent themes

### DIFF
--- a/ui/bits/css/_dailyFeed.scss
+++ b/ui/bits/css/_dailyFeed.scss
@@ -46,6 +46,10 @@ $marker-margin-top: -14px;
 
         background: $c-bg-box;
         border: 2px solid $c-contours;
+
+        @include if-transp {
+          background: hsl(from $c-bg-box h s l / 0.9);
+        }
       }
     }
 

--- a/ui/bits/css/forum/_post.scss
+++ b/ui/bits/css/forum/_post.scss
@@ -168,7 +168,6 @@
 
   blockquote {
     padding: 0 0.7em;
-    border-left: 0.3em solid;
     unicode-bidi: plaintext;
     position: relative;
   }
@@ -180,4 +179,8 @@
   h3 {
     font-size: 1.2em;
   }
+}
+
+.forum-topic .preview {
+  @include backdrop-blur-if-transparent;
 }

--- a/ui/challenge/css/_page.scss
+++ b/ui/challenge/css/_page.scss
@@ -75,6 +75,10 @@
     ---font: #{$c-secondary};
     ---bg: #{color-mix(in oklab, $c-secondary 10%, $c-bg)};
 
+    @include if-transp {
+      ---bg: #{color-mix(in oklab, $c-secondary 10%, transparent)};
+    }
+
     padding: $block-gap 4vw;
     margin-bottom: 4rem;
     font-size: 1.5em;

--- a/ui/editor/css/_tools.scss
+++ b/ui/editor/css/_tools.scss
@@ -3,6 +3,8 @@
     @extend %flex-column;
 
     cursor: default;
+    grid-area: tools;
+    align-self: center;
 
     button,
     .button,
@@ -23,15 +25,13 @@
       cursor: not-allowed;
     }
 
-    grid-area: tools;
-    align-self: center;
-
     > * {
       margin: 0.5rem 0;
     }
 
     select {
       @extend %page-link !optional;
+      @include backdrop-blur-if-transparent;
 
       width: 100%;
 
@@ -105,7 +105,7 @@
     }
 
     .actions {
-      @extend %flex-column;
+      @extend %flex-column, %box-radius;
       @include backdrop-blur-if-transparent;
 
       justify-content: stretch;

--- a/ui/lib/css/abstract/_extends.scss
+++ b/ui/lib/css/abstract/_extends.scss
@@ -160,6 +160,8 @@
 }
 
 %dropdown-shadow {
+  @include backdrop-blur-if-transparent;
+
   @include if-transp {
     @include back-blur;
   }

--- a/ui/lib/css/component/_box.scss
+++ b/ui/lib/css/component/_box.scss
@@ -3,6 +3,7 @@ $vp-max-width: 1200px;
 
 .box {
   @extend %box-shadow;
+  @include backdrop-blur-if-transparent;
 
   background: $c-bg-box;
 
@@ -32,12 +33,6 @@ $vp-max-width: 1200px;
 
   &__pad {
     @extend %box-padding-horiz;
-  }
-
-  @include if-transp {
-    position: relative;
-
-    @include back-blur;
   }
 }
 

--- a/ui/lib/css/component/_calendar-mselect.scss
+++ b/ui/lib/css/component/_calendar-mselect.scss
@@ -5,6 +5,10 @@
   background: $c-bg-zebra;
   padding: 1em 2em;
 
+  @include if-transp {
+    backdrop-filter: none;
+  }
+
   &--top {
     margin-bottom: 2em;
   }

--- a/ui/lib/css/component/_markdown-editor.scss
+++ b/ui/lib/css/component/_markdown-editor.scss
@@ -61,7 +61,7 @@
   }
 
   .header-tab.active.write-tab::after {
-    background-color: $c-bg-input;
+    background-color: hsl(from var(--c-bg-input) h s l / 100);
   }
 
   .content {

--- a/ui/lib/css/component/_markdown.scss
+++ b/ui/lib/css/component/_markdown.scss
@@ -188,7 +188,7 @@
 @mixin rendered-markdown-quote {
   blockquote {
     color: $c-font-dim;
-    border-inline-start: 0.3em solid $c-font-dimmer;
+    border-inline-start: 0.3em solid hsl(from var(--c-font-dimmer) h s l / 80);
     padding-inline-start: 1em;
   }
 }

--- a/ui/lib/css/component/_material.scss
+++ b/ui/lib/css/component/_material.scss
@@ -38,11 +38,11 @@
     }
 
     @include if-transp {
-      filter: drop-shadow(0 1px 1px $c-font-shadow);
+      filter: brightness(1.3) drop-shadow(0 1px 1px $c-font-shadow);
+    }
 
-      @include if-not-light {
-        filter: brightness(1.3) drop-shadow(0 1px 1px $c-font-shadow);
-      }
+    @include if-transp-light {
+      filter: brightness(0.7) drop-shadow(0 1px 1px $c-font-shadow);
     }
   }
 

--- a/ui/lib/css/game/_clock.scss
+++ b/ui/lib/css/game/_clock.scss
@@ -73,6 +73,7 @@
 
   .time {
     @extend %roboto, %box-shadow;
+    @include backdrop-blur-if-transparent;
 
     background: $c-bg-box;
     min-width: 3em;

--- a/ui/lib/css/header/_header.scss
+++ b/ui/lib/css/header/_header.scss
@@ -38,10 +38,10 @@
     }
 
     @include if-transp {
-      @include back-blur(6px);
+      @include back-blur;
 
       border: none;
-      background: linear-gradient(180deg, color-mix(in oklab, $c-bg 50%, transparent) 10%, transparent 90%);
+      background: linear-gradient(180deg, color-mix(in oklab, $c-bg 60%, transparent) 20%, transparent 90%);
     }
 
     .dropdown {

--- a/ui/lib/css/header/_topnav-visible.scss
+++ b/ui/lib/css/header/_topnav-visible.scss
@@ -27,12 +27,8 @@
         text-transform: uppercase;
         border-inline-start: 2px solid transparent;
 
-        @include if-light {
-          text-shadow: 0 1px 0 $c-font-shadow;
-        }
-
         @include if-transp {
-          text-shadow: 0.5px 1px 1px $c-bg-opaque;
+          text-shadow: 0.5px 1px 1px $c-font-shadow;
         }
 
         &:focus-visible {

--- a/ui/lib/css/theme/_theme.transp.light.scss
+++ b/ui/lib/css/theme/_theme.transp.light.scss
@@ -15,7 +15,7 @@ html.transp.light {
   --c-bg-mid: hsl(0 0% 85% / 0.4);
   --c-bg-zebra: hsl(0 0% 100% / 0.2);
   --c-bg-zebra2: hsl(0 0% 100% / 0.35);
-  --c-bg-popup: hsl(0 0% 100% / 0.6);
+  --c-bg-popup: hsl(0 0% 100% / 0.75);
   --c-bg-input: hsl(0 0% 100% / 0.7);
   --c-bg-variation: hsl(0 0% 100% / 0.25);
   --c-bg-header-dropdown: hsl(0 0% 100% / 0.75);

--- a/ui/lobby/css/_feed.scss
+++ b/ui/lobby/css/_feed.scss
@@ -37,6 +37,10 @@
 
         background: $c-bg-box;
         border: 2px solid $c-contours;
+
+        @include if-transp {
+          background: hsl(from $c-bg-box h s l / 0.9);
+        }
       }
     }
 

--- a/ui/user/css/_show.scss
+++ b/ui/user/css/_show.scss
@@ -192,7 +192,7 @@
 
   .new-player {
     padding: 1.5em;
-    overflow-y: scroll;
+    overflow-y: auto;
 
     h2 {
       font-size: 1.5em;


### PR DESCRIPTION
# Why

While using light transparent theme for a while on PROD spotted few small display issues. Also incorporated few changes based on the users feedback in forum:
* https://lichess.org/forum/lichess-feedback/background-image-now-can-select-dark-and-light-theme

# How

Small tweaks and fixes for transparent themes:
* avoid double blur on box containers
* slightly improve popovers readability (still did not figured out why blur is not working for them in every usecase, will follow up)
* apply blur for live game clocks background and under selects on board editor page

# Preview

<img width="1190" height="1066" alt="Screenshot 2026-08-24 at 11 20 18" src="https://github.com/user-attachments/assets/735f9398-a24f-4d44-aa6f-f1428602807c" />
<img width="449" height="480" alt="Screenshot 2026-08-24 at 12 41 13" src="https://github.com/user-attachments/assets/cb05b90c-cf38-4275-90bb-e1a014c6eb7e" />
<img width="717" height="668" alt="Screenshot 2026-08-24 at 11 19 12" src="https://github.com/user-attachments/assets/fb67aa64-4fa7-4a39-8ca8-43c7902016e2" />
<img width="380" height="512" alt="Screenshot 2026-08-24 at 11 35 42" src="https://github.com/user-attachments/assets/1c05c077-a7c1-40b3-8f03-0797b7cbb91d" />
