### PR TITLE
ui(lib): do not color nested interrupts borders

### DIFF
--- a/ui/lib/css/tree/_tree.scss
+++ b/ui/lib/css/tree/_tree.scss
@@ -7,8 +7,8 @@ $disclosure-btn-size: calc(15px + var(---button-size-pointer-adjust, 0px));
   }
 
   .#{$name},
-  .#{$name} + lines,
-  &-inline .#{$name} + interrupt {
+  .#{$name} >  + lines,
+  &-inline .#{$name} + interrupt:not(:has(interrupt)) {
     --c-annotation-border: rgb(from var(--c-#{$name}) r g b / calc(alpha * 0.6));
 
     & interrupt {


### PR DESCRIPTION
# Why

Fixes #21605

# How

Do not color nested interrupts borders in inline view.

# Preview

<img width="404" height="772" alt="Screenshot 2026-09-12 at 23 15 30" src="https://github.com/user-attachments/assets/0897cc84-f7b6-4479-8745-32e9ce723670" />
