### PR TITLE
ui(lib): fix updated logo hover style

### DIFF
--- a/ui/lib/css/header/_title.scss
+++ b/ui/lib/css/header/_title.scss
@@ -19,8 +19,9 @@
   &:hover {
     color: $c-primary;
 
-    span {
-      color: $c-primary-dim;
+    .site-icon svg {
+      fill: $c-primary-dim;
+      stroke: $c-primary-dim;
     }
   }
 


### PR DESCRIPTION
# Why

Spotted that updated logo does not inherits hover color correctly.

# How

Fix updated logo hover style.

# Preview

### Before
<img width="190" height="63" alt="Screenshot 2026-09-07 at 09 18 34" src="https://github.com/user-attachments/assets/b9ca7cc3-c5de-49b7-baf8-9c547e84af3c" />

### After
<img width="190" height="63" alt="Screenshot 2026-09-07 at 09 19 22" src="https://github.com/user-attachments/assets/eaed242c-a7a9-49d8-8715-7dea98778ed3" />
