### PR TITLE
Fix castling arrows pointing at rook square instead of king destination

### DIFF
--- a/ui/analyse/src/autoShape.ts
+++ b/ui/analyse/src/autoShape.ts
@@ -2,7 +2,7 @@ import type { DrawModifiers, DrawShape } from '@lichess-org/chessground/draw';
 import { opposite } from '@lichess-org/chessground/util';
 import { between, ray, knightAttacks } from 'chessops/attacks';
 import { parseFen } from 'chessops/fen';
-import { isDrop, type Square } from 'chessops/types';
+import { isDrop, type NormalMove, type Square } from 'chessops/types';
 import { parseUci, makeSquare } from 'chessops/util';
 
 import { winningChances } from 'lib/ceval';
@@ -76,6 +76,14 @@ function drawManeuver(ctrl: AnalyseCtrl, color: Color, moves: Uci[], brush: stri
   } else if (moves[0]) makeShapesFromUci(color, moves[0], brush).forEach(s => shapes.push(s));
 }
 
+function castlingKingDest(move: NormalMove): Square | undefined {
+  if (move.from !== 4 && move.from !== 60) return undefined;
+  const rank = move.from === 4 ? 0 : 56;
+  if (move.to === rank) return rank + 2;
+  if (move.to === rank + 7) return rank + 6;
+  return undefined;
+}
+
 export function makeShapesFromUci(
   color: Color,
   uci: Uci | undefined,
@@ -84,9 +92,12 @@ export function makeShapesFromUci(
 ): DrawShape[] {
   if (!uci || uci === 'Current Position') return [];
   const move = parseUci(uci)!;
-  const to = makeSquare(move.to);
-  if (isDrop(move)) return [{ orig: to, brush }, pieceDrop(to, move.role, color)];
+  if (isDrop(move)) {
+    const to = makeSquare(move.to);
+    return [{ orig: to, brush }, pieceDrop(to, move.role, color)];
+  }
 
+  const to = makeSquare(castlingKingDest(move) ?? move.to);
   const shapes: DrawShape[] = [{ orig: makeSquare(move.from), dest: to, brush, modifiers }];
   if (move.promotion) shapes.push(pieceDrop(to, move.promotion, color));
   return shapes;


### PR DESCRIPTION
### The problem

On the analysis board (standard chess), arrows drawn for the engine's best
move, PV lines, threats, and retro-analysis all start on the king's square
and end on the ROOK's square for castling moves, instead of ending where the
king actually lands (g1/c1/g8/c8).

### Root cause

Lichess's chess logic always encodes castling moves using the
Chess960/UCI_960 convention, a king move onto its own rook's square (e.g.
e1h1 for White kingside castling), even in standard chess games. This is
required to disambiguate castling in Chess960 positions.

makeShapesFromUci in ui/analyse/src/autoShape.ts, which every arrow/highlight
in this file is built from, draws the shape directly from the parsed UCI
move's from/to squares without accounting for this encoding.
