### PR TITLE
ui(bits): daily feed icon tweaks

### DIFF
--- a/ui/bits/css/_dailyFeed.scss
+++ b/ui/bits/css/_dailyFeed.scss
@@ -10,12 +10,20 @@ $marker-margin-top: -14px;
     border-inline-start: 3px solid $c-contours;
   }
 
-  .atom {
-    font-size: 2.6em;
-    color: $c-font-dimmer;
+  .box__top__actions {
+    .button {
+      height: 3em;
+    }
 
-    &:hover {
-      color: $c-accent;
+    .atom {
+      @include transition(color);
+
+      font-size: 2.4em;
+      color: $c-font-dimmer;
+
+      &:hover {
+        color: $c-accent;
+      }
     }
   }
 


### PR DESCRIPTION
# Why

Refs https://github.com/lichess-org/lila/issues/21483#issuecomment-5559445855

# How

Fix sizing of daily feed header icons.

# Preview

<img width="1152" height="256" alt="Screenshot 2026-09-07 at 09 08 27" src="https://github.com/user-attachments/assets/5b907a28-4f2d-4a24-b38d-dd65b4b7f03a" />
