### PR TITLE
ui(user): fix online players rating alignment

### DIFF
--- a/ui/user/css/_list.scss
+++ b/ui/user/css/_list.scss
@@ -26,6 +26,10 @@ $user-list-width: 30ch;
 
     .user-link {
       @extend %ellipsis;
+
+      .text {
+        display: inline-flex;
+      }
     }
 
     a:not(.user-link) {


### PR DESCRIPTION
# Why

Refs #21483

# How

Fix online players rating alignment

# Preview

### Before

<img width="340" height="275" alt="Screenshot 2026-09-06 at 09 47 08" src="https://github.com/user-attachments/assets/25de0376-1c95-46f7-b14a-9c62907406ac" />

### After

<img width="341" height="256" alt="Screenshot 2026-09-06 at 09 42 22" src="https://github.com/user-attachments/assets/3671da31-ffd7-490f-a188-5ba510c1aa57" />
