### PR TITLE
ui(lib): tweaks and fixes for mselect and cmn-toggle

### DIFF
--- a/ui/lib/css/component/_mselect.scss
+++ b/ui/lib/css/component/_mselect.scss
@@ -13,7 +13,7 @@ $c-mselect: $c-primary;
   &__label {
     @extend %box-radius, %flex-between-nowrap, %metal-with-border;
     @include backdrop-blur-if-transparent;
-    @include padding-direction(0.3rem, 0.6rem, 0.3rem, 1rem);
+    @include padding-direction(0.3rem, 0.65rem, 0.3rem, 1rem);
 
     gap: 1ch;
     cursor: pointer;
@@ -22,11 +22,14 @@ $c-mselect: $c-primary;
       @include icon-mask($icon-moreTriangle, 0.7rem);
 
       color: $c-mselect;
-      margin-inline: 0.4em 0;
     }
 
     &:focus-visible {
       outline: $outline;
+    }
+
+    .svg-icon {
+      font-size: 85%;
     }
   }
 
@@ -77,7 +80,7 @@ $c-mselect: $c-primary;
     gap: 0.5em;
     white-space: nowrap;
     display: block;
-    padding: 0.3em 1em;
+    padding: 0.3em 1em 0.3rem calc(1rem - 3px);
     visibility: hidden;
     opacity: 0;
     color: $c-mselect;
@@ -98,6 +101,10 @@ $c-mselect: $c-primary;
     &:focus-visible {
       outline: $outline;
       outline-offset: -2px;
+    }
+
+    .svg-icon {
+      font-size: 85%;
     }
   }
 }

--- a/ui/lib/css/form/_cmn-toggle.scss
+++ b/ui/lib/css/form/_cmn-toggle.scss
@@ -37,15 +37,14 @@
   }
 
   &::before {
-    @extend %box-radius;
-    @include icon-mask($icon-x);
+    @include icon-mask($icon-x, 9px);
     @include transition(margin-inline-start color);
 
     align-self: center;
-    inset: 6px;
+    left: 7px;
+    top: 0;
     z-index: 1;
-    width: 10px;
-    color: $c-font-dimmer;
+    background-color: $c-font-dimmer;
   }
 
   &::after {
@@ -98,9 +97,10 @@
   }
 
   &::before {
-    @include icon-mask($icon-checkmark);
+    @include icon-mask($icon-checkmark, 12px);
 
     color: $c-good;
+    left: 6px;
   }
 }
 


### PR DESCRIPTION
# Why

Refs https://github.com/lichess-org/lila/issues/21483#issuecomment-5523810259

# How

Tweaks and fixes for mselect and cmn-toggle elements after icon switch to SVG. Few minor spacing tweaks has been made along.

# Preview

<img width="345" height="74" alt="Screenshot 2026-09-05 at 09 42 52" src="https://github.com/user-attachments/assets/632ecb29-c86e-4d4f-929d-d6c427ff2180" />
<img width="345" height="384" alt="Screenshot 2026-09-05 at 09 42 46" src="https://github.com/user-attachments/assets/e0b54ef9-e9a3-4e63-a70e-9805f5b71d3b" />
<img width="344" height="74" alt="Screenshot 2026-09-05 at 10 10 35" src="https://github.com/user-attachments/assets/3b754218-6d7a-48c2-b09b-11d582edc251" />
<img width="344" height="74" alt="Screenshot 2026-09-05 at 10 10 29" src="https://github.com/user-attachments/assets/f899123c-cda8-4d99-8ce3-8f7ddc05689f" />
