### PR TITLE
i18n: remove no longer used key

### DIFF
--- a/modules/coreI18n/src/main/key.scala
+++ b/modules/coreI18n/src/main/key.scala
@@ -2312,7 +2312,6 @@ object I18nKey:
     val `theme`: I18nKey = "theme"
     val `light`: I18nKey = "light"
     val `dark`: I18nKey = "dark"
-    val `transparent`: I18nKey = "transparent"
     val `picture`: I18nKey = "picture"
     val `deviceTheme`: I18nKey = "deviceTheme"
     val `roundness`: I18nKey = "roundness"

--- a/translation/source/site.xml
+++ b/translation/source/site.xml
@@ -844,7 +844,6 @@ Playing rated games will increase stability.</string>
   <string name="theme">Theme</string>
   <string name="light">Light</string>
   <string name="dark">Dark</string>
-  <string name="transparent">Transparent</string>
   <string name="picture">Picture</string>
   <string name="deviceTheme">Device theme</string>
   <string name="roundness">Roundness</string>

--- a/ui/@types/lichess/i18n.d.ts
+++ b/ui/@types/lichess/i18n.d.ts
@@ -4755,8 +4755,6 @@ interface I18n {
     tpTimeSpentOnTV: I18nFormat;
     /** Time spent playing: %s */
     tpTimeSpentPlaying: I18nFormat;
-    /** Transparent */
-    transparent: string;
     /** Troll */
     troll: string;
     /** Try another move for black */


### PR DESCRIPTION
# How

Remove no longer used i18n key for transparent theme which got replace by background image toggle.

> [!note]
> I was not sure what's the removal process exactly should be done, so I left the key in all dest translation files, and edited the source hoping the next sync will do that manually. If manual removal is required, just ping me.