### PR TITLE
ui(insight): tweaks and fixes for transparent themes

### DIFF
--- a/ui/insight/css/_filters.scss
+++ b/ui/insight/css/_filters.scss
@@ -1,7 +1,16 @@
 #insight .filters {
+  @include backdrop-blur-if-transparent;
+
+  position: relative;
+  z-index: $z-mz-menu-4;
+
   .box {
-    border-bottom-width: 0;
+    border-radius: 0;
     overflow: visible;
+
+    @include if-transp {
+      backdrop-filter: none;
+    }
   }
 
   .box:last-child {
@@ -26,6 +35,10 @@
 
   .ms-choice {
     @include transition;
+
+    @include if-transp {
+      background: none;
+    }
 
     padding: 15px 10px;
     border-width: 0 0 1px 0;

--- a/ui/insight/css/_insight.scss
+++ b/ui/insight/css/_insight.scss
@@ -133,6 +133,10 @@
     height: var(---header-height);
     background: $c-bg-zebra;
 
+    @include if-transp {
+      background: $c-bg-box;
+    }
+
     h2 {
       line-height: var(---header-height);
     }

--- a/ui/lib/css/vendor/_multiple-select.scss
+++ b/ui/lib/css/vendor/_multiple-select.scss
@@ -59,7 +59,7 @@
   padding: 0;
   position: absolute;
   z-index: 1000;
-  background: $c-bg-box;
+  background: $c-bg-opaque;
   border: $border;
 }
 


### PR DESCRIPTION
# Why

Fixes #21438
* #21438

# How

Ensure correct z order, eliminate double blur and background from some elements, adjust color shades for redability in transparent themes.

# Preview

<img width="614" height="539" alt="Screenshot 2026-08-29 at 10 38 23" src="https://github.com/user-attachments/assets/aed910a7-09e1-469d-bb33-8e47f0946d23" />
