### PR TITLE
ui(challenge): improve menu appearance in transparent theme

### DIFF
--- a/ui/challenge/css/_challenge.scss
+++ b/ui/challenge/css/_challenge.scss
@@ -1,18 +1,16 @@
 #challenge-app {
   @extend %box-radius-left, %dropdown-shadow;
 
-  overflow: hidden scroll;
+  overflow: hidden auto;
   max-height: 90vh;
   width: 300px;
   text-align: center;
 
   .empty {
-    background: $c-bg-header-dropdown;
     padding: 2rem 0;
   }
 
   .challenge {
-    background: $c-bg-header-dropdown;
     border-bottom: $border;
     padding-bottom: 0.5em;
 


### PR DESCRIPTION
# Why

Spotted that challenge menu is not semi-transparent in themes with background image active.

# How

Remove additional background color from sections, container already uses the the correct color. Switch scroll to auto so there is no permanent scroll track visible.

# Preview

<table><tr><th>Transparent light</th><th>Light</th></tr>
<tr><td>
<img width="344" height="172" alt="Screenshot 2026-09-08 at 10 45 28" src="https://github.com/user-attachments/assets/200f42e1-019f-47df-bdb1-c2f2c8cad2bb" /></td><td>
<img width="344" height="172" alt="Screenshot 2026-09-08 at 10 47 15" src="https://github.com/user-attachments/assets/7cd35e6d-dddf-4a5f-bed4-837fb6cf7700" /></td></tr>
<tr><td>
<img width="344" height="172" alt="Screenshot 2026-09-08 at 10 46 32" src="https://github.com/user-attachments/assets/99ca22eb-0b5b-4c42-ab49-96bf92762c52" /></td><td>
<img width="344" height="172" alt="Screenshot 2026-09-08 at 10 46 54" src="https://github.com/user-attachments/assets/dea7412a-d661-4ae9-95b3-570788633b51" /></td></tr>
</table>
