### PR TITLE
ui(analyse): fix study edit count labels position

### DIFF
--- a/ui/analyse/css/study/_buttons.scss
+++ b/ui/analyse/css/study/_buttons.scss
@@ -20,6 +20,17 @@ $c-study-button: $c-accent;
       display: flex;
       align-items: center;
       justify-content: center;
+
+      .data-count {
+        position: absolute;
+
+        &::after {
+          @include inline-end(-22px);
+
+          top: -12px;
+          padding: 0 4px;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
# Why

Refs https://github.com/lichess-org/lila/issues/21483#issuecomment-5559086952

# How

Fix study edit count labels position.

# Preview

<img width="527" height="158" alt="Screenshot 2026-09-07 at 09 37 15" src="https://github.com/user-attachments/assets/f295c766-3831-4c71-ba00-117c29539786" />
