### PR TITLE
ui(msg): small spacing tweaks after switch to new icons

### DIFF
--- a/ui/msg/css/_convo.scss
+++ b/ui/msg/css/_convo.scss
@@ -21,6 +21,7 @@
       flex: 0 0 $msg-top-height;
       background: $c-bg-zebra2;
       border-bottom: $border;
+      padding-inline-start: 1em;
 
       &__left {
         @extend %flex-center-nowrap;

--- a/ui/msg/css/_side.scss
+++ b/ui/msg/css/_side.scss
@@ -54,6 +54,8 @@
       @extend %flex-center-nowrap;
 
       cursor: pointer;
+      padding-inline-start: 0.75em;
+      gap: 0.5ch;
 
       &:hover {
         background: color-mix(in oklab, $c-secondary 15%, $c-bg);

--- a/ui/msg/css/_side.scss
+++ b/ui/msg/css/_side.scss
@@ -69,6 +69,10 @@
       .user-link {
         flex: 0 0 auto;
         font-size: 2.3em;
+
+        icon {
+          width: 18px;
+        }
       }
 
       &__user {


### PR DESCRIPTION
# Why

Refs #21483
Refs https://lichess.org/forum/lichess-feedback/green-dot-suddenly-smaller

# How

Small spacing tweaks in massages view after switch to new icons. Probably not ideal matching old sizes and style, but definitively better.

# Preview

<img width="1351" height="591" alt="Screenshot 2026-09-06 at 09 30 30" src="https://github.com/user-attachments/assets/22e09ca1-c2b2-47b9-b86e-c4ee00f3327f" />

