### PR TITLE
Fix memory leak in event stream bus subscriptions

### DIFF
--- a/modules/api/src/main/EventStream.scala
+++ b/modules/api/src/main/EventStream.scala
@@ -72,8 +72,8 @@ final class EventStream(
       override def postStop() =
         super.postStop()
         channels.foreach(Bus.unsubscribeActorRefDyn(self, _))
-        Bus.subscribeActorRef[lila.core.challenge.PositiveEvent](self)
-        Bus.subscribeActorRef[NegativeEvent](self)
+        Bus.unsubscribeActorRef[lila.core.challenge.PositiveEvent](self)
+        Bus.unsubscribeActorRef[NegativeEvent](self)
         queue.complete()
 
       self ! SetOnline


### PR DESCRIPTION
Looks like a typo

Tested on `lila-docker` by opening and closing `/api/stream/event` connections and counting `ActorTellable` instances with `jcmd GC.class_histogram`, before and after the change.

Claude Code helped verify the problem after I discovered it.
Prompt (with the 2 changed lines given as context): Verify if these two lines cause a memory leak or cause other problems