### PR TITLE
ui(lib): control bar icons sizing and position tweaks

### DIFF
--- a/ui/lib/css/chess/_control.scss
+++ b/ui/lib/css/chess/_control.scss
@@ -10,8 +10,13 @@
     @extend %box-radius-bottom;
     @include prevent-select;
 
+    line-height: unset;
     -webkit-touch-callout: none;
     text-align: center;
+
+    .svg-icon {
+      margin-top: 5px;
+    }
   }
 
   [data-act='opening-explorer'],
@@ -42,13 +47,19 @@
         font-size: 0.75em;
       }
 
-      &[data-act='line'] {
+      &[data-act='line'],
+      &[data-act='prev'],
+      &[data-act='next'] {
         font-size: 0.9em;
       }
     }
   }
 
   @include mq-is-col1 {
+    .fbt .svg-icon {
+      margin-top: unset;
+    }
+
     .jumps .fbt[data-act='prev'],
     .jumps .fbt[data-act='next'] {
       padding-inline: 6px;


### PR DESCRIPTION
# Why

Refs https://github.com/lichess-org/lila/issues/21483#issuecomment-5523810259

# How

Control bar icons sizing and position tweaks. 

Overall, all icons are slightly larger than on PROD, but this does not look that bad IMO.

# Preview

<img width="369" height="119" alt="Screenshot 2026-09-05 at 10 19 02" src="https://github.com/user-attachments/assets/261d9045-0e82-482f-86a9-f1b2f1b2a592" />
<img width="464" height="210" alt="Screenshot 2026-09-05 at 10 19 17" src="https://github.com/user-attachments/assets/44bccac4-ab1a-4a3f-9b51-d66318f8e105" />
