### PR TITLE
ui(tournament): fix shields render in leaderboard

### DIFF
--- a/ui/tournament/css/_leaderboard.scss
+++ b/ui/tournament/css/_leaderboard.scss
@@ -69,24 +69,23 @@ $user-list-width: 35ch;
   height: 80px;
   background: url('../images/trophy/shield-gold.png') no-repeat;
   background-size: contain;
-  font-size: 40px;
-  line-height: 76px;
   text-align: center;
-  letter-spacing: normal;
-  color: #333;
-  text-shadow: 0 0 6px #fff;
   filter: drop-shadow(0 0 10px $c-brag);
 
-  > .svg-icon {
-    width: 1em;
-    height: 1em;
+  .svg-icon {
+    background: linear-gradient(90deg, #000 0%, #444 100%);
+    width: 1.75em;
+    margin-top: 18px;
   }
 
   @media (max-width: at-most($small)) {
     width: 50.25px;
     height: 60px;
-    font-size: 30px;
-    line-height: 57px;
+
+    .svg-icon {
+      width: 1.45em;
+      margin-top: 14px;
+    }
   }
 }
 


### PR DESCRIPTION
# Why

Refs https://github.com/lichess-org/lila/issues/21483#issuecomment-5514380251

# How

Fix shields render in tournament leaderboard. 

An appearance has been slightly altered, since it looks like elements using mask cannot cast shadows.

# Preview

<img width="1124" height="693" alt="Screenshot 2026-09-03 at 09 50 42" src="https://github.com/user-attachments/assets/c4a58d55-5ca6-4e6b-87cf-5f1b1352f6fb" />

<img width="407" height="856" alt="Screenshot 2026-09-03 at 09 50 54" src="https://github.com/user-attachments/assets/0ec307f3-4fd0-4afb-87b1-f020e07580e0" />
