### PR TITLE
ui(puzzle): improve notation glyph readability in active cell

### DIFF
--- a/ui/puzzle/css/_tools.scss
+++ b/ui/puzzle/css/_tools.scss
@@ -43,6 +43,10 @@
     &:hover glyph {
       color: $c-font-dim;
     }
+
+    &.active glyph {
+      color: white;
+    }
   }
 }
 


### PR DESCRIPTION
# How

Improve notation glyph readability in active cell in puzzles.

# Preview

### Before

<img width="374" height="263" alt="Screenshot 2026-09-10 at 10 16 01" src="https://github.com/user-attachments/assets/08ccb722-5b18-43c1-959b-0c277d8f138c" />
<img width="374" height="263" alt="Screenshot 2026-09-10 at 10 17 47" src="https://github.com/user-attachments/assets/89609372-35f4-40b2-b4c5-ae36a87ca31c" />


### After

<img width="374" height="263" alt="Screenshot 2026-09-10 at 10 14 26" src="https://github.com/user-attachments/assets/922ae30c-8c7e-4de7-82de-02a650836e81" />
<img width="374" height="263" alt="Screenshot 2026-09-10 at 10 14 31" src="https://github.com/user-attachments/assets/e9daddcb-cbb1-4f88-b30b-6f35e89e9adb" />
