### PR TITLE
fix grid blowout on Safaris under 14

### DIFF
--- a/ui/lobby/css/_layout.scss
+++ b/ui/lobby/css/_layout.scss
@@ -3,6 +3,7 @@
 
   grid-area: main;
   display: grid;
+  grid-template-columns: minmax(0, 1fr);
   grid-template-areas: 'app' 'table' 'side' 'blog' 'support' 'feed' 'tv' 'puzzle' 'tours' 'timeline' 'about';
   gap: $block-gap;
 


### PR DESCRIPTION
Because

<img width="304" height="336" alt="image" src="https://github.com/user-attachments/assets/a4a597ac-b795-40cf-93a9-bd5dfd94787e" />

Is marginally better than

<img width="304" height="336" alt="image" src="https://github.com/user-attachments/assets/8d96db6d-2ec6-44a1-ba06-dd5aa30c0301" />
