### PR TITLE
ui(relay): place `aside` before the main content in DOM

### DIFF
--- a/modules/relay/src/main/ui/RelayUi.scala
+++ b/modules/relay/src/main/ui/RelayUi.scala
@@ -72,6 +72,7 @@ final class RelayUi(helpers: Helpers)(
 
   def showPreload(rt: WithTourAndStudy, data: RelayJsonView.JsData)(using Translate): Tag =
     main(cls := "analyse is-relay has-relay-tour")(
+      st.aside(cls := "relay-tour__side")(div(cls := "relay-tour__side__preload")),
       div(cls := "box relay-tour")(
         div(cls := "relay-tour__header")(
           div(cls := "relay-tour__header__content")(
@@ -85,8 +86,7 @@ final class RelayUi(helpers: Helpers)(
             rt.tour.image.map: imgId =>
               img(src := thumbnail.url(imgId, _.Size.Large))
         )
-      ),
-      st.aside(cls := "relay-tour__side")(div(cls := "relay-tour__side__preload"))
+      )
     )
 
   object thumbnail:

--- a/ui/analyse/css/study/relay/_tour.scss
+++ b/ui/analyse/css/study/relay/_tour.scss
@@ -14,8 +14,6 @@
   &__side {
     @extend %flex-column;
 
-    overflow: hidden;
-
     &__preload {
       @extend %box-neat;
 

--- a/ui/analyse/src/study/relay/relayView.ts
+++ b/ui/analyse/src/study/relay/relayView.ts
@@ -31,8 +31,8 @@ export function relayView(
     const resizable = displayColumns() > (ctx.hasRelayTour ? 1 : 2);
 
     return [
-      renderRelayTour(ctx),
       tourSide(ctx, resizable && deps.relayManager(relay, study)),
+      renderRelayTour(ctx),
       !resizable && deps.relayManager(relay, study),
     ];
   };


### PR DESCRIPTION
# Why

Proper fix for the mselect overlay issue.

Refs:
* #21395

# How

`aside` must be always placed in DOM before main content, which was true for almost all pages, but not the relay.

We use grid layouts to the content is rearranged anyway, but having a different order in DOM was causing z-index and order calculation issues.

Also the overflow prevention for side node does not appear to do much besides clipping the box shadows of children elements.

# Preview

### Before

<img width="1029" height="641" alt="Screenshot 2026-08-24 at 14 17 47" src="https://github.com/user-attachments/assets/c569d41d-9b81-43f5-ae19-87b3b72286f5" />

### After

<img width="1029" height="641" alt="Screenshot 2026-08-24 at 14 17 54" src="https://github.com/user-attachments/assets/3f228065-6003-4c41-a1cc-4f2fb372d94d" />
