### PR TITLE
ui(tournament): fix stats alignment

### DIFF
--- a/ui/tournament/css/_user.scss
+++ b/ui/tournament/css/_user.scss
@@ -64,6 +64,7 @@
 
     th span .svg-icon {
       width: 2em;
+      vertical-align: middle;
     }
   }
 }


### PR DESCRIPTION
### Exact URL of where the bug happened
https://lichess.org/@/thibault/tournaments/chart

### Additional information
Refs #21483 

#### Before
<img width="1369" height="620" alt="before" src="https://github.com/user-attachments/assets/606e488c-caca-4b87-9524-773c2e666d67" />


#### After
<img width="1367" height="611" alt="after" src="https://github.com/user-attachments/assets/6b342cec-1fb6-4b2e-ad9c-303d39c4fae4" />

