### PR TITLE
ui(analyse): fix server eval chart transparency with bg image

### DIFF
--- a/ui/analyse/src/study/serverEval.ts
+++ b/ui/analyse/src/study/serverEval.ts
@@ -49,7 +49,7 @@ export function view(ctrl: ServerEval): VNode {
   if (!ctrl.root.settings.showStaticAnalysis) return disabled();
   if (!analysis) return ctrl.requested ? requested() : requestButton(ctrl);
   const mainline = ctrl.requested ? ctrl.root.data.treeParts : ctrl.analysedMainline();
-  const chart = h('canvas.study__server-eval.ready.' + analysis.id, {
+  const chart = h('canvas.study__server-eval-canvas.ready.' + analysis.id, {
     hook: onInsert(el => {
       requestIdleCallbackSafe(async () => {
         (await site.asset.loadEsm<ChartGame>('chart.game'))


### PR DESCRIPTION
# Why

Spotted that server eval chart always have almost solid background, even in transparent themes.

# How

Found out that `.server-eval` class is applied twice, to the container and to the chart canvas itself, which leads to blur effects and background colors stacking. Change class on canvas to be unique to avoid that. Confirm that it does not change appearance unintentionally (origin class only had background color and text align).

# Preview

### Light with bg

<img width="940" height="277" alt="Screenshot 2026-09-11 at 09 21 09" src="https://github.com/user-attachments/assets/92e7741c-5392-4ea7-992f-5d1bb3936e11" />

### Light without bg

<img width="940" height="277" alt="Screenshot 2026-09-11 at 09 21 23" src="https://github.com/user-attachments/assets/1cb37056-85d1-4945-b3d9-085c6789b763" />
