### PR TITLE
ui(user): avoid using static size for online icon

### DIFF
--- a/ui/lib/css/component/_user-link.scss
+++ b/ui/lib/css/component/_user-link.scss
@@ -19,7 +19,7 @@
     color: $c-good;
 
     &::before {
-      @include icon-mask($icon-disc, 12px);
+      @include icon-mask($icon-disc, 80%);
     }
 
     &.patron {


### PR DESCRIPTION
# Why

Refs https://github.com/lichess-org/lila/issues/21483#issuecomment-5557850719

# How

Avoid using static size for online icon, align with other `user-link` icons so it's sized correctly.

# Preview

<img width="276" height="161" alt="Screenshot 2026-09-06 at 10 09 53" src="https://github.com/user-attachments/assets/cee0e08a-41d5-4f01-8b16-af45e0baa14d" />
