### PR TITLE
ui(forum): adjust poster cell spacing

### DIFF
--- a/ui/bits/css/forum/_table.scss
+++ b/ui/bits/css/forum/_table.scss
@@ -50,7 +50,6 @@
       span {
         display: flex;
         align-items: center;
-        gap: 0.5rem;
       }
     }
 


### PR DESCRIPTION
# Why

I think the similar appearance was on PROD before, but spotted it and thought that when looking for SVG regressions.

# How

I think we can adjust poster cell spacing, since I felt to me like an issue.

# Preview

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td><img width="487" height="560" alt="Screenshot 2026-09-02 at 11 06 03" src="https://github.com/user-attachments/assets/349938bc-921f-485f-8b33-627e3590c032" /></td><td><img width="487" height="560" alt="Screenshot 2026-09-02 at 11 05 58" src="https://github.com/user-attachments/assets/d495f70e-ebd9-4a1e-b44b-698b100cc6ea" /></td></tr>
</table>
