### PR TITLE
ui(lib): user powertip content fixes related to icons

### DIFF
--- a/ui/lib/css/component/_btn-rack.scss
+++ b/ui/lib/css/component/_btn-rack.scss
@@ -3,7 +3,7 @@
   @include prevent-select;
 
   display: inline-flex;
-  align-items: center;
+  align-items: stretch;
   border: $border;
   border-top: 0;
 

--- a/ui/lib/css/component/_power-tip.scss
+++ b/ui/lib/css/component/_power-tip.scss
@@ -38,7 +38,6 @@
 
       .user-link {
         flex: 0 0 auto;
-        display: block;
         font-size: 1.1em;
       }
 
@@ -74,6 +73,10 @@
         max-width: 25%;
         padding: 2px 3px;
         text-align: left;
+
+        .svg-icon {
+          float: left;
+        }
       }
 
       body.no-rating & {

--- a/ui/lib/css/component/_user-link.scss
+++ b/ui/lib/css/component/_user-link.scss
@@ -108,7 +108,6 @@ a.user-link {
   aspect-ratio: 1;
   vertical-align: middle;
   margin-left: 0.5ch;
-  transform: translateY(-0.1em);
 
   // keeps the username easily selectable
   body.no-flair & {


### PR DESCRIPTION
# Why

Refs https://github.com/lichess-org/lila/issues/21483#issuecomment-5522403514

# How

User powertip content fixes related to icons, I also removed no longer needed user flair icon translate.

# Preview

<img width="351" height="214" alt="Screenshot 2026-09-04 at 11 18 27" src="https://github.com/user-attachments/assets/a4714196-baa4-4cfc-bd1b-7c052c996bd0" />
