### PR TITLE
ui(analyse): small coloring tweaks for moves tree

### DIFF
--- a/ui/analyse/src/treeView/inlineView.ts
+++ b/ui/analyse/src/treeView/inlineView.ts
@@ -74,7 +74,9 @@ export class InlineView {
               {
                 class: {
                   inaccuracy: comment.text.startsWith('Inaccuracy.'),
-                  mistake: comment.text.startsWith('Mistake.'),
+                  mistake:
+                    comment.text.startsWith('Mistake.') ||
+                    comment.text.startsWith('Checkmate is now unavoidable.'),
                   blunder: comment.text.startsWith('Blunder.'),
                   ...classes,
                 },

--- a/ui/lib/css/tree/_tree.scss
+++ b/ui/lib/css/tree/_tree.scss
@@ -1,4 +1,4 @@
-$c-annotation-border: var(--c-annotation-border, rgb(from $c-font r g b / calc(alpha * 0.12)));
+$c-annotation-border: var(--c-annotation-border, rgb(from $c-font r g b / calc(alpha * 0.2)));
 $disclosure-btn-size: calc(15px + var(---button-size-pointer-adjust, 0px));
 
 @mixin annotation-color($name) {
@@ -10,6 +10,10 @@ $disclosure-btn-size: calc(15px + var(---button-size-pointer-adjust, 0px));
   .#{$name} + lines,
   &-inline .#{$name} + interrupt {
     --c-annotation-border: rgb(from var(--c-#{$name}) r g b / calc(alpha * 0.6));
+
+    & interrupt {
+      --c-annotation-border: #{$c-annotation-border};
+    }
   }
 
   .#{$name}.active {


### PR DESCRIPTION
# Why

Refs, discussion on Discord:
* https://discord.com/channels/280713822073913354/352976626558042122/1541159976754483302

# How

Avoid coloring nested expand variation triggers and branches, adjust default branch color opacity for better visibility, apply correct comment class to unavoidable checkmates.

> [!note]
> We should also explore adding the comment `type` field to the data instead of matching via text value, which will break if we make those comments translatable at some point in the future.

# Preview

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td><img width="455" height="292" alt="Screenshot 2026-08-29 at 12 27 13" src="https://github.com/user-attachments/assets/c674f71c-680b-47a1-82cd-281dcfdcec3d" /></td><td><img width="455" height="290" alt="Screenshot 2026-08-29 at 12 23 10" src="https://github.com/user-attachments/assets/c3189ff9-9c87-47de-949e-3c4c0f17f3bf" /></td></tr>
<tr><td><img width="455" height="292" alt="Screenshot 2026-08-29 at 12 27 24" src="https://github.com/user-attachments/assets/b1b7710b-44fd-4bfb-9ddb-650aa073b5c9" /></td><td><img width="455" height="304" alt="Screenshot 2026-08-29 at 12 23 32" src="https://github.com/user-attachments/assets/812066ec-3213-4521-8dcd-0b51b28cb3ad" /></td></tr>
<tr><td><img width="455" height="304" alt="Screenshot 2026-08-29 at 12 26 52" src="https://github.com/user-attachments/assets/851a3780-d679-4ab7-9824-bd7f6b1329c3" /></td><td><img width="455" height="304" alt="Screenshot 2026-08-29 at 12 25 19" src="https://github.com/user-attachments/assets/b0d44f86-4ebc-44b7-b856-3e189215fc8d" /></td></tr>
</table>
