### PR TITLE
Remove broken slist css key from shield page

### DIFF
--- a/modules/tournament/src/main/ui/TournamentList.scala
+++ b/modules/tournament/src/main/ui/TournamentList.scala
@@ -320,7 +320,7 @@ final class TournamentList(helpers: Helpers, ui: TournamentUi)(
 
     def byCateg(categ: TournamentShield.Category, awards: List[TournamentShield.Award])(using Context) =
       Page("Tournament shields")
-        .css("tournament.leaderboard", "slist"):
+        .css("tournament.leaderboard"):
           main(cls := "page-menu page-small tournament-categ-shields")(
             shieldMenu,
             div(cls := "page-menu__content box")(


### PR DESCRIPTION
https://lichess.org/tournament/shields/bullet attempts to use a CSS bundle that doesn't exist and 404s on every request for it. It looks fine on prod and doesn't seem like anything on that page uses it, so let's remove it.

<img width="415" height="60" alt="image" src="https://github.com/user-attachments/assets/710b54cc-6c18-47e4-9eb5-5217fd0dc672" />


## Testing

Built in docker and renders the same as prod, minus the 404 (which is what we want).

<img width="1505" height="576" alt="image" src="https://github.com/user-attachments/assets/3a5cdf00-6993-4e3c-aef3-c7b0ba301abb" />

