### PR TITLE
ui: restore typography colors, fix Security page icons

### DIFF
--- a/ui/lib/css/base/_typography.scss
+++ b/ui/lib/css/base/_typography.scss
@@ -40,3 +40,15 @@ h2 {
 
   font-size: 1em;
 }
+
+.is-green .svg-icon {
+  color: var(--c-good);
+}
+
+.is-red .svg-icon {
+  color: var(--c-bad);
+}
+
+.is-gold .svg-icon {
+  color: var(--c-brag);
+}

--- a/ui/user/css/_account.scss
+++ b/ui/user/css/_account.scss
@@ -9,7 +9,7 @@
   }
 
   .icon span {
-    font-size: 3.5em;
+    width: 56px;
   }
 
   .ip {


### PR DESCRIPTION
# Why

Refs: https://github.com/lichess-org/lila/issues/21483#issuecomment-5500243317

# How

Restore typography color classes, fix Security page icons sizing.

# Preview

<img width="1108" height="778" alt="Screenshot 2026-09-02 at 10 01 11" src="https://github.com/user-attachments/assets/2a8b8723-c6b8-4cb9-9683-998e4c30057e" />
