### PR TITLE
Permit everyone use timestamp in forum

### DIFF
--- a/modules/forum/src/main/ForumExpand.scala
+++ b/modules/forum/src/main/ForumExpand.scala
@@ -15,7 +15,7 @@ final class ForumTextExpand(markdown: lila.memo.MarkdownCache)(using Executor, S
     strikeThrough = true,
     blockQuote = true,
     code = true,
-    timestamp = false,
+    timestamp = true,
     sourceMap = true,
     removeHtmlEntities = true,
     maxPgns = lila.memo.Max(10)


### PR DESCRIPTION
Not everyone will know how to use it, but it's also useful in cases where exact times are mentioned.

And I don't see how it could be abused.

text <img width="519" height="414" alt="image" src="https://github.com/user-attachments/assets/ea5dd9cd-9c80-4e0e-829d-4445755877b5" />

rendered 
<img width="714" height="430" alt="image" src="https://github.com/user-attachments/assets/69bd0798-0e51-4080-9b29-12c63efef692" />
