### PR TITLE
ui(dasher): fix patron/online icons in dasher, adjust spacing

### DIFF
--- a/ui/dasher/css/_link.scss
+++ b/ui/dasher/css/_link.scss
@@ -20,7 +20,7 @@
     padding: 0.5rem 1rem;
     width: 100%;
     text-align: start;
-    gap: 0.5em;
+    gap: 0.6em;
   }
 
   .links a:hover,
@@ -36,10 +36,14 @@
   }
 
   .links a .line {
-    width: 16px;
+    margin-inline-end: 0;
 
-    &::before {
-      width: 11px;
+    &:not(.patron) {
+      width: 16px;
+
+      &::before {
+        width: 11px;
+      }
     }
   }
 


### PR DESCRIPTION
# Why

https://github.com/lichess-org/lila/issues/21483#issuecomment-5541178510

# How

Fix patron/online icons in dasher, adjust spacing.

# Preview

<img width="242" height="451" alt="Screenshot 2026-09-05 at 09 23 37" src="https://github.com/user-attachments/assets/1d862f19-bff4-4570-bb0e-49a4d9e07cc0" />
<img width="242" height="451" alt="Screenshot 2026-09-05 at 09 23 26" src="https://github.com/user-attachments/assets/64a4a40c-6365-4d4d-82db-317afed5406b" />
