### PR TITLE
build: refresh and tweak build commands output

### DIFF
--- a/ui/.build/package.json
+++ b/ui/.build/package.json
@@ -23,6 +23,7 @@
     "fast-xml-parser": "5.11.1",
     "json-stringify-pretty-compact": "4.0.0",
     "micromatch": "4.0.8",
+    "picocolors": "^1.1.1",
     "postcss": "^8.5.28",
     "typescript": "7.0.2"
   },

--- a/ui/.build/pnpm-lock.yaml
+++ b/ui/.build/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       micromatch:
         specifier: 4.0.8
         version: 4.0.8
+      picocolors:
+        specifier: ^1.1.1
+        version: 1.1.1
       postcss:
         specifier: ^8.5.28
         version: 8.5.28

--- a/ui/.build/src/build.ts
+++ b/ui/.build/src/build.ts
@@ -1,10 +1,11 @@
 import { execSync } from 'node:child_process';
 import fs from 'node:fs';
 import { chdir } from 'node:process';
+import pc from 'picocolors';
 
 import { definedUnique } from './algo.ts';
 import { clean } from './clean.ts';
-import { env, errorMark, c } from './env.ts';
+import { env, errorMark } from './env.ts';
 import { esbuild, stopEsbuild } from './esbuild.ts';
 import { hash } from './hash.ts';
 import { i18n } from './i18n.ts';
@@ -23,25 +24,25 @@ export async function build(pkgs: string[]): Promise<void> {
     try {
       chdir(env.rootDir);
       if (env.install) execSync('pnpm install', { stdio: 'inherit' });
-      if (!pkgs.length) env.log(`Parsing packages in '${c.cyan(env.uiDir)}'`);
+      if (!pkgs.length) env.log(`Parsing packages in '${pc.cyan(env.uiDir)}'`);
 
       await Promise.allSettled([parsePackages(), fs.promises.mkdir(env.buildTempDir)]);
 
       pkgs
         .filter(x => !env.packages.has(x))
-        .forEach(x => env.exit(`${errorMark} - unknown package '${c.magenta(x)}'`));
+        .forEach(x => env.exit(`${errorMark} - unknown package '${pc.magenta(x)}'`));
 
       env.building =
         pkgs.length === 0 ? [...env.packages.values()] : definedUnique(pkgs.flatMap(p => env.deps(p)));
 
-      if (pkgs.length) env.log(`Building ${c.grey(env.building.map(x => x.name).join(', '))}`);
+      if (pkgs.length) env.log(`Building ${pc.gray(env.building.map(x => x.name).join(', '))}`);
     } finally {
       monitor(pkgs);
     }
     await Promise.all([i18n(), sync().then(hash).then(sass), tsc(), esbuild()]);
   } catch (e) {
     env.log(`${errorMark} ${e instanceof Error ? (e.stack ?? e.message) : String(e)}`);
-    if (env.watch) env.log(c.grey('Watching...'));
+    if (env.watch) env.log(pc.gray('Watching...'));
     else env.exit();
   }
 }

--- a/ui/.build/src/clean.ts
+++ b/ui/.build/src/clean.ts
@@ -1,7 +1,8 @@
 import fg from 'fast-glob';
 import { promises as fs } from 'node:fs';
+import pc from 'picocolors';
 
-import { env, c } from './env.ts';
+import { env } from './env.ts';
 
 const globOpts: fg.Options = {
   absolute: true,
@@ -25,14 +26,19 @@ const allGlobs = [
 export async function clean(globs?: string[] | 'force'): Promise<void> {
   if (!env.clean && !globs) return;
 
-  for (const glob of Array.isArray(globs) ? globs : allGlobs) {
-    env.log(`Cleaning '${c.cyan(glob)}'...`);
-    for await (const f of fg.stream(glob, { cwd: env.rootDir, ...globOpts })) {
-      if (f.includes('ui/.build') && !f.includes('/build')) continue; // skip .build/node_modules
-      if (f.slice(-1) === '/') await fs.rm(f, { recursive: true });
-      else await fs.unlink(f);
-    }
+  const startedAt = Date.now();
+  const patterns = Array.isArray(globs) ? globs : allGlobs;
+  for (const glob of patterns) {
+    env.log(`Cleaning '${pc.cyan(glob)}'...`);
   }
+
+  const files = new Set(
+    (await Promise.all(patterns.map(glob => fg(glob, { cwd: env.rootDir, ...globOpts }))))
+      .flat()
+      .filter(f => !f.includes('ui/.build') || f.includes('/build')),
+  );
+  await Promise.all([...files].map(f => (f.endsWith('/') ? fs.rm(f, { recursive: true }) : fs.unlink(f))));
+  env.log(`Done ${pc.gray(`(${((Date.now() - startedAt) / 1000).toFixed(3)}s)`)}`);
 }
 
 export async function deepClean(): Promise<void> {

--- a/ui/.build/src/console.ts
+++ b/ui/.build/src/console.ts
@@ -1,8 +1,9 @@
 import { transform } from 'esbuild';
 import stringify from 'json-stringify-pretty-compact';
 import { createServer, IncomingMessage, ServerResponse } from 'node:http';
+import pc from 'picocolors';
 
-import { env, errorMark, warnMark, c } from './env.ts';
+import { env, errorMark, warnMark } from './env.ts';
 
 export async function startConsole() {
   if (!env.remoteLog || !env.watch) return;
@@ -34,7 +35,7 @@ export async function startConsole() {
 
         if (typeof val !== 'string') val = stringify(val, { indent: 2, maxLength: 80 });
 
-        env.log(`${mark}${c.grey(val)}`, ip);
+        env.log(`${mark}${pc.gray(val)}`, ip);
         return res
           .writeHead(200, { 'Access-Control-Allow-Origin': '*', 'Access-Control-Allow-Methods': 'POST' })
           .end();

--- a/ui/.build/src/env.ts
+++ b/ui/.build/src/env.ts
@@ -104,11 +104,10 @@ export const env = new (class {
 
     const prefix = (
       (this.logTime ? `${pc.gray(prettyTime())} ` : '') +
-      (ctx && this.logCtx ? colorForCtx(ctx)(` ${ctx} `) : '')
+      (ctx && this.logCtx ? colorForCtx(ctx)(`${ctx} ${pc.dim('⏵')} `) : '')
     ).trim();
 
-    for (const line of trimLines(text))
-      console.log(`${prefix ? `${prefix} ${pc.dim(pc.gray('⏵'))} ` : ' '}${line}`);
+    for (const line of trimLines(text)) console.log(`${prefix ? prefix : ' '}${line}`);
   }
 
   exit(d?: any, ctx = 'build'): void {
@@ -178,18 +177,18 @@ export const trimLines = (s: string): string[] => s.split(/[\n\r\f]+/).filter(x 
 export type Context = 'sass' | 'tsc' | 'esbuild' | 'sync' | 'hash' | 'i18n' | 'web';
 
 const contextColors: Record<string, (text: string) => string> = {
-  build: pc.bgGreen,
-  sass: pc.bgMagenta,
-  tsc: pc.bgYellow,
-  esbuild: pc.bgBlue,
-  sync: pc.bgCyan,
-  hash: pc.bgBlackBright,
-  i18n: pc.bgBlueBright,
-  web: pc.bgCyanBright,
+  build: pc.green,
+  sass: pc.magenta,
+  tsc: pc.yellow,
+  esbuild: pc.magentaBright,
+  sync: pc.cyan,
+  hash: pc.blue,
+  i18n: pc.blueBright,
+  web: pc.cyanBright,
 };
 
 function colorForCtx(ctx: string): (text: string) => string {
-  return contextColors[ctx] ?? pc.bgWhiteBright;
+  return contextColors[ctx] ?? pc.whiteBright;
 }
 
 export const errorMark: string = pc.red('✘ ') + pc.redBright('[ERROR]');

--- a/ui/.build/src/env.ts
+++ b/ui/.build/src/env.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import { join, resolve, dirname } from 'node:path';
 import ps from 'node:process';
+import pc from 'picocolors';
 
 import { definedUnique, isEquivalent } from './algo.ts';
 
@@ -42,7 +43,6 @@ export const env = new (class {
   readonly lockFile = join(this.buildDir, 'instance.lock');
   readonly buildTempDir = join(this.buildDir, 'build');
   readonly cssTempDir = join(this.buildTempDir, 'css');
-  readonly buildSrcDir = join(this.buildDir, 'src');
   readonly typesDir = join(this.uiDir, '@types');
   readonly i18nSrcDir = join(this.rootDir, 'translation', 'source');
   readonly i18nDestDir = join(this.rootDir, 'translation', 'dest');
@@ -56,7 +56,6 @@ export const env = new (class {
   install = true;
   logTime = true;
   logCtx = true;
-  logColor = true;
   remoteLog: string | boolean = false;
   startTime?: number;
 
@@ -65,6 +64,7 @@ export const env = new (class {
   building: Package[] = [];
   mustSucceed = new Set<() => boolean>();
   onSuccess = new Set<() => void>();
+  private readonly contextStartedAt = new Map<Context, number>();
 
   readonly status = {} as Record<Context, number | false | undefined>;
 
@@ -103,11 +103,12 @@ export const env = new (class {
           : JSON.stringify(d);
 
     const prefix = (
-      (this.logTime ? prettyTime() : '') + (ctx && this.logCtx ? `[${escape(ctx, colorForCtx(ctx))}]` : '')
+      (this.logTime ? `${pc.gray(prettyTime())} ` : '') +
+      (ctx && this.logCtx ? colorForCtx(ctx)(` ${ctx} `) : '')
     ).trim();
 
-    for (const line of trimLines(this.logColor ? text : stripColorEscapes(text)))
-      console.log(`${prefix ? prefix + ' - ' : ''}${line}`);
+    for (const line of trimLines(text))
+      console.log(`${prefix ? `${prefix} ${pc.dim(pc.gray('⏵'))} ` : ' '}${line}`);
   }
 
   exit(d?: any, ctx = 'build'): void {
@@ -117,22 +118,29 @@ export const env = new (class {
 
   begin(ctx: Context, enable?: boolean): boolean {
     if (enable === false) this.status[ctx] = false;
-    else if (enable === true || this.status[ctx] !== false) this.status[ctx] = undefined;
+    else if (enable === true || this.status[ctx] !== false) {
+      if (!this.contextStartedAt.has(ctx)) this.contextStartedAt.set(ctx, Date.now());
+      this.status[ctx] = undefined;
+    }
     return this.status[ctx] !== false;
   }
 
   setStatus(ctx: Context, code: number | undefined): void {
-    if (code !== undefined && code !== this.status[ctx] && ['tsc', 'esbuild', 'sass', 'i18n'].includes(ctx)) {
+    if (code !== undefined && code !== this.status[ctx]) {
+      const startedAt = this.contextStartedAt.get(ctx);
+      const took =
+        code === 0 && startedAt ? pc.gray(` (${((Date.now() - startedAt) / 1000).toFixed(3)}s)`) : '';
       this.log(
-        `${code === 0 ? 'Done' : c.red('Failed')}${this.watch ? ` - ${c.grey('Watching')}...` : ''}`,
+        `${code === 0 ? `Done${took}` : pc.red('Failed')}${this.watch ? ` ${pc.green('⦿ Watching…')}` : ''}`,
         ctx,
       );
+      this.contextStartedAt.delete(ctx);
     }
     this.status[ctx] = code;
     if (this.buildOk()) {
       if (this.startTime) {
-        const doneMsg = `Done in ${c.green(String((Date.now() - this.startTime) / 1000))}s`;
-        this.log(doneMsg + (this.stdin ? `. Press ${c.grey('<space>')} to trigger clean rebuild` : ''));
+        const doneMsg = `Done in ${pc.greenBright(String((Date.now() - this.startTime) / 1000) + 's')}`;
+        this.log(doneMsg + (this.stdin ? `. Press ${pc.gray('<space>')} to trigger clean rebuild` : ''));
       }
       this.onSuccess.forEach(yay => yay());
       this.startTime = undefined;
@@ -169,72 +177,30 @@ export const trimLines = (s: string): string[] => s.split(/[\n\r\f]+/).filter(x 
 
 export type Context = 'sass' | 'tsc' | 'esbuild' | 'sync' | 'hash' | 'i18n' | 'web';
 
-const codes = {
-  black: '30',
-  red: '31',
-  green: '32',
-  yellow: '33',
-  blue: '34',
-  magenta: '35',
-  cyan: '36',
-  white: '37',
-  grey: '90',
-  error: '31',
-  warn: '33',
-  greenBold: '32;1',
-  yellowBold: '33;1',
-  blueBold: '34;1',
-  magentaBold: '35;1',
-  cyanBold: '36;1',
-  greyBold: '90;1',
+const contextColors: Record<string, (text: string) => string> = {
+  build: pc.bgGreen,
+  sass: pc.bgMagenta,
+  tsc: pc.bgYellow,
+  esbuild: pc.bgBlue,
+  sync: pc.bgCyan,
+  hash: pc.bgBlackBright,
+  i18n: pc.bgBlueBright,
+  web: pc.bgCyanBright,
 };
 
-function colorForCtx(ctx: string) {
-  return (
-    {
-      build: codes.green,
-      sass: codes.magenta,
-      tsc: codes.yellow,
-      esbuild: codes.blueBold,
-      sync: codes.cyan,
-      hash: codes.blue,
-      i18n: codes.cyanBold,
-      manifest: codes.white,
-      web: codes.magentaBold,
-    }[ctx] ?? codes.grey
-  );
+function colorForCtx(ctx: string): (text: string) => string {
+  return contextColors[ctx] ?? pc.bgWhiteBright;
 }
 
-function escape(text: string, code?: string) {
-  return env.logColor && code ? `\x1b[${code}m${stripColorEscapes(text)}\x1b[0m` : text;
-}
+export const errorMark: string = pc.red('✘ ') + pc.redBright('[ERROR]');
+export const warnMark: string = pc.yellow('⚠ ') + pc.yellowBright('[WARNING]');
 
-function colorLines(text: string, code: string) {
-  return trimLines(text)
-    .map(t => escape(t, code))
-    .join('\n');
-}
-
-export const c: Record<keyof typeof codes, (text: string) => string> = Object.keys(codes).reduce(
-  (acc, key) => {
-    acc[key as keyof typeof codes] = (text: string) => colorLines(text, codes[key as keyof typeof codes]);
-    return acc;
-  },
-  {} as Record<keyof typeof codes, (text: string) => string>,
-);
-
-export const errorMark: string = c.red('✘ ') + c.error('[ERROR]');
-export const warnMark: string = c.yellow('⚠ ') + c.warn('[WARNING]');
-
-function pad2(n: number) {
-  return n < 10 ? `0${n}` : `${n}`;
-}
-
-function stripColorEscapes(text: string) {
-  return text.replace(/\x1b\[[0-9;]*m/, '');
-}
+const timeFormatter = new Intl.DateTimeFormat('en-GB', {
+  hour: '2-digit',
+  minute: '2-digit',
+  second: '2-digit',
+});
 
 function prettyTime() {
-  const now = new Date();
-  return `${pad2(now.getHours())}:${pad2(now.getMinutes())}:${pad2(now.getSeconds())} `;
+  return timeFormatter.format(new Date());
 }

--- a/ui/.build/src/env.ts
+++ b/ui/.build/src/env.ts
@@ -130,7 +130,7 @@ export const env = new (class {
       const took =
         code === 0 && startedAt ? pc.gray(` (${((Date.now() - startedAt) / 1000).toFixed(3)}s)`) : '';
       this.log(
-        `${code === 0 ? `Done${took}` : pc.red('Failed')}${this.watch ? ` ${pc.green('⦿ Watching…')}` : ''}`,
+        `${code === 0 ? `Done${took}` : pc.red('Failed')}${this.watch ? ` ${pc.green('• Watching…')}` : ''}`,
         ctx,
       );
       this.contextStartedAt.delete(ctx);

--- a/ui/.build/src/esbuild.ts
+++ b/ui/.build/src/esbuild.ts
@@ -1,9 +1,10 @@
 import es from 'esbuild';
 import fs from 'node:fs';
 import { join, basename } from 'node:path';
+import pc from 'picocolors';
 
 import { definedMap } from './algo.ts';
-import { env, errorMark, warnMark, c } from './env.ts';
+import { env, errorMark, warnMark } from './env.ts';
 import { type Manifest, updateManifest } from './manifest.ts';
 import { makeTask, stopTask } from './task.ts';
 
@@ -135,8 +136,8 @@ function esbuildLog(msgs: es.Message[], error = false): void {
         ? `:${msg.location.column}`
         : '';
     const srcText = msg.location?.lineText;
-    env.log(`${error ? errorMark : warnMark} - '${c.cyan(file + line)}' - ${msg.text}`, 'esbuild');
-    if (srcText) env.log('  ' + c.magenta(srcText), 'esbuild');
+    env.log(`${error ? errorMark : warnMark} - '${pc.cyan(file + line)}' - ${msg.text}`, 'esbuild');
+    if (srcText) env.log('  ' + pc.magenta(srcText), 'esbuild');
   }
 }
 

--- a/ui/.build/src/hash.ts
+++ b/ui/.build/src/hash.ts
@@ -1,9 +1,10 @@
 import crypto from 'node:crypto';
 import fs from 'node:fs';
 import { relative, join, resolve } from 'node:path';
+import pc from 'picocolors';
 
 import { isEquivalent } from './algo.ts';
-import { env, c, type Package } from './env.ts';
+import { env, type Package } from './env.ts';
 import { type Manifest, updateManifest } from './manifest.ts';
 import { isClose } from './parse.ts';
 import { makeTask } from './task.ts';
@@ -104,29 +105,27 @@ async function replaceAllWithHashUrls(name: string, files: Record<string, string
     (data, [from, to]) => data.replaceAll(from, to),
     await fs.promises.readFile(name, 'utf8'),
   );
-  const hash = crypto.createHash('sha256').update(result).digest('hex').slice(0, 8);
+  const hash = getHash(result);
   await fs.promises.writeFile(join(env.hashOutDir, hashedBasename(name, hash)), result);
   return { name: relative(env.outDir, name), hash };
 }
 
 async function hashAndLink(name: string) {
   const src = join(env.outDir, name);
-  const hash = crypto
-    .createHash('sha256')
-    .update(await fs.promises.readFile(src))
-    .digest('hex')
-    .slice(0, 8);
+  const [content, { mtime }] = await Promise.all([fs.promises.readFile(src), fs.promises.stat(src)]);
+  const hash = getHash(content);
   const link = join(env.hashOutDir, hashedBasename(name, hash));
-  const [{ mtime }] = await Promise.all([
-    fs.promises.stat(join(env.outDir, name)),
-    fs.promises.symlink(relative(env.outDir, name), link).catch(() => {}),
-  ]);
+  await fs.promises.symlink(relative(env.outDir, name), link).catch(() => {});
   await fs.promises.lutimes(link, mtime, mtime);
   return hash;
 }
 
+export function getHash(content: string | Buffer) {
+  return crypto.createHash('sha256').update(content).digest('hex').slice(0, 8);
+}
+
 const hashLog = (src: string, hashName: string, pkgName?: string): void =>
   env.log(
-    `${pkgName ? c.grey(pkgName) + ' ' : ''}'${c.cyan(src)}' -> '${c.cyan(join('public', 'hashed', hashName))}'`,
+    `${pkgName ? pc.gray(pkgName) + ' ' : ''}'${pc.cyan(src)}' -> '${pc.cyan(join('public', 'hashed', hashName))}'`,
     'hash',
   );

--- a/ui/.build/src/i18n.ts
+++ b/ui/.build/src/i18n.ts
@@ -1,12 +1,12 @@
 import { transform } from 'esbuild';
 import fg from 'fast-glob';
 import { XMLParser } from 'fast-xml-parser';
-import crypto from 'node:crypto';
 import fs from 'node:fs';
 import { join, basename } from 'node:path';
 
 import { zip } from './algo.ts';
 import { env } from './env.ts';
+import { getHash } from './hash.ts';
 import { type Manifest, updateManifest } from './manifest.ts';
 import { readable, isClose } from './parse.ts';
 import { makeTask } from './task.ts';
@@ -188,7 +188,7 @@ export async function i18nManifest(): Promise<void> {
     (await fg.glob('*.js', { cwd: env.i18nJsDir, absolute: true })).map(async file => {
       const name = basename(file, '.js');
       const content = await fs.promises.readFile(file, 'utf-8');
-      const hash = crypto.createHash('md5').update(content).digest('hex').slice(0, 12);
+      const hash = getHash(content);
       const manifestPath = `i18n/${name}`;
       const destPath = join(env.jsOutDir, `${manifestPath}.${hash}.js`);
       i18n[manifestPath] = { hash };
@@ -209,7 +209,7 @@ export async function i18nManifest(): Promise<void> {
           })
           .join(',') +
         '}';
-      const hash = crypto.createHash('md5').update(content).digest('hex').slice(0, 12);
+      const hash = getHash(content);
       const manifestPath = `i18n/${locale}`;
       const destPath = join(env.jsOutDir, `${manifestPath}.${hash}.js`);
       i18n[manifestPath] = { hash };

--- a/ui/.build/src/main.ts
+++ b/ui/.build/src/main.ts
@@ -14,7 +14,6 @@ const args: Record<string, string> = {
   '--sass': '',
   '--esbuild': '',
   '--i18n': '',
-  '--no-color': '',
   '--no-time': '',
   '--no-context': '',
   '--help': 'h',
@@ -43,7 +42,6 @@ Options:
                       <url> or localhost:8666 (default). if used with --watch, the watch process
                       will listen for http on 8666 and display received messages in build logs
   --clean-exit        clean all build artifacts and exit
-  --no-color          don't use color in logs
   --no-time           don't log the time
   --no-context        don't log the context
 
@@ -89,7 +87,6 @@ if (['--tsc', '--sass', '--esbuild', '--i18n'].filter(x => argv.includes(x)).len
 
 env.logTime = !boolArg('--no-time');
 env.logCtx = !boolArg('--no-context');
-env.logColor = !boolArg('--no-color');
 env.watch = boolArg('--watch');
 env.prod = boolArg('--prod');
 env.debug = boolArg('--debug');

--- a/ui/.build/src/manifest.ts
+++ b/ui/.build/src/manifest.ts
@@ -1,11 +1,12 @@
 import cps from 'node:child_process';
-import crypto from 'node:crypto';
 import fs from 'node:fs';
 import { join } from 'node:path';
+import pc from 'picocolors';
 
 import { shallowSort, isContained } from './algo.ts';
 import { jsLogger } from './console.ts';
-import { env, c } from './env.ts';
+import { env } from './env.ts';
+import { getHash } from './hash.ts';
 
 const manifest = {
   i18n: {} as Manifest,
@@ -76,7 +77,7 @@ async function writeManifest() {
   clientJs.push(`s.manifest={\ncss:{${cssLines}},\njs:{${jsLines}},\nhashed:{${hashedLines}}\n};`);
 
   const hashable = clientJs.join('\n');
-  const hash = crypto.createHash('sha256').update(hashable).digest('hex').slice(0, 8);
+  const hash = getHash(hashable);
 
   const clientManifest = hashable + `\ns.info.date='${new Date().toISOString().split('.')[0] + '+00:00'}';\n`;
   const serverManifest = JSON.stringify(
@@ -93,9 +94,9 @@ async function writeManifest() {
     fs.promises.writeFile(join(env.jsOutDir, `manifest.json`), serverManifest),
   ]);
   manifest.dirty = false;
-  const serverHash = crypto.createHash('sha256').update(serverManifest).digest('hex').slice(0, 8);
+  const serverHash = getHash(serverManifest);
   env.log(
-    `'${c.cyan(`public/compiled/manifest.${hash}.js`)}', '${c.cyan(`public/compiled/manifest.json`)}' ${c.grey(serverHash)}`,
+    `'${pc.cyan(`public/compiled/manifest.${hash}.js`)}', '${pc.cyan(`public/compiled/manifest.json`)}' ${pc.gray(serverHash)}`,
     'manifest',
   );
 }

--- a/ui/.build/src/sass.ts
+++ b/ui/.build/src/sass.ts
@@ -1,13 +1,13 @@
 import autoprefixer from 'autoprefixer';
 import cps from 'node:child_process';
-import crypto from 'node:crypto';
 import fs from 'node:fs';
 import { basename, dirname, join, relative, resolve } from 'node:path';
 import ps from 'node:process';
+import pc from 'picocolors';
 import postcss from 'postcss';
 
-import { c, env, errorMark, trimLines } from './env.ts';
-import { hashedBasename, symlinkTargetHashes } from './hash.ts';
+import { env, errorMark, trimLines } from './env.ts';
+import { getHash, hashedBasename, symlinkTargetHashes } from './hash.ts';
 import { updateManifest } from './manifest.ts';
 import { glob, readable } from './parse.ts';
 import { makeTask, runTask, addIncludes } from './task.ts';
@@ -74,7 +74,7 @@ export async function sass(): Promise<string | undefined> {
       const buildSources = [...remaining];
       remaining = new Set(await compile(buildSources, remaining.size < concreteAll.size));
 
-      if (remaining.size) throw `in ${[...remaining].map(s => `'${c.cyan(s)}'`).join(', ')}`;
+      if (remaining.size) throw `in ${[...remaining].map(s => `'${pc.cyan(s)}'`).join(', ')}`;
       const replacements = urlReplacements();
       updateManifest({
         css: Object.fromEntries(
@@ -92,11 +92,11 @@ async function compile(sources: string[], logAll = true): Promise<string[]> {
     (await fs.promises.realpath(
       join(env.buildDir, 'node_modules', `sass-embedded-${ps.platform}-${ps.arch}`, 'dart-sass', 'sass'),
     ));
-  if (!(await readable(sassBin))) env.exit(`Sass executable not found '${c.cyan(sassBin)}'`, 'sass');
+  if (!(await readable(sassBin))) env.exit(`Sass executable not found '${pc.cyan(sassBin)}'`, 'sass');
 
   return new Promise(resolveWithErrors => {
     if (!sources.length) return resolveWithErrors([]);
-    if (logAll) sources.forEach(src => env.log(`Building '${c.cyan(src)}'`, 'sass'));
+    if (logAll) sources.forEach(src => env.log(`Building '${pc.cyan(src)}'`, 'sass'));
     else env.log('Building', 'sass');
 
     const sassArgs = ['--no-error-css', '--stop-on-error', '--no-color', '--quiet', '--quiet-deps'];
@@ -202,7 +202,7 @@ async function hashCss(src: string, replacements: Record<string, string> | undef
     content = content.replaceAll(search, replace);
     modified = true;
   }
-  const hash = crypto.createHash('sha256').update(content).digest('hex').slice(0, 8);
+  const hash = getHash(content);
   const baseName = basename(src, '.css');
   const outName = join(env.cssOutDir, `${baseName}.${hash}.css`);
   await Promise.allSettled([
@@ -251,7 +251,7 @@ function dependsOn(srcFile: string, bset = new Set<string>()): Set<string> {
 function sassError(error: string) {
   for (const err of trimLines(error)) {
     if (err.startsWith('Error:')) {
-      env.log(c.grey('-'.repeat(75)), 'sass');
+      env.log(pc.gray('-'.repeat(75)), 'sass');
       env.log(`${errorMark} - ${err.slice(7)}`, 'sass');
     } else env.log(err, 'sass');
   }

--- a/ui/.build/src/sync.ts
+++ b/ui/.build/src/sync.ts
@@ -1,8 +1,9 @@
 import fs from 'node:fs';
 import { join, dirname } from 'node:path';
+import pc from 'picocolors';
 
 import { isEquivalent } from './algo.ts';
-import { env, c } from './env.ts';
+import { env } from './env.ts';
 import { isGlob, isFolder, isClose } from './parse.ts';
 import { makeTask } from './task.ts';
 
@@ -17,15 +18,15 @@ export async function sync(): Promise<void[] | undefined> {
         always: true,
         debounce: 300,
         execute: async (files, fullList) => {
-          if (exact && files.length === 0) throw `Not found '${c.cyan(sync.src)}`;
+          if (exact && files.length === 0) throw `Not found '${pc.cyan(sync.src)}`;
           const logEvery = !isEquivalent(files, fullList);
           if (!logEvery)
-            env.log(`${c.grey(pkg.name)} '${c.cyan(sync.src)}' -> '${c.cyan(sync.dest)}'`, 'sync');
+            env.log(`${pc.gray(pkg.name)} '${pc.cyan(sync.src)}' -> '${pc.cyan(sync.dest)}'`, 'sync');
           await Promise.all(
             files.map(async f => {
               if ((await syncOne(f, join(env.rootDir, sync.dest, f.slice(root.length)))) && logEvery)
                 env.log(
-                  `${c.grey(pkg.name)} '${c.cyan(f.slice(root.length))}' -> '${c.cyan(sync.dest)}'`,
+                  `${pc.gray(pkg.name)} '${pc.cyan(f.slice(root.length))}' -> '${pc.cyan(sync.dest)}'`,
                   'sync',
                 );
             }),

--- a/ui/.build/src/task.ts
+++ b/ui/.build/src/task.ts
@@ -2,9 +2,10 @@ import fg from 'fast-glob';
 import mm from 'micromatch';
 import fs from 'node:fs';
 import { join, relative, basename } from 'node:path';
+import pc from 'picocolors';
 
 import { randomToken, definedUnique } from './algo.ts';
-import { type Context, type Package, env, c, errorMark } from './env.ts';
+import { type Context, type Package, env, errorMark } from './env.ts';
 import { glob, isFolder, subfolders, isClose } from './parse.ts';
 
 const fsWatches = new Map<AbsPath, FSWatch>();
@@ -154,7 +155,7 @@ async function execute(t: Task, firstRun = false): Promise<void> {
     t.status = 'error';
     const message = e instanceof Error ? (e.stack ?? e.message) : String(e);
     if (!env.watch) env.exit(`${errorMark} ${message}`, t.ctx);
-    else if (e) env.log(`${errorMark} ${t.pkg?.name ? `[${c.grey(t.pkg.name)}] ` : ''}- ${message}`, t.ctx);
+    else if (e) env.log(`${errorMark} ${t.pkg?.name ? `[${pc.gray(t.pkg.name)}] ` : ''}- ${message}`, t.ctx);
     if (t.ctx && !t.noEnvStatus) env.setStatus(t.ctx, -1);
   } finally {
     activeTaskCount--;

--- a/ui/.build/src/tsc.ts
+++ b/ui/.build/src/tsc.ts
@@ -3,8 +3,9 @@ import { spawn, type ChildProcess } from 'node:child_process';
 import fs from 'node:fs';
 import { join, relative, resolve } from 'node:path';
 import { createInterface } from 'node:readline';
+import pc from 'picocolors';
 
-import { env, c, errorMark, warnMark } from './env.ts';
+import { env, errorMark, warnMark } from './env.ts';
 
 let tscPs: ChildProcess | undefined;
 
@@ -32,7 +33,7 @@ export async function tsc(): Promise<void> {
     JSON.stringify({ files: [], references: buildPaths.map(path => ({ path })) }),
   );
   env.log(
-    `Typechecking ${c.grey('tsc --build')} '${c.cyan(configFile)}' ${c.grey(args.slice(7).join(' '))}`,
+    `Type checking ${pc.gray('tsc --build')} '${pc.cyan(configFile)}' ${pc.gray(args.slice(7).join(' '))}`,
     'tsc',
   );
 
@@ -109,8 +110,8 @@ function tscLog({ code, text, file, line, col, warning }: Diagnostic): void {
   const prelude = `${warning ? warnMark : errorMark} ts${code} `;
   let loc = '';
   if (file) {
-    loc = `${c.grey('in')} '${c.cyan(relative(env.uiDir, resolve(env.rootDir, file)))}`;
-    if (line !== undefined) loc += c.grey(`:${line}:${col}`);
+    loc = `${pc.gray('in')} '${pc.cyan(relative(env.uiDir, resolve(env.rootDir, file)))}`;
+    if (line !== undefined) loc += pc.gray(`:${line}:${col}`);
     loc += `' - `;
   }
   env.log(`${prelude}${loc}${text}`, 'tsc');


### PR DESCRIPTION
# How

Summary of changes:
* use [`picocolor`](https://www.npmjs.com/package/picocolors) instead of harcoded color values and helpers
* adjust coloring, use background colors for context prefixes
* print running time of sub tasks in "Done" message
* speed up `clean` task slightly, add timings
* format time via `Intl.DateTimeFormat`
* extract hashing function, reuse across tasks
* emphasize a bit "Watching" mode
* drop "no-color" arg in favour of build-in picocolors https://no-color.org/ support

# Preview

<img width="832" height="253" alt="Screenshot 2026-09-08 at 12 59 13" src="https://github.com/user-attachments/assets/2f70d515-7af1-45cf-9a0e-35bbd1851997" />
<img width="832" height="253" alt="Screenshot 2026-09-08 at 12 59 56" src="https://github.com/user-attachments/assets/cfc6ca7f-a319-4a89-ad85-dfdf1352bd4f" />
<img width="832" height="253" alt="Screenshot 2026-09-08 at 13 00 29" src="https://github.com/user-attachments/assets/9d988ee9-6d9d-4ce2-a3a8-fba1cc4a3423" />
<img width="832" height="253" alt="Screenshot 2026-09-08 at 13 09 25" src="https://github.com/user-attachments/assets/6b9f8bd5-d7b4-4b9c-9f30-8ad6a2c7a9bd" />

