### PR TITLE
ui(lib): Markdown header anchor links fix

### DIFF
--- a/ui/lib/css/component/_markdown.scss
+++ b/ui/lib/css/component/_markdown.scss
@@ -87,16 +87,23 @@
   h2,
   h3,
   h4 {
+    position: relative;
+
     a[id] {
       opacity: 0;
+      width: 3rem;
+      left: -2.5rem;
+      position: absolute;
 
       &::before {
         @include icon-mask($icon-Link);
 
         color: $c-font-dimmer;
-        margin-left: -3rem;
-        width: 3rem;
-        position: absolute;
+        width: 1.75rem;
+
+        &:hover {
+          opacity: 0.8;
+        }
       }
     }
 


### PR DESCRIPTION
# Why

Refs https://github.com/lichess-org/lila/issues/21483#issuecomment-5502905504

# How

Alter the way we size and place links, make sure icons are always centered, and use correct size.

Also, those changes fixes font-weight beight inherited by icon, and adds a alight opacity change when icon is hovered.

# Preview

https://github.com/user-attachments/assets/4542e23e-1c03-4cb1-b03a-2d063fa38e95

