### PR TITLE
fix: blog like and follow button hover state in light mode

### DIFF
--- a/ui/lib/css/component/_button.scss
+++ b/ui/lib/css/component/_button.scss
@@ -148,6 +148,12 @@
     &:not(.disabled):hover {
       color: $c-font;
     }
+
+    @include if-light {
+      &:hover {
+        filter: none;
+      }
+    }
   }
 
   &.button-inverse {


### PR DESCRIPTION
closes #21436

before:
<img width="869" height="176" alt="Screenshot 2026-08-30 at 2 24 23 AM" src="https://github.com/user-attachments/assets/38cf8d01-cd9c-4711-bf21-119c30045ba7" />


after:
<img width="869" height="176" alt="Screenshot 2026-08-30 at 2 25 19 AM" src="https://github.com/user-attachments/assets/a2dc98f7-ea1b-4153-9827-f34eae045a5d" />


