### PR TITLE
ui(analyse): align Add buttons size and style in study

### DIFF
--- a/ui/analyse/css/study/_chapters.scss
+++ b/ui/analyse/css/study/_chapters.scss
@@ -24,7 +24,7 @@ $span-width: 1.5em;
       color: $c-primary;
     }
 
-    > span {
+    > span:not(.svg-icon) {
       @extend %flex-center-center;
 
       flex: 0 0 $span-width;

--- a/ui/analyse/css/study/_list.scss
+++ b/ui/analyse/css/study/_list.scss
@@ -62,7 +62,6 @@
 
     .svg-icon {
       color: $c-link;
-      margin-top: -2px;
     }
   }
 }

--- a/ui/analyse/css/study/_members.scss
+++ b/ui/analyse/css/study/_members.scss
@@ -77,11 +77,6 @@
   .button-thin {
     width: 100%;
     text-align: start;
-
-    .svg-icon {
-      width: 1em;
-      opacity: 1;
-    }
   }
 
   .admin button {


### PR DESCRIPTION
# Why

Refs #21483

# How

Align "Add" buttons size and style in study.

# Preview

<img width="375" height="256" alt="Screenshot 2026-09-07 at 09 01 36" src="https://github.com/user-attachments/assets/41d34f10-2379-4f91-9c7c-0e56c8769beb" />
<img width="375" height="256" alt="Screenshot 2026-09-07 at 08 59 37" src="https://github.com/user-attachments/assets/18908de0-cc22-4452-86d6-fe0f62eb0c45" />

