### PR TITLE
Fix image resize in markdown preview

### DIFF
--- a/ui/lib/src/view/markdownImgResizer.ts
+++ b/ui/lib/src/view/markdownImgResizer.ts
@@ -25,7 +25,7 @@ export async function wireMarkdownImgResizers({
   let matching = 0;
 
   for (const img of root.querySelectorAll<HTMLImageElement>('img')) {
-    if (!globalImageLinkRe.test(`![](${img.src})`)) continue;
+    if (`![](${img.src})`.search(globalImageLinkRe) === -1) continue;
     const index = matching++;
 
     if (img.closest('.markdown-img-resizer')) continue; // already wrapped


### PR DESCRIPTION
RegExp.test() advances lastIndex on a global regex, so use String.search (which doesn't).

This bug prevented resizing of any image that occurred within the first 50'ish characters of a post.