### PR TITLE
Board editor: add local engine analysis for puzzle composition

### DIFF
--- a/app/controllers/Editor.scala
+++ b/app/controllers/Editor.scala
@@ -35,6 +35,7 @@ final class Editor(env: Env) extends LilaController(env):
       .map(Fen.Full.clean)
     Ok.page:
       views.boardEditor(fen, positionsJson, endgamePositionsJson)
+    .map(_.enforceCrossSiteIsolation)
 
   def data = Open:
     JsonOk(views.boardEditor.jsData())

--- a/modules/web/src/main/ui/BoardEditorUi.scala
+++ b/modules/web/src/main/ui/BoardEditorUi.scala
@@ -26,6 +26,7 @@ final class BoardEditorUi(helpers: Helpers):
       )
       .i18n(_.variant)
       .css("editor")
+      .csp(_.withWebAssembly)
       .flag(_.zoom)
       .graph(
         title = "Chess board editor",

--- a/ui/editor/css/_tools.scss
+++ b/ui/editor/css/_tools.scss
@@ -1,132 +1,143 @@
-.board-editor {
-  &__tools {
-    @extend %flex-column;
+.board-editor__tools {
+  @extend %flex-column;
 
-    cursor: default;
-    grid-area: tools;
-    align-self: center;
+  cursor: default;
+  grid-area: tools;
+  align-self: center;
 
-    button,
-    .button,
-    select,
-    label,
-    input[type='checkbox'] {
-      cursor: pointer;
+  button,
+  .button,
+  select,
+  label,
+  input[type='checkbox'] {
+    cursor: pointer;
+  }
+
+  input[type='text'],
+  input[type='number'] {
+    cursor: text;
+  }
+
+  button:disabled,
+  select:disabled,
+  input:disabled {
+    cursor: not-allowed;
+  }
+
+  > * {
+    margin: 0.5rem 0;
+  }
+
+  select {
+    @extend %page-link !optional;
+    @include backdrop-blur-if-transparent;
+
+    width: 100%;
+
+    &.positions option:checked {
+      font-style: italic;
+    }
+  }
+
+  .metadata {
+    @extend %box-neat;
+
+    background: $c-bg-box;
+    padding: 1rem;
+    white-space: nowrap;
+
+    .color {
+      margin-bottom: 1em;
     }
 
-    input[type='text'],
-    input[type='number'] {
-      cursor: text;
-    }
-
-    button:disabled,
-    select:disabled,
-    input:disabled {
-      cursor: not-allowed;
-    }
-
-    > * {
-      margin: 0.5rem 0;
-    }
-
-    select {
-      @extend %page-link !optional;
-      @include backdrop-blur-if-transparent;
-
-      width: 100%;
-
-      &.positions option:checked {
-        font-style: italic;
-      }
-    }
-
-    .metadata {
-      @extend %box-neat;
-
-      background: $c-bg-box;
-      padding: 1rem;
-      white-space: nowrap;
-
-      .color {
-        margin-bottom: 1em;
-      }
-
-      .castling {
-        div {
-          @extend %flex-between;
-        }
-
-        label,
-        input {
-          display: inline-block;
-          margin: 3px;
-          vertical-align: middle;
-        }
-
-        input.not-allowed {
-          visibility: hidden;
-        }
-      }
-
-      .enpassant {
+    .castling {
+      div {
         @extend %flex-between;
-
-        margin-top: 1em;
-
-        label {
-          font-weight: bold;
-        }
-
-        select {
-          width: 9ch;
-        }
       }
 
-      .chess960-position-row {
-        @extend %flex-center;
-
-        gap: 0.5rem;
-
-        .form-label {
-          flex: 0 0 100%;
-          margin: 0;
-        }
-
-        .button {
-          width: auto;
-        }
+      label,
+      input {
+        display: inline-block;
+        margin: 3px;
+        vertical-align: middle;
       }
 
-      #chess960-position-id {
-        &:invalid {
-          border-color: $c-error;
-        }
+      input.not-allowed {
+        visibility: hidden;
       }
     }
 
-    .actions {
-      @extend %flex-column, %box-radius;
-      @include backdrop-blur-if-transparent;
+    .enpassant {
+      @extend %flex-between;
 
-      justify-content: stretch;
+      margin-top: 1em;
+
+      label {
+        font-weight: bold;
+      }
+
+      select {
+        width: 9ch;
+      }
+    }
+
+    .chess960-position-row {
+      @extend %flex-center;
+
+      gap: 0.5rem;
+
+      .form-label {
+        flex: 0 0 100%;
+        margin: 0;
+      }
 
       .button {
-        @extend %page-link !optional;
-
-        width: 100%;
-        text-align: start;
-        display: flex;
-        align-items: center;
-        text-transform: none;
-
-        &.disabled {
-          cursor: default;
-        }
-
-        &::before {
-          color: var(--c-font);
-        }
+        width: auto;
       }
+    }
+
+    #chess960-position-id {
+      &:invalid {
+        border-color: $c-error;
+      }
+    }
+  }
+
+  .actions {
+    @extend %flex-column, %box-radius;
+    @include backdrop-blur-if-transparent;
+
+    justify-content: stretch;
+
+    .button {
+      @extend %page-link !optional;
+
+      width: 100%;
+      text-align: start;
+      display: flex;
+      align-items: center;
+      text-transform: none;
+
+      &.disabled {
+        cursor: default;
+      }
+
+      &::before {
+        color: var(--c-font);
+      }
+    }
+  }
+
+  .ceval-wrap {
+    @extend %box-neat;
+
+    &,
+    .ceval {
+      @extend %box-radius;
+    }
+
+    .pv_box {
+      @extend %box-radius-bottom;
     }
   }
 }

--- a/ui/editor/css/build/editor.scss
+++ b/ui/editor/css/build/editor.scss
@@ -4,4 +4,7 @@
 @import '../../../lib/css/component/board-resize';
 @import '../../../lib/css/component/continue-with';
 @import '../../../lib/css/component/copy-me';
+@import '../../../lib/css/form/cmn-toggle';
+@import '../../../lib/css/form/range';
+@import '../../../lib/css/ceval/ceval';
 @import '../editor';

--- a/ui/editor/src/ctrl.ts
+++ b/ui/editor/src/ctrl.ts
@@ -9,7 +9,10 @@ import { type Setup, Material, RemainingChecks, defaultSetup } from 'chessops/se
 import type { Rules, Square } from 'chessops/types';
 import { Castles, defaultPosition, Position, setupPosition } from 'chessops/variant';
 
-import { defined, propWithEffect, type Prop } from 'lib';
+import { defined, prop, propWithEffect, type Prop } from 'lib';
+import { CevalCtrl, useFirstEval, type CevalHandler, type CevalOpts } from 'lib/ceval';
+import { completeNode } from 'lib/tree/node';
+import type { TreeNode } from 'lib/tree/types';
 import { prompt } from 'lib/view';
 
 import {
@@ -31,7 +34,7 @@ import {
   CASTLING_TOGGLES,
 } from './interfaces';
 
-export default class EditorCtrl {
+export default class EditorCtrl implements CevalHandler {
   options: Options;
   chessground?: CgApi;
   selected: Prop<Selected>;
@@ -47,6 +50,13 @@ export default class EditorCtrl {
   fullmoves: number;
   guessCastlingToggles: boolean;
   chess960PositionId?: number;
+  ceval: CevalCtrl;
+  cevalNode: TreeNode;
+  ongoing = false;
+  showEvalGauge: Prop<boolean> = prop(false);
+  threatMode: Prop<boolean> = prop(false);
+  private readonly cevalEnabledProp = prop(false);
+  private cevalPosition?: string;
 
   constructor(
     readonly cfg: Config,
@@ -80,7 +90,9 @@ export default class EditorCtrl {
           const state = this.getState();
           if (state.legalFen)
             window.location.assign(this.makeAnalysisUrl(state.legalFen, this.bottomColor()));
-        });
+        })
+        .bind('l', () => this.cevalEnabled(!this.cevalEnabled()))
+        .bind('x', () => this.toggleThreatMode());
 
     this.castlingToggles = { K: false, Q: false, k: false, q: false };
     const params = new URLSearchParams(location.search);
@@ -102,6 +114,11 @@ export default class EditorCtrl {
       this.initialFen = INITIAL_FEN;
       this.setSetup(defaultSetup());
     });
+
+    const cevalFen = this.getLegalFen() || this.getFen();
+    this.cevalNode = this.makeCevalNode(cevalFen);
+    this.ceval = new CevalCtrl(this.makeCevalOpts(cevalFen));
+    this.cevalPosition = `${this.variant}:${cevalFen}`;
 
     new MutationObserver(mutations => {
       for (const m of mutations) {
@@ -130,6 +147,112 @@ export default class EditorCtrl {
     return `${fen.substring(0, epIndex)}${enPassant}${fen.substring(epEndIndex)}`;
   }
 
+  private makeCevalNode(fen: FEN): TreeNode {
+    const ply = Math.max(0, (this.fullmoves - 1) * 2 + (this.turn === 'black' ? 1 : 0));
+    return completeNode(this.variant)({ ply, fen });
+  }
+
+  private makeCevalOpts(fen: FEN): CevalOpts {
+    return {
+      variant: {
+        key: this.variant,
+        name: this.variant,
+        short: this.variant,
+      },
+      initialFen: fen,
+      emit: (ev, meta) => {
+        if (!ev) {
+          this.cevalEnabled(false);
+          return;
+        }
+
+        const node = this.cevalNode;
+        if (meta.threatMode) {
+          if (!node.threat || useFirstEval(ev, node.threat, this.ceval.search.multiPv)) node.threat = ev;
+        } else if (
+          ev.fen === node.fen &&
+          (!node.ceval || useFirstEval(ev, node.ceval, this.ceval.search.multiPv))
+        ) {
+          node.ceval = ev;
+        }
+        this.redraw();
+      },
+      onUciHover: () => {},
+      redraw: this.redraw,
+      onSelectEngine: () => {
+        this.updateCeval(true);
+        this.redraw();
+      },
+    };
+  }
+
+  private updateCeval(force: boolean = false): void {
+    const legalFen = this.getLegalFen();
+    const fen = legalFen || this.getFen();
+    const position = `${this.variant}:${fen}`;
+    if (!force && this.cevalPosition === position) return;
+
+    this.cevalPosition = position;
+    this.cevalNode = this.makeCevalNode(fen);
+    const wasUnloaded = this.ceval.wasUnloadedByAnotherWindow;
+    this.ceval.init(this.makeCevalOpts(fen));
+    this.ceval.wasUnloadedByAnotherWindow = wasUnloaded;
+    if (legalFen && this.cevalEnabled()) this.startCeval();
+  }
+
+  cevalEnabled = (enable?: boolean): boolean => {
+    const enabled = this.cevalEnabledProp() && !this.ceval.wasUnloadedByAnotherWindow;
+    if (enable === undefined) return enabled;
+
+    this.cevalEnabledProp(enable);
+    if (enable && this.ceval.wasUnloadedByAnotherWindow) this.ceval.reset();
+    if (enable !== enabled) {
+      if (enable) this.startCeval();
+      else {
+        this.threatMode(false);
+        this.ceval.reset();
+      }
+      this.ceval.showEnginePrefs(false);
+      this.redraw();
+    }
+    return enable;
+  };
+
+  startCeval = (): void => {
+    if (!this.ceval.download) this.ceval.reset();
+    if (!this.cevalEnabled() || !this.ceval.analysable || this.cevalNode.outcome()) return;
+    this.ceval.start('', [this.cevalNode], undefined, this.threatMode());
+  };
+
+  clearCeval = (): void => {
+    this.cevalNode.ceval = undefined;
+    this.cevalNode.threat = undefined;
+    this.startCeval();
+  };
+
+  toggleThreatMode(v: boolean = !this.threatMode()): void {
+    if (v === this.threatMode() || this.cevalNode.check() || !this.cevalEnabled()) return;
+    this.threatMode(v);
+    this.startCeval();
+    this.redraw();
+  }
+
+  nextNodeBest(): string | undefined {
+    return undefined;
+  }
+
+  playUciList(_uciList: string[]): void {
+    // The board editor has no move tree to navigate.
+  }
+
+  getOrientation(): Color {
+    return this.bottomColor();
+  }
+
+  getNode(): TreeNode {
+    return this.cevalNode;
+  }
+
   onChange(): void {
     // We can use the first field of the fen now; it's the ep and castle fields that may be inaccurate at the moment.
     this.chess960PositionId = boardFenToChess960Id(this.getFen().split(' ')[0]) ?? this.chess960PositionId;
@@ -143,6 +266,7 @@ export default class EditorCtrl {
       window.history.replaceState(null, '', this.makeEditorUrl(fen, this.bottomColor()));
     }
     this.options.onChange?.(fen);
+    this.updateCeval();
     this.redraw();
   }
 

--- a/ui/editor/src/ctrl.ts
+++ b/ui/editor/src/ctrl.ts
@@ -186,7 +186,7 @@ export default class EditorCtrl implements CevalHandler {
     };
   }
 
-  private updateCeval(force: boolean = false): void {
+  private updateCeval(force?: boolean): void {
     const legalFen = this.getLegalFen();
     const fen = legalFen || this.getFen();
     const position = `${this.variant}:${fen}`;
@@ -230,9 +230,10 @@ export default class EditorCtrl implements CevalHandler {
     this.startCeval();
   };
 
-  toggleThreatMode(v: boolean = !this.threatMode()): void {
-    if (v === this.threatMode() || this.cevalNode.check() || !this.cevalEnabled()) return;
-    this.threatMode(v);
+  toggleThreatMode(v?: boolean): void {
+    const enable = v ?? !this.threatMode();
+    if (enable === this.threatMode() || this.cevalNode.check() || !this.cevalEnabled()) return;
+    this.threatMode(enable);
     this.startCeval();
     this.redraw();
   }

--- a/ui/editor/src/view.ts
+++ b/ui/editor/src/view.ts
@@ -5,6 +5,7 @@ import { lichessRules } from 'chessops/compat';
 import { parseFen } from 'chessops/fen';
 import { parseSquare, makeSquare } from 'chessops/util';
 
+import { view as cevalView } from 'lib/ceval';
 import { fenToEpd } from 'lib/game/chess';
 import { licon, type LiconValue } from 'lib/licon';
 import {
@@ -170,6 +171,7 @@ function controls(ctrl: EditorCtrl, state: EditorState): VNode {
         ]);
 
   return div('.board-editor__tools', [
+    ...(ctrl.cfg.embed ? [] : [div('.ceval-wrap', [cevalView.renderCeval(ctrl), cevalView.renderPvs(ctrl)])]),
     div('.metadata', [
       div(
         '.color',


### PR DESCRIPTION
## Description

Adds optional local engine analysis to the Board Editor, primarily to make it easier to compose and verify chess puzzles.

When creating a chess puzzle or problem, the position is often built manually by adding, removing and moving pieces in the Board Editor. Being able to see Stockfish's evaluation immediately while modifying the position makes it much easier to verify whether the intended solution is correct, whether there is a forced mate (#1, #2, etc.), and whether alternative solutions exist.

The implementation reuses Lichess' existing ceval components instead of introducing a separate evaluation UI. This provides the same local Stockfish evaluation, engine settings, MultiPV, PV lines, depth/NPS information and threat mode already used elsewhere in Lichess.

The engine is disabled by default in the Board Editor and runs entirely in the browser.

When the edited position changes, the evaluation is restarted automatically. Invalid positions are not analysed, and analysis resumes when the position becomes valid again if local evaluation is still enabled.

The Board Editor page also opts into WebAssembly through the existing CSP helper required by Stockfish.

No opening explorer or server-side analysis is added.

## Manual testing

Tested locally with lila-docker on Fedora.

Verified:

- local evaluation is disabled by default
- evaluation can be enabled and disabled
- adding, moving and removing pieces restarts analysis
- changing the side to move restarts analysis
- invalid positions stop analysis
- restoring a valid position resumes analysis
- mate scores are displayed correctly
- MultiPV and engine settings work
- threat mode works
- keyboard shortcuts L and X work
- normal Analysis Board engine evaluation still works
- clean TypeScript/Sass build
- `git diff --check` passes

<img width="1239" height="1038" alt="Screenshot_20260911_140519" src="https://github.com/user-attachments/assets/f4aa46ef-120e-4b9a-9590-ff400e91825f" />

<img width="1240" height="1037" alt="Screenshot_20260911_140603" src="https://github.com/user-attachments/assets/b8b36dc1-1443-4b2f-8c5f-eb80dc78929f" />

## AI assistance

This change was developed with assistance from ChatGPT (OpenAI).

I reviewed, ran and manually tested the resulting code locally.

The main prompts/instructions given to the AI were:

- Add optional browser-side Stockfish analysis directly to the Lichess Board Editor.
- The main use case is composing and verifying chess puzzles by modifying the position.
- Reuse the existing Lichess ceval implementation and UI as much as possible instead of implementing a new engine interface.
- Keep the engine disabled by default and independent from the Analysis Board preference.
- Re-evaluate automatically when the edited position changes.
- Do not analyse illegal positions, and resume when they become legal again.
- Reuse existing engine settings, MultiPV, PV rendering, threat mode and keyboard shortcuts where possible.
- Keep the changes minimal and focused on adapting the Board Editor to the existing CevalCtrl/CevalHandler APIs.
- Preserve Lichess' existing cross-tab engine coordination.


