### PR TITLE
ui(analyse): studies list tweaks

### DIFF
--- a/ui/analyse/css/study/_list-widget.scss
+++ b/ui/analyse/css/study/_list-widget.scss
@@ -40,9 +40,12 @@
 
       color: $c-font-dim;
       unicode-bidi: plaintext;
-      display: flex;
+      display: block;
 
       .svg-icon {
+        float: left;
+        top: 1.5px;
+        position: relative;
         color: $c-font-dimmer;
       }
     }


### PR DESCRIPTION
# Why

Supersedes #21567

Refs https://github.com/lichess-org/lila/issues/21483

# How

Alternative approach to fixing alignment, which still allows text to properly overflow with ellipsis.

# Preview

<img width="1149" height="464" alt="Screenshot 2026-09-07 at 08 50 59" src="https://github.com/user-attachments/assets/756eb874-1a4b-4494-96aa-0d76fc71261d" />
