### PR TITLE
ui(header): replace logo with raw SVG, adjust sizing, restore shadow

### DIFF
--- a/modules/web/src/main/ui/layout.scala
+++ b/modules/web/src/main/ui/layout.scala
@@ -311,7 +311,7 @@ final class layout(helpers: Helpers, assetHelper: lila.web.ui.AssetFullHelper)(
           a(cls := "site-title", href := langHref("/"), testId("site-title"))(
             if ctx.kid.yes then span(title := trans.site.kidMode.txt(), cls := "kiddo")(":)")
             else ctx.isBot.option(botImage),
-            div(cls := "site-icon")(iconEl(Icon.logo)),
+            div(cls := "site-icon")(lila.web.ui.bits.logo),
             div(cls := "site-name")(siteNameFrag)
           ),
           (!isAppealUser).option(

--- a/ui/lib/css/header/_title.scss
+++ b/ui/lib/css/header/_title.scss
@@ -34,14 +34,14 @@
 
   .site-icon {
     display: none;
-    font-size: 24px;
 
-    .svg-icon {
+    svg {
       display: block;
-    }
-
-    @media (min-height: at-least($tall)) {
-      font-size: 36px;
+      width: 1.25em;
+      fill: $c-font-dim;
+      stroke: $c-font-dim;
+      stroke-width: 1px;
+      filter: drop-shadow(0.5px 0.5px 0 $c-shade);
     }
   }
 

--- a/ui/lib/css/header/_title.scss
+++ b/ui/lib/css/header/_title.scss
@@ -37,11 +37,12 @@
 
     svg {
       display: block;
-      width: 1.25em;
-      fill: $c-font-dim;
-      stroke: $c-font-dim;
-      stroke-width: 1px;
-      filter: drop-shadow(0.5px 0.5px 0 $c-shade);
+      width: 1.2em;
+      fill: $c-font;
+      stroke: $c-font;
+      stroke-width: 1.4px;
+      filter: drop-shadow(0 1px 0 $c-font-shadow);
+      overflow: visible;
     }
   }
 


### PR DESCRIPTION
# Why

Spotted that logo become a bit too big. Also to make it more crisp we want to try restore shadow.

# How

Replace site header logo with raw SVG, adjust sizing, restore shadow.

> [!important]
> @ornicar the UI bits SVG logo might be slightly outdated, since it's a bit too slim. I have added the stroke to adjust the weight, but still is less chunky that what's shipped on PROD currently. Leaving it for you to decide if this look good, or we need to update SVG content.

# Preview

<img width="665" height="373" alt="Screenshot 2026-09-06 at 12 07 52" src="https://github.com/user-attachments/assets/2c5e7122-cc58-4513-b60f-17dca7222e90" />

<img width="665" height="373" alt="Screenshot 2026-09-06 at 12 08 10" src="https://github.com/user-attachments/assets/73d2d383-f902-49c6-896e-3adba21dad69" />
