### PR TITLE
ui(bits): fix streamers list icons size and visibility

### DIFF
--- a/ui/bits/css/streamer/_header.scss
+++ b/ui/bits/css/streamer/_header.scss
@@ -129,6 +129,16 @@
 
   gap: 1em;
   margin: 1.5em $box-padding 1em 0;
+
+  h1 {
+    display: flex;
+    gap: 0.5ch;
+
+    .svg-icon {
+      color: $c-font-dim;
+      width: 0.55em;
+    }
+  }
 }
 
 .streamer-profile {

--- a/ui/bits/css/streamer/_list.scss
+++ b/ui/bits/css/streamer/_list.scss
@@ -8,7 +8,9 @@
 
 .streamer-list {
   h1 {
-    &::before {
+    display: flex;
+
+    .svg-icon {
       display: none;
 
       @include mq-at-least-picture {
@@ -35,9 +37,8 @@
     h1 {
       @include fluid-size('font-size', 23px, 40px);
 
-      &::before {
+      .svg-icon {
         display: inline;
-        margin-inline-end: 0.2em;
 
         @include mq-at-least-picture {
           display: none;


### PR DESCRIPTION
# Why

Refs https://github.com/lichess-org/lila/issues/21483#issuecomment-5558986301

# How

Fix streamers list icons size and visibility (some older classes were missed during refactor, causing altered appearance).

# Preview

<img width="1104" height="522" alt="Screenshot 2026-09-07 at 09 52 16" src="https://github.com/user-attachments/assets/e955b22b-b74c-4675-a940-4fa28d675be5" />

<img width="455" height="597" alt="Screenshot 2026-09-07 at 09 52 37" src="https://github.com/user-attachments/assets/44fbee84-fd35-46cc-8dc4-df38e71bfd31" />
