### PR TITLE
ui(lib): an idea how to prevent outside cords overlap

### DIFF
--- a/ui/keyboardMove/css/_keyboardMove.scss
+++ b/ui/keyboardMove/css/_keyboardMove.scss
@@ -28,13 +28,6 @@
   }
 }
 
-// outer coordinates hang 15px below the board, see lib/css/theme/board/_coords.scss
-@include mq-at-least-col2 {
-  .coords-out .keyboard-move {
-    margin-block-start: calc(15px + 0.5rem);
-  }
-}
-
 .keyboard-move-help {
   td.tips li {
     list-style: disc;

--- a/ui/lib/css/theme/board/_coords.scss
+++ b/ui/lib/css/theme/board/_coords.scss
@@ -30,6 +30,6 @@
   }
 
   .coords-out .main-board {
-    margin-bottom: 12px;
+    margin-bottom: 15px;
   }
 }

--- a/ui/lib/css/theme/board/_coords.scss
+++ b/ui/lib/css/theme/board/_coords.scss
@@ -28,4 +28,8 @@
       color: $c-font-page !important;
     }
   }
+
+  .coords-out .main-board {
+    margin-bottom: 12px;
+  }
 }

--- a/ui/lib/css/theme/board/_coords.scss
+++ b/ui/lib/css/theme/board/_coords.scss
@@ -30,6 +30,6 @@
   }
 
   .coords-out .main-board {
-    margin-bottom: 15px;
+    margin-bottom: 12px;
   }
 }


### PR DESCRIPTION
# Why

Outside cords display being a bit of problematic for a while, they can be often overlapped with other page content.

Refs #21484

# How

This experiments add the bottom margin to the main board container when coords display is set to outside, since coords are elements inside `cg-container` placed relatively with negative offset.

It solves the puzzle view overlay, but I was not able to reproduce locally the vies state from a referenced issue (however, it also might help in there).

> [!important]
> This change might need a bit more testing before shipping it.

# Preview

### Before
<img width="810" height="820" alt="Screenshot 2026-09-10 at 11 06 50" src="https://github.com/user-attachments/assets/f56166b2-e504-4909-8917-1973c843addc" />

### After
<img width="810" height="820" alt="Screenshot 2026-09-10 at 11 02 08" src="https://github.com/user-attachments/assets/853bb432-c482-495f-98fb-36354818db8a" />
