### PR TITLE
ui(lobby): tweaks for tournament table players cell

### DIFF
--- a/modules/tournament/src/main/ui/TournamentUi.scala
+++ b/modules/tournament/src/main/ui/TournamentUi.scala
@@ -90,9 +90,8 @@ final class TournamentUi(helpers: Helpers)(getTourName: GetTourName):
                 iconEl := Icon.group,
                 cls := "text tour-team-icon",
                 title := trans.team.teamBattle.txt()
-              ):
-                visiblePlayers
-            case None => td(iconEl := Icon.user, cls := "text")(visiblePlayers)
+              )(visiblePlayers)
+            case None => visiblePlayers.fold(td)(td(iconEl := Icon.user, cls := "text")(_))
         )
     )
 

--- a/ui/lobby/css/_box.scss
+++ b/ui/lobby/css/_box.scss
@@ -69,6 +69,16 @@
           color: $c-link;
         }
       }
+
+      &.text {
+        display: flex;
+        height: 100%;
+
+        .svg-icon {
+          width: 1em;
+          color: $c-font-dim;
+        }
+      }
     }
 
     tr:last-child td {


### PR DESCRIPTION
# Why

Refs https://github.com/lichess-org/lila/issues/21483#issuecomment-5559386646

# How

Tweaks for tournament table players cell in lobby.

# Preview

<img width="732" height="131" alt="Screenshot 2026-09-07 at 09 26 21" src="https://github.com/user-attachments/assets/4f8a8cdc-26ca-4c2d-b4ba-6fa2416ead5c" />
