### PR TITLE
Show "<user> cannot see your chat right now" notification to the sender

### DIFF
--- a/modules/coreI18n/src/main/key.scala
+++ b/modules/coreI18n/src/main/key.scala
@@ -1647,6 +1647,7 @@ object I18nKey:
     val `strength`: I18nKey = "strength"
     val `toggleTheChat`: I18nKey = "toggleTheChat"
     val `chat`: I18nKey = "chat"
+    val `xCannotSeeYourChatRightNow`: I18nKey = "xCannotSeeYourChatRightNow"
     val `resign`: I18nKey = "resign"
     val `checkmate`: I18nKey = "checkmate"
     val `stalemate`: I18nKey = "stalemate"

--- a/translation/source/site.xml
+++ b/translation/source/site.xml
@@ -18,6 +18,7 @@
   <string name="strength">Strength</string>
   <string name="toggleTheChat">Toggle the chat</string>
   <string name="chat">Chat</string>
+  <string name="xCannotSeeYourChatRightNow">%s cannot see your chat right now.</string>
   <string name="resign">Resign</string>
   <string name="checkmate">Checkmate</string>
   <string name="stalemate">Stalemate</string>

--- a/ui/@types/lichess/i18n.d.ts
+++ b/ui/@types/lichess/i18n.d.ts
@@ -4901,6 +4901,8 @@ interface I18n {
     withNobody: string;
     /** Write a private note about this user */
     writeAPrivateNoteAboutThisUser: string;
+    /** %s cannot see your chat right now. */
+    xCannotSeeYourChatRightNow: I18nFormat;
     /** %1$s competes in %2$s */
     xCompetesInY: I18nFormat;
     /** %1$s created team %2$s */

--- a/ui/lib/src/chat/chatCtrl.ts
+++ b/ui/lib/src/chat/chatCtrl.ts
@@ -142,6 +142,8 @@ export class ChatCtrl {
   };
 
   private readonly onMessage = (line: Line): void => {
+    const previous = this.data.lines[this.data.lines.length - 1];
+    if (line.hidden && previous?.hidden) return;
     this.data.lines.push(line);
     const nb = this.data.lines.length;
     if (nb > this.maxLines) {

--- a/ui/lib/src/chat/discussion.ts
+++ b/ui/lib/src/chat/discussion.ts
@@ -18,6 +18,17 @@ const whisperRegex = /^\/[wW](?:hisper)?\s/;
 const scrollState = { pinToBottom: true, lastScrollTop: 0 };
 let resizeObserver: ResizeObserver | null = null;
 
+export function isChatVisible(): boolean {
+  const el = document.querySelector<HTMLElement>('.mchat');
+  const rect = el?.getBoundingClientRect();
+  return Boolean(
+    el &&
+    rect &&
+    el.querySelector('.mchat__messages') &&
+    Math.min(rect.bottom, window.innerHeight) - Math.max(rect.top, 0) >= 48,
+  );
+}
+
 const scrollToBottom = (el: HTMLElement, smooth: boolean): void => {
   if (document.hidden || !smooth) el.scrollTop = el.scrollHeight;
   else if (el.scrollTop + el.clientHeight < el.scrollHeight)

--- a/ui/lib/src/chat/interfaces.ts
+++ b/ui/lib/src/chat/interfaces.ts
@@ -46,6 +46,7 @@ export interface Line {
   u?: string; // username
   t: string; // text
   d: boolean; // deleted
+  hidden?: boolean;
   c?: Color;
   r?: boolean; // troll
   pc?: PatronColor;

--- a/ui/lib/src/view/complete.ts
+++ b/ui/lib/src/view/complete.ts
@@ -56,7 +56,7 @@ export function complete<Result>(opts: CompleteOpts<Result>): void {
   const update = () => {
     const term = opts.input.value.trim();
     if (term.length >= minLength && (!opts.regex || term.match(opts.regex)))
-      fetchResults(term).then(renderResults, console.log);
+      fetchResults(term).then(renderResults, site.debug ? console.log : () => {});
     else $container.addClass('none');
   };
 

--- a/ui/round/src/round.ts
+++ b/ui/round/src/round.ts
@@ -1,6 +1,7 @@
 import { attributesModule, classModule, init } from 'snabbdom';
 
 import { myUserId } from 'lib';
+import { isChatVisible } from 'lib/chat/discussion';
 import standaloneChat from 'lib/chat/standalone';
 import { finished, type TourPlayer } from 'lib/game';
 import { setClockWidget } from 'lib/game/clock/clockWidget';
@@ -131,8 +132,16 @@ async function boot(
           if (
             line.u === 'lichess' &&
             (startsWithPrefix(line.t, 'warning') || startsWithPrefix(line.t, 'reminder'))
-          )
+          ) {
             alert(line.t);
+          } else if (data.opponent.user && !data.player.spectator) {
+            if (line.hidden) {
+              line.t = i18n.site.xCannotSeeYourChatRightNow(data.opponent.user.username);
+              chat.instance?.redraw();
+            } else if (line.u?.toLowerCase() === chat.data.opponentId && !isChatVisible()) {
+              pubsub.emit('socket.send', 'chatHidden');
+            }
+          }
         });
     }
   }


### PR DESCRIPTION
This requires https://github.com/lichess-org/lila-ws/pull/911

It shows in non-tournament/non-simul games when one player sends a chat message but the other player can't see it due to tabs, zen mode, or viewport culling

<img width="358" height="112" alt="image" src="https://github.com/user-attachments/assets/2ebc585d-84b1-4d2d-addb-26aaa258e657" />
