### PR TITLE
ui(relay): small visual tweaks for list and admin pane

### DIFF
--- a/ui/analyse/css/study/relay/_admin.scss
+++ b/ui/analyse/css/study/relay/_admin.scss
@@ -12,6 +12,15 @@
     font-size: 1.2em;
     padding: 0.4em 0.6em;
     border-bottom: $border;
+
+    .svg-icon {
+      width: 1em;
+    }
+
+    span,
+    a {
+      display: flex;
+    }
   }
 
   .state {

--- a/ui/bits/css/relay/_card.scss
+++ b/ui/bits/css/relay/_card.scss
@@ -70,7 +70,7 @@
   }
 
   &__info {
-    @extend %flex-center-nowrap;
+    @extend %flex-between;
 
     margin-right: 1rem;
     color: $c-font-dim;
@@ -78,16 +78,25 @@
   }
 
   &__live {
-    @extend %flex-between;
+    @extend %flex-center;
 
-    flex: 1;
     color: $c-live;
     font-weight: bold;
+    gap: 1ch;
+
+    &__crowd text {
+      display: flex;
+
+      .svg-icon {
+        width: 1em;
+      }
+    }
   }
 
   &__finished {
     color: $c-good;
     font-weight: bold;
+    display: flex;
   }
 
   &__title {


### PR DESCRIPTION
# Why

Refs #21483

# How

Small visual tweaks for list and admin pane. Additionally I decided to space-out info content in the same way no matter of status. I think it is a slightly more readable that way.

# Preview

<img width="540" height="240" alt="Screenshot 2026-09-06 at 09 13 27" src="https://github.com/user-attachments/assets/4e82a42c-f06b-4daa-90b4-251794ac33c2" />
<img width="1039" height="490" alt="Screenshot 2026-09-06 at 09 11 43" src="https://github.com/user-attachments/assets/85c80f03-fabf-4c97-b3c2-0a7cf9aebb1b" />
<img width="351" height="205" alt="Screenshot 2026-09-06 at 09 01 39" src="https://github.com/user-attachments/assets/534cb67e-a645-4290-a24a-1bffa944c4ae" />
