### PR TITLE
Honour the outside coordinates preference when material is shown

### DIFF
--- a/ui/analyse/css/_player-clock.scss
+++ b/ui/analyse/css/_player-clock.scss
@@ -21,6 +21,11 @@ $clock-height: 20px;
     top: var(---cg-height, 100%);
     z-index: 1; // over the board coords
 
+    // outer file coordinates hang 15px below the board, see lib/css/theme/board/_coords.scss
+    .coords-out .is2d & {
+      top: calc(var(---cg-height, 100%) + 15px);
+    }
+
     .is3d & {
       top: calc(var(---cg-height, 100%) + 15px);
     }

--- a/ui/analyse/src/view/components.ts
+++ b/ui/analyse/src/view/components.ts
@@ -77,7 +77,7 @@ export function viewContext(ctrl: AnalyseCtrl, deps?: typeof studyDeps): ViewCon
     playerBars,
     playerStrips: playerBars ? undefined : renderPlayerStrips(ctrl),
     gaugeOn: ctrl.showEvalGauge(),
-    needsInnerCoords: ctrl.data.pref.showCaptured || ctrl.showEvalGauge() || !!playerBars,
+    needsInnerCoords: ctrl.showEvalGauge() || !!playerBars,
     hasRelayTour: ctrl.study?.relay?.tourShow() || false,
   };
 }


### PR DESCRIPTION
Fixes #15635

### Problem

With **Board coordinates: outside the board**, the analysis board draws them on the squares anyway.

`needsInnerCoords` in `ui/analyse/src/view/components.ts` is:

```ts
needsInnerCoords: ctrl.data.pref.showCaptured || ctrl.showEvalGauge() || !!playerBars,
```

`showCaptured` is on by default, so for most users the preference is overridden on `/analysis`
before the eval gauge or player bars are involved at all. Reproduced on a local lila with
coordinates set to outside, engine off, no player bars:

| reading | value |
| --- | --- |
| `pref.coords` | `2` (outside) |
| `pref.showCaptured` | `true` |
| `showEvalGauge()` | `false` |
| player bars | none |
| body class | **`coords-in`** |

<img width="1456" height="839" alt="15635-1-before-coords-inside" src="https://github.com/user-attachments/assets/72898f8c-8147-4cd1-a870-21eb617c0922" />

<img width="1020" height="380" alt="15635-2-before-zoom" src="https://github.com/user-attachments/assets/de1395bd-a9de-4f61-b1b3-e79a6848847f" />

### Why the override exists

Not arbitrary. `.analyse__player_strip.bottom` is absolutely positioned at the bottom edge of the board and given `z-index: 1`, with the comment *"over the board coords"*. Outer file coordinates hang 15px below the board (`bottom: -15px` in `lib/css/theme/board/_coords.scss`), so the strip lands on top of them. Measured on the position after `1. e4 d5 2. exd5`, where the strip shows a pawn and `+1`:

| | value |
| --- | --- |
| file coordinates | 839 → 856 |
| strip | starts at 841 |
| overlap | **15px**, painted over by `z-index: 1` |

### Fix

Move the strip below the coordinates when they are outside, then stop forcing inner coordinates for `showCaptured`.

The 15px offset is not new: `.is3d &` in the same rule already does exactly this. The new rule is scoped to `.coords-out .is2d` because outer file coordinates only exist on 2d boards (`.coords-out .is2d coords.files` in `_coords.scss`).

`showEvalGauge()` and `playerBars` still force inner coordinates. The gauge case is the one @kraktus described on the issue - it occupies the gutter the rank coordinates need, which is a horizontal conflict rather than a vertical one, so it is not addressed here.

### Testing

Checked by hand on a local lila (lila-docker), coordinates set to outside, on the position after
`1. e4 d5 2. exd5` so the strip has real content:

| case | before | after |
| --- | --- | --- |
| material shown, no gauge | `coords-in` — preference ignored | `coords-out` — honoured |
| strip vs file coordinates | 15px overlap | 0px overlap, material still visible |
| eval gauge on | `coords-in` | `coords-in`, unchanged |
| gauge on then off again | — | returns to `coords-out` |

<img width="1456" height="839" alt="15635-3-after-coords-outside" src="https://github.com/user-attachments/assets/a66e0a60-5b33-4a62-86da-d7f6f26a1d1a" />

<img width="1020" height="202" alt="15635-4-after-zoom" src="https://github.com/user-attachments/assets/551b4d60-22de-4873-978f-c7cc89013495" />


`pnpm lint`, `pnpm check-format` and `tsc` are clean.

Coordinates set to *inside* are untouched by construction: `forceInnerCoords` returns early unless `pref.coords === Outside`.

I have not exercised the player-bars path (studies and broadcasts), which keeps its override either way.