### PR TITLE
ui(tournament): fix shields render in leaderboard category

### DIFF
--- a/ui/tournament/css/_leaderboard.scss
+++ b/ui/tournament/css/_leaderboard.scss
@@ -90,12 +90,15 @@ $user-list-width: 35ch;
 }
 
 .tournament-categ-shields {
-  font-size: 1.1em;
-
   .shield-trophy {
     @include inline-start(calc($box-padding - 10px));
 
     transform: scale(0.7);
+
+    .svg-icon {
+      margin-top: 24px;
+      transform: scale(1.2);
+    }
   }
 
   li {


### PR DESCRIPTION
# How

Refs #21483

Fix trophy shields view in tournament category list.

> I have replaced icons manually in DOM, since I have games generated only in one category locally.

# Preview

<img width="1048" height="497" alt="Screenshot 2026-09-03 at 10 10 24" src="https://github.com/user-attachments/assets/cb7cc11e-987a-412f-9c2b-e0f6bc1193e7" />

