### PR TITLE
ui(analyse): small tweaks for action menu content appearance

### DIFF
--- a/ui/analyse/css/_action-menu.scss
+++ b/ui/analyse/css/_action-menu.scss
@@ -10,7 +10,7 @@
   .inner {
     display: flex;
     flex-direction: column;
-    padding: $analyse-block-gap;
+    padding: $analyse-block-gap calc($analyse-block-gap * 3);
     gap: $analyse-block-gap;
   }
 
@@ -54,7 +54,8 @@
 
       &::before {
         padding-inline-end: 8px;
-        font-size: 1.7em;
+        font-size: 1.5em;
+        color: $c-font-dim;
       }
 
       &:hover {

--- a/ui/analyse/css/_action-menu.scss
+++ b/ui/analyse/css/_action-menu.scss
@@ -10,8 +10,8 @@
   .inner {
     display: flex;
     flex-direction: column;
-    padding: 0 calc($analyse-block-gap * 3) calc($analyse-block-gap * 3);
-    gap: $analyse-block-gap;
+    padding: 0 1rem 1rem;
+    gap: 1rem;
   }
 
   h2 {

--- a/ui/analyse/css/_action-menu.scss
+++ b/ui/analyse/css/_action-menu.scss
@@ -10,7 +10,7 @@
   .inner {
     display: flex;
     flex-direction: column;
-    padding: $analyse-block-gap calc($analyse-block-gap * 3);
+    padding: 0 calc($analyse-block-gap * 3) calc($analyse-block-gap * 3);
     gap: $analyse-block-gap;
   }
 
@@ -60,6 +60,10 @@
 
       &:hover {
         color: $c-primary;
+
+        &::before {
+          color: $c-primary-dim;
+        }
       }
     }
   }

--- a/ui/analyse/css/_tools.scss
+++ b/ui/analyse/css/_tools.scss
@@ -16,7 +16,7 @@
       font-size: 0.9rem;
       line-height: 1.9em;
       background: color-mix(in oklab, $c-secondary 40%, $c-bg);
-      padding: 0 7px;
+      padding: 0 1rem;
 
       a {
         font-weight: bold;


### PR DESCRIPTION
# Why

Spotted that buttons, and especially used icons are quite close to the container bolder in analyse settings pane.

# How

Adjust the analyse action menu container padding, reduce icons size slightly, use dim font color for icons.

# Preview

### Before
<img width="417" height="323" alt="Screenshot 2026-09-08 at 20 46 41" src="https://github.com/user-attachments/assets/dd11dfd0-175c-4324-af7d-7fa374ccb8fe" />


### After
<img width="417" height="323" alt="Screenshot 2026-09-08 at 20 45 49" src="https://github.com/user-attachments/assets/8b192dc5-7985-425d-8051-2822bbd63c2b" />

