### PR TITLE
ui(lobby): fix games row rating icons

### DIFF
--- a/ui/lobby/css/app/_hook-list.scss
+++ b/ui/lobby/css/app/_hook-list.scss
@@ -91,7 +91,8 @@
     &:last-child .svg-icon {
       margin-inline-end: 8px;
       line-height: 0.9;
-      width: 1.6em;
+      width: 1.4em;
+      float: left;
     }
 
     .svg-icon {


### PR DESCRIPTION
# Why

Refs #21483

# How

Fix lobby games row rating icons size and aligment.

# Preview

### Before

<img width="719" height="477" alt="Screenshot 2026-09-06 at 10 18 35" src="https://github.com/user-attachments/assets/0d0b5c82-2e88-45a0-a627-96ff6e7437c2" />

### After
<img width="719" height="477" alt="Screenshot 2026-09-06 at 10 18 28" src="https://github.com/user-attachments/assets/ee85cff6-2fbb-4a31-b18c-37fc4d99a26a" />
