### PR TITLE
Use image description field as alt text for blogs

### DIFF
--- a/ui/bits/src/toastEditor.ts
+++ b/ui/bits/src/toastEditor.ts
@@ -93,6 +93,7 @@ function toastImageUploadHook(el: HTMLElement) {
         throw `You can only upload ${el.dataset.imageCountMax} images here.`;
       }
       const name = image instanceof File ? image.name : 'image';
+      const desc = el.querySelector<HTMLInputElement>('#toastuiAltTextInput')?.value;
       const { width, height } = await naturalSize(image);
       if (!width || !height) throw `Unsupported image '${name}'`;
       const formData = new FormData();
@@ -104,7 +105,7 @@ function toastImageUploadHook(el: HTMLElement) {
         method: 'POST',
         body: formData,
       });
-      setUrlCallback(imageUrl, name);
+      setUrlCallback(imageUrl, desc || name);
     } catch (e) {
       setUrlCallback('');
       alert(e instanceof ValidationError ? e.message : `Image upload failed: ${e}`);


### PR DESCRIPTION
Closes #18925

## Photo:

Tested in lila-docker
<img width="1350" height="191" alt="blog" src="https://github.com/user-attachments/assets/3e54942e-cbfe-4f74-a5d0-94f122b1198c" />
