### PR TITLE
Eval bar gradient: Make the eval bar just one single thing

### DIFF
--- a/ui/analyse/css/study/panel/_multiboard.scss
+++ b/ui/analyse/css/study/panel/_multiboard.scss
@@ -1,3 +1,9 @@
+@property --multiEvalPercent {
+  syntax: '<percentage>';
+  inherits: false;
+  initial-value: 50%;
+}
+
 .study__multiboard {
   padding-bottom: 0.5em;
 
@@ -150,6 +156,7 @@
     opacity: 0.4;
     margin-left: 4px;
     background: linear-gradient(to top, var(--c-eval-mini-gauge-white), var(--c-eval-mini-gauge-black));
+    transition: --multiEvalPercent 1s ease;
 
     &::after {
       content: '';
@@ -159,28 +166,24 @@
       box-shadow: 0 0 3px rgb(0 0 0 / 0.5) inset;
     }
 
-    &__black {
-      display: none;
-      width: 100%;
-      height: 50%;
-      background: var(--c-eval-mini-gauge-black);
-    }
-
     &--flip {
       background: linear-gradient(to bottom, var(--c-eval-mini-gauge-white), var(--c-eval-mini-gauge-black));
-
-      .mini-game__gauge__black {
-        position: absolute;
-        bottom: 0;
-      }
     }
 
     &--set {
       opacity: 1;
-      background: var(--c-eval-mini-gauge-white);
+      background: linear-gradient(
+        to top,
+        var(--c-eval-mini-gauge-white) var(--multiEvalPercent),
+        var(--c-eval-mini-gauge-black) var(--multiEvalPercent)
+      );
 
-      .mini-game__gauge__black {
-        display: block;
+      &.mini-game__gauge--flip {
+        background: linear-gradient(
+          to bottom,
+          var(--c-eval-mini-gauge-white) var(--multiEvalPercent),
+          var(--c-eval-mini-gauge-black) var(--multiEvalPercent)
+        );
       }
 
       tick {

--- a/ui/analyse/css/study/panel/_multiboard.scss
+++ b/ui/analyse/css/study/panel/_multiboard.scss
@@ -1,4 +1,4 @@
-@property --multiEvalPercent {
+@property --multi-eval-percent {
   syntax: '<percentage>';
   inherits: false;
   initial-value: 50%;
@@ -156,7 +156,7 @@
     opacity: 0.4;
     margin-left: 4px;
     background: linear-gradient(to top, var(--c-eval-mini-gauge-white), var(--c-eval-mini-gauge-black));
-    transition: --multiEvalPercent 1s ease;
+    transition: --multi-eval-percent 1s ease;
 
     &::after {
       content: '';
@@ -174,15 +174,15 @@
       opacity: 1;
       background: linear-gradient(
         to top,
-        var(--c-eval-mini-gauge-white) var(--multiEvalPercent),
-        var(--c-eval-mini-gauge-black) var(--multiEvalPercent)
+        var(--c-eval-mini-gauge-white) var(--multi-eval-percent),
+        var(--c-eval-mini-gauge-black) var(--multi-eval-percent)
       );
 
       &.mini-game__gauge--flip {
         background: linear-gradient(
           to bottom,
-          var(--c-eval-mini-gauge-white) var(--multiEvalPercent),
-          var(--c-eval-mini-gauge-black) var(--multiEvalPercent)
+          var(--c-eval-mini-gauge-white) var(--multi-eval-percent),
+          var(--c-eval-mini-gauge-black) var(--multi-eval-percent)
         );
       }
 

--- a/ui/analyse/src/study/multiBoard.ts
+++ b/ui/analyse/src/study/multiBoard.ts
@@ -326,9 +326,17 @@ export const verticalEvalGauge = (
 ): MaybeVNode => {
   const baseTag = `span.mini-game__gauge${orientation === 'black' ? ' mini-game__gauge--flip' : ''}`;
   return chap.check === '#'
-    ? h(baseTag + ` mini-game__gauge--set`, { attrs: { 'data-id': chap.id, title: 'Checkmate', style: `--multiEvalPercent: ${fenColor(chap.fen) === 'white' ? 100 : 0}%` } }, [
-        h('tick'),
-      ])
+    ? h(
+        baseTag + ` mini-game__gauge--set`,
+        {
+          attrs: {
+            'data-id': chap.id,
+            title: 'Checkmate',
+            style: `--multi-eval-percent: ${fenColor(chap.fen) === 'white' ? 100 : 0}%`,
+          },
+        },
+        [h('tick')],
+      )
     : h(
         baseTag,
         {
@@ -341,7 +349,7 @@ export const verticalEvalGauge = (
               const cev = cloudEval.getCloudEval(chap.fen) || prevNodeCloud;
               if (cev?.chances !== prevNodeCloud?.chances) {
                 elm.style.setProperty(
-                  '--multiEvalPercent',
+                  '--multi-eval-percent',
                   `${Math.round(((1 - (cev?.chances || 0)) / 2) * 100)}%`,
                 );
                 if (cev) {

--- a/ui/analyse/src/study/multiBoard.ts
+++ b/ui/analyse/src/study/multiBoard.ts
@@ -326,10 +326,7 @@ export const verticalEvalGauge = (
 ): MaybeVNode => {
   const baseTag = `span.mini-game__gauge${orientation === 'black' ? ' mini-game__gauge--flip' : ''}`;
   return chap.check === '#'
-    ? h(baseTag + ` mini-game__gauge--set`, { attrs: { 'data-id': chap.id, title: 'Checkmate' } }, [
-        h('span.mini-game__gauge__black', {
-          attrs: { style: `height: ${fenColor(chap.fen) === 'white' ? 100 : 0}%` },
-        }),
+    ? h(baseTag + ` mini-game__gauge--set`, { attrs: { 'data-id': chap.id, title: 'Checkmate', style: `--multiEvalPercent: ${fenColor(chap.fen) === 'white' ? 100 : 0}%` } }, [
         h('tick'),
       ])
     : h(
@@ -343,9 +340,10 @@ export const verticalEvalGauge = (
               const prevNodeCloud: CloudEval | undefined = old.data?.cloud;
               const cev = cloudEval.getCloudEval(chap.fen) || prevNodeCloud;
               if (cev?.chances !== prevNodeCloud?.chances) {
-                (elm.firstChild as HTMLElement).style.height = `${Math.round(
-                  ((1 - (cev?.chances || 0)) / 2) * 100,
-                )}%`;
+                elm.style.setProperty(
+                  '--multiEvalPercent',
+                  `${Math.round(((1 - (cev?.chances || 0)) / 2) * 100)}%`,
+                );
                 if (cev) {
                   elm.title = renderScore(cev);
                   elm.classList.add('mini-game__gauge--set');
@@ -355,7 +353,7 @@ export const verticalEvalGauge = (
             },
           },
         },
-        [h('span.mini-game__gauge__black'), h('tick')],
+        [h('tick')],
       );
 };
 

--- a/ui/lib/css/ceval/_eval-gauge.scss
+++ b/ui/lib/css/ceval/_eval-gauge.scss
@@ -1,4 +1,4 @@
-@property --evalPercent {
+@property --eval-percent {
   syntax: '<percentage>';
   inherits: false;
   initial-value: 50%;
@@ -10,12 +10,12 @@
   width: $block-gap;
   height: var(---cg-height, 100%);
   position: relative;
-  background: linear-gradient(to top, #c0c0c0 var(--evalPercent), #444 var(--evalPercent));
-  transition: --evalPercent 1s ease;
+  background: linear-gradient(to top, #c0c0c0 var(--eval-percent), #444 var(--eval-percent));
+  transition: --eval-percent 1s ease;
   overflow: hidden;
 
   @include if-light {
-    background: linear-gradient(to top, #fff var(--evalPercent), #606060 var(--evalPercent));
+    background: linear-gradient(to top, #fff var(--eval-percent), #606060 var(--eval-percent));
   }
 
   @include mq-is-col1 {

--- a/ui/lib/css/ceval/_eval-gauge.scss
+++ b/ui/lib/css/ceval/_eval-gauge.scss
@@ -1,14 +1,21 @@
+@property --evalPercent {
+  syntax: '<percentage>';
+  inherits: false;
+  initial-value: 50%;
+}
+
 .eval-gauge {
   @extend %box-radius;
 
   width: $block-gap;
   height: var(---cg-height, 100%);
   position: relative;
-  background: #c0c0c0;
+  background: linear-gradient(to top, #c0c0c0 var(--evalPercent), #444 var(--evalPercent));
+  transition: --evalPercent 1s ease;
   overflow: hidden;
 
   @include if-light {
-    background: #fff;
+    background: linear-gradient(to top, #fff var(--evalPercent), #606060 var(--evalPercent));
   }
 
   @include mq-is-col1 {
@@ -51,17 +58,6 @@
       opacity: 1;
       border-bottom: 7px solid $c-accent-cloud !important;
       margin-top: -3px;
-    }
-  }
-
-  .black {
-    width: 100%;
-    height: 50%;
-    transition: height 1s;
-    background: #444;
-
-    @include if-light {
-      background: #606060;
     }
   }
 }

--- a/ui/lib/src/ceval/view/main.ts
+++ b/ui/lib/src/ceval/view/main.ts
@@ -137,8 +137,8 @@ export function renderGauge(ctrl: CevalHandler): VNode | undefined {
   } else ev = gaugeLast;
   return hl(
     'div.eval-gauge',
-    { class: { empty: !defined(bestEv), reverse: ctrl.getOrientation() === 'black' } },
-    [hl('div.black', { attrs: { style: `height: ${100 - (ev + 1) * 50}%` } }), gaugeTicks],
+    { class: { empty: !defined(bestEv), reverse: ctrl.getOrientation() === 'black' }, attrs: { style: `--evalPercent: ${100 - (ev + 1) * 50}%` } },
+    [gaugeTicks],
   );
 }
 

--- a/ui/lib/src/ceval/view/main.ts
+++ b/ui/lib/src/ceval/view/main.ts
@@ -137,7 +137,10 @@ export function renderGauge(ctrl: CevalHandler): VNode | undefined {
   } else ev = gaugeLast;
   return hl(
     'div.eval-gauge',
-    { class: { empty: !defined(bestEv), reverse: ctrl.getOrientation() === 'black' }, attrs: { style: `--evalPercent: ${100 - (ev + 1) * 50}%` } },
+    {
+      class: { empty: !defined(bestEv), reverse: ctrl.getOrientation() === 'black' },
+      attrs: { style: `--eval-percent: ${100 - (ev + 1) * 50}%` },
+    },
     [gaugeTicks],
   );
 }


### PR DESCRIPTION
- Delete "div.black"
- Make the eval bar use only one thing

Note: I did some research on what I could do, and ended up deciding on this approach. I had help from the free Copolot AI, but the original idea was mine.

maybe also resolves #21371