### PR TITLE
ui(lobby): fix activity entries alignment

### DIFF
--- a/ui/lobby/css/_timeline.scss
+++ b/ui/lobby/css/_timeline.scss
@@ -17,6 +17,10 @@
       font-weight: normal;
     }
 
+    .user-link {
+      float: left;
+    }
+
     &:hover a {
       color: $c-link;
     }


### PR DESCRIPTION
# Why

Refs #21483

# How

Fix lobby activity entries alignment.

# Preview

### Before

<img width="359" height="474" alt="Screenshot 2026-09-06 at 11 48 38" src="https://github.com/user-attachments/assets/0d7e78c3-17c5-4e25-a265-9cc92e64b61b" />


### After

<img width="359" height="474" alt="Screenshot 2026-09-06 at 11 49 23" src="https://github.com/user-attachments/assets/a9693b2e-9aa2-4d3f-9606-c90a4022e5cc" />
