### PR TITLE
Migrate bloom-filter

### DIFF
--- a/modules/api/src/main/GameStreamByOauthOrigin.scala
+++ b/modules/api/src/main/GameStreamByOauthOrigin.scala
@@ -3,7 +3,7 @@ package lila.api
 import org.apache.pekko.stream.scaladsl.*
 import play.api.libs.json.*
 import play.api.mvc.RequestHeader
-import bloomfilter.mutable.BloomFilter
+import se.thanh.pds.bloomfilter.BloomFilter
 import scalalib.net.UserAgent
 
 import lila.common.{ Bus, HTTPRequest }
@@ -88,7 +88,7 @@ final class GameStreamByOauthOrigin(
         mon.users("recentlySeen").update(recentlySeenUsers.size)
 
         def matches(game: Game) = game.nonAi &&
-          game.players.exists(_.userId.exists(id => tokenUsers.mightContain(id.value)))
+          game.players.exists(_.userId.exists(id => tokenUsers.contains(id.value)))
 
         val subStart = Bus.sub[StartGame]: e =>
           if matches(e.game) then queue.offer(e.game)

--- a/modules/clas/src/main/ClasUserFilters.scala
+++ b/modules/clas/src/main/ClasUserFilters.scala
@@ -59,17 +59,15 @@ final class ClasUserFilters(using Executor, Materializer, Scheduler)(colls: Clas
 private trait CacheBackend[A]:
   def mightContain(a: A): Boolean
   def add(a: A): Unit
-  def dispose(): Unit
 
 // Stick to [String], it does unsafe operations that don't play well with opaque types
 private final class BloomFilterCache(estimatedCount: Int) extends CacheBackend[String]:
   private val bloom: BloomFilter[String] = BloomFilter[String](estimatedCount + 100, 0.00003)
   export bloom.{ contains as mightContain, add }
-  override def dispose(): Unit = ()
 
 private final class SetCache[A] extends CacheBackend[A]:
   private val set = scala.collection.mutable.Set.empty[A]
-  export set.{ contains as mightContain, clear as dispose }
+  export set.contains as mightContain
   def add(a: A): Unit = set.add(a)
 
 private def makeCacheBackend(estimatedCount: Int): CacheBackend[String] =
@@ -99,7 +97,6 @@ private final class ClasUserCache(name: String)(
       .addEffect: nb =>
         logNb(nb)
         lila.mon.clas.bloomFilter(name).count.update(nb)
-        backend.dispose()
         backend = nextBackend
       .monSuccess(lila.mon.clas.bloomFilter(name).fu)
 

--- a/modules/clas/src/main/ClasUserFilters.scala
+++ b/modules/clas/src/main/ClasUserFilters.scala
@@ -2,7 +2,7 @@ package lila.clas
 
 import org.apache.pekko.stream.Materializer
 import org.apache.pekko.stream.scaladsl.*
-import bloomfilter.mutable.BloomFilter
+import se.thanh.pds.bloomfilter.BloomFilter
 import reactivemongo.pekkostream.cursorProducer
 import reactivemongo.api.bson.BSONNull
 import play.api.Mode
@@ -64,7 +64,8 @@ private trait CacheBackend[A]:
 // Stick to [String], it does unsafe operations that don't play well with opaque types
 private final class BloomFilterCache(estimatedCount: Int) extends CacheBackend[String]:
   private val bloom: BloomFilter[String] = BloomFilter[String](estimatedCount + 100, 0.00003)
-  export bloom.{ mightContain, add, dispose }
+  export bloom.{ contains as mightContain, add }
+  override def dispose(): Unit = ()
 
 private final class SetCache[A] extends CacheBackend[A]:
   private val set = scala.collection.mutable.Set.empty[A]

--- a/modules/memo/src/main/ViewerCount.scala
+++ b/modules/memo/src/main/ViewerCount.scala
@@ -1,7 +1,7 @@
 package lila.memo
 
 import play.api.mvc.RequestHeader
-import bloomfilter.mutable.BloomFilter
+import se.thanh.pds.bloomfilter.BloomFilter
 import scalalib.net.UserAgent
 
 import lila.core.userId.UserId
@@ -28,14 +28,13 @@ private final class ViewerCount(initialCount: Int, maxCount: Int):
     if !alive then logger.warn("hit on dead viewer count")
     else
       val s = encode(a)
-      if !bloom.mightContain(s) then
+      if !bloom.contains(s) then
         bloom.add(s)
         count += 1
 
   def get: Int = count
 
   def kill(): Unit =
-    bloom.dispose()
     alive = false
 
 object ViewerCount:

--- a/modules/security/src/main/DisposableEmailDomain.scala
+++ b/modules/security/src/main/DisposableEmailDomain.scala
@@ -1,7 +1,7 @@
 package lila.security
 
 import play.api.libs.ws.StandaloneWSClient
-import bloomfilter.mutable.BloomFilter
+import se.thanh.pds.bloomfilter.BloomFilter
 import org.apache.pekko.stream.scaladsl.*
 import scalalib.net.Domain
 
@@ -35,14 +35,13 @@ final class DisposableEmailDomain(
                 nextBloom.add(domain)
                 nb + 1
       .map: nb =>
-        bloomFilter.dispose()
         bloomFilter = nextBloom
         lila.mon.email.disposableDomain.update(nb)
 
   def isDisposable(domain: Domain): Boolean =
     val all = expandDomains(domain)
     !all.exists(DisposableEmailDomain.whitelisted) && all.exists: d =>
-      bloomFilter.mightContain(d.lower.value) ||
+      bloomFilter.contains(d.lower.value) ||
         domainFragmentRegex.find(d.lower.value)
 
   // foo.bar.aaa.com -> List(aaa.com, bar.aaa.com, foo.bar.aaa.com)

--- a/modules/ublog/src/main/UblogViewCounter.scala
+++ b/modules/ublog/src/main/UblogViewCounter.scala
@@ -1,6 +1,6 @@
 package lila.ublog
 
-import bloomfilter.mutable.BloomFilter
+import se.thanh.pds.bloomfilter.BloomFilter
 
 import lila.db.dsl.{ *, given }
 import lila.memo.ViewerCount.*
@@ -17,7 +17,7 @@ final class UblogViewCounter(colls: UblogColls)(using mode: play.api.Mode)(using
     if post.live then
       post.copy(views =
         val key = s"${post.id}${encode(makeViewer(ctx.req, ctx.userId))}"
-        if bloomFilter.mightContain(key) then post.views
+        if bloomFilter.contains(key) then post.views
         else
           bloomFilter.add(key)
           lila.mon.ublog.view.increment()

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -30,7 +30,7 @@ object Dependencies:
   val uaparser = "org.uaparser" %% "uap-scala" % "0.21.0"
   val apacheText = "org.apache.commons" % "commons-text" % "1.15.0"
   val apacheMath = "org.apache.commons" % "commons-math3" % "3.6.1"
-  val bloomFilter = "com.github.alexandrnikitin" %% "bloom-filter" % "0.13.1_lila-1"
+  val bloomFilter = "com.github.lenguyenthanh" % "scala-probabilistic-data-structures" % "0.0.1"
   val kittens = "org.typelevel" %% "kittens" % "3.5.0"
 
   val scalacheck = "org.scalacheck" %% "scalacheck" % "1.19.0" % Test


### PR DESCRIPTION
This helps removing `sun.misc.unsafe` usage and the responsibility of
release allocated off-heap memory after use. Not only that, this is also
faster then original implementation:
https://www.thanh.se/scala-probabilistic-data-structures/#benchmarks