### PR TITLE
ui(coach): fix rating display on list and profile

### DIFF
--- a/ui/bits/css/coach/_widget.scss
+++ b/ui/bits/css/coach/_widget.scss
@@ -1,7 +1,6 @@
 .coach-widget {
   position: relative;
   display: flex;
-  padding-bottom: 1rem;
 
   @include transition;
 
@@ -74,12 +73,16 @@
     .rating td {
       @extend %flex-center;
 
+      gap: 0.5em;
+
       a {
         display: flex;
         color: $c-font;
+        gap: 0.5em;
 
-        span {
-          margin-inline-start: 0.5em;
+        .svg-icon {
+          width: 16px;
+          margin-inline-end: 0.2em;
         }
       }
     }

--- a/ui/bits/css/coach/_widget.scss
+++ b/ui/bits/css/coach/_widget.scss
@@ -89,7 +89,7 @@
 
     .flag img {
       margin-inline-start: 0.5em;
-      vertical-align: text-bottom;
+      vertical-align: bottom;
       aspect-ratio: 1;
     }
 


### PR DESCRIPTION
# Why

Refs https://github.com/lichess-org/lila/issues/21483#issuecomment-5523902280

# How

Fix coach rating display on list and profile, avoid spacing if there is no FIDE ranking.

# Preview

<img width="1000" height="490" alt="Screenshot 2026-09-04 at 12 29 45" src="https://github.com/user-attachments/assets/d1489289-bcde-4eed-90f1-b85c5815c8c5" />

