### PR TITLE
ui: fix mselect options on mobile, fix fullscreen mask

### DIFF
--- a/ui/analyse/css/study/relay/_layout.scss
+++ b/ui/analyse/css/study/relay/_layout.scss
@@ -31,10 +31,13 @@ body {
 
 main.is-relay {
   .relay-tour {
-    @include back-blur;
-
     grid-area: relay-tour;
-    backdrop-filter: none;
+
+    @include if-transp {
+      @include back-blur;
+
+      backdrop-filter: none;
+    }
 
     &__side {
       grid-area: side;

--- a/ui/analyse/css/study/relay/_layout.scss
+++ b/ui/analyse/css/study/relay/_layout.scss
@@ -31,7 +31,10 @@ body {
 
 main.is-relay {
   .relay-tour {
+    @include back-blur;
+
     grid-area: relay-tour;
+    backdrop-filter: none;
 
     &__side {
       grid-area: side;

--- a/ui/analyse/src/study/relay/relayTourView.ts
+++ b/ui/analyse/src/study/relay/relayTourView.ts
@@ -292,7 +292,7 @@ const tourSelect = (ctx: RelayViewContext, group: RelayGroup) => {
         group.tours.find(t => t.id === relay.data.tour.id)?.name || relay.data.tour.name,
       ),
       relay.tourSelectShow() && [
-        hl('label.fullscreen-mask', { on: { click: updateCheckboxAndToggle } }),
+        hl('div.fullscreen-mask', { on: { click: updateCheckboxAndToggle } }),
         hl(
           'nav.mselect__list',
           group.tours.map(tour =>
@@ -368,7 +368,7 @@ const roundSelect = (relay: RelayCtrl, study: StudyCtrl) => {
         ],
       ),
       relay.roundSelectShow() && [
-        hl('label.fullscreen-mask', { on: { click: updateCheckboxAndToggle } }),
+        hl('div.fullscreen-mask', { on: { click: updateCheckboxAndToggle } }),
         hl(
           'div.relay-tour__round-select__list.mselect__list',
           {

--- a/ui/lib/css/abstract/_extends.scss
+++ b/ui/lib/css/abstract/_extends.scss
@@ -305,10 +305,7 @@
 
 %fullscreen-mask {
   position: fixed;
-  top: -100vh;
-  left: -100vw;
-  width: 300vw;
-  height: 300vh;
+  inset: 0;
   background: $c-page-mask;
   z-index: $z-fullscreen-mask-110;
 }

--- a/ui/lib/css/component/_mselect.scss
+++ b/ui/lib/css/component/_mselect.scss
@@ -32,12 +32,6 @@ $c-mselect: $c-primary;
     }
   }
 
-  &__toggle:checked ~ .mselect__label {
-    @include transition(opacity);
-
-    opacity: 0;
-  }
-
   &__toggle:focus-visible ~ .mselect__label {
     outline: $outline;
   }
@@ -62,7 +56,7 @@ $c-mselect: $c-primary;
 
       @media (max-width: $small) {
         position: fixed;
-        top: 50%;
+        top: calc(50vh - $site-header-height);
         transform: translateY(-50%) scale(1, 1);
 
         dialog & {

--- a/ui/lobby/src/view/setup/components/variantPicker.ts
+++ b/ui/lobby/src/view/setup/components/variantPicker.ts
@@ -52,7 +52,7 @@ export const variantPicker = (setupCtrl: SetupController) => {
 
   if (isOpen) {
     children.push(
-      hl('label.fullscreen-mask', { on: { click: updateCheckboxAndToggle } }),
+      hl('div.fullscreen-mask', { on: { click: updateCheckboxAndToggle } }),
       hl(
         'div.mselect__list',
         hl(


### PR DESCRIPTION
# Why

We have recived a report that mselect renders incorrectly in some broadcasts.

<img width="400" alt="Screenshot_20260831-172831" src="https://github.com/user-attachments/assets/60b4bdef-97a8-4623-a9e9-120b9d7aa6eb" />

# How

Summary of changes:
* fix mselect positioning on mobile, use viewport height, account for sidebar (the issue with percentage is that we do not disable page scroll, and on large broadcasts page can be lengthy)
* do not hide mselect trigger when options are shown
* fix fullscreen mask being cropped in transparent themes (backdrop-filter messes with fullscreen-mask, we would need to refactor this a bit, so it's not a nested child, and root node instead, but for now this approach should work)

# Preview

<img width="409" height="860" alt="Screenshot 2026-08-31 at 19 45 36" src="https://github.com/user-attachments/assets/c1cb9732-c23b-49d4-86e0-d1e51f058916" />

<img width="1789" height="520" alt="Screenshot 2026-08-31 at 19 45 04" src="https://github.com/user-attachments/assets/e56f4479-0d88-4a09-8060-441eb1ba2946" />
