### PR TITLE
ui(swiss): edit form fields arrangement tweaks

### DIFF
--- a/modules/gathering/src/main/ui/GatheringUi.scala
+++ b/modules/gathering/src/main/ui/GatheringUi.scala
@@ -131,6 +131,14 @@ final class GatheringFormUi(helpers: Helpers):
       disabled = disabledAfterStart
     )
 
+  def description(field: Field)(using Translate) =
+    form3.group(
+      field,
+      trans.site.tournDescription(),
+      help = trans.site.tournDescriptionHelp().some,
+      half = true
+    )(form3.textarea(_)(rows := 5))
+
   def payouts(field: Field)(using Option[Me], Translate) =
     Granter
       .opt(_.ManageTournament)

--- a/modules/swiss/src/main/ui/SwissFormUi.scala
+++ b/modules/swiss/src/main/ui/SwissFormUi.scala
@@ -139,7 +139,7 @@ final class SwissFormUi(helpers: Helpers)(
       form3.group(
         form("description"),
         trans.site.tournDescription(),
-        help = trans.site.tournDescriptionHelp().some,
+        help = trans.site.tournDescriptionHelp().some
       )(form3.textarea(_)(rows := 4))
     def position =
       form3.group(

--- a/modules/swiss/src/main/ui/SwissFormUi.scala
+++ b/modules/swiss/src/main/ui/SwissFormUi.scala
@@ -84,8 +84,9 @@ final class SwissFormUi(helpers: Helpers)(
 
     def tournamentFields =
       form3.fieldset("Tournament", toggle = true.some)(
-        form3.split(name, nbRounds),
-        form3.split(startsAt, description),
+        name,
+        form3.split(nbRounds, startsAt),
+        description,
         gatheringFormUi.payouts(form("payouts"))
       )
 
@@ -139,7 +140,6 @@ final class SwissFormUi(helpers: Helpers)(
         form("description"),
         trans.site.tournDescription(),
         help = trans.site.tournDescriptionHelp().some,
-        half = true
       )(form3.textarea(_)(rows := 4))
     def position =
       form3.group(

--- a/modules/swiss/src/main/ui/SwissFormUi.scala
+++ b/modules/swiss/src/main/ui/SwissFormUi.scala
@@ -86,8 +86,7 @@ final class SwissFormUi(helpers: Helpers)(
       form3.fieldset("Tournament", toggle = true.some)(
         name,
         form3.split(nbRounds, startsAt),
-        description,
-        gatheringFormUi.payouts(form("payouts"))
+        form3.split(description, gatheringFormUi.payouts(form("payouts")))
       )
 
     def gameFields =
@@ -139,8 +138,9 @@ final class SwissFormUi(helpers: Helpers)(
       form3.group(
         form("description"),
         trans.site.tournDescription(),
-        help = trans.site.tournDescriptionHelp().some
-      )(form3.textarea(_)(rows := 4))
+        help = trans.site.tournDescriptionHelp().some,
+        half = true
+      )(form3.textarea(_)(rows := 5))
     def position =
       form3.group(
         form("position"),

--- a/modules/swiss/src/main/ui/SwissFormUi.scala
+++ b/modules/swiss/src/main/ui/SwissFormUi.scala
@@ -86,7 +86,10 @@ final class SwissFormUi(helpers: Helpers)(
       form3.fieldset("Tournament", toggle = true.some)(
         name,
         form3.split(nbRounds, startsAt),
-        form3.split(description, gatheringFormUi.payouts(form("payouts")))
+        form3.split(
+          gatheringFormUi.description(form("description")),
+          gatheringFormUi.payouts(form("payouts"))
+        )
       )
 
     def gameFields =
@@ -134,13 +137,6 @@ final class SwissFormUi(helpers: Helpers)(
           form3.select(_, GatheringClock.incrementChoices, disabled = disabledAfterStart)
         )
       )
-    def description =
-      form3.group(
-        form("description"),
-        trans.site.tournDescription(),
-        help = trans.site.tournDescriptionHelp().some,
-        half = true
-      )(form3.textarea(_)(rows := 5))
     def position =
       form3.group(
         form("position"),

--- a/modules/tournament/src/main/ui/TournamentForm.scala
+++ b/modules/tournament/src/main/ui/TournamentForm.scala
@@ -92,7 +92,10 @@ final class TournamentForm(val helpers: Helpers, showUi: TournamentShow)(
       form3.globalError(form),
       form3.fieldset("Tournament", toggle = true.some, disabled = fields.frozen)(
         form3.split(fields.name, fields.minutes),
-        form3.split(fields.description, gatheringFormUi.payouts(form.prefix("payouts")))
+        form3.split(
+          gatheringFormUi.description(form.prefix("description")),
+          gatheringFormUi.payouts(form.prefix("payouts"))
+        )
       ),
       form3.fieldset("Games", toggle = true.some, disabled = fields.frozen)(
         fields.clock,
@@ -110,7 +113,7 @@ final class TournamentForm(val helpers: Helpers, showUi: TournamentShow)(
       form3.globalError(form),
       form3.fieldset("Tournament", toggle = true.some, disabled = fields.frozen)(
         form3.split(fields.name, fields.minutes),
-        form3.split(fields.description),
+        form3.split(gatheringFormUi.description(form.prefix("description"))),
         gatheringFormUi.payouts(form.prefix("payouts"))
       ),
       form3.fieldset("Games", toggle = false.some, disabled = fields.frozen)(
@@ -407,13 +410,6 @@ final class TourFields(tourForm: TournamentForm)(form: Form[?], tour: Option[Tou
     form3.fieldset("Start date", toggle = tour.forall(_.isCreated).some, disabled = frozen)(
       form3.split(waitMinutes, startDate)
     )
-  def description =
-    form3.group(
-      form.prefix("description"),
-      trans.site.tournDescription(),
-      help = trans.site.tournDescriptionHelp().some,
-      half = true
-    )(form3.textarea(_)(rows := 4))
   def entryCode =
     form3.group(
       form.prefix("password"),

--- a/modules/tournament/src/main/ui/TournamentForm.scala
+++ b/modules/tournament/src/main/ui/TournamentForm.scala
@@ -92,8 +92,7 @@ final class TournamentForm(val helpers: Helpers, showUi: TournamentShow)(
       form3.globalError(form),
       form3.fieldset("Tournament", toggle = true.some, disabled = fields.frozen)(
         form3.split(fields.name, fields.minutes),
-        form3.split(fields.description),
-        gatheringFormUi.payouts(form.prefix("payouts"))
+        form3.split(fields.description, gatheringFormUi.payouts(form.prefix("payouts")))
       ),
       form3.fieldset("Games", toggle = true.some, disabled = fields.frozen)(
         fields.clock,
@@ -412,7 +411,8 @@ final class TourFields(tourForm: TournamentForm)(form: Form[?], tour: Option[Tou
     form3.group(
       form.prefix("description"),
       trans.site.tournDescription(),
-      help = trans.site.tournDescriptionHelp().some
+      help = trans.site.tournDescriptionHelp().some,
+      half = true
     )(form3.textarea(_)(rows := 4))
   def entryCode =
     form3.group(


### PR DESCRIPTION
# How

Switch tour edit form fields arrangement tweaks.

# Preview

### Before

<img width="957" height="772" alt="Screenshot 2026-09-12 at 22 51 19" src="https://github.com/user-attachments/assets/4e87c2fc-de79-4133-9fbc-b429b773156e" />

### After

<img width="957" height="772" alt="Screenshot 2026-09-12 at 22 34 35" src="https://github.com/user-attachments/assets/5614c269-7dd3-436f-b50f-608fce0deae0" />
