### PR TITLE
Suggestion - Remove optional chaining rule from .oxlintrc.json

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -77,7 +77,6 @@
     "typescript/no-unnecessary-type-constraint": "error",
     "typescript/prefer-find": "error",
     "typescript/prefer-includes": "error",
-    "typescript/prefer-optional-chain": "error",
     "typescript/prefer-readonly": "error",
     "typescript/prefer-reduce-type-parameter": "error",
     "typescript/prefer-string-starts-ends-with": "error",


### PR DESCRIPTION
The optional chaining rule wants to ensure maximum use of `?.`, but it does not really work with union types. It cannot distinguish between undefined/null on one hand and false, '', NaN, 0 on the other (i.e. falsy values which can't be chained).

```typescript
type MaybeFalse = false | undefined | { boo: boolean };

function func(arg: MaybeFalse) {
  if (arg && arg.boo) ... // my preference, but the lint rule does not allow this
  if (arg?.boo) ... // ts doesn't like oxlint's recommended concise improvement
  if (arg !== false && arg?.boo) ... // allowed, but against the spirit of the lint rule (conciseness)
}
```

Since this rule is cosmetic and does not enforce any code correctness, I recommend you junk it.