### PR TITLE
ui(storm): fix reload view icon placement

### DIFF
--- a/ui/storm/css/_storm.scss
+++ b/ui/storm/css/_storm.scss
@@ -33,7 +33,7 @@
 
     .svg-icon {
       width: 15em;
-      line-height: 1.2em;
+      margin: 0 auto;
     }
 
     p {


### PR DESCRIPTION
# Why

Refs https://github.com/lichess-org/lila/issues/21483#issuecomment-5524093831

# How

Fix Storm reload view icon placement.

# Preview

<img width="690" height="517" alt="Screenshot 2026-09-04 at 11 57 04" src="https://github.com/user-attachments/assets/f94436df-cdc0-4672-a424-8ff0879e07da" />
