### PR TITLE
let only fairy/mv stockfish handle non-standard material (fixes #15359)

### DIFF
--- a/ui/analyse/src/interfaces.ts
+++ b/ui/analyse/src/interfaces.ts
@@ -1,6 +1,6 @@
 import type { VNode } from 'snabbdom';
 
-import type { ExternalEngineInfo } from 'lib/ceval';
+import type { ExternalEngineInfoFromServer } from 'lib/ceval';
 import type { ChatCtrl, ChatPlugin, ChatOpts } from 'lib/chat/interfaces';
 import type { Player, Status, Source, Clock } from 'lib/game';
 import type { Coords, MoveEvent } from 'lib/prefs';
@@ -59,7 +59,7 @@ export interface AnalyseData {
     id: string;
   };
   puzzle?: OpeningPuzzle;
-  externalEngines?: ExternalEngineInfo[];
+  externalEngines?: ExternalEngineInfoFromServer[];
 }
 
 export interface AnalysePref {

--- a/ui/lib/src/ceval/ctrl.ts
+++ b/ui/lib/src/ceval/ctrl.ts
@@ -210,7 +210,7 @@ export class CevalCtrl {
   }
 
   get isCacheable(): boolean {
-    return Boolean(this.engines.active()?.capabilities?.includes('cloudEval'));
+    return Boolean(this.engines.active()?.supportsCloudEval);
   }
 
   get showingCloud(): boolean {

--- a/ui/lib/src/ceval/ctrl.ts
+++ b/ui/lib/src/ceval/ctrl.ts
@@ -1,8 +1,9 @@
 // no side effects allowed due to re-export by index.ts
 
-import type { Rules } from 'chessops';
+import { isStandardMaterial } from 'chessops/chess';
 import { lichessRules } from 'chessops/compat';
 import { parseFen } from 'chessops/fen';
+import { type Rules } from 'chessops/types';
 import { setupPosition } from 'chessops/variant';
 
 import { clamp } from '@/algo';
@@ -45,6 +46,7 @@ interface Started {
 
 export class CevalCtrl {
   rules: Rules;
+  nonStandardMaterial: boolean;
   analysable: boolean;
   engines: Engines;
   storedEngine: Prop<string>;
@@ -89,10 +91,19 @@ export class CevalCtrl {
   init(opts?: CevalOpts): void {
     if (opts) this.opts = opts;
     this.reset();
-    this.analysable = Boolean(this.engines.getEngine({ variant: this.opts.variant.key }));
     this.rules = lichessRules(this.opts.variant.key);
-    if (this.analysable && this.opts.initialFen)
-      this.analysable = parseFen(this.opts.initialFen).chain(x => setupPosition(this.rules, x)).isOk;
+    const pos = this.opts.initialFen
+      ? parseFen(this.opts.initialFen).chain(x => setupPosition(this.rules, x))
+      : undefined;
+    this.nonStandardMaterial =
+      this.rules === 'chess' &&
+      !!pos?.unwrap(
+        pos => !isStandardMaterial(pos),
+        _ => false,
+      );
+    this.analysable =
+      !pos?.isErr &&
+      !!this.engines.getEngine({ rules: this.rules, nonStandardMaterial: this.nonStandardMaterial });
     this.engines.setActive(this.opts.custom?.engine?.id ?? this.storedEngine());
     if (this.worker?.getInfo().id !== this.engines.active()?.id) this.unload();
   }
@@ -138,7 +149,14 @@ export class CevalCtrl {
         min: 16,
         max: active.maxHash,
       }),
-      engine: (custom?.engine && this.engines.getEngine({ id: custom.engine.id })) || active,
+      engine:
+        (custom?.engine &&
+          this.engines.getEngine({
+            id: custom.engine.id,
+            rules: this.rules,
+            nonStandardMaterial: this.nonStandardMaterial,
+          })) ||
+        active,
       search:
         typeof maybeSearch === 'object'
           ? maybeSearch
@@ -230,7 +248,7 @@ export class CevalCtrl {
       return;
     }
     const work: Work = {
-      variant: this.opts.variant.key,
+      variant: this.rules,
       threads,
       hashSize,
       gameId: s.gameId,
@@ -265,7 +283,11 @@ export class CevalCtrl {
     }
 
     if (this.worker?.getInfo().id !== engine.id) this.unload();
-    this.worker ??= this.engines.makeEngine({ id: engine.id, variant: this.opts.variant.key });
+    this.worker ??= this.engines.makeEngine({
+      id: engine.id,
+      rules: this.rules,
+      nonStandardMaterial: this.nonStandardMaterial,
+    });
     this.worker.start(work);
   };
 

--- a/ui/lib/src/ceval/engines/engines.ts
+++ b/ui/lib/src/ceval/engines/engines.ts
@@ -1,12 +1,6 @@
 import { type Rules } from 'chessops/types';
 
-import type {
-  BrowserEngineInfo,
-  ExternalEngineInfo,
-  EngineInfo,
-  EngineCapability,
-  CevalEngine,
-} from '@/ceval';
+import type { BrowserEngineInfo, ExternalEngineInfo, EngineInfo, CevalEngine } from '@/ceval';
 import { isAndroid, isIos, isIPad, features as browserSupport } from '@/device';
 import { log } from '@/permalog';
 import { xhrHeader } from '@/xhr';
@@ -60,7 +54,8 @@ export class Engines {
           tech: 'NNUE',
           requires: ['sharedMem', 'simd', 'dynamicImportFromWorker'],
           minMem: 2560,
-          capabilities: ['cloudEval', 'puzzleReport'],
+          supportsCloudEval: true,
+          supportsPuzzleReport: true,
           assets: {
             root: 'npm/stockfish-web',
             js: 'sf_19.js',
@@ -77,7 +72,8 @@ export class Engines {
           tech: 'NNUE',
           requires: ['sharedMem', 'simd', 'dynamicImportFromWorker'],
           minMem: 1536,
-          capabilities: ['cloudEval', 'puzzleReport'],
+          supportsCloudEval: true,
+          supportsPuzzleReport: true,
           preferred: true,
           assets: {
             root: 'npm/stockfish-web',
@@ -96,7 +92,7 @@ export class Engines {
             tech: 'NNUE',
             requires: ['sharedMem', 'simd', 'dynamicImportFromWorker'],
             variants: [key],
-            capabilities: ['cloudEval'],
+            supportsCloudEval: true,
             assets: {
               root: 'npm/stockfish-web',
               nnue: [`${nnue}.nnue`],
@@ -134,7 +130,7 @@ export class Engines {
           tech: 'HCE',
           requires: ['sharedMem', 'simd', 'dynamicImportFromWorker'],
           variants: ['chess', ...variants.map(v => v.key)],
-          capabilities: ['nonStandardMaterial'],
+          supportsNonStandardMaterial: true,
           assets: {
             root: 'npm/stockfish-web',
             js: 'fsf_14.js',
@@ -169,7 +165,7 @@ export class Engines {
           requires: ['sharedMem'],
           minThreads: 1,
           variants: ['chess', ...variants.map(v => v.key)],
-          capabilities: ['nonStandardMaterial'],
+          supportsNonStandardMaterial: true,
           assets: {
             version: 'a022fa',
             root: 'npm/stockfish-mv.wasm',
@@ -237,17 +233,11 @@ export class Engines {
       })) ?? [];
   }
 
-  getEngine(selector?: {
-    id?: string;
-    rules: Rules;
-    nonStandardMaterial: boolean;
-    capability?: EngineCapability;
-  }): EngineInfo | undefined {
+  getEngine(selector?: { id?: string; rules: Rules; nonStandardMaterial: boolean }): EngineInfo | undefined {
     const id = selector?.id ?? this.activeEngine?.id;
     const engines = this.supporting({
       rules: selector?.rules || 'chess',
-      nonStandardMaterial: selector?.nonStandardMaterial || false,
-      capability: selector?.capability,
+      nonStandardMaterial: !!selector?.nonStandardMaterial,
     });
     return engines.find(info => info.id === id) ?? engines.find(info => info.preferred) ?? engines[0];
   }
@@ -287,7 +277,6 @@ export class Engines {
   supporting(selector: {
     rules: Rules;
     nonStandardMaterial: boolean;
-    capability?: EngineCapability;
     filter?: 'browser' | 'external';
   }): EngineInfo[] {
     const engines: EngineInfo[] = [
@@ -296,9 +285,8 @@ export class Engines {
     ];
     return engines.filter(
       info =>
-        (!selector.nonStandardMaterial || info.capabilities?.includes('nonStandardMaterial')) &&
-        (info.variants ?? ['chess']).includes(selector.rules) &&
-        (!selector.capability || info.capabilities?.includes(selector.capability)),
+        (!selector.nonStandardMaterial || info.supportsNonStandardMaterial) &&
+        (info.variants ?? ['chess']).includes(selector.rules),
     );
   }
 

--- a/ui/lib/src/ceval/engines/engines.ts
+++ b/ui/lib/src/ceval/engines/engines.ts
@@ -1,6 +1,12 @@
-import { lichessRules } from 'chessops/compat';
+import { type Rules } from 'chessops/types';
 
-import type { BrowserEngineInfo, ExternalEngineInfo, EngineInfo, EngineTrust, CevalEngine } from '@/ceval';
+import type {
+  BrowserEngineInfo,
+  ExternalEngineInfo,
+  EngineInfo,
+  EngineCapability,
+  CevalEngine,
+} from '@/ceval';
 import { isAndroid, isIos, isIPad, features as browserSupport } from '@/device';
 import { log } from '@/permalog';
 import { xhrHeader } from '@/xhr';
@@ -22,15 +28,15 @@ export class Engines {
   externalEngines: ExternalEngineInfo[];
 
   constructor(private readonly ctrl: CevalCtrl) {
-    type Variant = { key: VariantKey; nnue: string };
+    type Variant = { key: Rules; nnue: string };
     const variants: Variant[] = [
       { key: 'antichess', nnue: 'antichess-dd3cbe53cd4e' },
       { key: 'atomic', nnue: 'atomic-2cf13ff256cc' },
       { key: 'crazyhouse', nnue: 'crazyhouse-8ebf84784ad2' },
       { key: 'horde', nnue: 'horde-28173ddccabe' },
-      { key: 'kingOfTheHill', nnue: 'kingofthehill-978b86d0e6a4' },
-      { key: 'threeCheck', nnue: '3check-cb5f517c228b' },
-      { key: 'racingKings', nnue: 'racingkings-636b95f085e3' },
+      { key: 'kingofthehill', nnue: 'kingofthehill-978b86d0e6a4' },
+      { key: '3check', nnue: '3check-cb5f517c228b' },
+      { key: 'racingkings', nnue: 'racingkings-636b95f085e3' },
     ];
     const relaxedSimdPair = (base: WithMake): [WithMake, WithMake] => [
       {
@@ -54,7 +60,7 @@ export class Engines {
           tech: 'NNUE',
           requires: ['sharedMem', 'simd', 'dynamicImportFromWorker'],
           minMem: 2560,
-          capabilities: ['cloudEval', 'staticAnalysis', 'puzzleReport'],
+          capabilities: ['cloudEval', 'puzzleReport'],
           assets: {
             root: 'npm/stockfish-web',
             js: 'sf_19.js',
@@ -80,6 +86,26 @@ export class Engines {
         },
         make: (e: BrowserEngineInfo) => new StockfishWebEngine(e, this.statusCallback),
       }),
+      ...variants.map(
+        ({ key, nnue }: Variant): WithMake => ({
+          info: {
+            id: `__fsfnnue-${key}`,
+            name: 'Fairy Stockfish 14+ NNUE',
+            short: 'FSF 14+',
+            url: 'https://github.com/lichess-org/stockfish-web#fsf_14-fairy-stockfish-14',
+            tech: 'NNUE',
+            requires: ['sharedMem', 'simd', 'dynamicImportFromWorker'],
+            variants: [key],
+            capabilities: ['cloudEval'],
+            assets: {
+              root: 'npm/stockfish-web',
+              nnue: [`${nnue}.nnue`],
+              js: 'fsf_14.js',
+            },
+          },
+          make: (e: BrowserEngineInfo) => new StockfishWebEngine(e, this.statusCallback),
+        }),
+      ),
       {
         info: {
           id: '__sf14nnue',
@@ -99,26 +125,6 @@ export class Engines {
         },
         make: (e: BrowserEngineInfo) => new ThreadedEngine(e, this.statusCallback),
       },
-      ...variants.map(
-        ({ key, nnue }: Variant): WithMake => ({
-          info: {
-            id: `__fsfnnue-${key}`,
-            name: 'Fairy Stockfish 14+ NNUE',
-            short: 'FSF 14+',
-            url: 'https://github.com/lichess-org/stockfish-web#fsf_14-fairy-stockfish-14',
-            tech: 'NNUE',
-            requires: ['sharedMem', 'simd', 'dynamicImportFromWorker'],
-            variants: [key],
-            capabilities: ['cloudEval', 'staticAnalysis'],
-            assets: {
-              root: 'npm/stockfish-web',
-              nnue: [`${nnue}.nnue`],
-              js: 'fsf_14.js',
-            },
-          },
-          make: (e: BrowserEngineInfo) => new StockfishWebEngine(e, this.statusCallback),
-        }),
-      ),
       {
         info: {
           id: '__fsfhce',
@@ -127,34 +133,14 @@ export class Engines {
           url: 'https://github.com/lichess-org/stockfish-web#fsf_14-fairy-stockfish-14',
           tech: 'HCE',
           requires: ['sharedMem', 'simd', 'dynamicImportFromWorker'],
-          variants: variants.map(v => v.key),
+          variants: ['chess', ...variants.map(v => v.key)],
+          capabilities: ['nonStandardMaterial'],
           assets: {
             root: 'npm/stockfish-web',
             js: 'fsf_14.js',
           },
         },
         make: (e: BrowserEngineInfo) => new StockfishWebEngine(e, this.statusCallback),
-      },
-      {
-        info: {
-          id: '__sf11mv',
-          name: 'Stockfish 11 Multi-Variant',
-          short: 'SF 11 MV',
-          tech: 'HCE',
-          requires: ['sharedMem'],
-          minThreads: 1,
-          variants: variants.map(v => v.key),
-          assets: {
-            version: 'a022fa',
-            root: 'npm/stockfish-mv.wasm',
-            js: 'stockfish.js',
-            wasm: 'stockfish.wasm',
-          },
-        },
-        make: (e: BrowserEngineInfo) =>
-          new ThreadedEngine(e, undefined, (v: VariantKey) =>
-            v === 'antichess' ? 'giveaway' : lichessRules(v),
-          ),
       },
       {
         info: {
@@ -173,6 +159,26 @@ export class Engines {
           },
         },
         make: (e: BrowserEngineInfo) => new ThreadedEngine(e, undefined),
+      },
+      {
+        info: {
+          id: '__sf11mv',
+          name: 'Stockfish 11 Multi-Variant',
+          short: 'SF 11 MV',
+          tech: 'HCE',
+          requires: ['sharedMem'],
+          minThreads: 1,
+          variants: ['chess', ...variants.map(v => v.key)],
+          capabilities: ['nonStandardMaterial'],
+          assets: {
+            version: 'a022fa',
+            root: 'npm/stockfish-mv.wasm',
+            js: 'stockfish.js',
+            wasm: 'stockfish.wasm',
+          },
+        },
+        make: (e: BrowserEngineInfo) =>
+          new ThreadedEngine(e, undefined, (v: Rules) => (v === 'antichess' ? 'giveaway' : v)),
       },
       {
         info: {
@@ -225,6 +231,7 @@ export class Engines {
     this.externalEngines =
       this.ctrl.opts.externalEngines?.map(e => ({
         tech: 'EXTERNAL',
+        preferred: true,
         maxMovetime: 30 * 1000, // broker timeouts prevent long search
         ...e,
       })) ?? [];
@@ -232,31 +239,34 @@ export class Engines {
 
   getEngine(selector?: {
     id?: string;
-    variant?: VariantKey;
-    capability?: EngineTrust;
+    rules: Rules;
+    nonStandardMaterial: boolean;
+    capability?: EngineCapability;
   }): EngineInfo | undefined {
     const id = selector?.id ?? this.activeEngine?.id;
-    const variant = selector?.variant || 'standard';
-    const localEngines = [...this.localEngineMap.values()]
-      .filter(e => !selector?.capability || e.info.capabilities?.includes(selector.capability))
-      .map(e => e.info);
-    return (
-      this.externalEngines.find(e => e.id === id && externalEngineSupports(e, variant)) ??
-      localEngines.find(e => e.id === id && e.variants?.includes(variant)) ??
-      localEngines.find(e => e.preferred && e.variants?.includes(variant)) ??
-      localEngines.find(e => e.variants?.includes(variant)) ??
-      this.externalEngines.find(e => externalEngineSupports(e, variant))
-    );
+    const engines = this.supporting({
+      rules: selector?.rules || 'chess',
+      nonStandardMaterial: selector?.nonStandardMaterial || false,
+      capability: selector?.capability,
+    });
+    return engines.find(info => info.id === id) ?? engines.find(info => info.preferred) ?? engines[0];
   }
 
   active(): EngineInfo | undefined {
-    this.activeEngine ??= this.getEngine({ variant: this.ctrl.opts.variant.key });
+    this.activeEngine ??= this.getEngine({
+      rules: this.ctrl.rules,
+      nonStandardMaterial: this.ctrl.nonStandardMaterial,
+    });
     return this.activeEngine;
   }
 
   setActive(id: string): EngineInfo | undefined {
     if (!this.activeEngine || id !== this.activeEngine.id) {
-      this.activeEngine = this.getEngine({ id, variant: this.ctrl.opts.variant.key });
+      this.activeEngine = this.getEngine({
+        id,
+        rules: this.ctrl.rules,
+        nonStandardMaterial: this.ctrl.nonStandardMaterial,
+      });
     }
     return this.activeEngine;
   }
@@ -274,28 +284,27 @@ export class Engines {
     return true;
   }
 
-  supporting(
-    variant: VariantKey,
-    capability?: EngineTrust,
-    filter: 'browser' | 'external' | 'all' = 'all',
-  ): EngineInfo[] {
-    const engines: EngineInfo[] = [];
-    if (filter !== 'browser') {
-      engines.push(...this.externalEngines.filter(e => externalEngineSupports(e, variant)));
-    }
-    if (filter !== 'external') {
-      for (const { info } of this.localEngineMap.values()) {
-        if (!info.variants?.includes(variant)) continue;
-        if (capability && !info.capabilities?.includes(capability)) continue;
-        engines.push(info);
-      }
-    }
-    return engines;
+  supporting(selector: {
+    rules: Rules;
+    nonStandardMaterial: boolean;
+    capability?: EngineCapability;
+    filter?: 'browser' | 'external';
+  }): EngineInfo[] {
+    const engines: EngineInfo[] = [
+      ...(selector.filter !== 'browser' ? this.externalEngines : []),
+      ...(selector.filter !== 'external' ? [...this.localEngineMap.values()].map(e => e.info) : []),
+    ];
+    return engines.filter(
+      info =>
+        (!selector.nonStandardMaterial || info.capabilities?.includes('nonStandardMaterial')) &&
+        (info.variants ?? ['chess']).includes(selector.rules) &&
+        (!selector.capability || info.capabilities?.includes(selector.capability)),
+    );
   }
 
-  makeEngine(selector?: { id?: string; variant?: VariantKey }): CevalEngine {
+  makeEngine(selector?: { id?: string; rules: Rules; nonStandardMaterial: boolean }): CevalEngine {
     const e = (this.activeEngine = this.getEngine(selector));
-    if (!e) throw Error(`Engine not found ${selector?.id ?? selector?.variant}`);
+    if (!e) throw Error(`Engine not found ${selector?.id ?? selector?.rules}`);
 
     return e.tech === 'EXTERNAL'
       ? new ExternalEngine(e, this.statusCallback)
@@ -314,14 +323,6 @@ export class Engines {
   };
 }
 
-function externalEngineSupports(e: EngineInfo, v: VariantKey) {
-  const names = [v.toLowerCase()];
-  if (v === 'standard' || v === 'fromPosition' || v === 'chess960') names.push('chess');
-  if (v === 'threeCheck') names.push('3check');
-  if (v === 'antichess') names.push('giveaway');
-  return (e.variants ?? []).filter(v => names.includes(v.toLowerCase())).length;
-}
-
 function maxHashMB() {
   if (isAndroid())
     return 64; // budget androids are easy to crash @ 128
@@ -333,7 +334,7 @@ function maxHashMB() {
 
 const maxHash = maxHashMB();
 const withDefaults = (engine: BrowserEngineInfo): BrowserEngineInfo => ({
-  variants: ['standard', 'chess960', 'fromPosition'],
+  variants: ['chess'],
   minMem: 1024,
   maxHash,
   minThreads: 2,

--- a/ui/lib/src/ceval/engines/threadedEngine.ts
+++ b/ui/lib/src/ceval/engines/threadedEngine.ts
@@ -1,3 +1,5 @@
+import type { Rules } from 'chessops';
+
 import { Cache } from '../cache';
 import { Protocol } from '../protocol';
 import {
@@ -39,7 +41,7 @@ export class ThreadedEngine implements CevalEngine {
   constructor(
     readonly info: BrowserEngineInfo,
     readonly status: EngineNotifier | undefined,
-    readonly variantMap?: (v: string) => string,
+    readonly variantMap?: (v: Rules) => string,
   ) {}
 
   onError = (err: Error): void => {

--- a/ui/lib/src/ceval/protocol.ts
+++ b/ui/lib/src/ceval/protocol.ts
@@ -1,3 +1,5 @@
+import { type Rules } from 'chessops/types';
+
 import type { LocalEval } from '@/tree/types';
 
 import { defined } from '../index';
@@ -14,7 +16,7 @@ export class Protocol {
   private send: ((cmd: string) => void) | undefined;
   private options: Map<string, string | number> = new Map<string, string>();
 
-  constructor(readonly variantMap?: (v: VariantKey) => string) {}
+  constructor(readonly variantMap?: (v: Rules) => string) {}
 
   connected(send: (cmd: string) => void): void {
     this.send = send;
@@ -157,8 +159,8 @@ export class Protocol {
       console.warn(`SF: ${command}`);
   }
 
-  uciVariant(key: VariantKey): string {
-    return this.variantMap?.(key) ?? (key === 'threeCheck' ? '3check' : key.toLowerCase());
+  uciVariant(key: Rules): string {
+    return this.variantMap?.(key) ?? key;
   }
 
   private emit(ev = this.currentEval, work = this.work) {

--- a/ui/lib/src/ceval/types.ts
+++ b/ui/lib/src/ceval/types.ts
@@ -1,3 +1,5 @@
+import type { Rules } from 'chessops';
+
 import type { Feature } from '@/device';
 import type { ClientEval, LocalEval, ServerEval, TreeNode, TreePath } from '@/tree/types';
 import type { MaybeVNode } from '@/view';
@@ -8,7 +10,7 @@ import type { CevalCtrl } from './ctrl';
 export type WinningChances = number;
 export type SearchBy = { movetime: number } | { depth: number } | { nodes: number };
 export type Search = { by: SearchBy; multiPv: number; indeterminate?: boolean };
-export type EngineTrust = 'cloudEval' | 'staticAnalysis' | 'puzzleReport';
+export type EngineCapability = 'cloudEval' | 'puzzleReport' | 'nonStandardMaterial';
 
 export interface EvalMeta {
   path: TreePath;
@@ -18,7 +20,7 @@ export interface EvalMeta {
 }
 
 export interface Work extends EvalMeta {
-  variant: VariantKey;
+  variant: Rules;
   threads: number;
   hashSize?: number;
   gameId?: string; // send ucinewgame when changed
@@ -36,17 +38,17 @@ export interface BaseEngineInfo {
   name: string;
   short?: string;
   url?: string;
-  variants?: VariantKey[];
+  variants?: Rules[];
   minThreads?: number;
   maxThreads?: number;
   maxHash?: number;
   maxMovetime?: number;
   requires?: Feature[];
-  capabilities?: EngineTrust[];
+  capabilities?: EngineCapability[];
 }
 
 export interface ExternalEngineInfoFromServer extends BaseEngineInfo {
-  variants: VariantKey[];
+  variants: Rules[];
   maxHash: number;
   maxThreads: number;
   providerData?: string;
@@ -57,6 +59,7 @@ export interface ExternalEngineInfoFromServer extends BaseEngineInfo {
 
 export interface ExternalEngineInfo extends ExternalEngineInfoFromServer {
   tech: 'EXTERNAL';
+  preferred: true;
   cloudEval?: false;
 }
 

--- a/ui/lib/src/ceval/types.ts
+++ b/ui/lib/src/ceval/types.ts
@@ -10,7 +10,6 @@ import type { CevalCtrl } from './ctrl';
 export type WinningChances = number;
 export type SearchBy = { movetime: number } | { depth: number } | { nodes: number };
 export type Search = { by: SearchBy; multiPv: number; indeterminate?: boolean };
-export type EngineCapability = 'cloudEval' | 'puzzleReport' | 'nonStandardMaterial';
 
 export interface EvalMeta {
   path: TreePath;
@@ -39,12 +38,14 @@ export interface BaseEngineInfo {
   short?: string;
   url?: string;
   variants?: Rules[];
+  supportsNonStandardMaterial?: boolean;
   minThreads?: number;
   maxThreads?: number;
   maxHash?: number;
   maxMovetime?: number;
   requires?: Feature[];
-  capabilities?: EngineCapability[];
+  supportsPuzzleReport?: boolean;
+  supportsCloudEval?: boolean;
 }
 
 export interface ExternalEngineInfoFromServer extends BaseEngineInfo {
@@ -60,7 +61,6 @@ export interface ExternalEngineInfoFromServer extends BaseEngineInfo {
 export interface ExternalEngineInfo extends ExternalEngineInfoFromServer {
   tech: 'EXTERNAL';
   preferred: true;
-  cloudEval?: false;
 }
 
 export interface BrowserEngineInfo extends BaseEngineInfo {

--- a/ui/lib/src/ceval/view/settings.ts
+++ b/ui/lib/src/ceval/view/settings.ts
@@ -193,7 +193,10 @@ function setupTick(v: VNode, ceval: CevalCtrl) {
 
 function engineSelection({ ceval }: CevalHandler) {
   const active = ceval.engines.active();
-  const engines = ceval.engines.supporting(ceval.opts.variant.key);
+  const engines = ceval.engines.supporting({
+    rules: ceval.rules,
+    nonStandardMaterial: ceval.nonStandardMaterial,
+  });
   const external = ceval.engines.external;
 
   return hl('div.setting', [
@@ -228,7 +231,14 @@ function engineSelection({ ceval }: CevalHandler) {
       {
         attrs: { title: 'Engine information' },
         on: {
-          click: () => engineInfo(ceval.engines.supporting(ceval.opts.variant.key, undefined, 'browser')),
+          click: () =>
+            engineInfo(
+              ceval.engines.supporting({
+                rules: ceval.rules,
+                nonStandardMaterial: ceval.nonStandardMaterial,
+                filter: 'browser',
+              }),
+            ),
         },
       },
       [snabIcon('infoCircle')],

--- a/ui/puzzle/src/report.ts
+++ b/ui/puzzle/src/report.ts
@@ -42,7 +42,7 @@ export default class Report {
       ctrl.data.puzzle.themes.some((t: ThemeKey) => t.toLowerCase().includes('mate')) ||
       // positions with 7 pieces or less can be checked with the tablebase
       pieceCount(ev.fen) <= 7 ||
-      !ctrl.ceval.engines.active()?.capabilities?.includes('puzzleReport') ||
+      !ctrl.ceval.engines.active()?.supportsPuzzleReport ||
       // if the user has chosen to hide the dialog less than a week ago
       this.tsHideReportDialog() > Date.now() - 1000 * 3600 * 24 * 7
     )


### PR DESCRIPTION
Official Stockfish does not support non-standard material. Stockfish 19 validates this and exits, making the issue particularly obvious.

- Refactor to switch from `VariantKey` lilaism to UCI `Rules` as early as possible.
- Deduplicate the selection logic in `getEngine` and `supporting`.
- Add `nonStandardMaterial` to the engine selector, looking for a new `nonStandardMaterial` capability.
- Declare that Fairy Stockfish and Multi-Variant Stockfish support standard chess. They are currently not obsoleted by anything, which helps here, but also means they are shown when Stockfish 19 is usable and better. For now only adjusted the order.
- Drop unused `staticAnalysis` capability.