### PR TITLE
bbb event and tournament log diffs

### DIFF
--- a/modules/common/src/main/ProductDiff.scala
+++ b/modules/common/src/main/ProductDiff.scala
@@ -1,0 +1,68 @@
+package lila.common
+
+object ProductDiff:
+
+  private def truncate(max: Int)(s: String): String =
+    if s.length <= max then s else s.take(max) + "..."
+
+  private def nestedProduct(value: Any): Option[Product] = value match
+    case p: Product if !p.isInstanceOf[Option[?]] => Some(p)
+    case Some(p: Product) => Some(p)
+    case _ => None
+
+  def apply[A <: Product](
+      prev: Option[A],
+      next: A,
+      ignoredFields: Set[String] = Set.empty,
+      nestedFields: Set[String] = Set.empty,
+      maxLength: Int = Int.MaxValue
+  ): String =
+    val trunc = truncate(maxLength)
+
+    def fieldLine(prefix: String)(name: String, value: Any) =
+      s"$prefix $name: ${trunc(value.toString)}"
+
+    def changedLine(name: String, prevVal: Any, nextVal: Any) =
+      s"${fieldLine("-")(name, prevVal)}\n${fieldLine("+")(name, nextVal)}"
+
+    def nestedDiff(name: String, prevVal: Any, nextVal: Any): List[String] =
+      (nestedProduct(prevVal), nestedProduct(nextVal)) match
+        case (Some(pv), Some(nv)) if pv.productArity == nv.productArity =>
+          pv.productElementNames
+            .zip(pv.productIterator)
+            .zip(nv.productIterator)
+            .collect:
+              case ((k, a), b) if a != b => changedLine(s"$name.$k", a, b)
+            .toList
+        case _ => List(changedLine(name, prevVal, nextVal))
+
+    def newLines(name: String, value: Any): List[String] =
+      if value == None then Nil
+      else if nestedFields(name)
+      then
+        nestedProduct(value).fold(List(fieldLine("+")(name, value))): p =>
+          p.productElementNames
+            .zip(p.productIterator)
+            .collect:
+              case (k, v) if v != None => fieldLine("+")(s"$name.$k", v)
+            .toList
+      else List(fieldLine("+")(name, value))
+
+    prev match
+      case None =>
+        next.productElementNames
+          .zip(next.productIterator)
+          .collect:
+            case (name, value) if !ignoredFields(name) => newLines(name, value)
+          .flatten
+          .mkString("\n")
+      case Some(old) =>
+        old.productElementNames
+          .zip(old.productIterator)
+          .zip(next.productIterator)
+          .flatMap:
+            case ((name, _), _) if ignoredFields(name) => Nil
+            case ((_, prevVal), nextVal) if prevVal == nextVal => Nil
+            case ((name, prevVal), nextVal) if nestedFields(name) => nestedDiff(name, prevVal, nextVal)
+            case ((name, prevVal), nextVal) => List(changedLine(name, prevVal, nextVal))
+          .mkString("\n")

--- a/modules/common/src/main/ProductDiff.scala
+++ b/modules/common/src/main/ProductDiff.scala
@@ -1,5 +1,7 @@
 package lila.common
 
+import lila.core.data.DiffStr
+
 object ProductDiff:
 
   private def truncate(max: Int)(s: String): String =
@@ -15,8 +17,8 @@ object ProductDiff:
       next: A,
       ignoredFields: Set[String] = Set.empty,
       nestedFields: Set[String] = Set.empty,
-      maxLength: Int = Int.MaxValue
-  ): String =
+      maxLength: Int = 20_000
+  ): Option[DiffStr] =
     val trunc = truncate(maxLength)
 
     def fieldLine(prefix: String)(name: String, value: Any) =
@@ -48,14 +50,13 @@ object ProductDiff:
             .toList
       else List(fieldLine("+")(name, value))
 
-    prev match
+    val lineIterator = prev match
       case None =>
         next.productElementNames
           .zip(next.productIterator)
           .collect:
             case (name, value) if !ignoredFields(name) => newLines(name, value)
           .flatten
-          .mkString("\n")
       case Some(old) =>
         old.productElementNames
           .zip(old.productIterator)
@@ -65,4 +66,5 @@ object ProductDiff:
             case ((_, prevVal), nextVal) if prevVal == nextVal => Nil
             case ((name, prevVal), nextVal) if nestedFields(name) => nestedDiff(name, prevVal, nextVal)
             case ((name, prevVal), nextVal) => List(changedLine(name, prevVal, nextVal))
-          .mkString("\n")
+
+    lineIterator.mkString("\n").nonEmptyOption.map(DiffStr.apply)

--- a/modules/core/src/main/data.scala
+++ b/modules/core/src/main/data.scala
@@ -37,6 +37,9 @@ object data:
   opaque type SafeJsonStr = String
   object SafeJsonStr extends OpaqueString[SafeJsonStr]
 
+  opaque type DiffStr = String
+  object DiffStr extends OpaqueString[DiffStr]
+
   opaque type Url = String
   object Url extends OpaqueString[Url]:
     val trackingParametersRegex = """(?i)(?:\?|&(?:amp;)?)(?:utm\\?_\w+|gclid|gclsrc|\\?_ga)=\w+""".r

--- a/modules/core/src/main/irc.scala
+++ b/modules/core/src/main/irc.scala
@@ -54,6 +54,5 @@ trait IrcApi:
       tpe: "arena" | "event",
       name: String,
       url: Call,
-      from: Instant,
-      to: Option[Instant]
+      diff: String
   ): Funit

--- a/modules/core/src/main/irc.scala
+++ b/modules/core/src/main/irc.scala
@@ -6,6 +6,7 @@ import play.api.mvc.Call
 import lila.core.id.{ RelayRoundId, RelayTourId, UblogPostId, StudyChapterId }
 import lila.core.userId.{ UserId, MyId, ModId, UserName }
 import lila.core.study.data.StudyChapterName
+import lila.core.data.DiffStr
 
 enum ModDomain:
   case Admin, Cheat, Boost, Comm, Other
@@ -46,7 +47,7 @@ trait IrcApi:
       tourName: String,
       tourSlug: String,
       tourId: RelayTourId,
-      diff: String,
+      diff: DiffStr,
       impersonatedBy: Option[ModId] = None
   )(using MyId): Funit
   def bbb(
@@ -54,5 +55,5 @@ trait IrcApi:
       tpe: "arena" | "event",
       name: String,
       url: Call,
-      diff: String
+      diff: DiffStr
   ): Funit

--- a/modules/event/src/main/EventApi.scala
+++ b/modules/event/src/main/EventApi.scala
@@ -98,13 +98,22 @@ final class EventApi(
       startsAt = nowInstant.plusDays(7)
     )
 
+  private val bbbIgnoredFields = Set("_id", "createdBy", "createdAt", "updatedBy", "updatedAt")
+
   private def notifyBBB(next: Event, prev: Option[Event])(using me: MyId) =
-    if prev.map(_.featureDates).forall(_ != next.featureDates) then
-      ircApi.bbb(
-        me,
-        "event",
-        next.title,
-        routes.Event.show(next.id),
-        next.featureSince,
-        next.featureUntil.some
-      )
+    val diff = prev match
+      case None =>
+        next.productElementNames
+          .zip(next.productIterator)
+          .collect:
+            case (name, value) if !bbbIgnoredFields(name) => s"+ $name: $value"
+          .mkString("\n")
+      case Some(old) =>
+        old.productElementNames
+          .zip(old.productIterator)
+          .zip(next.productIterator)
+          .collect:
+            case ((name, prevVal), nextVal) if !bbbIgnoredFields(name) && prevVal != nextVal =>
+              s"- $name: $prevVal\n+ $name: $nextVal"
+          .mkString("\n")
+    if diff.nonEmpty then ircApi.bbb(me, "event", next.title, routes.Event.show(next.id), diff)

--- a/modules/event/src/main/EventApi.scala
+++ b/modules/event/src/main/EventApi.scala
@@ -98,22 +98,7 @@ final class EventApi(
       startsAt = nowInstant.plusDays(7)
     )
 
-  private val bbbIgnoredFields = Set("_id", "createdBy", "createdAt", "updatedBy", "updatedAt")
-
   private def notifyBBB(next: Event, prev: Option[Event])(using me: MyId) =
-    val diff = prev match
-      case None =>
-        next.productElementNames
-          .zip(next.productIterator)
-          .collect:
-            case (name, value) if !bbbIgnoredFields(name) => s"+ $name: $value"
-          .mkString("\n")
-      case Some(old) =>
-        old.productElementNames
-          .zip(old.productIterator)
-          .zip(next.productIterator)
-          .collect:
-            case ((name, prevVal), nextVal) if !bbbIgnoredFields(name) && prevVal != nextVal =>
-              s"- $name: $prevVal\n+ $name: $nextVal"
-          .mkString("\n")
+    val ignoredFields = Set("_id", "createdBy", "createdAt", "updatedBy", "updatedAt")
+    val diff = lila.common.ProductDiff(prev, next, ignoredFields)
     if diff.nonEmpty then ircApi.bbb(me, "event", next.title, routes.Event.show(next.id), diff)

--- a/modules/event/src/main/EventApi.scala
+++ b/modules/event/src/main/EventApi.scala
@@ -99,6 +99,6 @@ final class EventApi(
     )
 
   private def notifyBBB(next: Event, prev: Option[Event])(using me: MyId) =
-    val ignoredFields = Set("_id", "createdBy", "createdAt", "updatedBy", "updatedAt")
-    val diff = lila.common.ProductDiff(prev, next, ignoredFields)
-    if diff.nonEmpty then ircApi.bbb(me, "event", next.title, routes.Event.show(next.id), diff)
+    lila.common
+      .ProductDiff(prev, next, ignoredFields = Set("_id", "createdBy", "createdAt", "updatedBy", "updatedAt"))
+      .foreach(ircApi.bbb(me, "event", next.title, routes.Event.show(next.id), _))

--- a/modules/irc/src/main/IrcApi.scala
+++ b/modules/irc/src/main/IrcApi.scala
@@ -8,6 +8,7 @@ import lila.core.id.*
 import lila.core.irc.*
 import lila.core.userId.ModId
 import lila.core.study.data.StudyChapterName
+import lila.core.data.DiffStr
 
 final class IrcApi(
     zulip: ZulipClient,
@@ -42,6 +43,7 @@ final class IrcApi(
     def linkifyPostsAndUsers(msg: String) = linkifyPosts(linkifyUsers(msg))
     def fixImageUrl(url: String) = url.replace("/display?", "/display.jpg?")
     def time(t: Instant) = s"<time:$t>"
+    def diff(diff: DiffStr) = s"```diff\n$diff\n```"
 
   def commReportBurst(user: LightUser): Funit =
     val md = markdown.linkifyUsers(s"Burst of comm reports about @${user.name}")
@@ -122,10 +124,10 @@ final class IrcApi(
     zulip(_.mod.commsPublic, "forum-log"):
       s"${markdown.userLink(mod.name)} :$icon: ${markdown.linkifyPostsAndUsers(text)}"
 
-  def bbb(by: MyId, tpe: "arena" | "event", name: String, url: Call, diff: String): Funit =
+  def bbb(by: MyId, tpe: "arena" | "event", name: String, url: Call, diff: DiffStr): Funit =
     val link = markdown.lichessLink(url.url, name)
     val text =
-      s"${markdown.userLink(lightUser(by.userId))} [$tpe] $link\n```spoiler changes\n```diff\n$diff\n```\n```"
+      s"${markdown.userLink(lightUser(by.userId))} [$tpe] $link\n```spoiler changes\n```${markdown.diff(diff)}\n```"
     zulip(_.bbb, "log")(text)
 
   def ublogPost(
@@ -163,7 +165,7 @@ final class IrcApi(
       tourName: String,
       tourSlug: String,
       tourId: RelayTourId,
-      diff: String,
+      diff: DiffStr,
       impersonatedBy: Option[ModId] = None
   )(using
       userId: MyId
@@ -172,7 +174,7 @@ final class IrcApi(
     val impersonator = impersonatedBy.map(id => lightUser(id.userId))
     val channelUser = impersonator.getOrElse(user)
     zulip(_.broadcastLogs, s"/${channelUser.name}"):
-      s"${markdown.userLink(user.name)}${impersonatedByText(impersonator)} updated ${markdown.lichessLink(s"/broadcast/$tourSlug/$tourId", tourName)}\n```diff\n$diff\n```"
+      s"${markdown.userLink(user.name)}${impersonatedByText(impersonator)} updated ${markdown.lichessLink(s"/broadcast/$tourSlug/$tourId", tourName)}\n${markdown.diff(diff)}"
 
   def openingEdit(user: LightUser, opening: String, moves: String): Funit =
     zulip(_.content, "/opening edits"):

--- a/modules/irc/src/main/IrcApi.scala
+++ b/modules/irc/src/main/IrcApi.scala
@@ -124,7 +124,8 @@ final class IrcApi(
 
   def bbb(by: MyId, tpe: "arena" | "event", name: String, url: Call, diff: String): Funit =
     val link = markdown.lichessLink(url.url, name)
-    val text = s"${markdown.userLink(lightUser(by.userId))} [$tpe] $link\n```spoiler changes\n```diff\n$diff\n```\n```"
+    val text =
+      s"${markdown.userLink(lightUser(by.userId))} [$tpe] $link\n```spoiler changes\n```diff\n$diff\n```\n```"
     zulip(_.bbb, "log")(text)
 
   def ublogPost(

--- a/modules/irc/src/main/IrcApi.scala
+++ b/modules/irc/src/main/IrcApi.scala
@@ -124,7 +124,7 @@ final class IrcApi(
 
   def bbb(by: MyId, tpe: "arena" | "event", name: String, url: Call, diff: String): Funit =
     val link = markdown.lichessLink(url.url, name)
-    val text = s"${markdown.userLink(lightUser(by.userId))} [$tpe] $link\n```diff\n$diff\n```"
+    val text = s"${markdown.userLink(lightUser(by.userId))} [$tpe] $link\n```spoiler changes\n```diff\n$diff\n```\n```"
     zulip(_.bbb, "log")(text)
 
   def ublogPost(

--- a/modules/irc/src/main/IrcApi.scala
+++ b/modules/irc/src/main/IrcApi.scala
@@ -122,17 +122,9 @@ final class IrcApi(
     zulip(_.mod.commsPublic, "forum-log"):
       s"${markdown.userLink(mod.name)} :$icon: ${markdown.linkifyPostsAndUsers(text)}"
 
-  def bbb(
-      by: MyId,
-      tpe: "arena" | "event",
-      name: String,
-      url: Call,
-      from: Instant,
-      to: Option[Instant]
-  ): Funit =
+  def bbb(by: MyId, tpe: "arena" | "event", name: String, url: Call, diff: String): Funit =
     val link = markdown.lichessLink(url.url, name)
-    val times = s"${markdown.time(from)} → ${to.fold("?")(markdown.time)}"
-    val text = s"${markdown.userLink(lightUser(by.userId))} [$tpe] $link $times"
+    val text = s"${markdown.userLink(lightUser(by.userId))} [$tpe] $link\n```diff\n$diff\n```"
     zulip(_.bbb, "log")(text)
 
   def ublogPost(

--- a/modules/relay/src/main/RelayNotifierAdmin.scala
+++ b/modules/relay/src/main/RelayNotifierAdmin.scala
@@ -76,31 +76,15 @@ private final class RelayNotifierAdmin(roundRepo: RelayRoundRepo, irc: IrcApi, p
 
   def tourChange(prev: RelayTour, tour: RelayTour, impersonatedBy: Option[ModId])(using Me): Funit =
     val ignoredFields = Set("id", "createdAt", "active", "live", "syncedAt", "note")
-    val changes = prev.productElementNames
-      .zip(prev.productIterator)
-      .zip(tour.productIterator)
-      .flatMap:
-        case ((name, _), _) if ignoredFields(name) => Nil
-        case ((_, prevVal), nextVal) if prevVal == nextVal => Nil
-        case (("info", prevInfo: RelayTour.Info), nextInfo: RelayTour.Info) =>
-          prevInfo.productElementNames
-            .zip(prevInfo.productIterator)
-            .zip(nextInfo.productIterator)
-            .collect:
-              case ((k, pv), nv) if pv != nv =>
-                s"- info.$k: ${truncate(pv.toString)}\n+ info.$k: ${truncate(nv.toString)}"
-            .toList
-        case ((name, prevVal), nextVal) =>
-          List(s"- $name: ${truncate(prevVal.toString)}\n+ $name: ${truncate(nextVal.toString)}")
-      .toList
-    changes.nonEmpty.so:
-      irc.broadcastTourUpdate(
-        tour.name.value,
-        tour.slug,
-        tour.id,
-        changes.mkString("\n"),
-        impersonatedBy
-      )
+    val diff = lila.common.ProductDiff(
+      prev.some,
+      tour,
+      ignoredFields,
+      nestedFields = Set("info", "spotlight"),
+      maxLength = 300
+    )
+    diff.nonEmpty.so:
+      irc.broadcastTourUpdate(tour.name.value, tour.slug, tour.id, diff, impersonatedBy)
 
   def imageDelete(t: RelayTour, tag: Option[String], impersonatedBy: Option[ModId])(using Me): Funit =
     t.official.so:
@@ -113,6 +97,3 @@ private final class RelayNotifierAdmin(roundRepo: RelayRoundRepo, irc: IrcApi, p
       val fieldName = tag | "image"
       val diff = s"- $fieldName: ${t.image.fold("(none)")(_.toString)}\n+ $fieldName: (uploaded)"
       irc.broadcastTourUpdate(t.name.value, t.slug, t.id, diff, impersonatedBy)
-
-  private def truncate(s: String): String =
-    if s.length <= 300 then s else s.take(300) + "..."

--- a/modules/relay/src/main/RelayNotifierAdmin.scala
+++ b/modules/relay/src/main/RelayNotifierAdmin.scala
@@ -5,6 +5,7 @@ import com.github.blemale.scaffeine.Cache
 import lila.study.ChapterPreviewApi
 import lila.core.irc.IrcApi
 import lila.core.userId.ModId
+import lila.core.data.DiffStr
 
 private final class RelayNotifierAdmin(roundRepo: RelayRoundRepo, irc: IrcApi, previewApi: ChapterPreviewApi)(
     using
@@ -71,29 +72,28 @@ private final class RelayNotifierAdmin(roundRepo: RelayRoundRepo, irc: IrcApi, p
 
   def tourCreate(tour: RelayTour)(using Me): Funit =
     tour.official.so:
-      val diff = s"+ tier: ${tour.tier.fold("(none)")(_.toString)}"
+      val diff = DiffStr(s"+ tier: ${tour.tier.fold("(none)")(_.toString)}")
       irc.broadcastTourUpdate(tour.name.value, tour.slug, tour.id, diff)
 
   def tourChange(prev: RelayTour, tour: RelayTour, impersonatedBy: Option[ModId])(using Me): Funit =
-    val ignoredFields = Set("id", "createdAt", "active", "live", "syncedAt", "note")
-    val diff = lila.common.ProductDiff(
-      prev.some,
-      tour,
-      ignoredFields,
-      nestedFields = Set("info", "spotlight"),
-      maxLength = 300
-    )
-    diff.nonEmpty.so:
-      irc.broadcastTourUpdate(tour.name.value, tour.slug, tour.id, diff, impersonatedBy)
+    lila.common
+      .ProductDiff(
+        prev.some,
+        tour,
+        ignoredFields = Set("id", "createdAt", "active", "live", "syncedAt", "note"),
+        nestedFields = Set("info", "spotlight"),
+        maxLength = 300
+      )
+      .so(irc.broadcastTourUpdate(tour.name.value, tour.slug, tour.id, _, impersonatedBy))
 
   def imageDelete(t: RelayTour, tag: Option[String], impersonatedBy: Option[ModId])(using Me): Funit =
     t.official.so:
       val fieldName = tag | "image"
-      val diff = s"- $fieldName: ${t.image.fold("(none)")(_.toString)}\n+ $fieldName: (removed)"
+      val diff = DiffStr(s"- $fieldName: ${t.image.fold("(none)")(_.toString)}\n+ $fieldName: (removed)")
       irc.broadcastTourUpdate(t.name.value, t.slug, t.id, diff, impersonatedBy)
 
   def imageUpload(t: RelayTour, tag: Option[String], impersonatedBy: Option[ModId])(using Me): Funit =
     t.official.so:
       val fieldName = tag | "image"
-      val diff = s"- $fieldName: ${t.image.fold("(none)")(_.toString)}\n+ $fieldName: (uploaded)"
+      val diff = DiffStr(s"- $fieldName: ${t.image.fold("(none)")(_.toString)}\n+ $fieldName: (uploaded)")
       irc.broadcastTourUpdate(t.name.value, t.slug, t.id, diff, impersonatedBy)

--- a/modules/tournament/src/main/TournamentApi.scala
+++ b/modules/tournament/src/main/TournamentApi.scala
@@ -797,16 +797,23 @@ final class TournamentApi(
         _.flatMap { LightPov(_, userId) }
 
   private def notifyBBB(next: Tournament, prev: Option[Tournament])(using me: MyId) =
-    next.homepageSince.map: start =>
-      if prev.forall(_.homepageSince != start.some) then
-        ircApi.bbb(
-          me,
-          "arena",
-          next.name,
-          routes.Tournament.show(next.id),
-          start,
-          next.finishesAt.some
-        )
+    val ignoredFields = Set("id", "status", "nbPlayers", "createdAt", "createdBy", "winnerId", "featuredId")
+    val diff = prev match
+      case None =>
+        next.productElementNames
+          .zip(next.productIterator)
+          .collect:
+            case (name, value) if !ignoredFields(name) => s"+ $name: $value"
+          .mkString("\n")
+      case Some(old) =>
+        old.productElementNames
+          .zip(old.productIterator)
+          .zip(next.productIterator)
+          .collect:
+            case ((name, prevVal), nextVal) if !ignoredFields(name) && prevVal != nextVal =>
+              s"- $name: $prevVal\n+ $name: $nextVal"
+          .mkString("\n")
+    if diff.nonEmpty then ircApi.bbb(me, "arena", next.name, routes.Tournament.show(next.id), diff)
 
   private def Parallel[A: Zero](tourId: TourId, action: String)(
       fetch: TourId => Fu[Option[Tournament]]

--- a/modules/tournament/src/main/TournamentApi.scala
+++ b/modules/tournament/src/main/TournamentApi.scala
@@ -797,14 +797,14 @@ final class TournamentApi(
         _.flatMap { LightPov(_, userId) }
 
   private def notifyBBB(next: Tournament, prev: Option[Tournament])(using me: MyId) =
-    val ignoredFields = Set("id", "status", "nbPlayers", "createdAt", "createdBy", "winnerId", "featuredId")
-    val diff = lila.common.ProductDiff(
-      prev,
-      next,
-      ignoredFields,
-      nestedFields = Set("spotlight", "conditions", "teamBattle", "schedule")
-    )
-    if diff.nonEmpty then ircApi.bbb(me, "arena", next.name, routes.Tournament.show(next.id), diff)
+    lila.common
+      .ProductDiff(
+        prev,
+        next,
+        ignoredFields = Set("id", "status", "nbPlayers", "createdAt", "createdBy", "winnerId", "featuredId"),
+        nestedFields = Set("spotlight", "conditions", "teamBattle", "schedule")
+      )
+      .foreach(ircApi.bbb(me, "arena", next.name, routes.Tournament.show(next.id), _))
 
   private def Parallel[A: Zero](tourId: TourId, action: String)(
       fetch: TourId => Fu[Option[Tournament]]
@@ -836,9 +836,7 @@ final class TournamentApi(
       tournamentTop(tourId).map { top =>
         val lastHash: Int = ~lastPublished.getIfPresent(tourId)
         if lastHash != top.hashCode then
-          Bus.pub(
-            lila.core.round.TourStanding(tourId, JsonView.top(top, lightUserApi.sync))
-          )
+          Bus.pub(lila.core.round.TourStanding(tourId, JsonView.top(top, lightUserApi.sync)))
           lastPublished.put(tourId, top.hashCode)
       }
 

--- a/modules/tournament/src/main/TournamentApi.scala
+++ b/modules/tournament/src/main/TournamentApi.scala
@@ -798,21 +798,12 @@ final class TournamentApi(
 
   private def notifyBBB(next: Tournament, prev: Option[Tournament])(using me: MyId) =
     val ignoredFields = Set("id", "status", "nbPlayers", "createdAt", "createdBy", "winnerId", "featuredId")
-    val diff = prev match
-      case None =>
-        next.productElementNames
-          .zip(next.productIterator)
-          .collect:
-            case (name, value) if !ignoredFields(name) => s"+ $name: $value"
-          .mkString("\n")
-      case Some(old) =>
-        old.productElementNames
-          .zip(old.productIterator)
-          .zip(next.productIterator)
-          .collect:
-            case ((name, prevVal), nextVal) if !ignoredFields(name) && prevVal != nextVal =>
-              s"- $name: $prevVal\n+ $name: $nextVal"
-          .mkString("\n")
+    val diff = lila.common.ProductDiff(
+      prev,
+      next,
+      ignoredFields,
+      nestedFields = Set("spotlight", "conditions", "teamBattle", "schedule")
+    )
     if diff.nonEmpty then ircApi.bbb(me, "arena", next.name, routes.Tournament.show(next.id), diff)
 
   private def Parallel[A: Zero](tourId: TourId, action: String)(


### PR DESCRIPTION
Display what changed when Events or Tournaments (for BBB) are updated:

| before | after |
| - | - |
| <img width="1021" height="156" alt="image" src="https://github.com/user-attachments/assets/395d9a8b-1218-4f86-96b2-8bb3fb583de6" /> | <img width="1008" height="188" alt="image" src="https://github.com/user-attachments/assets/7459114b-45ee-4f8c-836f-03380c75498b" /> |

`ProductDiff` compares the old state and the new state and generates a markdown string in `diff` format, showing where there are changes. AI was used (Claude code) to help refactor the now 3 places where this was being done (Event, Tournament, and official Broadcasts) into this new object.