### PR TITLE
allow full-width hovers on topnav user search results

### DIFF
--- a/ui/cli/css/_clinput.scss
+++ b/ui/cli/css/_clinput.scss
@@ -29,6 +29,10 @@
       color: $c-primary;
     }
   }
+
+  .complete-result {
+    width: 100%;
+  }
 }
 
 body.clinput #top {


### PR DESCRIPTION
### The hover/hilite target shrank to the username bounds rather than stretching to the end:
<img width="292" height="203" alt="image" src="https://github.com/user-attachments/assets/3668282d-6f95-4486-9eed-d81bda1abb19" />

### So add a 100% and get:
<img width="292" height="203" alt="image" src="https://github.com/user-attachments/assets/5ec44dbc-18d5-425e-ae84-76722ab17766" />
