### PR TITLE
ui(forum): correct spacing in poster cell

### DIFF
--- a/ui/bits/css/forum/_table.scss
+++ b/ui/bits/css/forum/_table.scss
@@ -50,6 +50,11 @@
       span {
         display: flex;
         align-items: center;
+        gap: 0.5ch;
+      }
+
+      .user-link {
+        gap: 0;
       }
     }
 


### PR DESCRIPTION
# Why

Refs #21483

# How

Correct spacing on forum lists in poster cell.

# Preview

### Before

<img width="391" height="488" alt="Screenshot 2026-09-06 at 09 58 28" src="https://github.com/user-attachments/assets/d978f923-8ec8-44ef-bc11-4508f5b26b57" />

### After

<img width="391" height="488" alt="Screenshot 2026-09-06 at 09 59 19" src="https://github.com/user-attachments/assets/5752d1e0-e5f4-46da-910a-3e05ec025329" />

