### PR TITLE
Dont queue spurious sass task on startup & rebuilds

### DIFF
--- a/ui/.build/src/build.ts
+++ b/ui/.build/src/build.ts
@@ -47,6 +47,8 @@ export async function build(pkgs: string[]): Promise<void> {
 }
 
 export function stopBuild(): Promise<any> {
+  env.mustSucceed.clear();
+  env.onSuccess.clear();
   stopTask();
   stopSass();
   stopManifest(true);
@@ -60,19 +62,21 @@ function monitor(pkgs: string[]) {
     includes: [
       { cwd: env.rootDir, path: 'package.json' },
       { cwd: env.typesDir, path: '*/package.json' },
-      { cwd: env.typesDir, path: 'lichess/*.d.ts' },
+      { cwd: env.typesDir, path: '*/*.d.ts' },
       { cwd: env.uiDir, path: '*/package.json' },
       { cwd: env.uiDir, path: '*/tsconfig.json' },
     ],
     debounce: 1000,
     monitorOnly: true,
     execute: async files => {
+      const cleanTsc = files.some(name => name.endsWith('tsconfig.json') || name.endsWith('.d.ts'));
       if (files.some(name => name.endsWith('package.json'))) {
         if (!env.install) env.exit('Exiting due to package.json change');
         await stopBuild();
         if (env.clean) await clean();
+        else if (cleanTsc) await clean(['ui/*/tsconfig.tsbuildinfo']);
         build(pkgs);
-      } else if (files.some(name => name.endsWith('.d.ts') || name.endsWith('tsconfig.json'))) {
+      } else if (cleanTsc) {
         stopManifest();
         await Promise.allSettled([stopTsc(), stopEsbuild()]);
         await clean(['ui/*/tsconfig.tsbuildinfo']);

--- a/ui/.build/src/env.ts
+++ b/ui/.build/src/env.ts
@@ -132,7 +132,7 @@ export const env = new (class {
     if (this.buildOk()) {
       if (this.startTime) {
         const doneMsg = `Done in ${c.green(String((Date.now() - this.startTime) / 1000))}s`;
-        this.log(doneMsg + (this.stdin ? `. Press ${c.grey('<enter>')} to clean and rebuild` : ''));
+        this.log(doneMsg + (this.stdin ? `. Press ${c.grey('<space>')} to trigger clean rebuild` : ''));
       }
       this.onSuccess.forEach(yay => yay());
       this.startTime = undefined;

--- a/ui/.build/src/main.ts
+++ b/ui/.build/src/main.ts
@@ -17,7 +17,6 @@ const args: Record<string, string> = {
   '--no-color': '',
   '--no-time': '',
   '--no-context': '',
-  '--no-corepack': '',
   '--help': 'h',
   '--watch': 'w',
   '--prod': 'p',
@@ -34,7 +33,7 @@ const usage = `Usage:
 
 Options:
   -h, --help          show this help and exit
-  -w, --watch         build and watch for changes
+  -w, --watch         build and watch for changes. press <space> while watching to trigger a clean rebuild
   -c, --clean         clean all build artifacts and build fresh
   -k, --kill          if another ui/build instance is running, kill it rather than bail
   -p, --prod          build minified assets (prod builds)
@@ -47,7 +46,6 @@ Options:
   --no-color          don't use color in logs
   --no-time           don't log the time
   --no-context        don't log the context
-  --no-corepack       don't use corepack to install pnpm (protect or restricted system node installs)
 
 Exclusive Options:    (any of these will disable other functions)
   --tsc               run tsc on {package}/tsconfig.json and dependencies
@@ -122,7 +120,7 @@ if (env.watch && 'setRawMode' in ps.stdin) {
   ps.stdin.on('data', (key: Buffer) => {
     if (key[0] === 3 || key[0] === 27) {
       ps.exit(0);
-    } else if ((key[0] === 13 || key[0] === 10) && tasksIdle()) {
+    } else if (key[0] === 32 && tasksIdle()) {
       stopBuild().then(() => clean('force').then(() => build(argv.filter(x => !x.startsWith('-')))));
     }
   });

--- a/ui/.build/src/task.ts
+++ b/ui/.build/src/task.ts
@@ -94,7 +94,7 @@ export function taskOk(ctx?: Context): boolean {
 
 export const tasksIdle = (): boolean => activeTaskCount === 0;
 
-export function addIncludes(includes: CwdPath | CwdPath[], key: TaskKey): void {
+export async function addIncludes(includes: CwdPath[], key: TaskKey): Promise<void> {
   const t = tasks.get(key);
   if (!t) return;
 
@@ -104,7 +104,11 @@ export function addIncludes(includes: CwdPath | CwdPath[], key: TaskKey): void {
     if (mm.isMatch(join(include.cwd, include.path), existing)) continue;
 
     t.includes.push(include);
-    if (env.watch) watchGlob(include, key);
+    if (!env.watch) continue;
+
+    const globs = await fg.glob(include.path, { cwd: include.cwd, absolute: true });
+    await Promise.all(globs.map(async f => t.fileTimes.set(f, await cachedFileTime(f))));
+    watchGlob(include, key);
   }
 }
 


### PR DESCRIPTION
The addIncludes function in task.ts is a watch convenience. It should not be globbed on first run.
Always blow away tsbuildinfos whenever they might be stale.
Restore the original 'hit <space> to rebuild' key command. I changed it on suspicion that raw mode stdin was being dropped. But all keystrokes were ignored due to the addIncludes bug creating a dead sass task