### PR TITLE
Show fifty-move rule in analysis UI

### DIFF
--- a/ui/analyse/src/ctrl.ts
+++ b/ui/analyse/src/ctrl.ts
@@ -24,7 +24,7 @@ import {
 import { CevalCtrl, useFirstEval, sanIrreversible, type CevalHandler, type CevalOpts } from 'lib/ceval';
 import { ChatCtrl } from 'lib/chat/chatCtrl';
 import { displayColumns } from 'lib/device';
-import { playable, playedTurns, fenToEpd, validUci } from 'lib/game';
+import { playable, playedTurns, fenToEpd, validUci, isFiftyMoves } from 'lib/game';
 import { plyColor } from 'lib/game/chess';
 import { PromotionCtrl } from 'lib/game/promotion';
 import { pubsub } from 'lib/pubsub';
@@ -342,7 +342,7 @@ export default class AnalyseCtrl implements CevalHandler {
   }
 
   private showGround(): void {
-    if (this.node.pos().isErr || this.node.outcome()) this.ceval.reset();
+    if (this.node.pos().isErr || this.node.outcome() || isFiftyMoves(this.node.fen)) this.ceval.reset();
     this.withCg(cg => {
       cg.set(this.makeCgOpts());
       this.setAutoShapes();
@@ -808,7 +808,8 @@ export default class AnalyseCtrl implements CevalHandler {
   startCeval = () => {
     if (!this.asyncReady) return;
     if (!this.ceval.download) this.ceval.reset();
-    if (this.node.threefold || !this.cevalEnabled() || this.node.outcome()) return;
+    if (this.node.threefold || isFiftyMoves(this.node.fen) || !this.cevalEnabled() || this.node.outcome())
+      return;
     this.ceval.start(this.path, this.nodeList, undefined, this.threatMode());
     this.evalCache.fetch(this.path, this.ceval.search.multiPv);
   };
@@ -840,7 +841,8 @@ export default class AnalyseCtrl implements CevalHandler {
       this.showEvaluation() &&
       this.isCevalAllowed() &&
       (this.cevalEnabled() || !!this.node.eval || !!this.node.ceval) &&
-      !this.node.outcome()
+      !this.node.outcome() &&
+      !isFiftyMoves(this.node.fen)
     );
   }
 

--- a/ui/analyse/src/practice/practiceCtrl.ts
+++ b/ui/analyse/src/practice/practiceCtrl.ts
@@ -4,6 +4,7 @@ import { parseUci } from 'chessops/util';
 import { defined, prop, type Prop, requestIdleCallbackSafe } from 'lib';
 import { api } from 'lib/api';
 import { winningChances, type CustomCeval } from 'lib/ceval';
+import { isFiftyMoves } from 'lib/game';
 import { storedBooleanPropWithEffect } from 'lib/storage';
 import { path as treePath } from 'lib/tree/tree';
 import type { TablebaseHit, TreeNode, TreePath } from 'lib/tree/types';
@@ -105,10 +106,9 @@ export function make(root: AnalyseCtrl): PracticeCtrl {
 
     if (outcome?.winner) verdict = 'goodMove';
     else {
-      const isFiftyMoves = node.fen.split(' ')[4] === '100';
       const nodeEval: EvalScore =
         tbhitToEval(node.tbhit) ||
-        (node.threefold || (outcome && !outcome.winner) || isFiftyMoves
+        (node.threefold || (outcome && !outcome.winner) || isFiftyMoves(node.fen)
           ? { cp: 0 }
           : (node.ceval as EvalScore));
       const prevEval: EvalScore = tbhitToEval(prev.tbhit) || prev.ceval!;

--- a/ui/analyse/src/practice/practiceView.ts
+++ b/ui/analyse/src/practice/practiceView.ts
@@ -2,7 +2,7 @@ import type { Outcome } from 'chessops/types';
 
 import type { Prop } from 'lib';
 import { api } from 'lib/api';
-import { fixCrazySan } from 'lib/game/chess';
+import { fixCrazySan, isFiftyMoves } from 'lib/game/chess';
 import { hl, type VNode, bind, onInsert, type MaybeVNodes } from 'lib/view';
 
 import type AnalyseCtrl from '@/ctrl';
@@ -43,14 +43,14 @@ const renderOffTrack = (ctrl: PracticeCtrl): VNode =>
 
 function renderEnd(root: AnalyseCtrl, end: Outcome): VNode {
   const color = end.winner || root.turnColor();
-  const isFiftyMoves = root.practice?.currentNode().fen.split(' ')[4] === '100';
+  const fiftyMoves = root.practice && isFiftyMoves(root.practice.currentNode().fen);
   return hl('div.player', [
     color ? hl('div.no-square', hl('piece.king.' + color)) : hl('div.icon.off', '!'),
     hl('div.instruction', [
       hl('strong', end.winner ? i18n.site.checkmate : i18n.site.draw),
       end.winner
         ? hl('em', hl('color', i18n.site[end.winner === 'white' ? 'whiteWinsGame' : 'blackWinsGame']))
-        : isFiftyMoves
+        : fiftyMoves
           ? i18n.site.drawByFiftyMoves
           : hl('em', i18n.site.theGameIsADraw),
     ]),
@@ -107,9 +107,9 @@ export default function (root: AnalyseCtrl): VNode | undefined {
   const ctrl = root.practice;
   if (!ctrl) return undefined;
   const comment: Comment | null = ctrl.comment();
-  const isFiftyMoves = ctrl.currentNode().fen.split(' ')[4] === '100';
+  const fiftyMoves = isFiftyMoves(ctrl.currentNode().fen);
   const running: boolean = ctrl.running();
-  const end = ctrl.currentNode().threefold || isFiftyMoves ? { winner: undefined } : root.node.outcome();
+  const end = ctrl.currentNode().threefold || fiftyMoves ? { winner: undefined } : root.node.outcome();
   return hl('div.practice-box.training-box.sub-box.' + (comment ? comment.verdict : 'no-verdict'), [
     hl('div.title', i18n.site.practiceWithComputer),
     hl(

--- a/ui/analyse/src/study/practice/studyPracticeSuccess.ts
+++ b/ui/analyse/src/study/practice/studyPracticeSuccess.ts
@@ -1,3 +1,4 @@
+import { isFiftyMoves } from 'lib/game';
 import type { TreeNode } from 'lib/tree/types';
 
 import type AnalyseCtrl from '@/ctrl';
@@ -43,7 +44,7 @@ export default function (root: AnalyseCtrl, goal: Goal, nbMoves: number): boolea
   switch (goal.result) {
     case 'drawIn':
     case 'equalIn':
-      if (node.threefold) return true;
+      if (node.threefold || isFiftyMoves(node.fen)) return true;
       if (isDrawish(node) === false) return false;
       if (nbMoves > goal.moves!) return false;
       if (outcome && !outcome.winner) return true;
@@ -63,7 +64,7 @@ export default function (root: AnalyseCtrl, goal: Goal, nbMoves: number): boolea
       if (!node.uci[4]) return null;
       return isWinning(node, goal.cp!, root.bottomColor());
     case 'mate':
-      if (node.threefold) return false;
+      if (node.threefold || isFiftyMoves(node.fen)) return false;
       if (isDrawish(node)) return false;
       if (node.pos().unwrap().isStalemate()) return false;
   }

--- a/ui/analyse/src/view/components.ts
+++ b/ui/analyse/src/view/components.ts
@@ -6,11 +6,12 @@ import { renderEval as normalizeEval } from 'lib/ceval';
 import { dispatchChessgroundResize } from 'lib/chessgroundResize';
 import { isMobile } from 'lib/device';
 import { playable } from 'lib/game';
-import { fixCrazySan, plyToTurn } from 'lib/game/chess';
+import { fixCrazySan, plyToTurn, isFiftyMoves } from 'lib/game/chess';
 import statusView from 'lib/game/view/status';
 import { licon } from 'lib/licon';
 import * as Prefs from 'lib/prefs';
 import { storage } from 'lib/storage';
+import { treeOps } from 'lib/tree';
 import { path as treePath } from 'lib/tree/tree';
 import type { ClientEval, Glyph, ServerEval, TreeNode, TreePath } from 'lib/tree/types';
 import {
@@ -263,6 +264,8 @@ export function renderResult(ctrl: AnalyseCtrl): VNode[] {
     if (result === '½-0') return render(result, i18n.study.blackDefeatWhiteCanNotWin);
     if (result === '0-½') return render(result, i18n.study.whiteDefeatBlackCanNotWin);
     return render('½-½', i18n.site.draw);
+  } else if (isFiftyMoves(treeOps.last(ctrl.mainline)?.fen ?? '')) {
+    return render('½-½', `${i18n.site.fiftyMovesWithoutProgress} • ${i18n.site.draw}`);
   }
   return [];
 }

--- a/ui/lib/src/ceval/view/main.ts
+++ b/ui/lib/src/ceval/view/main.ts
@@ -11,6 +11,7 @@ import { setupPosition } from 'chessops/variant';
 import { h } from 'snabbdom';
 
 import { isTouchDevice } from '@/device';
+import { isFiftyMoves } from '@/game/chess';
 import { blurIfPrimaryClick, defined, notNull, requestIdleCallbackSafe } from '@/index';
 import { licon } from '@/licon';
 import type { ClientEval, LocalEval, PvData } from '@/tree/types';
@@ -155,7 +156,8 @@ export function renderCeval(ctrl: CevalHandler): VNode[] {
     threat = threatMode ? node.threat : undefined,
     bestEv = threat || getBestEval(ctrl),
     search = ceval.search,
-    download = ceval.download;
+    download = ceval.download,
+    fiftyMoves = isFiftyMoves(node.fen);
   let pearl: LooseVNode,
     percent = 0;
 
@@ -176,10 +178,10 @@ export function renderCeval(ctrl: CevalHandler): VNode[] {
     percent = 100;
   } else {
     if (!enabled) pearl = h('pearl', h('icon'));
-    else if (node.outcome() || node.threefold) pearl = h('pearl', '-');
+    else if (node.outcome() || node.threefold || fiftyMoves) pearl = h('pearl', '-');
     else if (ceval.state === CevalState.Failed) pearl = h('pearl', icon(licon.CautionCircle)('.is-red'));
     else pearl = h('pearl', h('icon.ddloader'));
-    percent = node.outcome() ? 100 : 0;
+    percent = node.outcome() || fiftyMoves ? 100 : 0;
   }
   if (download) percent = Math.min(100, Math.round((100 * download.bytes) / download.total));
   else if (ceval.search.indeterminate || (percent > 0 && !ceval.isComputing)) percent = 100;
@@ -217,9 +219,11 @@ export function renderCeval(ctrl: CevalHandler): VNode[] {
               ? [i18n.site.gameOver]
               : node.threefold
                 ? [i18n.site.threefoldRepetition]
-                : threatMode
-                  ? [threatInfo(ctrl, threat)]
-                  : localEvalNodes(ctrl, { client, server }),
+                : fiftyMoves
+                  ? [i18n.site.fiftyMovesWithoutProgress]
+                  : threatMode
+                    ? [threatInfo(ctrl, threat)]
+                    : localEvalNodes(ctrl, { client, server }),
           ),
         ]),
       ]

--- a/ui/lib/src/game/chess.ts
+++ b/ui/lib/src/game/chess.ts
@@ -23,6 +23,12 @@ export const plyOpponentColor = (ply: number): Color => opposite(plyColor(ply));
 
 export const pieceCount = (fen: FEN): number => fen.split(/\s/)[0].split(/[nbrqkp]/i).length - 1;
 
+// FIDE fifty-move rule: 100 halfmoves in the FEN clock.
+export function isFiftyMoves(fen: FEN): boolean {
+  const halfmoves = Number(fen.split(' ')[4]);
+  return Number.isFinite(halfmoves) && halfmoves >= 100;
+}
+
 export function fen960(): string {
   const [dark, light] = [2 * Math.floor(Math.random() * 4), 1 + 2 * Math.floor(Math.random() * 4)];
   const files = shuffle([0, 1, 2, 3, 4, 5, 6, 7].filter(f => f !== dark && f !== light));

--- a/ui/lib/src/game/view/status.ts
+++ b/ui/lib/src/game/view/status.ts
@@ -1,4 +1,5 @@
 import type { GameData, Source, StatusName } from '@/game';
+
 import { isFiftyMoves } from '../chess';
 
 export function bishopOnColor(expandedFen: string, offset: 0 | 1): boolean {

--- a/ui/lib/src/game/view/status.ts
+++ b/ui/lib/src/game/view/status.ts
@@ -1,4 +1,5 @@
 import type { GameData, Source, StatusName } from '@/game';
+import { isFiftyMoves } from '../chess';
 
 export function bishopOnColor(expandedFen: string, offset: 0 | 1): boolean {
   if (expandedFen.length !== 64) throw new Error('Expanded FEN expected to be 64 characters');
@@ -98,7 +99,7 @@ export function statusOf(d: StatusData): string {
           return `${d.ply % 2 === 0 ? i18n.site.whiteLeftTheGame : i18n.site.blackLeftTheGame} • ${i18n.site.draw}`;
       }
     case 'draw': {
-      if (d.fiftyMoves || d.fen.split(' ')[4] === '100')
+      if (d.fiftyMoves || isFiftyMoves(d.fen))
         return `${i18n.site.fiftyMovesWithoutProgress} • ${i18n.site.draw}`;
       if (d.threefold) return `${i18n.site.threefoldRepetition} • ${i18n.site.draw}`;
       if (insufficientMaterial(d.variant, d.fen))

--- a/ui/lib/tests/status.test.ts
+++ b/ui/lib/tests/status.test.ts
@@ -2,7 +2,25 @@ import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 
 import { each } from '../../.test/helpers.mts';
+import { isFiftyMoves } from '../src/game/chess';
 import { bishopOnColor, expandFen, insufficientMaterial } from '../src/game/view/status';
+
+describe('fifty-move rule from FEN', () => {
+  test('starting position is not fifty-move', () =>
+    assert.strictEqual(isFiftyMoves('rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1'), false));
+
+  test('99 halfmoves is not fifty-move', () =>
+    assert.strictEqual(isFiftyMoves('8/p4p2/1p2p1p1/r1k1P1Pp/P1P2P1P/R1K5/8/8 b - - 99 81'), false));
+
+  test('exactly 100 halfmoves is fifty-move', () =>
+    assert.strictEqual(isFiftyMoves('8/p4p2/1p2p1p1/r1k1P1Pp/P1P2P1P/R1K5/8/8 b - - 100 81'), true));
+
+  test('more than 100 halfmoves is still fifty-move', () =>
+    assert.strictEqual(isFiftyMoves('8/p4p2/1p2p1p1/r1k1P1Pp/P1P2P1P/R1K5/8/8 b - - 150 106'), true));
+
+  test('incomplete FEN without clocks is not fifty-move', () =>
+    assert.strictEqual(isFiftyMoves('8/8/8/8/8/8/8/8 w - -'), false));
+});
 
 describe('expand fen', () => {
   test('starting position', () =>


### PR DESCRIPTION
Fixes #15036

When analysing a position that has already hit the fifty-move rule (FEN halfmove clock >= 100), the UI gave no reason for the draw. Threefold already shows in the engine panel; fifty-move did not.

## Changes
- Shared `isFiftyMoves(fen)` helper (100+ halfmoves, not only exactly 100)
- Engine panel: pearl `-` and "Fifty moves without progress", same as threefold
- Move-list result on unfinished/synthetic analysis: 1/2-1/2 Fifty moves without progress
- Skip local engine eval and hide the eval gauge on those positions
- Practice with computer / study practice treat fifty-move as a draw, including clocks past 100

## Testing
- Added unit tests in `ui/lib/tests/status.test.ts` for 0 / 99 / 100 / 150 / incomplete FEN
- I could not run a full local Lichess stack (Mongo/Scala) in this environment, so this PR is a **draft** per CONTRIBUTING. Please treat UI verification on https://lichess.org/analysis/standard/8/p4p2/1p2p1p1/r1k1P1Pp/P1P2P1P/R1K5/8/8_b_-_-_100_81 as still needed.

## AI disclosure
This work was produced by **Grok 4.6** (xAI Grok Build CLI), an AI coding agent, on behalf of this GitHub account.

Prompts used:
1. Look up a Lichess todo that can be implemented, implement it, and open a pull request. Limit work to one important but not too big feature.
2. Say that you are AI. Change workspace and GitHub (work in the Lichess repo, not the previous local chess-database project).

I reviewed the existing threefold-repetition handling and mirrored that path for fifty-move. I did not generate tests without reading the analysis/ceval code first.