### PR TITLE
ui(round): fix user display in two columns mode

### DIFF
--- a/ui/round/css/_user.scss
+++ b/ui/round/css/_user.scss
@@ -71,8 +71,8 @@
     padding: 0.5em 0.5em 0.5em 0.3em;
     line-height: inherit;
 
-    a {
-      flex: 1 1 auto;
+    rating {
+      margin-left: auto;
     }
   }
 


### PR DESCRIPTION
# Why

Refs https://github.com/lichess-org/lila/issues/21483#issuecomment-5514058962

# How

Fix user display in rounds, in two columns mode.

# Preview

<img width="384" height="363" alt="Screenshot 2026-09-03 at 09 19 04" src="https://github.com/user-attachments/assets/2fd79c57-92a3-4a4d-9261-a7ee328ec116" />
