### PR TITLE
Fix memory leak in waiting users on tournament destroy

### DIFF
--- a/modules/tournament/src/main/TournamentApi.scala
+++ b/modules/tournament/src/main/TournamentApi.scala
@@ -218,7 +218,7 @@ final class TournamentApi(
   yield
     cached.tourCache.clear(tour.id)
     publish()
-    socket.reload(tour.id)
+    socket.finish(tour.id)
 
   private[tournament] def finish(oldTour: Tournament): Funit =
     Parallel(oldTour.id, "finish")(cached.tourCache.started) { tour =>


### PR DESCRIPTION
Fixes a memory leak after a tournament is destroyed with waiting players.

`socket.finish` calls `waitingUsers.remove()` before `reload()`, so switching to it adds the cleanup and keeps the existing reload

## Testing:
In `lila-docker`, created a tournament with 2 players, closed both tabs so no pairing would form, and waited for the tournament to begin. Then, cancelled the tournament, so it ended with zero pairings and was deleted from the database. Observed a `lila.tournament.WaitingUsers` instance in the heap using `jcmd GC.class_histogram` before the fix but not after.