### PR TITLE
Fix flair picker theme for transparent themes

### DIFF
--- a/ui/bits/src/bits.flairPicker.ts
+++ b/ui/bits/src/bits.flairPicker.ts
@@ -1,5 +1,7 @@
 import { Picker } from 'emoji-mart';
 
+import { currentTheme } from 'lib/device';
+
 type Config = {
   element: HTMLElement;
   close: (e: PointerEvent) => void;
@@ -8,12 +10,6 @@ type Config = {
 
 export async function initModule(cfg: Config): Promise<void> {
   if (cfg.element.classList.contains('emoji-done')) return;
-  const theme =
-    document.body.dataset.theme === 'system'
-      ? 'auto'
-      : document.body.dataset.theme === 'light'
-        ? 'light'
-        : 'dark';
   const opts = {
     ...cfg,
     onClickOutside: cfg.close,
@@ -23,7 +19,7 @@ export async function initModule(cfg: Config): Promise<void> {
     previewEmoji: 'people.backhand-index-pointing-up',
     noResultsEmoji: 'smileys.crying-face',
     skinTonePosition: 'none',
-    theme,
+    theme: currentTheme(),
     exceptEmojis: cfg.element.dataset.exceptEmojis?.split(' '),
   };
   const picker = new Picker(opts);


### PR DESCRIPTION
closes #21440

before: 
<img width="1423" height="772" alt="Screenshot 2026-08-29 at 11 54 11 PM" src="https://github.com/user-attachments/assets/56349d0e-e50a-433f-bb0f-557f7aa57c34" />

after:
<img width="1423" height="772" alt="Screenshot 2026-08-29 at 11 54 02 PM" src="https://github.com/user-attachments/assets/0c716fcb-682e-412e-910a-6b1ec7bb74aa" />
