### PR TITLE
Store ceval results in idb for replays and chapters

### DIFF
--- a/modules/coreI18n/src/main/key.scala
+++ b/modules/coreI18n/src/main/key.scala
@@ -2052,7 +2052,7 @@ object I18nKey:
     val `oneUrlPerLine`: I18nKey = "oneUrlPerLine"
     val `inlineNotation`: I18nKey = "inlineNotation"
     val `makeAStudy`: I18nKey = "makeAStudy"
-    val `clearSavedMoves`: I18nKey = "clearSavedMoves"
+    val `clearLocalData`: I18nKey = "clearLocalData"
     val `previouslyOnLichessTV`: I18nKey = "previouslyOnLichessTV"
     val `onlinePlayers`: I18nKey = "onlinePlayers"
     val `activePlayers`: I18nKey = "activePlayers"

--- a/translation/source/site.xml
+++ b/translation/source/site.xml
@@ -557,7 +557,7 @@ Playing rated games will increase stability.</string>
   <string name="oneUrlPerLine">One URL per line.</string>
   <string name="inlineNotation">Inline notation</string>
   <string name="makeAStudy">For safekeeping and sharing, consider making a study.</string>
-  <string name="clearSavedMoves">Clear moves</string>
+  <string name="clearLocalData">Clear local data</string>
   <string name="previouslyOnLichessTV">Previously on Lichess TV</string>
   <string name="onlinePlayers">Online players</string>
   <string name="activePlayers">Active players</string>

--- a/ui/@types/lichess/i18n.d.ts
+++ b/ui/@types/lichess/i18n.d.ts
@@ -3439,8 +3439,8 @@ interface I18n {
     clearBoard: string;
     /** Clear field */
     clearField: string;
-    /** Clear moves */
-    clearSavedMoves: string;
+    /** Clear local data */
+    clearLocalData: string;
     /** Clear search */
     clearSearch: string;
     /** Click here to read it */

--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -102,6 +102,7 @@ export default class AnalyseCtrl implements CevalHandler {
   onMainline = true;
   synthetic: boolean; // false if coming from a real game
   ongoing: boolean; // true if real game is ongoing
+  asyncReady = false; // cannot accurately draw movelist or start ceval until this is true
   private readonly cevalEnabledProp = storedBooleanProp('engine.enabled', false);
 
   // display flags
@@ -191,7 +192,6 @@ export default class AnalyseCtrl implements CevalHandler {
     if (location.hash === '#practice' || this.study?.data.chapter.practice) this.togglePractice();
     else if (location.hash === '#menu') requestIdleCallbackSafe(this.actionMenu.toggle, 500);
     this.setCevalPracticeOpts();
-    this.startCeval();
     keyboard.bind(this);
 
     const urlEngine = new URLSearchParams(location.search).get('engine');
@@ -230,7 +230,7 @@ export default class AnalyseCtrl implements CevalHandler {
         redraw();
       }
     });
-    this.mergeIdbThenShowTreeView();
+    this.asyncLoadThenShow();
     (window as any).lichess.analysis = {
       playUci: this.playUci,
       navigate: this.navigate,
@@ -242,7 +242,7 @@ export default class AnalyseCtrl implements CevalHandler {
     this.data = data;
     this.synthetic = data.game.id === 'synthetic';
     this.ongoing = !this.synthetic && playable(data);
-    this.treeView.hidden = true;
+    this.asyncReady = false;
     const prevTree = merge && this.tree.root;
     this.tree = makeTree(treeReconstruct(this.data.treeParts, this.variantKey, this.data.sidelines));
     if (prevTree) this.tree.merge(prevTree);
@@ -495,9 +495,8 @@ export default class AnalyseCtrl implements CevalHandler {
     this.setPath(treePath.root);
     this.initCeval();
     this.instanciateEvalCache();
-    this.startCeval();
     this.cgVersion.js++;
-    this.mergeIdbThenShowTreeView();
+    this.asyncLoadThenShow();
   }
 
   changePgn(pgn: string, andReload: boolean): AnalyseData | undefined {
@@ -728,8 +727,12 @@ export default class AnalyseCtrl implements CevalHandler {
         !(ev.cloud && this.ceval.engines.external)
       ) {
         node.ceval = ev;
+        if (!ev.cloud) this.idbTree.saveCeval(path, ev);
       } else if (!ev.cloud) {
-        if (node.ceval?.cloud && this.ceval.isDeeper()) node.ceval = ev;
+        if (node.ceval?.cloud && this.ceval.isDeeper()) {
+          node.ceval = ev;
+          this.idbTree.saveCeval(path, ev);
+        }
       }
 
       if (!isThreat) this.liveAnnotate?.onNewCeval(path, node, this.tree);
@@ -782,14 +785,15 @@ export default class AnalyseCtrl implements CevalHandler {
 
   cevalEnabled = (enable?: boolean): boolean | 'force' => {
     const force = Boolean(this.study?.practice || this.practice || this.retro?.forceCeval());
-    const unforcedState = this.cevalEnabledProp() && this.isCevalAllowed() && !this.ceval.wasUnloaded;
+    const unforcedState =
+      this.cevalEnabledProp() && this.isCevalAllowed() && !this.ceval.wasUnloadedByAnotherWindow;
 
     if (enable === undefined) return force ? 'force' : unforcedState;
     if (!force) {
       this.showCevalProp(enable);
       this.cevalEnabledProp(enable);
     }
-    if (enable && this.ceval.wasUnloaded) this.ceval.reset();
+    if (enable && this.ceval.wasUnloadedByAnotherWindow) this.ceval.reset();
     if (enable !== unforcedState) {
       if (enable) this.startCeval();
       else {
@@ -804,6 +808,7 @@ export default class AnalyseCtrl implements CevalHandler {
   };
 
   startCeval = () => {
+    if (!this.asyncReady) return;
     if (!this.ceval.download) this.ceval.reset();
     if (this.node.threefold || !this.cevalEnabled() || this.node.outcome()) return;
     this.ceval.start(this.path, this.nodeList, undefined, this.threatMode());
@@ -1092,10 +1097,13 @@ export default class AnalyseCtrl implements CevalHandler {
     if (node.eval && !node.eval.knodes && this.data.analysis?.nodesPerMove)
       node.eval.knodes = this.data.analysis.nodesPerMove / 1000;
   };
-  private async mergeIdbThenShowTreeView() {
+
+  private async asyncLoadThenShow() {
     await this.idbTree.merge();
-    this.treeView.hidden = false;
+    this.asyncReady = true;
     this.idbTree.revealNode();
+    this.setAutoShapes();
+    this.startCeval();
     this.redraw();
   }
 }

--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -230,7 +230,6 @@ export default class AnalyseCtrl implements CevalHandler {
         redraw();
       }
     });
-    this.asyncLoadThenShow();
     (window as any).lichess.analysis = {
       playUci: this.playUci,
       navigate: this.navigate,
@@ -242,7 +241,6 @@ export default class AnalyseCtrl implements CevalHandler {
     this.data = data;
     this.synthetic = data.game.id === 'synthetic';
     this.ongoing = !this.synthetic && playable(data);
-    this.asyncReady = false;
     const prevTree = merge && this.tree.root;
     this.tree = makeTree(treeReconstruct(this.data.treeParts, this.variantKey, this.data.sidelines));
     if (prevTree) this.tree.merge(prevTree);
@@ -260,6 +258,7 @@ export default class AnalyseCtrl implements CevalHandler {
     this.fork = new ForkCtrl(this);
 
     site.sound.preloadBoardSounds();
+    this.asyncLoadThenShow();
   }
 
   get variantKey(): VariantKey {
@@ -496,7 +495,6 @@ export default class AnalyseCtrl implements CevalHandler {
     this.initCeval();
     this.instanciateEvalCache();
     this.cgVersion.js++;
-    this.asyncLoadThenShow();
   }
 
   changePgn(pgn: string, andReload: boolean): AnalyseData | undefined {
@@ -1099,7 +1097,10 @@ export default class AnalyseCtrl implements CevalHandler {
   };
 
   private async asyncLoadThenShow() {
-    await this.idbTree.merge();
+    this.asyncReady = false;
+    const tree = this.tree;
+    await this.idbTree.load();
+    if (this.tree !== tree) return;
     this.asyncReady = true;
     this.idbTree.revealNode();
     this.setAutoShapes();

--- a/ui/analyse/src/idbTree.ts
+++ b/ui/analyse/src/idbTree.ts
@@ -1,8 +1,9 @@
 import { memoize } from 'lib';
+import { useFirstEval } from 'lib/ceval';
 import { objectStorage } from 'lib/objectStorage';
 import { completeNode } from 'lib/tree/node';
 import * as treeOps from 'lib/tree/ops';
-import type { TreeNodeLite, TreePath } from 'lib/tree/types';
+import type { LocalEval, TreeNodeLite, TreePath } from 'lib/tree/types';
 
 import type AnalyseCtrl from './ctrl';
 
@@ -12,6 +13,9 @@ export class IdbTree {
   private readonly collapseDb = memoize(() => objectStorage<TreePath[]>({ store: 'analyse-collapse' }));
   private readonly moveDb = memoize(() =>
     objectStorage<{ root: TreeNodeLite | undefined }>({ store: 'analyse-state', db: 'lichess' }),
+  );
+  private readonly cevalDb = memoize(() =>
+    objectStorage<{ path: TreePath; ceval: LocalEval }, [string, TreePath]>({ store: 'analyse-ceval' }),
   );
 
   constructor(private readonly ctrl: AnalyseCtrl) {}
@@ -83,9 +87,10 @@ export class IdbTree {
     this.cache.movesDirty = !this.ctrl.tree.pathExists(path + node.id);
   }
 
-  clear = async (what?: 'analysis' | 'collapse' | 'moves'): Promise<void> => {
+  clear = async (what?: 'analysis' | 'ceval' | 'collapse' | 'moves'): Promise<void> => {
     if (this.noop) return;
     await Promise.all([
+      (!what || what === 'ceval') && this.cevalDb().then(db => db.remove(this.cevalRange())),
       (!what || what === 'collapse') && this.collapseDb().then(db => db.remove(this.id)),
       !this.ctrl.study && (!what || what === 'moves') && this.moveDb().then(db => db.remove(this.id)),
     ]);
@@ -94,37 +99,59 @@ export class IdbTree {
 
   async saveMoves(force = false): Promise<IDBValidKey | undefined> {
     if (this.noop || this.ctrl.study || !(this.cache.movesDirty || force)) return undefined;
-    return this.moveDb().then(db =>
-      db.put(this.id, { root: treeOps.structuredCloneLite(this.ctrl.tree.root) }),
-    );
+    const root = treeOps.structuredCloneLite(this.ctrl.tree.root);
+    treeOps.updateAll(root, node => {
+      delete node.ceval;
+      delete node.threat;
+    });
+    return this.moveDb().then(db => db.put(this.id, { root }));
+  }
+
+  async saveCeval(path: TreePath, ceval: LocalEval): Promise<IDBValidKey | undefined> {
+    if (this.noop) return undefined;
+    const id = this.id;
+    this.cache.cevals.set(path, ceval);
+    return this.cevalDb().then(db => db.put([id, path], { path, ceval }));
   }
 
   async merge(): Promise<void> {
     if (this.noop || !('indexedDB' in window) || !window.indexedDB) return;
     try {
-      this.cacheMap.set(this.id, { movesDirty: false });
-      await Promise.all([
-        this.collapseDb()
-          .then(db => db.getOpt(this.id))
-          .then(collapsedPaths => {
-            if (!collapsedPaths) return this.collapseDefault();
-            for (const path of collapsedPaths) {
-              this.ctrl.tree.updateAt(path, n => (n.collapsed = true));
-            }
-          }),
-        !this.ctrl.study &&
-          this.moveDb()
-            .then(db => db.getOpt(this.id))
-            .then(moves => {
-              if (moves?.root) {
-                this.ctrl.tree.merge(completeNode(this.ctrl.variantKey)(moves.root));
-                this.cache.movesDirty = true;
-              }
-            }),
+      const id = this.id;
+      const state: State = { movesDirty: false, cevals: new Map() };
+      this.cacheMap.set(id, state);
+      const [collapsedPaths, moves, cevals] = await Promise.all([
+        this.collapseDb().then(db => db.getOpt(id)),
+        !this.ctrl.study ? this.moveDb().then(db => db.getOpt(id)) : undefined,
+        this.cevalDb().then(db => db.getMany(this.cevalRange(id))),
       ]);
+      if (id !== this.id) return;
+      if (moves?.root) {
+        this.ctrl.tree.merge(completeNode(this.ctrl.variantKey)(moves.root));
+        state.movesDirty = true;
+      }
+      for (const { path, ceval } of cevals) {
+        this.ctrl.tree.updateAt(path, node => {
+          if (
+            node.fen === ceval.fen &&
+            (!node.ceval || useFirstEval(ceval, node.ceval, this.ctrl.ceval.search.multiPv))
+          )
+            node.ceval = ceval;
+        });
+        state.cevals.set(path, ceval);
+      }
+      if (!collapsedPaths) this.collapseDefault();
+      else
+        for (const path of collapsedPaths) {
+          this.ctrl.tree.updateAt(path, n => (n.collapsed = true));
+        }
     } catch (e) {
       console.log('IDB error.', e);
     }
+  }
+
+  get hasLocalCeval(): boolean {
+    return this.cache.cevals.size > 0;
   }
 
   get movesDirty(): boolean {
@@ -141,9 +168,13 @@ export class IdbTree {
 
   private get cache() {
     if (this.cacheMap.has(this.id)) return this.cacheMap.get(this.id)!;
-    const state: State = { movesDirty: false };
+    const state: State = { movesDirty: false, cevals: new Map() };
     this.cacheMap.set(this.id, state);
     return state;
+  }
+
+  private cevalRange(id = this.id): IDBKeyRange {
+    return IDBKeyRange.bound([id], [id, []]);
   }
 
   private async saveCollapsed() {
@@ -197,4 +228,4 @@ export class IdbTree {
   }
 }
 
-type State = { movesDirty: boolean };
+type State = { movesDirty: boolean; cevals: Map<TreePath, LocalEval> };

--- a/ui/analyse/src/idbTree.ts
+++ b/ui/analyse/src/idbTree.ts
@@ -114,7 +114,7 @@ export class IdbTree {
     return this.cevalDb().then(db => db.put([id, path], { path, ceval }));
   }
 
-  async merge(): Promise<void> {
+  async load(): Promise<void> {
     if (this.noop || !('indexedDB' in window) || !window.indexedDB) return;
     try {
       const id = this.id;
@@ -158,7 +158,7 @@ export class IdbTree {
   }
 
   private get id(): string {
-    return this.ctrl.study?.data.chapter.id ?? this.ctrl.data.game.id;
+    return this.ctrl.opts.study?.chapter.id ?? this.ctrl.data.game.id;
   }
 
   private get noop(): boolean {

--- a/ui/analyse/src/idbTree.ts
+++ b/ui/analyse/src/idbTree.ts
@@ -130,13 +130,12 @@ export class IdbTree {
         this.ctrl.tree.merge(completeNode(this.ctrl.variantKey)(moves.root));
         state.movesDirty = true;
       }
+      const multiPv = this.ctrl.ceval.search.multiPv;
       for (const { path, ceval } of cevals) {
         this.ctrl.tree.updateAt(path, node => {
-          if (
-            node.fen === ceval.fen &&
-            (!node.ceval || useFirstEval(ceval, node.ceval, this.ctrl.ceval.search.multiPv))
-          )
+          if (node.fen === ceval.fen && (!node.ceval || useFirstEval(ceval, node.ceval, multiPv))) {
             node.ceval = ceval;
+          }
         });
         state.cevals.set(path, ceval);
       }

--- a/ui/analyse/src/treeView/treeView.ts
+++ b/ui/analyse/src/treeView/treeView.ts
@@ -18,8 +18,11 @@ export class TreeView {
   constructor(readonly ctrl: AnalyseCtrl) {}
   private autoScrollRequest: ScrollBehavior | false = false;
 
-  hidden = true;
   mode: 'column' | 'inline';
+
+  get hidden(): boolean {
+    return !this.ctrl.asyncReady;
+  }
 
   render(concealOf?: ConcealOf): VNode {
     this.mode = concealOf || !this.ctrl.settings.inline ? 'column' : 'inline';

--- a/ui/analyse/src/view/actionMenu.ts
+++ b/ui/analyse/src/view/actionMenu.ts
@@ -138,16 +138,16 @@ export function view(ctrl: AnalyseCtrl): VNode {
           [snabIcon('swords'), i18n.site.continueFromHere],
         ),
       studyButton(ctrl),
-      ctrl.idbTree.movesDirty &&
+      (ctrl.idbTree.movesDirty || ctrl.idbTree.hasLocalCeval) &&
         hl(
           'a',
           {
             attrs: {
-              title: i18n.site.clearSavedMoves,
+              title: i18n.site.clearLocalData,
             },
-            hook: bind('click', () => ctrl.idbTree.clear('moves')),
+            hook: bind('click', () => ctrl.idbTree.clear()),
           },
-          [snabIcon('trash'), i18n.site.clearSavedMoves],
+          [snabIcon('trash'), i18n.site.clearLocalData],
         ),
       hl(
         'button',

--- a/ui/lib/src/ceval/ctrl.ts
+++ b/ui/lib/src/ceval/ctrl.ts
@@ -286,26 +286,26 @@ export class CevalCtrl {
     };
     const emitter = throttleWithFlush(125, (ev: LocalEval, meta: EvalMeta) => {
       this.curEval = ev;
-      if (this.curEval.bestmove && this.curEval.bestmove !== '(none)' && working.movetime !== false) {
-        this.curEval.millis = Math.max(this.curEval.millis, working.movetime);
+      if (ev.bestmove && ev.bestmove !== '(none)' && working.movetime !== false) {
+        ev.millis = Math.max(ev.millis, working.movetime);
       }
       if (!working.fen) {
-        working.fen = this.curEval.fen;
-        storage.fire('ceval.fen', this.curEval.fen); // will pause other tabs
+        working.fen = ev.fen;
+        storage.fire('ceval.fen', ev.fen); // will pause other tabs
       }
       const color = meta.ply % 2 === (meta.threatMode ? 1 : 0) ? 'white' : 'black';
-      this.curEval.pvs.sort((a, b) => povChances(color, b) - povChances(color, a));
+      ev.pvs.sort((a, b) => povChances(color, b) - povChances(color, a));
 
       if (this.lastStarted && !working.dontStop) {
         const evNode = working.started.steps[working.started.steps.length - 1];
-        if (working.movetime && evNode.ceval?.cloud && this.curEval.millis > 500) {
+        if (working.movetime && evNode.ceval?.cloud && ev.millis > 500) {
           const targetNodes = evNode.ceval.nodes;
-          const likelyNodes = Math.round((working.movetime * this.curEval.nodes) / this.curEval.millis);
+          const likelyNodes = Math.round((working.movetime * ev.nodes) / ev.millis);
 
           if (likelyNodes < targetNodes) this.worker?.stop();
         }
       }
-      working.emit(this.curEval, meta);
+      working.emit(ev, meta);
     });
     return (ev: LocalEval | undefined, meta: EvalMeta) => {
       if (!ev) {

--- a/ui/lib/src/ceval/ctrl.ts
+++ b/ui/lib/src/ceval/ctrl.ts
@@ -57,6 +57,7 @@ export class CevalCtrl {
   curEval: LocalEval | null = null;
   lastStarted?: Started;
   showEnginePrefs: Toggle = toggle(false);
+  wasUnloadedByAnotherWindow = false;
 
   private worker?: CevalEngine;
 
@@ -67,8 +68,10 @@ export class CevalCtrl {
 
     // another tab has started ceval, we should stop:
     storage.make('ceval.fen').listen(() => {
-      this.worker?.destroy();
+      if (!this.worker) return;
+      this.worker.destroy();
       this.worker = undefined; // release memory
+      this.wasUnloadedByAnotherWindow = true;
       this.opts.redraw();
     });
 
@@ -106,13 +109,14 @@ export class CevalCtrl {
 
   reset = (): void => {
     this.worker?.stop();
+    this.wasUnloadedByAnotherWindow = false;
     this.curEval = null;
     this.lastStarted = undefined;
     this.download = undefined;
   };
 
   start = (path: string, steps: Step[], gameId: string | undefined, threatMode = false): boolean => {
-    if (!this.available() || this.wasUnloaded) return false;
+    if (!this.available() || this.wasUnloadedByAnotherWindow) return false;
     this.isDeeper(false);
     this.doStart({ path, steps, gameId, threatMode });
     return true;
@@ -189,10 +193,6 @@ export class CevalCtrl {
 
   get isCacheable(): boolean {
     return Boolean(this.engines.active()?.capabilities?.includes('cloudEval'));
-  }
-
-  get wasUnloaded(): boolean {
-    return !this.worker && Boolean(this.lastStarted); // another tab started ceval
   }
 
   get showingCloud(): boolean {
@@ -286,7 +286,9 @@ export class CevalCtrl {
     };
     const emitter = throttleWithFlush(125, (ev: LocalEval, meta: EvalMeta) => {
       this.curEval = ev;
-
+      if (this.curEval.bestmove && this.curEval.bestmove !== '(none)' && working.movetime !== false) {
+        this.curEval.millis = Math.max(this.curEval.millis, working.movetime);
+      }
       if (!working.fen) {
         working.fen = this.curEval.fen;
         storage.fire('ceval.fen', this.curEval.fen); // will pause other tabs
@@ -296,9 +298,9 @@ export class CevalCtrl {
 
       if (this.lastStarted && !working.dontStop) {
         const evNode = working.started.steps[working.started.steps.length - 1];
-        if (working.movetime && evNode.ceval?.cloud && ev.millis > 500) {
+        if (working.movetime && evNode.ceval?.cloud && this.curEval.millis > 500) {
           const targetNodes = evNode.ceval.nodes;
-          const likelyNodes = Math.round((working.movetime * ev.nodes) / ev.millis);
+          const likelyNodes = Math.round((working.movetime * this.curEval.nodes) / this.curEval.millis);
 
           if (likelyNodes < targetNodes) this.worker?.stop();
         }

--- a/ui/lib/src/ceval/ctrl.ts
+++ b/ui/lib/src/ceval/ctrl.ts
@@ -287,7 +287,7 @@ export class CevalCtrl {
     const emitter = throttleWithFlush(125, (ev: LocalEval, meta: EvalMeta) => {
       this.curEval = ev;
       if (ev.bestmove && ev.bestmove !== '(none)' && working.movetime !== false) {
-        ev.millis = Math.max(ev.millis, working.movetime);
+        ev.millis = Math.max(ev.millis, working.movetime); // ensure bestmove eval matches movetime target
       }
       if (!working.fen) {
         working.fen = ev.fen;

--- a/ui/lib/src/ceval/view/main.ts
+++ b/ui/lib/src/ceval/view/main.ts
@@ -147,7 +147,7 @@ export function renderGauge(ctrl: CevalHandler): VNode | undefined {
 export function renderCeval(ctrl: CevalHandler): VNode[] {
   const ceval = ctrl.ceval;
   const node = ctrl.getNode(),
-    enabled = !ceval.wasUnloaded && ctrl.cevalEnabled(),
+    enabled = !ceval.wasUnloadedByAnotherWindow && ctrl.cevalEnabled(),
     client = node.ceval,
     server = node.eval,
     threatMode = ctrl.threatMode(),
@@ -269,7 +269,7 @@ export const renderCevalSwitch = (ctrl: CevalHandler): VNode | false =>
     id: 'analyse-toggle-ceval',
     title: i18n.site.toggleLocalEvaluation + ' (L)',
     checked: !!ctrl.cevalEnabled(),
-    propsChecked: !ctrl.ceval.wasUnloaded && !!ctrl.cevalEnabled(),
+    propsChecked: !ctrl.ceval.wasUnloadedByAnotherWindow && !!ctrl.cevalEnabled(),
     change: ctrl.cevalEnabled,
     disabled: !ctrl.ceval.analysable,
   });


### PR DESCRIPTION
These can be cleared with "Clear local data" in the hamburger. When users revolt, a setting could be added to disable this but it should really be the default. It is wasteful to recompute things.
