### PR TITLE
Make the password reveal button accessible

### DIFF
--- a/modules/coreI18n/src/main/key.scala
+++ b/modules/coreI18n/src/main/key.scala
@@ -1825,6 +1825,7 @@ object I18nKey:
     val `signupUsernameHint`: I18nKey = "signupUsernameHint"
     val `signupEmailPromise`: I18nKey = "signupEmailPromise"
     val `password`: I18nKey = "password"
+    val `showPassword`: I18nKey = "showPassword"
     val `changePassword`: I18nKey = "changePassword"
     val `changeEmail`: I18nKey = "changeEmail"
     val `email`: I18nKey = "email"

--- a/modules/ui/src/main/helper/Form3.scala
+++ b/modules/ui/src/main/helper/Form3.scala
@@ -234,8 +234,13 @@ final class Form3(formHelper: FormHelper & I18nHelper & AssetHelper, flairApi: F
         reveal.option(passwordRevealButton)
       )
 
-  def passwordRevealButton =
-    button(cls := "password-reveal", tpe := "button")(iconEl(Icon.eye))
+  def passwordRevealButton(using Translate) =
+    button(
+      cls := "password-reveal",
+      tpe := "button",
+      ariaTitle(trans.site.showPassword.txt()),
+      aria("pressed") := "false"
+    )(iconEl(Icon.eye))
 
   def passwordComplexityMeter(labelContent: Frag): Tag =
     div(cls := "password-complexity")(

--- a/translation/source/site.xml
+++ b/translation/source/site.xml
@@ -249,6 +249,7 @@
   <string name="signupUsernameHint">Be sure to choose a username appropriate for all ages. You cannot change it later, and accounts with inappropriate usernames will be closed!</string>
   <string name="signupEmailPromise">We will only send you emails about your account and never share your email.</string>
   <string name="password">Password</string>
+  <string name="showPassword">Show password</string>
   <string name="changePassword">Change password</string>
   <string name="changeEmail">Change email</string>
   <string name="email">Email</string>

--- a/ui/@types/lichess/i18n.d.ts
+++ b/ui/@types/lichess/i18n.d.ts
@@ -4509,6 +4509,8 @@ interface I18n {
     showHelpDialog: string;
     /** Show me everything */
     showMeEverything: string;
+    /** Show password */
+    showPassword: string;
     /** Show threat */
     showThreat: string;
     /** You have received a private message from Lichess. */

--- a/ui/lib/src/view/controls.ts
+++ b/ui/lib/src/view/controls.ts
@@ -62,7 +62,7 @@ export const addPasswordVisibilityToggleListener = (): void => {
       const type = $input.attr('type') === 'password' ? 'text' : 'password';
       $input.attr('type', type);
       $button.toggleClass('revealed', type === 'text');
-      $input[0]?.focus();
+      $button.attr('aria-pressed', String(type === 'text'));
     });
   });
 };


### PR DESCRIPTION
Fixes #21540.

### The problem

The show/hide password button is an icon-only button with no accessible name:

```html
<button class="password-reveal" type="button" data-icon=""></button>
```

With a screen reader it is announced only as "button". There is no way to know what it does, no way to tell whether the password is currently visible, and activating it moved focus into the password input, which threw me out of the control.

I am a blind NVDA user, so this is something I run into directly on the login page.

### The change

- `Form3.passwordRevealButton` now uses the existing `ariaTitle` helper (which sets both `title` and `aria-label`) with a new `showPassword` translation key, plus `aria-pressed` for the state. This follows the convention already used in the codebase: `iconEl` marks icons `aria-hidden="true"`, so an icon-only control is expected to carry its own label.
- The click handler keeps `aria-pressed` in sync and no longer moves focus.

The button comes from a shared helper, so this covers the login, signup, password reset and account password forms.

### Why the focus call was removed rather than kept for mouse only

My first attempt kept `$input.focus()` for pointer activation and skipped it for keyboard activation via `e.detail !== 0`. Testing with NVDA showed that this does not work: screen readers activate a button by synthesizing a mouse click at the element's coordinates. The event I measured arrives with `detail: 1`, `pointerType: "mouse"`, `isTrusted: true`, and identical coordinates on every activation — indistinguishable from a physical click. Any such heuristic therefore fails for exactly the users it is meant to help.

Moving focus as a side effect of activating a control is an unexpected context change anyway, so the call is gone entirely. If you would rather keep the convenience for mouse users, I am happy to discuss alternatives, but I could not find a way to detect the input method reliably.

### Manual testing

Tested on a local instance (lila-docker) with NVDA on Windows and Chrome.

Before: tabbing to the control announces only "button"; activating it moves focus to the password field.

After: it is announced as "Show password" with its pressed state; activating it toggles the state, the input type flips, and focus stays on the button. Checked with both screen reader activation and a real mouse click.

### AI disclosure

Per `AI_POLICY.md`: I used Claude (Claude Code) as an assistant on this change. I found the bug myself with my screen reader, chose the approach, and did the manual NVDA testing; the assistant located the relevant code, wrote the patch, and ran the build and checks. Our conversation was in Portuguese. In summary, I asked it to find the code responsible for the button and check whether an issue already existed, to explain the project's conventions for icon-only buttons so the fix would follow them rather than invent one, to apply the change and run the required checks, and — after my NVDA test showed focus was still being moved — to investigate why and correct the approach. The measurement quoted above came from instrumenting the page and activating the button with NVDA myself.
