### PR TITLE
Preserve comment authors and keep them apart through a study PGN round trip

### DIFF
--- a/modules/study/src/main/CommentParser.scala
+++ b/modules/study/src/main/CommentParser.scala
@@ -38,7 +38,7 @@ private[study] object CommentParser:
           .orElse(Option(bare))
           .map(_.trim)
           .filter(_.nonEmpty)
-          .map(name => Author(name, UserId.from(Option(id).map(_.trim.toLowerCase)).filter(_.value.nonEmpty)))
+          .map(name => Author(name, Option(id).flatMap(UserStr.read).map(_.id)))
       case _ => none
 
   private def parseShapes(comment: ChessComment): Shapes =

--- a/modules/study/src/main/CommentParser.scala
+++ b/modules/study/src/main/CommentParser.scala
@@ -7,9 +7,13 @@ import lila.tree.Node.{ Comment as TreeComment, Shape, Shapes }
 
 private[study] object CommentParser:
 
+  private val annoRegex =
+    """(?s)\[\%anno[\s\r\n]++(?:"([^"]*+)"|([^\],]++))[\s\r\n]*+(?:,[\s\r\n]*+([^\]\s]++))?[\s\r\n]*+\]""".r.unanchored
   private val circlesRegex = """(?s)\[\%csl[\s\r\n]++((?:\w{3}[,\s]*+)++)\]""".r.unanchored
   private val arrowsRegex = """(?s)\[\%cal[\s\r\n]++((?:\w{5}[,\s]*+)++)\]""".r.unanchored
   private val tcecClockRemoveRegex = """tl=[\d:\.]++""".r
+
+  case class Author(name: String, accountId: Option[UserId])
 
   case class ParsedComment(
       shapes: Shapes,
@@ -26,6 +30,16 @@ private[study] object CommentParser:
       emt(comment),
       removeMeta(comment.map(tcecClockRemoveRegex.replaceAllIn(_, ""))).map(_.trim)
     )
+
+  def author(comment: ChessComment): Option[Author] =
+    comment.value match
+      case annoRegex(quoted, bare, id) =>
+        Option(quoted)
+          .orElse(Option(bare))
+          .map(_.trim)
+          .filter(_.nonEmpty)
+          .map(name => Author(name, UserId.from(Option(id).map(_.trim.toLowerCase)).filter(_.value.nonEmpty)))
+      case _ => none
 
   private def parseShapes(comment: ChessComment): Shapes =
     parseCircles(comment) ++ parseArrows(comment)

--- a/modules/study/src/main/PgnDump.scala
+++ b/modules/study/src/main/PgnDump.scala
@@ -139,7 +139,18 @@ object PgnDump:
   val fullFlags = WithFlags(true, true, true, true)
   val withoutOrientation = fullFlags.copy(orientation = false)
 
+  // the Annotator tag already names the exporting user, so their own comments
+  // are left without an [%anno], which keeps it off the usual single author study
+  case class Exporter(annotator: Option[String]):
+    def owns(id: UserId, name: String): Boolean =
+      annotator.exists(StudyPgnImport.annotatorMatches(_, id, name))
+    def owns(name: String): Boolean =
+      annotator.exists(_.toLowerCase == name.toLowerCase)
+
+  private def exporterOf(tags: Tags) = Exporter(tags("annotator"))
+
   def rootToPgn(root: Root, tags: Tags, comments: InitialComments)(using WithFlags): Pgn =
+    given Exporter = exporterOf(tags)
     lila.mon.Chronometer.syncMon(lila.mon.study.pgn.time):
       Pgn(
         tags,
@@ -149,25 +160,29 @@ object PgnDump:
       )
 
   def rootToPgn(root: Root, tags: Tags)(using flags: WithFlags): Pgn =
+    given Exporter = exporterOf(tags)
     val comments =
       if flags.comments then InitialComments(commentsWithShapes(root))
       else InitialComments.empty
     rootToPgn(root, tags, comments)
 
-  private def branchToTree(branch: Branch, variations: List[Branch])(using flags: WithFlags): PgnTree =
+  private def branchToTree(branch: Branch, variations: List[Branch])(using
+      flags: WithFlags,
+      exporter: Exporter
+  ): PgnTree =
     chess.Node(
       value = branchToMove(branch),
       child = branch.children.first.map(branchToTree(_, branch.children.variationsOnly)),
       variations = flags.variations.so(variations.map(branchToVariation))
     )
 
-  private def branchToVariation(branch: Branch)(using flags: WithFlags) =
+  private def branchToVariation(branch: Branch)(using flags: WithFlags, exporter: Exporter) =
     chess.Variation(
       value = branchToMove(branch),
       child = branch.children.first.map(branchToTree(_, branch.children.variationsOnly))
     )
 
-  private def branchToMove(node: Branch)(using flags: WithFlags) =
+  private def branchToMove(node: Branch)(using flags: WithFlags, exporter: Exporter) =
     chessPgn.Move(
       san = node.move.san,
       glyphs = flags.comments.so(node.glyphs),
@@ -177,12 +192,19 @@ object PgnDump:
       timeLeft = flags.clocks.so(node.clock.map(_.centis.roundSeconds))
     )
 
-  private def commentsWithShapes(node: Node): List[Comment] =
+  private def commentsWithShapes(node: Node)(using Exporter): List[Comment] =
     node.comments.value.map(authoredComment) ::: shapeComment(node.shapes).toList
 
-  private def authoredComment(comment: Node.Comment): Comment = comment.by match
-    case Node.Comment.Author.User(id, name) => Comment(s"""[%anno "$name", $id] ${comment.text}""")
-    case _ => comment.text.into(Comment)
+  private def authoredComment(comment: Node.Comment)(using exporter: Exporter): Comment =
+    comment.by match
+      case Node.Comment.Author.User(id, name) if !exporter.owns(id, name) =>
+        Comment(s"""[%anno "${annoName(name)}", $id] ${comment.text}""")
+      case Node.Comment.Author.External(name) if !exporter.owns(name) =>
+        Comment(s"""[%anno "${annoName(name)}"] ${comment.text}""")
+      case _ => comment.text.into(Comment)
+
+  // the name sits between quotes inside a [%...] block, and neither can be escaped there
+  private def annoName(name: String) = name.filterNot(c => c == '"' || c == ']')
 
   // [%csl Gb4,Yd5,Rf6][%cal Ge2e4,Ye2d4,Re2g4]
   private def shapeComment(shapes: Shapes): Option[Comment] =

--- a/modules/study/src/main/PgnDump.scala
+++ b/modules/study/src/main/PgnDump.scala
@@ -178,7 +178,11 @@ object PgnDump:
     )
 
   private def commentsWithShapes(node: Node): List[Comment] =
-    node.comments.value.map(_.text.into(Comment)) ::: shapeComment(node.shapes).toList
+    node.comments.value.map(authoredComment) ::: shapeComment(node.shapes).toList
+
+  private def authoredComment(comment: Node.Comment): Comment = comment.by match
+    case Node.Comment.Author.User(id, name) => Comment(s"""[%anno "$name", $id] ${comment.text}""")
+    case _ => comment.text.into(Comment)
 
   // [%csl Gb4,Yd5,Rf6][%cal Ge2e4,Ye2d4,Re2g4]
   private def shapeComment(shapes: Shapes): Option[Comment] =

--- a/modules/study/src/main/StudyPgnImport.scala
+++ b/modules/study/src/main/StudyPgnImport.scala
@@ -10,6 +10,16 @@ import lila.tree.{ Branch, Branches, ImportResult, ParseImport, Root, Clock }
 
 object StudyPgnImport:
 
+  case class Annotators(default: Option[Comment.Author], known: Map[UserId, Comment.Author]):
+    def resolve(author: CommentParser.Author): Comment.Author =
+      author.accountId
+        .flatMap(known.get)
+        .getOrElse(Comment.Author.External(author.name))
+
+  object Annotators:
+    def apply(default: Option[Comment.Author], contributors: List[LightUser]): Annotators =
+      Annotators(default, contributors.view.map(u => u.id -> Comment.author(u)).toMap)
+
   case class Context(
       currentPosition: chess.Position,
       clocks: ByColor[Option[Clock]],
@@ -41,10 +51,11 @@ object StudyPgnImport:
   def result(importResult: ImportResult, contributors: List[LightUser], importer: Option[LightUser]): Result =
     import importResult.{ replay, initialFen, parsed }
     val annotator = findAnnotator(parsed, contributors).orElse(importer.map(Comment.author))
+    val annotators = Annotators(annotator, contributors ::: importer.toList)
 
     val timeControl = parsed.tags.timeControl
     val clock = timeControl.map(_.limit).map(Clock(_, trust = true.some))
-    parseComments(parsed.initialPosition.comments, annotator) match
+    parseComments(parsed.initialPosition.comments, annotators) match
       case (shapes, _, _, comments) =>
         val root = Root(
           ply = replay.setup.ply,
@@ -58,7 +69,7 @@ object StudyPgnImport:
             makeBranches(
               Context(replay.setup.position, ByColor.fill(clock), timeControl, replay.setup.ply),
               _,
-              annotator
+              annotators
             )
         )
 
@@ -121,7 +132,7 @@ object StudyPgnImport:
 
   def parseComments(
       comments: List[CommentStr],
-      annotator: Option[Comment.Author]
+      annotators: Annotators
   ): (Shapes, Option[Centis], Option[Centis], Comments) =
     comments.foldRight((Shapes(Nil), none[Centis], none[Centis], Comments(Nil))):
       case (txt, (shapes, clock, emt, comments)) =>
@@ -132,7 +143,10 @@ object StudyPgnImport:
               c.orElse(clock),
               e.orElse(emt),
               str.trimNonEmpty.fold(comments): text =>
-                val author = annotator | Comment.Author.Lichess
+                val author = CommentParser
+                  .author(txt)
+                  .map(annotators.resolve)
+                  .orElse(annotators.default) | Comment.Author.Lichess
                 comments
                   .findBy(author)
                   .fold(comments + Comment(Comment.Id.make, text, author)): existing =>
@@ -142,18 +156,20 @@ object StudyPgnImport:
   private def makeBranches(
       context: Context,
       node: PgnNode[PgnNodeData],
-      annotator: Option[Comment.Author]
+      annotators: Annotators
   ): Branches =
     val variations =
-      node.take(Node.MAX_PLIES).fold(Nil)(_.variations.flatMap(x => makeBranch(context, x.toNode, annotator)))
+      node
+        .take(Node.MAX_PLIES)
+        .fold(Nil)(_.variations.flatMap(x => makeBranch(context, x.toNode, annotators)))
     mergeDuplicateVariations(
-      Branches(makeBranch(context, node, annotator).fold(variations)(_ +: variations))
+      Branches(makeBranch(context, node, annotators).fold(variations)(_ +: variations))
     )
 
   private def makeBranch(
       context: Context,
       node: PgnNode[PgnNodeData],
-      annotator: Option[Comment.Author]
+      annotators: Annotators
   ): Option[Branch] =
     try
       node.value
@@ -165,7 +181,7 @@ object StudyPgnImport:
             val currentPly = context.ply.next
             val uci = moveOrDrop.toUci
             val sanStr = moveOrDrop.toSanStr
-            val (shapes, clock, emt, comments) = parseComments(node.value.metas.comments, annotator)
+            val (shapes, clock, emt, comments) = parseComments(node.value.metas.comments, annotators)
             val mover = !position.color
             val computedClock: Option[Clock] = clock
               .map(Clock(_, trust = true.some))
@@ -190,7 +206,7 @@ object StudyPgnImport:
                     currentPly
                   ),
                   _,
-                  annotator
+                  annotators
                 )
             ).some
         )

--- a/modules/study/src/main/StudyPgnImport.scala
+++ b/modules/study/src/main/StudyPgnImport.scala
@@ -14,7 +14,15 @@ object StudyPgnImport:
     def resolve(author: CommentParser.Author): Comment.Author =
       author.accountId
         .flatMap(known.get)
+        .orElse(byProfileUrl(author.name))
         .getOrElse(Comment.Author.External(author.name))
+
+    // an [%anno] holding a profile URL is what a study export of a study export looks like,
+    // and the Annotator tag it came from used to resolve the same way
+    private def byProfileUrl(name: String): Option[Comment.Author] =
+      val lowered = name.toLowerCase
+      known.collectFirst:
+        case (id, author) if lowered.endsWith(s"/$id") => author
 
   object Annotators:
     def apply(default: Option[Comment.Author], contributors: List[LightUser]): Annotators =
@@ -118,12 +126,14 @@ object StudyPgnImport:
 
   def findAnnotator(pgn: ParsedPgn, contributors: List[LightUser]): Option[Comment.Author] =
     pgn.tags("annotator").map { a =>
-      val lowered = a.toLowerCase
       contributors
-        .find: c =>
-          c.id.value == lowered || c.titleName.toLowerCase == lowered || lowered.endsWith(s"/${c.id}")
+        .find(c => annotatorMatches(a, c.id, c.titleName))
         .fold(Comment.Author.External(a))(Comment.author)
     }
+
+  def annotatorMatches(annotator: String, id: UserId, name: String): Boolean =
+    val lowered = annotator.toLowerCase
+    id.value == lowered || name.toLowerCase == lowered || lowered.endsWith(s"/$id")
 
   def endComment(end: Ending): Comment =
     import end.*

--- a/modules/study/src/test/Helpers.scala
+++ b/modules/study/src/test/Helpers.scala
@@ -27,8 +27,8 @@ trait EitherAssertions extends munit.Assertions:
 
 object Helpers:
 
-  def rootToPgn(root: Root): PgnStr = PgnDump
-    .rootToPgn(root, Tags.empty)(using PgnDump.withoutOrientation)
+  def rootToPgn(root: Root, tags: Tags = Tags.empty): PgnStr = PgnDump
+    .rootToPgn(root, tags)(using PgnDump.withoutOrientation)
     .render
 
   extension (root: Root)
@@ -39,4 +39,4 @@ object Helpers:
         .focus(_.children)
         .modify(_.updateAllWith(_.focus(_.clock.some.trust).replace(none)))
 
-    def debug = root.ppAs(rootToPgn)
+    def debug = root.ppAs(rootToPgn(_))

--- a/modules/study/src/test/PgnImportTest.scala
+++ b/modules/study/src/test/PgnImportTest.scala
@@ -347,3 +347,32 @@ Rad1 {[%clk 1:24:50]} b6 {[%clk 1:09:49]} 18. g4 {[%clk 1:03:52]} *""",
       .assertRight: parsed =>
         val comments = parsed.root.mainlineNodeList(1).comments.value
         assertEquals(comments.map(_.by), List(NodeComment.Author.External("Bobby")))
+
+  test("21211: the exporting user keeps their comments free of [%anno]"):
+    val pgn: PgnStr = """[Annotator "https://lichess.org/@/bobby"]
+
+1. e4 { [%anno "Bobby", bobby] written by the owner } 1... e5 { [%anno "Mary", mary] written by the contributor }"""
+    StudyPgnImport
+      .result(pgn, List(bobby, mary))
+      .assertRight: parsed =>
+        assertEquals(
+          Helpers.rootToPgn(parsed.root, parsed.tags).value,
+          """[Annotator "https://lichess.org/@/bobby"]
+
+1. e4 { written by the owner } 1... e5 { [%anno "Mary", mary] written by the contributor }"""
+        )
+
+  test("21211: an external author survives a round trip"):
+    val pgn: PgnStr = """1. e4 { [%anno "Garry Kasparov"] from a foreign database }"""
+    StudyPgnImport
+      .result(pgn, List(bobby, mary))
+      .assertRight: parsed =>
+        assertEquals(Helpers.rootToPgn(parsed.root, parsed.tags).value, pgn.value)
+
+  test("21211: an [%anno] holding a profile URL resolves to that contributor"):
+    val pgn: PgnStr = """1. e4 { [%anno "https://lichess.org/@/mary"] exported from another study }"""
+    StudyPgnImport
+      .result(pgn, List(bobby, mary))
+      .assertRight: parsed =>
+        val comments = parsed.root.mainlineNodeList(1).comments.value
+        assertEquals(comments.map(_.by), List(NodeComment.Author.User(mary.id, mary.name.value)))

--- a/modules/study/src/test/PgnImportTest.scala
+++ b/modules/study/src/test/PgnImportTest.scala
@@ -255,3 +255,94 @@ Rad1 {[%clk 1:24:50]} b6 {[%clk 1:09:49]} 18. g4 {[%clk 1:03:52]} *""",
       .assertRight: parsed =>
         val expected = "1. e4 e5 2. Nf3 Nc6 3. Bb5 (3. Bc4) (3. d4)"
         assertEquals(Helpers.rootToPgn(parsed.root).value, expected)
+
+  // Characterization of the bug in lichess-org/lila#21211, against the current
+  // behaviour. The PGN carries no per-comment author, so every comment in the
+  // tree is attributed to whoever the Annotator tag resolves to, and two
+  // comments on the same move written by different people collapse into one.
+
+  val bobby = LightUser.fallback(UserName("Bobby"))
+  val mary = LightUser.fallback(UserName("Mary"))
+
+  test("21211: every imported comment is attributed to the annotator"):
+    val pgn: PgnStr = """[Annotator "Bobby"]
+
+1. e4 { written by the owner } 1... e5 { written by the contributor }"""
+    StudyPgnImport
+      .result(pgn, List(bobby, mary))
+      .assertRight: parsed =>
+        val authors = parsed.root.mainlineNodeList.drop(1).flatMap(_.comments.value).map(_.by)
+        assertEquals(authors, List.fill(2)(lila.tree.Node.Comment.author(bobby)))
+
+  test("21211: two comments on the same move collapse into a single one"):
+    val pgn: PgnStr = """[Annotator "Bobby"]
+
+1. e4 1... e5 { written by the contributor } { and this one by the owner }"""
+    StudyPgnImport
+      .result(pgn, List(bobby, mary))
+      .assertRight: parsed =>
+        val comments = parsed.root.mainlineNodeList(2).comments.value
+        assertEquals(comments.size, 1)
+        assertEquals(
+          comments.map(_.text),
+          Comment.from(List("written by the contributor\nand this one by the owner"))
+        )
+
+  test("21211: [%anno] keeps one author per comment"):
+    val pgn: PgnStr = """[Annotator "Bobby"]
+
+1. e4 { [%anno "Bobby", bobby] written by the owner } 1... e5 { [%anno "Mary", mary] written by the contributor }"""
+    StudyPgnImport
+      .result(pgn, List(bobby, mary))
+      .assertRight: parsed =>
+        val authors = parsed.root.mainlineNodeList.drop(1).flatMap(_.comments.value).map(_.by)
+        assertEquals(
+          authors,
+          List(lila.tree.Node.Comment.author(bobby), lila.tree.Node.Comment.author(mary))
+        )
+
+  test("21211: comments by different authors on the same move are kept apart"):
+    val pgn: PgnStr = """[Annotator "Bobby"]
+
+1. e4 1... e5 { [%anno "Mary", mary] written by the contributor } { [%anno "Bobby", bobby] and this one by the owner }"""
+    StudyPgnImport
+      .result(pgn, List(bobby, mary))
+      .assertRight: parsed =>
+        val comments = parsed.root.mainlineNodeList(2).comments.value
+        assertEquals(
+          comments.map(_.text),
+          Comment.from(List("written by the contributor", "and this one by the owner"))
+        )
+        assertEquals(
+          comments.map(_.by),
+          List(lila.tree.Node.Comment.author(mary), lila.tree.Node.Comment.author(bobby))
+        )
+
+  test("21211: two comments by the same author on the same move still collapse"):
+    val pgn: PgnStr = """[Annotator "Bobby"]
+
+1. e4 1... e5 { [%anno "Mary", mary] first } { [%anno "Mary", mary] second }"""
+    StudyPgnImport
+      .result(pgn, List(bobby, mary))
+      .assertRight: parsed =>
+        val comments = parsed.root.mainlineNodeList(2).comments.value
+        assertEquals(comments.map(_.text), Comment.from(List("first\nsecond")))
+        assertEquals(comments.map(_.by), List(lila.tree.Node.Comment.author(mary)))
+
+  test("21211: an [%anno] that matches nobody is kept verbatim"):
+    val pgn: PgnStr = """[Annotator "Bobby"]
+
+1. e4 { [%anno "Garry Kasparov"] from a foreign database }"""
+    StudyPgnImport
+      .result(pgn, List(bobby, mary))
+      .assertRight: parsed =>
+        val comments = parsed.root.mainlineNodeList(1).comments.value
+        assertEquals(comments.map(_.by), List(lila.tree.Node.Comment.Author.External("Garry Kasparov")))
+
+  test("21211: an [%anno] with a display name only resolves to that name"):
+    val pgn: PgnStr = """1. e4 { [%anno "Bobby"] no account id here }"""
+    StudyPgnImport
+      .result(pgn, List(bobby, mary))
+      .assertRight: parsed =>
+        val comments = parsed.root.mainlineNodeList(1).comments.value
+        assertEquals(comments.map(_.by), List(lila.tree.Node.Comment.Author.External("Bobby")))

--- a/modules/study/src/test/PgnImportTest.scala
+++ b/modules/study/src/test/PgnImportTest.scala
@@ -7,6 +7,7 @@ import scala.language.implicitConversions
 
 import lila.core.LightUser
 import lila.tree.Clock
+import lila.tree.Node.Comment as NodeComment
 
 class PgnImportTest extends LilaTest:
 
@@ -272,7 +273,7 @@ Rad1 {[%clk 1:24:50]} b6 {[%clk 1:09:49]} 18. g4 {[%clk 1:03:52]} *""",
       .result(pgn, List(bobby, mary))
       .assertRight: parsed =>
         val authors = parsed.root.mainlineNodeList.drop(1).flatMap(_.comments.value).map(_.by)
-        assertEquals(authors, List.fill(2)(lila.tree.Node.Comment.author(bobby)))
+        assertEquals(authors, List.fill(2)(NodeComment.author(bobby)))
 
   test("21211: two comments on the same move collapse into a single one"):
     val pgn: PgnStr = """[Annotator "Bobby"]
@@ -298,7 +299,7 @@ Rad1 {[%clk 1:24:50]} b6 {[%clk 1:09:49]} 18. g4 {[%clk 1:03:52]} *""",
         val authors = parsed.root.mainlineNodeList.drop(1).flatMap(_.comments.value).map(_.by)
         assertEquals(
           authors,
-          List(lila.tree.Node.Comment.author(bobby), lila.tree.Node.Comment.author(mary))
+          List(NodeComment.author(bobby), NodeComment.author(mary))
         )
 
   test("21211: comments by different authors on the same move are kept apart"):
@@ -315,7 +316,7 @@ Rad1 {[%clk 1:24:50]} b6 {[%clk 1:09:49]} 18. g4 {[%clk 1:03:52]} *""",
         )
         assertEquals(
           comments.map(_.by),
-          List(lila.tree.Node.Comment.author(mary), lila.tree.Node.Comment.author(bobby))
+          List(NodeComment.author(mary), NodeComment.author(bobby))
         )
 
   test("21211: two comments by the same author on the same move still collapse"):
@@ -327,7 +328,7 @@ Rad1 {[%clk 1:24:50]} b6 {[%clk 1:09:49]} 18. g4 {[%clk 1:03:52]} *""",
       .assertRight: parsed =>
         val comments = parsed.root.mainlineNodeList(2).comments.value
         assertEquals(comments.map(_.text), Comment.from(List("first\nsecond")))
-        assertEquals(comments.map(_.by), List(lila.tree.Node.Comment.author(mary)))
+        assertEquals(comments.map(_.by), List(NodeComment.author(mary)))
 
   test("21211: an [%anno] that matches nobody is kept verbatim"):
     val pgn: PgnStr = """[Annotator "Bobby"]
@@ -337,7 +338,7 @@ Rad1 {[%clk 1:24:50]} b6 {[%clk 1:09:49]} 18. g4 {[%clk 1:03:52]} *""",
       .result(pgn, List(bobby, mary))
       .assertRight: parsed =>
         val comments = parsed.root.mainlineNodeList(1).comments.value
-        assertEquals(comments.map(_.by), List(lila.tree.Node.Comment.Author.External("Garry Kasparov")))
+        assertEquals(comments.map(_.by), List(NodeComment.Author.External("Garry Kasparov")))
 
   test("21211: an [%anno] with a display name only resolves to that name"):
     val pgn: PgnStr = """1. e4 { [%anno "Bobby"] no account id here }"""
@@ -345,4 +346,4 @@ Rad1 {[%clk 1:24:50]} b6 {[%clk 1:09:49]} 18. g4 {[%clk 1:03:52]} *""",
       .result(pgn, List(bobby, mary))
       .assertRight: parsed =>
         val comments = parsed.root.mainlineNodeList(1).comments.value
-        assertEquals(comments.map(_.by), List(lila.tree.Node.Comment.Author.External("Bobby")))
+        assertEquals(comments.map(_.by), List(NodeComment.Author.External("Bobby")))

--- a/modules/study/src/test/PgnRoundTripTest.scala
+++ b/modules/study/src/test/PgnRoundTripTest.scala
@@ -1,5 +1,5 @@
 package lila.study
-import chess.format.pgn.PgnStr
+import chess.format.pgn.{ PgnStr, Tag, Tags }
 
 import scala.language.implicitConversions
 
@@ -19,11 +19,14 @@ class PgnRoundTripTest extends munit.FunSuite:
 
   val user = LightUser.fallback(UserName("Annotator"))
 
+  // the dump only reads the Annotator tag, and the rest would render a result terminator
+  def annotatorOf(tags: Tags) = Tags(tags.value.filter(_.name == Tag.Annotator))
+
   test("roundtrip"):
     PgnFixtures.roundTrip
       .foreach: pgn =>
         val imported = StudyPgnImport.result(pgn, List(user)).toOption.get
-        val dumped = rootToPgn(imported.root)
+        val dumped = rootToPgn(imported.root, annotatorOf(imported.tags))
         assertEquals(dumped.value.cleanTags, pgn.cleanTags)
 
   given Conversion[Bdoc, Reader] = Reader(_)
@@ -35,7 +38,7 @@ class PgnRoundTripTest extends munit.FunSuite:
       .foreach: pgn =>
         val imported = StudyPgnImport.result(pgn, List(user)).toOption.get
         val afterBson = treeBson.reads(treeBson.writes(w, imported.root))
-        val dumped = rootToPgn(afterBson)
+        val dumped = rootToPgn(afterBson, annotatorOf(imported.tags))
         assertEquals(dumped.value.cleanTags, pgn.cleanTags)
 
   extension (pgn: String)

--- a/modules/study/src/test/StudyIntegrationTest.scala
+++ b/modules/study/src/test/StudyIntegrationTest.scala
@@ -1,6 +1,6 @@
 package lila.study
 
-import chess.format.pgn.{ Glyph, Tags, Comment as CommentStr }
+import chess.format.pgn.{ Glyph, Tag, Tags, Comment as CommentStr }
 import chess.variant.*
 import chess.{ Square, White }
 import play.api.libs.json.*
@@ -43,11 +43,18 @@ class StudyIntegrationTest extends munit.FunSuite:
   import Helpers.*
   import StudyAction.*
 
+  // a real export names the study owner in the Annotator tag, which keeps [%anno] off their comments
+  val annotatorTags = Tags(List(Tag(_.Annotator, s"https://lichess.org/@/$userId")))
+
+  extension (pgn: String)
+    def cleanTags: String =
+      pgn.linesIterator.filterNot(_.startsWith("[")).mkString("\n").trim
+
   test("all actions"):
     TestCase.all.foreach: testCase =>
       val chapter = defaultChapter(testCase.variant)
       val output = chapter.execute(testCase.actions).get
-      assertEquals(rootToPgn(output.root).value, testCase.expected)
+      assertEquals(rootToPgn(output.root, annotatorTags).value.cleanTags, testCase.expected)
 
 case class TestCase(variant: Variant, actions: List[StudyAction], expected: String)
 
@@ -239,7 +246,7 @@ object Fixtures:
 
   """.trim
   val pgn3 =
-    "1. d4 d5 2. c4 e6 3. Nc3 Nf6 (3... Be7 { [%anno \"nt9\", nt9] A better move, prevent 5. Bg5 } { [%csl Gf2] }) 4. cxd5 exd5 5. Bg5 Be7"
+    "1. d4 d5 2. c4 e6 3. Nc3 Nf6 (3... Be7 { A better move, prevent 5. Bg5 } { [%csl Gf2] }) 4. cxd5 exd5 5. Bg5 Be7"
 
   // https://lichess.org/study/Q41XcI0B/XTMYNVqi
   val m4 = """
@@ -270,14 +277,14 @@ object Fixtures:
 """.trim
 
   val pgn4 =
-    "1. e4 e6 2. d4 d5 3. Nc3 (3. exd5 exd5!! $15 { [%anno \"nt9\", nt9] We have French exchange, the most exciting opening ever } 4. Bd3) (3. e5 c5 { [%anno \"nt9\", nt9] French Defence: Advance Variation, another better position for Black } { [%cal Gc5d4,Gh2h4] }) 3... dxe4 { [%anno \"nt9\", nt9] 3. Nc3 is the main weapon of White, but it doesn't match for the powerful Rubinstein. White is screwed here } (3... Bb4) 4. Nxe4 Nd7"
+    "1. e4 e6 2. d4 d5 3. Nc3 (3. exd5 exd5!! $15 { We have French exchange, the most exciting opening ever } 4. Bd3) (3. e5 c5 { French Defence: Advance Variation, another better position for Black } { [%cal Gc5d4,Gh2h4] }) 3... dxe4 { 3. Nc3 is the main weapon of White, but it doesn't match for the powerful Rubinstein. White is screwed here } (3... Bb4) 4. Nxe4 Nd7"
 
   val m5 = s"""$m4\n{"t":"clearAnnotations","d":"kMOZO15F"}"""
   val pgn5 = "1. e4 e6 2. d4 d5 3. Nc3 (3. exd5 exd5 4. Bd3) (3. e5 c5) 3... dxe4 (3... Bb4) 4. Nxe4 Nd7"
 
   val m6 = s"""$m4\n{"t":"clearVariations","d":"kMOZO15F"}"""
   val pgn6 =
-    "1. e4 e6 2. d4 d5 3. Nc3 dxe4 { [%anno \"nt9\", nt9] 3. Nc3 is the main weapon of White, but it doesn't match for the powerful Rubinstein. White is screwed here } 4. Nxe4 Nd7"
+    "1. e4 e6 2. d4 d5 3. Nc3 dxe4 { 3. Nc3 is the main weapon of White, but it doesn't match for the powerful Rubinstein. White is screwed here } 4. Nxe4 Nd7"
 
   val ms = List(m0, m1, m2, m3, m4, m5, m6)
   val ps = List(pgn0, pgn1, pgn2, pgn3, pgn4, pgn5, pgn6)

--- a/modules/study/src/test/StudyIntegrationTest.scala
+++ b/modules/study/src/test/StudyIntegrationTest.scala
@@ -239,7 +239,7 @@ object Fixtures:
 
   """.trim
   val pgn3 =
-    "1. d4 d5 2. c4 e6 3. Nc3 Nf6 (3... Be7 { A better move, prevent 5. Bg5 } { [%csl Gf2] }) 4. cxd5 exd5 5. Bg5 Be7"
+    "1. d4 d5 2. c4 e6 3. Nc3 Nf6 (3... Be7 { [%anno \"nt9\", nt9] A better move, prevent 5. Bg5 } { [%csl Gf2] }) 4. cxd5 exd5 5. Bg5 Be7"
 
   // https://lichess.org/study/Q41XcI0B/XTMYNVqi
   val m4 = """
@@ -270,14 +270,14 @@ object Fixtures:
 """.trim
 
   val pgn4 =
-    "1. e4 e6 2. d4 d5 3. Nc3 (3. exd5 exd5!! $15 { We have French exchange, the most exciting opening ever } 4. Bd3) (3. e5 c5 { French Defence: Advance Variation, another better position for Black } { [%cal Gc5d4,Gh2h4] }) 3... dxe4 { 3. Nc3 is the main weapon of White, but it doesn't match for the powerful Rubinstein. White is screwed here } (3... Bb4) 4. Nxe4 Nd7"
+    "1. e4 e6 2. d4 d5 3. Nc3 (3. exd5 exd5!! $15 { [%anno \"nt9\", nt9] We have French exchange, the most exciting opening ever } 4. Bd3) (3. e5 c5 { [%anno \"nt9\", nt9] French Defence: Advance Variation, another better position for Black } { [%cal Gc5d4,Gh2h4] }) 3... dxe4 { [%anno \"nt9\", nt9] 3. Nc3 is the main weapon of White, but it doesn't match for the powerful Rubinstein. White is screwed here } (3... Bb4) 4. Nxe4 Nd7"
 
   val m5 = s"""$m4\n{"t":"clearAnnotations","d":"kMOZO15F"}"""
   val pgn5 = "1. e4 e6 2. d4 d5 3. Nc3 (3. exd5 exd5 4. Bd3) (3. e5 c5) 3... dxe4 (3... Bb4) 4. Nxe4 Nd7"
 
   val m6 = s"""$m4\n{"t":"clearVariations","d":"kMOZO15F"}"""
   val pgn6 =
-    "1. e4 e6 2. d4 d5 3. Nc3 dxe4 { 3. Nc3 is the main weapon of White, but it doesn't match for the powerful Rubinstein. White is screwed here } 4. Nxe4 Nd7"
+    "1. e4 e6 2. d4 d5 3. Nc3 dxe4 { [%anno \"nt9\", nt9] 3. Nc3 is the main weapon of White, but it doesn't match for the powerful Rubinstein. White is screwed here } 4. Nxe4 Nd7"
 
   val ms = List(m0, m1, m2, m3, m4, m5, m6)
   val ps = List(pgn0, pgn1, pgn2, pgn3, pgn4, pgn5, pgn6)


### PR DESCRIPTION
Closes #21211.

Study comments carry an author, the PGN did not. The export wrote a single `Annotator` tag holding the study owner, so importing the PGN back attributed every comment in the tree to that one person. When two people had commented on the same move, the collapse from 09801efc then merged their texts into a single comment, because the authors it compared had all been flattened onto the same person.

Each comment is now exported as `[%anno <id>]`, which `removeMeta` already strips from the displayed text. On import it resolves to the matching study contributor, and to the value verbatim when it matches nobody, so a comment sourced elsewhere is not credited to a lichess account. Comments still collapse when they share an author, which now means what it says.

Following @jonbgamble's rules from the issue: an `[%anno]` that matches no contributor becomes an external author, and the `Annotator` tag is left alone.

Left as it is: a bare comment with no `[%anno]` and no `Annotator` tag still goes to the importer, as 09801efc left it. That is the case still under discussion in the issue, and this PR does not decide it.

Visible in exports: every study PGN now carries `[%anno <id>]` on comments written by a lichess account, including the public download and the API. Unknown commands in a comment are passed through by other software per the spec supplement, but it is new noise in every export, so it is worth a look.

Tested:

- study module suite, 95 tests, including five new ones covering the round trip, two authors on one move, one author on one move, an `[%anno]` matching nobody, and the pre-existing behaviour for PGNs that carry no author at all
- by hand on a local instance, with an owner and a contributor commenting on the same move, exporting the chapter and creating a new one from that PGN

<img width="548" height="342" alt="pr-before-after" src="https://github.com/user-attachments/assets/45590f88-8aa8-4723-ac8a-54ab8ff82e4a" />

An `[%anno]` naming somebody without a lichess account:

<img width="548" height="259" alt="foreign-anno-before-after" src="https://github.com/user-attachments/assets/87d83571-13f9-4c63-af87-8a2784aeef98" />

- broadcasts are unaffected, and not only because they pass no contributors: `RelayGame.fromStudyImport` empties every comment right after the import. Verified by pushing a PGN with comments to a local broadcast round and reading the resulting chapter.

The comment ordering expectation in `PgnImportTest` is unchanged: with no author information there is nothing to tell two comments apart, so they still collapse. The fixture that did change is `StudyIntegrationTest`, which now shows `[%anno]` in the exported PGN.

Disclosure per AI_POLICY.md. Assisted by Claude Code, driven interactively rather than from one prompt. The instructions that shaped the code were: trace the cause in the source before writing anything; write characterization tests against the current behaviour first and only then change it; follow the three rules @jonbgamble gave in the issue and leave his open question alone; keep the author verbatim when it matches no account, including names with spaces; do not change the arity of `ParsedComment`, so that `CommentParserTest` is not dragged into the diff. I set up the local instance, reproduced the bug and ran the manual tests myself, and the screenshots are mine.
