### PR TITLE
ui: drop commit messages on /source page, open links in new tab

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -48,7 +48,7 @@ jobs:
           cache: sbt
       - name: Setup sbt
         uses: sbt/setup-sbt@bfea3c5f48abd221b04a6df4798aa5eb8b6a2baf # v1.5.6
-      - run: TZ=UTC git log -1 --date=iso-strict-local --pretty='format:app.version.commit = "%H"%napp.version.date = "%ad"%napp.version.message = """%s"""%n' | tee conf/version.conf
+      - run: TZ=UTC git log -1 --date=iso-strict-local --pretty='format:app.version.commit = "%H"%napp.version.date = "%ad"' | tee conf/version.conf
       - run: ./lila.sh -Depoll=true "test;stage"
       - run: cp LICENSE COPYING.md README.md target/universal/stage && git log -n 1 --pretty=oneline > target/universal/stage/commit.txt
       - run: cd target/universal/stage && tar --zstd -cvpf ../../../lila-3.0.tar.zst . && cd -

--- a/modules/web/src/main/WebConfig.scala
+++ b/modules/web/src/main/WebConfig.scala
@@ -63,10 +63,9 @@ object WebConfig:
     logRequests = c.get[Boolean]("net.http.log")
   )
 
-  final class LilaVersion(val date: String, val commit: String, val message: String)
+  final class LilaVersion(val date: String, val commit: String)
 
   def lilaVersion(c: Configuration): Option[LilaVersion] = (
     c.getOptional[String]("app.version.date"),
-    c.getOptional[String]("app.version.commit"),
-    c.getOptional[String]("app.version.message")
+    c.getOptional[String]("app.version.commit")
   ).mapN(LilaVersion.apply)

--- a/modules/web/src/main/ui/SitePages.scala
+++ b/modules/web/src/main/ui/SitePages.scala
@@ -210,20 +210,6 @@ final class SitePages(helpers: Helpers):
         )
 
   private val repoRoot = "https://github.com/lichess-org/lila"
-  private val pullRequestRegex = raw"#(\d+)".r
-
-  private def versionMessage(message: String): Frag =
-    pullRequestRegex.findFirstMatchIn(message) match
-      case None => message
-      case Some(m) =>
-        frag(
-          message.substring(0, m.start),
-          a(
-            href := s"$repoRoot/pull/${m.group(1)}",
-            target := "_blank"
-          )(m.matched),
-          message.substring(m.end)
-        )
 
   def source(title: String, rendered: Frag, version: Option[WebConfig.LilaVersion])(using
       Context
@@ -250,7 +236,7 @@ final class SitePages(helpers: Helpers):
                       span(a(href := s"$repoRoot/commits/${v.commit}"):
                         pre(v.commit.take(7)))
                     ),
-                    td(versionMessage(v.message)),
+                    td(cls := "github-auto-link")(v.message),
                     td:
                       a(href := s"$repoRoot/compare/${v.commit}...master"):
                         pre("...")
@@ -261,7 +247,7 @@ final class SitePages(helpers: Helpers):
                     timeTag(id := "asset-version-date"),
                     span(a(id := "asset-version-commit")(pre))
                   ),
-                  td(id := "asset-version-message"),
+                  td(id := "asset-version-message", cls := "github-auto-link"),
                   td(a(id := "asset-version-upcoming")(pre("...")))
                 )
               )

--- a/modules/web/src/main/ui/SitePages.scala
+++ b/modules/web/src/main/ui/SitePages.scala
@@ -209,6 +209,22 @@ final class SitePages(helpers: Helpers):
           }
         )
 
+  private val repoRoot = "https://github.com/lichess-org/lila"
+  private val pullRequestRegex = raw"#(\d+)".r
+
+  private def versionMessage(message: String): Frag =
+    pullRequestRegex.findFirstMatchIn(message) match
+      case None => message
+      case Some(m) =>
+        frag(
+          message.substring(0, m.start),
+          a(
+            href := s"$repoRoot/pull/${m.group(1)}",
+            target := "_blank"
+          )(m.matched),
+          message.substring(m.end)
+        )
+
   def source(title: String, rendered: Frag, version: Option[WebConfig.LilaVersion])(using
       Context
   ) =
@@ -231,12 +247,12 @@ final class SitePages(helpers: Helpers):
                     td(
                       span("Server"),
                       timeTag(v.date),
-                      span(a(href := s"https://github.com/lichess-org/lila/commits/${v.commit}"):
+                      span(a(href := s"$repoRoot/commits/${v.commit}"):
                         pre(v.commit.take(7)))
                     ),
-                    td(v.message),
+                    td(versionMessage(v.message)),
                     td:
-                      a(href := s"https://github.com/lichess-org/lila/compare/${v.commit}...master"):
+                      a(href := s"$repoRoot/compare/${v.commit}...master"):
                         pre("...")
                   ),
                 tr(

--- a/modules/web/src/main/ui/SitePages.scala
+++ b/modules/web/src/main/ui/SitePages.scala
@@ -211,15 +211,15 @@ final class SitePages(helpers: Helpers):
 
   private val repoRoot = "https://github.com/lichess-org/lila"
 
-  def source(title: String, rendered: Frag, version: Option[WebConfig.LilaVersion])(using
+  def source(pageTitle: String, rendered: Frag, version: Option[WebConfig.LilaVersion])(using
       Context
   ) =
-    SitePage(title = title, active = "source", contentCls = "page force-ltr")
+    SitePage(title = pageTitle, active = "source", contentCls = "page force-ltr")
       .css("bits.source")
       .js(esmInitBit("setAssetInfo")):
         frag(
           st.section(cls := "box")(
-            h1(cls := "box__top")(title),
+            h1(cls := "box__top")(pageTitle),
             table(cls := "slist slist-pad", id := "version")(
               thead(
                 tr(
@@ -232,23 +232,23 @@ final class SitePages(helpers: Helpers):
                   tr(
                     td(
                       span("Server"),
-                      timeTag(v.date),
-                      span(a(href := s"$repoRoot/commits/${v.commit}"):
-                        pre(v.commit.take(7)))
+                      timeTag(v.date)
                     ),
-                    td(cls := "github-auto-link")(v.message),
-                    td:
-                      a(href := s"$repoRoot/compare/${v.commit}...master"):
+                    td(span(a(href := s"$repoRoot/commits/${v.commit}"):
+                      pre(v.commit.take(7)))),
+                    td(
+                      a(href := s"$repoRoot/compare/${v.commit}...master", title := "Upcoming changes")(
                         pre("...")
+                      )
+                    )
                   ),
                 tr(
                   td(
                     "Assets",
-                    timeTag(id := "asset-version-date"),
-                    span(a(id := "asset-version-commit")(pre))
+                    timeTag(id := "asset-version-date")
                   ),
-                  td(id := "asset-version-message", cls := "github-auto-link"),
-                  td(a(id := "asset-version-upcoming")(pre("...")))
+                  td(a(id := "asset-version-commit")(pre)),
+                  td(a(id := "asset-version-upcoming", title := "Upcoming changes")(pre("...")))
                 )
               )
             )

--- a/ui/.build/src/manifest.ts
+++ b/ui/.build/src/manifest.ts
@@ -50,18 +50,12 @@ export function updateManifest(update: ManifestUpdate = {}): void {
 
 async function writeManifest() {
   if (!env.buildOk()) return;
-  const commitMessage = cps
-    .execSync('git log -1 --pretty=%s', { encoding: 'utf-8' })
-    .trim()
-    .replaceAll("'", '&#39;')
-    .replaceAll('"', '&quot;');
 
   const clientJs: string[] = [
     'if (!window.site) window.site={};',
     'const s=window.site;',
     's.info={};',
     `s.info.commit='${cps.execSync('git rev-parse -q HEAD', { encoding: 'utf-8' }).trim()}';`,
-    `s.info.message='${commitMessage}';`,
     `s.debug=${env.debug};`,
     's.asset={loadEsm:(m,o)=>import(`/assets/compiled/${m}${s.manifest.js[m]?"."+s.manifest.js[m]:""}.js`)' +
       '.then(x=>(x.initModule||x.default)(o.init))};',

--- a/ui/bits/css/build/bits.source.scss
+++ b/ui/bits/css/build/bits.source.scss
@@ -22,9 +22,5 @@
       float: left;
       margin-top: 8px;
     }
-
-    pre {
-      font-size: 13px;
-    }
   }
 }

--- a/ui/bits/css/build/bits.source.scss
+++ b/ui/bits/css/build/bits.source.scss
@@ -7,6 +7,15 @@
   td:first-child {
     @extend %flex-column;
 
-    gap: 1ch;
+    gap: 8px;
+    line-height: 1;
+
+    time {
+      color: $c-font-dim;
+    }
+
+    pre {
+      font-size: 13px;
+    }
   }
 }

--- a/ui/bits/css/build/bits.source.scss
+++ b/ui/bits/css/build/bits.source.scss
@@ -4,14 +4,23 @@
 @import '../page';
 
 #version {
+  th:first-child,
   td:first-child {
-    @extend %flex-column;
+    width: 1px;
+    white-space: nowrap;
+  }
 
-    gap: 8px;
+  td:last-child {
+    width: 1px;
+  }
+
+  td:first-child {
     line-height: 1;
 
     time {
       color: $c-font-dim;
+      float: left;
+      margin-top: 8px;
     }
 
     pre {

--- a/ui/bits/src/bits.ts
+++ b/ui/bits/src/bits.ts
@@ -1,4 +1,3 @@
-import { githubAutoLinks, githubRepoRoot } from 'lib';
 import { spinnerHtml } from 'lib/view';
 import { text } from 'lib/xhr';
 
@@ -189,6 +188,8 @@ function relayForm() {
   showSource();
 }
 
+const githubRepoRoot = 'https://github.com/lichess-org/lila';
+
 function setAssetInfo() {
   $('#asset-version-date').text(site.info.date);
   $('#asset-version-commit')
@@ -201,13 +202,6 @@ function setAssetInfo() {
     .attr('target', '_blank')
     .find('pre')
     .text('...');
-
-  $('#asset-version-message').text(site.info.message);
-
-  $('.github-auto-link').each(function (this: HTMLElement) {
-    if (!this.textContent) return;
-    this.innerHTML = githubAutoLinks(this.textContent);
-  });
 }
 
 function streamerSubscribe() {

--- a/ui/bits/src/bits.ts
+++ b/ui/bits/src/bits.ts
@@ -207,9 +207,8 @@ function setAssetInfo() {
   $('#asset-version-message').text(site.info.message);
 
   $('.github-auto-link').each(function (this: HTMLElement) {
-    const text = this.textContent || '';
-    const html = githubAutoLinks(text);
-    this.innerHTML = html;
+    if (!this.textContent) return;
+    this.innerHTML = githubAutoLinks(this.textContent);
   });
 }
 

--- a/ui/bits/src/bits.ts
+++ b/ui/bits/src/bits.ts
@@ -1,4 +1,4 @@
-import { githubAutoLinks } from 'lib';
+import { githubAutoLinks, githubRepoRoot } from 'lib';
 import { spinnerHtml } from 'lib/view';
 import { text } from 'lib/xhr';
 
@@ -190,16 +190,14 @@ function relayForm() {
 }
 
 function setAssetInfo() {
-  const repoRoot = 'https://github.com/lichess-org/lila';
-
   $('#asset-version-date').text(site.info.date);
   $('#asset-version-commit')
-    .attr('href', repoRoot + '/commits/' + site.info.commit)
+    .attr('href', githubRepoRoot + '/commits/' + site.info.commit)
     .attr('target', '_blank')
     .find('pre')
     .text(site.info.commit.slice(0, 7));
   $('#asset-version-upcoming')
-    .attr('href', repoRoot + '/compare/' + site.info.commit + '...master')
+    .attr('href', githubRepoRoot + '/compare/' + site.info.commit + '...master')
     .attr('target', '_blank')
     .find('pre')
     .text('...');

--- a/ui/bits/src/bits.ts
+++ b/ui/bits/src/bits.ts
@@ -203,22 +203,19 @@ function setAssetInfo() {
     .find('pre')
     .text('...');
 
-  const text = 'Merge pull request #21394 from Simek/ui-small-tweaks-for-transparent-themes';
+  const text = site.info.message;
   const match = text.match(/#(\d+)/);
 
   if (match?.index === undefined) {
     $('#asset-version-message').text(text);
   } else {
-    const before = text.slice(0, match.index);
-    const after = text.slice(match.index + match[0].length);
-
     $('#asset-version-message').append(
-      document.createTextNode(before),
+      document.createTextNode(text.slice(0, match.index)),
       $('<a>')
         .attr('href', repoRoot + '/pull/' + match[1])
         .attr('target', '_blank')
         .text(match[0]),
-      document.createTextNode(after),
+      document.createTextNode(text.slice(match.index + match[0].length)),
     );
   }
 }

--- a/ui/bits/src/bits.ts
+++ b/ui/bits/src/bits.ts
@@ -1,3 +1,4 @@
+import { githubAutoLinks } from 'lib';
 import { spinnerHtml } from 'lib/view';
 import { text } from 'lib/xhr';
 
@@ -203,21 +204,13 @@ function setAssetInfo() {
     .find('pre')
     .text('...');
 
-  const text = site.info.message;
-  const match = text.match(/#(\d+)/);
+  $('#asset-version-message').text(site.info.message);
 
-  if (match?.index === undefined) {
-    $('#asset-version-message').text(text);
-  } else {
-    $('#asset-version-message').append(
-      document.createTextNode(text.slice(0, match.index)),
-      $('<a>')
-        .attr('href', repoRoot + '/pull/' + match[1])
-        .attr('target', '_blank')
-        .text(match[0]),
-      document.createTextNode(text.slice(match.index + match[0].length)),
-    );
-  }
+  $('.github-auto-link').each(function (this: HTMLElement) {
+    const text = this.textContent || '';
+    const html = githubAutoLinks(text);
+    this.innerHTML = html;
+  });
 }
 
 function streamerSubscribe() {

--- a/ui/bits/src/bits.ts
+++ b/ui/bits/src/bits.ts
@@ -189,16 +189,38 @@ function relayForm() {
 }
 
 function setAssetInfo() {
+  const repoRoot = 'https://github.com/lichess-org/lila';
+
   $('#asset-version-date').text(site.info.date);
   $('#asset-version-commit')
-    .attr('href', 'https://github.com/lichess-org/lila/commits/' + site.info.commit)
+    .attr('href', repoRoot + '/commits/' + site.info.commit)
+    .attr('target', '_blank')
     .find('pre')
     .text(site.info.commit.slice(0, 7));
   $('#asset-version-upcoming')
-    .attr('href', 'https://github.com/lichess-org/lila/compare/' + site.info.commit + '...master')
+    .attr('href', repoRoot + '/compare/' + site.info.commit + '...master')
+    .attr('target', '_blank')
     .find('pre')
     .text('...');
-  $('#asset-version-message').text(site.info.message);
+
+  const text = 'Merge pull request #21394 from Simek/ui-small-tweaks-for-transparent-themes';
+  const match = text.match(/#(\d+)/);
+
+  if (match?.index === undefined) {
+    $('#asset-version-message').text(text);
+  } else {
+    const before = text.slice(0, match.index);
+    const after = text.slice(match.index + match[0].length);
+
+    $('#asset-version-message').append(
+      document.createTextNode(before),
+      $('<a>')
+        .attr('href', repoRoot + '/pull/' + match[1])
+        .attr('target', '_blank')
+        .text(match[0]),
+      document.createTextNode(after),
+    );
+  }
 }
 
 function streamerSubscribe() {

--- a/ui/lib/src/richText.ts
+++ b/ui/lib/src/richText.ts
@@ -16,6 +16,7 @@ export const newLineRegex: RegExp = /\n/g;
 export const userPattern: RegExp = /(^|[^\w@#/])@([a-z0-9_-]{2,30})/gi;
 export const movePattern: RegExp =
   /\b(\d+)\s*(\.+)\s*(?:[o0-]+[o0]|[NBRQK\u2654\u2655\u2656\u2657\u2658]?[a-h]?[1-8]?[x@]?[a-h][1-8](?:=[NBRQK\u2654\u2655\u2656\u2657\u2658\u2659])?)\+?#?[!\?=]{0,5}/gi;
+export const githubRefPattern: RegExp = /(^|[^\w#])#(\d+)\b/g;
 /* oxlint-enable no-inferrable-types */
 
 // looks like it has a @mention or #gameid or a url.tld
@@ -56,6 +57,14 @@ export const userLinkReplace = (_: string, prefix: string, user: string): string
   prefix + linkReplace('/@/' + user, '@' + user);
 
 export const expandMentions = (html: string): string => html.replace(userPattern, userLinkReplace);
+
+const githubRepoRoot = 'https://github.com/lichess-org/lila';
+
+const githubRefReplace = (_: string, prefix: string, id: string): string =>
+  prefix + linkHtml(`${githubRepoRoot}/issues/${id}`, `#${id}`);
+
+export const githubAutoLinks = (text: string): string =>
+  escapeHtml(text).replace(githubRefPattern, githubRefReplace);
 
 export function enrichText(text: string, allowNewlines = true): string {
   let html = autolink(escapeHtml(text), toLink);

--- a/ui/lib/src/richText.ts
+++ b/ui/lib/src/richText.ts
@@ -58,7 +58,7 @@ export const userLinkReplace = (_: string, prefix: string, user: string): string
 
 export const expandMentions = (html: string): string => html.replace(userPattern, userLinkReplace);
 
-const githubRepoRoot = 'https://github.com/lichess-org/lila';
+export const githubRepoRoot = 'https://github.com/lichess-org/lila';
 
 const githubRefReplace = (_: string, prefix: string, id: string): string =>
   prefix + linkHtml(`${githubRepoRoot}/issues/${id}`, `#${id}`);

--- a/ui/lib/src/richText.ts
+++ b/ui/lib/src/richText.ts
@@ -16,7 +16,6 @@ export const newLineRegex: RegExp = /\n/g;
 export const userPattern: RegExp = /(^|[^\w@#/])@([a-z0-9_-]{2,30})/gi;
 export const movePattern: RegExp =
   /\b(\d+)\s*(\.+)\s*(?:[o0-]+[o0]|[NBRQK\u2654\u2655\u2656\u2657\u2658]?[a-h]?[1-8]?[x@]?[a-h][1-8](?:=[NBRQK\u2654\u2655\u2656\u2657\u2658\u2659])?)\+?#?[!\?=]{0,5}/gi;
-export const githubRefPattern: RegExp = /(^|[^\w#])#(\d+)\b/g;
 /* oxlint-enable no-inferrable-types */
 
 // looks like it has a @mention or #gameid or a url.tld
@@ -57,14 +56,6 @@ export const userLinkReplace = (_: string, prefix: string, user: string): string
   prefix + linkReplace('/@/' + user, '@' + user);
 
 export const expandMentions = (html: string): string => html.replace(userPattern, userLinkReplace);
-
-export const githubRepoRoot = 'https://github.com/lichess-org/lila';
-
-const githubRefReplace = (_: string, prefix: string, id: string): string =>
-  prefix + linkHtml(`${githubRepoRoot}/issues/${id}`, `#${id}`);
-
-export const githubAutoLinks = (text: string): string =>
-  escapeHtml(text).replace(githubRefPattern, githubRefReplace);
 
 export function enrichText(text: string, allowNewlines = true): string {
   let html = autolink(escapeHtml(text), toLink);

--- a/ui/lib/tests/richText.test.ts
+++ b/ui/lib/tests/richText.test.ts
@@ -2,14 +2,7 @@ import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 
 import { each } from '../../.test/helpers.mts';
-import {
-  enhance,
-  type EnhanceOpts,
-  githubAutoLinks,
-  linkRegex,
-  movePattern,
-  userPattern,
-} from '../src/richText';
+import { enhance, type EnhanceOpts, linkRegex, movePattern, userPattern } from '../src/richText';
 
 describe('test regex patterns', () => {
   test('username mentions', () => {
@@ -81,43 +74,6 @@ describe('test regex patterns', () => {
     assert.strictEqual(
       enhance(`see ${url}`),
       `see <a target="_blank" rel="nofollow noreferrer" href="//${linked}">${linked}</a>`,
-    );
-  });
-});
-
-describe('githubAutoLinks', () => {
-  const link = (id: string) =>
-    `<a target="_blank" rel="nofollow noreferrer" href="https://github.com/lichess-org/lila/issues/${id}">#${id}</a>`;
-
-  test('links an issue/PR', () => {
-    assert.strictEqual(githubAutoLinks('fixes #123'), `fixes ${link('123')}`);
-  });
-
-  test('link merged PR', () => {
-    assert.strictEqual(githubAutoLinks('Merge pull request #21393'), `Merge pull request ${link('21393')}`);
-  });
-
-  test('links multiple refs', () => {
-    assert.strictEqual(githubAutoLinks('see #1 and #22'), `see ${link('1')} and ${link('22')}`);
-  });
-
-  test('leaves plain text untouched', () => {
-    assert.strictEqual(githubAutoLinks('no references here'), 'no references here');
-  });
-
-  test('does not link a bare hash', () => {
-    assert.strictEqual(githubAutoLinks('c# is a language'), 'c# is a language');
-  });
-
-  test('only matches digits', () => {
-    assert.strictEqual(githubAutoLinks('color#123456'), 'color#123456');
-    assert.strictEqual(githubAutoLinks('#123abc'), '#123abc');
-  });
-
-  test('escapes surrounding html', () => {
-    assert.strictEqual(
-      githubAutoLinks('<script>alert(1)</script> #123'),
-      `&lt;script&gt;alert(1)&lt;/script&gt; ${link('123')}`,
     );
   });
 });

--- a/ui/lib/tests/richText.test.ts
+++ b/ui/lib/tests/richText.test.ts
@@ -2,7 +2,14 @@ import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 
 import { each } from '../../.test/helpers.mts';
-import { enhance, type EnhanceOpts, githubAutoLinks, linkRegex, movePattern, userPattern } from '../src/richText';
+import {
+  enhance,
+  type EnhanceOpts,
+  githubAutoLinks,
+  linkRegex,
+  movePattern,
+  userPattern,
+} from '../src/richText';
 
 describe('test regex patterns', () => {
   test('username mentions', () => {

--- a/ui/lib/tests/richText.test.ts
+++ b/ui/lib/tests/richText.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 
 import { each } from '../../.test/helpers.mts';
-import { enhance, EnhanceOpts, linkRegex, movePattern, userPattern } from '../src/richText';
+import { enhance, type EnhanceOpts, githubAutoLinks, linkRegex, movePattern, userPattern } from '../src/richText';
 
 describe('test regex patterns', () => {
   test('username mentions', () => {
@@ -74,6 +74,43 @@ describe('test regex patterns', () => {
     assert.strictEqual(
       enhance(`see ${url}`),
       `see <a target="_blank" rel="nofollow noreferrer" href="//${linked}">${linked}</a>`,
+    );
+  });
+});
+
+describe('githubAutoLinks', () => {
+  const link = (id: string) =>
+    `<a target="_blank" rel="nofollow noreferrer" href="https://github.com/lichess-org/lila/issues/${id}">#${id}</a>`;
+
+  test('links an issue/PR', () => {
+    assert.strictEqual(githubAutoLinks('fixes #123'), `fixes ${link('123')}`);
+  });
+
+  test('link merged PR', () => {
+    assert.strictEqual(githubAutoLinks('Merge pull request #21393'), `Merge pull request ${link('21393')}`);
+  });
+
+  test('links multiple refs', () => {
+    assert.strictEqual(githubAutoLinks('see #1 and #22'), `see ${link('1')} and ${link('22')}`);
+  });
+
+  test('leaves plain text untouched', () => {
+    assert.strictEqual(githubAutoLinks('no references here'), 'no references here');
+  });
+
+  test('does not link a bare hash', () => {
+    assert.strictEqual(githubAutoLinks('c# is a language'), 'c# is a language');
+  });
+
+  test('only matches digits', () => {
+    assert.strictEqual(githubAutoLinks('color#123456'), 'color#123456');
+    assert.strictEqual(githubAutoLinks('#123abc'), '#123abc');
+  });
+
+  test('escapes surrounding html', () => {
+    assert.strictEqual(
+      githubAutoLinks('<script>alert(1)</script> #123'),
+      `&lt;script&gt;alert(1)&lt;/script&gt; ${link('123')}`,
     );
   });
 });


### PR DESCRIPTION
# How

Add regex based code to link PRs mentioned in commit messages shown on `/source` to make it easier to access given changeset. 

The formatter had to be implemented in Scala and JS since server message is set on server, while asset one is filled out dynamically client-side. Small visual tweaks for source rows, open all external link in new tab.

If this seems like too much hassle for the too niche usecase, if fine with closing this one.

# Preview

<img width="1153" height="360" alt="Screenshot 2026-08-27 at 11 54 46" src="https://github.com/user-attachments/assets/f56ef076-17f5-4b5f-9cf6-0466a37fdaad" />
