### PR TITLE
Add keyboard shortcuts between analysis and board editor

### DIFF
--- a/modules/web/src/main/ui/help.scala
+++ b/modules/web/src/main/ui/help.scala
@@ -108,6 +108,7 @@ object help:
           row(kbd("c"), trans.site.focusChat()),
           helpDialog,
           row(kbd("e"), trans.site.openingEndgameExplorer()),
+          row(kbd("b"), trans.site.boardEditor()),
           menu,
           row(
             frag(kbd("shift"), kbd("space")),

--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -1067,6 +1067,16 @@ export default class AnalyseCtrl implements CevalHandler {
 
   showBestMoveArrows = () => this.settings.showBestMoveArrows && !this.retro?.hideComputerLine(this.node);
 
+  boardEditorUrl = () =>
+    this.data.userAnalysis
+      ? '/editor?' +
+        new URLSearchParams({
+          fen: this.node.fen,
+          variant: this.data.game.variant.key,
+          color: this.chessground.state.orientation,
+        })
+      : `/${this.data.game.id}/edit?fen=${this.node.fen}`;
+
   private readonly resetAutoShapes = () => {
     if (
       this.showBestMoveArrows() ||

--- a/ui/analyse/src/keyboard.ts
+++ b/ui/analyse/src/keyboard.ts
@@ -58,6 +58,18 @@ export const bind = (ctrl: AnalyseCtrl) => {
       ctrl.redraw();
     })
     .bind('f', ctrl.flip)
+    .bind('b', () => {
+      const d = ctrl.data;
+      const url = d.userAnalysis
+        ? '/editor?' +
+          new URLSearchParams({
+            fen: ctrl.node.fen,
+            variant: d.game.variant.key,
+            color: ctrl.chessground.state.orientation,
+          })
+        : `/${d.game.id}/edit?fen=${ctrl.node.fen}`;
+      window.location.assign(url);
+    })
     .bind('?', () => {
       ctrl.keyboardHelp = !ctrl.keyboardHelp;
       if (ctrl.keyboardHelp) pubsub.emit('analysis.closeAll');

--- a/ui/analyse/src/keyboard.ts
+++ b/ui/analyse/src/keyboard.ts
@@ -58,18 +58,7 @@ export const bind = (ctrl: AnalyseCtrl) => {
       ctrl.redraw();
     })
     .bind('f', ctrl.flip)
-    .bind('b', () => {
-      const d = ctrl.data;
-      const url = d.userAnalysis
-        ? '/editor?' +
-          new URLSearchParams({
-            fen: ctrl.node.fen,
-            variant: d.game.variant.key,
-            color: ctrl.chessground.state.orientation,
-          })
-        : `/${d.game.id}/edit?fen=${ctrl.node.fen}`;
-      window.location.assign(url);
-    })
+    .bind('b', () => window.location.assign(ctrl.boardEditorUrl()))
     .bind('?', () => {
       ctrl.keyboardHelp = !ctrl.keyboardHelp;
       if (ctrl.keyboardHelp) pubsub.emit('analysis.closeAll');

--- a/ui/analyse/src/view/actionMenu.ts
+++ b/ui/analyse/src/view/actionMenu.ts
@@ -112,6 +112,8 @@ export function view(ctrl: AnalyseCtrl): VNode {
                     color: ctrl.chessground.state.orientation,
                   })
                 : `/${d.game.id}/edit?fen=${ctrl.node.fen}`,
+              'data-icon': licon.Pencil,
+              title: 'Hotkey: b',
               ...linkAttrs,
             },
           },

--- a/ui/analyse/src/view/actionMenu.ts
+++ b/ui/analyse/src/view/actionMenu.ts
@@ -104,14 +104,7 @@ export function view(ctrl: AnalyseCtrl): VNode {
           'a',
           {
             attrs: {
-              href: d.userAnalysis
-                ? '/editor?' +
-                  new URLSearchParams({
-                    fen: ctrl.node.fen,
-                    variant: d.game.variant.key,
-                    color: ctrl.chessground.state.orientation,
-                  })
-                : `/${d.game.id}/edit?fen=${ctrl.node.fen}`,
+              href: ctrl.boardEditorUrl(),
               title: 'Hotkey: b',
               ...linkAttrs,
             },

--- a/ui/analyse/src/view/actionMenu.ts
+++ b/ui/analyse/src/view/actionMenu.ts
@@ -112,7 +112,6 @@ export function view(ctrl: AnalyseCtrl): VNode {
                     color: ctrl.chessground.state.orientation,
                   })
                 : `/${d.game.id}/edit?fen=${ctrl.node.fen}`,
-              'data-icon': licon.Pencil,
               title: 'Hotkey: b',
               ...linkAttrs,
             },

--- a/ui/editor/src/ctrl.ts
+++ b/ui/editor/src/ctrl.ts
@@ -78,7 +78,8 @@ export default class EditorCtrl {
         })
         .bind('a', () => {
           const state = this.getState();
-          if (state.legalFen) window.location.assign(this.makeAnalysisUrl(state.legalFen, this.bottomColor()));
+          if (state.legalFen)
+            window.location.assign(this.makeAnalysisUrl(state.legalFen, this.bottomColor()));
         });
 
     this.castlingToggles = { K: false, Q: false, k: false, q: false };

--- a/ui/editor/src/ctrl.ts
+++ b/ui/editor/src/ctrl.ts
@@ -68,13 +68,18 @@ export default class EditorCtrl {
     );
 
     if (this.options.bindHotkeys !== false)
-      site.mousetrap.bind('f', () => {
-        if (this.chessground) {
-          this.chessground.toggleOrientation();
-          if (this.options.orientation) this.setOrientation(opposite(this.options.orientation));
-        }
-        this.onChange();
-      });
+      site.mousetrap
+        .bind('f', () => {
+          if (this.chessground) {
+            this.chessground.toggleOrientation();
+            if (this.options.orientation) this.setOrientation(opposite(this.options.orientation));
+          }
+          this.onChange();
+        })
+        .bind('a', () => {
+          const state = this.getState();
+          if (state.legalFen) window.location.assign(this.makeAnalysisUrl(state.legalFen, this.bottomColor()));
+        });
 
     this.castlingToggles = { K: false, Q: false, k: false, q: false };
     const params = new URLSearchParams(location.search);

--- a/ui/editor/src/view.ts
+++ b/ui/editor/src/view.ts
@@ -290,6 +290,7 @@ function controls(ctrl: EditorCtrl, state: EditorState): VNode {
             button(
               '.button.button-empty.text',
               {
+                title: 'Hotkey: f',
                 on: {
                   click() {
                     ctrl.chessground!.toggleOrientation();
@@ -302,6 +303,7 @@ function controls(ctrl: EditorCtrl, state: EditorState): VNode {
             a(state.legalFen ? ctrl.makeAnalysisUrl(state.legalFen, ctrl.bottomColor()) : '')(
               {
                 rel: 'nofollow',
+                title: 'Hotkey: a',
                 class: {
                   button: true,
                   'button-empty': true,


### PR DESCRIPTION
Closes #21366

In analysis adds board editor shortcut "b" ("e" was already taken").
In board editor adds analysis shortcut "a".


BWT buttons in board editor dont have tooltips, could be useful to display the hotkeys tooltips there too (for flip board and analysis board).