### PR TITLE
ui(lib): fix top nav background in transparent mode, adjust border color

### DIFF
--- a/ui/lib/css/header/_header.scss
+++ b/ui/lib/css/header/_header.scss
@@ -32,6 +32,7 @@
           color-mix(in oklab, $c-body-gradient 50%, $c-bg-page) 60px
         );
         border-color: $c-border;
+        box-shadow: 0 1px 5px 0 rgb(0 0 0 / 0.07);
       }
     }
 

--- a/ui/lib/css/header/_header.scss
+++ b/ui/lib/css/header/_header.scss
@@ -24,16 +24,14 @@
     padding: 0 var(---site-header-sticky-padding);
     border-bottom: 1px solid transparent;
 
-    &.scrolled {
-      background-image: linear-gradient(
-        to bottom,
-        $c-body-gradient,
-        color-mix(in oklab, $c-body-gradient 50%, $c-bg-page) 60px
-      );
-      border-color: black;
-
-      @include if-light {
-        border-color: hsl(0 0% 70%);
+    @include if-not-transp {
+      &.scrolled {
+        background-image: linear-gradient(
+          to bottom,
+          $c-body-gradient,
+          color-mix(in oklab, $c-body-gradient 50%, $c-bg-page) 60px
+        );
+        border-color: $c-border;
       }
     }
 


### PR DESCRIPTION
# How

Fix top nav background in transparent mode, adjust border color and add slight box shadow in regular themes.

The issue can be seen after refreshing page with content scrolled down.

# Preview

### Before

<img width="1485" height="647" alt="Screenshot 2026-09-11 at 13 53 10" src="https://github.com/user-attachments/assets/4b2bdb79-6f69-4172-aae5-256922bcfeaa" />

### After

<img width="1485" height="647" alt="Screenshot 2026-09-11 at 13 52 54" src="https://github.com/user-attachments/assets/b9e2e2cb-d633-40cd-95b3-11296ef9325a" />
