### PR TITLE
Show eval info for hovered inline nodes

### DIFF
--- a/ui/analyse/src/view/components.ts
+++ b/ui/analyse/src/view/components.ts
@@ -285,7 +285,8 @@ export function renderMoveNodes(
       : ev?.mate !== undefined
         ? `#${ev.mate}`
         : '';
-  const nodes = [h('san', fixCrazySan(node.san!))];
+  const attrs = !withEval && ev ? { title: `${evalText} · ${evalInfo(ev)}` } : undefined;
+  const nodes = [h('san', { attrs }, fixCrazySan(node.san!))];
   const relevantGlyphs = glyphs ?? node.glyphs;
   if (withGlyphs && relevantGlyphs)
     relevantGlyphs.forEach(g => nodes.push(h('glyph', { attrs: { title: g.name } }, g.symbol)));


### PR DESCRIPTION
<img width="355" height="92" alt="image" src="https://github.com/user-attachments/assets/cd2c9d7c-4b1b-4ebe-80e7-f48595e15821" />
