### PR TITLE
workspace: add prefer regexp test rule, fix code

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -99,6 +99,7 @@
     "unicorn/prefer-math-min-max": "error",
     "unicorn/prefer-native-coercion-functions": "error",
     "unicorn/prefer-node-protocol": "error",
+    "unicorn/prefer-regexp-test": "error",
     "unicorn/prefer-set-has": "error",
     "unicorn/require-number-to-fixed-digits-argument": "error",
     "unicorn/prefer-single-call": "error",

--- a/ui/analyse/src/view/nvuiView.ts
+++ b/ui/analyse/src/view/nvuiView.ts
@@ -277,7 +277,7 @@ function boardEventsHook(
   );
   $buttons.on('keydown', (e: KeyboardEvent) => {
     if (e.shiftKey && e.key.match(/^[ad]$/i)) jumpMoveOrLine(ctrl)(e);
-    else if (e.key.match(/^x$/i))
+    else if (/^x$/i.test(e.key))
       scanDirectionsHandler(ctrl.bottomColor(), ctrl.chessground.state.pieces, moveStyle.get())(e);
     else if (['o', 'l', 't'].includes(e.key)) boardCommandsHandler()(e);
     else if (e.key.startsWith('Arrow')) arrowKeyHandler(ctrl.bottomColor(), borderSound)(e);
@@ -290,8 +290,8 @@ function boardEventsHook(
         notify.set('Flipping the board');
         setTimeout(() => ctrl.flip(), 1000);
       }
-    } else if (e.code.match(/^Digit([1-8])$/)) positionJumpHandler()(e);
-    else if (e.key.match(/^[kqrbnp]$/i)) pieceJumpingHandler(selectSound, errorSound)(e);
+    } else if (/^Digit([1-8])$/.test(e.code)) positionJumpHandler()(e);
+    else if (/^[kqrbnp]$/i.test(e.key)) pieceJumpingHandler(selectSound, errorSound)(e);
     else if (e.key.toLowerCase() === 'm')
       possibleMovesHandler(ctrl.turnColor(), ctrl.chessground, ctrl.data.game.variant.key, ctrl.nodeList)(e);
     else if (e.key.toLowerCase() === 'v') notify.set(renderEvalAndDepth(ctrl));

--- a/ui/bits/src/bits.forum.ts
+++ b/ui/bits/src/bits.forum.ts
@@ -73,7 +73,7 @@ site.load.then(() => {
     $(el).replaceWith($('.forum-post__message', el));
   });
   $('.forum-post__message').each(function (this: HTMLElement) {
-    if (this.innerHTML.match(/(^|<br>)&gt;/)) {
+    if (/(^|<br>)&gt;/.test(this.innerHTML)) {
       const hiddenQuotes = '<span class=hidden-quotes>&gt;</span>';
       let result = '';
       let quote = [];
@@ -121,7 +121,7 @@ site.load.then(() => {
       const lines = quotedMarkdown(this.closest('article'))
         .replace(/!\[([^\]]*)]\(([^)]+)\)/g, '$1 ($2)') // unlink images
         .split('\n');
-      if (lines[0].match(/^(?:> )*@.+ said (?:in #\d+:$|\[\^\]\()/)) lines.shift();
+      if (/^(?:> )*@.+ said (?:in #\d+:$|\[\^\]\()/.test(lines[0])) lines.shift();
 
       if (lines.length === 0) return;
 

--- a/ui/cli/src/cli.ts
+++ b/ui/cli/src/cli.ts
@@ -63,8 +63,8 @@ function execute(e: string | Entry) {
   else if (isUser(e)) location.href = '/@/' + e.name;
   else if (e.startsWith('/')) command(e.replace(/\//g, ''));
   // 5kr1/p1p2p2/2b2Q2/3q2r1/2p4p/2P4P/P2P1PP1/1R1K3R b - - 1 23
-  else if (e.match(/^([1-8pnbrqk]+\/){7}.*/i)) location.href = '/analysis/standard/' + e.replace(/ /g, '_');
-  else if (e.match(/^[a-zA-Z0-9_-]{2,30}$/)) location.href = '/@/' + e;
+  else if (/^([1-8pnbrqk]+\/){7}.*/i.test(e)) location.href = '/analysis/standard/' + e.replace(/ /g, '_');
+  else if (/^[a-zA-Z0-9_-]{2,30}$/.test(e)) location.href = '/@/' + e;
   else location.href = '/player/search/' + e;
 }
 

--- a/ui/coordinateTrainer/src/ctrl.ts
+++ b/ui/coordinateTrainer/src/ctrl.ts
@@ -367,7 +367,7 @@ export default class CoordinateTrainerCtrl {
     } else if (input.value.length === 2 && input.value === this.currentKey) {
       input.value = '';
       this.handleCorrect();
-    } else if (input.value.length === 2 && !input.value.match(/[a-h][1-8]/)) {
+    } else if (input.value.length === 2 && !/[a-h][1-8]/.test(input.value)) {
       // if they've entered e.g. "ab", change this to "b"
       input.value = input.value[1];
     } else if (input.value.length >= 2) {

--- a/ui/keyboardMove/src/keyboardSubmit.ts
+++ b/ui/keyboardMove/src/keyboardSubmit.ts
@@ -12,7 +12,7 @@ const ambiguousPromotionCaptureRegex = /^([a-h][27]?x?)?[a-h](1|8)=?$/;
 const promotionRegex = /^([a-h]x?)?[a-h](1|8)=?[nbrqkNBRQK]$/;
 // accept partial ICCF because submit runs on every keypress
 const iccfRegex = /^[1-8][1-8]?[1-5]?$/;
-const isKey = (v: string): v is Key => !!v.match(keyRegex);
+const isKey = (v: string): v is Key => keyRegex.test(v);
 
 interface SubmitOpts {
   isTrusted: boolean;
@@ -30,7 +30,7 @@ export function makeSubmit(opts: Opts, clear: () => void): Submit {
 
     // consider 0's as O's for castling
     v = v.replace(/0/g, 'O');
-    if (v.match(iccfRegex)) {
+    if (iccfRegex.test(v)) {
       v = iccfToUci(v);
     }
     const { legalSans } = opts.ctrl;
@@ -72,7 +72,7 @@ export function makeSubmit(opts: Opts, clear: () => void): Submit {
       if (!foundUci) return;
       opts.ctrl.promote(foundUci.slice(0, 2) as Key, foundUci.slice(2) as Key, v.slice(-1).toUpperCase());
       clear();
-    } else if (v.match(crazyhouseRegex)) {
+    } else if (crazyhouseRegex.test(v)) {
       // Incomplete crazyhouse strings such as Q@ or Q@a should do nothing.
       if (v.length > 3 || (v.length > 2 && v.startsWith('@'))) {
         if (v.length === 3) v = 'P' + v;

--- a/ui/lib/src/chat/discussion.ts
+++ b/ui/lib/src/chat/discussion.ts
@@ -178,7 +178,7 @@ const setupHooks = (ctrl: ChatCtrl, chatEl: HTMLInputElement) => {
         txt = el.value;
 
       el.removeAttribute('placeholder');
-      if (!ctrl.opts.public) el.classList.toggle('whisper', !!txt.match(whisperRegex));
+      if (!ctrl.opts.public) el.classList.toggle('whisper', whisperRegex.test(txt));
       storage.set(txt);
     }),
   );

--- a/ui/lib/src/chat/spam.ts
+++ b/ui/lib/src/chat/spam.ts
@@ -50,10 +50,10 @@ const spamRegex = new RegExp(
     .join('|'),
 );
 
-const suspLink = (txt: string) => !!txt.match(spamRegex);
+const suspLink = (txt: string) => spamRegex.test(txt);
 
 const followMeRegex = /follow me|join my team/i;
-const followMe = (txt: string) => !!txt.match(followMeRegex);
+const followMe = (txt: string) => followMeRegex.test(txt);
 
 const teamUrlRegex = /lichess\.org\/team\//i;
-export const hasTeamUrl = (txt: string): boolean => !!txt.match(teamUrlRegex);
+export const hasTeamUrl = (txt: string): boolean => teamUrlRegex.test(txt);

--- a/ui/lib/src/nvui/command.ts
+++ b/ui/lib/src/nvui/command.ts
@@ -44,7 +44,7 @@ export const commands: () => Commands = memoize(() => ({
 }));
 
 function tryC<A>(c: string, regex: RegExp, f: (arg: string) => A | undefined): A | undefined {
-  return c.match(regex) ? f(c.replace(regex, '$1')) : undefined;
+  return regex.test(c) ? f(c.replace(regex, '$1')) : undefined;
 }
 
 export const boardCommands = (): VNode[] => [

--- a/ui/lib/src/nvui/handler.ts
+++ b/ui/lib/src/nvui/handler.ts
@@ -40,7 +40,7 @@ export function pieceJumpingHandler(selectSound: () => void, errorSound: () => v
       const $boardLive = $('.boardstatus');
       const promotionPiece = ev.key.toLowerCase();
       const promotionChoice = isAntichess ? /^[kqnrb]$/ : /^[qnrb]$/;
-      if (!promotionPiece.match(promotionChoice)) {
+      if (!promotionChoice.test(promotionPiece)) {
         const msg = 'Invalid promotion piece. q for queen, n for knight, r for rook, b for bishop';
         $boardLive.text(msg + (isAntichess ? ', k for king' : ''));
         return;
@@ -290,10 +290,10 @@ export function inputToMove(input: string, fen: string, chessground: CgApi): Uci
       role: charToRole(cleaned[0]) || 'pawn',
       key: cleaned.split('@')[1].slice(0, 2) as Key,
     };
-  if (cleaned.match(promotionRegex)) {
+  if (promotionRegex.test(cleaned)) {
     uci = sanToUci(cleaned.slice(0, -2), legalSans) || cleaned;
     promotion = cleaned.slice(-1);
-  } else if (cleaned.match(uciPromotionRegex)) {
+  } else if (uciPromotionRegex.test(cleaned)) {
     uci = cleaned.slice(0, -1);
     promotion = cleaned.slice(-1);
   } else if ('18'.includes(uci[3]) && chessground.state.pieces.get(uci.slice(0, 2) as Key)?.role === 'pawn')

--- a/ui/lib/src/nvui/render.ts
+++ b/ui/lib/src/nvui/render.ts
@@ -238,7 +238,7 @@ export function renderMainline(
 export const renderComments = (node: TreeNode, style: MoveStyle): string =>
   node.comments?.map(c => ` ${augmentLichessComment(c, style)}`).join('.') ?? '';
 
-export const isKey = (maybeKey: string): maybeKey is Key => !!maybeKey.match(/^[a-h][1-8]$/);
+export const isKey = (maybeKey: string): maybeKey is Key => /^[a-h][1-8]$/.test(maybeKey);
 
 export const keyFromAttrs = (el: HTMLElement): Key | undefined => {
   const maybeKey = `${el.getAttribute('file') ?? ''}${el.getAttribute('rank') ?? ''}`;

--- a/ui/lib/src/richText.ts
+++ b/ui/lib/src/richText.ts
@@ -25,7 +25,7 @@ const linkHtml = (href: string, content: string, expandable = true): string =>
   `<a${expandable ? '' : ' class="text"'} target="_blank" rel="nofollow noreferrer" href="${href}">${content}</a>`;
 
 export function toLink(url: string): string {
-  if (!url.match(/^[A-Za-z]+:\/\//)) url = 'https://' + url;
+  if (!/^[A-Za-z]+:\/\//.test(url)) url = 'https://' + url;
   return linkHtml(url, url.replace(/https?:\/\//, ''));
 }
 
@@ -85,7 +85,7 @@ const addPlies = (html: string) => html.replace(movePattern, moveReplacer);
 const addBoards = (html: string) => html.replace(boardPattern, boardReplacer);
 
 const userLinkReplacePawn = (orig: string, prefix: string, user: string) =>
-  user.match(pawnDropPattern) ? orig : userLinkReplace(orig, prefix, user);
+  pawnDropPattern.test(user) ? orig : userLinkReplace(orig, prefix, user);
 
 export interface EnhanceOpts {
   plies?: boolean;

--- a/ui/lib/src/view/markdownImgResizer.ts
+++ b/ui/lib/src/view/markdownImgResizer.ts
@@ -25,7 +25,7 @@ export async function wireMarkdownImgResizers({
   let matching = 0;
 
   for (const img of root.querySelectorAll<HTMLImageElement>('img')) {
-    if (!`![](${img.src})`.match(globalImageLinkRe)) continue;
+    if (!globalImageLinkRe.test(`![](${img.src})`)) continue;
     const index = matching++;
 
     if (img.closest('.markdown-img-resizer')) continue; // already wrapped

--- a/ui/puzzle/src/view/nvuiView.ts
+++ b/ui/puzzle/src/view/nvuiView.ts
@@ -197,7 +197,7 @@ function boardEventsHook(
   $board.on('click', 'button', e => nv.selectionHandler(() => opposite(ctrl.pov))(e));
   $board.on('keydown', 'button', (e: KeyboardEvent) => {
     if (e.shiftKey && e.key.match(/^[ad]$/i)) nextOrPrev(ctrl)(e);
-    else if (e.key.match(/^x$/i))
+    else if (/^x$/i.test(e.key))
       scanDirectionsHandler(
         ctrl.flipped() ? opposite(ctrl.pov) : ctrl.pov,
         ground.state.pieces,
@@ -209,8 +209,8 @@ function boardEventsHook(
     } else if (['o'].includes(e.key)) nv.boardCommandsHandler()(e);
     else if (e.key.startsWith('Arrow'))
       nv.arrowKeyHandler(ctrl.flipped() ? opposite(ctrl.pov) : ctrl.pov, borderSound)(e);
-    else if (e.code.match(/^Digit([1-8])$/)) nv.positionJumpHandler()(e);
-    else if (e.key.match(/^[kqrbnp]$/i)) nv.pieceJumpingHandler(selectSound, errorSound)(e);
+    else if (/^Digit([1-8])$/.test(e.code)) nv.positionJumpHandler()(e);
+    else if (/^[kqrbnp]$/i.test(e.key)) nv.pieceJumpingHandler(selectSound, errorSound)(e);
     else if (e.key.toLowerCase() === 'm') nv.possibleMovesHandler(ctrl.pov, ground, 'standard', steps)(e);
     else if (e.key === 'c') nv.lastCapturedCommandHandler(fenSteps, pieceStyle.get(), prefixStyle.get())();
     else if (e.key === 'i') {

--- a/ui/round/src/view/nvuiView.ts
+++ b/ui/round/src/view/nvuiView.ts
@@ -299,7 +299,7 @@ function boardEventsHook(ctx: RoundNvuiContext, el: HTMLElement): void {
 
   $board.on('keydown.nvui', 'button', (e: KeyboardEvent) => {
     if (e.shiftKey && e.key.match(/^[ad]$/i)) nextOrPrev(ctrl)(e);
-    else if (e.key.match(/^x$/i))
+    else if (/^x$/i.test(e.key))
       scanDirectionsHandler(
         ctrl.flip ? opposite(ctrl.data.player.color) : ctrl.data.player.color,
         ctrl.chessground.state.pieces,
@@ -319,8 +319,8 @@ function boardEventsHook(ctx: RoundNvuiContext, el: HTMLElement): void {
         pieceStyle.get(),
         prefixStyle.get(),
       )();
-    else if (e.code.match(/^Digit([1-8])$/)) nv.positionJumpHandler()(e);
-    else if (e.key.match(/^[kqrbnp]$/i))
+    else if (/^Digit([1-8])$/.test(e.code)) nv.positionJumpHandler()(e);
+    else if (/^[kqrbnp]$/i.test(e.key))
       nv.pieceJumpingHandler(selectSound, errorSound, ctrl.data.game.variant.key === 'antichess')(e);
     else if (e.key.toLowerCase() === 'm')
       nv.possibleMovesHandler(


### PR DESCRIPTION
# Why

Add prefer regexp test rule:
* https://oxc.rs/docs/guide/usage/linter/rules/unicorn/prefer-regexp-test.html

It returns a boolean on match (not a value/array of value), thus is a bit more efficient than match, also the return value does not need to be double negated.

# How

Add the new rule, use Oxlint autofix `pnpm lint:fix` to refactor the usecases producing warning, manually remove redundant double negation (since we do not have rule for that currently)