### PR TITLE
ui: fix round popup crop, avoid double blur on dropdowns

### DIFF
--- a/ui/lib/css/abstract/_extends.scss
+++ b/ui/lib/css/abstract/_extends.scss
@@ -160,8 +160,6 @@
 }
 
 %dropdown-shadow {
-  @include backdrop-blur-if-transparent;
-
   @include if-transp {
     @include back-blur;
   }

--- a/ui/round/css/_moves-col1.scss
+++ b/ui/round/css/_moves-col1.scss
@@ -1,6 +1,8 @@
 /* context: .rmoves */
 @include mq-is-col1 {
-  @include backdrop-blur-if-transparent;
+  @include if-transp {
+    @include back-blur;
+  }
 
   overflow: hidden;
 


### PR DESCRIPTION
# Why

Fixes #21580

# How

- Change the way we apply blur to the container where options popover DOM is added.
- Avoid applying blur twice via dropdown shadow extend (it causes the container to be almost non opaque)

# Preview

<img width="459" height="977" alt="Screenshot 2026-09-08 at 10 19 47" src="https://github.com/user-attachments/assets/7edf279a-d5e6-450a-bcea-37d3d72f1a12" />

<img width="371" height="599" alt="Screenshot 2026-09-08 at 10 19 32" src="https://github.com/user-attachments/assets/022cd87b-d451-4913-b58a-346402afaedf" />
