### PR TITLE
ui: an another batch of transparent theme tweaks

### DIFF
--- a/app/views/lobby/home.scala
+++ b/app/views/lobby/home.scala
@@ -91,9 +91,7 @@ object home:
             if ctx.isAuth then
               div(cls := "lobby__timeline")(
                 ctx.blind.option(h2(trans.site.timeline())),
-                views.timeline.entries(userTimeline),
-                userTimeline.nonEmpty.option:
-                  a(cls := "more", href := routes.Timeline.home)(trans.site.more(), " »")
+                views.timeline.entries(userTimeline)
               )
             else
               div(cls := "about-side")(

--- a/modules/timeline/src/main/TimelineUi.scala
+++ b/modules/timeline/src/main/TimelineUi.scala
@@ -10,13 +10,12 @@ final class TimelineUi(helpers: Helpers):
   import helpers.{ *, given }
 
   def entries(entries: Vector[Entry])(using Context) =
-    div(cls := "entries"):
-      frag(
-        filterEntries(entries).map: entry =>
-          div(cls := "entry")(renderEntry(entry)),
-        entries.nonEmpty.option:
-          a(cls := "more", href := routes.Timeline.home)(trans.site.more(), " »")
-      )
+    div(cls := "entries")(
+      filterEntries(entries).map: entry =>
+        div(cls := "entry")(renderEntry(entry)),
+      entries.nonEmpty.option:
+        a(cls := "more", href := routes.Timeline.home)(trans.site.more(), " »")
+    )
 
   def more(entries: Vector[Entry])(using Context) =
     Page(trans.site.timeline.txt())

--- a/modules/timeline/src/main/TimelineUi.scala
+++ b/modules/timeline/src/main/TimelineUi.scala
@@ -11,8 +11,12 @@ final class TimelineUi(helpers: Helpers):
 
   def entries(entries: Vector[Entry])(using Context) =
     div(cls := "entries"):
-      filterEntries(entries).map: entry =>
-        div(cls := "entry")(renderEntry(entry))
+      frag(
+        filterEntries(entries).map: entry =>
+          div(cls := "entry")(renderEntry(entry)),
+        entries.nonEmpty.option:
+          a(cls := "more", href := routes.Timeline.home)(trans.site.more(), " »")
+      )
 
   def more(entries: Vector[Entry])(using Context) =
     Page(trans.site.timeline.txt())

--- a/ui/analyse/css/_analyse.free.scss
+++ b/ui/analyse/css/_analyse.free.scss
@@ -17,6 +17,8 @@ $label-width: 5ch;
   }
 
   .copyable {
+    @include backdrop-blur-if-transparent;
+
     flex: 1 1 auto;
   }
 

--- a/ui/analyse/css/_player-clock.scss
+++ b/ui/analyse/css/_player-clock.scss
@@ -33,6 +33,7 @@ $clock-height: 20px;
 }
 
 .analyse__clock {
+  @include backdrop-blur-if-transparent;
   @extend %metal-bg;
 
   padding: 0 0.5em;

--- a/ui/bits/css/_clas.scss
+++ b/ui/bits/css/_clas.scss
@@ -319,9 +319,11 @@ h1 {
         color: $c-clas-light;
         font-weight: bold;
 
-        .dashboard-teacher-overview &,
-        .dashboard-teacher-progress & {
-          background: $c-bg-zebra;
+        @include if-not-transp {
+          .dashboard-teacher-overview &,
+          .dashboard-teacher-progress & {
+            background: $c-bg-zebra;
+          }
         }
       }
     }

--- a/ui/keyboardMove/css/_keyboardMove.scss
+++ b/ui/keyboardMove/css/_keyboardMove.scss
@@ -4,13 +4,14 @@
   height: fit-content;
 
   input {
+    @include transition;
+    @include backdrop-blur-if-transparent;
+
     width: 4.5em;
     font-size: 1.1em;
     font-weight: bold;
     margin-inline-end: 1rem;
     border: $border;
-
-    @include transition;
 
     &.wrong {
       background: $c-bad;

--- a/ui/lib/css/abstract/_theme.scss
+++ b/ui/lib/css/abstract/_theme.scss
@@ -29,6 +29,12 @@ $outline: 2px solid $c-primary;
   }
 }
 
+@mixin if-not-transp {
+  html:not(.transp) & {
+    @content;
+  }
+}
+
 @mixin theme-style {
   html.transp::before {
     content: ' ';

--- a/ui/lib/css/theme/_theme.transp.light.scss
+++ b/ui/lib/css/theme/_theme.transp.light.scss
@@ -13,8 +13,8 @@ html.transp.light {
   --c-bg-opaque: hsl(0 0% 100% / 0.9);
   --c-bg-low: hsl(0 0% 100% / 0.5);
   --c-bg-mid: hsl(0 0% 85% / 0.4);
-  --c-bg-zebra: hsl(0 0% 100% / 0.2);
-  --c-bg-zebra2: hsl(0 0% 100% / 0.35);
+  --c-bg-zebra: hsl(0 0% 100% / 0.28);
+  --c-bg-zebra2: hsl(0 0% 100% / 0.4);
   --c-bg-popup: hsl(0 0% 100% / 0.75);
   --c-bg-input: hsl(0 0% 100% / 0.7);
   --c-bg-variation: hsl(0 0% 100% / 0.25);

--- a/ui/lobby/css/_lobby.scss
+++ b/ui/lobby/css/_lobby.scss
@@ -38,10 +38,13 @@ body {
 
 .lobby__side {
   @extend %flex-column;
-  @include backdrop-blur-if-transparent;
 
   gap: $block-gap;
   overflow: hidden;
+
+  .entries {
+    @include backdrop-blur-if-transparent;
+  }
 }
 
 .lobby__nope {

--- a/ui/lobby/css/_stream.scss
+++ b/ui/lobby/css/_stream.scss
@@ -1,4 +1,6 @@
 .lobby__streams {
+  @include backdrop-blur-if-transparent;
+
   &:empty {
     display: none;
   }

--- a/ui/lobby/css/app/_pool.scss
+++ b/ui/lobby/css/app/_pool.scss
@@ -12,6 +12,10 @@
 
   @include fluid-size('font-size', 14px, 25px);
 
+  @include if-transp {
+    backdrop-filter: none;
+  }
+
   .spinner {
     flex: 0 0 auto;
     margin: 0.1em 0 0.6em 0;
@@ -51,6 +55,7 @@
 .lpool {
   @extend %flex-column, %box-radius, %break-word;
   @include transition;
+  @include backdrop-blur-if-transparent;
 
   justify-content: center;
   align-items: center;

--- a/ui/msg/css/_msg.scss
+++ b/ui/msg/css/_msg.scss
@@ -11,7 +11,6 @@ body {
 
 %msg-input-focus {
   outline: 0;
-  border-color: $c-bg-zebra2;
 
   &:focus {
     border-color: color-mix(in oklab, $c-secondary 50%, $c-bg);


### PR DESCRIPTION
# Why

Few more small, mostly backdrop blur related tweaks for the transparent theme, for things spotted in recent days using the themes on PROD.

# How

Summary of changes:
* do not blur certain containers on home/lobby, switch to blurring the content within them
* add backdrop blur to copyables under the board
* fix messages inputs border color
* tweak zebra background opacity in light transparent theme
* fix classes tabs contrast

Fixes #20953

# Preview

<img width="1070" height="469" alt="Screenshot 2026-08-28 at 11 03 59" src="https://github.com/user-attachments/assets/8d81824f-b638-4222-9f34-56d7f920eaa1" />
<img width="834" height="279" alt="Screenshot 2026-08-28 at 10 50 00" src="https://github.com/user-attachments/assets/5aef2b5d-9847-49e0-a9a0-7105058d929f" />
<img width="639" height="396" alt="Screenshot 2026-08-28 at 11 17 13" src="https://github.com/user-attachments/assets/1937a774-5047-4d57-b833-c24cbb089039" />

