### PR TITLE
Fix deleting the previously selected external engine

### DIFF
--- a/ui/lib/src/ceval/ctrl.ts
+++ b/ui/lib/src/ceval/ctrl.ts
@@ -209,6 +209,14 @@ export class CevalCtrl {
     this.opts.onSelectEngine?.();
   };
 
+  async deleteExternal(id: string): Promise<boolean> {
+    if (!(await this.engines.deleteExternal(id))) return false;
+    const next = this.engines.active();
+    if (next && this.storedEngine() !== next.id) this.selectEngine(next.id);
+    if (this.worker?.getInfo().id === id) this.unload();
+    return true;
+  }
+
   setPvBoard = (pvBoard: PvBoard | null): void => {
     this.pvBoard(pvBoard);
     this.opts.redraw();

--- a/ui/lib/src/ceval/engines/engines.ts
+++ b/ui/lib/src/ceval/engines/engines.ts
@@ -302,10 +302,11 @@ export class Engines {
   }
 
   async deleteExternal(id: string): Promise<boolean> {
-    if (this.externalEngines.every(e => e.id !== id)) return false;
+    if (!this.externalEngines.some(e => e.id === id)) return false;
     const r = await fetch(`/api/external-engine/${id}`, { method: 'DELETE', headers: xhrHeader });
     if (!r.ok) return false;
     this.externalEngines = this.externalEngines.filter(e => e.id !== id);
+    if (this.activeEngine?.id === id) this.activeEngine = undefined;
     this.active();
     return true;
   }

--- a/ui/lib/src/ceval/view/settings.ts
+++ b/ui/lib/src/ceval/view/settings.ts
@@ -217,8 +217,9 @@ function engineSelection({ ceval }: CevalHandler) {
           attrs: { title: 'Delete external engine' },
           hook: bind('click', async e => {
             (e.currentTarget as HTMLElement).blur();
-            if (await confirm('Remove external engine?'))
-              ceval.engines.deleteExternal(external.id).then(ok => ok && ceval.opts.redraw());
+            const id = ceval.engines.external?.id;
+            if (!id || !(await confirm('Remove external engine?'))) return;
+            if (await ceval.deleteExternal(id)) ceval.opts.redraw();
           }),
         },
         [snabIcon('trash')],

--- a/ui/lib/tests/engines.test.ts
+++ b/ui/lib/tests/engines.test.ts
@@ -1,0 +1,78 @@
+import assert from 'node:assert/strict';
+import { afterEach, describe, mock, test } from 'node:test';
+
+import { CevalCtrl } from '../src/ceval/ctrl';
+import type { ExternalEngineInfoFromServer } from '../src/ceval/types';
+
+const variant: Variant = { key: 'standard', name: 'Standard', short: 'Std' };
+
+const ext = (id: string): ExternalEngineInfoFromServer => ({
+  id,
+  name: id,
+  variants: ['chess'],
+  maxHash: 16,
+  maxThreads: 1,
+  clientSecret: 's',
+  endpoint: 'http://engine.test',
+});
+
+const makeCtrl = () =>
+  new CevalCtrl({
+    variant,
+    emit: () => {},
+    onUciHover: () => {},
+    redraw: () => {},
+    externalEngines: [ext('ext-a'), ext('ext-b')],
+  });
+
+describe('deleteExternal', () => {
+  afterEach(() => mock.restoreAll());
+
+  test('deletes the requested engine, not a previously selected one', async () => {
+    const fetchMock = mock.method(globalThis, 'fetch', async () => new Response(null, { status: 204 }));
+    const ceval = makeCtrl();
+    ceval.selectEngine('ext-a');
+    ceval.selectEngine('ext-b');
+
+    assert.equal(await ceval.deleteExternal('ext-b'), true);
+    assert.equal(fetchMock.mock.calls[0].arguments[0], '/api/external-engine/ext-b');
+    assert.deepEqual(
+      ceval.engines.externalEngines.map(e => e.id),
+      ['ext-a'],
+    );
+    assert.notEqual(ceval.engines.active()?.id, 'ext-b');
+    assert.equal(ceval.storedEngine(), ceval.engines.active()?.id);
+  });
+
+  test('keeps the current engine when deleting another', async () => {
+    mock.method(globalThis, 'fetch', async () => new Response(null, { status: 204 }));
+    const ceval = makeCtrl();
+    ceval.selectEngine('ext-b');
+
+    assert.equal(await ceval.deleteExternal('ext-a'), true);
+    assert.equal(ceval.engines.active()?.id, 'ext-b');
+    assert.equal(ceval.storedEngine(), 'ext-b');
+    assert.deepEqual(
+      ceval.engines.externalEngines.map(e => e.id),
+      ['ext-b'],
+    );
+  });
+
+  test('does not mutate state when the api fails', async () => {
+    mock.method(globalThis, 'fetch', async () => new Response(null, { status: 500 }));
+    const ceval = makeCtrl();
+    ceval.selectEngine('ext-a');
+
+    assert.equal(await ceval.deleteExternal('ext-a'), false);
+    assert.equal(ceval.engines.active()?.id, 'ext-a');
+    assert.equal(ceval.engines.externalEngines.length, 2);
+  });
+
+  test('returns false for an unknown engine without calling the api', async () => {
+    const fetchMock = mock.method(globalThis, 'fetch', async () => new Response(null, { status: 204 }));
+    const ceval = makeCtrl();
+
+    assert.equal(await ceval.deleteExternal('missing'), false);
+    assert.equal(fetchMock.mock.callCount(), 0);
+  });
+});


### PR DESCRIPTION
## Summary
- The trash button kept a stale engine id because `bind()` only attaches on insert, so switching engines and then deleting removed the previous selection instead of the current one.
- After a successful delete, clear the active engine if it was the one removed, persist the fallback, and unload a worker still running that engine so further deletes keep working without a reload.
- Adds unit coverage for switch-then-delete, deleting a non-active engine, API failure, and an unknown id.

Fixes https://github.com/lichess-org/lila/issues/21523

## AI disclosure
Cursor agent for the implementation, tests, and PR text. I reviewed the diff. The delete button kept a stale engine id (`bind()` is insert-only) and `active()` did not refresh after delete.

## Test plan
- [x] `pnpm test engines` — 4/4 passing (switch-then-delete, non-active delete, API failure, unknown id)
- [ ] Open analysis with at least two external engines
- [ ] Select engine A, switch to engine B, delete: B is removed and A remains
- [ ] Delete another engine without reloading the page
- [ ] Delete the currently selected engine: selection falls back and ceval keeps working