### PR TITLE
Broadcast round form: restore half width form inputs

### DIFF
--- a/modules/relay/src/main/ui/RelayFormUi.scala
+++ b/modules/relay/src/main/ui/RelayFormUi.scala
@@ -390,7 +390,7 @@ Hanna Marie ; Kozul, Zdenko"""),
           )(
             nav.tour.showRatingDiffs.option(
               form3.split(
-                form3.group(form("rated"), raw("")): field =>
+                form3.group(form("rated"), raw(""), half = true): field =>
                   val withDefault =
                     if nav.newRound && field.value.isEmpty then field.copy(value = "true".some) else field
                   form3.checkboxGroup(
@@ -419,7 +419,8 @@ Hanna Marie ; Kozul, Zdenko"""),
                 List("win", "draw").map: result =>
                   form3.group(
                     form("customScoring")(color.name)(result),
-                    raw(s"Points for a $result as ${color.name}")
+                    raw(s"Points for a $result as ${color.name}"),
+                    half = true
                   )(
                     form3.input(_)(tpe := "number", step := 0.01f, min := 0.0f, max := 10.0f)
                   )
@@ -433,7 +434,8 @@ Hanna Marie ; Kozul, Zdenko"""),
                 List("win", "draw").map: result =>
                   form3.group(
                     form("teamCustomScoring")(result),
-                    raw(s"Team points for a match $result")
+                    raw(s"Team points for a match $result"),
+                    half = true
                   )(
                     form3.input(_)(tpe := "number", step := 0.01f, min := 0.0f, max := 10.0f)
                   )


### PR DESCRIPTION
|Before|After|
|---|---|
|<img width="1476" height="1647" alt="image" src="https://github.com/user-attachments/assets/f82af53d-1ba2-433c-8a43-d5924d97879a" />|<img width="1488" height="959" alt="image" src="https://github.com/user-attachments/assets/72b6c343-1bf5-4f51-8a3b-d44cda5bebe4" />|