### PR TITLE
ui(relay): fix relay fallback image on the list

### DIFF
--- a/ui/bits/css/relay/_image.scss
+++ b/ui/bits/css/relay/_image.scss
@@ -2,13 +2,16 @@
   &--fallback {
     @extend %flex-center-center;
 
-    width: 66%;
     aspect-ratio: 2 / 1;
     background: linear-gradient(to bottom, rgb(from $c-primary r g b / 0.7), rgb(from $c-brag r g b / 0.7));
     background-repeat: no-repeat;
     box-shadow: 0 0 40px rgb(0 0 0 / 0.3) inset;
     color: $c-font;
     text-shadow: 0 0 40px white;
+
+    &.drop-target {
+      width: 66%;
+    }
 
     .svg-icon {
       flex: initial;


### PR DESCRIPTION
# How

Fix relay fallback image on the list. Looks like the fix for broken drop field in edit mode broken the display on the list. Now the width style is only applied in form, and grid cell looks correct.

Refs #21483

# Preview

### Before

<img width="481" height="325" alt="Screenshot 2026-09-02 at 12 04 19" src="https://github.com/user-attachments/assets/29e04ca9-b476-4c6e-9c98-f0bf78d7197d" />

### After

<img width="481" height="325" alt="Screenshot 2026-09-02 at 12 05 33" src="https://github.com/user-attachments/assets/9afff266-c4f3-40b6-b6fd-376d9541639d" />

<img width="481" height="325" alt="Screenshot 2026-09-02 at 12 05 33" src="https://github.com/user-attachments/assets/4402b7bc-bc48-483f-901e-1a57612f0949" />
