### PR TITLE
ui(build): automatically apply CSS prefixes based on browserslist

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,11 +50,5 @@
     "workspace-check": "pnpx @manypkg/cli check",
     "add-hooks": "git config get --all core.hooksPath | grep -Fxq bin/git-hooks || git config set --append core.hooksPath bin/git-hooks",
     "remove-hooks": "git config unset --value=bin/git-hooks core.hooksPath || true"
-  },
-  "browserslist": [
-    "defaults",
-    "not op_mini all",
-    "not kaios <= 4",
-    "firefox >= 115"
-  ]
+  }
 }

--- a/ui/.build/package.json
+++ b/ui/.build/package.json
@@ -17,14 +17,26 @@
   "dependencies": {
     "@types/micromatch": "4.0.10",
     "@types/node": "24.13.3",
+    "autoprefixer": "^10.5.4",
     "esbuild": "0.28.1",
     "fast-glob": "3.3.3",
     "fast-xml-parser": "5.10.1",
     "json-stringify-pretty-compact": "4.0.0",
     "micromatch": "4.0.8",
+    "postcss": "^8.5.26",
     "typescript": "7.0.2"
   },
   "scripts": {
     "dev": "node --no-warnings src/main.ts $@"
-  }
+  },
+  "browserslist": [
+    "defaults",
+    "not op_mini all",
+    "not kaios <= 4",
+    "firefox >= 115",
+    "chrome >= 112",
+    "edge >= 111",
+    "opera >= 97",
+    "safari >= 16.2"
+  ]
 }

--- a/ui/.build/pnpm-lock.yaml
+++ b/ui/.build/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@types/node':
         specifier: 24.13.3
         version: 24.13.3
+      autoprefixer:
+        specifier: ^10.5.4
+        version: 10.5.4(postcss@8.5.26)
       esbuild:
         specifier: 0.28.1
         version: 0.28.1
@@ -29,6 +32,9 @@ importers:
       micromatch:
         specifier: 4.0.8
         version: 4.0.8
+      postcss:
+        specifier: ^8.5.26
+        version: 8.5.26
       typescript:
         specifier: 7.0.2
         version: 7.0.2
@@ -237,14 +243,41 @@ packages:
   anynum@1.0.1:
     resolution: {integrity: sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==}
 
+  autoprefixer@10.5.4:
+    resolution: {integrity: sha512-MaU0U/za7N3r6brxD4YB/l4NSrFzLPlANv6wEuQVaIPlD3L4W9rFcQPbL/EilY9BHhHvhfcz3gInDLrEtWT4EA==}
+    engines: {node: ^10 || ^12 || >=14}
+    hasBin: true
+    peerDependencies:
+      postcss: ^8.1.0
+
+  baseline-browser-mapping@2.11.20:
+    resolution: {integrity: sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
+
+  browserslist@4.28.8:
+    resolution: {integrity: sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  caniuse-lite@1.0.30001810:
+    resolution: {integrity: sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==}
+
+  electron-to-chromium@1.5.416:
+    resolution: {integrity: sha512-K6bvB2BjnNrugtIih6ewlbBI9DXa976jIdiIlRLHhBoEI9a4JaQjjHyF+A1IQI543aQYR4LnmOrT/K5fZj0aPA==}
 
   esbuild@0.28.1:
     resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
     engines: {node: '>=18'}
     hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
 
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
@@ -263,6 +296,9 @@ packages:
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
+
+  fraction.js@5.3.4:
+    resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -294,13 +330,32 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  node-releases@2.0.54:
+    resolution: {integrity: sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==}
+    engines: {node: '>=18'}
+
   path-expression-matcher@1.6.2:
     resolution: {integrity: sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==}
     engines: {node: '>=14.0.0'}
 
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
   picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
+
+  postcss-value-parser@4.2.0:
+    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
+
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
+    engines: {node: ^10 || ^12 || >=14}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -350,6 +405,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
   strnum@2.4.1:
     resolution: {integrity: sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==}
 
@@ -364,6 +423,12 @@ packages:
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
+  update-browserslist-db@1.3.2:
+    resolution: {integrity: sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
 
   xml-naming@0.3.0:
     resolution: {integrity: sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==}
@@ -491,9 +556,32 @@ snapshots:
 
   anynum@1.0.1: {}
 
+  autoprefixer@10.5.4(postcss@8.5.26):
+    dependencies:
+      browserslist: 4.28.8
+      caniuse-lite: 1.0.30001810
+      fraction.js: 5.3.4
+      picocolors: 1.1.1
+      postcss: 8.5.26
+      postcss-value-parser: 4.2.0
+
+  baseline-browser-mapping@2.11.20: {}
+
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
+
+  browserslist@4.28.8:
+    dependencies:
+      baseline-browser-mapping: 2.11.20
+      caniuse-lite: 1.0.30001810
+      electron-to-chromium: 1.5.416
+      node-releases: 2.0.54
+      update-browserslist-db: 1.3.2(browserslist@4.28.8)
+
+  caniuse-lite@1.0.30001810: {}
+
+  electron-to-chromium@1.5.416: {}
 
   esbuild@0.28.1:
     optionalDependencies:
@@ -503,6 +591,8 @@ snapshots:
       '@esbuild/linux-x64': 0.28.1
       '@esbuild/win32-arm64': 0.28.1
       '@esbuild/win32-x64': 0.28.1
+
+  escalade@3.2.0: {}
 
   fast-glob@3.3.3:
     dependencies:
@@ -534,6 +624,8 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
+  fraction.js@5.3.4: {}
+
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -557,9 +649,23 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.1
 
+  nanoid@3.3.18: {}
+
+  node-releases@2.0.54: {}
+
   path-expression-matcher@1.6.2: {}
 
+  picocolors@1.1.1: {}
+
   picomatch@2.3.1: {}
+
+  postcss-value-parser@4.2.0: {}
+
+  postcss@8.5.26:
+    dependencies:
+      nanoid: 3.3.18
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   queue-microtask@1.2.3: {}
 
@@ -586,6 +692,8 @@ snapshots:
 
   sass-embedded-win32-x64@1.100.0:
     optional: true
+
+  source-map-js@1.2.1: {}
 
   strnum@2.4.1:
     dependencies:
@@ -619,5 +727,11 @@ snapshots:
       '@typescript/typescript-win32-x64': 7.0.2
 
   undici-types@7.18.2: {}
+
+  update-browserslist-db@1.3.2(browserslist@4.28.8):
+    dependencies:
+      browserslist: 4.28.8
+      escalade: 3.2.0
+      picocolors: 1.1.1
 
   xml-naming@0.3.0: {}

--- a/ui/.build/src/sass.ts
+++ b/ui/.build/src/sass.ts
@@ -1,9 +1,9 @@
+import autoprefixer from 'autoprefixer';
 import cps from 'node:child_process';
 import crypto from 'node:crypto';
 import fs from 'node:fs';
 import { basename, dirname, join, relative, resolve } from 'node:path';
 import ps from 'node:process';
-import autoprefixer from 'autoprefixer';
 import postcss from 'postcss';
 
 import { c, env, errorMark, trimLines } from './env.ts';

--- a/ui/.build/src/sass.ts
+++ b/ui/.build/src/sass.ts
@@ -3,6 +3,8 @@ import crypto from 'node:crypto';
 import fs from 'node:fs';
 import { basename, dirname, join, relative, resolve } from 'node:path';
 import ps from 'node:process';
+import autoprefixer from 'autoprefixer';
+import postcss from 'postcss';
 
 import { c, env, errorMark, trimLines } from './env.ts';
 import { hashedBasename, symlinkTargetHashes } from './hash.ts';
@@ -111,13 +113,23 @@ async function compile(sources: string[], logAll = true): Promise<string[]> {
     sassPs.stdout?.on('data', (buf: Buffer) => sassError(buf.toString('utf8')));
     sassPs.on('close', async (code: number) => {
       sassPs = undefined;
-      if (code === 0) resolveWithErrors([]);
+      if (code === 0)
+        Promise.all(sources.map(addVendorPrefixes))
+          .then(() => resolveWithErrors([]))
+          .catch(() => resolveWithErrors(sources));
       else
         Promise.all(sources.map(async s => ({ s, exists: await readable(absTempCss(s)) })))
           .then(srcExists => resolveWithErrors(srcExists.filter(({ exists }) => !exists).map(({ s }) => s)))
           .catch(() => resolveWithErrors(sources));
     });
   });
+}
+
+async function addVendorPrefixes(src: string): Promise<void> {
+  const cssPath = absTempCss(src);
+  const css = await fs.promises.readFile(cssPath, 'utf8');
+  const result = await postcss([autoprefixer]).process(css, { from: cssPath });
+  await fs.promises.writeFile(cssPath, result.css);
 }
 
 // recursively parse scss file and its imports to build dependency maps


### PR DESCRIPTION
# Why

Spotted that we sometimes specify vendor prefixes in SCSS directly. This can be avoided by hooking up PostCSS and autoprefixer to the SCSS build pipeline.

Refs:
* #21443

# How

Add PostCSS process step to SCSS build, move and updated `browserslist` to `ui/.build` project.

# Preview (dummy example)

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td><img width="455" height="84" alt="Screenshot 2026-08-30 at 09 46 21" src="https://github.com/user-attachments/assets/6fd09d3a-976a-4dfb-b51c-76ffeaf48ac4" /></td><td><img width="455" height="98" alt="Screenshot 2026-08-30 at 09 46 41" src="https://github.com/user-attachments/assets/e73e1352-7aad-4a01-9136-69f373bff85a" /></td></tr>
</table>
