### PR TITLE
recognize 'takes' when dest square is empty (en passant)

### DIFF
--- a/ui/voice/src/move/voice.move.ts
+++ b/ui/voice/src/move/voice.move.ts
@@ -432,7 +432,7 @@ export function initModule({
         addToks(udest, uci); // includes en passant
         if (uci.startsWith(uci[2])) {
           addToks(`P${udest}`);
-        } else if (dp || !uci.startsWith(uci[2])) {
+        } else {
           addToks(`${usrc}x${udest}`);
           addToks(`Px${udest}`);
           addToks(`${uci[0]}x${udest}`, uci);

--- a/ui/voice/src/move/voice.move.ts
+++ b/ui/voice/src/move/voice.move.ts
@@ -432,7 +432,7 @@ export function initModule({
         addToks(udest, uci); // includes en passant
         if (uci.startsWith(uci[2])) {
           addToks(`P${udest}`);
-        } else if (dp) {
+        } else if (dp || uci[0] !== uci[2]) {
           addToks(`${usrc}x${udest}`);
           addToks(`Px${udest}`);
           addToks(`${uci[0]}x${udest}`, uci);

--- a/ui/voice/src/move/voice.move.ts
+++ b/ui/voice/src/move/voice.move.ts
@@ -432,7 +432,7 @@ export function initModule({
         addToks(udest, uci); // includes en passant
         if (uci.startsWith(uci[2])) {
           addToks(`P${udest}`);
-        } else if (dp || uci[0] !== uci[2]) {
+        } else if (dp || !uci.startsWith(uci[2])) {
           addToks(`${usrc}x${udest}`);
           addToks(`Px${udest}`);
           addToks(`${uci[0]}x${udest}`, uci);


### PR DESCRIPTION
fixes #21391 

https://github.com/user-attachments/assets/07b95d26-4395-4a32-bd37-1ec47cef2c4c


Details (if needed)

<img width="500" height="190" alt="image" src="https://github.com/user-attachments/assets/7cd9408c-b0dc-4ef1-b3da-a1e198161d2a" />

line 432 supports en passant using the target square (for example: g6 in the video)

line 435 support 'takes' but only if the destination square is not empty (not the case with en passant) so we need to support a pawn going sideway to an empty square

When testing the fix, there is still disambiguation but only with one arrow ... this is likely due to my not so great accent
