### PR TITLE
Show more Lichess projects on the /source page

### DIFF
--- a/modules/web/src/main/ui/SitePages.scala
+++ b/modules/web/src/main/ui/SitePages.scala
@@ -211,6 +211,13 @@ final class SitePages(helpers: Helpers):
 
   private val repoRoot = "https://github.com/lichess-org/lila"
 
+  // actively maintained projects not (yet) in the CMS source page
+  private val moreProjects = List(
+    "berserk" -> "Python client for the Lichess API",
+    "broadcaster" -> "Broadcast your chess games on Lichess",
+    "dart-lc0" -> "Leela Chess Zero (lc0) bindings for the mobile app"
+  )
+
   def source(pageTitle: String, rendered: Frag, version: Option[WebConfig.LilaVersion])(using
       Context
   ) =
@@ -254,7 +261,15 @@ final class SitePages(helpers: Helpers):
             )
           ),
           br,
-          st.section(cls := "box box-pad body")(rendered)
+          st.section(cls := "box box-pad body")(rendered),
+          br,
+          st.section(cls := "box box-pad body")(
+            h2("More Lichess projects"),
+            ul(
+              moreProjects.map: (name, desc) =>
+                li(a(href := s"https://github.com/lichess-org/$name")(name), " ", desc)
+            )
+          )
         )
 
   def lag(using Context) =

--- a/modules/web/src/main/ui/SitePages.scala
+++ b/modules/web/src/main/ui/SitePages.scala
@@ -261,9 +261,8 @@ final class SitePages(helpers: Helpers):
             )
           ),
           br,
-          st.section(cls := "box box-pad body")(rendered),
-          br,
           st.section(cls := "box box-pad body")(
+            rendered,
             h2("More Lichess projects"),
             ul(
               moreProjects.map: (name, desc) =>


### PR DESCRIPTION
Adds [berserk](https://github.com/lichess-org/berserk), [broadcaster](https://github.com/lichess-org/broadcaster), and [dart-lc0](https://github.com/lichess-org/dart-lc0) to the [/source](https://lichess.org/source) page — appended in the view since the list itself is CMS content.

![Rendered with production CSS](https://raw.githubusercontent.com/philyawj/lila/pr-assets/folded-v2.png)

Drafted by Claude Fable 5 (Claude Code); @philyawj reviewing as human in the loop.
