### PR TITLE
disable recap

### DIFF
--- a/modules/recap/src/main/package.scala
+++ b/modules/recap/src/main/package.scala
@@ -3,6 +3,6 @@ package lila.recap
 export lila.core.lilaism.Lilaism.{ *, given }
 export lila.common.extensions.*
 
-val yearToRecap = 2025
+val yearToRecap = 2026
 private val dateStart = instantOf(yearToRecap, 1, 1, 0, 0)
 private val dateEnd = instantOf(yearToRecap + 1, 1, 1, 0, 0)

--- a/modules/recap/src/main/ui/RecapUi.scala
+++ b/modules/recap/src/main/ui/RecapUi.scala
@@ -27,8 +27,8 @@ final class RecapUi(helpers: Helpers):
   def notAvailable(year: Int) =
     Page("Recap not available yet"):
       main(cls := "page-small box box-pad page")(
-        h1(cls := "box__top")(s"Lichess Recap $year will be available soon."),
+        h1(cls := "box__top")(s"Your $year Lichess Recap"),
         div(
-          p("Check back at the end of the year!")
+          p("Your recap will be available at the end of the year. Check back then!")
         )
       )


### PR DESCRIPTION
to make upcoming changes

changing the `yearToRecap` like this will render this instead:

<img width="1324" height="642" alt="image" src="https://github.com/user-attachments/assets/405d9b9d-af9b-4bcb-aca0-c27262b89bf9" />
