### PR TITLE
ui(bits): flair picker i18n

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,6 +140,9 @@ importers:
 
   ui/bits:
     dependencies:
+      '@emoji-mart/data':
+        specifier: ^1.2.1
+        version: 1.2.1
       '@textcomplete/core':
         specifier: ^0.1.13
         version: 0.1.13
@@ -723,6 +726,9 @@ packages:
     engines: {node: '>=20.19.0'}
     peerDependencies:
       postcss-selector-parser: ^7.1.1
+
+  '@emoji-mart/data@1.2.1':
+    resolution: {integrity: sha512-no2pQMWiBy6gpBEiqGeU77/bFejDqUTRY7KX+0+iur13op3bqUsXdnwoZs6Xb1zbv0gAj5VvS1PWoUUckSr5Dw==}
 
   '@esbuild/aix-ppc64@0.28.0':
     resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
@@ -2491,6 +2497,8 @@ snapshots:
   '@csstools/selector-specificity@6.0.0(postcss-selector-parser@7.1.5)':
     dependencies:
       postcss-selector-parser: 7.1.5
+
+  '@emoji-mart/data@1.2.1': {}
 
   '@esbuild/aix-ppc64@0.28.0':
     optional: true

--- a/ui/bits/package.json
+++ b/ui/bits/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "type": "module",
   "dependencies": {
+    "@emoji-mart/data": "^1.2.1",
     "@textcomplete/core": "^0.1.13",
     "@textcomplete/textarea": "^0.1.13",
     "@toast-ui/editor": "3.2.2",

--- a/ui/bits/src/bits.flairPicker.ts
+++ b/ui/bits/src/bits.flairPicker.ts
@@ -12,15 +12,20 @@ type Config = {
 export async function initModule(cfg: Config): Promise<void> {
   if (cfg.element.classList.contains('emoji-done')) return;
 
+  const locale = getPickerLang();
+  const pickerLocaleData = locale !== 'en' ? (await localeLoaders[locale]()).default : undefined;
+
   const opts = {
     ...cfg,
     onClickOutside: cfg.close,
     data: makeEmojiData,
-    categories: categories.map(categ => categ[0]),
+    categories: CATEGORIES.map(categ => categ[0]),
     categoryIcons,
     previewEmoji: 'people.backhand-index-pointing-up',
     noResultsEmoji: 'smileys.crying-face',
     skinTonePosition: 'none',
+    i18n: pickerLocaleData,
+    locale,
     theme: currentTheme(),
     exceptEmojis: cfg.element.dataset.exceptEmojis?.split(' '),
   };
@@ -32,12 +37,18 @@ export async function initModule(cfg: Config): Promise<void> {
   pubsub.on('theme', () => picker.update({ theme: currentTheme() }));
 }
 
+function getPickerLang(): PickerLocale {
+  const htmlLang = $('html').attr('lang') ?? 'en-GB';
+  const lang = htmlLang.split('-')[0];
+  return (lang === 'en' || lang in localeLoaders ? lang : 'en') as PickerLocale;
+}
+
 const makeEmojiData = async () => {
   const res = await fetch(site.asset.url('flair/list.txt', { pathVersion: true }));
   const text = await res.text();
   const lines = text.split('\n').slice(0, -1);
   return {
-    categories: categories.map(([id, name]) => ({
+    categories: CATEGORIES.map(([id, name]) => ({
       id,
       name,
       emojis: lines.filter(line => line.startsWith(id)),
@@ -63,7 +74,7 @@ const makeEmojiData = async () => {
   };
 };
 
-const categories: [string, string][] = [
+const CATEGORIES: [string, string][] = [
   ['smileys', 'Smileys'],
   ['people', 'People'],
   ['nature', 'Animals & Nature'],
@@ -89,3 +100,29 @@ const categoryIcons = {
     svg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path d="M39.61 196.8L74.8 96.29C88.27 57.78 124.6 32 165.4 32H346.6C387.4 32 423.7 57.78 437.2 96.29L472.4 196.8C495.6 206.4 512 229.3 512 256V448C512 465.7 497.7 480 480 480H448C430.3 480 416 465.7 416 448V400H96V448C96 465.7 81.67 480 64 480H32C14.33 480 0 465.7 0 448V256C0 229.3 16.36 206.4 39.61 196.8V196.8zM109.1 192H402.9L376.8 117.4C372.3 104.6 360.2 96 346.6 96H165.4C151.8 96 139.7 104.6 135.2 117.4L109.1 192zM96 256C78.33 256 64 270.3 64 288C64 305.7 78.33 320 96 320C113.7 320 128 305.7 128 288C128 270.3 113.7 256 96 256zM416 320C433.7 320 448 305.7 448 288C448 270.3 433.7 256 416 256C398.3 256 384 270.3 384 288C384 305.7 398.3 320 416 320z"></path></svg>`,
   },
 };
+
+const localeLoaders = {
+  ar: () => import('@emoji-mart/data/i18n/ar.json'),
+  be: () => import('@emoji-mart/data/i18n/be.json'),
+  cs: () => import('@emoji-mart/data/i18n/cs.json'),
+  de: () => import('@emoji-mart/data/i18n/de.json'),
+  es: () => import('@emoji-mart/data/i18n/es.json'),
+  fa: () => import('@emoji-mart/data/i18n/fa.json'),
+  fi: () => import('@emoji-mart/data/i18n/fi.json'),
+  fr: () => import('@emoji-mart/data/i18n/fr.json'),
+  hi: () => import('@emoji-mart/data/i18n/hi.json'),
+  it: () => import('@emoji-mart/data/i18n/it.json'),
+  ja: () => import('@emoji-mart/data/i18n/ja.json'),
+  ko: () => import('@emoji-mart/data/i18n/ko.json'),
+  nl: () => import('@emoji-mart/data/i18n/nl.json'),
+  pl: () => import('@emoji-mart/data/i18n/pl.json'),
+  pt: () => import('@emoji-mart/data/i18n/pt.json'),
+  ru: () => import('@emoji-mart/data/i18n/ru.json'),
+  sa: () => import('@emoji-mart/data/i18n/sa.json'),
+  tr: () => import('@emoji-mart/data/i18n/tr.json'),
+  uk: () => import('@emoji-mart/data/i18n/uk.json'),
+  vi: () => import('@emoji-mart/data/i18n/vi.json'),
+  zh: () => import('@emoji-mart/data/i18n/zh.json'),
+};
+
+type PickerLocale = 'en' | keyof typeof localeLoaders;


### PR DESCRIPTION
# Why

While looking at `emoji-mart` repo spotted that it support several additional languages.

# How

Add required `@emoji-mark/data` dependency, create helper determining locale based on current HTML tag `lang` attribute, load dynamically only required locale for currently selected website language (or none for english, or languages without a i18n keys set.

# Preview

https://github.com/user-attachments/assets/49fdcd79-1a3c-4b55-8df0-84a8abef799a