### PR TITLE
Whitelist improvmx.com, an email forwarding service

### DIFF
--- a/modules/security/src/main/DisposableEmailDomain.scala
+++ b/modules/security/src/main/DisposableEmailDomain.scala
@@ -271,5 +271,6 @@ private object DisposableEmailDomain:
       "startmail.com",
       "palaciodegranda.com",
       "laudepalaciogranda.com",
-      "mozmail.com" // Mozilla Firefox Relay Domain
+      "mozmail.com", // Mozilla Firefox Relay Domain
+      "improvmx.com" // email forwarding for domains you own
     )


### PR DESCRIPTION
Lichess is blocking sign up from my very much real and non disposable email address (philfreo.com domain) because improvmx.com is inappropriately on some blacklists. 