### PR TITLE
ui(tournament): fix tournament table icons

### DIFF
--- a/ui/tournament/css/_user.scss
+++ b/ui/tournament/css/_user.scss
@@ -43,7 +43,8 @@
   }
 
   .svg-icon {
-    width: 4em;
+    width: 1.2em;
+    vertical-align: middle;
     opacity: 0.7;
   }
 


### PR DESCRIPTION
### Exact URL of where the bug happened
https://lichess.org/@/thibault/tournaments/created

### Additional information
Refs #21483 

#### Before
<img width="1443" height="716" alt="before" src="https://github.com/user-attachments/assets/04366c85-af09-411c-81a9-e60958e758a1" />

#### After
<img width="1439" height="678" alt="after" src="https://github.com/user-attachments/assets/f6f42be7-645c-4c49-ac27-0cf2560cb701" />
