### PR TITLE
align headers in report atom list

### DIFF
--- a/ui/mod/css/_report.scss
+++ b/ui/mod/css/_report.scss
@@ -130,11 +130,13 @@ $c-report-high-over: white;
     }
 
     .head {
-      display: block;
+      display: flex;
+      gap: 1ch;
     }
 
     .score {
       font-size: 0.9em;
+      margin: 0;
       padding: 0.1em 0.4em;
     }
   }


### PR DESCRIPTION
The old display may be intentional:

<img width="960" height="110" alt="image" src="https://github.com/user-attachments/assets/255eb6e6-3fae-4613-a22a-1e1daf39ac50" />

But if that's an svg-icon regression, this PR makes it:

<img width="960" height="96" alt="image" src="https://github.com/user-attachments/assets/851a2520-95c8-4710-9776-3dccaa46a4e2" />
